### PR TITLE
input: release resources when cb_init failed

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -233,6 +233,12 @@ void flb_input_initialize_all(struct flb_config *config)
                 flb_error("Failed initialize input %s",
                           in->name);
                 mk_list_del(&in->_head);
+                if (p->flags & FLB_INPUT_NET) {
+                    flb_free(in->tag);
+                    flb_free(in->host.uri);
+                    flb_free(in->host.name);
+                    flb_free(in->host.address);
+                }
                 flb_free(in);
             }
         }


### PR DESCRIPTION
I added releasing code.

If cb_init of input network plugin failed, some resources allocated at flb_input_new are not released.

## How to reproduce

I tested with in_tcp.
```
$ cmake .. -DFLB_MTRACE=yes -DFLB_DEBUG=yes
$ make
$ MALLOC_TRACE=./hoge.txt bin/fluent-bit -i tcp:/123.123.123.123 -o stdout # dummy address
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

[2016/12/09 21:57:26] [ info] [engine] started
[2016/12/09 21:57:26] [error] Error binding socket
[2016/12/09 21:57:26] [ warn] Cannot listen on 23.123.123.123 port 5170
[2016/12/09 21:57:26] [error] [in_tcp] could not bind address 23.123.123.123:5170. Aborting
[2016/12/09 21:57:26] [error] Failed initialize input tcp.0
^C[engine] caught signal
```

## mtrace log

```
$ mtrace bin/fluent-bit hoge.txt 

Memory not freed:
-----------------
           Address     Size     Caller
0x000000000158fb20      0xf  at /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/include/fluent-bit/flb_mem.h:54
0x000000000158fb40     0x15  at /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/include/fluent-bit/flb_mem.h:54
0x00000000015901b0    0x240  at 0x3a32211a83
0x0000000001590400      0xf  at 0x3a32681022
0x0000000001590420     0x14  at 0x3a3269cf82
0x0000000001590440     0x14  at 0x3a3269cf82
0x0000000001590460     0x15  at 0x3a3269cf82
0x0000000001590480     0x14  at 0x3a3269cf82
0x00000000015904e0      0x6  at /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/include/fluent-bit/flb_mem.h:54
0x0000000001590500     0x70  at /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/include/fluent-bit/flb_mem.h:54
0x0000000001590580      0x5  at /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/include/fluent-bit/flb_mem.h:54
0x0000000001590660     0xd6  at 0x3a3269e91c
0x00002b14100008c0     0x15  at 0x3a32217cd2
0x00002b14100008e0    0x496  at 0x3a3220aebf
0x00002b1410000d80     0x15  at 0x3a3220b174
0x00002b1410000da0     0x38  at 0x3a3220cd5d
0x00002b1410000de0    0x138  at 0x3a3220ff34
```

