### PR TITLE
lib: add new API flb_service_set(flb_ctx_t *ctx, ...)

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -120,5 +120,32 @@ struct flb_config {
 struct flb_config *flb_config_init();
 void flb_config_exit(struct flb_config *config);
 char *flb_config_prop_get(char *key, struct mk_list *list);
+int flb_config_set_property(struct flb_config *config,
+                            char *k, char *v);
+struct flb_service_config {
+    char    *key;
+    int     type;
+    size_t  offset;
+};
+
+enum conf_type {
+    FLB_CONF_TYPE_INT,
+    FLB_CONF_TYPE_BOOL,
+    FLB_CONF_TYPE_STR,
+    FLB_CONF_TYPE_OTHER,
+};
+
+#define FLB_CONF_STR_FLUSH    "Flush"
+#define FLB_CONF_STR_DAEMON   "Daemon"
+#define FLB_CONF_STR_LOGLEVEL "Log_Level"
+#ifdef FLB_HAVE_HTTP
+#define FLB_CONF_STR_HTTP_MONITOR "HTTP_Monitor"
+#define FLB_CONF_STR_HTTP_PORT    "HTTP_Port"
+#endif /* FLB_HAVE_HTTP */
+#ifdef FLB_HAVE_BUFFERING
+#define FLB_CONF_STR_BUF_PATH     "Buffer_Path"
+#define FLB_CONF_STR_BUF_WORKERS  "Buffer_Workers"
+#endif /*FLB_HAVE_BUFFERING*/
+
 
 #endif

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -41,6 +41,7 @@ FLB_EXPORT flb_input_t *flb_input(flb_ctx_t *ctx, char *input, void *data);
 FLB_EXPORT flb_output_t *flb_output(flb_ctx_t *ctx, char *output, void *data);
 FLB_EXPORT int flb_input_set(flb_input_t *input, ...);
 FLB_EXPORT int flb_output_set(flb_output_t *output, ...);
+FLB_EXPORT int flb_service_set(flb_ctx_t *ctx, ...);
 
 /* start stop the engine */
 FLB_EXPORT int flb_start(flb_ctx_t *ctx);

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -54,11 +54,11 @@ struct flb_service_config service_configs[] = {
 #endif
 
 #ifdef FLB_HAVE_BUFFERING
-    {FLB_CONF_STR_BUFFER_PATH,
+    {FLB_CONF_STR_BUF_PATH,
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, buffer_path)},
 
-    {FLB_CONF_STR_BUFFER_WORKERS,
+    {FLB_CONF_STR_BUF_WORKERS,
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, buffer_workers)},
 #endif
@@ -264,8 +264,8 @@ int flb_config_set_property(struct flb_config *config,
 {
     int i=0;
     int ret = -1;
-    int*  i_val = NULL;
-    char* s_val = NULL;
+    int*  i_val;
+    char* s_val;
     size_t len = strnlen(k, 256);
     char* key = service_configs[0].key;
 
@@ -277,12 +277,12 @@ int flb_config_set_property(struct flb_config *config,
                 ret = 0;
                 switch(service_configs[i].type){
                 case FLB_CONF_TYPE_INT:
-                    i_val         = (char*)config + service_configs[i].offset;
+                    i_val  = (int*)((char*)config + service_configs[i].offset);
                     *i_val = atoi(v);
                     break;
 
                 case FLB_CONF_TYPE_BOOL:
-                    i_val = (char*)config+service_configs[i].offset;
+                    i_val = (int*)((char*)config+service_configs[i].offset);
                     *i_val = atobool(v);
                     break;
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
+#include <stddef.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_macros.h>
@@ -28,6 +29,43 @@
 #include <fluent-bit/flb_plugins.h>
 #include <fluent-bit/flb_io_tls.h>
 #include <fluent-bit/flb_kernel.h>
+
+struct flb_service_config service_configs[] = {
+    {FLB_CONF_STR_FLUSH,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, flush)},
+
+    {FLB_CONF_STR_DAEMON,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, daemon)},
+
+    {FLB_CONF_STR_LOGLEVEL,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, log)},
+
+#ifdef FLB_HAVE_HTTP
+    {FLB_CONF_STR_HTTP_MONITOR,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, http_server)},
+
+    {FLB_CONF_STR_HTTP_PORT,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, http_port)},
+#endif
+
+#ifdef FLB_HAVE_BUFFERING
+    {FLB_CONF_STR_BUFFER_PATH,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, buffer_path)},
+
+    {FLB_CONF_STR_BUFFER_WORKERS,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, buffer_workers)},
+#endif
+
+    {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
+};
+
 
 struct flb_config *flb_config_init()
 {
@@ -174,4 +212,97 @@ char *flb_config_prop_get(char *key, struct mk_list *list)
     }
 
     return NULL;
+}
+
+static inline int prop_key_check(char *key, char *kv, int k_len)
+{
+    size_t len;
+
+    len = strnlen(key,256);
+    if (strncasecmp(key, kv, k_len) == 0 && len == k_len) {
+        return 0;
+    }
+    return -1;
+}
+
+static int set_log_level(struct flb_config *config, char *v_str)
+{
+    if (v_str != NULL && config->log != NULL) {
+        if (strcasecmp(v_str, "error") == 0) {
+            config->log->level = 1;
+        }
+        else if (strcasecmp(v_str, "warning") == 0) {
+            config->log->level = 2;
+        }
+        else if (strcasecmp(v_str, "info") == 0) {
+            config->log->level = 3;
+        }
+        else if (strcasecmp(v_str, "debug") == 0) {
+            config->log->level = 4;
+        }
+        else if (strcasecmp(v_str, "trace") == 0) {
+            config->log->level = 5;
+        }
+        else {
+            return -1;
+        }
+    }else{
+        flb_error("Not set log level");
+    }
+    return 0;
+}
+
+static inline int atobool(char*v)
+{
+    return  (strncasecmp("true", v, 256) == 0)
+        ? FLB_TRUE
+        : FLB_FALSE;
+}   
+
+int flb_config_set_property(struct flb_config *config,
+                            char *k, char *v)
+{
+    int i=0;
+    int ret = -1;
+    int*  i_val = NULL;
+    char* s_val = NULL;
+    size_t len = strnlen(k, 256);
+    char* key = service_configs[0].key;
+
+    while( key != NULL ){
+        if ( prop_key_check(key, k,len) == 0) {
+            if ( !strncasecmp(key, FLB_CONF_STR_LOGLEVEL ,256) ) {
+                ret = set_log_level(config, v);
+            }else{
+                ret = 0;
+                switch(service_configs[i].type){
+                case FLB_CONF_TYPE_INT:
+                    i_val         = (char*)config + service_configs[i].offset;
+                    *i_val = atoi(v);
+                    break;
+
+                case FLB_CONF_TYPE_BOOL:
+                    i_val = (char*)config+service_configs[i].offset;
+                    *i_val = atobool(v);
+                    break;
+
+                case FLB_CONF_TYPE_STR:
+                    s_val = (char*)config+service_configs[i].offset;
+                    s_val = strdup(v);
+                    break;
+
+                default:
+                    ret = -1;
+                }
+            }
+
+            if (ret < 0) {
+                flb_error("config parameter error");
+                return -1;
+            }
+            return 0;
+        }
+        key = service_configs[++i].key;
+    }
+    return 0;
 }

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -176,6 +176,34 @@ int flb_output_set(flb_output_t *output, ...)
     return 0;
 }
 
+/* Set a service property */
+int flb_service_set(flb_ctx_t *ctx, ...)
+{
+    int ret;
+    char *key;
+    char *value;
+    va_list va;
+
+    va_start(va, ctx);
+
+    while ((key = va_arg(va, char *))) {
+        value = va_arg(va, char *);
+        if (!value) {
+            /* Wrong parameter */
+            return -1;
+        }
+
+        ret = flb_config_set_property(ctx->config, key, value);
+        if (ret != 0) {
+            va_end(va);
+            return -1;
+        }
+    }
+
+    va_end(va);
+    return 0;
+}
+
 /* Load a configuration file that may be used by the input or output plugin */
 int flb_lib_config_file(struct flb_lib_ctx *ctx, char *path)
 {

--- a/tests/flb_test_engine.cpp
+++ b/tests/flb_test_engine.cpp
@@ -61,12 +61,14 @@ int check_routing(const char* tag, const char* match, bool expect)
     EXPECT_TRUE(output != NULL);
     flb_output_set(output, "match", match, NULL);
 
+    flb_service_set(ctx, "Flush", "1", "Daemon", "false", NULL);
+
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);
 
     /* start test */
     flb_lib_push(input, str, strlen(str));
-    sleep(5);/*waiting flush*/
+    sleep(1);/*waiting flush*/
 
     pthread_mutex_lock(&result_mutex);
     ret = result;


### PR DESCRIPTION
I added a new API `flb_service_set` for library mode.
User can set  global properties of the service with new API. (e.g. Flush)

I updated a test code `flb_test_engine.cpp` with new API to shorten flush time.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>