### PR TITLE
Syslog compatibility

### DIFF
--- a/conf/in_syslog.conf
+++ b/conf/in_syslog.conf
@@ -1,0 +1,57 @@
+[SERVICE]
+    # Flush
+    # =====
+    # Set an interval of seconds before to flush records to a destination
+    Flush        5
+
+    # Daemon
+    # ======
+    # Instruct Fluent Bit to run in foreground or background mode.
+    Daemon       Off
+
+    # Log_Level
+    # =========
+    # Set the verbosity level of the service, values can be:
+    #
+    # - error
+    # - warning
+    # - info
+    # - debug
+    # - trace
+    #
+    # By default 'info' is set, that means it includes 'error' and 'warning'.
+    #Log_Level    info
+
+# Head Input
+# ==========
+[INPUT]
+    Name syslog
+
+    # Path
+    # ====
+    # socket path. e.g. /dev/log (required)
+    #
+    Path    /dev/log
+
+    # Mode
+    # =====
+    Mode 0666
+
+    # Chunk Size
+    # ====
+    # . Default: 32KB
+    Chunk_size 32
+
+    # Buffer Size
+    # ====
+    # Buffer size. Default: 32KB
+    Buffer_size 32
+
+    # Parser
+    # ====
+    # Parser. Default: syslog
+    Parser syslog-socket
+
+[OUTPUT]
+    Name  stdout
+    Match syslog.*

--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -52,3 +52,11 @@
     Time_Key    time
     Time_Format %b %d %H:%M:%S
     Time_Keep   On
+
+[PARSER]
+    Name        syslog-socket
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+    Time_Keep   On

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -31,6 +31,7 @@ struct flb_syslog {
     /* Unix socket */
     int server_fd;
     char *unix_path;
+    mode_t mode;
 
     /* Buffers setup */
     size_t buffer_size;

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -82,6 +82,15 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
         return NULL;
     }
 
+    /* Socket mode */
+    tmp = flb_input_get_property("mode", i_ins);
+    if (tmp) {
+        ctx->mode = strtol(tmp, NULL, 8);
+    }
+    else {
+        ctx->mode = FLB_SYSLOG_MODE;
+    }
+
     return ctx;
 }
 

--- a/plugins/in_syslog/syslog_conf.h
+++ b/plugins/in_syslog/syslog_conf.h
@@ -22,8 +22,11 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
+#include <sys/stat.h>
 
 #include "syslog.h"
+
+#define FLB_SYSLOG_MODE S_IRWXU
 
 struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
                                       struct flb_config *config);

--- a/plugins/in_syslog/syslog_unix.c
+++ b/plugins/in_syslog/syslog_unix.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <sys/stat.h>
 
 #include "syslog.h"
 
@@ -37,10 +38,18 @@ int syslog_unix_create(struct flb_syslog *ctx)
     size_t address_length;
     struct sockaddr_un address;
 
+    umask(0);
+
     /* Create listening socket */
     fd = flb_net_socket_create(PF_UNIX, FLB_FALSE);
     if (fd == -1) {
       return -1;
+    }
+
+    if (fchmod(fd, ctx->mode) != 0) {
+        flb_errno();
+        close(fd);
+        return -1;
     }
 
     unlink(ctx->unix_path);


### PR DESCRIPTION
C syslog function is not guaranteed to create a message terminated by newline. Reproducible with glibc 2.12, may affect other versions.

Support for setting socket file mode for /dev/log support out of the box.

Added socket specific syslog parser as the system syslog function (sending to /dev/log) message format does not include host. RFC formats only apply to remote connections AFAIK.