### PR TITLE
Fix some leaks

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -214,6 +214,9 @@ void flb_input_exit_all(struct flb_config *config)
 {
     struct mk_list *tmp;
     struct mk_list *head;
+    struct mk_list *tmp_prop;
+    struct mk_list *head_prop;
+    struct flb_config_prop *prop;
     struct flb_input_instance *in;
     struct flb_input_plugin *p;
 
@@ -231,6 +234,15 @@ void flb_input_exit_all(struct flb_config *config)
 
         /* Let the engine remove any pending task */
         flb_engine_destroy_tasks(&in->tasks);
+
+        /* release properties */
+        mk_list_foreach_safe(head_prop, tmp_prop, &in->properties) {
+            prop = mk_list_entry(head_prop, struct flb_config_prop, _head);
+
+            free(prop->key);
+            free(prop->val);
+            free(prop);
+        }
 
         /* Unlink and release */
         mk_list_del(&in->_head);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -241,6 +241,8 @@ void flb_input_exit_all(struct flb_config *config)
 
             free(prop->key);
             free(prop->val);
+
+            mk_list_del(&prop->_head);
             free(prop);
         }
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -71,6 +71,9 @@ void flb_output_exit(struct flb_config *config)
 {
     struct mk_list *tmp;
     struct mk_list *head;
+    struct mk_list *tmp_prop;
+    struct mk_list *head_prop;
+    struct flb_config_prop *prop;
     struct flb_output_instance *ins;
     struct flb_output_plugin *p;
 
@@ -93,6 +96,14 @@ void flb_output_exit(struct flb_config *config)
 #ifdef FLB_HAVE_TLS
         flb_tls_context_destroy(ins->tls.context);
 #endif
+        /* release properties */
+        mk_list_foreach_safe(head_prop, tmp_prop, &ins->properties) {
+            prop = mk_list_entry(head_prop, struct flb_config_prop, _head);
+
+            free(prop->key);
+            free(prop->val);
+            free(prop);
+        }
 
         mk_list_del(&ins->_head);
         free(ins);

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -102,6 +102,8 @@ void flb_output_exit(struct flb_config *config)
 
             free(prop->key);
             free(prop->val);
+
+            mk_list_del(&prop->_head);
             free(prop);
         }
 


### PR DESCRIPTION
mtrace reports some leaks.

## fluent-bit.c

Amount of reports are different using -c option or not.
```
$ MALLOC_TRACE=./with_c.txt bin/fluent-bit -c ../conf/fluent-bit.conf
$ MALLOC_TRACE=./no_c.txt bin/fluent-bit -i cpu -o stdout
$ mtrace bin/fluent-bit with_c.txt |wc
     51     195    5918
$ mtrace bin/fluent-bit no_c.txt |wc
     11      35     452
```

It seems mk_rconf causes that leak.

## flb_input & flb_output

mtrace reports that leak is generated at src/flb_input.c:150.
```
$ MALLOC_TRACE=./head.txt bin/fluent-bit -c ../conf/in_head.conf
$ mtrace bin/fluent-bit head.txt
<snip>
0x0000000001734730     0x20  at /home/.../fluent-bit/src/flb_input.c:150
0x0000000001734760      0x5  at 0x3a32681022
0x0000000001734780      0xd  at 0x3a32681022
0x00000000017347a0     0x20  at /home/.../fluent-bit/src/flb_input.c:150
0x00000000017347d0      0x9  at 0x3a32681022
0x00000000017347f0      0x4  at 0x3a32681022
0x0000000001734810     0x20  at /home/.../fluent-bit/src/flb_input.c:150
<snip>
```

That line is 
``` c
 prop = malloc(sizeof(struct flb_config_prop));
```

I fixed it and same as flb_output.