### PR TITLE
[incomplete] modify filter API to be able to rename tag

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -36,7 +36,7 @@ struct flb_filter_plugin {
 
     /* Callbacks */
     int (*cb_init) (struct flb_filter_instance *, struct flb_config *, void *);
-    int (*cb_filter) (void *, size_t, char *, int,
+    int (*cb_filter) (void *, size_t, char **, int *,
                       void **, size_t *,
                       struct flb_filter_instance *,
                       void *, struct flb_config *);
@@ -67,7 +67,7 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
 void flb_filter_exit(struct flb_config *config);
 void flb_filter_do(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                    void *data, size_t bytes,
-                   char *tag, int tag_len,
+                   char **tag, int *tag_len,
                    struct flb_config *config);
 void flb_filter_initialize_all(struct flb_config *config);
 void flb_filter_set_context(struct flb_filter_instance *ins, void *context);

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -567,7 +567,7 @@ static inline void flb_input_buf_write_end(struct flb_input_instance *i)
     buf = i->mp_sbuf.data + i->mp_buf_write_size;
     flb_filter_do(&i->mp_sbuf, &i->mp_pck,
                   buf, bytes,
-                  i->tag, i->tag_len, i->config);
+                  &i->tag, &i->tag_len, i->config);
 
     /*
      * Update buffer size counter: this kind of input instance have just
@@ -609,7 +609,7 @@ static inline void flb_input_dbuf_write_end(struct flb_input_dyntag *dt)
     buf = dt->mp_sbuf.data + dt->mp_buf_write_size;
     flb_filter_do(&dt->mp_sbuf, &dt->mp_pck,
                   buf, bytes,
-                  dt->tag, dt->tag_len, dt->in->config);
+                  &dt->tag, &dt->tag_len, dt->in->config);
 
     /* Itearate each dyntag structure and count total bytes */
     flb_input_buf_size_set(in);

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -255,7 +255,7 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
 }
 
 static int cb_grep_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
+                          char **tag, int *tag_len,
                           void **out_buf, size_t *out_size,
                           struct flb_filter_instance *f_ins,
                           void *context,

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -230,7 +230,7 @@ static int pack_map_content(msgpack_packer *pck, msgpack_sbuffer *sbuf,
 }
 
 static int cb_kube_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
+                          char **tag, int *tag_len,
                           void **out_buf, size_t *out_bytes,
                           struct flb_filter_instance *f_ins,
                           void *filter_context,
@@ -251,7 +251,7 @@ static int cb_kube_filter(void *data, size_t bytes,
     (void) config;
 
     /* Check if we have some cached metadata for the incoming events */
-    ret = flb_kube_meta_get(ctx, tag, tag_len, &cache_buf, &cache_size);
+    ret = flb_kube_meta_get(ctx, *tag, *tag_len, &cache_buf, &cache_size);
     if (ret == -1) {
         return FLB_FILTER_NOTOUCH;
     }

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -210,7 +210,7 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
 }
 
 static int cb_modifier_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
+                          char **tag, int *tag_len,
                           void **out_buf, size_t *out_size,
                           struct flb_filter_instance *f_ins,
                           void *context,

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -37,7 +37,7 @@ static int cb_stdout_init(struct flb_filter_instance *f_ins,
 }
 
 static int cb_stdout_filter(void *data, size_t bytes,
-                            char *tag, int tag_len,
+                            char **tag, int *tag_len,
                             void **out_buf, size_t *out_bytes,
                             struct flb_filter_instance *f_ins,
                             void *filter_context,
@@ -55,7 +55,7 @@ static int cb_stdout_filter(void *data, size_t bytes,
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off)) {
-        printf("[%zd] %s: [", cnt++, tag);
+        printf("[%zd] %s: [", cnt++, *tag);
         flb_time_pop_from_msgpack(&tmp, &result, &p);
         printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
         msgpack_object_print(stdout, *p);

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -66,7 +66,7 @@ static void flb_filter_replace(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
 
 void flb_filter_do(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                    void *data, size_t bytes,
-                   char *tag, int tag_len,
+                   char **tag, int *tag_len,
                    struct flb_config *config)
 {
     int ret;
@@ -77,7 +77,7 @@ void flb_filter_do(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
 
     mk_list_foreach(head, &config->filters) {
         f_ins = mk_list_entry(head, struct flb_filter_instance, _head);
-        if (flb_router_match(tag, f_ins->match)) {
+        if (flb_router_match(*tag, f_ins->match)) {
             /* Reset filtered buffer */
             out_buf = NULL;
             out_size = 0;


### PR DESCRIPTION
To edit tag with filter plugin like fluentd, I modified filter API.
Then we can edit tag at filter plugin side.

This is a diff to rename tag with out_stdout.(just a sample)
```diff
diff --git a/plugins/filter_stdout/stdout.c b/plugins/filter_stdout/stdout.c
index 8289f4b..bfd3b7c 100644
--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -22,6 +22,8 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
 
 #include <msgpack.h>
 
@@ -53,6 +55,10 @@ static int cb_stdout_filter(void *data, size_t bytes,
     struct flb_time tmp;
     msgpack_object *p;
 
+    flb_free(*tag);
+    *tag = flb_strdup("hoge");
+    *tag_len = 4;
+
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off)) {
         printf("[%zd] %s: [", cnt++, *tag);

```