### PR TITLE
in_lib: filter plugin support (#173)

### DIFF
--- a/plugins/in_lib/in_lib.c
+++ b/plugins/in_lib/in_lib.c
@@ -85,7 +85,10 @@ static int in_lib_collect(struct flb_input_instance *i_ins,
     }
     ctx->buf_len = 0;
 
+    /* Mark the start of a 'buffer write' operation */
+    flb_input_buf_write_start(i_ins);
     ret = msgpack_sbuffer_write(&ctx->i_ins->mp_sbuf, pack, out_size);
+    flb_input_buf_write_end(i_ins);
     flb_free(pack);
 
     flb_pack_state_reset(&ctx->state);


### PR DESCRIPTION
One of #173 

I tested with this code.
https://gist.github.com/nokute78/40529577fffdaa93c0af4dabf75fe933

```
$ bin/hello_world
[0] test: [1486388712, {"key"=>"val 0"}]
[1] test: [1486388712, {"key"=>"val 1"}]
[2] test: [1486388712, {"key"=>"val 2"}]
[3] test: [1486388712, {"key"=>"val 3"}]
[4] test: [1486388712, {"key"=>"val 4"}]
.
.
.
[94] test: [1486388712, {"key"=>"val 94"}]
[95] test: [1486388712, {"key"=>"val 95"}]
[96] test: [1486388712, {"key"=>"val 96"}]
[97] test: [1486388712, {"key"=>"val 97"}]
[98] test: [1486388712, {"key"=>"val 98"}]
[99] test: [1486388712, {"key"=>"val 99"}]
[2017/02/06 22:45:12] [ info] [engine] started
[2017/02/06 22:45:22] [ warn] [engine] service will stop in 5 seconds
[2017/02/06 22:45:27] [ info] [engine] service stopped
```