### PR TITLE
in_cpu: release buffer when sscanf returns small number

### DIFF
--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -135,6 +135,9 @@ static inline double proc_cpu_load(int cpus, struct cpu_stats *cstats)
         }
 
         if (ret < 5) {
+            if (line) {
+                free(line);
+            }
             fclose(f);
             return -1;
         }


### PR DESCRIPTION
In proc_cpu_load(), a buffer 'line' is not released when return value of sscanf is less than 5. 
This patch is to check the buffer has been allocated. If so, it release the buffer on exit.

Signed-off-by: nokute78 <nokute78@gmail.com>