### PR TITLE
ci: add cd command before cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
   irc: "irc.freenode.net#fluent-bit"
 
 before_script:
+  - cd build
   - cmake -DFLB_ALL=On ../
 
 script: make


### PR DESCRIPTION
Sorry, #119 is not a proper patch.
I added `cd build` command before executing cmake.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>