### PR TITLE
head: add new option to display file path to read

### DIFF
--- a/conf/in_head.conf
+++ b/conf/in_head.conf
@@ -39,13 +39,13 @@
 
     # File
     # ====
-    # File path. e.g. /proc/uptime
+    # File path. e.g. /proc/uptime (required)
     #
     File    /path/to/file
 
     # Buf_Size
     # ====
-    # Buffer size to read file. Default 256
+    # Buffer size to read file. Default: 256
     Buf_Size 256
 
     # Total Interval
@@ -53,13 +53,18 @@
     #
     # Interval Sec
     # ====
-    # Read interval (sec) Default 1
+    # Read interval (sec) Default: 1
     Interval_Sec 1
 
     # Interval NSec
     # ====
-    # Read interval (nsec) Default 0
+    # Read interval (nsec) Default: 0
     Interval_NSec 0
+
+    # Add Path
+    # ====
+    # if true, append file path to each record. Default: false
+    Add_Path true
 
 [OUTPUT]
     Name  stdout

--- a/plugins/in_head/in_head.h
+++ b/plugins/in_head/in_head.h
@@ -37,6 +37,9 @@ struct flb_in_head_config {
 
     char     *filepath; /* to read */
 
+    char     add_path; /* add path mode */
+    size_t   path_len;
+
     int      interval_sec;
     int      interval_nsec;
 


### PR DESCRIPTION
I added a new option "add_path" to display file path.

## How to use

Using like this.

`$ bin/fluent-bit -i head -p file=/proc/uptime -p add_path=true -o stdout`

## Output

In this case, "path"=>"/proc/uptime" is appended with this option.

```
$ bin/fluent-bit -i head -p file=/proc/uptime -p add_path=true -o stdout
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

[2016/11/23 22:31:29] [ info] [engine] started
[0] head.0: [1479907890, {"head"=>"237197.57 226881.09
", "path"=>"/proc/uptime"}]
[1] head.0: [1479907891, {"head"=>"237198.57 226882.00
", "path"=>"/proc/uptime"}]
```


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>