### PR TITLE
in_head: release sbuffer at cb_exit

### DIFF
--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -228,6 +228,8 @@ int in_head_exit(void *data, struct flb_config *config)
     (void) *config;
     struct flb_in_head_config *head_config = data;
 
+    msgpack_sbuffer_destroy(&head_config->mp_sbuf);
+
     delete_head_config(head_config);
 
     return 0;


### PR DESCRIPTION
Referring mtrace, sbuffer is leaked.
So, I added release code to in_head_exit() like in_cpu_exit().

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>