### PR TITLE
Doc:fix URL

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,4 +8,4 @@ For every [Fluent Bit](http://fluentbit.io) release there is full documentation,
 
 If you are interested into provide some documentation contribution, please refer to the following GIT repository for more details:
 
-[http://github.com/fluent/fluent-bit/docs](http://github.com/fluent/fluent-bit/docs)
+[http://github.com/fluent/fluent-bit/docs](http://github.com/fluent/fluent-bit-docs)


### PR DESCRIPTION
I fixed wrong URL of documentation.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>