### PR TITLE
in_proc: add function to collect memory usage of process

### DIFF
--- a/plugins/in_proc/in_proc.h
+++ b/plugins/in_proc/in_proc.h
@@ -30,8 +30,30 @@
 
 #define FLB_CMD_LEN 256
 #define FLB_IN_PROC_NAME "in_proc"
+
+struct flb_in_proc_mem_linux {
+    uint64_t vmpeak;
+    uint64_t vmsize;
+    uint64_t vmlck;
+    uint64_t vmhwm;
+    uint64_t vmrss;
+    uint64_t vmdata;
+    uint64_t vmstk;
+    uint64_t vmexe;
+    uint64_t vmlib;
+    uint64_t vmpte;
+    uint64_t vmswap;
+};
+
+struct flb_in_proc_mem_offset {
+    char   *key;
+    char   *msgpack_key;
+    size_t offset;
+};
+
 struct flb_in_proc_config {
     uint8_t  alert;
+    uint8_t  alive;
 
     /* Checking process */
     char*  proc_name;
@@ -41,6 +63,9 @@ struct flb_in_proc_config {
     /* Time interval check */
     int interval_sec;
     int interval_nsec;
+
+    /* Memory */
+    uint8_t mem;
 };
 
 extern struct flb_input_plugin in_proc_plugin;


### PR DESCRIPTION
I add a new function to collect memory usage of "each process".

This is a sample. It reports memory usage of `bash`
```
ent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/01/14 23:43:31] [ info] [engine] started
[0] proc.0: [1484405012, {"alive"=>true, "proc_name"=>"bash", "pid"=>13344, "mem.VmPeak"=>114796000, "mem.VmSize"=>114796000, "mem.VmLck"=>0, "mem.VmHWM"=>4092000, "mem.VmRSS"=>2868000, "mem.VmData"=>2568000, "mem.VmStk"=>88000, "mem.VmExe"=>852000, "mem.VmLib"=>1988000, "mem.VmPTE"=>84000, "mem.VmSwap"=>920000}]
```

These values are come from `/proc/[pid]/status`.
```
$ cat /proc/13344/status 
Name:	bash
.
.
VmPeak:	  114796 kB
VmSize:	  114796 kB
VmLck:	       0 kB
VmHWM:	    4092 kB
VmRSS:	    2868 kB
VmData:	    2568 kB
VmStk:	      88 kB
VmExe:	     852 kB
VmLib:	    1988 kB
VmPTE:	      84 kB
VmSwap:	     920 kB
.
```