### PR TITLE
in_tail: fix cleanup functions

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -258,8 +258,8 @@ static int in_tail_exit(void *data, struct flb_config *config)
         flb_utils_split_free(ctx->exclude_list);
     }
 
-    flb_tail_config_destroy(ctx);
     flb_tail_file_remove_all(ctx);
+    flb_tail_config_destroy(ctx);
 
     return 0;
 }

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -258,8 +258,8 @@ static int in_tail_exit(void *data, struct flb_config *config)
         flb_utils_split_free(ctx->exclude_list);
     }
 
+    flb_tail_config_destroy(ctx);
     flb_tail_file_remove_all(ctx);
-    flb_free(ctx);
 
     return 0;
 }

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -145,9 +145,13 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
 {
     /* Close pipe ends */
     close(config->ch_manager[0]);
-    close(config->ch_manager[0]);
+    close(config->ch_manager[1]);
     close(config->ch_pending[0]);
     close(config->ch_pending[1]);
+
+    if (config->db != NULL) {
+        flb_tail_db_close(config->db);
+    }
 
     flb_free(config);
     return 0;


### PR DESCRIPTION
I fixed in_tail cleanup functions.

* Modified to call flb_tail_config_destroy() at exit callback.
* Modified to call flb_tail_db_close.
* Fixed port number.