### PR TITLE
in_tail: fix process_content when FLB_REGEX is false

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -265,7 +265,7 @@ static int process_content(struct flb_tail_file *file, off_t *bytes)
 #else
         flb_time_get(&out_time);
         flb_tail_file_pack_line(out_sbuf, out_pck, &out_time,
-                                file->buf_data, len, file);
+                                data, len, file);
 #endif
 
     go_next:


### PR DESCRIPTION
`file->buf_data` should have been `data`, which was missed in 98e86523.