### PR TITLE
Add out plugin tests (counter, flowcounter, exit, null, plot, retry)

### DIFF
--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -130,7 +130,7 @@ static void cb_plot_flush(void *data, size_t bytes,
                     key = NULL;
                     val = NULL;
                 }
-                else if (key->type != MSGPACK_OBJECT_STR) {
+                else if (key->type == MSGPACK_OBJECT_STR) {
                     if (ctx->key_len == key->via.str.size &&
                         memcmp(key->via.str.ptr, ctx->key_name, ctx->key_len) == 0) {
                         val = &(map->via.map.ptr[i].val);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,10 +42,16 @@ if(FLB_IN_LIB)
        )
   endif()
 
-   if(FLB_OUT_COUNTER)
+  if(FLB_OUT_COUNTER)
      list(APPEND check_PROGRAMS
        flb_test_counter.cpp
        )
+  endif()
+
+  if(FLB_OUT_FLOWCOUNTER)
+	 list(APPEND check_PROGRAMS
+	   flb_test_flowcounter.cpp
+	   )
   endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,12 @@ if(FLB_IN_LIB)
 	   flb_test_null.cpp
 	   )
   endif()
+
+  if(FLB_OUT_PLOT)
+     list(APPEND check_PROGRAMS
+	   flb_test_plot.cpp
+	   )
+  endif()
 endif()
 
 if(FLB_OUT_LIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,12 @@ if(FLB_IN_LIB)
 	   flb_test_flowcounter.cpp
 	   )
   endif()
+
+  if(FLB_OUT_EXIT)
+     list(APPEND check_PROGRAMS
+	   flb_test_exit.cpp
+	   )
+  endif()
 endif()
 
 if(FLB_OUT_LIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,12 @@ if(FLB_IN_LIB)
        flb_test_file.cpp
        )
   endif()
+
+   if(FLB_OUT_COUNTER)
+     list(APPEND check_PROGRAMS
+       flb_test_counter.cpp
+       )
+  endif()
 endif()
 
 if(FLB_OUT_LIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,12 @@ if(FLB_IN_LIB)
 	   flb_test_exit.cpp
 	   )
   endif()
+
+  if(FLB_OUT_NULL)
+     list(APPEND check_PROGRAMS
+	   flb_test_null.cpp
+	   )
+  endif()
 endif()
 
 if(FLB_OUT_LIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,12 @@ if(FLB_IN_LIB)
 	   flb_test_plot.cpp
 	   )
   endif()
+
+  if(FLB_OUT_RETRY)
+     list(APPEND check_PROGRAMS
+	   flb_test_retry.cpp
+	   )
+  endif()
 endif()
 
 if(FLB_OUT_LIB)

--- a/tests/flb_test_counter.cpp
+++ b/tests/flb_test_counter.cpp
@@ -1,0 +1,105 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+#include "data/json_small.h"
+#include "data/json_long.h"
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "counter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* It writes a very long JSON map (> 100KB) byte by byte */
+TEST(Outputs, json_long) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "counter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, json_small) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "counter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}

--- a/tests/flb_test_exit.cpp
+++ b/tests/flb_test_exit.cpp
@@ -1,0 +1,143 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+#include "data/json_small.h"
+#include "data/json_long.h"
+
+#define WAIT_STOP (5+1) /* pause in flb_engine_stop and buffer period */
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "exit", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(WAIT_STOP); /* waiting stop automatically */
+
+    /* call flb_stop() from out_exit plugin */
+    flb_destroy(ctx);
+}
+
+/* It writes a very long JSON map (> 100KB) byte by byte */
+TEST(Outputs, json_long) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "exit", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(WAIT_STOP); /* waiting stop automatically */
+
+    /* call flb_stop() from out_exit plugin */
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, json_small) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "exit", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(WAIT_STOP); /* waiting stop automatically */
+
+    /* call flb_stop() from out_exit plugin */
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, keep_alive) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "exit", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "flush_count", "10", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(WAIT_STOP); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}

--- a/tests/flb_test_flowcounter.cpp
+++ b/tests/flb_test_flowcounter.cpp
@@ -1,0 +1,275 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+#include "data/json_small.h"
+#include "data/json_long.h"
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* It writes a very long JSON map (> 100KB) byte by byte */
+TEST(Outputs, json_long) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, json_small) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, unit_second) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "Unit", "second", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, unit_minute) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "Unit", "minute", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, unit_hour) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "Unit", "hour", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, unit_day) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "Unit", "day", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, unit_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "flowcounter", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "Unit", "xxx", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}

--- a/tests/flb_test_null.cpp
+++ b/tests/flb_test_null.cpp
@@ -1,0 +1,105 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+#include "data/json_small.h"
+#include "data/json_long.h"
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* It writes a very long JSON map (> 100KB) byte by byte */
+TEST(Outputs, json_long) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, json_small) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}

--- a/tests/flb_test_plot.cpp
+++ b/tests/flb_test_plot.cpp
@@ -1,0 +1,136 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+
+#define TEST_LOGFILE "flb-test-file.log"
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "plot", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, json_multiple) {
+    int i;
+    int ret;
+    int bytes;
+    char p[100];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "plot", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "key", "val", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < 256; i++) {
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": %d,\"END_KEY\": \"JSON_END\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        EXPECT_EQ(bytes, strlen(p));
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    EXPECT_TRUE(fp != NULL);
+    if (fp != NULL) {
+        fseek(fp, 0L ,SEEK_END);
+        EXPECT_GT(ftell(fp), 0); /* file_size > 0 */
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+TEST(Outputs, key_mismatch) {
+    int i;
+    int ret;
+    int bytes;
+    char p[100];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "plot", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "key", "xxx", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < 256; i++) {
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": %d,\"END_KEY\": \"JSON_END\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        EXPECT_EQ(bytes, strlen(p));
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    EXPECT_TRUE(fp != NULL);
+    if (fp != NULL) {
+        fseek(fp, 0L ,SEEK_END);
+        EXPECT_EQ(ftell(fp), 0); /* file_size == 0 */
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}

--- a/tests/flb_test_retry.cpp
+++ b/tests/flb_test_retry.cpp
@@ -1,0 +1,74 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <gtest/gtest.h>
+#include <fluent-bit.h>
+#include "data/json_invalid.h"
+#include "data/json_small.h"
+#include "data/json_long.h"
+
+TEST(Outputs, json_invalid) {
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_INVALID;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "retry", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < (int) sizeof(JSON_INVALID) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        EXPECT_EQ(bytes, 1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST(Outputs, retry_normal) {
+    int i;
+    int ret;
+    int bytes;
+    char p[100];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    EXPECT_TRUE(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "retry", NULL);
+    EXPECT_TRUE(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "retry", "10", NULL);
+
+    ret = flb_start(ctx);
+    EXPECT_EQ(ret, 0);
+
+    for (i = 0; i < 256; i++) {
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": %d,\"END_KEY\": \"JSON_END\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        EXPECT_EQ(bytes, strlen(p));
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}

--- a/tests/flb_test_stdout.cpp
+++ b/tests/flb_test_stdout.cpp
@@ -36,6 +36,8 @@ TEST(Outputs, json_invalid) {
         total++;
     }
 
+    sleep(1); /* waiting flush */
+
     flb_stop(ctx);
     flb_destroy(ctx);
 }
@@ -71,6 +73,8 @@ TEST(Outputs, json_long) {
         total++;
     }
 
+    sleep(1); /* waiting flush */
+
     flb_stop(ctx);
     flb_destroy(ctx);
 }
@@ -104,6 +108,8 @@ TEST(Outputs, json_small) {
         EXPECT_EQ(bytes, 1);
         total++;
     }
+
+    sleep(1); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
Hi, I added new tests for out plugin the below.
- counter
- flowcounter
- exit
- null
- plot
- retry

Also, I fixed a bug of out_plot plugin found by these unit tests.

Could you confirm this change?