### PR TITLE
in_stdin: Add a time field to each record if it does not exist.

### DIFF
--- a/documentation/input/stdin.md
+++ b/documentation/input/stdin.md
@@ -6,6 +6,13 @@ The __stdin__ plugin allows to retrieve valid JSON text messages over the standa
 $ ./bin/fluent-bit -i stdin -o stdout
 ```
 
+As input data the _stdin_ plugin recognize the following JSON data formats:
+
+```bash
+1. { map => val, map => val, map => val }
+2. [ time, { map => val, map => val, map => val } ]
+```
+
 A better example to demonstrate how it works will be through a _Bash_ script that generate messages and write them to [Fluent Bit](http://fluentbit.io). Write the following content in a file named _test.sh_:
 
 ```bash
@@ -30,20 +37,20 @@ $ ./test.sh | bin/fluent-bit -i stdin -o stdout -V
 Fluent-Bit v0.2.0
 Copyright (C) Treasure Data
 
-[2015/07/29 13:51:02] [ info] Configuration
-flush time     : 5 seconds
-input plugins  : stdin
-collectors     :
-[2015/07/29 13:51:02] [ info] starting engine
-[2015/07/29 13:51:02] [debug] in_stdin read() = 21
-[2015/07/29 13:51:03] [debug] in_stdin read() = 21
-[2015/07/29 13:51:04] [debug] in_stdin read() = 21
-[2015/07/29 13:51:05] [debug] in_stdin read() = 21
-[2015/07/29 13:51:06] [debug] in_stdin read() = 21
-[0] {"key"=>"some value"}
-[1] {"key"=>"some value"}
-[2] {"key"=>"some value"}
-[3] {"key"=>"some value"}
-[4] {"key"=>"some value"}
+[2015/09/03 17:34:27] [ info] Configuration
+ flush time     : 5 seconds
+ input plugins  : stdin
+ collectors     :
+[2015/09/03 17:34:27] [ info] starting engine
+[2015/09/03 17:34:27] [debug] in_stdin read() = 21
+[2015/09/03 17:34:28] [debug] in_stdin read() = 21
+[2015/09/03 17:34:29] [debug] in_stdin read() = 21
+[2015/09/03 17:34:30] [debug] in_stdin read() = 21
+[2015/09/03 17:34:31] [debug] in_stdin read() = 21
+[0] [1441269267, {"key"=>"some value"}]
+[1] [1441269268, {"key"=>"some value"}]
+[2] [1441269269, {"key"=>"some value"}]
+[3] [1441269270, {"key"=>"some value"}]
+[4] [1441269271, {"key"=>"some value"}]
 
 ```

--- a/plugins/in_stdin/in_stdin.h
+++ b/plugins/in_stdin/in_stdin.h
@@ -26,12 +26,13 @@
 
 /* STDIN Input configuration & context */
 struct flb_in_stdin_config {
-    int fd;                     /* stdin file descriptor */
-    int buf_len;                /* read buffer length    */
-    char buf[8192 * 2];         /* read buffer: 16Kb max */
+    int fd;                           /* stdin file descriptor */
+    int buf_len;                      /* read buffer length    */
+    char buf[8192 * 2];               /* read buffer: 16Kb max */
 
-    int  msgp_len;              /* msgpack data length   */
-    char msgp[8192];            /* msgpack static buffer */
+    int buffer_id;
+    struct msgpack_sbuffer mp_sbuf;  /* msgpack sbuffer        */
+    struct msgpack_packer mp_pck;    /* msgpack packer         */
 };
 
 int in_stdin_init(struct flb_config *config);


### PR DESCRIPTION
This adds a time field to each record from stdin input, if it doesn't exist.

Now data source can feed these formats.
- { map => val, map => val, map => val }
- [ time, { map => val, map => val, map => val } ]

Signed-off-by: Takeshi HASEGAWA <hasegaw@gmail.com>