### PR TITLE
filter: add cleanup function

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -58,7 +58,7 @@ struct flb_filter_instance {
 int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v);
 struct flb_filter_instance *flb_filter_new(struct flb_config *config,
                                            char *filter, void *data);
-
+void flb_filter_exit(struct flb_config *config);
 void flb_filter_do(struct flb_input_instance *i_ins,
                    void *data, size_t bytes,
                    char *tag, int tag_len,

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -504,6 +504,7 @@ int flb_engine_shutdown(struct flb_config *config)
     flb_parser_exit(config);
 
     /* cleanup plugins */
+    flb_filter_exit(config);
     flb_input_exit_all(config);
     flb_output_exit(config);
 


### PR DESCRIPTION
I added a cleanup function `flb_filter_exit` for filter plugin like input/output plugin.
Could you review it?