### PR TITLE
in_tail: Avoid blocking on pending pipe

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -104,9 +104,9 @@ static int in_tail_collect_pending(struct flb_input_instance *i_ins,
         }
     }
 
-    /* If no more active files, consume signal byte so we don't get called again. */
+    /* If no more active files, consume pending signal so we don't get called again. */
     if (active == 0) {
-        consume_byte(ctx->ch_pending[0]);
+        tail_consume_pending(ctx);
     }
 
     return 0;

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -66,7 +66,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
         return NULL;
     }
     /* Make pending channel non-blocking */
-    for (i = 0; i < 1; i++) {
+    for (i = 0; i <= 1; i++) {
         ret = fcntl(ctx->ch_pending[i], F_SETFL, fcntl(ctx->ch_pending[i], F_GETFL) | O_NONBLOCK);
         if (ret == -1) {
             flb_errno();


### PR DESCRIPTION
When paused under heavy load, it is possible for the pending pipe to
fill up and then block - causing the entire fluent-bit process to
block/hang. This is due to adding a pending signal for every file, instead
of just one single signal. Similarly, every inotify event can also fill the pending pipe.

Fix is to use nonblocking mode for the pending pipe, and clear it out after all pending files are processed.