### PR TITLE
output: do not allocate tls.context if tls=false

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -103,7 +103,7 @@ void flb_output_exit(struct flb_config *config)
         flb_free(ins->match);
 
 #ifdef FLB_HAVE_TLS
-        if (ins->p->flags & FLB_IO_TLS) {
+        if (ins->p->flags & FLB_IO_TLS && ins->use_tls) {
             if (ins->tls.context) {
                 flb_tls_context_destroy(ins->tls.context);
             }
@@ -340,7 +340,7 @@ int flb_output_init(struct flb_config *config)
         p = ins->p;
 
 #ifdef FLB_HAVE_TLS
-        if (p->flags & FLB_IO_TLS) {
+        if (p->flags & FLB_IO_TLS && ins->use_tls) {
             ins->tls.context = flb_tls_context_new(ins->tls_verify,
                                                    ins->tls_ca_file,
                                                    ins->tls_crt_file,


### PR DESCRIPTION
Engine allocates tls.context in spite of  property 'tls=false'.
My patch is to reduce memory usage not to allocate these structure (about 3KB).

```
->06.82% (2,744B) 0x422B4E: flb_malloc (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
| ->06.82% (2,744B) 0x4230EA: flb_tls_context_new (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
|   ->06.82% (2,744B) 0x419999: flb_output_init (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
|     ->06.82% (2,744B) 0x41DB28: flb_engine_start (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
|       ->06.82% (2,744B) 0x41632C: main (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)

->01.41% (568B) 0x3A32666E89: __fopen_internal (in /lib64/libc-2.12.so)
  ->01.41% (568B) 0x487994: mbedtls_platform_entropy_poll (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  | ->01.41% (568B) 0x48728A: entropy_gather_internal (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |   ->01.41% (568B) 0x4873E9: mbedtls_entropy_func (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |     ->01.41% (568B) 0x47728F: mbedtls_ctr_drbg_reseed (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |       ->01.41% (568B) 0x476CA5: mbedtls_ctr_drbg_seed_entropy_len (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |         ->01.41% (568B) 0x476CFF: mbedtls_ctr_drbg_seed (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |           ->01.41% (568B) 0x42317A: flb_tls_context_new (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |             ->01.41% (568B) 0x419999: flb_output_init (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |               ->01.41% (568B) 0x41DB28: flb_engine_start (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
  |                 ->01.41% (568B) 0x41632C: main (in /home/taka/git/oss/pull_req/fluentbit_env/tmp/fluent-bit/build/bin/fluent-bit)
```