### PR TITLE
health: add new option proc_name to check status of process

### DIFF
--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -30,6 +30,12 @@
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_utils.h>
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <glob.h>
+
 #define DEFAULT_INTERVAL_SEC  1
 #define DEFAULT_INTERVAL_NSEC 0
 
@@ -47,6 +53,11 @@ struct flb_in_health_config {
     int add_port;
     int port;
 
+    /* Checking process */
+    pid_t  pid;
+    int    len_proc_name;
+    char*  proc_name;
+
     /* Time interval check */
     int interval_sec;
     int interval_nsec;
@@ -59,101 +70,71 @@ struct flb_in_health_config {
     msgpack_sbuffer mp_sbuf;
 };
 
-/* Collection aims to try to connect to the specified TCP server */
-static int in_health_collect(struct flb_config *config, void *in_context)
+#define CMD_LEN 256
+static pid_t get_pid_from_procname(const char* proc)
 {
-    uint8_t alive;
-    struct flb_in_health_config *ctx = in_context;
-    struct flb_upstream_conn *u_conn;
-    int map_num = 1;
+    pid_t ret = -1;
 
-    u_conn = flb_upstream_conn_get(ctx->u);
-    if (!u_conn) {
-        alive = FLB_FALSE;
-    }
-    else {
-        alive = FLB_TRUE;
-        flb_upstream_conn_release(u_conn);
-    }
+    glob_t glb;
+    int i;
+    int fd = -1;
+    long ret_scan = -1;
+    int ret_glb = -1;
+    ssize_t count;
 
-    if (alive == FLB_TRUE && ctx->alert == FLB_TRUE) {
-        FLB_INPUT_RETURN();
-    }
+    char cmdname[CMD_LEN];
 
-    /*
-     * Store the new data into the MessagePack buffer,
-     */
-    msgpack_pack_array(&ctx->mp_pck, 2);
-    msgpack_pack_uint64(&ctx->mp_pck, time(NULL));
-
-    /* extract map field */
-    if (ctx->add_host) {
-        map_num++;
-    }
-    if (ctx->add_port) {
-        map_num++;
-    }
-    msgpack_pack_map(&ctx->mp_pck, map_num);
-
-    /* Status */
-    msgpack_pack_bin(&ctx->mp_pck, 5);
-    msgpack_pack_bin_body(&ctx->mp_pck, "alive", 5);
-
-    if (alive) {
-        msgpack_pack_true(&ctx->mp_pck);
-    }
-    else {
-        msgpack_pack_false(&ctx->mp_pck);
+    if ((ret_glb = glob("/proc/*/cmdline", 0 ,NULL,&glb) != 0)) {
+        switch(ret_glb){
+        case GLOB_NOSPACE:
+            flb_warn("glob: no space");
+            break;
+        case GLOB_NOMATCH:
+            flb_warn("glob: no match");
+            break;
+        case GLOB_ABORTED:
+            flb_warn("glob: aborted");
+            break;
+        default:
+            flb_warn("glob: other error");
+        }
+        return ret;
     }
 
-    if (ctx->add_host) {
-        /* append hostname */
-        msgpack_pack_bin(&ctx->mp_pck, strlen("hostname"));
-        msgpack_pack_bin_body(&ctx->mp_pck, "hostname", strlen("hostname"));
-        msgpack_pack_bin(&ctx->mp_pck, ctx->len_host);
-        msgpack_pack_bin_body(&ctx->mp_pck, ctx->hostname, ctx->len_host);
-    }
+    for(i=0; i<glb.gl_pathc; i++){
+        fd = open(glb.gl_pathv[i], O_RDONLY);
+        if (fd<0) {
+            continue;
+        }
+        count = read(fd, &cmdname, CMD_LEN);
+        if (count<=0){
+            close(fd);
+            continue;
+        }
+        cmdname[CMD_LEN-1] = '\0';
 
-    if (ctx->add_port) {
-        /* append port number */
-        msgpack_pack_bin(&ctx->mp_pck, strlen("port"));
-        msgpack_pack_bin_body(&ctx->mp_pck, "port", strlen("port"));
-        msgpack_pack_int32(&ctx->mp_pck, ctx->port);
+        if (strncmp(proc, (const char*)&cmdname, CMD_LEN) == 0) {
+            sscanf((const char*)glb.gl_pathv[i],"/proc/%ld/cmdline",&ret_scan);
+            ret = (pid_t)ret_scan;
+            close(fd);
+            break;
+        }
+        close(fd);
     }
-
-    FLB_INPUT_RETURN();
-    return 0;
+    globfree(&glb);
+    return ret;
 }
 
-static int in_health_init(struct flb_input_instance *in,
-                          struct flb_config *config, void *data)
+static int get_pid_status(pid_t pid)
 {
-    int ret;
+    int ret =  kill(pid, 0);
+    return ((ret != ESRCH)  && (ret != EPERM) && (ret != ESRCH));
+}
+
+static int configure(struct flb_in_health_config *ctx,
+                     struct flb_input_instance *in)
+{
     char *pval;
-    struct flb_in_health_config *ctx;
-    (void) data;
-
-    /* Allocate space for the configuration */
-    ctx = flb_calloc(1, sizeof(struct flb_in_health_config));
-    if (!ctx) {
-        perror("calloc");
-        return -1;
-    }
-    ctx->alert = FLB_FALSE;
-    ctx->add_host = FLB_FALSE;
-    ctx->len_host = 0;
-    ctx->hostname = NULL;
-
-    ctx->add_port = FLB_FALSE;
-    ctx->port     = -1;
-
-    ctx->u = flb_upstream_create(config, in->host.name, in->host.port,
-                                 FLB_IO_TCP, NULL);
-    if (!ctx->u) {
-        flb_free(ctx);
-        flb_error("[in_health] could not initialize upstream");
-        return -1;
-    }
 
     /* interval settings */
     pval = flb_input_get_property("interval_sec", in);
@@ -202,6 +183,182 @@ static int in_health_init(struct flb_input_instance *in,
         }
     }
 
+    pval = flb_input_get_property("proc_name", in);
+    if (pval) {
+        ctx->proc_name = (char*)flb_malloc(CMD_LEN);
+        if (ctx->proc_name == NULL) {
+            return -1;
+        }
+        strncpy(ctx->proc_name, pval, CMD_LEN);
+        ctx->proc_name[CMD_LEN-1] = '\0';
+        ctx->len_proc_name = strlen(ctx->proc_name);
+    }
+
+    return 0;
+}
+
+/* Collection aims to try to connect to the specified TCP server */
+static int collect_upstream_conn(struct flb_config *config, void *in_context)
+{
+    uint8_t alive;
+    struct flb_in_health_config *ctx = in_context;
+    struct flb_upstream_conn *u_conn;
+    int map_num = 1;
+
+    u_conn = flb_upstream_conn_get(ctx->u);
+    if (!u_conn) {
+        alive = FLB_FALSE;
+    }
+    else {
+        alive = FLB_TRUE;
+        flb_upstream_conn_release(u_conn);
+    }
+
+    if (alive == FLB_TRUE && ctx->alert == FLB_TRUE) {
+        return 0;
+    }
+
+    /*
+     * Store the new data into the MessagePack buffer,
+     */
+    msgpack_pack_array(&ctx->mp_pck, 2);
+    msgpack_pack_uint64(&ctx->mp_pck, time(NULL));
+
+    /* extract map field */
+    if (ctx->add_host) {
+        map_num++;
+    }
+    if (ctx->add_port) {
+        map_num++;
+    }
+
+    msgpack_pack_map(&ctx->mp_pck, map_num);
+
+    /* Status */
+    msgpack_pack_bin(&ctx->mp_pck, 5);
+    msgpack_pack_bin_body(&ctx->mp_pck, "alive", 5);
+
+    if (alive) {
+        msgpack_pack_true(&ctx->mp_pck);
+    }
+    else {
+        msgpack_pack_false(&ctx->mp_pck);
+    }
+
+    if (ctx->add_host) {
+        /* append hostname */
+        msgpack_pack_bin(&ctx->mp_pck, strlen("hostname"));
+        msgpack_pack_bin_body(&ctx->mp_pck, "hostname", strlen("hostname"));
+        msgpack_pack_bin(&ctx->mp_pck, ctx->len_host);
+        msgpack_pack_bin_body(&ctx->mp_pck, ctx->hostname, ctx->len_host);
+    }
+
+    if (ctx->add_port) {
+        /* append port number */
+        msgpack_pack_bin(&ctx->mp_pck, strlen("port"));
+        msgpack_pack_bin_body(&ctx->mp_pck, "port", strlen("port"));
+        msgpack_pack_int32(&ctx->mp_pck, ctx->port);
+    }
+
+    return 0;
+}
+
+
+static int collect_process(struct flb_config *config, void *in_context)
+{
+    uint8_t alive = FLB_FALSE;
+    struct flb_in_health_config *ctx = in_context;
+
+    ctx->pid = get_pid_from_procname(ctx->proc_name);
+
+    if (ctx->pid >= 0 && get_pid_status(ctx->pid)) {
+        alive = FLB_TRUE;
+    }
+
+    if (alive == FLB_TRUE && ctx->alert == FLB_TRUE) {
+        return 0;
+    }
+
+    /*
+     * Store the new data into the MessagePack buffer,
+     */
+    msgpack_pack_array(&ctx->mp_pck, 2);
+    msgpack_pack_uint64(&ctx->mp_pck, time(NULL));
+
+    /* 3 = alive, proc_name, pid */
+    msgpack_pack_map(&ctx->mp_pck, 3);
+
+    /* Status */
+    msgpack_pack_bin(&ctx->mp_pck, 5);
+    msgpack_pack_bin_body(&ctx->mp_pck, "alive", 5);
+
+    if (alive) {
+        msgpack_pack_true(&ctx->mp_pck);
+    }
+    else {
+        msgpack_pack_false(&ctx->mp_pck);
+    }
+
+    /* proc name */
+    msgpack_pack_bin(&ctx->mp_pck, strlen("proc_name"));
+    msgpack_pack_bin_body(&ctx->mp_pck, "proc_name", strlen("proc_name"));
+    msgpack_pack_bin(&ctx->mp_pck, ctx->len_proc_name);
+    msgpack_pack_bin_body(&ctx->mp_pck, ctx->proc_name, ctx->len_proc_name);
+
+    /* pid */
+    msgpack_pack_bin(&ctx->mp_pck, strlen("pid"));
+    msgpack_pack_bin_body(&ctx->mp_pck, "pid", strlen("pid"));
+    msgpack_pack_int64(&ctx->mp_pck, ctx->pid);
+
+    return 0;
+}
+
+
+static int in_health_collect(struct flb_config *config, void *in_context)
+{
+    struct flb_in_health_config *ctx = in_context;
+
+    if (ctx->u != NULL) {
+        collect_upstream_conn(config, in_context);
+    }
+    if (ctx->proc_name != NULL){
+        collect_process(config, in_context);
+    }
+    
+    FLB_INPUT_RETURN();
+    return 0;
+}
+
+static int in_health_init(struct flb_input_instance *in,
+                          struct flb_config *config, void *data)
+{
+    int ret;
+
+    struct flb_in_health_config *ctx;
+    (void) data;
+
+    /* Allocate space for the configuration */
+    ctx = flb_calloc(1, sizeof(struct flb_in_health_config));
+    if (!ctx) {
+        perror("calloc");
+        return -1;
+    }
+    ctx->alert = FLB_FALSE;
+    ctx->add_host = FLB_FALSE;
+    ctx->len_host = 0;
+    ctx->hostname = NULL;
+
+    ctx->add_port = FLB_FALSE;
+    ctx->port     = -1;
+
+    ctx->proc_name = NULL;
+
+    if (in->host.name != NULL) {
+        ctx->u = flb_upstream_create(config, in->host.name, in->host.port,
+                                 FLB_IO_TCP, NULL);
+    }
+
+    configure(ctx, in);
 
     /* initialize MessagePack buffers */
     msgpack_sbuffer_init(&ctx->mp_sbuf);
@@ -252,7 +409,11 @@ int in_health_exit(void *data, struct flb_config *config)
 
     /* Remove msgpack buffer and destroy context */
     msgpack_sbuffer_destroy(&ctx->mp_sbuf);
-    flb_upstream_destroy(ctx->u);
+    if (ctx->u != NULL) {
+        flb_upstream_destroy(ctx->u);
+    }
+
+    flb_free(ctx->proc_name);
     flb_free(ctx->hostname);
     flb_free(ctx);
 


### PR DESCRIPTION
I added new option "proc_name" of in_health.
This option is to check process status.

## How to use

Using like that.

Shell1
```
$ yes > /dev/null
.
(Ctrl+C)
```

Shell2
`$ bin/fluent-bit -i health -p proc_name=yes -o stdout`

## Output

In this case, "proc_name"->"yes" is appended with this new option.
"alive" is "true" while executing "yes" command.

```
$ bin/fluent-bit -i health -p proc_name=yes -o stdout
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

[2016/11/22 00:19:59] [ info] [engine] started
[0] health.0: [1479741600, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[1] health.0: [1479741601, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[2] health.0: [1479741602, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[3] health.0: [1479741603, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[0] health.0: [1479741604, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[1] health.0: [1479741605, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[2] health.0: [1479741606, {"alive"=>true, "proc_name"=>"yes", "pid"=>17862}]
[3] health.0: [1479741607, {"alive"=>false, "proc_name"=>"yes", "pid"=>-1}]
[4] health.0: [1479741608, {"alive"=>false, "proc_name"=>"yes", "pid"=>-1}]

```

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>