### PR TITLE
out_flowcounter: add new mode 'event_based' (#311)

### DIFF
--- a/plugins/out_flowcounter/out_flowcounter.h
+++ b/plugins/out_flowcounter/out_flowcounter.h
@@ -36,6 +36,7 @@ struct flb_out_fcount_buffer {
 struct flb_out_fcount_config {
     char*     unit;
     int32_t   tick;
+    int       event_based;
 
     struct flb_out_fcount_buffer *buf;
     int index;


### PR DESCRIPTION
Now , out_flowcounter is based on timestamp of each event.
However, first timestamp comes from timestamp of host which executes fluent-bit.
So, the difference (event time and host timestamp) causes range error.

I added new mode 'event_based'.
If it is true, the plugin uses timestamp of each event(as usual)
If it is false, the plugin uses host timestamp only (Default, to fix #311)