### PR TITLE
parser: fix to handle types 'string'

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -772,6 +772,10 @@ int flb_parser_typecast(char *key, int key_len,
                     error = FLB_TRUE;
                 }
                 break;
+            case FLB_PARSER_TYPE_STRING:
+                msgpack_pack_str(pck, val_len);
+                msgpack_pack_str_body(pck, val, val_len);
+                break;
             default:
                 error = FLB_TRUE;
             }


### PR DESCRIPTION
Parser supports `types` and default type is `string`.
But explicit definition `string` causes warning.

This PR is to suppress the warning message.

## The warning to be fixed

parsers.conf is 

```python
[PARSER]
    Name dummy_test
    Format regex
    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<message>.+)$
    Types INT:integer FLOAT:float BOOL:bool message:string
```

The `message:string` causes the warning.

The configuration file is
```python
[SERVICE]
    Parsers_File /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/parsers.conf

[INPUT]
    Name dummy
    Tag  dummy.data
    Dummy {"data":"100 0.5 true This is example"}

[FILTER]
    Name parser
    Match dummy.*
    Key_Name data
    Parser dummy_test

[OUTPUT]
    Name stdout
    Match *
```

The warning message is
```
$ bin/fluent-bit -c dummy.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/07/20 22:55:26] [ info] [engine] started
[2017/07/20 22:55:27] [ warn] [PARSER] key=message cast error. save as string.
[2017/07/20 22:55:28] [ warn] [PARSER] key=message cast error. save as string.
```

This PR will suppress `[ warn] [PARSER] key=message cast error. save as string.`