### PR TITLE
fix build error when HAVE_TSL is No

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -287,19 +287,27 @@ int cb_es_init(struct flb_output_instance *ins,
         return -1;
     }
 
+#ifdef HAVE_TLS
     if (ins->use_tls == FLB_TRUE) {
         io_type = FLB_IO_TLS;
     }
     else {
         io_type = FLB_IO_TCP;
     }
+#else
+    io_type = FLB_IO_TCP;
+#endif
 
     /* Prepare an upstream handler */
     upstream = flb_upstream_create(config,
                                    ins->host.name,
                                    ins->host.port,
                                    io_type,
+#ifdef HAVE_TLS
                                    &ins->tls);
+#else
+                                   NULL);
+#endif
     if (!upstream) {
         free(ctx);
         return -1;

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -44,7 +44,12 @@ int cb_http_init(struct flb_output_instance *ins, struct flb_config *config,
     upstream = flb_upstream_create(config,
                                    ins->host.name,
                                    ins->host.port,
-                                   FLB_IO_TCP, (void *) &ins->tls);
+                                   FLB_IO_TCP,
+#ifdef HAVE_TLS
+                                   (void *) &ins->tls);
+#else
+                                   NULL);    
+#endif
     if (!upstream) {
         return -1;
     }


### PR DESCRIPTION
I fixed build error which is caused by undefined member.

Error log is
```
$ cmake .. -DWITH_TLS=No -DWITH_OUT_TD=No
$ make 
...
Scanning dependencies of target flb-plugin-out_es
[ 61%] Building C object plugins/out_es/CMakeFiles/flb-plugin-out_es.dir/es_bulk.c.o
[ 62%] Building C object plugins/out_es/CMakeFiles/flb-plugin-out_es.dir/es.c.o
/home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/plugins/out_es/es.c: In function ‘cb_es_init’:
/home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/plugins/out_es/es.c:302: error: ‘struct flb_output_instance’ has no member named ‘tls’

```