### PR TITLE
in_forward: duplicate 'listen' to prevent double free

### DIFF
--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -39,7 +39,7 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
     if (!i_ins->host.listen) {
         listen = flb_input_get_property("listen", i_ins);
         if (listen) {
-            config->listen = listen;
+            config->listen = strdup(listen);
         }
         else {
             config->listen = strdup("0.0.0.0");


### PR DESCRIPTION
Freeing config->listen causes segfault.

In some cases, input property 'listen' is used as config->listen.
config->listen is freed at fw_config_destroy().
However, property is also freed at flb_input_exit_all().

## How to reproduce 

1. Execute fluent-bit using in_forward.conf
2. Ctrl+c



## Log

```
$ bin/fluent-bit -c ../conf/in_forward.conf 
Fluent-Bit v0.9.0
Copyright (C) Treasure Data

[2016/07/22 18:19:06] [ info] starting engine
[2016/07/22 18:19:06] [ info] [in_fw] binding 0.0.0.0:24224
^C[engine] caught signal
*** glibc detected *** bin/fluent-bit: corrupted double-linked list: 0x00000000018a79e0 ***
======= Backtrace: =========
/lib64/libc.so.6[0x3a32675f3e]
/lib64/libc.so.6[0x3a326763c3]
/lib64/libc.so.6[0x3a32678d68]
bin/fluent-bit[0x48f682]
bin/fluent-bit(mk_event_loop_destroy+0x2c)[0x48fcf3]
bin/fluent-bit(flb_config_exit+0x22a)[0x4132ad]
bin/fluent-bit(flb_engine_shutdown+0x3c)[0x41520c]
bin/fluent-bit[0x40feed]
/lib64/libc.so.6[0x3a32632660]
/lib64/libc.so.6(epoll_wait+0x13)[0x3a326e9083]
bin/fluent-bit[0x48fbe6]
bin/fluent-bit(mk_event_wait+0x18)[0x48fead]
bin/fluent-bit(flb_engine_start+0x3b5)[0x414dcb]
bin/fluent-bit[0x410a76]
/lib64/libc.so.6(__libc_start_main+0xfd)[0x3a3261ed1d]
bin/fluent-bit[0x40fa59]
======= Memory map: ========
00400000-004bb000 r-xp 00000000 fd:00 1462073                            /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/bin/fluent-bit
006bb000-006c1000 rw-p 000bb000 fd:00 1462073                            /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/bin/fluent-bit
006c1000-006c3000 rw-p 00000000 00:00 0 
018a7000-018c8000 rw-p 00000000 00:00 0                                  [heap]
3a32200000-3a32220000 r-xp 00000000 fd:00 136093                         /lib64/ld-2.12.so
3a3241f000-3a32420000 r--p 0001f000 fd:00 136093                         /lib64/ld-2.12.so
3a32420000-3a32421000 rw-p 00020000 fd:00 136093                         /lib64/ld-2.12.so
3a32421000-3a32422000 rw-p 00000000 00:00 0 
3a32600000-3a3278a000 r-xp 00000000 fd:00 136094                         /lib64/libc-2.12.so
3a3278a000-3a3298a000 ---p 0018a000 fd:00 136094                         /lib64/libc-2.12.so
3a3298a000-3a3298e000 r--p 0018a000 fd:00 136094                         /lib64/libc-2.12.so
3a3298e000-3a32990000 rw-p 0018e000 fd:00 136094                         /lib64/libc-2.12.so
3a32990000-3a32994000 rw-p 00000000 00:00 0 
3a32a00000-3a32a83000 r-xp 00000000 fd:00 136148                         /lib64/libm-2.12.so
3a32a83000-3a32c82000 ---p 00083000 fd:00 136148                         /lib64/libm-2.12.so
3a32c82000-3a32c83000 r--p 00082000 fd:00 136148                         /lib64/libm-2.12.so
3a32c83000-3a32c84000 rw-p 00083000 fd:00 136148                         /lib64/libm-2.12.so
3a32e00000-3a32e17000 r-xp 00000000 fd:00 136095                         /lib64/libpthread-2.12.so
3a32e17000-3a33017000 ---p 00017000 fd:00 136095                         /lib64/libpthread-2.12.so
3a33017000-3a33018000 r--p 00017000 fd:00 136095                         /lib64/libpthread-2.12.so
3a33018000-3a33019000 rw-p 00018000 fd:00 136095                         /lib64/libpthread-2.12.so
3a33019000-3a3301d000 rw-p 00000000 00:00 0 
3a33200000-3a33202000 r-xp 00000000 fd:00 136811                         /lib64/libdl-2.12.so
3a33202000-3a33402000 ---p 00002000 fd:00 136811                         /lib64/libdl-2.12.so
3a33402000-3a33403000 r--p 00002000 fd:00 136811                         /lib64/libdl-2.12.so
3a33403000-3a33404000 rw-p 00003000 fd:00 136811                         /lib64/libdl-2.12.so
3a33a00000-3a33a15000 r-xp 00000000 fd:00 136359                         /lib64/libz.so.1.2.3
3a33a15000-3a33c14000 ---p 00015000 fd:00 136359                         /lib64/libz.so.1.2.3
3a33c14000-3a33c15000 r--p 00014000 fd:00 136359                         /lib64/libz.so.1.2.3
3a33c15000-3a33c16000 rw-p 00015000 fd:00 136359                         /lib64/libz.so.1.2.3
3a3c600000-3a3c616000 r-xp 00000000 fd:00 139218                         /lib64/libgcc_s-4.4.7-20120601.so.1
3a3c616000-3a3c815000 ---p 00016000 fd:00 139218                         /lib64/libgcc_s-4.4.7-20120601.so.1
3a3c815000-3a3c816000 rw-p 00015000 fd:00 139218                         /lib64/libgcc_s-4.4.7-20120601.so.1
2b1cd82e0000-2b1cd82e3000 rw-p 00000000 00:00 0 
2b1cd82f2000-2b1cd82f5000 rw-p 00000000 00:00 0 
2b1cdc000000-2b1cdc021000 rw-p 00000000 00:00 0 
2b1cdc021000-2b1ce0000000 ---p 00000000 00:00 0 
7ffc2a333000-7ffc2a348000 rw-p 00000000 00:00 0                          [stack]
7ffc2a354000-7ffc2a355000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
```


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>