### PR TITLE
lib: fix looking for output instance

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -55,7 +55,7 @@ static inline struct flb_output_instance *out_instance_get(flb_ctx_t *ctx,
     struct mk_list *head;
     struct flb_output_instance *o_ins;
 
-    mk_list_foreach(head, &ctx->config->inputs) {
+    mk_list_foreach(head, &ctx->config->outputs) {
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
 
         /*


### PR DESCRIPTION
`flb_test_engine` is failed in two test cases.
```C
        {"cpu.rpi","cpu.ard", false },
        {"cpu.rpi","mem.*",   false },
```
I fixed looking for an output instance at `out_instance_get`.