### PR TITLE
in_tail: add new option 'path_key" to append a filepath to each record

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -90,6 +90,13 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
         }
     }
 
+    ctx->add_path_field = FLB_FALSE;
+    /* Config: determine whether appending or not */
+    tmp = flb_input_get_property("add_path_field", i_ins);
+    if (tmp && (strcasecmp(tmp, "true") == 0 || strcasecmp(tmp, "on") == 0) ) {
+        ctx->add_path_field = FLB_TRUE;
+    }
+
 #ifdef FLB_HAVE_REGEX
     /* Parser / Format */
     tmp = flb_input_get_property("parser", i_ins);

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_macros.h>
 
 struct flb_tail_config {
     int fd_notify;             /* inotify fd               */
@@ -43,6 +44,7 @@ struct flb_tail_config {
     int rotate_wait;           /* sec to wait on rotated files */
     char *path;                /* lookup path (glob)           */
     char *exclude_path;        /* exclude path                 */
+    char add_path_field;       /* add path field to record     */
 
     /* Database */
     struct flb_sqldb *db;

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -161,26 +161,20 @@ static int append_record_to_map(char **data, size_t *data_size,
     msgpack_packer_init(&pck, sbuf, msgpack_sbuffer_write);
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, *data, *data_size, &off)) {
-        root = result.data;
-        ret = unpack_and_pack(&pck, &root, &first_map,
-                              key, key_len, val, val_len);
-        if (ret < 0) {
-            /* fail! */
-            break;
-        }
-        first_map = FLB_TRUE;
+    msgpack_unpack_next(&result, *data, *data_size, &off);
+    root = result.data;
+    ret = unpack_and_pack(&pck, &root, &first_map,
+                          key, key_len, val, val_len);
+    if (ret < 0) {
+        /* fail! */
+        msgpack_sbuffer_free(sbuf);
     }
-
-    if (ret >= 0) {
+    else {
         /* success !*/
         flb_free(*data);
-
-        *data = (char*)flb_malloc(sbuf->size);
-        memcpy(*data, sbuf->data, sbuf->size);
+        *data      = sbuf->data;
         *data_size = sbuf->size;
     }
-    msgpack_sbuffer_free(sbuf);
 
     return 0;
 }

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -39,6 +39,7 @@ static inline void consume_bytes(char *buf, int bytes, int length)
 }
 
 static inline void generate_record_body(struct flb_tail_config *ctx,
+                                        struct flb_tail_file *file,
                                         msgpack_packer *mp_pck,
                                         char *line, int line_len)
 {
@@ -46,7 +47,7 @@ static inline void generate_record_body(struct flb_tail_config *ctx,
     int path_len = 0;
     if (ctx->add_path_field) {
         map_num++;
-        path_len = strlen(ctx->path);
+        path_len = strlen(file->name);
     }
 
     msgpack_pack_map(mp_pck, map_num);
@@ -54,7 +55,7 @@ static inline void generate_record_body(struct flb_tail_config *ctx,
         msgpack_pack_str(mp_pck, 4);
         msgpack_pack_str_body(mp_pck, "path", 4);
         msgpack_pack_str(mp_pck, path_len);
-        msgpack_pack_str_body(mp_pck, ctx->path, path_len);
+        msgpack_pack_str_body(mp_pck, file->name, path_len);
     }
 
     msgpack_pack_str(mp_pck, 3);
@@ -74,7 +75,7 @@ static inline int pack_line(time_t time, char *line,
         msgpack_sbuffer_init(&mp_sbuf);
         msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-        generate_record_body(ctx, &mp_pck, line, line_len);
+        generate_record_body(ctx, file, &mp_pck, line, line_len);
 
         flb_input_dyntag_append_raw(ctx->i_ins,
                                     file->tag_buf,
@@ -88,7 +89,7 @@ static inline int pack_line(time_t time, char *line,
         msgpack_pack_array(&ctx->i_ins->mp_pck, 2);
         msgpack_pack_uint64(&ctx->i_ins->mp_pck, time);
 
-        generate_record_body(ctx, &ctx->i_ins->mp_pck, line, line_len);
+        generate_record_body(ctx, file, &ctx->i_ins->mp_pck, line, line_len);
     }
 
     return 0;


### PR DESCRIPTION
I added a new option "add_path_field" to in_tail plugin. (see also #206)
If it is true, in_tail appends a file path to each record.

## example 

This is a case to read 3 files.
```
[taka@localhost build]$ cat sample/a.txt 
aaa
[taka@localhost build]$ cat sample/b.txt 
bbb
[taka@localhost build]$ cat sample/c.txt 
ccc
ddd
```

So, the command is 
```
$ fluent-bit -i tail -p 'path=sample/*.txt' -p add_path_field=true -o stdout
```

Result is 
```
$ bin/fluent-bit -i tail -p 'path=sample/*.txt' -p add_path_field=true -o stdout
Fluent-Bit v0.11.0
Copyright (C) Treasure Data

[2017/03/04 21:34:28] [ info] [engine] started
[0] tail.0: [1488630868, {"path"=>"sample/a.txt", "log"=>"aaa"}]
[1] tail.0: [1488630868, {"path"=>"sample/b.txt", "log"=>"bbb"}]
[2] tail.0: [1488630868, {"path"=>"sample/c.txt", "log"=>"ccc"}]
[3] tail.0: [1488630868, {"path"=>"sample/c.txt", "log"=>"ddd"}]
^C[engine] caught signal
```