### PR TITLE
Collector and in_head support high resolution interval (#48)

### DIFF
--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -107,19 +107,26 @@ static int in_head_config_read(struct flb_in_head_config *head_config,
 
     /* interval settings */
     pval = mk_rconf_section_get_key(section, "interval_sec", MK_RCONF_STR);
-    if (pval != NULL && atoi(pval) > 0) {
+    if (pval != NULL && atoi(pval) >= 0) {
         head_config->interval_sec = atoi(pval);
     }
     else {
         head_config->interval_sec = DEFAULT_INTERVAL_SEC;
     }
     pval = mk_rconf_section_get_key(section, "interval_nsec", MK_RCONF_STR);
-    if (pval != NULL && atoi(pval) > 0) {
+    if (pval != NULL && atoi(pval) >= 0) {
         head_config->interval_nsec = atoi(pval);
     }
     else {
         head_config->interval_nsec = DEFAULT_INTERVAL_NSEC;
     }
+
+    if ( head_config->interval_sec <= 0 && head_config->interval_nsec <= 0){
+        /* Illegal settings. Override them. */
+        head_config->interval_sec = DEFAULT_INTERVAL_SEC;
+        head_config->interval_nsec = DEFAULT_INTERVAL_NSEC;
+    }
+        
 
     flb_trace("Head config: buf_size=%d path=%s",
               head_config->buf_size, head_config->filepath);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -320,7 +320,8 @@ int flb_engine_start(struct flb_config *config)
         if (collector->type == FLB_COLLECT_TIME) {
             event->mask = MK_EVENT_EMPTY;
             event->status = MK_EVENT_NONE;
-            fd = mk_event_timeout_create(evl, collector->seconds, 0, event);
+            fd = mk_event_timeout_create(evl, collector->seconds, 
+                                         collector->nanoseconds, event);
             if (fd == -1) {
                 continue;
             }


### PR DESCRIPTION
I added new code using high resolution interval (#48)

* Collector

Collector support high resolution interval.
We can pass 'nanoseconds' to flb_input_set_collector_time(). (it was not used.)
My patch makes the value applied in flb_engine_start().

* in_head

We can set interval which is less than 1 second.