### PR TITLE
lib: flb_libco: Fix ppc64 function arguments

### DIFF
--- a/lib/flb_libco/ppc.c
+++ b/lib/flb_libco/ppc.c
@@ -279,7 +279,8 @@ static uint32_t* co_create_(unsigned size, uintptr_t entry) {
   return t;
 }
 
-cothread_t co_create(unsigned int size, void (*entry_)(void)) {
+cothread_t co_create(unsigned int size, void (*entry_)(void),
+                     size_t *out_size) {
   uintptr_t entry = (uintptr_t)entry_;
   uint32_t* t = 0;
 
@@ -289,6 +290,7 @@ cothread_t co_create(unsigned int size, void (*entry_)(void)) {
     t = co_create_(size, entry);
   }
 
+  *out_size = size;
   if(t) {
     uintptr_t sp;
     int shift;


### PR DESCRIPTION
This software currently does not built on Power due to duplicated
function.

  lib/flb_libco/ppc.c:282:12: error: conflicting types for 'co_create'
    cothread_t co_create(unsigned int size, void (*entry_)(void)) {

  lib/flb_libco/libco.h:19:12: note: previous declaration of 'co_create' was here
    cothread_t co_create(unsigned int, void (*)(void), size_t *);

This is happening because commit
b2bb2227cd2712df1946c438ec733b5956e9ecd8 forgot to change the function
name on ppc source code.

Signed-off-by: Breno Leitao <breno.leitao@gmail.com>