### PR TITLE
input: add NULL guard to flb_input_new()

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -72,6 +72,10 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
     struct flb_input_plugin *plugin;
     struct flb_input_instance *instance = NULL;
 
+    if (!input) {
+        return NULL;
+    }
+
     mk_list_foreach(head, &config->in_plugins) {
         plugin = mk_list_entry(head, struct flb_input_plugin, _head);
         if (!check_protocol(plugin->name, input)) {


### PR DESCRIPTION
If user passes NULL to flb_input_new as an input plugin name,
fluent-bit will be hangup at strlen() called from check_protocol().

I added NULL guard like flb_output_new().


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>