### PR TITLE
in_disk: filter plugin support (#173)

### DIFF
--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -157,6 +157,9 @@ static int in_disk_collect(struct flb_input_instance *i_ins,
     read_total  *= 512;
     write_total *= 512;
 
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
+
     msgpack_pack_array(&i_ins->mp_pck, 2);
     msgpack_pack_uint64(&i_ins->mp_pck, time(NULL));
     msgpack_pack_map(&i_ins->mp_pck, num_map);
@@ -169,6 +172,8 @@ static int in_disk_collect(struct flb_input_instance *i_ins,
     msgpack_pack_bin(&i_ins->mp_pck, strlen(STR_KEY_WRITE));
     msgpack_pack_bin_body(&i_ins->mp_pck, STR_KEY_WRITE, strlen(STR_KEY_WRITE));
     msgpack_pack_uint64(&i_ins->mp_pck, write_total);
+
+    flb_input_buf_write_end(i_ins);
 
     return 0;
 }


### PR DESCRIPTION
One of #173 

I fixed like this.
```
$ bin/fluent-bit -i disk -o null -F stdout -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/02/06 22:14:35] [ info] [engine] started
[0] disk.0: [1486386876, {"read_size"=>0, "write_size"=>0}]
[0] disk.0: [1486386877, {"read_size"=>0, "write_size"=>110592}]
```