### PR TITLE
in_proc: filter plugin support (#173)

### DIFF
--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -252,6 +252,10 @@ static int generate_record_linux(struct flb_input_instance *i_ins,
     /*
      * Store the new data into the MessagePack buffer,
      */
+
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
+
     msgpack_pack_array(&i_ins->mp_pck, 2);
     msgpack_pack_uint64(&i_ins->mp_pck, time(NULL));
 
@@ -299,6 +303,8 @@ static int generate_record_linux(struct flb_input_instance *i_ins,
         msgpack_pack_bin_body(&i_ins->mp_pck, "fd", strlen("fd"));
         msgpack_pack_uint64(&i_ins->mp_pck, fds);
     }
+
+    flb_input_buf_write_end(i_ins);
 
     return 0;
 }


### PR DESCRIPTION
One of #173 

I fixed like this
```
$ bin/fluent-bit -i proc -p proc_name=fluent-bit  -o null -F stdout -m '*'
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/02/06 22:25:34] [ info] [engine] started
[0] proc.0: [1486387535, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>20353, "mem.VmPeak"=>15396000, "mem.VmSize"=>15396000, "mem.VmLck"=>0, "mem.VmHWM"=>1164000, "mem.VmRSS"=>1164000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>2416000, "mem.VmLib"=>2328000, "mem.VmPTE"=>64000, "mem.VmSwap"=>0, "fd"=>18}]
[0] proc.0: [1486387536, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>20353, "mem.VmPeak"=>15396000, "mem.VmSize"=>15396000, "mem.VmLck"=>0, "mem.VmHWM"=>1208000, "mem.VmRSS"=>1208000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>2416000, "mem.VmLib"=>2328000, "mem.VmPTE"=>68000, "mem.VmSwap"=>0, "fd"=>18}]
```