### PR TITLE
filter_kubernetes: new tls_verify option

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -52,6 +52,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     ctx->merge_json_log = FLB_FALSE;
     ctx->dummy_meta = FLB_FALSE;
     ctx->tls_debug = -1;
+    ctx->tls_verify = FLB_TRUE;
 
     /* Buffer size for HTTP Client when reading responses from API Server */
     ctx->buffer_size = (FLB_HTTP_DATA_SIZE_MAX * 8);
@@ -77,6 +78,11 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     tmp = flb_filter_get_property("tls.debug", i);
     if (tmp) {
         ctx->tls_debug = atoi(tmp);
+    }
+
+    tmp = flb_filter_get_property("tls.verify", i);
+    if (tmp) {
+        ctx->tls_verify = flb_utils_bool(tmp);
     }
 
     /* Merge JSON log */

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -63,6 +63,7 @@ struct flb_kube {
     int use_journal;
     int dummy_meta;
     int tls_debug;
+    int tls_verify;
 
     /* HTTP Client Setup */
     size_t buffer_size;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -600,7 +600,7 @@ static int flb_kube_network_init(struct flb_kube *ctx, struct flb_config *config
         if (!ctx->tls_ca_file) {
             ctx->tls_ca_file  = flb_strdup(FLB_KUBE_CA);
         }
-        ctx->tls.context = flb_tls_context_new(FLB_TRUE,
+        ctx->tls.context = flb_tls_context_new(ctx->tls_verify,
                                                ctx->tls_debug,
                                                ctx->tls_ca_file,
                                                NULL, NULL, NULL);


### PR DESCRIPTION
Signed-off-by: Kushal Bhandari <kushwiz@gmail.com>

This option is required to specify is TLS verify is required or not because in cases where the CA certificates of the cluster are not verified or the chain is incomplete the filter_kubernetes would not work.