### PR TITLE
tests: fix fails of test for in_proc plugin

### DIFF
--- a/tests/flb_test_in_proc.cpp
+++ b/tests/flb_test_in_proc.cpp
@@ -96,54 +96,8 @@ TEST(Inputs, absent_process) {
     int out_ffd;
 
     /* initialize */
-    ret = pthread_mutex_init(&result_mutex, NULL);
     result = 0;
     EXPECT_EQ(ret, 0);
-
-    ctx = flb_create();
-
-    in_ffd = flb_input(ctx, (char *) "proc", NULL);
-    EXPECT_TRUE(in_ffd >= 0);
-    flb_input_set(ctx, in_ffd, "tag", "test",
-                  "interval_sec", "1", "proc_name", " ",
-                  "alert", "true", "mem", "on", "fd", "on", NULL);
-
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
-    EXPECT_TRUE(out_ffd >= 0);
-    flb_output_set(ctx, out_ffd, "match", "test", NULL);
-
-    flb_service_set(ctx, "Flush", "2", NULL);
-
-    ret = flb_start(ctx);
-    EXPECT_EQ(ret, 0);
-
-    /* start test */
-    pthread_mutex_lock(&result_mutex);
-    ret = result; /* No data should be flushed */
-    pthread_mutex_unlock(&result_mutex);
-    EXPECT_EQ(ret, 0);
-
-    sleep(2);
-    pthread_mutex_lock(&result_mutex);
-    ret = result; /* 2sec passed, data should be flushed */
-    result = 0;   /* clear flag */
-    pthread_mutex_unlock(&result_mutex);
-    EXPECT_EQ(ret, 1);
-
-    /* finalize */
-    flb_stop(ctx);
-    flb_destroy(ctx);
-
-    ret = pthread_mutex_destroy(&result_mutex);
-    EXPECT_EQ(ret, 0);
-}
-
-TEST(Inputs, illegal_parameters) {
-
-    int           ret    = 0;
-    flb_ctx_t    *ctx    = NULL;
-    int in_ffd;
-    int out_ffd;
 
     ctx = flb_create();
 

--- a/tests/flb_test_in_proc.cpp
+++ b/tests/flb_test_in_proc.cpp
@@ -55,7 +55,7 @@ TEST(Inputs, selfcheck)
     EXPECT_TRUE(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test",
                   "interval_sec", "1", "proc_name", "flb_test_in_proc",
-                  "alert", "true",NULL);
+                  "alert", "true", "mem", "on", "fd", "on", NULL);
 
     out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
     EXPECT_TRUE(out_ffd >= 0);
@@ -105,8 +105,8 @@ TEST(Inputs, absent_process) {
     in_ffd = flb_input(ctx, (char *) "proc", NULL);
     EXPECT_TRUE(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test",
-                  "interval_sec", "1", "proc_name", "",
-                  "alert", "true",NULL);
+                  "interval_sec", "1", "proc_name", " ",
+                  "alert", "true", "mem", "on", "fd", "on", NULL);
 
     out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
     EXPECT_TRUE(out_ffd >= 0);
@@ -136,4 +136,32 @@ TEST(Inputs, absent_process) {
 
     ret = pthread_mutex_destroy(&result_mutex);
     EXPECT_EQ(ret, 0);
+}
+
+TEST(Inputs, illegal_parameters) {
+
+    int           ret    = 0;
+    flb_ctx_t    *ctx    = NULL;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "proc", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test",
+                  "interval_sec", "1", "proc_name", "",
+                  "alert", "true", "mem", "on", "fd", "on", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    flb_service_set(ctx, "Flush", "2", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0); // error occurs but return value is true
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
 }


### PR DESCRIPTION
Hi, I found an small issue about test failure for in_proc plugin.

The root cause was;
- No considered NULL checking for property "proc_name"

Could you review it?