### PR TITLE
in_health: filter plugin support (#173)

### DIFF
--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -79,6 +79,10 @@ static int in_health_collect(struct flb_input_instance *i_ins,
     /*
      * Store the new data into the MessagePack buffer,
      */
+
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
+
     msgpack_pack_array(&i_ins->mp_pck, 2);
     msgpack_pack_uint64(&i_ins->mp_pck, time(NULL));
 
@@ -116,6 +120,8 @@ static int in_health_collect(struct flb_input_instance *i_ins,
         msgpack_pack_bin_body(&i_ins->mp_pck, "port", strlen("port"));
         msgpack_pack_int32(&i_ins->mp_pck, ctx->port);
     }
+
+    flb_input_buf_write_end(i_ins);
 
     FLB_INPUT_RETURN();
     return 0;


### PR DESCRIPTION
One of #173 

I fixed like this
```
$ bin/fluent-bit -i health://google.com:80  -o null -F stdout -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/02/06 22:22:29] [ info] [engine] started
[0] health.0: [1486387350, {"alive"=>true}]
[0] health.0: [1486387351, {"alive"=>true}]
```