### PR TITLE
in_cpu: do not allocate if data size is 0

### DIFF
--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -353,6 +353,12 @@ void *in_cpu_flush(void *in_context, size_t *size)
 
     sbuf = &ctx->mp_sbuf;
     *size = sbuf->size;
+
+    if (sbuf->size==0) {
+        return NULL;
+    }
+
+
     buf = flb_malloc(sbuf->size);
     if (!buf) {
         return NULL;


### PR DESCRIPTION
I fixed to prevent 0 byte allocation.