### PR TITLE
Allow user to decide whether they want to include annotations in Kubernetes filter

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -50,6 +50,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     }
     ctx->config = config;
     ctx->merge_json_log = FLB_FALSE;
+    ctx->annotations = FLB_TRUE;
     ctx->dummy_meta = FLB_FALSE;
     ctx->tls_debug = -1;
     ctx->tls_verify = FLB_TRUE;
@@ -173,6 +174,12 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;
+    }
+
+    /* Include Kubernetes Annotations */
+    tmp = flb_filter_get_property("annotations", i);
+    if (tmp) {
+        ctx->annotations = flb_utils_bool(tmp);
     }
 
     /* Use Systemd Journal */

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -61,6 +61,7 @@ struct flb_kube {
     int api_port;
     int api_https;
     int use_journal;
+    int annotations;
     int dummy_meta;
     int tls_debug;
     int tls_verify;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -244,7 +244,7 @@ static void cb_results(unsigned char *name, unsigned char *value,
     return;
 }
 
-static int merge_meta(struct flb_kube_meta *meta,
+static int merge_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
                       char *api_buf, size_t api_size,
                       char **out_buf, size_t *out_size)
 {
@@ -360,7 +360,9 @@ static int merge_meta(struct flb_kube_meta *meta,
 
         else if (size == 11 && strncmp(ptr, "annotations", 11) == 0) {
             have_annotations = i;
-            map_size++;
+            if (ctx->annotations == FLB_TRUE) {
+                map_size++;
+            }
         }
 
         if (have_uid >= 0 && have_labels >= 0 && have_annotations >= 0) {
@@ -413,7 +415,7 @@ static int merge_meta(struct flb_kube_meta *meta,
         msgpack_pack_object(&mp_pck, v);
     }
 
-    if (have_annotations >= 0) {
+    if (have_annotations >= 0 && ctx->annotations == FLB_TRUE) {
         k = meta_val.via.map.ptr[have_annotations].key;
         v = meta_val.via.map.ptr[have_annotations].val;
 
@@ -560,7 +562,7 @@ static int get_and_merge_meta(struct flb_kube *ctx, struct flb_kube_meta *meta,
         return -1;
     }
 
-    ret = merge_meta(meta,
+    ret = merge_meta(meta, ctx,
                      api_buf, api_size,
                      &merge_buf, &merge_size);
     flb_free(api_buf);


### PR DESCRIPTION
This addresses my actual concern here in issue #422. I think this is a good starting point in allowing users to decide what metadata to include. What do you guys think?