### PR TITLE
Fix compilation error and segfault which is happened when FLB_BUFFERING is No.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,6 @@ set(src
   flb_kernel.c
   flb_input.c
   flb_output.c
-  flb_buffer.c
-  flb_buffer_chunk.c
-  flb_buffer_qchunk.c
   flb_config.c
   flb_network.c
   flb_utils.c
@@ -66,6 +63,15 @@ if(FLB_STATS)
     ${extra_libs}
     "cJSON"
     "m"
+    )
+endif()
+
+if(FLB_BUFFERING)
+  set(src
+    ${src}
+    "flb_buffer.c"
+    "flb_buffer_chunk.c"
+    "flb_buffer_qchunk.c"
     )
 endif()
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -100,7 +100,9 @@ void flb_output_exit(struct flb_config *config)
         free(ins->match);
 
 #ifdef FLB_HAVE_TLS
-        flb_tls_context_destroy(ins->tls.context);
+        if ( ins->p->flags & FLB_IO_TLS ) {
+            flb_tls_context_destroy(ins->tls.context);
+        }
 #endif
         /* release properties */
         mk_list_foreach_safe(head_prop, tmp_prop, &ins->properties) {

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -315,7 +315,9 @@ struct flb_task *flb_task_create_direct(uint64_t ref_id,
     task->i_ins     = i_ins;
     task->dt        = NULL;
     task->mapped    = FLB_TRUE;
+#ifdef FLB_HAVE_BUFFERING
     memcpy(&task->hash_hex, hash, 41);
+#endif
     mk_list_add(&task->_head, &i_ins->tasks);
 
     /* Iterate output instances and try to match the routes */


### PR DESCRIPTION
I fixed these issues which is happened when `FLB_BUFFERING` is No.

* Compilation error which is caused `flb_buffer_qchunk.c`

I fixed not to use source code and variable which need to define `FLB_BUFFERING`.

* Segfault 

`ins->tls.context` is initialized if `(p->flags & FLB_IO_TLS)` is true.
So, I fixed the value is released when the condition is same.