### PR TITLE
out_counter: nanosecond support

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -21,6 +21,7 @@
 #define FLB_TIME_H
 
 #include <time.h>
+#include <msgpack.h>
 struct flb_time {
     struct timespec tm;
 };
@@ -44,10 +45,11 @@ enum flb_time_eventtime_fmt {
     FLB_TIME_ETFMT_OTHER,
 };
 
+int flb_time_get(struct flb_time *tm);
 double flb_time_to_double(struct flb_time *tm);
 int flb_time_diff(struct flb_time *time1,
-                  struct flb_time *time0,struct flb_time *result);
-int flb_time_append_to_msgpack(struct flb_time *time, msgpack_packer *pk, int fmt);
+                  struct flb_time *time0, struct flb_time *result);
+int flb_time_append_to_msgpack(struct flb_time *tm, msgpack_packer *pk, int fmt);
 int flb_time_pop_from_msgpack(struct flb_time *time, msgpack_unpacked *upk,
                               msgpack_object **map);
 

--- a/plugins/out_counter/counter.c
+++ b/plugins/out_counter/counter.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-
+#include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_output.h>
 
 int cb_counter_init(struct flb_output_instance *ins,
@@ -50,6 +50,7 @@ void cb_counter_flush(void *data, size_t bytes,
 
     msgpack_unpacked result;
     size_t off = 0, cnt = 0;
+    struct flb_time tm;
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off)) {
@@ -57,8 +58,8 @@ void cb_counter_flush(void *data, size_t bytes,
     }
     msgpack_unpacked_destroy(&result);
 
-    time_t t = time(NULL);
-    printf("%lu,%lu\n", t, cnt);
+    flb_time_get(&tm);
+    printf("%f,%lu\n", flb_time_to_double(&tm), cnt);
 
     FLB_OUTPUT_RETURN(FLB_OK);
 }

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -50,6 +50,16 @@ static int _flb_time_get(struct flb_time *tm)
 #endif
 }
 
+int flb_time_get(struct flb_time *tm)
+{
+    return _flb_time_get(tm);
+}
+
+double flb_time_to_double(struct flb_time *tm)
+{
+    return (double)(tm->tm.tv_sec) + ((double)tm->tm.tv_nsec/(double)ONESEC_IN_NSEC);
+}
+
 int flb_time_diff(struct flb_time *time1,
                   struct flb_time *time0,struct flb_time *result)
 {


### PR DESCRIPTION
This is a Step2 to support nanosecond.(#193)

I updated out_counter to support nanosecond.
I also added new timer API.
* to convert double from flb_time.
* to get current flb_time.