### PR TITLE
IPv6 support

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -33,7 +33,7 @@ int flb_net_socket_nonblocking(int sockfd);
 int flb_net_socket_tcp_fastopen(int sockfd);
 
 /* Socket handling */
-int flb_net_socket_create();
+int flb_net_socket_create(int family, int nonblock);
 int flb_net_tcp_connect(char *host, unsigned long port);
 int flb_net_server(char *port, char *listen_addr);
 int flb_net_bind(int socket_fd, const struct sockaddr *addr,


### PR DESCRIPTION
Implement IPv6 support.

```
$ ./fluent-bit -V -i cpu -o fluentd://[::1]:12224
Fluent-Bit v0.1.0
Copyright (C) Treasure Data

[2015/05/27 00:24:43] [ info] Configuration
 flush time     : 5 seconds
 input plugins  : cpu 
 collectors     : [cpu 1s,0ns] 
[2015/05/27 00:24:43] [ info] starting engine
[2015/05/27 00:24:44] [debug] [in_cpu] CPU 1.00% (buffer=0)
[2015/05/27 00:24:45] [debug] [in_cpu] CPU 0.00% (buffer=1)
[2015/05/27 00:24:46] [debug] [in_cpu] CPU 0.00% (buffer=2)
[2015/05/27 00:24:47] [debug] [in_cpu] CPU 0.00% (buffer=3)
[2015/05/27 00:24:48] [ info] Flush buf 97 bytes
[2015/05/27 00:24:48] [debug] [in_cpu] CPU 0.00% (buffer=0)
[2015/05/27 00:24:49] [debug] [in_cpu] CPU 2.00% (buffer=1)
[2015/05/27 00:24:50] [debug] [in_cpu] CPU 0.00% (buffer=2)
[2015/05/27 00:24:51] [debug] [in_cpu] CPU 0.00% (buffer=3)
[2015/05/27 00:24:52] [debug] [in_cpu] CPU 0.00% (buffer=4)
[2015/05/27 00:24:53] [ info] Flush buf 117 bytes
[2015/05/27 00:24:53] [debug] [in_cpu] CPU 0.00% (buffer=0)
[2015/05/27 00:24:54] [debug] [in_cpu] CPU 0.00% (buffer=1)
[2015/05/27 00:24:55] [debug] [in_cpu] CPU 0.00% (buffer=2)
[2015/05/27 00:24:56] [debug] [in_cpu] CPU 0.00% (buffer=3)
[2015/05/27 00:24:57] [debug] [in_cpu] CPU 0.00% (buffer=4)
[2015/05/27 00:24:58] [ info] Flush buf 117 bytes
```