### PR TITLE
Build: fix build error on OSX with clang

### DIFF
--- a/lib/monkey/mk_core/include/mk_thread.h
+++ b/lib/monkey/mk_core/include/mk_thread.h
@@ -21,6 +21,7 @@
 #ifndef MK_THREAD_H
 #define MK_THREAD_H
 
+#include <pthread.h>
 #include "mk_thread_channel.h"
 
 #define MK_THREAD_DEAD       0


### PR DESCRIPTION
```
[ 14%] Building C object lib/monkey/mk_core/CMakeFiles/mk_core.dir/mk_thread_channel.c.o
In file included from /Users/yamamoto-ma/LOCAL/src/fluent-bit/lib/monkey/mk_core/mk_thread_channel.c:25:
/Users/yamamoto-ma/LOCAL/src/fluent-bit/lib/monkey/mk_core/include/mk_thread.h:31:1: error: unknown type name 'pthread_key_t'; did you mean 'pthread_attr_t'?
pthread_key_t mk_thread_scheduler;
^~~~~~~~~~~~~
pthread_attr_t
/usr/include/sys/_pthread/_pthread_attr_t.h:30:33: note: 'pthread_attr_t' declared here
typedef __darwin_pthread_attr_t pthread_attr_t;
                                ^
1 error generated.
make[2]: *** [lib/monkey/mk_core/CMakeFiles/mk_core.dir/mk_thread_channel.c.o] Error 1
make[1]: *** [lib/monkey/mk_core/CMakeFiles/mk_core.dir/all] Error 2
make: *** [all] Error 2
```

Signed-off-by: Masaya YAMAMOTO &lt;pandax381@gmail.com&gt;