### PR TITLE
task: reduce memory usage

### DIFF
--- a/include/fluent-bit/flb_task_map.h
+++ b/include/fluent-bit/flb_task_map.h
@@ -23,7 +23,6 @@
 #include <inttypes.h>
 
 struct flb_task_map {
-    uint8_t id;
     void    *task;
 };
 

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -44,8 +44,7 @@ static int map_get_task_id(struct flb_config *config)
     int i;
 
     for (i = 0; i < sizeof(config->tasks_map); i++) {
-        if (config->tasks_map[i].id == 0) {
-            config->tasks_map[i].id = 1;
+        if (config->tasks_map[i].task == NULL) {
             return i;
         }
     }
@@ -213,7 +212,6 @@ void flb_task_destroy(struct flb_task *task)
     }
 
     /* Release task_id */
-    task->config->tasks_map[task->id].id   = 0;
     task->config->tasks_map[task->id].task = NULL;
 
     /* Remove routes */


### PR DESCRIPTION
Refer to Valgrind, the size of `flb_config` is about 33KB.
```
$ valgrind --tool=massif bin/fluent-bit -i cpu -o stdout
.
$ ms_print massif.out.7631 
.
->55.89% (33,120B) 0x41334B: flb_config_init (in /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/bin/fluent-bit)
| ->55.89% (33,120B) 0x41092E: main (in /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/bin/fluent-bit)
.
```

It is caused by this member. 
``` c
    struct flb_task_map tasks_map[2048];
```
`flb_task_map` is like this.
``` c
struct flb_task_map {
    uint8_t id;
    void    *task;
};
```
So, the size of array `tasks_map` is (8 + 8) *2048= 32.7KB.

By the way, the value `id` is used like `bool`.
So, I deleted `id` to reduce memory usage.


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>