### PR TITLE
filter_record_modifier: fix handling empty msgpack

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -253,6 +253,7 @@ static int cb_modifier_filter(void *data, size_t bytes,
 
         /* grep keys */
         if (obj->type == MSGPACK_OBJECT_MAP) {
+            map_num = obj->via.map.size;
             removed_map_num = make_bool_map(ctx, obj,
                                             bool_map, obj->via.map.size);
         } else {
@@ -264,6 +265,10 @@ static int cb_modifier_filter(void *data, size_t bytes,
         }
 
         removed_map_num += ctx->records_num;
+        if (removed_map_num <= 0) {
+            continue;
+        }
+
         msgpack_pack_array(&tmp_pck, 2);
         flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
 


### PR DESCRIPTION
Now, if user removes all key-value pairs with filter_record_modifier, all key-value pairs remain.
This PR is to fix it.

## Issue

Using this configuration file, the output should be blank.
```
[INPUT]
    Name disk
    Tag  disk

[OUTPUT]
    Name stdout
    Match *

[FILTER]
    Name record_modifier
    Match *
    Remove_key read_size
    Remove_key write_size
```

However, no pairs are removed.
```
$ bin/fluent-bit -c test.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/06/07 22:52:12] [ info] [engine] started
[0] disk: [1496843533.001570594, {"read_size"=>0, "write_size"=>0}]
[1] disk: [1496843534.002714136, {"read_size"=>0, "write_size"=>0}]
[2] disk: [1496843535.002754669, {"read_size"=>0, "write_size"=>0}]
[3] disk: [1496843536.002622451, {"read_size"=>0, "write_size"=>221184}]

```