### PR TITLE
fix fd leak in out_fluentd

### DIFF
--- a/plugins/out_fluentd/out_fluentd.c
+++ b/plugins/out_fluentd/out_fluentd.c
@@ -65,7 +65,7 @@ int cb_fluentd_pre_run(void *out_context, struct flb_config *config)
 
 int cb_fluentd_flush(void *data, size_t bytes, void *out_context)
 {
-    int fd;
+    int fd, len;
     struct flb_out_fluentd_config *ctx = out_context;
     (void) ctx;
 
@@ -76,7 +76,10 @@ int cb_fluentd_flush(void *data, size_t bytes, void *out_context)
     }
 
     /* FIXME: plain TCP write */
-    return write(fd, data, bytes);
+    len = write(ctx->fd, data, bytes);
+    close(fd);
+
+    return len;
 }
 
 /* Plugin reference */

--- a/plugins/out_fluentd/out_fluentd.c
+++ b/plugins/out_fluentd/out_fluentd.c
@@ -76,7 +76,7 @@ int cb_fluentd_flush(void *data, size_t bytes, void *out_context)
     }
 
     /* FIXME: plain TCP write */
-    len = write(ctx->fd, data, bytes);
+    len = write(fd, data, bytes);
     close(fd);
 
     return len;


### PR DESCRIPTION
out_fluentd plugin causes following fd/socket leakage.
cb_flush_buf handler should close sockets it opened.

```
# about 5mins after fluent-bit executed

$ lsof -p 2705                                                                                                                                                                                                                         [1056/1953]
lsof: WARNING: can't stat() fuse.gvfsd-fuse file system /run/user/112/gvfs
      Output information may be incomplete.
COMMAND    PID    USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME
fluent-bi 2705 enukane  cwd    DIR    8,1     4096 817620 /home/enukane/Dev/fluent-bit/build
fluent-bi 2705 enukane  rtd    DIR    8,1     4096      2 /
fluent-bi 2705 enukane  txt    REG    8,1    56056 818517 /home/enukane/Dev/fluent-bit/build/bin/fluent-bit
fluent-bi 2705 enukane  mem    REG    8,1  1754876 671725 /lib/i386-linux-gnu/libc-2.19.so
fluent-bi 2705 enukane  mem    REG    8,1   134380 671728 /lib/i386-linux-gnu/ld-2.19.so
fluent-bi 2705 enukane    0u   CHR   4,64      0t0   8239 /dev/ttyS0
fluent-bi 2705 enukane    1u   CHR   4,64      0t0   8239 /dev/ttyS0
fluent-bi 2705 enukane    2u   CHR   4,64      0t0   8239 /dev/ttyS0
fluent-bi 2705 enukane    3u  IPv4  14907      0t0    TCP 192.168.0.230:59222->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane    4u  0000    0,9        0   7811 anon_inode
fluent-bi 2705 enukane    5u  0000    0,9        0   7811 anon_inode
fluent-bi 2705 enukane    6u  0000    0,9        0   7811 anon_inode
fluent-bi 2705 enukane    8u  IPv4  14909      0t0    TCP 192.168.0.230:59224->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane    9u  IPv4  14914      0t0    TCP 192.168.0.230:59226->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   10u  IPv4  14931      0t0    TCP 192.168.0.230:59228->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   11u  IPv4  16078      0t0    TCP 192.168.0.230:59230->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   12u  IPv4  14958      0t0    TCP 192.168.0.230:59232->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   13u  IPv4  14966      0t0    TCP 192.168.0.230:59234->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   14u  IPv4  14971      0t0    TCP 192.168.0.230:59236->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   15u  IPv4  14973      0t0    TCP 192.168.0.230:59238->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   16u  IPv4  14975      0t0    TCP 192.168.0.230:59240->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   17u  IPv4  14990      0t0    TCP 192.168.0.230:59242->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   18u  IPv4  15060      0t0    TCP 192.168.0.230:59244->192.168.0.240:11185 (ESTABLISHED)
fluent-bi 2705 enukane   19u  IPv4  15122      0t0    TCP 192.168.0.230:59246->192.168.0.240:11185 (ESTABLISHED)
(snip)
fluent-bi 2705 enukane   59u  IPv4  17373      0t0    TCP 192.168.0.230:59326->192.168.0.240:11185 (ESTABLISHED)
```

As my ubuntu's file-max is about ~40000, this won't be a problem for a while.