### PR TITLE
in_head: filter plugin support (#173)

### DIFF
--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -61,6 +61,9 @@ static int in_head_collect(struct flb_input_instance *i_ins,
         num_map++;
     }
 
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
+
     msgpack_pack_array(&i_ins->mp_pck, 2);
     msgpack_pack_uint64(&i_ins->mp_pck, time(NULL));
 
@@ -81,6 +84,8 @@ static int in_head_collect(struct flb_input_instance *i_ins,
     }
 
     ret = 0;
+
+    flb_input_buf_write_end(i_ins);
     flb_stats_update(in_head_plugin.stats_fd, 0, 1);
 
  collect_fin:


### PR DESCRIPTION
One of #173 

I fixed like this
```
$ bin/fluent-bit -i head -p file=/proc/uptime -o null -F stdout -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/02/06 22:18:16] [ info] [engine] started
[0] head.0: [1486387097, {"head"=>"647217.91 617385.81\x0a"}]
[0] head.0: [1486387098, {"head"=>"647218.91 617386.73\x0a"}]
```