### PR TITLE
in_health: prevent segfault when hostname is not given

### DIFF
--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -133,6 +133,11 @@ static int in_health_init(struct flb_input_instance *in,
     struct flb_in_health_config *ctx;
     (void) data;
 
+    if (in->host.name == NULL) {
+        flb_error("[in_health] no input 'Host' is given");
+        return -1;
+    }
+
     /* Allocate space for the configuration */
     ctx = flb_calloc(1, sizeof(struct flb_in_health_config));
     if (!ctx) {


### PR DESCRIPTION
in_health causes segfault if hostname is not given.
I fixed it.
```
$ bin/fluent-bit -i health -o stdout
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

Segmentation fault
```