### PR TITLE
Build: fix failed to generate the executable file #9

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,8 +40,9 @@ install(TARGETS fluent-bit-shared LIBRARY DESTINATION lib)
 
 # Executable
 if(NOT WITHOUT_BIN)
+  find_package (Threads)
   add_executable(fluent-bit-bin fluent-bit.c)
-  target_link_libraries(fluent-bit-bin fluent-bit-static)
+  target_link_libraries(fluent-bit-bin fluent-bit-static ${CMAKE_THREAD_LIBS_INIT})
   set_target_properties(fluent-bit-bin
     PROPERTIES OUTPUT_NAME fluent-bit)
   install(TARGETS fluent-bit-bin RUNTIME DESTINATION bin)


### PR DESCRIPTION
Fixed: Issue #9 

linking pthread library:

```
$ make
...
Linking C executable ../bin/fluent-bit
[ 81%] Built target fluent-bit-bin
Scanning dependencies of target fluent-bit-shared
[ 84%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_pack.c.o
[ 86%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_input.c.o
[ 89%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_output.c.o
[ 92%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_config.c.o
[ 94%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_network.c.o
[ 97%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_utils.c.o
[100%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_engine.c.o
Linking C shared library ../library/libfluent-bit.so
[100%] Built target fluent-bit-shared
```

Signed-off-by: Masaya YAMAMOTO &lt;pandax381@gmail.com&gt;