### PR TITLE
include: add FLB_INLINE to implemented functions

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -339,7 +339,7 @@ struct flb_libco_in_params {
 
 struct flb_libco_in_params libco_in_param;
 
-static void input_params_set(struct flb_thread *th,
+static FLB_INLINE void input_params_set(struct flb_thread *th,
                              struct flb_input_collector *coll,
                              struct flb_config *config,
                              void *context)
@@ -351,7 +351,7 @@ static void input_params_set(struct flb_thread *th,
     co_switch(th->callee);
 }
 
-static void input_pre_cb_collect()
+static FLB_INLINE void input_pre_cb_collect()
 {
     struct flb_input_collector *coll = libco_in_param.coll;
     struct flb_config *config = libco_in_param.config;

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -226,7 +226,7 @@ static FLB_INLINE int flb_output_thread_destroy_id(int id, struct flb_task *task
 }
 
 /* When an output_thread is going to be destroyed, this callback is triggered */
-static void cb_output_thread_destroy(void *data)
+static FLB_INLINE void cb_output_thread_destroy(void *data)
 {
     struct flb_output_thread *out_th;
 
@@ -311,7 +311,7 @@ struct flb_libco_out_params {
 
 struct flb_libco_out_params libco_param;
 
-static void output_params_set(struct flb_thread *th,
+static FLB_INLINE void output_params_set(struct flb_thread *th,
                               void *data, size_t bytes,
                               char *tag, int tag_len,
                               struct flb_input_instance *i_ins,
@@ -332,7 +332,7 @@ static void output_params_set(struct flb_thread *th,
     co_switch(th->callee);
 }
 
-static void output_pre_cb_flush()
+static FLB_INLINE void output_pre_cb_flush()
 {
     void *data   = libco_param.data;
     size_t bytes = libco_param.bytes;

--- a/include/fluent-bit/flb_plugins.h.in
+++ b/include/fluent-bit/flb_plugins.h.in
@@ -30,7 +30,7 @@
 @FLB_OUT_PLUGINS_DECL@
 @FLB_FILTER_PLUGINS_DECL@
 
-void flb_register_plugins(struct flb_config *config)
+void FLB_INLINE flb_register_plugins(struct flb_config *config)
 {
     struct flb_input_plugin *in;
     struct flb_output_plugin *out;

--- a/include/fluent-bit/flb_thread_libco.h
+++ b/include/fluent-bit/flb_thread_libco.h
@@ -103,7 +103,7 @@ static FLB_INLINE void flb_thread_resume(struct flb_thread *th)
     co_switch(th->callee);
 }
 
-static struct flb_thread *flb_thread_new(size_t data_size,
+static FLB_INLINE struct flb_thread *flb_thread_new(size_t data_size,
                                          void (*cb_destroy) (void *))
 
 {

--- a/include/fluent-bit/flb_thread_pthreads.h
+++ b/include/fluent-bit/flb_thread_pthreads.h
@@ -82,7 +82,7 @@ static FLB_INLINE void flb_thread_prepare()
 {
 }
 
-static struct flb_thread *flb_thread_new()
+static FLB_INLINE struct flb_thread *flb_thread_new()
 {
     struct flb_thread *th;
 

--- a/include/fluent-bit/flb_thread_ucontext.h
+++ b/include/fluent-bit/flb_thread_ucontext.h
@@ -103,7 +103,7 @@ static FLB_INLINE void flb_thread_resume(struct flb_thread *th)
     swapcontext(&th->caller, &th->callee);
 }
 
-static struct flb_thread *flb_thread_new(size_t data_size,
+static FLB_INLINE struct flb_thread *flb_thread_new(size_t data_size,
                                          void (*cb_destroy) (void *))
 
 {


### PR DESCRIPTION
To fix #190 

I fixed NON-inline functions which are implemented header.
If the header is included, the function is implemented at a file and libfluent-bit.so and they are conflicted.