### PR TITLE
hash: bound the hashtable size

### DIFF
--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -26,12 +26,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* Eviction modes when the table reach full capacity (if any) */
+#define FLB_HASH_EVICT_NONE       0
+#define FLB_HASH_EVICT_OLDER      1
+#define FLB_HASH_EVICT_LESS_USED  2
+
 struct flb_hash_entry {
+    time_t created;
+    uint64_t hits;
     char *key;
     size_t key_len;
     char *val;
     size_t val_size;
-    struct mk_list _head;
+    struct mk_list _head;         /* link to flb_hash_table->chains */
+    struct mk_list _head_parent;  /* link to flb_hash->entries */
 };
 
 struct flb_hash_table {
@@ -40,11 +48,15 @@ struct flb_hash_table {
 };
 
 struct flb_hash {
+    int evict_mode;
+    int max_entries;
+    int total_count;
     size_t size;
+    struct mk_list entries;
     struct flb_hash_table *table;
 };
 
-struct flb_hash *flb_hash_create(size_t size);
+struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries);
 void flb_hash_destroy(struct flb_hash *ht);
 
 int flb_hash_add(struct flb_hash *ht, char *key, int key_len,

--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -30,6 +30,7 @@
 #define FLB_HASH_EVICT_NONE       0
 #define FLB_HASH_EVICT_OLDER      1
 #define FLB_HASH_EVICT_LESS_USED  2
+#define FLB_HASH_EVICT_RANDOM     3
 
 struct flb_hash_entry {
     time_t created;
@@ -38,6 +39,7 @@ struct flb_hash_entry {
     size_t key_len;
     char *val;
     size_t val_size;
+    struct flb_hash_table *table; /* link to parent flb_hash_table */
     struct mk_list _head;         /* link to flb_hash_table->chains */
     struct mk_list _head_parent;  /* link to flb_hash->entries */
 };

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -169,7 +169,8 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
              ctx->api_https ? "https" : "http",
              ctx->api_host, ctx->api_port);
 
-    ctx->hash_table = flb_hash_create(FLB_HASH_TABLE_SIZE);
+    ctx->hash_table = flb_hash_create(FLB_HASH_TABLE_SIZE,
+                                      FLB_HASH_EVICT_NONE, -1);
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -169,8 +169,9 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
              ctx->api_https ? "https" : "http",
              ctx->api_host, ctx->api_port);
 
-    ctx->hash_table = flb_hash_create(FLB_HASH_TABLE_SIZE,
-                                      FLB_HASH_EVICT_NONE, -1);
+    ctx->hash_table = flb_hash_create(FLB_HASH_EVICT_RANDOM,
+                                      FLB_HASH_TABLE_SIZE,
+                                      FLB_HASH_TABLE_SIZE);
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;

--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -99,7 +99,7 @@ struct flb_env *flb_env_create()
     }
 
     /* Create the hash-table */
-    ht = flb_hash_create(FLB_ENV_SIZE, FLB_HASH_EVICT_NONE, -1);
+    ht = flb_hash_create(FLB_HASH_EVICT_NONE, FLB_ENV_SIZE, -1);
     if (!ht) {
         flb_free(env);
         return NULL;

--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -99,7 +99,7 @@ struct flb_env *flb_env_create()
     }
 
     /* Create the hash-table */
-    ht = flb_hash_create(FLB_ENV_SIZE);
+    ht = flb_hash_create(FLB_ENV_SIZE, FLB_HASH_EVICT_NONE, -1);
     if (!ht) {
         flb_free(env);
         return NULL;

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -87,12 +87,13 @@ static unsigned int gen_hash(const void *key, int len)
 static inline void flb_hash_entry_free(struct flb_hash_entry *entry)
 {
     mk_list_del(&entry->_head);
+    mk_list_del(&entry->_head_parent);
     flb_free(entry->key);
     flb_free(entry->val);
     flb_free(entry);
 }
 
-struct flb_hash *flb_hash_create(size_t size)
+struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries)
 {
     int i;
     struct flb_hash_table *tmp;
@@ -108,6 +109,10 @@ struct flb_hash *flb_hash_create(size_t size)
         return NULL;
     }
 
+    mk_list_init(&ht->entries);
+    ht->evict_mode = evict_mode;
+    ht->max_entries = max_entries;
+    ht->total_count = 0;
     ht->size = size;
     ht->table = flb_calloc(1, sizeof(struct flb_hash_table) * size);
     if (!ht->table) {
@@ -162,6 +167,20 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
         return -1;
     }
 
+    /* Check capacity */
+    if (ht->max_entries > 0 && ht->total_count >= ht->max_entries) {
+        /* FIXME: handle eviction mode */
+        if (ht->evict_mode == FLB_HASH_EVICT_NONE) {
+
+        }
+        else if (ht->evict_mode == FLB_HASH_EVICT_OLDER) {
+
+        }
+        else if (ht->evict_mode == FLB_HASH_EVICT_LESS_USED) {
+
+        }
+    }
+
     /* Generate hash number */
     hash = gen_hash(key, key_len);
     id = (hash % ht->size);
@@ -172,6 +191,8 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
         flb_errno();
         return -1;
     }
+    entry->created = time(NULL);
+    entry->hits = 0;
 
     /* Store the key and value as a new memory region */
     entry->key = flb_strdup(key);
@@ -183,6 +204,7 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
         flb_free(entry);
         return -1;
     }
+
     /*
      * Copy the buffer and append a NULL byte in case the caller set and
      * expects a string.
@@ -197,6 +219,7 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
     /* Check if the new key already exists */
     if (table->count == 0) {
         mk_list_add(&entry->_head, &table->chains);
+        mk_list_add(&entry->_head_parent, &ht->entries);
     }
     else {
         mk_list_foreach_safe(head, tmp, &table->chains) {
@@ -208,6 +231,7 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
             }
         }
         mk_list_add(&entry->_head, &table->chains);
+        mk_list_add(&entry->_head_parent, &ht->entries);
     }
 
     table->count++;
@@ -270,6 +294,7 @@ int flb_hash_get(struct flb_hash *ht, char *key, int key_len,
         return -1;
     }
 
+    entry->hits++;
     *out_buf = entry->val;
     *out_size = entry->val_size;
 

--- a/tests/internal/hashtable.c
+++ b/tests/internal/hashtable.c
@@ -79,7 +79,7 @@ void test_create_zero()
 {
     struct flb_hash *ht;
 
-    ht  = flb_hash_create(0);
+    ht  = flb_hash_create(0, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht == NULL);
 }
 
@@ -91,7 +91,7 @@ void test_single()
     size_t out_size;
     struct flb_hash *ht;
 
-    ht = flb_hash_create(1);
+    ht = flb_hash_create(1, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht != NULL);
 
     ret = ht_add(ht, "key", "value");
@@ -112,7 +112,7 @@ void test_small_table()
     struct map *m;
     struct flb_hash *ht;
 
-    ht = flb_hash_create(1);
+    ht = flb_hash_create(1, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht != NULL);
 
     for (i = 0; i < sizeof(entries) / sizeof(struct map); i++) {
@@ -129,7 +129,7 @@ void test_medium_table()
     struct map *m;
     struct flb_hash *ht;
 
-    ht = flb_hash_create(8);
+    ht = flb_hash_create(8, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht != NULL);
 
     for (i = 0; i < sizeof(entries) / sizeof(struct map); i++) {
@@ -151,7 +151,7 @@ void test_chaining()
     struct flb_hash_table *table;
     struct flb_hash *ht;
 
-    ht = flb_hash_create(8);
+    ht = flb_hash_create(8, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht != NULL);
 
     for (i = 0; i < sizeof(entries) / sizeof(struct map); i++) {
@@ -187,7 +187,7 @@ void test_delete_all()
     struct flb_hash_table *table;
     struct flb_hash *ht;
 
-    ht = flb_hash_create(8);
+    ht = flb_hash_create(8, FLB_HASH_EVICT_NONE, -1);
     TEST_CHECK(ht != NULL);
 
     total = sizeof(entries) / sizeof(struct map);


### PR DESCRIPTION
The hashtable is being used as a cache for kubernetes metadata and
environment variables. The drawback is the hashtable is unbounded and
doesn't resize itself. Thus over time it uses more memory and
performance becomes worse as the chains get longer.

For Kubernetes this can be particularly bad in busy environments as the
cache key uses podname, which will change every time a deployment
occurs.

By bounding the hashtable we ensure memory doesn't become unbounded and
performance remains constant. For a cache it should be okay to evict
old entries.

This implementation tries to keep things simple by performing eviction
on adding a key to the table. As long as the hashtable size isn't
exceeded, the behaviour remains the same as before - the table is looked
up via hash function, and the table chain is extended.

When the hashtable size is exceeded, the housekeeping will remove all
prior keys in a random chain to bring down the hashtable size.  The
advantage of a random eviction is it's simple and fast versus
constructing an LRU list (or something else).