### PR TITLE
out_file: support csv format

### DIFF
--- a/plugins/out_file/file.h
+++ b/plugins/out_file/file.h
@@ -20,4 +20,10 @@
 #ifndef FLB_OUT_FILE
 #define FLB_OUT_FILE
 
+enum {
+    FLB_OUT_FILE_FMT_JSON,
+    FLB_OUT_FILE_FMT_CSV,
+    FLB_OUT_FILE_FMT_OTHER,
+};
+
 #endif


### PR DESCRIPTION
This PR is to support csv output file format.

I added new properties "format" and "delimiter".

## example 

configuration file is
```python
[INPUT]
    Name mem
    Tag  mem.usage

[OUTPUT]
    Name file
    Match *
    Path  mem.csv

    Format csv
    #Delimiter \t

# filter_stdout to expose streaming data
[FILTER]
    Name stdout
    Match *
```

```sh
$ bin/fluent-bit -c file.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/04/21 23:16:16] [ info] [engine] started
[0] mem.usage: [1492784177.002298028, {"Mem.total"=>3920464, "Mem.used"=>2001032, "Mem.free"=>1919432, "Swap.total"=>2064380, "Swap.used"=>0, "Swap.free"=>2064380}]
[0] mem.usage: [1492784178.000651208, {"Mem.total"=>3920464, "Mem.used"=>2001204, "Mem.free"=>1919260, "Swap.total"=>2064380, "Swap.used"=>0, "Swap.free"=>2064380}]
[0] mem.usage: [1492784179.001232752, {"Mem.total"=>3920464, "Mem.used"=>2001188, "Mem.free"=>1919276, "Swap.total"=>2064380, "Swap.used"=>0, "Swap.free"=>2064380}]
[0] mem.usage: [1492784180.003776752, {"Mem.total"=>3920464, "Mem.used"=>2001188, "Mem.free"=>1919276, "Swap.total"=>2064380, "Swap.used"=>0, "Swap.free"=>2064380}]
[0] mem.usage: [1492784181.001713812, {"Mem.total"=>3920464, "Mem.used"=>2001328, "Mem.free"=>1919136, "Swap.total"=>2064380, "Swap.used"=>0, "Swap.free"=>2064380}]
^C[engine] caught signal
```

The file is written like this.
```
$ cat mem.csv 
1492784177.002298,3920464,2001032,1919432,2064380,0,2064380
1492784178.000651,3920464,2001204,1919260,2064380,0,2064380
1492784179.001233,3920464,2001188,1919276,2064380,0,2064380
1492784180.003777,3920464,2001188,1919276,2064380,0,2064380
```