### PR TITLE
in_tail: fix missing option 'path_key'

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -102,6 +102,14 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
     }
 
     /* Config: determine whether appending or not */
+    ctx->path_key = flb_input_get_property("path_key", i_ins);
+    if (ctx->path_key != NULL) {
+        ctx->path_key_len = strlen(ctx->path_key);
+    }
+    else {
+        ctx->path_key_len = 0;
+    }
+
     tmp = flb_input_get_property("ignore_older", i_ins);
     if (tmp) {
         ctx->ignore_older = flb_utils_time_to_seconds(tmp);


### PR DESCRIPTION
'path_key' option is broken with latest commit.

This PR is to fix it.