### PR TITLE
in_proc: add new function to count file decriptors

### DIFF
--- a/plugins/in_proc/in_proc.h
+++ b/plugins/in_proc/in_proc.h
@@ -66,6 +66,9 @@ struct flb_in_proc_config {
 
     /* Memory */
     uint8_t mem;
+
+    /* File descriptor */
+    uint8_t fds;
 };
 
 extern struct flb_input_plugin in_proc_plugin;


### PR DESCRIPTION
I added a new function to count file descriptors.
It is useful to check fd leak.

```
$ bin/fluent-bit -i proc -p proc_name=fluent-bit -p fd=true -p mem=false -o stdout
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/01/22 21:21:02] [ info] [engine] started
[0] proc.0: [1485087663, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>3188, "fd"=>18}]
[1] proc.0: [1485087664, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>3188, "fd"=>18}]
[2] proc.0: [1485087665, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>3188, "fd"=>18}]
[3] proc.0: [1485087666, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>3188, "fd"=>18}]
```

fluent-bit read `/proc/[PID]/fd` and count up file descriptors.
```
$ ls -lt /proc/`pidof fluent-bit`/fd |wc
     18     206    1127
```