### PR TITLE
parser: support hexadecimal format

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -62,6 +62,7 @@ enum {
     FLB_PARSER_TYPE_FLOAT,
     FLB_PARSER_TYPE_BOOL,
     FLB_PARSER_TYPE_STRING,
+    FLB_PARSER_TYPE_HEX,
 };
 
 static inline time_t flb_parser_tm2time(const struct tm *src)

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -326,6 +326,9 @@ static int proc_types_str(char *types_str, struct flb_parser_types **types)
         else if(!strcasecmp(type_str, "float")){
             (*types)[i].type = FLB_PARSER_TYPE_FLOAT;
         }
+        else if(!strcasecmp(type_str, "hex")){
+            (*types)[i].type = FLB_PARSER_TYPE_HEX;
+        }
         else {
             (*types)[i].type = FLB_PARSER_TYPE_STRING;
         }
@@ -758,6 +761,17 @@ int flb_parser_typecast(char *key, int key_len,
                     msgpack_pack_int64(pck, lval);
                 }
                 break;
+            case FLB_PARSER_TYPE_HEX:
+                {
+                    unsigned long long lval;
+                    tmp_char = val[val_len];
+                    val[val_len] = '\0';
+                    lval = strtoull(val, NULL, 16);
+                    val[val_len] = tmp_char;
+                    msgpack_pack_uint64(pck, lval);
+                }
+                break;
+
             case FLB_PARSER_TYPE_FLOAT:
                 {
                     double dval;


### PR DESCRIPTION
This patch is to convert hexadecimal string to unsigned integer.
e.g. `"hex":"0xff"` -> `"hex":255`

Some logs contain hexadecimal value.
e.g. 
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security_Guide/sec-Understanding_Audit_Log_Files.html
This patch is to convert these strings.

## configuration
parsers.conf
```
[PARSER]
    Name dummy_test
    Format regex
    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<HEX_VAL>[^ ]+) (?<message>.+)$
    Types INT:integer FLOAT:float BOOL:bool HEX_VAL:hex
```

conf 
```
[SERVICE]
    Parsers_File /home/taka/git/oss/pull_req/fluentbit_env/fluent-bit/build/parsers.conf

[INPUT]
    Name dummy
    dummy {"test":"100 12.1 true 0xff strings"}

[FILTER]
    Name parser
    Match *
    Key_Name test
    Parser dummy_test

[OUTPUT]
    Name stdout
    Match *
```

output . "HEX_VAL" is converted to unsigned integer from string.
```
$ bin/fluent-bit -c dummy2.conf 
Fluent-Bit v0.13.0
Copyright (C) Treasure Data

[2017/10/21 14:15:48] [ info] [engine] started
[0] dummy.0: [1508562949.000313879, {"INT"=>100, "FLOAT"=>12.100000, "BOOL"=>true, "HEX_VAL"=>255, "message"=>"strings"}]
[1] dummy.0: [1508562950.000538296, {"INT"=>100, "FLOAT"=>12.100000, "BOOL"=>true, "HEX_VAL"=>255, "message"=>"strings"}]
```