### PR TITLE
Clean up flb_config.c

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -185,10 +185,6 @@ void flb_config_exit(struct flb_config *config)
     if (config->http_port) {
         free(config->http_port);
     }
-
-    if (config->http_server) {
-        free(config->http_server);
-    }
 #endif
 
 #ifdef FLB_HAVE_STATS

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -269,7 +269,7 @@ int flb_config_set_property(struct flb_config *config,
     int i=0;
     int ret = -1;
     int *i_val;
-    char *s_val;
+    char **s_val;
     size_t len = strnlen(k, 256);
     char *key = service_configs[0].key;
 
@@ -292,8 +292,11 @@ int flb_config_set_property(struct flb_config *config,
                     break;
 
                 case FLB_CONF_TYPE_STR:
-                    s_val = (char*)config+service_configs[i].offset;
-                    s_val = strdup(v);
+                    s_val = (char**)((char*)config+service_configs[i].offset);
+                    if ( *s_val != NULL ) {
+                        free(*s_val); /* release before overwriting */
+                    }
+                    *s_val = strdup(v);
                     break;
 
                 default:


### PR DESCRIPTION
I fixed `flb_config.c`

* Preventing illegal access(CID 152995)

I used wrong pointer type, so my code breaks memory when user sets `http_port` or `buffer_path`.
I fixed to use proper pointer.

* Releasing pointer before overwriting(also CID 152995)

If user sets `http_port` or `buffer_path` twice or more, previous pointer is not released.

* Preventing releasing non-pointer.

`http_server` is boolean, however it is released at `flb_config_exit`