### PR TITLE
filter_parser: support "reserve_data" 

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -47,5 +47,7 @@ char* flb_msgpack_to_json_str(size_t size, msgpack_unpacked *data);
 int flb_msgpack_raw_to_json_str(char *buf, size_t buf_size,
                                 char **out_buf, size_t *out_size);
 int flb_pack_time_now(msgpack_packer *pck);
-
+int flb_msgpack_expand_map(char *map_data, size_t map_size,
+                           msgpack_object_kv **obj_arr, int obj_arr_len,
+                           char** out_buf, int* out_size);
 #endif

--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -25,6 +25,9 @@
 struct filter_parser_ctx {
     char     *key_name;
     int    key_name_len;
+
+    int    reserve_data;
+
     struct flb_parser *parser;
 };
 


### PR DESCRIPTION
To implement feature request ("reserve_data" #307) 

This option is to save key-value pairs which are not parsed.

## Example (Configuration file)

This is an example to treat record ` {"data":"100 0.5 true This is example", "hoge":"moge"}`
`"data":"100 0.5 true This is example"` will be parsed and fluent-bit will generate parsed key-value pairs.
If "Reserve_data true", fluent-bit will save other key-value pair (in this case, `"hoge":"moge"`).

```
[SERVICE]
    Parsers_File /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/reserve_data_parser.conf

[INPUT]
    Name dummy
    Tag  dummy.data
    Dummy {"data":"100 0.5 true This is example", "hoge":"moge"}

[FILTER]
    Name parser
    Match dummy.*
    Key_Name data
    Parser dummy_test
    Reserve_data true

[OUTPUT]
    Name stdout
    Match *
```

parser file is 
```
[PARSER]
    Name dummy_test
    Format regex
    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<message>.+)$
```

## Example (output)
Not parsed key-value pair `"hoge":"moge"` is saved with "reserve_data" feature.

```
$ bin/fluent-bit -c reserve_data.conf 
Fluent-Bit v0.12.0
Copyright (C) Treasure Data

[2017/07/26 00:04:41] [ info] [engine] started
[0] dummy.data: [1500995082.000452300, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "message"=>"This is example", "hoge"=>"moge"}]
[1] dummy.data: [1500995083.000472678, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "message"=>"This is example", "hoge"=>"moge"}]
[2] dummy.data: [1500995084.001591656, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "message"=>"This is example", "hoge"=>"moge"}]
[3] dummy.data: [1500995085.001157903, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "message"=>"This is example", "hoge"=>"moge"}]
```