### PR TITLE
[MQTT] fix leaks

### DIFF
--- a/plugins/in_mqtt/mqtt.c
+++ b/plugins/in_mqtt/mqtt.c
@@ -75,6 +75,10 @@ void *in_mqtt_flush(void *in_context, size_t *size)
     char *buf;
     struct flb_in_mqtt_config *ctx = in_context;
 
+    if (ctx->msgp_len <= 0) {
+        return NULL;
+    }
+
     buf = malloc(ctx->msgp_len);
     memcpy(buf, ctx->msgp, ctx->msgp_len);
     *size = ctx->msgp_len;

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -166,18 +166,22 @@ int flb_pack_json(char *js, size_t len, char **buffer, int *size)
     }
     ret = json_tokenise(js, len, &state);
     if (ret != 0) {
-        return ret;
+        goto flb_pack_json_end;
     }
 
     buf = tokens_to_msgpack(js, state.tokens, state.tokens_count, &out);
     if (!buf) {
-        return -1;
+        ret = -1;
+        goto flb_pack_json_end;
     }
 
     *size = out;
     *buffer = buf;
 
-    return 0;
+    ret = 0;
+ flb_pack_json_end:
+    flb_pack_state_reset(&state);
+    return ret;
 }
 
 /* Initialize a JSON packer state */


### PR DESCRIPTION
mtrace reports flb_pack.c and mqtt.c are leaking.
I fixed these two leaks.

```
0x00eddaf0        0  at /home/pi/git/fluent-bit/plugins/in_mqtt/mqtt.c:78
0x00eddb00        0  at /home/pi/git/fluent-bit/plugins/in_mqtt/mqtt.c:78
0x00eddb10        0  at /home/pi/git/fluent-bit/plugins/in_mqtt/mqtt.c:78
0x00eddb20        0  at /home/pi/git/fluent-bit/plugins/in_mqtt/mqtt.c:78
0x00ede3c0   0x1000  at /home/pi/git/fluent-bit/src/flb_pack.c:189
0x00edf3c8   0x1000  at /home/pi/git/fluent-bit/src/flb_pack.c:189
0x00ee0818   0x1000  at /home/pi/git/fluent-bit/src/flb_pack.c:189
0x00ee1938   0x1000  at /home/pi/git/fluent-bit/src/flb_pack.c:189
```