### PR TITLE
mk_core: fix timeout given to EVFILT_TIMER in some BSD

### DIFF
--- a/lib/mk_core/mk_event_kqueue.c
+++ b/lib/mk_core/mk_event_kqueue.c
@@ -166,7 +166,13 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     event->type = MK_EVENT_NOTIFICATION;
     event->mask = MK_EVENT_EMPTY;
 
+#ifdef NOTE_SECONDS
+    /* FreeBSD or LINUX_KQUEUE defined */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, expire, event);
+#else
+    /* Other BSD have no NOTE_SECONDS & specify milliseconds */
+    EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, expire * 1000, event);
+#endif
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);
     if (ret < 0) {
         close(fd);


### PR DESCRIPTION
Fixed timeout parameter given to EV_SET(EVFILT_TIMER) in some BSD.

Only FreeBSD (or LINUX_SECOND?) has NOTE_SECONDS defined and specify seconds
in EV_SET(EVFILT_TIMER). Other BSD (NetBSD, OpenBSD, DragonFlyBSD) requires milliseconds.
This caused 1000 times faster timeout & flushing.

I've tested this patch in NetBSD environment (on my netbsd-work branch).