### PR TITLE
examples: release the buffer at user callback.

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -26,7 +26,10 @@ int my_stdout(void* data, size_t size)
     printf("[%s]",__FUNCTION__);
     msgpack_object_print(stdout, *(msgpack_object*)data);
     printf("\n");
-    
+
+    /* User has to release the buffer. */
+    free(data);
+
     return 0;
 }
 


### PR DESCRIPTION
I fixed memory leak.
User should release a buffer which passed from engine after using the buffer.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>