### PR TITLE
flowcounter: rename flowcount to flowcounter (add er)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ option(FLB_OUT_RETRY   "Enable Retry test output plugin"     No)
 option(FLB_OUT_STDOUT  "Enable STDOUT output plugin"        Yes)
 option(FLB_OUT_LIB     "Enable library mode output plugin"  Yes)
 option(FLB_OUT_NULL    "Enable dev null output plugin"      Yes)
-option(FLB_OUT_FLOWCOUNT "Enable flowcount output plugin"   Yes)
+option(FLB_OUT_FLOWCOUNTER "Enable flowcount output plugin" Yes)
 
 # Enable all features
 if(FLB_ALL)
@@ -111,7 +111,7 @@ if(FLB_ALL)
   set(FLB_OUT_TD       1)
   set(FLB_OUT_STDOUT   1)
   set(FLB_OUT_LIB      1)
-  set(FLB_OUT_FLOWCOUNT 1)
+  set(FLB_OUT_FLOWCOUNTER 1)
 endif()
 
 # Macro to set definitions

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ bin/fluent-bit -i cpu -o stdout
 | name               | option                  | description  |
 |--------------------|-------------------------|---------------------------------------------------------------------------------|
 | Elasticsearch      | es | flush records to a Elasticsearch server |
-| FlowCount          | flowcount| count records |
+| FlowCounter        | flowcounter| count records |
 | Forward            | forward  | flush records to a [Fluentd](http://fluentd.org) service. On the [Fluentd](http://fluentd.org) side, it requires an __in_forward__.|
 | NATS               | nats | flush records to a NATS server |
 | HTTP               | http | flush records to a HTTP end point |

--- a/conf/out_flowcounter.conf
+++ b/conf/out_flowcounter.conf
@@ -19,11 +19,11 @@
 
 [INPUT]
     Name random
-    Tag  flowcount_test
+    Tag  flowcounter_test
 
 # To count records.
 [OUTPUT]
-    Name flowcount
+    Name flowcounter
 
     # Unit
     # ====
@@ -31,9 +31,9 @@
     # second/minute/hour/day   Default: minute
     Unit second
 
-    Match flowcount_test
+    Match flowcounter_test
 
 # To display records.
 [OUTPUT]
     Name  stdout
-    Match flowcount_test
+    Match flowcounter_test

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -90,7 +90,7 @@ REGISTER_OUT_PLUGIN("out_stdout")
 REGISTER_OUT_PLUGIN("out_retry")
 REGISTER_OUT_PLUGIN("out_td")
 REGISTER_OUT_PLUGIN("out_lib")
-REGISTER_OUT_PLUGIN("out_flowcount")
+REGISTER_OUT_PLUGIN("out_flowcounter")
 
 if(ENABLE_TESTS)
   REGISTER_OUT_PLUGIN("out_null")

--- a/plugins/out_flowcount/CMakeLists.txt
+++ b/plugins/out_flowcount/CMakeLists.txt
@@ -1,4 +1,0 @@
-set(src
-  out_flowcount.c)
-
-FLB_PLUGIN(out_flowcount "${src}" "")

--- a/plugins/out_flowcounter/CMakeLists.txt
+++ b/plugins/out_flowcounter/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  out_flowcounter.c)
+
+FLB_PLUGIN(out_flowcounter "${src}" "")

--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -27,9 +27,9 @@
 #include <msgpack.h>
 
 
-#include "out_flowcount.h"
+#include "out_flowcounter.h"
 
-#define PLUGIN_NAME "out_flowcount"
+#define PLUGIN_NAME "out_flowcounter"
 
 static int configure(struct flb_out_fcount_config *ctx,
                       struct flb_output_instance   *ins)
@@ -178,9 +178,9 @@ static int out_fcount_exit(void *data, struct flb_config* config)
     return 0;
 }
 
-struct flb_output_plugin out_flowcount_plugin = {
-    .name         = "flowcount",
-    .description  = "FlowCount",
+struct flb_output_plugin out_flowcounter_plugin = {
+    .name         = "flowcounter",
+    .description  = "FlowCounter",
     .cb_init      = out_fcount_init,
     .cb_flush     = out_fcount_flush,
     .cb_exit      = out_fcount_exit,

--- a/plugins/out_flowcounter/out_flowcounter.h
+++ b/plugins/out_flowcounter/out_flowcounter.h
@@ -17,18 +17,10 @@
  *  limitations under the License.
  */
 
-#ifndef FLB_OUT_FLOWCOUNT
-#define FLB_OUT_FLOWCOUNT
+#ifndef FLB_OUT_FLOWCOUNTER
+#define FLB_OUT_FLOWCOUNTER
 
 #include <stdint.h>
-/*
-enum {
-    FLB_UNIT_SEC = 0,
-    FLB_UNIT_MIN,
-    FLB_UNIT_HOUR,
-    FLB_UNIT_DAY,
-};
-*/
 
 #define FLB_UNIT_SEC  "second"
 #define FLB_UNIT_MIN  "minute"


### PR DESCRIPTION
Counting plugin was renamed out_flowcount**er** ( I added "er" )

I misunderstood @kzk 's comment of #130
Sorry and Thanks @kzk !

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>