### PR TITLE
out_lib: releasing buffer at user side

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -26,6 +26,8 @@ int my_stdout_json(void* data, size_t size)
     printf("[%s]",__FUNCTION__);
     printf("%s",(char*)data);
     printf("\n");
+
+    flb_lib_free(data);
     return 0;
 }
 
@@ -34,6 +36,8 @@ int my_stdout_msgpack(void* data, size_t size)
     printf("[%s]",__FUNCTION__);
     msgpack_object_print(stdout, *(msgpack_object*)data);
     printf("\n");
+
+    flb_lib_free(data);
     return 0;
 }
 

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -42,6 +42,7 @@ FLB_EXPORT int flb_input_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_output_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_filter_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_service_set(flb_ctx_t *ctx, ...);
+FLB_EXPORT int  flb_lib_free(void *data);
 FLB_EXPORT double flb_time_now();
 
 /* start stop the engine */

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -136,9 +136,6 @@ static void out_lib_flush(void *data, size_t bytes,
 
         /* Invoke user callback */
         ctx->user_callback(data_for_user, data_size);
-
-        /* Buffer: data_for_user is always allocated, so always release it */
-        flb_free(data_for_user);
     }
 
     msgpack_unpacked_destroy(&result);

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -349,6 +349,17 @@ int flb_lib_config_file(struct flb_lib_ctx *ctx, char *path)
     return 0;
 }
 
+/* This is a wrapper to release a buffer which comes from out_lib_flush() */
+int flb_lib_free(void* data)
+{
+    if (data == NULL) {
+        return -1;
+    }
+    flb_free(data);
+    return 0;
+}
+
+
 /* Push some data into the Engine */
 int flb_lib_push(flb_ctx_t *ctx, int ffd, void *data, size_t len)
 {


### PR DESCRIPTION
Now, out_lib releases the buffer after invoking callback to avoid difference of malloc engine.

However, this approach may cause some bugs.
e.g. User stores the data at callback and reads it at other thread. On the thread, the buffer is already released.

So, I added a new library API to release the buffer of out_lib.
It helps to avoid difference of malloc engine and also user can handle the lifecycle of the buffer. 