### PR TITLE
time: fix wrong calculation

### DIFF
--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -78,7 +78,7 @@ int flb_time_diff(struct flb_time *time1,
         }
         else{
             result->tm.tv_nsec = ONESEC_IN_NSEC
-                               - time1->tm.tv_nsec - time0->tm.tv_nsec;
+                               + time1->tm.tv_nsec - time0->tm.tv_nsec;
             result->tm.tv_sec--;
         }
     }


### PR DESCRIPTION
I fixed wrong calculation.

e.g. 
nsec1 = 10, nsec0 = 90.
result of nanosecond should be 999999920. (1000000000 + 10 - 90.)
(and  decrement second).