### PR TITLE
in_kmsg: fix timestamp check

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -186,7 +186,7 @@ static inline int process_line(char *line, struct flb_in_kmsg_config *ctx)
         tv.tv_usec = val;
     }
     else {
-        tv.tv_usec = 0;
+        tv.tv_usec = val % 1000000;
     }
     ts = ctx->boot_time.tv_sec + tv.tv_sec;
 


### PR DESCRIPTION
in_kmsg always reports that usec is 0.

in_kmsg seems to expect that the timestamp is separated by '.'.
But it isn't separeted on my raspberry pi2.
It may be depend on kernel version.
```
pi@raspberrypi /tmp $ uname -a
Linux raspberrypi 4.1.2-v7+ #4 SMP PREEMPT Fri Jul 24 20:20:26 JST 2015 armv7l GNU/Linux
pi@raspberrypi /tmp $ cat /dev/kmsg
6,222,40009803,-;cfg80211: Calling CRDA to update world regulatory domain
6,223,43169817,-;cfg80211: Calling CRDA to update world regulatory domain
6,224,46329819,-;cfg80211: Calling CRDA to update world regulatory domain
6,225,49489832,-;cfg80211: Exceeded CRDA call max attempts. Not calling CRDA
```

https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg

Signed-off-by: nokute78 <nokute78@gmail.com>