### PR TITLE
hello_world: Fixed segfault caused by flb_lib_stop()

### DIFF
--- a/examples/hello_world/hello_world.c
+++ b/examples/hello_world/hello_world.c
@@ -33,6 +33,9 @@ int main()
         exit(EXIT_FAILURE);
     }
 
+    /* Start the background worker */
+    flb_lib_start(ctx);
+
     /* Push some data */
     for (i = 0; i < 100; i++) {
         n = snprintf(tmp, sizeof(tmp) - 1, "{\"key\": \"val %i\"}", i);


### PR DESCRIPTION
hello_world (not cpp) causes segfault.

backtrace
```
Program received signal SIGSEGV, Segmentation fault.
0x0000003e434081c3 in pthread_join () from /lib64/libpthread.so.0
Missing separate debuginfos, use: debuginfo-install glibc-2.12-1.166.el6_7.3.x86_64 zlib-1.2.3-29.el6.x86_64
(gdb) bt
#0  0x0000003e434081c3 in pthread_join () from /lib64/libpthread.so.0
#1  0x00002aaaaaac62ff in flb_lib_stop () from /home/(snip)/fluent-bit/build/library/libfluent-bit.so
#2  0x0000000000400c99 in main ()
(gdb) 
```

I think the segfault is caused by uninitialized ctx->config->worker.
So, I added initializing code, flb_lib_start(). It's similar to hello_world.cc.

test result
```
$ bin/hello_world
[2016/01/20 19:35:43] [ info] starting engine
[0] {"key"=>"val 0"}
[1] {"key"=>"val 1"}
[2] {"key"=>"val 2"}
[3] {"key"=>"val 3"}
[4] {"key"=>"val 4"}

(snip)

[97] {"key"=>"val 97"}
[98] {"key"=>"val 98"}
[99] {"key"=>"val 99"}
$ 
```