### PR TITLE
filter_stdout: nanosecond support(#193)

### DIFF
--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -21,6 +21,7 @@
 
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_time.h>
 
 #include <msgpack.h>
 
@@ -49,12 +50,16 @@ static int cb_stdout_filter(void *data, size_t bytes,
     (void) f_ins;
     (void) filter_context;
     (void) config;
+    struct flb_time tmp;
+    msgpack_object *p;
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off)) {
-        printf("[%zd] %s: ", cnt++, tag);
-        msgpack_object_print(stdout, result.data);
-        printf("\n");
+        printf("[%zd] %s: [", cnt++, tag);
+        flb_time_pop_from_msgpack(&tmp, &result, &p);
+        printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
+        msgpack_object_print(stdout, *p);
+        printf("]\n");
     }
     msgpack_unpacked_destroy(&result);
 


### PR DESCRIPTION
This PR is to support nanosecond for filter_stdout.

This is a sample output.
```
$ bin/fluent-bit -i random -o stdout -F stdout -m '*'
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/04/17 21:27:44] [ info] [engine] started
[0] random.0: [1492432065.000872449, {"rand_value"=>18018567782972291650}]
[0] random.0: [1492432066.000194421, {"rand_value"=>4834213566149347330}]
[0] random.0: [1492432067.000505875, {"rand_value"=>18194037506161953329}]
[0] random.0: [1492432068.000892927, {"rand_value"=>10508887116319800125}]
[0] random.0: [1492432065.000872449, {"rand_value"=>18018567782972291650}]
[1] random.0: [1492432066.000194421, {"rand_value"=>4834213566149347330}]
[2] random.0: [1492432067.000505875, {"rand_value"=>18194037506161953329}]
[3] random.0: [1492432068.000892927, {"rand_value"=>10508887116319800125}]
```