### PR TITLE
out_flowcounter: multiple input support(#155)

### DIFF
--- a/plugins/out_flowcounter/out_flowcounter.h
+++ b/plugins/out_flowcounter/out_flowcounter.h
@@ -27,12 +27,19 @@
 #define FLB_UNIT_HOUR "hour"
 #define FLB_UNIT_DAY  "day"
 
+struct flb_out_fcount_buffer {
+    time_t until;
+    uint64_t counts;
+    uint64_t bytes;
+};
+
 struct flb_out_fcount_config {
     char*     unit;
     int32_t   tick;
-    uint64_t bytes;
-    uint64_t counts;
-    time_t   last_checked;
+
+    struct flb_out_fcount_buffer *buf;
+    int index;
+    int size;
 };
 
 #endif


### PR DESCRIPTION
This PR is to fix #155.

This is a sample output with in_cpu (output every seconds) and in_random(output every 5 seconds).
Then "counts" is 2 in every 5 seconds. (others are 1).
```
$ bin/fluent-bit -i cpu -t hoge -i random -p interval_sec=5 -t hoge -o flowcounter -p unit=second -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/01/07 23:07:40] [ info] [engine] started
[out_flowcounter] [1483798060, {"counts":0, "bytes":0, "counts/second":0, "bytes/second":0 }]
[out_flowcounter] [1483798061, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798062, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798063, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798064, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798065, {"counts":2, "bytes":154, "counts/second":2, "bytes/second":154 }]
[out_flowcounter] [1483798066, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798067, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798068, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798069, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798070, {"counts":2, "bytes":154, "counts/second":2, "bytes/second":154 }]
[out_flowcounter] [1483798071, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798072, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
[out_flowcounter] [1483798073, {"counts":1, "bytes":126, "counts/second":1, "bytes/second":126 }]
```