### PR TITLE
http_client: fix buffer new_size calculation

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -584,8 +584,9 @@ int flb_http_buffer_increase(struct flb_http_client *c, size_t size,
     /* Limit exceeded, adjust */
     if (c->resp.data_size_max != 0) {
         if (new_size > c->resp.data_size_max) {
-            new_size = c->resp.data_size_max - c->resp.data_size;
-            if (new_size <= 0) {
+            new_size = c->resp.data_size_max;
+            if (new_size <= c->resp.data_size) {
+                /* Can't expand the buffer any further. */
                 return -1;
             }
         }


### PR DESCRIPTION
The prior calculation was incorrectly shrinking the buffer when it
reached its limit, leading to data corruption.

Here's an example of what the buffer was resizing to (with added debug
statement):

[2017/11/02 10:56:00] [ info] [filter_kube] testing connectivity with
API server...
resizing http buffer to 28672
resizing http buffer to 4096
resizing http buffer to 28672
resizing http buffer to 4096
Segmentation fault (core dumped)

This is for a max_size of 32768.

I've changed the calculation to cap to the max_size, and return -1 if the buffer has already been realloc'd to the cap.

Signed-off-by: James Ravn <james@r-vn.org>