### PR TITLE
error: convert octal error code into decimal

### DIFF
--- a/include/fluent-bit/flb_error.h
+++ b/include/fluent-bit/flb_error.h
@@ -20,14 +20,14 @@
 #ifndef FLB_ERROR_H
 #define FLB_ERROR_H
 
-#define FLB_ERR_CFG_FILE             010
-#define FLB_ERR_CFG_FILE_FORMAT      011
-#define FLB_ERR_CFG_FLUSH            020
-#define FLB_ERR_CFG_FLUSH_CREATE     021
-#define FLB_ERR_CFG_FLUSH_REGISTER   022
-#define FLB_ERR_INPUT_INVALID        050
-#define FLB_ERR_INPUT_UNDEF          051
-#define FLB_ERR_INPUT_UNSUP          052
+#define FLB_ERR_CFG_FILE              10
+#define FLB_ERR_CFG_FILE_FORMAT       11
+#define FLB_ERR_CFG_FLUSH             20
+#define FLB_ERR_CFG_FLUSH_CREATE      21
+#define FLB_ERR_CFG_FLUSH_REGISTER    22
+#define FLB_ERR_INPUT_INVALID         50
+#define FLB_ERR_INPUT_UNDEF           51
+#define FLB_ERR_INPUT_UNSUP           52
 #define FLB_ERR_OUTPUT_UNDEF         100
 #define FLB_ERR_OUTPUT_INVALID       101
 #define FLB_ERR_OUTPUT_UNIQ          102


### PR DESCRIPTION
refer #87 
I converted octal error code into decimal.

I checked this simple code and all codes were unique.
``` c
#include <fluent-bit/flb_error.h>
#include <stdio.h>

int main(void)
{
     int error[] = {
       FLB_ERR_CFG_FILE,
       FLB_ERR_CFG_FILE_FORMAT,
       FLB_ERR_CFG_FLUSH,
       FLB_ERR_CFG_FLUSH_CREATE,
       FLB_ERR_CFG_FLUSH_REGISTER,
       FLB_ERR_INPUT_INVALID,
       FLB_ERR_INPUT_UNDEF,
       FLB_ERR_INPUT_UNSUP,
       FLB_ERR_OUTPUT_UNDEF,
       FLB_ERR_OUTPUT_INVALID,
       FLB_ERR_OUTPUT_UNIQ,
       -1,
     };
     int i=0;
     
     while( error[i++] > 0 ){
       printf("%d\n",error[i]);
     }
     return 0;
}
```

```
$ bin/test
11
20
21
22
50
51
52
100
101
102
-1
```
Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>