### PR TITLE
[mqtt] add exit callback

### DIFF
--- a/plugins/in_mqtt/mqtt.c
+++ b/plugins/in_mqtt/mqtt.c
@@ -113,6 +113,16 @@ int in_mqtt_collect(struct flb_config *config, void *in_context)
     return 0;
 }
 
+static int in_mqtt_exit(void *data, struct flb_config *config)
+{
+    (void) *config;
+    struct flb_in_mqtt_config *ctx = data;
+
+    mqtt_config_free(ctx);
+
+    return 0;
+}
+
 /* Plugin reference */
 struct flb_input_plugin in_mqtt_plugin = {
     .name         = "mqtt",
@@ -121,5 +131,6 @@ struct flb_input_plugin in_mqtt_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_mqtt_collect,
     .cb_flush_buf = in_mqtt_flush,
+    .cb_exit      = in_mqtt_exit,
     .flags        = FLB_INPUT_NET,
 };

--- a/plugins/in_mqtt/mqtt_config.c
+++ b/plugins/in_mqtt/mqtt_config.c
@@ -38,7 +38,7 @@ struct flb_in_mqtt_config *mqtt_config_init(struct flb_input_instance *i_ins)
     if (!i_ins->host.listen) {
         listen = flb_input_get_property("listen", i_ins);
         if (listen) {
-            config->listen = listen;
+            config->listen = strdup(listen);
         }
         else {
             config->listen = strdup("0.0.0.0");


### PR DESCRIPTION
I added exit callback to in_mqtt.
However it causes double-free in the case of using in_mqtt.conf.

The root cause of double-free is here. (mqtt_config.c)
```c
    /* Listen interface (if not set, defaults to 0.0.0.0) */
    if (!i_ins->host.listen) {
        listen = flb_input_get_property("listen", i_ins);
        if (listen) {
            config->listen = listen;
        }
        else {
            config->listen = strdup("0.0.0.0");
        }
    }
```
flb_input_get_property() returns the part of prop list which will be freed at flb_input_exit_all().
So, I duplicated it with strdup() to prevent double-free at in_mqtt_exit().