### PR TITLE
Add a function to convert msgpack to JSON

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -21,7 +21,19 @@
 #include <fluent-bit.h>
 #include <msgpack.h>
 
-int my_stdout(void* data, size_t size)
+int my_stdout_json(void* data, size_t size)
+{
+    printf("[%s]",__FUNCTION__);
+    printf("%s",(char*)data);
+    printf("\n");
+
+    /* User has to release the buffer. */
+    free(data);
+
+    return 0;
+}
+
+int my_stdout_msgpack(void* data, size_t size)
 {
     printf("[%s]",__FUNCTION__);
     msgpack_object_print(stdout, *(msgpack_object*)data);
@@ -32,7 +44,6 @@ int my_stdout(void* data, size_t size)
 
     return 0;
 }
-
 
 int main()
 {
@@ -53,8 +64,16 @@ int main()
     flb_input_set(ctx, in_ffd, "tag", "test", NULL);
 
     /* Register my callback function */
-    out_ffd = flb_output(ctx, "lib", my_stdout);
+
+    /* JSON format */
+    out_ffd = flb_output(ctx, "lib", my_stdout_json);
+    flb_output_set(ctx, out_ffd, "match", "test", "format", "json", NULL);
+
+    /* Msgpack format */
+    /*
+    out_ffd = flb_output(ctx, "lib", my_stdout_msgpack);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    */
 
     /* Start the background worker */
     flb_start(ctx);

--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -28,7 +28,7 @@ int my_stdout_json(void* data, size_t size)
     printf("\n");
 
     /* User has to release the buffer. */
-    free(data);
+    flb_free(data);
 
     return 0;
 }
@@ -40,7 +40,7 @@ int my_stdout_msgpack(void* data, size_t size)
     printf("\n");
 
     /* User has to release the buffer. */
-    free(data);
+    flb_free(data);
 
     return 0;
 }

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -41,5 +41,6 @@ int flb_pack_json_state(char *js, size_t len,
 void flb_pack_print(char *data, size_t bytes);
 int flb_msgpack_to_json(char* json_str, size_t str_len,
                         msgpack_unpacked* data);
+char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked* data);
 
 #endif

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -39,8 +39,8 @@ int flb_pack_json_state(char *js, size_t len,
                         struct flb_pack_state *state);
 
 void flb_pack_print(char *data, size_t bytes);
-int flb_msgpack_to_json(char* json_str, size_t str_len,
-                        msgpack_unpacked* data);
-char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked* data);
+int flb_msgpack_to_json(char *json_str, size_t str_len,
+                        msgpack_unpacked *data);
+char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked *data);
 
 #endif

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -21,7 +21,7 @@
 #define FLB_PACK_H
 
 #include <jsmn/jsmn.h>
-
+#include <msgpack.h>
 struct flb_pack_state {
     int multiple;         /* support multiple jsons? */
     int tokens_count;     /* number of parsed tokens */
@@ -39,5 +39,7 @@ int flb_pack_json_state(char *js, size_t len,
                         struct flb_pack_state *state);
 
 void flb_pack_print(char *data, size_t bytes);
+int flb_msgpack_to_json(char* json_str, size_t str_len,
+                        msgpack_unpacked* data);
 
 #endif

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -100,7 +100,7 @@ static void out_lib_flush(void *data, size_t bytes,
     size_t off = 0;
     size_t last_off = 0;
     size_t alloc_size = 0;
-    size_t ret_size = 0;
+    int    ret = 0;
     struct flb_out_lib_config *ctx = out_context;
     unsigned char* data_for_user   = NULL;
     (void) i_ins;
@@ -128,16 +128,17 @@ static void out_lib_flush(void *data, size_t bytes,
                 flb_error("[%s] allocate failed",PLUGIN_NAME);
                 continue;/* FIXME */
             }
-            ret_size =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
-            if (ret_size > alloc_size) {
+            ret =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
+            if (ret<0) {
                 /* buffer size is small, so retry with bigger buffer */
                 flb_free(data_for_user);
-                data_for_user = flb_calloc(1, ret_size);
+                alloc_size *= 2;
+                data_for_user = flb_calloc(1, alloc_size);
                 if (data_for_user == NULL) {
                     flb_error("[%s] allocate failed",PLUGIN_NAME);
                     continue;/* FIXME */
                 }
-                ret_size =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
+                ret =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
             }
             break;
         default:

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -21,10 +21,34 @@
 
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_utils.h>
-
+#include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
 #include "out_lib.h"
+
+#define PLUGIN_NAME "out_lib"
+static int configure(struct flb_out_lib_config *ctx,
+                      struct flb_output_instance   *ins)
+{
+    char* format = NULL;
+    
+    /* default */
+    ctx->format = FLB_OUT_LIB_FMT_MSGPACK;
+
+    format = flb_output_get_property("format", ins);
+    if (format == NULL) {
+        /* using default */
+        return 0;
+    }
+
+    flb_debug("[%s]fomrat is \"%s\"",PLUGIN_NAME, format);
+
+    if (!strcasecmp(format, FLB_FMT_STR_JSON)) {
+        ctx->format = FLB_OUT_LIB_FMT_JSON;
+    }
+
+    return 0;
+}
 
 
 /**
@@ -55,10 +79,12 @@ static int out_lib_init(struct flb_output_instance *ins,
         /* set user callback */
         ctx->user_callback = ins->data;
     }else{
-        flb_error("[out_lib] Callback is NULL");
+        flb_error("[%s] Callback is NULL",PLUGIN_NAME);
         flb_free(ctx);
         return -1;
     }
+
+    configure(ctx, ins);
 
     flb_output_set_context(ins, ctx);
     return 0;
@@ -72,6 +98,9 @@ static void out_lib_flush(void *data, size_t bytes,
 {
     msgpack_unpacked result;
     size_t off = 0;
+    size_t last_off = 0;
+    size_t alloc_size = 0;
+    size_t ret_size = 0;
     struct flb_out_lib_config *ctx = out_context;
     unsigned char* data_for_user   = NULL;
     (void) i_ins;
@@ -80,17 +109,41 @@ static void out_lib_flush(void *data, size_t bytes,
     (void) tag_len;
 
     if (ctx->user_callback == NULL) {
-        flb_error("[out_lib] Callback is NULL");
+        flb_error("[%s] Callback is NULL",PLUGIN_NAME);
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off)) {
-        data_for_user = flb_calloc(1, bytes);
-        /* FIXME: Now we return raw msgpack
-                  we should return JSON format.
-         */
-        memcpy(data_for_user, &result.data, bytes);
+        switch(ctx->format){
+        case FLB_OUT_LIB_FMT_MSGPACK:
+            data_for_user = flb_calloc(1, bytes);
+            memcpy(data_for_user, &result.data, bytes);
+            break;
+        case FLB_OUT_LIB_FMT_JSON:
+            alloc_size = (off - last_off)+128;/* JSON is larger than msgpack */
+            last_off   = off;
+            data_for_user = flb_calloc(1, alloc_size);
+            if (data_for_user == NULL) {
+                flb_error("[%s] allocate failed",PLUGIN_NAME);
+                continue;/* FIXME */
+            }
+            ret_size =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
+            if (ret_size > alloc_size) {
+                /* buffer size is small, so retry with bigger buffer */
+                flb_free(data_for_user);
+                data_for_user = flb_calloc(1, ret_size);
+                if (data_for_user == NULL) {
+                    flb_error("[%s] allocate failed",PLUGIN_NAME);
+                    continue;/* FIXME */
+                }
+                ret_size =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
+            }
+            break;
+        default:
+            flb_error("[%s] unknown format",PLUGIN_NAME);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
         ctx->user_callback((void*)data_for_user, bytes);
     }
     msgpack_unpacked_destroy(&result);

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -100,7 +100,6 @@ static void out_lib_flush(void *data, size_t bytes,
     size_t off = 0;
     size_t last_off = 0;
     size_t alloc_size = 0;
-    int    ret = 0;
     struct flb_out_lib_config *ctx = out_context;
     unsigned char* data_for_user   = NULL;
     (void) i_ins;
@@ -118,34 +117,23 @@ static void out_lib_flush(void *data, size_t bytes,
         switch(ctx->format){
         case FLB_OUT_LIB_FMT_MSGPACK:
             data_for_user = flb_calloc(1, bytes);
-            memcpy(data_for_user, &result.data, bytes);
+            if (data_for_user != NULL) {
+                memcpy(data_for_user, &result.data, bytes);
+            }
             break;
         case FLB_OUT_LIB_FMT_JSON:
             alloc_size = (off - last_off)+128;/* JSON is larger than msgpack */
             last_off   = off;
-            data_for_user = flb_calloc(1, alloc_size);
-            if (data_for_user == NULL) {
-                flb_error("[%s] allocate failed",PLUGIN_NAME);
-                continue;/* FIXME */
-            }
-            ret =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
-            if (ret<0) {
-                /* buffer size is small, so retry with bigger buffer */
-                flb_free(data_for_user);
-                alloc_size *= 2;
-                data_for_user = flb_calloc(1, alloc_size);
-                if (data_for_user == NULL) {
-                    flb_error("[%s] allocate failed",PLUGIN_NAME);
-                    continue;/* FIXME */
-                }
-                ret =  flb_msgpack_to_json(data_for_user, alloc_size, &result);
-            }
+            data_for_user = flb_msgpack_to_json_str(alloc_size, &result);
             break;
         default:
             flb_error("[%s] unknown format",PLUGIN_NAME);
             FLB_OUTPUT_RETURN(FLB_ERROR);
         }
-        ctx->user_callback((void*)data_for_user, bytes);
+
+        if (data_for_user != NULL) {
+            ctx->user_callback((void*)data_for_user, bytes);
+        }
     }
     msgpack_unpacked_destroy(&result);
     FLB_OUTPUT_RETURN(FLB_OK);

--- a/plugins/out_lib/out_lib.h
+++ b/plugins/out_lib/out_lib.h
@@ -20,7 +20,17 @@
 #ifndef FLB_OUT_LIB
 #define FLB_OUT_LIB
 
+enum {
+    FLB_OUT_LIB_FMT_MSGPACK = 0,
+    FLB_OUT_LIB_FMT_JSON,
+    FLB_OUT_LIB_FMT_ERROR,
+};
+
+#define FLB_FMT_STR_MSGPACK "msgpack"
+#define FLB_FMT_STR_JSON    "json"
+
 struct flb_out_lib_config{
+    int format;
     int (*user_callback)(void* data, size_t size);
 };
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -330,7 +330,7 @@ static int msgpack2json(char *buf, int *off, size_t left, msgpack_object *o)
         {
             char temp[32] = {0};
             ret = try_to_write(buf, off, left, temp,
-                snprintf(temp, 31, "%lu", (unsigned long)o->via.u64));
+                 snprintf(temp, sizeof(temp)-1, "%lu", (unsigned long)o->via.u64));
         }
         break;
 
@@ -338,7 +338,7 @@ static int msgpack2json(char *buf, int *off, size_t left, msgpack_object *o)
         {
             char temp[32] = {0};
             ret = try_to_write(buf, off, left, temp,
-                 snprintf(temp, 31, "%ld", (signed long)o->via.i64));
+                 snprintf(temp, sizeof(temp)-1, "%ld", (signed long)o->via.i64));
         }
         break;
 
@@ -346,7 +346,7 @@ static int msgpack2json(char *buf, int *off, size_t left, msgpack_object *o)
         {
             char temp[32] = {0};
             ret = try_to_write(buf, off, left, temp,
-                 snprintf(temp, 31, "%f", o->via.f64));
+                 snprintf(temp, sizeof(temp)-1, "%f", o->via.f64));
         }
         break;
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -295,7 +295,7 @@ void flb_pack_print(char *data, size_t bytes)
 }
 
 
-inline int try_to_write(char* buf, int* off, size_t left,
+static inline int try_to_write(char* buf, int* off, size_t left,
                         char* str, size_t str_len)
 {
     if (str_len <= 0){

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -476,7 +476,8 @@ char *flb_msgpack_to_json_str(size_t size, msgpack_unpacked *data)
             /* buffer is small. retry.*/
             size += 128;
             flb_free(buf);
-        } else {
+        }
+        else {
             break;
         }
     }

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -329,24 +329,24 @@ static int msgpack2json(char *buf, int *off, size_t left, msgpack_object *o)
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
         {
             char temp[32] = {0};
-            ret = try_to_write(buf, off, left, temp,
-                 snprintf(temp, sizeof(temp)-1, "%lu", (unsigned long)o->via.u64));
+            i = snprintf(temp, sizeof(temp)-1, "%lu", (unsigned long)o->via.u64);
+            ret = try_to_write(buf, off, left, temp, i);
         }
         break;
 
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
         {
             char temp[32] = {0};
-            ret = try_to_write(buf, off, left, temp,
-                 snprintf(temp, sizeof(temp)-1, "%ld", (signed long)o->via.i64));
+            i = snprintf(temp, sizeof(temp)-1, "%ld", (signed long)o->via.i64);
+            ret = try_to_write(buf, off, left, temp, i);
         }
         break;
 
     case MSGPACK_OBJECT_FLOAT:
         {
             char temp[32] = {0};
-            ret = try_to_write(buf, off, left, temp,
-                 snprintf(temp, sizeof(temp)-1, "%f", o->via.f64));
+            i = snprintf(temp, sizeof(temp)-1, "%f", o->via.f64);
+            ret = try_to_write(buf, off, left, temp, i);
         }
         break;
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -295,8 +295,8 @@ void flb_pack_print(char *data, size_t bytes)
 }
 
 
-static inline int try_to_write(char* buf, int* off, size_t left,
-                        char* str, size_t str_len)
+static inline int try_to_write(char *buf, int *off, size_t left,
+                        char *str, size_t str_len)
 {
     if (str_len <= 0){
         str_len = strlen(str);
@@ -304,12 +304,12 @@ static inline int try_to_write(char* buf, int* off, size_t left,
     if (left <= *off+str_len) {
         return FLB_FALSE;
     }
-    strncpy(buf+*off, str, str_len);
+    memcpy(buf+*off, str, str_len);
     *off += str_len;
     return FLB_TRUE;
 }
 
-static int msgpack2json(char* buf, int *off, size_t left, msgpack_object *o)
+static int msgpack2json(char *buf, int *off, size_t left, msgpack_object *o)
 {
     int ret = FLB_FALSE;
     int i;
@@ -329,39 +329,39 @@ static int msgpack2json(char* buf, int *off, size_t left, msgpack_object *o)
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
         {
             char temp[32] = {0};
-            snprintf(temp, 31, "%lu", (unsigned long)o->via.u64);
-            ret = try_to_write(buf, off, left,temp,0);
+            ret = try_to_write(buf, off, left, temp,
+                snprintf(temp, 31, "%lu", (unsigned long)o->via.u64));
         }
         break;
 
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
         {
             char temp[32] = {0};
-            snprintf(temp, 31, "%ld", (signed long)o->via.i64);
-            ret = try_to_write(buf,off,left,temp,0);
+            ret = try_to_write(buf, off, left, temp,
+                 snprintf(temp, 31, "%ld", (signed long)o->via.i64));
         }
         break;
 
     case MSGPACK_OBJECT_FLOAT:
         {
             char temp[32] = {0};
-            snprintf(temp, 31, "%f", o->via.f64);
-            ret = try_to_write(buf,off,left,temp,0);
+            ret = try_to_write(buf, off, left, temp,
+                 snprintf(temp, 31, "%f", o->via.f64));
         }
         break;
 
     case MSGPACK_OBJECT_STR:
-        if (try_to_write(buf,off,left, "\"",1) && 
-            try_to_write(buf,off,left, (char*)o->via.str.ptr, o->via.str.size) &&
-            try_to_write(buf,off,left, "\"",1)) {
+        if (try_to_write(buf, off, left, "\"", 1) && 
+            try_to_write(buf, off, left, (char*)o->via.str.ptr, o->via.str.size) &&
+            try_to_write(buf, off, left, "\"", 1)) {
             ret = FLB_TRUE;
         }
         break;
 
     case MSGPACK_OBJECT_BIN:
-        if (try_to_write(buf,off,left, "\"",1) &&
-            try_to_write(buf,off,left, (char*)o->via.bin.ptr, o->via.bin.size) &&
-            try_to_write(buf,off,left, "\"",1)) {
+        if (try_to_write(buf, off, left, "\"", 1) &&
+            try_to_write(buf, off, left, (char*)o->via.bin.ptr, o->via.bin.size) &&
+            try_to_write(buf, off, left, "\"", 1)) {
             ret = FLB_TRUE;
         }
         break;
@@ -369,50 +369,50 @@ static int msgpack2json(char* buf, int *off, size_t left, msgpack_object *o)
     case MSGPACK_OBJECT_ARRAY:
         loop = o->via.array.size;
 
-        if (!try_to_write(buf,off,left, "[",1)) {
+        if (!try_to_write(buf, off, left, "[", 1)) {
             goto msg2json_end;
         }
         if (loop != 0) {
             msgpack_object* p = o->via.array.ptr;
-            if (!msgpack2json(buf,off,left,p)) {
+            if (!msgpack2json(buf, off, left, p)) {
                 goto msg2json_end;
             }
             for (i=1; i<loop; i++) {
-                if (!try_to_write(buf,off,left,", ",2) ||
-                    !msgpack2json(buf,off,left,p+i)) {
+                if (!try_to_write(buf, off, left, ", ", 2) ||
+                    !msgpack2json(buf, off, left, p+i)) {
                     goto msg2json_end;
                 }
             }
         }
 
-        ret = try_to_write(buf,off,left, "]",1);
+        ret = try_to_write(buf, off, left, "]", 1);
         break;
 
     case MSGPACK_OBJECT_MAP:
         loop = o->via.map.size;
-        if (!try_to_write(buf,off,left, "{",1)) {
+        if (!try_to_write(buf, off, left, "{", 1)) {
             goto msg2json_end;
         }
         if (loop != 0) {
             msgpack_object_kv *p = o->via.map.ptr;
-            if (!msgpack2json(buf,off,left,&p->key) ||
-                !try_to_write(buf,off,left, ":",1)  ||
-                !msgpack2json(buf,off,left,&p->val)) {
+            if (!msgpack2json(buf, off, left, &p->key) ||
+                !try_to_write(buf, off, left, ":", 1)  ||
+                !msgpack2json(buf, off, left, &p->val)) {
                     goto msg2json_end;
             }
             for (i=1; i<loop; i++) {
                 if (
-                  !try_to_write(buf,off,left, ", ",2) ||
-                  !msgpack2json(buf,off,left,&(p+i)->key) ||
-                  !try_to_write(buf,off,left, ":",1)  ||
-                  !msgpack2json(buf,off,left,&(p+i)->val) ) {
+                  !try_to_write(buf, off, left, ", ", 2) ||
+                  !msgpack2json(buf, off, left, &(p+i)->key) ||
+                  !try_to_write(buf, off, left, ":", 1)  ||
+                  !msgpack2json(buf, off, left, &(p+i)->val) ) {
                     goto msg2json_end;
 
                 }
             }
         }
 
-        ret = try_to_write(buf,off,left, "}",1);
+        ret = try_to_write(buf, off, left, "}", 1);
         break;
 
     default:
@@ -432,8 +432,8 @@ static int msgpack2json(char* buf, int *off, size_t left, msgpack_object *o)
  *  @param  data     The msgpack_unpacked data.
  *  @return success  ? a number characters filled : negative value
  */
-int flb_msgpack_to_json(char* json_str, size_t str_len,
-                        msgpack_unpacked* data)
+int flb_msgpack_to_json(char *json_str, size_t str_len,
+                        msgpack_unpacked *data)
 {
     int ret = -1;
     int off = 0;
@@ -442,7 +442,7 @@ int flb_msgpack_to_json(char* json_str, size_t str_len,
         return -1;
     }
 
-    ret = msgpack2json(json_str,&off, str_len, &data->data);
+    ret = msgpack2json(json_str, &off, str_len, &data->data);
     json_str[str_len-1] = '\0';
     return ret ? off: ret;
 }
@@ -455,9 +455,9 @@ int flb_msgpack_to_json(char* json_str, size_t str_len,
  *  @param  data     The msgpack_unpacked data.
  *  @return success  ? allocated json str ptr : NULL
  */
-char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked* data)
+char *flb_msgpack_to_json_str(size_t size, msgpack_unpacked *data)
 {
-    char* ret = NULL;
+    char *buf = NULL;
 
     if (data == NULL) {
         return NULL;
@@ -466,19 +466,19 @@ char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked* data)
         size = 128;
     }
     while(1) {
-        ret = (char*)flb_malloc(size);
-        if (ret == NULL) {
+        buf = (char *)flb_malloc(size);
+        if (buf == NULL) {
             flb_warn("[%s] can't allocate buffer");
             return NULL;
         }
 
-        if ( flb_msgpack_to_json(ret, size, data) < 0 ){
+        if (flb_msgpack_to_json(buf, size, data) < 0){
             /* buffer is small. retry.*/
             size += 128;
-            flb_free(ret);
+            flb_free(buf);
         } else {
             break;
         }
     }
-    return ret;
+    return buf;
 }


### PR DESCRIPTION
I added a generic converting function flb_msgpack_to_json.

## why

Now, we have 3 different functions to convert msgpack to JSON.
(at out_http, out_nats, out_es)
Duplicate code is hard to maintain.

## man of function.
The new function is similar to snprintf.
We can pass 3 args, str_ptr, length of pointer, and msgpack data.
`int flb_msgpack_to_json(char* json_str, size_t str_len, msgpack_unpacked* data)`
It returns a number of characters filled or negative value if error happened.

If return value is larger than str_len, it means buffer is small.
So, user should re-allocate bigger buffer and retry to convert.

## try to it

I pushed a patch to make out_lib using new function.

@edsiper 
Could you review and check this new function?
If you say OK, I will replace legacy converting function.