### PR TITLE
Debug: add mtrace(3) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,17 +93,18 @@ if(FLB_ALL)
   set(FLB_OUT_LIB      1)
 endif()
 
-# Enable Debug symbols if specified
-if(FLB_DEBUG)
-  set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
 # Macro to set definitions
 macro(FLB_DEFINITION var)
   add_definitions(-D${var})
   set(FLB_BUILD_FLAGS "${FLB_BUILD_FLAGS}#ifndef ${var}\n#define ${var}\n#endif\n")
   set(FLB_INFO_FLAGS "${FLB_INFO_FLAGS} ${var}")
 endmacro()
+
+# Enable Debug symbols if specified
+if(FLB_DEBUG)
+  set(CMAKE_BUILD_TYPE "Debug")
+  FLB_DEFINITION(FLB_HAVE_MTRACE)
+endif()
 
 # General Headers
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ endmacro()
 # Enable Debug symbols if specified
 if(FLB_DEBUG)
   set(CMAKE_BUILD_TYPE "Debug")
-  FLB_DEFINITION(FLB_HAVE_MTRACE)
 endif()
 
 # General Headers
@@ -212,6 +211,17 @@ check_c_source_compiles("
 
 if(FLB_VALGRIND OR FLB_HAVE_VALGRIND)
   FLB_DEFINITION(FLB_HAVE_VALGRIND)
+endif()
+
+# mtrace support
+check_c_source_compiles("
+  #include <mcheck.h>
+  int main() {
+     return 0;
+  }" FLB_HAVE_MTRACE)
+
+if(FLB_HAVE_MTRACE AND FLB_DEBUG)
+  FLB_DEFINITION(FLB_HAVE_MTRACE)
 endif()
 
 check_c_source_compiles("

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(FLB_STATS              "Enable stats support"         No)
 option(FLB_VALGRIND           "Enable Valgrind support"      No)
 option(FLB_TRACE              "Enable trace mode"            No)
 option(FLB_TESTS              "Enable tests"                 No)
+option(FLB_MTRACE             "Enable mtrace support"        No)
 
 # Advanced options for Flushing methods
 # =====================================
@@ -214,14 +215,16 @@ if(FLB_VALGRIND OR FLB_HAVE_VALGRIND)
 endif()
 
 # mtrace support
-check_c_source_compiles("
-  #include <mcheck.h>
-  int main() {
-     return 0;
-  }" FLB_HAVE_MTRACE)
-
-if(FLB_HAVE_MTRACE AND FLB_DEBUG)
-  FLB_DEFINITION(FLB_HAVE_MTRACE)
+if(FLB_MTRACE)
+  check_c_source_compiles("
+    #include <mcheck.h>
+    int main() {
+       return 0;
+    }" FLB_HAVE_MTRACE)
+  
+  if(FLB_HAVE_MTRACE AND FLB_DEBUG)
+    FLB_DEFINITION(FLB_HAVE_MTRACE)
+  endif()
 endif()
 
 check_c_source_compiles("

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -27,6 +27,10 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_utils.h>
 
+#ifdef FLB_HAVE_MTRACE
+#include <mcheck.h>
+#endif
+
 extern struct flb_input_plugin in_lib_plugin;
 
 flb_ctx_t *flb_create()
@@ -34,6 +38,11 @@ flb_ctx_t *flb_create()
     int ret;
     flb_ctx_t *ctx;
     struct flb_config *config;
+
+#ifdef FLB_HAVE_MTRACE
+    /* Start tracing malloc and free */
+    mtrace();
+#endif
 
     ctx = calloc(1, sizeof(flb_ctx_t));
     if (!ctx) {
@@ -93,6 +102,11 @@ void flb_destroy(flb_ctx_t *ctx)
     /* Remove resources from the event loop */
     mk_event_loop_destroy(ctx->event_loop);
     free(ctx);
+
+#ifdef FLB_HAVE_MTRACE
+    /* Stop tracing malloc and free */
+    muntrace();
+#endif
 }
 
 /* Defines a new input instance */

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -37,6 +37,10 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_engine.h>
 
+#ifdef FLB_HAVE_MTRACE
+#include <mcheck.h>
+#endif
+
 struct flb_config *config;
 
 #define PLUGIN_INPUT    0
@@ -120,6 +124,10 @@ static void flb_signal_handler(int signal)
     case SIGHUP:
     case SIGTERM:
         flb_engine_shutdown(config);
+#ifdef FLB_HAVE_MTRACE
+        /* Stop tracing malloc and free */
+        muntrace();
+#endif
         _exit(EXIT_SUCCESS);
     default:
         break;
@@ -364,6 +372,11 @@ int main(int argc, char **argv)
         { "help",    no_argument      , NULL, 'h' },
         { NULL, 0, NULL, 0 }
     };
+
+#ifdef FLB_HAVE_MTRACE
+    /* Start tracing malloc and free */
+    mtrace();
+#endif
 
     /* Signal handler */
     flb_signal_init();


### PR DESCRIPTION
I added mtrace(3) support.
mtrace(3) helps to reveal a buffer which is not released.

## Building
Build with -DFLB_DEBUG=Yes and -DFLB_MTRACE=Yes

``` sh
$ cmake .. -DFLB_DEBUG=Yes -DFLB_MTRACE=Yes
$ make
```

## Execution

Execution with MALLOC_TRACE.
MALLOC_TRACE represents a file path to output tracing data.

``` sh 
$ MALLOC_TRACE=./trace.txt bin/fluent-bit -i cpu -o stdout
```
## Analysis

Analysis with mtrace(1).
On CentOS, glibc-utils package has mtrace(1).

``` sh
$ mtrace bin/fluent-bit trace.txt 

Memory not freed:
-----------------
           Address     Size     Caller
0x0000000000c027b0     0x10  at /home/../fluent-bit/src/flb_log.c:37
0x0000000000c027d0      0xf  at 0x3a32681022
0x0000000000c027f0     0x14  at 0x3a3269cf82
0x0000000000c02810     0x14  at 0x3a3269cf82
0x0000000000c02830     0x15  at 0x3a3269cf82
0x0000000000c02850     0x14  at 0x3a3269cf82
0x0000000000c02a30     0xd6  at 0x3a3269e91c
$
```

Refering trace.txt , 0x3a32681022 is a strdup.
It seems to be called around flb_log_init().

```
@ bin/fluent-bit:(flb_log_init+0x1c)[0x410a50] + 0xc027b0 0x10
@ /lib64/libc.so.6:(__strdup+0x22)[0x3a32681022] + 0xc027d0 0xf
@ /lib64/libc.so.6:[0x3a32666e8b] + 0xc027f0 0x238
```

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>