### PR TITLE
tests: migrate test of td to new API

### DIFF
--- a/tests/flb_test_td.cpp
+++ b/tests/flb_test_td.cpp
@@ -8,25 +8,25 @@
 TEST(TD, json_long) {
     int ret;
     flb_ctx_t *ctx;
-    flb_input_t *input;
-    flb_output_t *output;
+    int in_ffd;
+    int out_ffd;
 
     ctx = flb_create();
 
-    input = flb_input(ctx, (char *) "lib", NULL);
-    EXPECT_TRUE(input != NULL);
-    flb_input_set(input, "tag", "test", NULL);
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
 
-    output = flb_output(ctx, (char *) "td", NULL);
-    EXPECT_TRUE(output != NULL);
-    flb_output_set(output, "match", "test", NULL);
+    out_ffd = flb_output(ctx, (char *) "td", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
 
     ret = flb_lib_config_file(ctx, (char *) "/tmp/td.conf");
 
     ret = flb_start(ctx);
     EXPECT_EQ(ret, 0);
 
-    flb_lib_push(input, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
 
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
I fixed `flb_test_td.cpp` to be able to compile when using new API.