### PR TITLE
test: rename property and add sentinel value NULL

### DIFF
--- a/tests/flb_test_elasticsearch.cpp
+++ b/tests/flb_test_elasticsearch.cpp
@@ -16,11 +16,11 @@ TEST(Outputs, json_es) {
 
     input = flb_input(ctx, (char *) "lib", NULL);
     EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test");
+    flb_input_set(input, "tag", "test", NULL);
 
     output = flb_output(ctx, (char *) "es", NULL);
     EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "tag", "test");
+    flb_output_set(output, "match", "test", NULL);
 
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);

--- a/tests/flb_test_stdout.cpp
+++ b/tests/flb_test_stdout.cpp
@@ -20,11 +20,11 @@ TEST(Outputs, json_invalid) {
 
     input = flb_input(ctx, (char *) "lib", NULL);
     EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test");
+    flb_input_set(input, "tag", "test", NULL);
 
     output = flb_output(ctx, (char *) "stdout", NULL);
     EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "tag", "test");
+    flb_output_set(output, "match", "test", NULL);
 
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);
@@ -55,11 +55,11 @@ TEST(Outputs, json_long) {
 
     input = flb_input(ctx, (char *) "lib", NULL);
     EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test");
+    flb_input_set(input, "tag", "test", NULL);
 
     output = flb_output(ctx, (char *) "stdout", NULL);
     EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "tag", "test");
+    flb_output_set(output, "match", "test", NULL);
 
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);
@@ -89,11 +89,11 @@ TEST(Outputs, json_small) {
 
     input = flb_input(ctx, (char *) "lib", NULL);
     EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test");
+    flb_input_set(input, "tag", "test", NULL);
 
     output = flb_output(ctx, (char *) "stdout", NULL);
     EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "tag", "test");
+    flb_output_set(output, "match", "test", NULL);
 
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);

--- a/tests/flb_test_td.cpp
+++ b/tests/flb_test_td.cpp
@@ -15,11 +15,11 @@ TEST(TD, json_long) {
 
     input = flb_input(ctx, (char *) "lib", NULL);
     EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test");
+    flb_input_set(input, "tag", "test", NULL);
 
     output = flb_output(ctx, (char *) "td", NULL);
     EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "tag", "test");
+    flb_output_set(output, "match", "test", NULL);
 
     ret = flb_lib_config_file(ctx, (char *) "/tmp/td.conf");
 


### PR DESCRIPTION
I modified all of test codes.

* add sentinel value 'NULL' to prevent segfault
* rename output property 'tag' to 'match'


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>