### PR TITLE
Update [PARSER] for mongodb (parser.conf)

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -65,7 +65,7 @@
 [PARSER]
     Name    mongodb
     Format  regex
-    Regex   ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<context>[^ ]+)\s+\[(?<connection>[^\]]+)]\s+(?<message>.*)$
+    Regex   ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$
     Time_Format %Y-%m-%dT%H:%M:%S.%L
     Time_Keep   On
     Time_Key time


### PR DESCRIPTION
- Fix field naming connection-> context
- Fix field naming context -> component
- Add an optional "ms" field that will be the Microseconds the query took to execute (won't be there if it's not a COMMAND)
- ref: https://docs.mongodb.com/manual/reference/log-messages/