### PR TITLE
in_tail: ignore null characters in a line

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -189,7 +189,15 @@ static int process_content(struct flb_tail_file *file, off_t *bytes)
 
     /* Parse the data content */
     data = file->buf_data;
-    while ((p = strchr(data, '\n'))) {
+    while ((data - file->buf_data) < file->buf_len) {
+        p = strchr(data, '\n');
+        /* Remove leading null characters. */
+        if (!p) {
+            data++;
+            processed_bytes++;
+            continue;
+        }
+
         len = (p - data);
 
         if (file->skip_next == FLB_TRUE) {


### PR DESCRIPTION
in_tail plugin stops working when it meets null characters in a line.  

A logger can emit null characters (`\0`) to a log file if it runs on an embedded device and the device is unplugged accidentally. In this case, the in-tail plugin stops parsing lines of the log file that contains null characters. If the buffer is full with null characters and legal characters except a new line (`\n`), it skips the file saying that the line is too long, although the actual line length without null characters is less than the chunk size (typically 32k).

To deal with this issue, I modified the in_tail plugin to ignore null characters in a line. Following are the fluent-bit config and test results.

fluent-bit.conf
```
      [SERVICE]
          Flush      2
          Daemon     off
          Log_Level  trace
      
      [INPUT]
          Name       tail
          Tag        app
          Path       /data/app.log
      
      [OUTPUT]
          Name          stdout
          Match         *
```
master branch (without this patch)
```
      [2017/11/10 10:15:52] [trace] [task 0x7f97b9ac5000] created (id=0)
      [2017/11/10 10:15:52] [debug] [task->buffer] worker_id=0
      [2017/11/10 10:15:52] [debug] [task] created task=0x7f97b9ac5000 id=0 OK
      [2017/11/10 10:15:52] [trace] [thread 0x7f97b9a5c0c0] created (custom data at 0x7f97b9a5c0e0, size=64
      [0] app: [1510308951.173123524, {"log"=>"2017-11-09T04:29:21.145Z [10] INFO sample logs line 1"}]
      [2017/11/10 10:15:52] [trace] [engine] [task event] task_id=0 thread_id=0 return=OK
      [2017/11/10 10:15:52] [trace] [thread] destroy thread=0x7f97b9a5c0c0 data=0x7f97b9a5c0e0
      [2017/11/10 10:15:52] [debug] [task] destroy task=0x7f97b9ac5000 (task_id=0)
```
master branch (with this patch)
```
      [2017/11/10 10:17:07] [trace] [task 0x13f7af0] created (id=0)
      [0] app: [1510309026.937226426, {"log"=>"2017-11-09T04:29:21.145Z [10] INFO sample logs line 1"}]
      [1] app: [1510309026.937243514, {"log"=>"2017-11-09T04:29:21.147Z [11] INFO sample logs line 2"}]
      [2] app: [1510309026.937243832, {"log"=>"2017-11-09T04:29:21.149Z [10] INFO sample logs line 3"}]
      [2017/11/10 10:17:07] [debug] [task->buffer] worker_id=0
      [2017/11/10 10:17:07] [debug] [task] created task=0x13f7af0 id=0 OK
      [2017/11/10 10:17:07] [trace] [thread 0x13f7c20] created (custom data at 0x13f7c40, size=64
      [2017/11/10 10:17:07] [trace] [engine] [task event] task_id=0 thread_id=0 return=OK
      [2017/11/10 10:17:07] [trace] [thread] destroy thread=0x13f7c20 data=0x13f7c40
      [2017/11/10 10:17:07] [debug] [task] destroy task=0x13f7af0 (task_id=0)
```

This patch not only ignores null characters in the buffer, but removes some legal characters before null characters. (This does not mean the last null character, `file->buf_data[file->buf_len]`) For example, a text `aaaaa\0\0\0\0\0\0bbbbb` is parsed as `bbbbb`, not `aaaaabbbbb`, because filtering out null characters from the buffer requires a copy of the buffer which can leads a performance issue.