### PR TITLE
filter_record_modifier: add new plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ option(FLB_OUT_FLOWCOUNTER "Enable flowcount output plugin"     Yes)
 option(FLB_FILTER_GREP     "Enable grep filter"                 Yes)
 option(FLB_FILTER_STDOUT   "Enable stdout filter"               Yes)
 option(FLB_FILTER_KUBERNETES "Enable kubernetes filter"         Yes)
+option(FLB_FILTER_RECORD_MODIFIER "Enable record_modifier filter" Yes)
 
 # Enable all features
 if(FLB_ALL)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -141,6 +141,7 @@ REGISTER_FILTER_PLUGIN("filter_stdout")
 if(FLB_REGEX)
   REGISTER_FILTER_PLUGIN("filter_kubernetes")
 endif()
+REGISTER_FILTER_PLUGIN("filter_record_modifier")
 
 # Register external input and output plugins
 if(EXT_IN_PLUGINS)

--- a/plugins/filter_record_modifier/CMakeLists.txt
+++ b/plugins/filter_record_modifier/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  filter_modifier.c)
+
+FLB_PLUGIN(filter_record_modifier "${src}" "")

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -1,0 +1,323 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2017 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_time.h>
+
+#include <msgpack.h>
+#include "filter_modifier.h"
+
+#define PLUGIN_NAME "filter_record_modifier"
+
+static int configure(struct record_modifier_ctx *ctx,
+                     struct flb_filter_instance *f_ins)
+{
+    struct mk_list *head = NULL;
+    struct mk_list *split;
+    struct flb_config_prop *prop = NULL;
+    struct modifier_key    *mod_key;
+    struct modifier_record *mod_record;
+    struct flb_split_entry *sentry;
+
+    ctx->records_num = 0;
+    ctx->remove_keys_num = 0;
+    ctx->whitelist_keys_num = 0;
+
+    /* Iterate all filter properties */
+    mk_list_foreach(head, &f_ins->properties) {
+        prop = mk_list_entry(head, struct flb_config_prop, _head);
+
+        if (!strcasecmp(prop->key, "remove_key")) {
+            mod_key = flb_malloc(sizeof(struct modifier_key));
+            mod_key->key     = prop->val;
+            mod_key->key_len = strlen(prop->val);
+            mk_list_add(&mod_key->_head, &ctx->remove_keys);
+            ctx->remove_keys_num++;
+        }
+        else if (!strcasecmp(prop->key, "whitelist_key")) {
+            mod_key = flb_malloc(sizeof(struct modifier_key));
+            mod_key->key     = prop->val;
+            mod_key->key_len = strlen(prop->val);
+            mk_list_add(&mod_key->_head, &ctx->whitelist_keys);
+            ctx->whitelist_keys_num++;
+        }
+        else if (!strcasecmp(prop->key, "record")) {
+            mod_record = flb_malloc(sizeof(struct modifier_record));
+            split = flb_utils_split(prop->val, ' ', 1);
+            if (mk_list_size(split) != 2) {
+                flb_error("[%s] invalid record parameters",PLUGIN_NAME);
+                free(mod_record);
+                continue;
+            }
+            /* Get first value (field) */
+            sentry = mk_list_entry_first(split, struct flb_split_entry, _head);
+            mod_record->key = flb_strndup(sentry->value, sentry->len);
+            mod_record->key_len = sentry->len;
+
+            sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
+            mod_record->val = flb_strndup(sentry->value, sentry->len);
+            mod_record->val_len = sentry->len;
+            
+            flb_utils_split_free(split);
+            mk_list_add(&mod_record->_head, &ctx->records);
+            ctx->records_num++;
+        }
+    }
+
+    if (ctx->remove_keys_num > 0 && ctx->whitelist_keys_num > 0) {
+        flb_error("remove_keys and whitelist_keys are exclusive with each other.");
+        return -1;
+    }
+    return 0;
+}
+
+static int delete_list(struct record_modifier_ctx *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct modifier_key *key;
+    struct modifier_record *record;
+
+    mk_list_foreach_safe(head, tmp, &ctx->remove_keys) {
+        key = mk_list_entry(head, struct modifier_key,  _head);
+        mk_list_del(&key->_head);
+        free(key);
+    }
+    mk_list_foreach_safe(head, tmp, &ctx->whitelist_keys) {
+        key = mk_list_entry(head, struct modifier_key,  _head);
+        mk_list_del(&key->_head);
+        free(key);
+    }
+    mk_list_foreach_safe(head, tmp, &ctx->records) {
+        record = mk_list_entry(head, struct modifier_record,  _head);
+        free(record->key);
+        free(record->val);
+        mk_list_del(&record->_head);
+        free(record);
+    }
+
+    return 0;
+}
+
+
+static int cb_modifier_init(struct flb_filter_instance *f_ins,
+                        struct flb_config *config,
+                        void *data)
+{
+    struct record_modifier_ctx *ctx = NULL;
+
+    /* Create context */
+    ctx = flb_malloc(sizeof(struct record_modifier_ctx));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+    mk_list_init(&ctx->records);
+    mk_list_init(&ctx->remove_keys);
+    mk_list_init(&ctx->whitelist_keys);
+
+    if ( configure(ctx, f_ins) < 0 ){
+        delete_list(ctx);
+        return -1;
+    }
+
+    flb_filter_set_context(f_ins, ctx);
+
+    return 0;
+}
+
+static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
+                         char *bool_map, int map_num)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct mk_list *check = NULL;
+    msgpack_object_kv *kv;
+    struct modifier_key *mod_key;
+
+    char result;
+    char is_to_delete;
+    msgpack_object *key;
+    int ret = map_num;
+    int i;
+
+    for (i=0; i<map_num; i++) {
+        bool_map[i] = 1;              
+    }
+    bool_map[map_num] = -1;/* tail of map */
+
+    if (ctx->remove_keys_num > 0) {
+        check = &(ctx->remove_keys);
+        is_to_delete = FLB_TRUE;
+    }
+    else if(ctx->whitelist_keys_num > 0) {
+        check = &(ctx->whitelist_keys);
+        is_to_delete = FLB_FALSE;
+    }
+
+    if (check != NULL){
+        kv = map->via.map.ptr;
+        for(i=0; i<map_num; i++){
+            key = &(kv+i)->key;
+            result = FLB_FALSE;
+            
+            mk_list_foreach_safe(head, tmp, check) {
+                mod_key = mk_list_entry(head, struct modifier_key,  _head);
+                if (key->via.bin.size != mod_key->key_len &&
+                    key->via.str.size != mod_key->key_len) {
+                    continue;
+                }
+                if ((key->type == MSGPACK_OBJECT_BIN &&
+                     !strncasecmp(key->via.bin.ptr, mod_key->key,
+                                 mod_key->key_len)) || 
+                    (key->type == MSGPACK_OBJECT_STR &&
+                     !strncasecmp(key->via.str.ptr, mod_key->key,
+                                 mod_key->key_len))
+                    ) {
+                    result = FLB_TRUE;
+                    break;
+                }
+            }
+            if (result == is_to_delete) {
+                bool_map[i] = 0;
+                ret--;
+            }
+        }
+    }
+
+    return ret;
+}
+
+static int cb_modifier_filter(void *data, size_t bytes,
+                          char *tag, int tag_len,
+                          void **out_buf, size_t *out_size,
+                          struct flb_filter_instance *f_ins,
+                          void *context,
+                          struct flb_config *config)
+{
+    struct record_modifier_ctx *ctx = context;
+    char is_modified = FLB_FALSE;
+    size_t off = 0;
+    int i;
+    int ret;
+    int removed_map_num  = 0;
+    int map_num          = 0;
+    char bool_map[128];
+    (void) f_ins;
+    (void) config;
+    struct flb_time tm;
+    struct modifier_record *mod_rec;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    msgpack_unpacked result;
+    msgpack_object  *obj;
+    msgpack_object_kv *kv;
+    struct mk_list *tmp;
+    struct mk_list *head;
+
+    /* Create temporal msgpack buffer */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+    /* Iterate each item to know map number */
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+        map_num = 0;
+        removed_map_num = 0;
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+
+        flb_time_pop_from_msgpack(&tm, &result, &obj);
+
+        /* grep keys */
+        if (obj->type == MSGPACK_OBJECT_MAP) {
+            removed_map_num = make_bool_map(ctx, obj,
+                                            bool_map, obj->via.map.size);
+        } else {
+            continue;
+        }
+
+        if (removed_map_num != map_num) {
+            is_modified = FLB_TRUE;
+        }
+
+        removed_map_num += ctx->records_num;
+        msgpack_pack_array(&tmp_pck, 2);
+        flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
+
+        msgpack_pack_map(&tmp_pck, removed_map_num);
+        kv = obj->via.map.ptr;
+        for(i=0; bool_map[i] >= 0; i++) {
+            if (bool_map[i]) {
+                ret = msgpack_pack_object(&tmp_pck, (kv+i)->key);
+                ret = msgpack_pack_object(&tmp_pck, (kv+i)->val);
+            }
+        }
+
+        /* append record */
+        if (ctx->records_num > 0) {
+            is_modified = FLB_TRUE;
+            mk_list_foreach_safe(head, tmp, &ctx->records) {
+                mod_rec = mk_list_entry(head, struct modifier_record,  _head);
+                msgpack_pack_str(&tmp_pck, mod_rec->key_len);
+                msgpack_pack_str_body(&tmp_pck,
+                                      mod_rec->key, mod_rec->key_len);
+                msgpack_pack_str(&tmp_pck, mod_rec->val_len);
+                msgpack_pack_str_body(&tmp_pck,
+                                      mod_rec->val, mod_rec->val_len);
+            }
+        }
+    }
+    msgpack_unpacked_destroy(&result);
+
+    if (is_modified != FLB_TRUE) {
+        /* Destroy the buffer to avoid more overhead */
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return FLB_FILTER_NOTOUCH;
+    }
+
+    /* link new buffers */
+    *out_buf  = tmp_sbuf.data;
+    *out_size = tmp_sbuf.size;
+    return FLB_FILTER_MODIFIED;
+}
+
+static int cb_modifier_exit(void *data, struct flb_config *config)
+{
+    struct record_modifier_ctx *ctx = data;
+
+    delete_list(ctx);
+
+    free(ctx);
+    return 0;
+}
+
+struct flb_filter_plugin filter_record_modifier_plugin = {
+    .name         = "record_modifier",
+    .description  = "modify record",
+    .cb_init      = cb_modifier_init,
+    .cb_filter    = cb_modifier_filter,
+    .cb_exit      = cb_modifier_exit,
+    .flags        = 0
+};

--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -1,0 +1,47 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2017 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FILTER_RECORD_MODIFIER_H
+#define FLB_FILTER_RECORD_MODIFIER_H
+
+struct modifier_record {
+    char *key;
+    char *val;
+    int  key_len;
+    int  val_len;
+    struct mk_list _head;
+};
+
+struct modifier_key {
+    char *key;
+    int   key_len;
+    struct mk_list _head;
+};
+
+struct record_modifier_ctx {
+    int records_num;
+    int remove_keys_num;
+    int whitelist_keys_num;
+    struct mk_list records;
+    struct mk_list remove_keys;
+    struct mk_list whitelist_keys;
+};
+
+
+#endif /* FLB_FILTER_RECORD_MODIFIER_H */


### PR DESCRIPTION
I added new filter plugin "filter_record_modifier".
It is based on https://github.com/repeatedly/fluent-plugin-record-modifier.

This plugin is to filter and append key-value pair.
It supports
* remove_key (if matched, removed the key-val)
* whitelist_key (if NOT matched, removed the key-val)
* record (append the record)

## example

This is a example to edit a record from in_mem.
The original format is
```
{"Mem.total"=>1016024, "Mem.used"=>758792, "Mem.free"=>257232, "Swap.total"=>2064380, "Swap.used"=>7780, "Swap.free"=>2056600}
```

### using remove_key

To remove "Mem.total" with removed_key, we can set the property like this.
```
[INPUT]
    Name mem
    Tag  cpu.local

[OUTPUT]
    Name  stdout
    Match *
[FILTER]
    Name record_modifier
    Match *
    remove_key Mem.total
```

And output is (Mem.total is removed!)
```
$ bin/fluent-bit -c fluent-bit.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/04/12 23:12:53] [ info] [engine] started
[0] cpu.local: [1492006374.000000000, {"Mem.used"=>770960, "Mem.free"=>245064, "Swap.total"=>2064380, "Swap.used"=>7780, "Swap.free"=>2056600}]
[1] cpu.local: [1492006375.000000000, {"Mem.used"=>770960, "Mem.free"=>245064, "Swap.total"=>2064380, "Swap.used"=>7780, "Swap.free"=>2056600}]
```

### using whitelist_key

This is a example of whitelist_key.
```
[INPUT]
    Name mem
    Tag  cpu.local

[OUTPUT]
    Name  stdout
    Match *
[FILTER]
    Name record_modifier
    Match *
    whitelist_key Mem.total
```

And output is (only Mem.total is wrote.)
```
$ bin/fluent-bit -c fluent-bit.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/04/12 23:15:34] [ info] [engine] started
[0] cpu.local: [1492006535.000000000, {"Mem.total"=>1016024}]
[1] cpu.local: [1492006536.000000000, {"Mem.total"=>1016024}]
```

### append record

This is a example of record.

```
[INPUT]
    Name mem
    Tag  cpu.local

[OUTPUT]
    Name  stdout
    Match *
[FILTER]
    Name record_modifier
    Match *
    record host ${HOSTNAME}
    record aa cc
```
And output is (two k-v is appended the tail of record.)
```
$ export HOSTNAME=`hostname`
$ bin/fluent-bit -c fluent-bit.conf
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/04/12 23:21:03] [ info] [engine] started
[0] cpu.local: [1492006864.000000000, {"Mem.total"=>1016024, "Mem.used"=>759644, "Mem.free"=>256380, "Swap.total"=>2064380, "Swap.used"=>7780, "Swap.free"=>2056600, "host"=>"localhost.localdomain", "aa"=>"cc"}]
[1] cpu.local: [1492006865.000000000, {"Mem.total"=>1016024, "Mem.used"=>759644, "Mem.free"=>256380, "Swap.total"=>2064380, "Swap.used"=>7780, "Swap.free"=>2056600, "host"=>"localhost.localdomain", "aa"=>"cc"}]

```