### PR TITLE
Build: porting Mac OS X (and othrer BSD systems).

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -21,6 +21,7 @@
 #define FLB_NETWORK_H
 
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN  23

--- a/lib/mk_core/mk_event_kqueue.c
+++ b/lib/mk_core/mk_event_kqueue.c
@@ -178,6 +178,7 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
      * FIXME: the timeout event is not triggered when using libkqueue, need
      * to confirm how it behave on native OSX.
      */
+    event->mask = MK_EVENT_READ;
 
     return fd;
 }

--- a/plugins/out_fluentd/fluentd.c
+++ b/plugins/out_fluentd/fluentd.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <assert.h>
 
 #include <fluent-bit/flb_output.h>

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -74,7 +75,7 @@ int cb_td_flush(void *data, size_t bytes, void *out_context,
 {
     int n;
     char buf[1024];
-    size_t w_bytes;
+    ssize_t w_bytes;
     size_t out_len;
     char *request;
     struct flb_out_td_config *ctx = out_context;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
   ${extra_headers}
   )
 
+include(CheckSymbolExists)
 check_symbol_exists(accept4 "sys/socket.h" HAVE_ACCEPT4)
 
 # Let the core aware about TLS/SSL if enabled

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(
   ${extra_headers}
   )
 
+check_symbol_exists(accept4 "sys/socket.h" HAVE_ACCEPT4)
+
 # Let the core aware about TLS/SSL if enabled
 if(WITH_SSL_TLS)
   add_definitions(-DHAVE_SSL_TLS)

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -125,7 +125,7 @@ static int flb_engine_handle_event(int fd, int mask, struct flb_config *config)
     struct mk_list *head;
     struct flb_input_collector *collector;
 
-    if (mask & FLB_ENGINE_READ) {
+    if (mask & MK_EVENT_READ) {
         /* Check if we need to flush */
         if (config->flush_fd == fd) {
             consume_byte(fd);

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -35,6 +35,10 @@
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_utils.h>
 
+#ifndef SOL_TCP
+#define SOL_TCP IPPROTO_TCP
+#endif
+
 int flb_net_socket_reset(int sockfd)
 {
     int status = 1;
@@ -207,8 +211,13 @@ int flb_net_accept(int server_fd)
     struct sockaddr sock_addr;
     socklen_t socket_size = sizeof(struct sockaddr);
 
+#ifdef HAVE_ACCEPT4
     remote_fd = accept4(server_fd, &sock_addr, &socket_size,
                         SOCK_NONBLOCK | SOCK_CLOEXEC);
+#else
+    remote_fd = accept(server_fd, &sock_addr, &socket_size);
+    flb_net_socket_nonblocking(remote_fd);
+#endif
 
     if (remote_fd == -1) {
         perror("accept4");


### PR DESCRIPTION
I wrote a patch to build on Mac OS X.

```
$ cmake -DWITH_IN_MEM=0 ../
-- The C compiler identification is AppleClang 6.0.0.6000054
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- The CXX compiler identification is AppleClang 6.0.0.6000054
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find GTest (missing:  GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY) 
-- Found ZLIB: /usr/lib/libz.dylib (found version "1.2.5") 
-- Looking for include file pthread.h
-- Looking for include file pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE  
-- Performing Test MSGPACK_ENABLE_GCC_CXX_ATOMIC
-- Performing Test MSGPACK_ENABLE_GCC_CXX_ATOMIC - Failed
-- Could NOT find Doxygen (missing:  DOXYGEN_EXECUTABLE) 
-- Looking for accept4
-- Looking for accept4 - not found
-- Configuring done
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   fluent-bit-shared

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: /Users/yamamoto-ma/LOCAL/src/fluent-bit/build
$ make
Scanning dependencies of target msgpack
[  2%] Building CXX object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/object.cpp.o
[  5%] Building C object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/unpack.c.o
[  8%] Building C object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/objectc.c.o
[ 10%] Building C object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/version.c.o
[ 13%] Building C object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/vrefbuffer.c.o
[ 16%] Building C object lib/msgpack-0.5.9/CMakeFiles/msgpack.dir/src/zone.c.o
Linking CXX static library ../../library/libmsgpack.a
[ 16%] Built target msgpack
Scanning dependencies of target mk_core
[ 18%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_iov.c.o
[ 21%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_rconf.c.o
[ 24%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_string.c.o
[ 27%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_memory.c.o
[ 29%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_event.c.o
[ 32%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_utils.c.o
[ 35%] Building C object lib/mk_core/CMakeFiles/mk_core.dir/mk_rbtree.c.o
Linking C static library ../../library/libmk_core.a
[ 35%] Built target mk_core
Scanning dependencies of target jsmn
[ 37%] Building C object lib/jsmn/CMakeFiles/jsmn.dir/jsmn.c.o
Linking C static library ../../library/libjsmn.a
[ 37%] Built target jsmn
Scanning dependencies of target flb-plugin-in_cpu
[ 40%] Building C object plugins/in_cpu/CMakeFiles/flb-plugin-in_cpu.dir/in_cpu.c.o
Linking C static library ../../library/libflb-plugin-in_cpu.a
[ 40%] Built target flb-plugin-in_cpu
Scanning dependencies of target flb-plugin-in_kmsg
[ 43%] Building C object plugins/in_kmsg/CMakeFiles/flb-plugin-in_kmsg.dir/in_kmsg.c.o
Linking C static library ../../library/libflb-plugin-in_kmsg.a
[ 43%] Built target flb-plugin-in_kmsg
Scanning dependencies of target flb-plugin-out_fluentd
[ 45%] Building C object plugins/out_fluentd/CMakeFiles/flb-plugin-out_fluentd.dir/__/__/src/flb_network.c.o
[ 48%] Building C object plugins/out_fluentd/CMakeFiles/flb-plugin-out_fluentd.dir/fluentd.c.o
Linking C static library ../../library/libflb-plugin-out_fluentd.a
[ 48%] Built target flb-plugin-out_fluentd
Scanning dependencies of target flb-plugin-out_td
[ 51%] Building C object plugins/out_td/CMakeFiles/flb-plugin-out_td.dir/td_http.c.o
[ 54%] Building C object plugins/out_td/CMakeFiles/flb-plugin-out_td.dir/td_config.c.o
[ 56%] Building C object plugins/out_td/CMakeFiles/flb-plugin-out_td.dir/td.c.o
Linking C static library ../../library/libflb-plugin-out_td.a
[ 56%] Built target flb-plugin-out_td
Scanning dependencies of target flb-plugin-out_stdout
[ 59%] Building C object plugins/out_stdout/CMakeFiles/flb-plugin-out_stdout.dir/stdout.c.o
Linking C static library ../../library/libflb-plugin-out_stdout.a
[ 59%] Built target flb-plugin-out_stdout
Scanning dependencies of target fluent-bit-static
[ 62%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_pack.c.o
[ 64%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_input.c.o
[ 67%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_output.c.o
[ 70%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_config.c.o
[ 72%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_network.c.o
[ 75%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_utils.c.o
[ 78%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_engine.c.o
Linking C static library ../library/libfluent-bit.a
[ 78%] Built target fluent-bit-static
Scanning dependencies of target fluent-bit-bin
[ 81%] Building C object src/CMakeFiles/fluent-bit-bin.dir/fluent-bit.c.o
Linking C executable ../bin/fluent-bit
[ 81%] Built target fluent-bit-bin
Scanning dependencies of target fluent-bit-shared
[ 83%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_pack.c.o
[ 86%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_input.c.o
[ 89%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_output.c.o
[ 91%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_config.c.o
[ 94%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_network.c.o
[ 97%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_utils.c.o
[100%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_engine.c.o
Linking C shared library ../library/libfluent-bit.dylib
[100%] Built target fluent-bit-shared
```

Signed-off-by: pandax381 &lt;pandax381@gmail.com&gt;