### PR TITLE
filter_record_modifier: cast -1 from int to string for loop condition test

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -148,7 +148,7 @@ static int cb_modifier_init(struct flb_filter_instance *f_ins,
 }
 
 static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
-                         char *bool_map, int map_num)
+                         bool_map_t *bool_map, int map_num)
 {
     struct mk_list *tmp;
     struct mk_list *head;
@@ -163,9 +163,9 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
     int i;
 
     for (i=0; i<map_num; i++) {
-        bool_map[i] = 1;              
+        bool_map[i] = TO_BE_REMAINED;
     }
-    bool_map[map_num] = -1;/* tail of map */
+    bool_map[map_num] = TAIL_OF_ARRAY;/* tail of map */
 
     if (ctx->remove_keys_num > 0) {
         check = &(ctx->remove_keys);
@@ -200,7 +200,7 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
                 }
             }
             if (result == is_to_delete) {
-                bool_map[i] = 0;
+                bool_map[i] = TO_BE_REMOVED;
                 ret--;
             }
         }
@@ -223,7 +223,7 @@ static int cb_modifier_filter(void *data, size_t bytes,
     int ret;
     int removed_map_num  = 0;
     int map_num          = 0;
-    char bool_map[128];
+    bool_map_t bool_map[128];
     (void) f_ins;
     (void) config;
     struct flb_time tm;
@@ -269,8 +269,8 @@ static int cb_modifier_filter(void *data, size_t bytes,
 
         msgpack_pack_map(&tmp_pck, removed_map_num);
         kv = obj->via.map.ptr;
-        for(i=0; bool_map[i] != (char)-1; i++) {
-            if (bool_map[i]) {
+        for(i=0; bool_map[i] != TAIL_OF_ARRAY; i++) {
+            if (bool_map[i] == TO_BE_REMAINED) {
                 ret = msgpack_pack_object(&tmp_pck, (kv+i)->key);
                 ret = msgpack_pack_object(&tmp_pck, (kv+i)->val);
             }

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -269,7 +269,7 @@ static int cb_modifier_filter(void *data, size_t bytes,
 
         msgpack_pack_map(&tmp_pck, removed_map_num);
         kv = obj->via.map.ptr;
-        for(i=0; bool_map[i] >= 0; i++) {
+        for(i=0; bool_map[i] != (char)-1; i++) {
             if (bool_map[i]) {
                 ret = msgpack_pack_object(&tmp_pck, (kv+i)->key);
                 ret = msgpack_pack_object(&tmp_pck, (kv+i)->val);

--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -43,5 +43,11 @@ struct record_modifier_ctx {
     struct mk_list whitelist_keys;
 };
 
+typedef enum {
+    TO_BE_REMOVED = 0,
+    TO_BE_REMAINED = 1,
+    TAIL_OF_ARRAY = 2
+} bool_map_t;
+
 
 #endif /* FLB_FILTER_RECORD_MODIFIER_H */


### PR DESCRIPTION
With some OS, the cast from int to string of -1 is 377. 
In that case the loop ` for(i=0; bool_map[i] >= 0; i++)` is infinite.
This fix add a cast of -1 to be sure to compare the -1 stored as string in bool_map with a -1 cast in string too. ` for(i=0; bool_map[i] != (char)-1; i++)`

Signed-off-by: Loris Bererd <bererd.loris@gmail.com>