### PR TITLE
Input plugins: no longer flushes empty buffer

### DIFF
--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -158,6 +158,9 @@ void *in_cpu_flush(void *in_context, int *size)
     msgpack_sbuffer *sbuf;
     struct flb_in_cpu_config *ctx = in_context;
 
+    if (ctx->data_idx == 0)
+        return NULL;
+
     sbuf = &ctx->mp_sbuf;
     *size = sbuf->size;
     buf = malloc(sbuf->size);

--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -107,6 +107,9 @@ void *in_kmsg_flush(void *in_context, int *size)
     msgpack_sbuffer *sbuf;
     struct flb_in_kmsg_config *ctx = in_context;
 
+    if (ctx->buffer_id == 0)
+        return NULL;
+
     sbuf = &ctx->mp_sbuf;
     *size = sbuf->size;
     buf = malloc(sbuf->size);

--- a/plugins/in_mem/in_mem.c
+++ b/plugins/in_mem/in_mem.c
@@ -99,6 +99,9 @@ void *in_mem_flush(void *in_context, int *size)
     char *buf;
     struct flb_in_mem_config *ctx = in_context;
 
+    if (ctx->idx == 0)
+        return NULL;
+
     buf = malloc(ctx->sbuf.size);
     if (!buf) {
         return NULL;


### PR DESCRIPTION
plugins/in_cpu: no longer flushes empty buffer
plugins/in_mem: no longer flushes empty buffer
plugins/in_kmsg: no longer flushes empty buffer

This changes avoid allocating and flushing unnecessary empty
buffers (size == 0). These also suppress error messages when
no updates in flush interval(typically every 5 seconds).

Signed-off-by: Takeshi HASEGAWA <hasegaw@gmail.com>