### PR TITLE
XBee input plugin update

### DIFF
--- a/conf/xbee_input.conf
+++ b/conf/xbee_input.conf
@@ -1,0 +1,16 @@
+# XBee Input
+# ==========
+# This configuration file specify the information to be used
+# when gathering data from XBee input plugin. All key fields
+# in the 'XBEE' section are mandatory.
+
+[XBEE]
+    # File
+    # ====
+    # Filename of serial port. e.g. /dev/ttyS0, /dev/ttyAMA0
+    File    /dev/ttyUSB0
+
+    # Baudrate
+    # ========
+    # Specify the bitrate to communicate using the port.
+    Baudrate 9600

--- a/plugins/in_xbee/CMakeLists.txt
+++ b/plugins/in_xbee/CMakeLists.txt
@@ -3,6 +3,6 @@ add_subdirectory(lib/libxbee-v3)
 include_directories(lib/libxbee-v3)
 
 set(src
-  in_xbee.c)
+  in_xbee.c in_xbee_config.c)
 
 FLB_PLUGIN(in_xbee "${src}" "xbee")

--- a/plugins/in_xbee/in_xbee.c
+++ b/plugins/in_xbee/in_xbee.c
@@ -29,6 +29,7 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_engine.h>
+#include <msgpack.h>
 
 #include "in_xbee.h"
 #include "in_xbee_config.h"
@@ -40,36 +41,101 @@
  */
 void xbee_init(void);
 
+
+
+void in_xbee_rx_queue_raw(struct flb_in_xbee_config *ctx, const char *buf ,int len)
+{
+    /* Increase buffer position */
+    ctx->buffer_id++;
+
+    msgpack_pack_array(&ctx->mp_pck, 2);
+    msgpack_pack_uint64(&ctx->mp_pck, time(NULL));
+    msgpack_pack_map(&ctx->mp_pck, 1);
+    msgpack_pack_bin(&ctx->mp_pck, 4);
+    msgpack_pack_bin_body(&ctx->mp_pck, "data", 4);
+    msgpack_pack_bin(&ctx->mp_pck, len);
+    msgpack_pack_bin_body(&ctx->mp_pck, buf, len);
+}
+
+
+void in_xbee_rx_queue_msgpack(struct flb_in_xbee_config *ctx, const char *buf ,int len)
+{
+    /* Increase buffer position */
+    ctx->buffer_id++;
+
+    msgpack_pack_array(&ctx->mp_pck, 2);
+    msgpack_pack_uint64(&ctx->mp_pck, time(NULL));
+    msgpack_pack_bin_body(&ctx->mp_pck, buf, len);
+}
+
+int in_xbee_rx_validate_msgpack(const char *buf, int len)
+{
+    msgpack_unpacked result;
+    msgpack_unpacked_init(&result);
+
+    size_t off = 0;
+    if (! msgpack_unpack_next(&result, buf, len, &off)) {
+        goto fail;
+    }
+
+    if (result.data.type != MSGPACK_OBJECT_MAP) {
+        goto fail;
+    }
+    /* ToDo: validate msgpack length */
+
+    /* can handle as MsgPack */
+
+    msgpack_unpacked_destroy(&result);
+    return 1;
+
+fail:
+    msgpack_unpacked_destroy(&result);
+    return 0;
+}
+
 void in_xbee_cb(struct xbee *xbee, struct xbee_con *con,
                 struct xbee_pkt **pkt, void **data)
 {
-    struct iovec *v;
     struct flb_in_xbee_config *ctx;
+    int ret;
 
-	if ((*pkt)->dataLen == 0) {
-		flb_debug("xbee data length too short, skip");
-		return;
-	}
-
-    ctx = *data;
-
-    if (ctx->buffer_len + 1 >= FLB_XBEE_BUFFER_SIZE) {
-        /* fixme: use flb_engine_flush() */
+    if ((*pkt)->dataLen == 0) {
+        flb_debug("xbee data length too short, skip");
         return;
     }
 
-    /* Insert entry into the iovec */
-    v = &ctx->buffer[ctx->buffer_len];
-    v->iov_base = malloc((*pkt)->dataLen);
-    memcpy(v->iov_base, (*pkt)->data, (*pkt)->dataLen);
-    v->iov_len = (*pkt)->dataLen;
-    ctx->buffer_len++;
+    ctx = *data;
+
+#if 0
+    int i;
+    for (i = 0; i < (*pkt)->dataLen; i++) {
+        printf("%2.2x ", *((unsigned char*) (*pkt)->data + i));
+    }
+    printf("\n");
+#endif
+
+    if (ctx->buffer_id + 1 >= FLB_XBEE_BUFFER_SIZE) {
+        flb_debug("buffer is full (FixMe)");
+        return;
+#if 0
+        ret = flb_engine_flush(config, &in_xbee_plugin, NULL);
+        if (ret == -1) {
+            ctx->buffer_id = 0;
+        } 
+#endif
+    }
+
+    if (in_xbee_rx_validate_msgpack((const char*) (*pkt)->data, (*pkt)->dataLen)) {
+        in_xbee_rx_queue_msgpack(ctx, (const char*) (*pkt)->data, (*pkt)->dataLen);
+    } else {
+        in_xbee_rx_queue_raw(ctx, (const char*) (*pkt)->data, (*pkt)->dataLen);
+    }
 }
 
 /* Callback triggered by timer */
 int in_xbee_collect(struct flb_config *config, void *in_context)
 {
-    int ret;
+    int ret = 0;
     void *p = NULL;
     (void) config;
     struct flb_in_xbee_config *ctx = in_context;
@@ -83,41 +149,52 @@ int in_xbee_collect(struct flb_config *config, void *in_context)
     return 0;
 }
 
-void *in_xbee_flush_iov(void *in_context, int *size)
+void *in_xbee_flush(void *in_context, int *size)
 {
+    char *buf;
+    msgpack_sbuffer *sbuf;
     struct flb_in_xbee_config *ctx = in_context;
 
-    *size = ctx->buffer_len;
-    return ctx->buffer;
-}
+    if (ctx->buffer_id == 0)
+        return NULL;
 
-void in_xbee_flush_end(void *in_context)
-{
-    int i;
-    struct iovec *iov;
-    struct flb_in_xbee_config *ctx = in_context;
-
-    for (i = 0; i < ctx->buffer_len; i++) {
-        iov = &ctx->buffer[i];
-        free(iov->iov_base);
-        iov->iov_len = 0;
+    sbuf = &ctx->mp_sbuf;
+    *size = sbuf->size;
+    buf = malloc(sbuf->size);
+    if (!buf) {
+        return NULL;
     }
 
-    ctx->buffer_len = 0;
+    /* set a new buffer and re-initialize our MessagePack context */
+    memcpy(buf, sbuf->data, sbuf->size);
+    msgpack_sbuffer_destroy(&ctx->mp_sbuf);
+    msgpack_sbuffer_init(&ctx->mp_sbuf);
+    msgpack_packer_init(&ctx->mp_pck, &ctx->mp_sbuf, msgpack_sbuffer_write);
+
+    ctx->buffer_id = 0;
+
+    return buf;
 }
 
-/* Init kmsg input */
+/* Init xbee input */
 int in_xbee_init(struct flb_config *config)
 {
     int ret;
     int opt_baudrate = 9600;
-    char *tmp;
     char *opt_device;
     struct stat dev_st;
-	struct xbee *xbee;
-	struct xbee_con *con;
-	struct xbee_conAddress address;
+    struct xbee *xbee;
+    struct xbee_con *con;
+    struct xbee_conAddress address;
     struct flb_in_xbee_config *ctx;
+    struct xbee_conSettings settings;
+
+    /* Prepare the configuration context */
+    ctx = calloc(1, sizeof(struct flb_in_xbee_config));
+    if (!ctx) {
+        perror("calloc");
+        return -1;
+    }
 
     if (!config->file) {
         flb_utils_error_c("XBee input plugin needs configuration file");
@@ -136,13 +213,6 @@ int in_xbee_init(struct flb_config *config)
     /* Check an optional baudrate */
     if (ctx->baudrate)
         opt_baudrate = atoi((char*) ctx->baudrate);
-
-    /* set context */
-    ret = flb_input_set_context("xbee", ctx, config);
-    if (ret == -1) {
-        flb_utils_error_c("Could not set configuration for"
-                "XBee input plugin");
-    }
 
     /* initialize MessagePack buffers */
     msgpack_sbuffer_init(&ctx->mp_sbuf);
@@ -173,52 +243,57 @@ int in_xbee_init(struct flb_config *config)
     /* Init library */
     xbee_init();
 
-	ret = xbee_setup(&xbee, "xbeeZB", opt_device, opt_baudrate);
+    ret = xbee_setup(&xbee, "xbeeZB", opt_device, opt_baudrate);
     if (ret != XBEE_ENONE) {
         flb_utils_error_c("xbee_setup");
-		return ret;
-	}
+        return ret;
+    }
 
     /* FIXME: just a built-in example */
-	memset(&address, 0, sizeof(address));
-	address.addr64_enabled = 1;
-	address.addr64[0] = 0x00;
-	address.addr64[1] = 0x13;
-	address.addr64[2] = 0xA2;
-	address.addr64[3] = 0x00;
+    memset(&address, 0, sizeof(address));
+    address.addr64_enabled = 1;
+#if 0
+    address.addr64[0] = 0x00;
+    address.addr64[1] = 0x13;
+    address.addr64[2] = 0xA2;
+    address.addr64[3] = 0x00;
     address.addr64[4] = 0x40;
     address.addr64[5] = 0xB7;
-    address.addr64[6] = 0xB1;
-    address.addr64[7] = 0xEB;
+#endif
+    address.addr64[6] = 0xFF;
+    address.addr64[7] = 0xFF;
+
+    if (ctx->xbeeLogLevel >= 0)
+        xbee_logLevelSet(xbee, ctx->xbeeLogLevel);
 
     /* Prepare a connection with the peer XBee */
-	if ((ret = xbee_conNew(xbee, &con, "Data", &address)) != XBEE_ENONE) {
-		xbee_log(xbee, -1, "xbee_conNew() returned: %d (%s)", ret, xbee_errorToStr(ret));
-		return ret;
-	}
-
-    /* Prepare the configuration context */
-    ctx = calloc(1, sizeof(struct flb_in_xbee_config));
-    if (!ctx) {
-        perror("calloc");
-        free(opt_device);
-        return -1;
+    if ((ret = xbee_conNew(xbee, &con, "Data", &address)) != XBEE_ENONE) {
+        xbee_log(xbee, -1, "xbee_conNew() returned: %d (%s)", ret, xbee_errorToStr(ret));
+        return ret;
     }
+
+
+    xbee_conSettings(con, NULL, &settings);
+    settings.disableAck = 1;
+    settings.catchAll = 1;
+    xbee_conSettings(con, &settings, NULL);
+
+
     ctx->device     = opt_device;
     ctx->baudrate   = opt_baudrate;
     ctx->con        = con;
     ctx->buffer_len = 0;
 
-	if ((ret = xbee_conDataSet(con, ctx, NULL)) != XBEE_ENONE) {
-		xbee_log(xbee, -1, "xbee_conDataSet() returned: %d", ret);
-		return ret;
-	}
+    if ((ret = xbee_conDataSet(con, ctx, NULL)) != XBEE_ENONE) {
+        xbee_log(xbee, -1, "xbee_conDataSet() returned: %d", ret);
+        return ret;
+    }
 
 
-	if ((ret = xbee_conCallbackSet(con, in_xbee_cb, NULL)) != XBEE_ENONE) {
-		xbee_log(xbee, -1, "xbee_conCallbackSet() returned: %d", ret);
-		return ret;
-	}
+    if ((ret = xbee_conCallbackSet(con, in_xbee_cb, NULL)) != XBEE_ENONE) {
+        xbee_log(xbee, -1, "xbee_conCallbackSet() returned: %d", ret);
+        return ret;
+    }
 
 
     /* Set the context */
@@ -252,7 +327,5 @@ struct flb_input_plugin in_xbee_plugin = {
     .cb_init      = in_xbee_init,
     .cb_pre_run   = NULL,
     .cb_collect   = in_xbee_collect,
-    .cb_flush_buf = NULL,
-    .cb_flush_iov = in_xbee_flush_iov,
-    .cb_flush_end = in_xbee_flush_end,
+    .cb_flush_buf = in_xbee_flush,
 };

--- a/plugins/in_xbee/in_xbee.h
+++ b/plugins/in_xbee/in_xbee.h
@@ -28,21 +28,6 @@
 #define IN_XBEE_COLLECT_SEC        0
 #define IN_XBEE_COLLECT_NSEC       15000
 
-#define FLB_XBEE_BUFFER_SIZE       128
-
-struct flb_in_xbee_config {
-    /* XBee setup */
-    int  baudrate;
-    char *device;
-
-    /* Active connection context */
-	struct xbee_con *con;
-
-    /* buffering */
-    int buffer_len;
-    struct iovec buffer[FLB_XBEE_BUFFER_SIZE];
-};
-
 extern struct flb_input_plugin in_xbee_plugin;
 
 #endif

--- a/plugins/in_xbee/in_xbee_config.c
+++ b/plugins/in_xbee/in_xbee_config.c
@@ -27,6 +27,7 @@ struct flb_in_xbee_config *xbee_config_read(struct flb_in_xbee_config *config, s
 {
     char *file;
     char *baudrate;
+    char *xbee_loglevel;
     struct mk_rconf_section *section;
 
     section = mk_rconf_section_get(conf, "xbee");
@@ -37,6 +38,7 @@ struct flb_in_xbee_config *xbee_config_read(struct flb_in_xbee_config *config, s
     /* Validate xbee section keys */
     file = mk_rconf_section_get_key(section, "file", MK_RCONF_STR);
     baudrate = mk_rconf_section_get_key(section, "baudrate", MK_RCONF_STR);
+    xbee_loglevel = mk_rconf_section_get_key(section, "XBeeLogLevel", MK_RCONF_STR);
 
     if (!file) {
         flb_utils_error_c("[xbee] error reading filename from "
@@ -51,6 +53,7 @@ struct flb_in_xbee_config *xbee_config_read(struct flb_in_xbee_config *config, s
     config->fd       = -1;
     config->file     = file;
     config->baudrate  = baudrate;
+    config->xbeeLogLevel = xbee_loglevel ? atoi(xbee_loglevel) : -1;
 
     flb_debug("[xbee] / device='%s' baudrate='%s'",
               config->file, config->baudrate);

--- a/plugins/in_xbee/in_xbee_config.c
+++ b/plugins/in_xbee/in_xbee_config.c
@@ -1,0 +1,59 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <mk_core/mk_core.h>
+#include <fluent-bit/flb_utils.h>
+
+#include "in_xbee_config.h"
+
+struct flb_in_xbee_config *xbee_config_read(struct flb_in_xbee_config *config, struct mk_rconf *conf)
+{
+    char *file;
+    char *baudrate;
+    struct mk_rconf_section *section;
+
+    section = mk_rconf_section_get(conf, "xbee");
+    if (!section) {
+        return NULL;
+    }
+
+    /* Validate xbee section keys */
+    file = mk_rconf_section_get_key(section, "file", MK_RCONF_STR);
+    baudrate = mk_rconf_section_get_key(section, "baudrate", MK_RCONF_STR);
+
+    if (!file) {
+        flb_utils_error_c("[xbee] error reading filename from "
+                "configuration");
+    }
+
+    if (!baudrate) {
+        flb_utils_error_c("[xbee] error reading baudrate from "
+                "configuration");
+    }
+
+    config->fd       = -1;
+    config->file     = file;
+    config->baudrate  = baudrate;
+
+    flb_debug("[xbee] / device='%s' baudrate='%s'",
+              config->file, config->baudrate);
+
+    return config;
+}

--- a/plugins/in_xbee/in_xbee_config.h
+++ b/plugins/in_xbee/in_xbee_config.h
@@ -27,19 +27,20 @@
 #define FLB_XBEE_BUFFER_SIZE       128
 
 struct flb_in_xbee_config {
-    int fd;           /* Socket to destination/backend */
-
-    char *file;
-    char *bitrate;
+    struct flb_config *config;
 
     /* Tag: used to extend original tag */
     int  tag_len;              /* The real string length     */
     char tag[32];              /* Custom Tag for this input  */
 
     /* XBee setup */
+    char *file;
     int  baudrate;
-    char *device;
+
     int xbeeLogLevel;
+    int xbeeDisableAck;
+    int xbeeCatchAll;
+    char *xbeeMode;
 
     /* Active connection context */
     struct xbee_con *con;
@@ -51,7 +52,9 @@ struct flb_in_xbee_config {
     msgpack_packer  mp_pck;
     msgpack_sbuffer mp_sbuf;
     int buffer_id;
+    pthread_mutex_t mtx_mp;
 };
 
+struct flb_in_xbee_config *xbee_config_read(struct flb_in_xbee_config *config, struct mk_rconf *conf);
 
 #endif

--- a/plugins/in_xbee/in_xbee_config.h
+++ b/plugins/in_xbee/in_xbee_config.h
@@ -1,0 +1,56 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_XBEE_CONFIG_H
+#define FLB_IN_XBEE_CONFIG_H
+
+#include <mk_core/mk_core.h>
+#include <termios.h>
+#include <msgpack.h>
+
+#define FLB_XBEE_BUFFER_SIZE       128
+
+struct flb_in_xbee_config {
+    int fd;           /* Socket to destination/backend */
+
+    char *file;
+    char *bitrate;
+
+    /* Tag: used to extend original tag */
+    int  tag_len;              /* The real string length     */
+    char tag[32];              /* Custom Tag for this input  */
+
+    /* XBee setup */
+    int  baudrate;
+    char *device;
+
+    /* Active connection context */
+    struct xbee_con *con;
+
+    /* buffering */
+    int buffer_len;
+    struct iovec buffer[FLB_XBEE_BUFFER_SIZE];
+
+    /* MessagePack buffers */
+    msgpack_packer  mp_pck;
+    msgpack_sbuffer mp_sbuf;
+};
+
+
+#endif

--- a/plugins/in_xbee/in_xbee_config.h
+++ b/plugins/in_xbee/in_xbee_config.h
@@ -39,17 +39,18 @@ struct flb_in_xbee_config {
     /* XBee setup */
     int  baudrate;
     char *device;
+    int xbeeLogLevel;
 
     /* Active connection context */
     struct xbee_con *con;
 
     /* buffering */
     int buffer_len;
-    struct iovec buffer[FLB_XBEE_BUFFER_SIZE];
 
     /* MessagePack buffers */
     msgpack_packer  mp_pck;
     msgpack_sbuffer mp_sbuf;
+    int buffer_id;
 };
 
 


### PR DESCRIPTION
Updated version of XBee input plugin. Major changes:
- Now the plugin receives any broadcasted payloads over XBee
- Read parameters from a configuration file

Supported Format:
- [ time, { key => val, ... } ]
- [ { key => val, ... } ]

Signed-off-by: Takeshi HASEGAWA <<hasegaw@gmail.com>>