### PR TITLE
add missing prefix 'FLB_'

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -48,7 +48,7 @@ struct flb_config {
     int daemon;         /* Run as a daemon ?              */
     int shutdown_fd;    /* Shutdown FD, 5 seconds         */
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
     int stats_fd;       /* Stats FD, 1 second             */
     struct flb_stats *stats_ctx;
 #endif

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -24,7 +24,7 @@
 #include <mk_core.h>
 #include <fluent-bit/flb_log.h>
 
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
 #include <fluent-bit/flb_io_tls.h>
 #endif
 

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -145,7 +145,7 @@ struct flb_input_instance {
      */
     void *data;
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
     int stats_fd;
 #endif
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -168,7 +168,7 @@ struct flb_output_instance {
      */
     struct mk_list th_queue;
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
     int stats_fd;
 #endif
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -102,7 +102,7 @@ struct flb_output_instance {
     int use_tls;                         /* bool, try to use TLS for I/O */
     char *match;                         /* match rule for tag/routing   */
 
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
     int tls_verify;                      /* Verify certs (default: true) */
     char *tls_ca_file;                   /* CA root cert                 */
     char *tls_crt_file;                  /* Certificate                  */
@@ -172,7 +172,7 @@ struct flb_output_instance {
     int stats_fd;
 #endif
 
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
     struct flb_tls tls;
 #else
     void *tls;

--- a/include/fluent-bit/flb_stats.h
+++ b/include/fluent-bit/flb_stats.h
@@ -17,7 +17,7 @@
  *  limitations under the License.
  */
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
 
 #ifndef FLB_STATS_H
 #define FLB_STATS_H
@@ -144,4 +144,4 @@ int flb_stats_register(struct mk_event_loop *evl, struct flb_config *config);
 #define flb_stats_reset(a) do {} while(0)
 #define flb_stats_register(a, b) do{} while(0)
 
-#endif /* HAVE_STATS  */
+#endif /* FLB_HAVE_STATS  */

--- a/include/fluent-bit/flb_tls.h
+++ b/include/fluent-bit/flb_tls.h
@@ -34,5 +34,5 @@ int net_io_tls_read(struct flb_thread *th, struct flb_upstream_conn *u_conn,
 int flb_io_tls_connect(struct flb_upstream_conn *u_conn,
                        struct flb_thread *th);
 
-#endif /* HAVE_TLS */
+#endif /* FLB_HAVE_TLS */
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -116,7 +116,7 @@ void flb_config_exit(struct flb_config *config)
     mk_event_del(config->evl, &config->event_flush);
     close(config->flush_fd);
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
     flb_stats_exit(config);
 #endif
 

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -320,7 +320,7 @@ int flb_engine_start(struct flb_config *config)
     struct flb_thread *th;
     struct flb_engine_task *task;
 
-#ifdef HAVE_HTTP
+#ifdef FLB_HAVE_HTTP
     if (config->http_server == FLB_TRUE) {
         flb_http_server_start(config);
     }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -34,7 +34,7 @@
 #include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_http_server.h>
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
 #include <fluent-bit/flb_stats.h>
 #endif
 
@@ -236,7 +236,7 @@ static inline int flb_engine_manager(int fd, struct flb_config *config)
         flb_engine_flush(config, NULL);
         return FLB_ENGINE_STOP;
     }
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
     else if (val == FLB_ENGINE_STATS) {
         flb_trace("[engine] collect stats");
         //flb_stats_collect(config);
@@ -264,7 +264,7 @@ static FLB_INLINE int flb_engine_handle_event(int fd, int mask,
         else if (config->shutdown_fd == fd) {
             return FLB_ENGINE_SHUTDOWN;
         }
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
         else if (config->stats_fd == fd) {
             consume_byte(fd);
             return FLB_ENGINE_STATS;
@@ -376,7 +376,7 @@ int flb_engine_start(struct flb_config *config)
         flb_utils_error(FLB_ERR_CFG_FLUSH_CREATE);
     }
 
-    /* Initialize the stats interface (just if HAVE_STATS is defined) */
+    /* Initialize the stats interface (just if FLB_HAVE_STATS is defined) */
     flb_stats_init(config);
 
     /* For each Collector, register the event into the main loop */
@@ -438,7 +438,7 @@ int flb_engine_start(struct flb_config *config)
                     flb_info("[engine] service stopped");
                     return flb_engine_shutdown(config);
                 }
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
                 else if (ret == FLB_ENGINE_STATS) {
                     //flb_stats_collect(config);
                 }

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -267,7 +267,7 @@ int flb_io_net_write(struct flb_upstream_conn *u_conn, void *data,
     if (u->flags & FLB_IO_TCP) {
         ret = net_io_write(th, u_conn, data, len, out_len);
     }
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
     else if (u->flags & FLB_IO_TLS) {
         ret = net_io_tls_write(th, u_conn, data, len, out_len);
     }
@@ -297,7 +297,7 @@ ssize_t flb_io_net_read(struct flb_upstream_conn *u_conn, void *buf, size_t len)
     if (u->flags & FLB_IO_TCP) {
         ret = net_io_read(th, u_conn, buf, len);
     }
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
     else if (u->flags & FLB_IO_TLS) {
         ret = net_io_tls_read(th, u_conn, buf, len);
     }

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -87,7 +87,7 @@ void flb_output_exit(struct flb_config *config)
         free(ins->host.name);
         free(ins->match);
 
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
         flb_tls_context_destroy(ins->tls.context);
 #endif
 
@@ -153,7 +153,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
         instance->host.name = NULL;
 
         instance->use_tls        = FLB_FALSE;
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
         instance->tls.context    = NULL;
         instance->tls_verify     = FLB_TRUE;
         instance->tls_ca_file    = NULL;
@@ -208,7 +208,7 @@ int flb_output_set_property(struct flb_output_instance *out, char *k, char *v)
     else if (prop_key_check("port", k, len) == 0) {
         out->host.port = atoi(v);
     }
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
     else if (prop_key_check("tls", k, len) == 0) {
         if (strcasecmp(v, "true") == 0 || strcasecmp(v, "on") == 0) {
             out->use_tls = FLB_TRUE;
@@ -275,7 +275,7 @@ int flb_output_init(struct flb_config *config)
         ins = mk_list_entry(head, struct flb_output_instance, _head);
         p = ins->p;
 
-#ifdef HAVE_TLS
+#ifdef FLB_HAVE_TLS
         if (p->flags & FLB_IO_TLS) {
             ins->tls.context = flb_tls_context_new(ins->tls_verify,
                                                    ins->tls_ca_file,

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -293,7 +293,7 @@ int flb_output_init(struct flb_config *config)
         }
 
 
-#ifdef HAVE_STATS
+#ifdef FLB_HAVE_STATS
         //struct flb_stats *stats;
         //stats = &out->stats;
         //stats->n = -1;


### PR DESCRIPTION
I added prefix to HAVE_STATS, HAVE_HTTP and HAVE_TLS.

I checked like this.
```
$ find . -name "*.[ch]"|xargs grep HAVE_ |grep -v FLB_HAVE_ |grep -v lib
```