### PR TITLE
in_head: add key property

### DIFF
--- a/conf/in_head.conf
+++ b/conf/in_head.conf
@@ -66,6 +66,11 @@
     # if true, append file path to each record. Default: false
     Add_Path true
 
+    # Key
+    # ====
+    # Rename key Default: head
+    Key head
+
 [OUTPUT]
     Name  stdout
     Match head.*

--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -71,8 +71,9 @@ static int in_head_collect(struct flb_input_instance *i_ins,
     flb_pack_time_now(&i_ins->mp_pck);
     msgpack_pack_map(&i_ins->mp_pck, num_map);
 
-    msgpack_pack_str(&i_ins->mp_pck, 4);
-    msgpack_pack_str_body(&i_ins->mp_pck, "head", 4);
+    msgpack_pack_str(&i_ins->mp_pck, head_config->key_len);
+    msgpack_pack_str_body(&i_ins->mp_pck, head_config->key,
+                          head_config->key_len);
     msgpack_pack_str(&i_ins->mp_pck, head_config->buf_len);
     msgpack_pack_str_body(&i_ins->mp_pck,
                           head_config->buf, head_config->buf_len);
@@ -108,6 +109,16 @@ static int in_head_config_read(struct flb_in_head_config *head_config,
         return -1;
     }
     head_config->filepath = filepath;
+
+    pval = flb_input_get_property("key", in);
+    if (pval) {
+        head_config->key      = pval;
+        head_config->key_len  = strlen(pval);
+    }
+    else {
+        head_config->key      = "head";
+        head_config->key_len  = 4;
+    }
 
     /* buffer size setting */
     pval = flb_input_get_property("buf_size", in);

--- a/plugins/in_head/in_head.h
+++ b/plugins/in_head/in_head.h
@@ -33,6 +33,8 @@ struct flb_in_head_config {
     size_t    buf_size; /* size of buf */
     ssize_t   buf_len;  /* read size */
     char     *buf;      /* read buf */
+    char     *key;
+    int      key_len;
 
     char     *filepath; /* to read */
 


### PR DESCRIPTION
feature request #299.

I added "key" option to in_head.
It makes to be able to change the key name of in_head.

## Configuration file

```python
[INPUT]
    Name head
    File /proc/meminfo
    Key  meminfo
    Tag  head.meminfo


[OUTPUT]
    Name stdout
    Match *
```

result is this. key is renamed as "meminfo". 
"meminfo"->"..."

```shell
$ bin/fluent-bit -c a.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/06/17 12:54:25] [ info] [engine] started
[0] head.meminfo: [1497671666.001193509, {"meminfo"=>"MemTotal:        3920464 kB
MemFree:          392792 kB
Buffers:          180328 kB
Cached:          2658532 kB
SwapCached:            8 kB
Active:          1601776 kB
Inactive:        1487980 kB
Active(anon):      98456 kB
Inactive(anon):   156756 kB
Acti"}]
```