### PR TITLE
out_es: modify converting timestamp

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -231,7 +231,7 @@ static char *elasticsearch_format(void *data, size_t bytes,
         s = strftime(time_formatted, sizeof(time_formatted) - 1,
                      ctx->time_key_format, &tm);
         len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
-                       ".%" PRIu64 "Z", tms.tm.tv_nsec);
+                       ".%" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec);
 
         s += len;
         msgpack_pack_str(&tmp_pck, s);


### PR DESCRIPTION
timespec.tv_nsec is 'long' (signed 32/64 bit integer).
out_es converts timestamp like this.
```c
        len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
                       ".%" PRIu64 "Z", tms.tm.tv_nsec);
```
On 32bit system (e.g. raspberry pi 2), it may cause wrong conversion. 

It is a sample code.
```c
#include <stdio.h>
#include <stdint.h>
#include <inttypes.h>

int main(void)
{
  long val = 10;
  printf("val=%" PRIu64 "\n", val);
  printf("val=%" PRIu64 "\n", (uint64_t)val);

  return 0;
}
```

And output on raspberry pi 2 is
```
pi@raspberrypi /tmp $ ./a.out
val=145721776104988
val=10
```


Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>