### PR TITLE
ouput: report error message if user sets undefined output plugin

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -258,5 +258,5 @@ void flb_output_pre_run(struct flb_config *config);
 void flb_output_exit(struct flb_config *config);
 void flb_output_set_context(struct flb_output_instance *ins, void *context);
 int flb_output_init(struct flb_config *config);
-
+int flb_output_check(struct flb_config *config);
 #endif

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -329,3 +329,12 @@ void flb_output_set_context(struct flb_output_instance *ins, void *context)
 {
     ins->context = context;
 }
+
+/* Check that at least one Output is enabled */
+int flb_output_check(struct flb_config *config)
+{
+    if (mk_list_is_empty(&config->outputs) == 0) {
+        return -1;
+    }
+    return 0;
+}

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -491,6 +491,12 @@ int main(int argc, char **argv)
         flb_utils_error(FLB_ERR_INPUT_UNDEF);
     }
 
+    /* Outputs */
+    ret = flb_output_check(config);
+    if (ret == -1) {
+        flb_utils_error(FLB_ERR_OUTPUT_UNDEF);
+    }
+
     flb_banner();
     if (config->verbose == FLB_TRUE) {
         flb_utils_print_setup(config);


### PR DESCRIPTION
I added a code to check output plugin name.(like checking input plugin name.)

If user sets undefined output plugin name (e.g. '-o aaa'), 
fluent-bit reports an error that output target is invalid.
```
$ bin/fluent-bit -i cpu -o aaa
Error: Invalid output target. Aborting
```

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>