### PR TITLE
bin: make logfile configurable with configuration file

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -101,7 +101,7 @@ struct flb_config {
     struct flb_kernel *kernel;
 
     /* Logging */
-    char *logfile;
+    char *log_file;
     struct flb_log *log;
 
     /* Workers: threads spawn using flb_worker_create() */
@@ -155,7 +155,7 @@ enum conf_type {
 
 #define FLB_CONF_STR_FLUSH    "Flush"
 #define FLB_CONF_STR_DAEMON   "Daemon"
-#define FLB_CONF_STR_LOGFILE  "Logfile"
+#define FLB_CONF_STR_LOGFILE  "Log_File"
 #define FLB_CONF_STR_LOGLEVEL "Log_Level"
 #ifdef FLB_HAVE_HTTP
 #define FLB_CONF_STR_HTTP_MONITOR "HTTP_Monitor"

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -45,7 +45,7 @@ struct flb_service_config service_configs[] = {
 
     {FLB_CONF_STR_LOGFILE,
      FLB_CONF_TYPE_STR,
-     offsetof(struct flb_config, logfile)},
+     offsetof(struct flb_config, log_file)},
 
     {FLB_CONF_STR_LOGLEVEL,
      FLB_CONF_TYPE_STR,
@@ -143,8 +143,8 @@ void flb_config_exit(struct flb_config *config)
     struct mk_list *head;
     struct flb_input_collector *collector;
 
-    if (config->logfile) {
-        flb_free(config->logfile);
+    if (config->log_file) {
+        flb_free(config->log_file);
     }
 
     if (config->log) {

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -459,14 +459,6 @@ int main(int argc, char **argv)
         }
     }
 
-    if (!config->logfile) {
-        config->log = flb_log_init(config, FLB_LOG_STDERR, config->verbose, NULL);
-    }
-    else {
-        config->log = flb_log_init(config, FLB_LOG_FILE, config->verbose,
-                                   config->logfile);
-    }
-
     /* Validate config file */
     if (cfg_file) {
         if (access(cfg_file, R_OK) != 0) {
@@ -478,6 +470,14 @@ int main(int argc, char **argv)
         if (ret != 0) {
             flb_utils_error(FLB_ERR_CFG_FILE_FORMAT);
         }
+    }
+
+    if (!config->logfile) {
+        config->log = flb_log_init(config, FLB_LOG_STDERR, config->verbose, NULL);
+    }
+    else {
+        config->log = flb_log_init(config, FLB_LOG_FILE, config->verbose,
+                                   config->logfile);
     }
 
     /* Validate flush time (seconds) */

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -74,7 +74,7 @@ static void flb_help(int rc, struct flb_config *config)
     printf("  -o, --output=OUTPUT\tset an output\n");
     printf("  -p, --prop=\"A=B\"\tset plugin configuration property\n");
     printf("  -e, --plugin=FILE\tload an external plugin (shared lib)\n");
-    printf("  -l, --logfile=FILE\twrite log info to a file\n");
+    printf("  -l, --log_file=FILE\twrite log info to a file\n");
     printf("  -t, --tag=TAG\t\tset plugin tag, same as '-p tag=abc'\n");
     printf("  -v, --verbose\t\tenable verbose mode\n");
 #ifdef FLB_HAVE_HTTP
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
         { "daemon",      no_argument      , NULL, 'd' },
         { "flush",       required_argument, NULL, 'f' },
         { "http",        no_argument      , NULL, 'H' },
-        { "logfile",     required_argument, NULL, 'l' },
+        { "log_file",    required_argument, NULL, 'l' },
         { "port",        required_argument, NULL, 'P' },
         { "input",       required_argument, NULL, 'i' },
         { "match",       required_argument, NULL, 'm' },
@@ -419,7 +419,7 @@ int main(int argc, char **argv)
             last_plugin = PLUGIN_OUTPUT;
             break;
         case 'l':
-            config->logfile = flb_strdup(optarg);
+            config->log_file = flb_strdup(optarg);
             break;
         case 'p':
             if (last_plugin == PLUGIN_INPUT) {
@@ -472,12 +472,12 @@ int main(int argc, char **argv)
         }
     }
 
-    if (!config->logfile) {
+    if (!config->log_file) {
         config->log = flb_log_init(config, FLB_LOG_STDERR, config->verbose, NULL);
     }
     else {
         config->log = flb_log_init(config, FLB_LOG_FILE, config->verbose,
-                                   config->logfile);
+                                   config->log_file);
     }
 
     /* Validate flush time (seconds) */


### PR DESCRIPTION
I moved logfile settings to be configurable with file.
We can set `logfile` with configuration file like this.

```
[SERVICE]
    logfile ./log.txt

    Flush        5
    Daemon       Off
    Log_Level    info
    HTTP_Monitor Off
    HTTP_Port    2020

[INPUT]
    Name cpu
    Tag  cpu.local

[OUTPUT]
    Name  stdout
    Match **
```