### PR TITLE
filter: check context is not NULL

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -203,6 +203,10 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
 
 void flb_kube_conf_destroy(struct flb_kube *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
+
     if (ctx->hash_table) {
         flb_hash_destroy(ctx->hash_table);
     }

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -315,8 +315,10 @@ static int cb_parser_exit(void *data, struct flb_config *config)
 {
     struct filter_parser_ctx *ctx = data;
 
-    delete_parsers(ctx);
-    flb_free(ctx);
+    if (ctx != NULL) {
+        delete_parsers(ctx);
+        flb_free(ctx);
+    }
     return 0;
 }
 

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -325,9 +325,10 @@ static int cb_modifier_exit(void *data, struct flb_config *config)
 {
     struct record_modifier_ctx *ctx = data;
 
-    delete_list(ctx);
-
-    flb_free(ctx);
+    if (ctx != NULL) {
+        delete_list(ctx);
+        flb_free(ctx);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Check context is not NULL when tearing down a filter. This prevents a
segmentation fault if the filter has not been initialized yet.

This is possible when an output plugin fails to initialize - the engine
will shutdown the server before the filters have chance to be
initialized.

Signed-off-by: James Ravn <james@r-vn.org>