### PR TITLE
tests: runtime: out_plot, out_file: fix conflicts by accessing the same file name

### DIFF
--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -21,7 +21,6 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_error.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_str.h>
 #include <fluent-bit/flb_pack.h>
 
@@ -293,7 +292,7 @@ static int in_disk_init(struct flb_input_instance *in,
                                        disk_config->interval_sec,
                                        disk_config->interval_nsec, config);
     if (ret < 0) {
-        flb_utils_error_c("could not set collector for disk input plugin");
+        flb_error("could not set collector for disk input plugin");
         goto init_error;
     }
 

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -25,7 +25,6 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_error.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
 
@@ -149,7 +148,7 @@ static int in_dummy_init(struct flb_input_instance *in,
                                        tm.tv_sec,
                                        tm.tv_nsec, config);
     if (ret < 0) {
-        flb_utils_error_c("could not set collector for dummy input plugin");
+        flb_error("could not set collector for dummy input plugin");
         config_destroy(ctx);
         return -1;
     }

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -19,7 +19,6 @@
 
 #include <msgpack.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 
 #include "fw.h"
@@ -94,7 +93,9 @@ static int in_fw_init(struct flb_input_instance *in,
                                          ctx->server_fd,
                                          config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for IN_FW input plugin");
+        flb_error("Could not set collector for IN_FW input plugin");
+        fw_config_destroy(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -369,7 +369,7 @@ static int in_head_init(struct flb_input_instance *in,
 
     head_config->buf = flb_malloc(head_config->buf_size);
     if (head_config->buf == NULL) {
-        flb_utils_error_c("could not allocate head buffer");
+        flb_error("could not allocate head buffer");
         goto init_error;
     }
 
@@ -383,7 +383,7 @@ static int in_head_init(struct flb_input_instance *in,
                                        head_config->interval_sec,
                                        head_config->interval_nsec, config);
     if (ret < 0) {
-        flb_utils_error_c("could not set collector for head input plugin");
+        flb_error("could not set collector for head input plugin");
         goto init_error;
     }
 

--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -22,7 +22,6 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_upstream.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
@@ -220,7 +219,9 @@ static int in_health_init(struct flb_input_instance *in,
                                        ctx->interval_nsec,
                                        config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for Health input plugin");
+        flb_error("Could not set collector for Health input plugin");
+        flb_free(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -19,7 +19,6 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_time.h>
 
@@ -281,7 +280,9 @@ int in_kmsg_init(struct flb_input_instance *in,
     /* get the system boot time */
     ret = boot_time(&ctx->boot_time);
     if (ret == -1) {
-        flb_utils_error_c("Could not get system boot time for kmsg input plugin");
+        flb_error("Could not get system boot time for kmsg input plugin");
+        flb_free(ctx);
+        return -1;
     }
 
     /* set context */
@@ -293,7 +294,9 @@ int in_kmsg_init(struct flb_input_instance *in,
                                         ctx->fd,
                                         config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for kmsg input plugin");
+        flb_error("Could not set collector for kmsg input plugin");
+        flb_free(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_lib/in_lib.c
+++ b/plugins/in_lib/in_lib.c
@@ -118,7 +118,9 @@ int in_lib_init(struct flb_input_instance *in,
     ctx->buf_len = 0;
 
     if (!ctx->buf_data) {
-        flb_utils_error_c("Could not allocate initial buf memory buffer");
+        flb_error("Could not allocate initial buf memory buffer");
+        flb_free(ctx);
+        return -1;
     }
 
     /* Init communication channel */
@@ -134,7 +136,10 @@ int in_lib_init(struct flb_input_instance *in,
                                         ctx->fd,
                                         config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for LIB input plugin");
+        flb_error("Could not set collector for LIB input plugin");
+        flb_free(ctx->buf_data);
+        flb_free(ctx);
+        return -1;
     }
 
     flb_pack_state_init(&ctx->state);

--- a/plugins/in_lib/in_lib.h
+++ b/plugins/in_lib/in_lib.h
@@ -22,7 +22,6 @@
 
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 
 #define LIB_BUF_CHUNK   65536

--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -269,7 +269,7 @@ static int in_netif_init(struct flb_input_instance *in,
         return -1;
     }
 
-    if ( configure(ctx, in, &interval_sec, &interval_nsec) < 0) {
+    if (configure(ctx, in, &interval_sec, &interval_nsec) < 0) {
         config_destroy(ctx);
         return -1;
     }
@@ -284,7 +284,9 @@ static int in_netif_init(struct flb_input_instance *in,
                                        interval_nsec,
                                        config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for Proc input plugin");
+        flb_error("Could not set collector for Proc input plugin");
+        config_destroy(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -19,7 +19,6 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
@@ -476,7 +475,7 @@ static int in_proc_init(struct flb_input_instance *in,
     configure(ctx, in);
 
     if (ctx->proc_name == NULL) {
-        flb_error("[%s] \"proc_name\" is NULL",FLB_IN_PROC_NAME);
+        flb_error("[%s] \"proc_name\" is NULL", FLB_IN_PROC_NAME);
         flb_free(ctx);
         return -1;
     }
@@ -491,7 +490,9 @@ static int in_proc_init(struct flb_input_instance *in,
                                        ctx->interval_nsec,
                                        config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for Proc input plugin");
+        flb_error("Could not set collector for Proc input plugin");
+        flb_free(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_random/random.c
+++ b/plugins/in_random/random.c
@@ -21,7 +21,6 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_error.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_stats.h>
 #include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
@@ -164,7 +163,7 @@ static int in_random_init(struct flb_input_instance *in,
                                        ctx->interval_sec,
                                        ctx->interval_nsec, config);
     if (ret < 0) {
-        flb_utils_error_c("could not set collector for head input plugin");
+        flb_error("could not set collector for head input plugin");
         flb_free(ctx);
         return -1;
     }

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -202,7 +202,9 @@ static int in_stdin_init(struct flb_input_instance *in,
     fd = dup(STDIN_FILENO);
     if (fd == -1) {
         perror("dup");
-        flb_utils_error_c("Could not open standard input!");
+        flb_error("Could not open standard input!");
+        flb_free(ctx);
+        return -1;
     }
     ctx->fd = fd;
 
@@ -230,7 +232,9 @@ static int in_stdin_init(struct flb_input_instance *in,
                                         ctx->fd,
                                         config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for STDIN input plugin");
+        flb_error("Could not set collector for STDIN input plugin");
+        flb_free(ctx);
+        return -1;
     }
     ctx->coll_fd = ret;
 

--- a/plugins/in_stdin/in_stdin.h
+++ b/plugins/in_stdin/in_stdin.h
@@ -22,7 +22,6 @@
 
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
 
 /* STDIN Input configuration & context */
 struct flb_in_stdin_config {

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -19,7 +19,6 @@
 
 #include <msgpack.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 
 #include "tcp.h"
@@ -93,7 +92,9 @@ static int in_tcp_init(struct flb_input_instance *in,
                                         ctx->server_fd,
                                         config);
     if (ret == -1) {
-        flb_utils_error_c("Could not set collector for IN_TCP input plugin");
+        flb_error("Could not set collector for IN_TCP input plugin");
+        tcp_config_destroy(ctx);
+        return -1;
     }
 
     return 0;

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -24,7 +24,6 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_http_client.h>
@@ -151,7 +150,7 @@ int cb_td_init(struct flb_output_instance *ins, struct flb_config *config,
 
     ctx = td_config_init(ins);
     if (!ctx) {
-        flb_utils_warn_c("[out_td] Error reading configuration");
+        flb_warn("[out_td] Error reading configuration");
         return -1;
     }
 

--- a/plugins/out_td/td_config.c
+++ b/plugins/out_td/td_config.c
@@ -19,7 +19,6 @@
 
 #include <stdlib.h>
 #include <fluent-bit.h>
-#include <fluent-bit/flb_utils.h>
 
 #include "td_config.h"
 
@@ -36,15 +35,18 @@ struct flb_out_td_config *td_config_init(struct flb_output_instance *o_ins)
     db_table = flb_output_get_property("Table", o_ins);
 
     if (!api) {
-        flb_utils_error_c("[out_td] error reading API key value");
+        flb_error("[out_td] error reading API key value");
+        return NULL;
     }
 
     if (!db_name) {
-        flb_utils_error_c("[out_td] error reading Database name");
+        flb_error("[out_td] error reading Database name");
+        return NULL;
     }
 
     if (!db_table) {
-        flb_utils_error_c("[out_td] error reading Table name");
+        flb_error("[out_td] error reading Table name");
+        return NULL;
     }
 
     config = flb_malloc(sizeof(struct flb_out_td_config));

--- a/tests/runtime/flb_test_file.c
+++ b/tests/runtime/flb_test_file.c
@@ -28,7 +28,7 @@ TEST_LIST = {
 };
 
 
-#define TEST_LOGFILE "flb-test-file.log"
+#define TEST_LOGFILE "flb_test_file_dummy.log"
 
 void flb_test_file_json_invalid(void)
 {

--- a/tests/runtime/flb_test_plot.c
+++ b/tests/runtime/flb_test_plot.c
@@ -19,7 +19,7 @@ TEST_LIST = {
     {NULL, NULL}
 };
 
-#define TEST_LOGFILE "flb-test-file.log"
+#define TEST_LOGFILE "flb_test_plot_dummy.log"
 
 void flb_test_plot_json_invalid(void)
 {


### PR DESCRIPTION
Hi,

I found an issue in the case of runtime tests in multi-thread execution.
Plot and file tests are sometimes failed because conflicted by accessing the same file name.

For example;
```
ctest -j 8
```