### PR TITLE
in_kmsg: release sbuffer at cb_exit

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -326,6 +326,8 @@ static int in_kmsg_exit(void *data, struct flb_config *config)
         close(ctx->fd);
     }
 
+    msgpack_sbuffer_destroy(&ctx->mp_sbuf);
+
     free(ctx);
     return 0;
 }


### PR DESCRIPTION
Refer to mtrace, sbuffer is leaked when fluent-bit catches Ctrl+C before flushing.


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>