### PR TITLE
build: fix Travis CI error

### DIFF
--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -23,7 +23,6 @@
 #include <pthread.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_buffer.h>
-#include <fluent-bit/flb_thread.h>
 #include <fluent-bit/flb_input.h>
 
 /* Task status */


### PR DESCRIPTION
`flb_task.h` includes `flb_thread.h`.
And `flb_thread_*.h` defines `struct  flb_thread` which contains `struct flb_task` which is defined at `flb_task.h`

So, pre-processing is 
1. `flb_task.h` includes `flb_thread.h`
2. `struct flb_thread` is defined. (`flb_task` is not defined at this time. ) at `flb_thread_*.h`
3. `struct flb_task` is defined at `flb_task.h`


Step2 causes build error.


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>