### PR TITLE
Readme: Update plugin information and add Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Fluent Bit](http://fluentbit.io) is a data collector for Linux, Embedded Linux, OSX and BSD family operating systems. It's part of the [Fluentd](http://fluentd.org) project ecosystem, it allows to collects information from different sources, buffer and dispatch them to different outputs such as Elastic, Nats or [Fluentd](http://fluentd.org) within others. Despites it have a strong focus on Embedded & IoT environments, its fully supported on common x86 and x86_64 architectures.
 
-# Quick Start
+## Quick Start
 
 ```
 $ cd build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [Fluent Bit](http://fluentbit.io) is a data collector for Linux, Embedded Linux, OSX and BSD family operating systems. It's part of the [Fluentd](http://fluentd.org) project ecosystem, it allows to collects information from different sources, buffer and dispatch them to different outputs such as Elastic, Nats or [Fluentd](http://fluentd.org) within others. Despites it have a strong focus on Embedded & IoT environments, its fully supported on common x86 and x86_64 architectures.
 
+# Quick Start
+
+```
+$ cd build
+$ cmake ..
+$ make
+$ bin/fluent-bit -i cpu -o stdout
+```
+
 ## Features
 
 [Fluent Bit](http://fluentbit.io) support the following features through plugins:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 | name               | option  | description  |
 |--------------------|---------|---------------------------------------------------------------------------------|
 | CPU                | cpu     | gather CPU usage between snapshots of one second. It support multiple cores     |
+| Forward            | forward | Fluentd forward protocol |
 | Memory             | mem     | usage of system memory |
 | MQTT               | mqtt    | start a MQTT server and receive publish messages |
 | Kernel Ring Buffer | kmsg    | read Linux Kernel messages, same behavior as the __dmesg__ command line program |
@@ -24,8 +25,9 @@
 | name               | option                  | description  |
 |--------------------|-------------------------|---------------------------------------------------------------------------------|
 | Elasticsearch      | es | flush records to a Elasticsearch server |
-| Fluentd            | fluentd  | flush records to a [Fluentd](http://fluentd.org) service. On the [Fluentd](http://fluentd.org) side, it requires an __in_forward__.|
+| Forward            | forward  | flush records to a [Fluentd](http://fluentd.org) service. On the [Fluentd](http://fluentd.org) side, it requires an __in_forward__.|
 | NATS               | nats | flush records to a NATS server |
+| HTTP               | http | flush records to a HTTP end point |
 | Standard Output    | stdout                  | prints the records to the standard output stream |
 | Treasure Data      | td                      | flush records to [Treasure Data](http://treasuredata.com) service (cloud analytics)|
 


### PR DESCRIPTION
I updated readme.

* add in_forward and out_http
* rename out_forward
* add Quick Start section

'Quick Start' makes fluent-bit more attractive.
It will be easier for user and developer to try to use fluent-bit.

(Old 'Build' section helped me to try fluent-bit and contribute.)