### PR TITLE
in_mem: fix overflow when reading in_mem generated msgpack maps #6

### DIFF
--- a/plugins/in_mem/in_mem.c
+++ b/plugins/in_mem/in_mem.c
@@ -104,6 +104,7 @@ void *in_mem_flush(void *in_context, int *size)
         return NULL;
     }
     memcpy(buf, ctx->sbuf.data, ctx->sbuf.size);
+    *size = ctx->sbuf.size;
     msgpack_sbuffer_destroy(&ctx->sbuf);
     msgpack_sbuffer_init(&ctx->sbuf);
     msgpack_packer_init(&ctx->pckr, &ctx->sbuf, msgpack_sbuffer_write);


### PR DESCRIPTION
Sorry, cause of issue #6, was missing a set of size of msgpack data at in_mem_flush().

After the fix:
```
$ ./fluent-bit -i mem -o stdout
Fluent-Bit v0.1.0
Copyright (C) Treasure Data

[2015/06/03 10:49:16] [ info] starting engine
[0] {"time"=>1433296157, "total"=>501760, "free"=>220720}
[1] {"time"=>1433296158, "total"=>501760, "free"=>220720}
[2] {"time"=>1433296159, "total"=>501760, "free"=>220720}
[3] {"time"=>1433296160, "total"=>501760, "free"=>220720}
[2015/06/03 10:49:21] [ info] Flush buf 128 bytes
[0] {"time"=>1433296161, "total"=>501760, "free"=>220720}
[1] {"time"=>1433296162, "total"=>501760, "free"=>220720}
[2] {"time"=>1433296163, "total"=>501760, "free"=>220720}
[3] {"time"=>1433296164, "total"=>501760, "free"=>220720}
[4] {"time"=>1433296165, "total"=>501760, "free"=>220720}
[2015/06/03 10:49:26] [ info] Flush buf 160 bytes
```

Signed-off-by: Masaya YAMAMOTO &lt;pandax381@gmail.com&gt;