### PR TITLE
cleanup in_tcp

### DIFF
--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -32,7 +32,7 @@ static void *in_tcp_flush(void *in_context, size_t *size)
     msgpack_sbuffer *sbuf;
     struct flb_in_tcp_config *ctx = in_context;
 
-    if (ctx->buffer_id == 0) {
+    if (ctx->buffer_id == 0|| sbuf->size <= 0) {
         return NULL;
     }
 

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -107,6 +107,7 @@ static int in_tcp_init(struct flb_input_instance *in,
     else {
         flb_error("[in_tcp] could not bind address %s:%s. Aborting",
                   ctx->listen, ctx->tcp_port);
+        tcp_config_destroy(ctx);
         return -1;
     }
     flb_net_socket_nonblocking(ctx->server_fd);

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -86,6 +86,7 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *i_ins)
 
 int tcp_config_destroy(struct flb_in_tcp_config *config)
 {
+    flb_free(config->listen);
     flb_free(config->tcp_port);
     flb_free(config);
 


### PR DESCRIPTION
I fixed in_tcp.

* prevent allocating 0byte at cb_flush.
* add missing release code.
* add release code when initialize failed.