### PR TITLE
use the system provided mbedtls (set via cmake -DFLB_SYSTEM_MBEDTLS=1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(fluent-bit)
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Update CFLAGS
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC ")
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -46,6 +48,8 @@ option(FLB_POSIX_TLS          "Force POSIX thread storage"   No)
 option(FLB_WITHOUT_INOTIFY    "Disable inotify support"      No)
 option(FLB_SQLDB              "Enable SQL embedded DB"       No)
 option(FLB_HTTP_SERVER        "Enable HTTP Server"           No)
+# Usage of System Libraries
+option(FLB_SYSTEM_MBEDTLS     "Use mbedtls provided by system"  No)
 
 # Metrics: Experimental Feature, disabled by default on 0.12 series
 # but enabled in the upcoming 0.13 release. Note that development
@@ -228,11 +232,22 @@ endif()
 
 if(FLB_TLS)
   FLB_DEFINITION(FLB_HAVE_TLS)
-  option(ENABLE_TESTING  OFF)
-  option(ENABLE_PROGRAMS OFF)
-  option(INSTALL_MBEDTLS_HEADERS OFF)
-  add_subdirectory(lib/mbedtls-2.5.1 EXCLUDE_FROM_ALL)
-  include_directories(lib/mbedtls-2.5.1/include)
+  if (FLB_SYSTEM_MBEDTLS)
+    find_package(ZLIB REQUIRED)
+    find_package(MbedTls REQUIRED)
+    include_directories(${ZLIB_INCLUDE_DIRS} ${MBEDTLS_INCLUDE_DIR})
+    add_definitions(-DFLB_SYSTEM_MBEDTLS=1)
+    set(extra_libs
+      ${extra_libs}
+      ${MBEDTLS_LIBRARY}
+      ${ZLIB_LIBRARIES})
+  else()
+    option(ENABLE_TESTING  OFF)
+    option(ENABLE_PROGRAMS OFF)
+    option(INSTALL_MBEDTLS_HEADERS OFF)
+    add_subdirectory(lib/mbedtls-2.5.1 EXCLUDE_FROM_ALL)
+    include_directories(lib/mbedtls-2.5.1/include)
+  endif()
 endif()
 
 # Metrics

--- a/cmake/FindMbedTls.cmake
+++ b/cmake/FindMbedTls.cmake
@@ -1,0 +1,16 @@
+set(_MBEDTLS_REQUIRED_VARS MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARY)
+
+find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h
+  PATHS /usr/include /sw/include /usr/local/include)
+mark_as_advanced(MBEDTLS_INCLUDE_DIR)
+
+find_library(MBEDTLS_LIBRARY mbedtls
+  PATHS /usr/lib /lib /sw/lib /usr/local/lib)
+mark_as_advanced(MBEDTLS_LIBRARY)
+
+if (MBEDTLS_INCLUDE_DIR AND MBEDTLS_LIBRARY)
+  SET(MBEDTLS_FOUND True)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MBEDTLS DEFAULT_MSG ${_MBEDTLS_REQUIRED_VARS})

--- a/plugins/out_td/td_http.c
+++ b/plugins/out_td/td_http.c
@@ -25,7 +25,13 @@
 #include <fluent-bit/flb_http_client.h>
 
 #include "td_config.h"
+
+#ifdef FLB_SYSTEM_MBEDTLS
+#include "zlib.h"
+#define Z_DEFAULT_WINDOW_BITS 15
+#else
 #include "miniz/miniz.c"
+#endif
 
 #define TD_HTTP_HEADER_SIZE  512
 
@@ -107,10 +113,10 @@ static void *gzip_compress(void *data, size_t len, size_t *out_len)
     *out_len = strm.total_out;
 
     /* Construct the GZip CRC32 (footer) */
-    mz_ulong crc;
+    ulong crc;
     int footer_start = strm.total_out + 10;
 
-    crc = mz_crc32(MZ_CRC32_INIT, data, len);
+    crc = crc32(0, data, len);
     pb = buf;
     pb[footer_start] = crc & 0xFF;
     pb[footer_start + 1] = (crc >> 8) & 0xFF;

--- a/plugins/out_td/td_http.c
+++ b/plugins/out_td/td_http.c
@@ -113,7 +113,7 @@ static void *gzip_compress(void *data, size_t len, size_t *out_len)
     *out_len = strm.total_out;
 
     /* Construct the GZip CRC32 (footer) */
-    ulong crc;
+    uLong crc;
     int footer_start = strm.total_out + 10;
 
     crc = crc32(0, data, len);


### PR DESCRIPTION
Hey, i noticed issue #403 and wanted to contribue. If you are okay with my style of changes i will continue to add changes to allow usage of both system libraries and the current way into your cmake build system without a big intervention. :)
This change allows to use the mbedtls version installable via the system's package manager. In this case i used v2.6.0. To enable usage of the system provided library call cmake with -DFLB_SYSTEM_MBEDTLS=1.

File td_http.c: In case of system libraries, the include to miniz.c is replaced with zlib.h as the system mbedtls may already contain zlib defines, which would cause issues. Below the call to crc32 behaves just the same as before as by using miniz.c as it defines crc32 to be mz_crc32 and MZ_CRC32_INIT is equal to 0 - and this constant is not defined in zlib.h.