### PR TITLE
input: 'Host' and 'Port' are configurable with flb_input_set_property

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -164,6 +164,14 @@ int flb_input_set_property(struct flb_input_instance *in, char *k, char *v)
         in->tag     = flb_strdup(v);
         in->tag_len = strlen(v);
     }
+    else if (in->p->flags & FLB_INPUT_NET) {
+        if (prop_key_check("host", k, len) == 0) {
+            in->host.name   = flb_strdup(v);
+        }
+        else if (prop_key_check("port", k, len) == 0) {
+            in->host.port = atoi(v);
+        }
+    }
     else {
         /* Append any remaining configuration key to prop list */
         prop = flb_malloc(sizeof(struct flb_config_prop));


### PR DESCRIPTION
Refer to documentation about in_health, we can set property 'Host' and 'Port'.
However, they can't be set with command line option and configuration file.
http://fluentbit.io/documentation/0.9/input/health.html

I fixed them.
We can set like this with this PR.
```
$ bin/fluent-bit -i health -p host=google.com -p port=80 -o stdout
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

[2016/12/22 21:34:35] [ info] [engine] started
[0] health.0: [1482410076, {"alive"=>true}]
```

And with configuration file.
```
[INPUT]
    Name health
    Tag  cpu.local
    host google.com
    port 80

[OUTPUT]
    Name  stdout
    Match **
```


```
$ bin/fluent-bit -c fluent-bit.conf 
Fluent-Bit v0.10.0
Copyright (C) Treasure Data

[2016/12/22 21:35:33] [ info] [engine] started
[0] cpu.local: [1482410134, {"alive"=>true}]
```
