### PR TITLE
log: fix memory leaks in the error case

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -217,7 +217,9 @@ void flb_config_exit(struct flb_config *config)
     flb_worker_exit(config);
 
     /* Event flush */
-    mk_event_del(config->evl, &config->event_flush);
+    if (config->evl) {
+        mk_event_del(config->evl, &config->event_flush);
+    }
     close(config->flush_fd);
 
     /* Release scheduler */
@@ -237,7 +239,9 @@ void flb_config_exit(struct flb_config *config)
     flb_free(config->buffer_path);
 #endif
 
-    mk_event_loop_destroy(config->evl);
+    if (config->evl) {
+        mk_event_loop_destroy(config->evl);
+    }
     flb_free(config);
 }
 

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -95,6 +95,7 @@ flb_ctx_t *flb_create()
     int ret;
     flb_ctx_t *ctx;
     struct flb_config *config;
+    struct flb_log *log;
 
 #ifdef FLB_HAVE_MTRACE
     /* Start tracing malloc and free */
@@ -115,7 +116,11 @@ flb_ctx_t *flb_create()
     ctx->config = config;
 
     /* Initialize logger */
-    flb_log_init(config, FLB_LOG_STDERR, FLB_LOG_INFO, NULL);
+    log = flb_log_init(config, FLB_LOG_STDERR, FLB_LOG_INFO, NULL);
+    if (!log) {
+        flb_free(ctx);
+        return NULL;
+    }
 
     /* Initialize our pipe to send data to our worker */
     ret = flb_pipe_create(config->ch_data);

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -118,6 +118,7 @@ flb_ctx_t *flb_create()
     /* Initialize logger */
     log = flb_log_init(config, FLB_LOG_STDERR, FLB_LOG_INFO, NULL);
     if (!log) {
+        flb_config_exit(ctx->config);
         flb_free(ctx);
         return NULL;
     }
@@ -126,6 +127,7 @@ flb_ctx_t *flb_create()
     ret = flb_pipe_create(config->ch_data);
     if (ret == -1) {
         perror("pipe");
+        flb_config_exit(ctx->config);
         flb_free(ctx);
         return NULL;
     }
@@ -133,6 +135,7 @@ flb_ctx_t *flb_create()
     /* Create the event loop to receive notifications */
     ctx->event_loop = mk_event_loop_create(256);
     if (!ctx->event_loop) {
+        flb_config_exit(ctx->config);
         flb_free(ctx);
         return NULL;
     }
@@ -146,6 +149,7 @@ flb_ctx_t *flb_create()
                                   ctx->event_channel);
     if (ret != 0) {
         flb_error("[lib] could not create notification channels");
+        flb_config_exit(ctx->config);
         flb_destroy(ctx);
         return NULL;
     }

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -253,6 +253,7 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
     if (ret == -1) {
         pthread_mutex_unlock(&pth_mutex);
         mk_event_loop_destroy(log->evl);
+        flb_free(log->worker);
         flb_free(log);
         return NULL;
     }

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -181,6 +181,7 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
     if (!evl) {
         fprintf(stderr, "[log] could not create event loop\n");
         flb_free(log);
+        config->log = NULL;
         return NULL;
     }
 
@@ -194,8 +195,9 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
     ret = flb_pipe_create(log->ch_mng);
     if (ret == -1) {
         fprintf(stderr, "[log] could not create pipe(2)");
+        mk_event_loop_destroy(log->evl);
         flb_free(log);
-        mk_event_loop_destroy(evl);
+        config->log = NULL;
         return NULL;
     }
     MK_EVENT_NEW(&log->event);
@@ -205,8 +207,9 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
                        FLB_LOG_MNG, MK_EVENT_READ, &log->event);
     if (ret == -1) {
         fprintf(stderr, "[log] could not register event\n");
+        mk_event_loop_destroy(log->evl);
         flb_free(log);
-        mk_event_loop_destroy(evl);
+        config->log = NULL;
         return NULL;
     }
 
@@ -218,8 +221,9 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
     worker = flb_malloc(sizeof(struct flb_worker));
     if (!worker) {
         flb_errno();
+        mk_event_loop_destroy(log->evl);
         flb_free(log);
-        mk_event_loop_destroy(evl);
+        config->log = NULL;
         return NULL;
     }
     worker->func   = NULL;
@@ -232,8 +236,9 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
     ret = flb_log_worker_init(worker);
     if (ret == -1) {
         flb_errno();
+        mk_event_loop_destroy(log->evl);
         flb_free(log);
-        mk_event_loop_destroy(evl);
+        config->log = NULL;
         flb_free(worker);
         return NULL;
     }
@@ -255,6 +260,7 @@ struct flb_log *flb_log_init(struct flb_config *config, int type,
         mk_event_loop_destroy(log->evl);
         flb_free(log->worker);
         flb_free(log);
+        config->log = NULL;
         return NULL;
     }
 


### PR DESCRIPTION
Hi, I found small issues about initializing and try to fix them.
I added changes below;
- NULL checking for flb_log_init()
- free pointer if flb_worker_create() is failed

Could you review it?