### PR TITLE
in_systemd: skip last journald entry already processed

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -79,7 +79,6 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
     char *key;
     char *val;
     char *tag;
-    char *tmp;
     char *last_tag = NULL;
     char *cursor = NULL;
     size_t last_tag_len;
@@ -105,16 +104,6 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
     }
 
     while ((ret_j = sd_journal_next(ctx->j)) > 0) {
-        /* If the cursor is the same as the one stored, we have already read that entry */
-        tmp = flb_systemd_db_get_cursor(ctx);
-        if (tmp) {
-          if (sd_journal_test_cursor(ctx->j, tmp) > 0) {
-            flb_info("[in_systemd] cursor already seen, skipping", tmp);
-            continue;
-          }
-          flb_free(tmp);
-        }
-
         /* If the tag is composed dynamically, gather the Systemd Unit name */
         if (ctx->dynamic_tag) {
             ret = sd_journal_get_data(ctx->j, "_SYSTEMD_UNIT", &data, &length);

--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -79,6 +79,7 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
     char *key;
     char *val;
     char *tag;
+    char *tmp;
     char *last_tag = NULL;
     char *cursor = NULL;
     size_t last_tag_len;
@@ -104,6 +105,16 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
     }
 
     while ((ret_j = sd_journal_next(ctx->j)) > 0) {
+        /* If the cursor is the same as the one stored, we have already read that entry */
+        tmp = flb_systemd_db_get_cursor(ctx);
+        if (tmp) {
+          if (sd_journal_test_cursor(ctx->j, tmp) > 0) {
+            flb_info("[in_systemd] cursor already seen, skipping", tmp);
+            continue;
+          }
+          flb_free(tmp);
+        }
+
         /* If the tag is composed dynamically, gather the Systemd Unit name */
         if (ctx->dynamic_tag) {
             ret = sd_journal_get_data(ctx->j, "_SYSTEMD_UNIT", &data, &length);

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -144,6 +144,9 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
             ret = sd_journal_seek_cursor(ctx->j, tmp);
             if (ret == 0) {
                 flb_info("[in_systemd] seek_cursor=%.40s... OK", tmp);
+
+                /* Skip the first entry, already processed */
+                sd_journal_next_skip(ctx->j, 1);
             }
             else {
                 flb_warn("[in_systemd] seek_cursor failed");


### PR DESCRIPTION
When ``DB`` parameter is used to store the last cursor, each new start
process as the first entry the one pointed by the stored cursor.

This change checks for each entry if cursor is the same as the one
stored and skip if it is true.