### PR TITLE
filter_parser: add new plugin filter_parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ option(FLB_OUT_FLOWCOUNTER "Enable flowcount output plugin"     Yes)
 
 option(FLB_FILTER_GREP     "Enable grep filter"                 Yes)
 option(FLB_FILTER_STDOUT   "Enable stdout filter"               Yes)
+option(FLB_FILTER_PARSER   "Enable parser filter"               Yes)
 option(FLB_FILTER_KUBERNETES "Enable kubernetes filter"         Yes)
 option(FLB_FILTER_RECORD_MODIFIER "Enable record_modifier filter" Yes)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ bin/fluent-bit -i cpu -o stdout
 | Grep               | grep       | Match or exclude specific records by patterns |
 | Kubernetes         | kubernetes | Enrich logs with Kubernetes Metadata |
 | Stdout             | stdout     | Print records to the standard output interface |
+| Parser             | parser     | Parse records |
 
 
 ### Output Plugins

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -141,6 +141,7 @@ REGISTER_FILTER_PLUGIN("filter_stdout")
 
 if(FLB_REGEX)
   REGISTER_FILTER_PLUGIN("filter_kubernetes")
+  REGISTER_FILTER_PLUGIN("filter_parser")
 endif()
 REGISTER_FILTER_PLUGIN("filter_record_modifier")
 

--- a/plugins/filter_parser/CMakeLists.txt
+++ b/plugins/filter_parser/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  filter_parser.c)
+
+FLB_PLUGIN(filter_parser "${src}" "")

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -1,0 +1,230 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2017 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_mem.h>
+#include <msgpack.h>
+
+#include <string.h>
+
+#include "filter_parser.h"
+
+static int msgpackobj2char(msgpack_object *obj,
+                           char **ret_char, int *ret_char_size)
+{
+    int ret = -1;
+
+    if (obj->type == MSGPACK_OBJECT_STR) {
+        *ret_char      = (char*)obj->via.str.ptr;
+        *ret_char_size = obj->via.str.size;
+        ret = 0;
+    }
+    else if (obj->type == MSGPACK_OBJECT_BIN) {
+        *ret_char      = (char*)obj->via.bin.ptr;
+        *ret_char_size = obj->via.bin.size;
+        ret = 0;
+    }
+    
+    return ret;
+}
+
+static int configure(struct filter_parser_ctx *ctx,
+                     struct flb_filter_instance *f_ins,
+                     struct flb_config *config)
+{
+
+    struct flb_config_prop *prop = NULL;
+    struct mk_list *head = NULL;
+
+    ctx->key_name = NULL;
+    ctx->parser   = NULL;
+
+    /* Iterate all filter properties */
+    mk_list_foreach(head, &f_ins->properties) {
+        prop = mk_list_entry(head, struct flb_config_prop, _head);
+
+        if (!strcasecmp(prop->key, "key_name")) {
+            ctx->key_name = prop->val;
+            ctx->key_name_len = strlen(prop->val);
+        }
+        if (!strcasecmp(prop->key, "parser")) {
+            ctx->parser  = flb_parser_get(prop->val, config);
+            if (ctx->parser == NULL) {
+                flb_error("[filter_parser] requested parser '%s' not found", prop->val);
+            }
+        }
+    }
+
+    if (ctx->key_name == NULL) {
+        flb_error("[filter_parser] \"key_name\" is missing\n");
+        return -1;
+    }
+    if (ctx->parser == NULL) {
+        flb_error("[filter_parser] Invalid \"parser\"\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int cb_parser_init(struct flb_filter_instance *f_ins,
+                          struct flb_config *config,
+                          void *data)
+{
+    (void) f_ins;
+    (void) config;
+    (void) data;
+
+    struct filter_parser_ctx *ctx = NULL;
+
+    /* Create context */
+    ctx = flb_malloc(sizeof(struct filter_parser_ctx));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+
+    if ( configure(ctx, f_ins, config) < 0 ){
+        flb_free(ctx);
+        return -1;
+    }
+
+    flb_filter_set_context(f_ins, ctx);
+
+    return 0;
+}
+
+static int cb_parser_filter(void *data, size_t bytes,
+                            char *tag, int tag_len,
+                            void **ret_buf, size_t *ret_bytes,
+                            struct flb_filter_instance *f_ins,
+                            void *context,
+                            struct flb_config *config)
+{
+    struct filter_parser_ctx *ctx = context;
+    msgpack_unpacked result;
+    size_t off = 0;
+    (void) f_ins;
+    (void) config;
+    struct flb_time tm;
+    msgpack_object *obj;
+
+    msgpack_object_kv *kv;
+    int i;
+    int ret = FLB_FILTER_NOTOUCH;
+    int map_num;
+    char *key_str;
+    int key_len;
+    char *val_str;
+    int val_len;
+    char *out_buf;
+    size_t out_size;
+    struct flb_time not_use;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+
+    /* Create temporal msgpack buffer */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+        out_buf = NULL;
+        
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+        flb_time_pop_from_msgpack(&tm, &result, &obj);        
+        if (obj->type == MSGPACK_OBJECT_MAP) {
+            map_num = obj->via.map.size;
+            for(i=0; i<map_num; i++) {
+                kv = &obj->via.map.ptr[i];
+                if ( msgpackobj2char(&kv->key, &key_str, &key_len) < 0 ) {
+                    /* key is not string */
+                    continue;
+                }
+                if (key_len == ctx->key_name_len &&
+                    !strncmp(key_str, ctx->key_name, key_len)) {
+                    if ( msgpackobj2char(&kv->val, &val_str, &val_len) < 0 ) {
+                        /* val is not string */
+                        continue;
+                    }
+                    if ( flb_parser_do(ctx->parser,
+                                        val_str, val_len,
+                                       (void **)&out_buf, &out_size, &not_use) >= 0) {
+                        break;
+                    }
+                    else {
+                        flb_warn("[filter_parser] parse error");
+                    }
+                }
+            }
+
+            if (out_buf != NULL) {
+                msgpack_pack_array(&tmp_pck, 2);
+                flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
+                msgpack_sbuffer_write(&tmp_sbuf, out_buf, out_size);
+                flb_free(out_buf);
+                ret = FLB_FILTER_MODIFIED;
+            }
+            else {
+                /* re-use original data*/
+                msgpack_pack_object(&tmp_pck, result.data);
+            }
+        }
+        else {
+            continue;
+        }
+    }
+    msgpack_unpacked_destroy(&result);
+
+    if (ret == FLB_FILTER_NOTOUCH) {
+        /* Destroy the buffer to avoid more overhead */
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return FLB_FILTER_NOTOUCH;
+    }
+
+    *ret_buf = tmp_sbuf.data;
+    *ret_bytes = tmp_sbuf.size;
+
+
+
+    return ret;
+}
+
+
+static int cb_parser_exit(void *data, struct flb_config *config)
+{
+    struct filter_parser_ctx *ctx = data;
+
+    flb_free(ctx);
+    return 0;
+}
+
+struct flb_filter_plugin filter_parser_plugin = {
+    .name         = "parser",
+    .description  = "Parse events",
+    .cb_init      = cb_parser_init,
+    .cb_filter    = cb_parser_filter,
+    .cb_exit      = cb_parser_exit,
+    .flags        = 0
+};

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -138,7 +138,7 @@ static int cb_parser_filter(void *data, size_t bytes,
     int val_len;
     char *out_buf;
     size_t out_size;
-    struct flb_time not_use;
+    struct flb_time parsed_time;
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
 
@@ -170,7 +170,10 @@ static int cb_parser_filter(void *data, size_t bytes,
                     }
                     if ( flb_parser_do(ctx->parser,
                                         val_str, val_len,
-                                       (void **)&out_buf, &out_size, &not_use) >= 0) {
+                                       (void **)&out_buf, &out_size, &parsed_time) >= 0) {
+                        if (flb_time_to_double(&parsed_time) != 0) {
+                            flb_time_copy(&tm, &parsed_time);
+                        }
                         break;
                     }
                     else {

--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2017 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FILTER_PARSER_H
+#define FLB_FILTER_PARSER_H
+
+#include <fluent-bit/flb_parser.h>
+
+struct filter_parser_ctx {
+    char     *key_name;
+    int    key_name_len;
+    struct flb_parser *parser;
+};
+
+#endif /* FLB_FILTER_PARSER_H */


### PR DESCRIPTION
I added a new plugin filter_parser.
It parses records at filter plugin.

## Configuration file

I got a nginx log from 
https://raw.githubusercontent.com/elastic/examples/master/ElasticStack_NGINX/nginx_logs

This example is to parse record which is generated  by in_head.

```
[SERVICE]
    Parsers_File /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/conf/parsers.conf

[INPUT]
    Name head
    file /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/nginx.log
    line 1


[FILTER]
    Name parser
    Match *
    Key_Name head
    Parser nginx

[OUTPUT]
    Name stdout
    Match *
```

## result
```
$ bin/fluent-bit -c dummy.conf  
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/06/24 00:23:23] [ info] [engine] started
[0] head.0: [1498231404.001205864, {"remote"=>"93.180.71.3", "host"=>"-", "user"=>"-", "method"=>"GET", "path"=>"/downloads/product_1", "code"=>"304", "size"=>"0", "referer"=>"-", "agent"=>"Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.21)"}]
```