### PR TITLE
in_mem: filter plugin support (#173)

### DIFF
--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -209,6 +209,9 @@ static int in_mem_collect(struct flb_input_instance *i_ins,
         entries += 2;
     }
 
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
+
     msgpack_pack_array(&i_ins->mp_pck, 2);
     msgpack_pack_uint64(&i_ins->mp_pck, time(NULL));
     msgpack_pack_map(&i_ins->mp_pck, entries);
@@ -241,6 +244,7 @@ static int in_mem_collect(struct flb_input_instance *i_ins,
               total, free);
     ++ctx->idx;
 
+    flb_input_buf_write_end(i_ins);
     flb_stats_update(in_mem_plugin.stats_fd, 0, 1);
     return 0;
 }


### PR DESCRIPTION
One of #173 

I fixed like this.
```
$ bin/fluent-bit -i mem -o null -F stdout -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/02/06 22:09:21] [ info] [engine] started
[0] mem.0: [1486386562, {"total"=>1016044, "free"=>277188}]
[0] mem.0: [1486386563, {"total"=>1016044, "free"=>277188}]
```