### PR TITLE
in_forward: release resources when binding failed

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -79,6 +79,7 @@ static int in_fw_init(struct flb_input_instance *in,
     else {
         flb_error("[in_fw] could not bind address %s:%s. Aborting",
                   ctx->listen, ctx->tcp_port);
+        fw_config_destroy(ctx);
         return -1;
     }
     flb_net_socket_nonblocking(ctx->server_fd);


### PR DESCRIPTION
I added a code to release resources which allocated at fw_config_init.