### PR TITLE
lib: add a wrapper to release a buffer which comes from out_lib_flush

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -28,7 +28,7 @@ int my_stdout(void* data, size_t size)
     printf("\n");
 
     /* User has to release the buffer. */
-    free(data);
+    flb_lib_free(data);
 
     return 0;
 }

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -49,6 +49,8 @@ FLB_EXPORT int flb_stop(flb_ctx_t *ctx);
 /* data ingestion for "lib" input instance */
 FLB_EXPORT int flb_lib_push(flb_input_t *input, void *data, size_t len);
 
+FLB_EXPORT int  flb_lib_free(void*data);
+
 int flb_lib_config_file(struct flb_lib_ctx *ctx, char *path);
 
 #endif

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -205,6 +205,16 @@ int flb_lib_push(flb_input_t *input, void *data, size_t len)
     return ret;
 }
 
+/* This is a wrapper to release a buffer which comes from out_lib_flush() */
+int flb_lib_free(void* data)
+{
+    if (data == NULL) {
+        return -1;
+    }
+    free(data);
+    return 0;
+}
+
 static void flb_lib_worker(void *data)
 {
     struct flb_config *config = data;


### PR DESCRIPTION
I added a new wrapper function `flb_lib_free` to release a buffer which comes from `out_lib_flush`.


Now, `out_lib` sends raw msgpack to user callback.
User should release the msgpack with `free(3)` after using that.

In the future, the data format which `out_lib` sends may be changed.
The way to release the buffer also may be changed. (e.g. It may be need to call mk_list_del and so on)
It also affect user program which uses fluent-bit as library.

So, new release function prevents rewriting user program even if the data format is changed.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>