### PR TITLE
conf: parser: add docker-daemon pattern

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -38,6 +38,14 @@
     Time_Keep   On
 
 [PARSER]
+    Name        docker-daemon
+    Format      regex
+    Regex       time="(?<time>[^ ]*)" level=(?<level>[^ ]*) msg="(?<msg>[^ ].*)"
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On
+
+[PARSER]
     Name        syslog-rfc5424
     Format      regex
     Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|-)) (?<message>.+)$


### PR DESCRIPTION
The pattern will match docker daemon logs usually saved in `/var/log/docker.log`:
```
time="2017-10-22T12:33:52Z" level=warning msg="Running experimental build"
time="2017-10-22T12:33:52.467735758Z" level=info msg="libcontainerd: new containerd process, pid: 30587"
time="2017-10-22T12:33:53.469642684Z" level=warning msg="failed to rename /mnt/data/docker/tmp for background deletion: %!s(<nil>). Deleting synchronously"
time="2017-10-22T12:33:53.479675410Z" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2017-10-22T12:33:53.480678652Z" level=info msg="Loading containers: start."
time="2017-10-22T12:33:53.867581187Z" level=info msg="Default bridge (docker0) is assigned with an IP address 172.17.0.0/16. Daemon option --bip can be used to set a preferred IP address"
time="2017-10-22T12:33:54.091797299Z" level=info msg="Loading containers: done."
time="2017-10-22T12:33:54.140960068Z" level=info msg="Daemon has completed initialization"
time="2017-10-22T12:33:54.141025273Z" level=info msg="Docker daemon" commit=v17.05.0-ce graphdriver=overlay2 version=17.05.0-ce
time="2017-10-22T12:33:54.160699426Z" level=info msg="API listen on /var/run/docker.sock"
```

Currently the `msg` property doesn't get renamed to `message`.
Either we rename it to keep it consistent with the other parsers or we keep it like it is to prevent renaming confusion.