### PR TITLE
config: release http_port string

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -51,7 +51,7 @@ struct flb_config *flb_config_init()
     config->kernel       = flb_kernel_info();
     config->verbose      = 3;
     config->http_server  = FLB_FALSE;
-    config->http_port    = FLB_CONFIG_HTTP_PORT;
+    config->http_port    = strdup(FLB_CONFIG_HTTP_PORT);
 
     mk_list_init(&config->collectors);
     mk_list_init(&config->in_plugins);
@@ -126,6 +126,10 @@ void flb_config_exit(struct flb_config *config)
     /* Event flush */
     mk_event_del(config->evl, &config->event_flush);
     close(config->flush_fd);
+
+    if (config->http_server) {
+        free(config->http_server);
+    }
 
 #ifdef FLB_HAVE_STATS
     flb_stats_exit(config);


### PR DESCRIPTION
I added a code to release http_port.

http_port was static pointer (=FLB_CONFIG_HTTP_PORT).
On the other hand ,it was allocated at fluent-bit.c.
So, I use strdup to make http_port freeable.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>