### PR TITLE
in_mqtt: drop data when buffer is full (#63)

### DIFF
--- a/plugins/in_mqtt/mqtt.h
+++ b/plugins/in_mqtt/mqtt.h
@@ -20,15 +20,17 @@
 #ifndef FLB_IN_MQTT_H
 #define FLB_IN_MQTT_H
 
+#define MQTT_MSGP_BUF_SIZE 8192
+
 struct flb_in_mqtt_config {
-    int server_fd;               /* TCP server file descriptor  */
+    int server_fd;                 /* TCP server file descriptor  */
 
-    char *listen;                /* Listen interface            */
-    char *tcp_port;              /* TCP Port                    */
+    char *listen;                  /* Listen interface            */
+    char *tcp_port;                /* TCP Port                    */
 
-    int msgp_len;                /* msgpack data length         */
-    char msgp[8192];             /* msgpack static buffer       */
-    struct mk_event_loop *evl;   /* Event loop file descriptor  */
+    int msgp_len;                  /* msgpack data length         */
+    char msgp[MQTT_MSGP_BUF_SIZE]; /* msgpack static buffer       */
+    struct mk_event_loop *evl;     /* Event loop file descriptor  */
 };
 
 int in_mqtt_collect(struct flb_config *config, void *in_context);

--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -176,8 +176,13 @@ static int mqtt_data_append(char *buf, int len,
     memcpy(buf, sbuf->data, sbuf->size);
     msgpack_sbuffer_destroy(&mp_sbuf);
 
-    memcpy(ctx->msgp + ctx->msgp_len, buf, out);
-    ctx->msgp_len += out;
+    if ( ctx->msgp_len + out <= MQTT_MSGP_BUF_SIZE ) {
+        memcpy(ctx->msgp + ctx->msgp_len, buf, out);
+        ctx->msgp_len += out;
+    }else{
+        /* Drop incoming JSON */
+        /* FIXME */
+    }
     free(buf);
 
     return 0;


### PR DESCRIPTION
To fix #63 

Received data is dropped when the buffer of in_mqtt is full.

Signed-off-by: nokute78 <nokute78@gmail.com>