### PR TITLE
lib: add new library API for filter plugin

### DIFF
--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -37,8 +37,10 @@ FLB_EXPORT flb_ctx_t *flb_create();
 FLB_EXPORT void flb_destroy(flb_ctx_t *ctx);
 FLB_EXPORT int flb_input(flb_ctx_t *ctx, char *input, void *data);
 FLB_EXPORT int flb_output(flb_ctx_t *ctx, char *output, void *data);
+FLB_EXPORT int flb_filter(flb_ctx_t *ctx, char *filter, void *data);
 FLB_EXPORT int flb_input_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_output_set(flb_ctx_t *ctx, int ffd, ...);
+FLB_EXPORT int flb_filter_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_service_set(flb_ctx_t *ctx, ...);
 
 /* start stop the engine */


### PR DESCRIPTION
I added API for filter plugin.
It is similar to API for input/output plugin.
```C
    filter_ffd = flb_filter(ctx, "stdout", NULL);
    flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
```

sample code is
https://gist.github.com/nokute78/67712ad25cbf829d12f4c1dece842ab7

## output sample
```
$ bin/out_lib 
[2017/02/02 22:13:25] [ info] [engine] started
[0] test: [1486041206, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000}]
[0] test: [1486041207, {"cpu_p"=>7.000000, "user_p"=>6.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>6.000000, "cpu0.p_system"=>1.000000}]
[0] test: [1486041208, {"cpu_p"=>4.000000, "user_p"=>2.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>4.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>2.000000}]
[0] test: [1486041209, {"cpu_p"=>2.000000, "user_p"=>2.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>0.000000}]
[my_stdout_json][1486041206, {"cpu_p":0.000000, "user_p":0.000000, "system_p":0.000000, "cpu0.p_cpu":0.000000, "cpu0.p_user":0.000000, "cpu0.p_system":0.000000}]
[my_stdout_json][1486041207, {"cpu_p":7.000000, "user_p":6.000000, "system_p":1.000000, "cpu0.p_cpu":7.000000, "cpu0.p_user":6.000000, "cpu0.p_system":1.000000}]
[my_stdout_json][1486041208, {"cpu_p":4.000000, "user_p":2.000000, "system_p":2.000000, "cpu0.p_cpu":4.000000, "cpu0.p_user":2.000000, "cpu0.p_system":2.000000}]
[my_stdout_json][1486041209, {"cpu_p":2.000000, "user_p":2.000000, "system_p":0.000000, "cpu0.p_cpu":2.000000, "cpu0.p_user":2.000000, "cpu0.p_system":0.000000}]
[0] test: [1486041210, {"cpu_p"=>3.000000, "user_p"=>2.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>1.000000}]
```