### PR TITLE
Add new option "User_Header"

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -26,7 +26,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_task_map.h>
-
+#include <msgpack.h>
 #ifdef FLB_HAVE_TLS
 #include <fluent-bit/flb_io_tls.h>
 #endif
@@ -45,6 +45,9 @@ struct flb_config_prop {
     char *val;
     struct mk_list _head;
 };
+
+/* reuse flb_config_prop as flb_config_user_header */
+#define flb_config_user_header flb_config_prop
 
 /* Main struct to hold the configuration of the runtime service */
 struct flb_config {
@@ -95,6 +98,10 @@ struct flb_config {
     struct flb_output_plugin *output;   /* output plugin in use     */
     struct mk_event_loop *evl;          /* the event loop (mk_core) */
 
+    /* Header to append */
+    struct mk_list user_headers;
+    int    header_num;
+
     /* Kernel info */
     struct flb_kernel *kernel;
 
@@ -133,6 +140,9 @@ void flb_config_exit(struct flb_config *config);
 char *flb_config_prop_get(char *key, struct mk_list *list);
 int flb_config_set_property(struct flb_config *config,
                             char *k, char *v);
+int flb_config_get_user_header_num(struct flb_config *config);
+int flb_config_append_user_header(struct flb_config *config,
+                                  msgpack_packer *mp_pck);
 struct flb_service_config {
     char    *key;
     int     type;
@@ -150,6 +160,7 @@ enum conf_type {
 #define FLB_CONF_STR_DAEMON   "Daemon"
 #define FLB_CONF_STR_LOGFILE  "Logfile"
 #define FLB_CONF_STR_LOGLEVEL "Log_Level"
+#define FLB_CONF_STR_USER_HEADER "User_Header"
 #ifdef FLB_HAVE_HTTP
 #define FLB_CONF_STR_HTTP_MONITOR "HTTP_Monitor"
 #define FLB_CONF_STR_HTTP_PORT    "HTTP_Port"

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -28,5 +28,5 @@ void flb_utils_warn_c(const char *msg);
 void flb_message(int type, char *file, int line, const char *fmt, ...);
 int flb_utils_set_daemon();
 void flb_utils_print_setup(struct flb_config *config);
-
+int flb_utils_parse_key_value(const char* kv, char** key, char** value);
 #endif

--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -39,6 +39,7 @@ static int in_head_collect(struct flb_config *config, void *in_context)
     struct flb_in_head_config *head_config = in_context;
     int fd = -1;
     int ret = -1;
+    int header_num = flb_config_get_user_header_num(config);
 
     /* open at every collect callback */
     fd = open(head_config->filepath, O_RDONLY);
@@ -58,7 +59,12 @@ static int in_head_collect(struct flb_config *config, void *in_context)
 
     msgpack_pack_array(&head_config->mp_pck, 2);
     msgpack_pack_uint64(&head_config->mp_pck, time(NULL));
-    msgpack_pack_map(&head_config->mp_pck, 1);
+    if ( header_num > 0 ) {
+        msgpack_pack_map(&head_config->mp_pck, 1+header_num);
+        flb_config_append_user_header(config, &head_config->mp_pck);
+    } else {
+        msgpack_pack_map(&head_config->mp_pck, 1);
+    }
 
     msgpack_pack_bin(&head_config->mp_pck, 4);
     msgpack_pack_bin_body(&head_config->mp_pck, "head", 4);

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -363,7 +363,6 @@ int flb_config_set_property(struct flb_config *config,
                 ret = set_log_level(config, v);
             } else if (!strncasecmp(key, FLB_CONF_STR_USER_HEADER, 256)) {
                 /* User header */
-                flb_info("aaaa");
                 ret = set_user_header(config, v);
             }
             else{

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -183,3 +183,23 @@ void flb_utils_print_setup(struct flb_config *config)
 
     }
 }
+
+/* parse kv connected with '=' (e.g. "KEY=VALUE") */
+int flb_utils_parse_key_value(const char* kv, char** key, char** value)
+{
+    int len;
+    int sep;
+
+    len = strlen(kv);
+    sep = mk_string_char_search(kv, '=', len);
+    if (sep == -1) {
+        return -1;
+    }
+
+    *key   = mk_string_copy_substr(kv, 0, sep);
+    if (!*key) {
+        return -1;
+    }
+    *value = flb_strdup(kv + sep + 1);
+    return 0;
+}

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -154,52 +154,28 @@ static void flb_signal_init()
 static int input_set_property(struct flb_input_instance *in, char *kv)
 {
     int ret;
-    int len;
-    int sep;
     char *key;
     char *value;
-
-    len = strlen(kv);
-    sep = mk_string_char_search(kv, '=', len);
-    if (sep == -1) {
-        return -1;
+    if( !flb_utils_parse_key_value(kv, &key, &value) ) {
+        ret = flb_input_set_property(in, key, value);
+        flb_free(key);
+        flb_free(value);
     }
-
-    key = mk_string_copy_substr(kv, 0, sep);
-    value = kv + sep + 1;
-
-    if (!key) {
-        return -1;
-    }
-
-    ret = flb_input_set_property(in, key, value);
-    flb_free(key);
     return ret;
 }
 
 static int output_set_property(struct flb_output_instance *out, char *kv)
 {
-    int ret;
-    int len;
-    int sep;
     char *key;
     char *value;
+    int  ret = -1;
 
-    len = strlen(kv);
-    sep = mk_string_char_search(kv, '=', len);
-    if (sep == -1) {
-        return -1;
+    if( !flb_utils_parse_key_value(kv, &key, &value) ) {
+        ret = flb_output_set_property(out, key, value);
+        flb_free(key);
+        flb_free(value);
     }
 
-    key = mk_string_copy_substr(kv, 0, sep);
-    value = kv + sep + 1;
-
-    if (!key) {
-        return -1;
-    }
-
-    ret = flb_output_set_property(out, key, value);
-    flb_free(key);
     return ret;
 }
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -80,6 +80,7 @@ static void flb_help(int rc, struct flb_config *config)
     printf("  -P, --port\t\tset HTTP server TCP port (default: %s)\n",
            FLB_CONFIG_HTTP_PORT);
 #endif
+    printf("  -u, --user_header=\"KEY=VALUE\"\tset user header\n");
     printf("  -q, --quiet\t\tquiet mode\n");
     printf("  -V, --version\t\tshow version number\n");
     printf("  -h, --help\t\tprint this help\n\n");
@@ -318,6 +319,7 @@ int main(int argc, char **argv)
         { "output",      required_argument, NULL, 'o' },
         { "prop",        required_argument, NULL, 'p' },
         { "tag",         required_argument, NULL, 't' },
+        { "user_header", required_argument, NULL, 'u' },
         { "version",     no_argument      , NULL, 'V' },
         { "verbose",     no_argument      , NULL, 'v' },
         { "quiet",       no_argument      , NULL, 'q' },
@@ -340,7 +342,7 @@ int main(int argc, char **argv)
     }
 
     /* Parse the command line options */
-    while ((opt = getopt_long(argc, argv, "b:B:c:df:i:m:o:p:t:l:vqVhHP:",
+    while ((opt = getopt_long(argc, argv, "b:B:c:df:i:m:o:p:t:l:u:vqVhHP:",
                               long_opts, NULL)) != -1) {
 
         switch (opt) {
@@ -393,6 +395,9 @@ int main(int argc, char **argv)
             else if (last_plugin == PLUGIN_OUTPUT) {
                 output_set_property(out, optarg);
             }
+            break;
+        case 'u':
+            flb_config_set_property(config, FLB_CONF_STR_USER_HEADER ,optarg);
             break;
         case 't':
             if (in) {


### PR DESCRIPTION
I added a new option "User_Header" .
The option is only used by `in_head` and `fluent-bit binary` now.

## Use case

We can append 
* hostname
* uuid
* mac address

## Sample (with command line option)
We can set additional data with `-u` option.

This is a sample to append `hostname` with `-u hostname=$HOSTNAME`
```sh
$ bin/fluent-bit -i head -p file=/proc/uptime -o stdout -u hostname=$HOSTNAME
Fluent-Bit v0.9.0
Copyright (C) Treasure Data

[2016/10/28 22:13:34] [ info] [engine] started
[0] head.0: [1477660415, {"hostname"=>"localhost.localdomain", "head"=>"18394.48 17446.09
"}]
```

## Sample (in library mode)

We can also set like this in library mode.
```c
    flb_service_set(ctx, "User_Header", "hostname=localhost", NULL);
```