### PR TITLE
regex: include unistd.h for BSDs and macOS

### DIFF
--- a/include/fluent-bit/flb_regex.h
+++ b/include/fluent-bit/flb_regex.h
@@ -23,6 +23,10 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <onigmo.h>
 
 struct flb_regex {


### PR DESCRIPTION
Travis CI reports that macOS can't compile fluent-bit.
https://travis-ci.org/fluent/fluent-bit/jobs/198991560

It is because there is no definition of `ssize_t` and it is defined with unistd.h or sys/types.h.



