### PR TITLE
tests: fix the test ends before flushing

### DIFF
--- a/tests/flb_test_file.cpp
+++ b/tests/flb_test_file.cpp
@@ -88,6 +88,8 @@ TEST(Outputs, json_long) {
         total++;
     }
 
+    sleep(1); /* waiting flush */
+
     flb_stop(ctx);
     flb_destroy(ctx);
 
@@ -132,6 +134,8 @@ TEST(Outputs, json_small) {
         EXPECT_EQ(bytes, 1);
         total++;
     }
+
+    sleep(1); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
Hi, I found a small issue about test failure for out_file plugin.

The root cause was;
- sometimes the test ends before flushing

Could you review it?