### PR TITLE
Dockerfile to allow automatic builds on new version tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM gcr.io/google-containers/debian-base-amd64:0.3 as builder
+
+# Fluent Bit version
+ENV FLB_MAJOR 0
+ENV FLB_MINOR 12
+ENV FLB_PATCH 10
+ENV FLB_VERSION 0.12.10
+
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
+
+COPY . /tmp/src/
+RUN rm -rf /tmp/src/build/*
+
+RUN apt-get update && apt-get install -y build-essential cmake make wget unzip libsystemd-dev
+WORKDIR /tmp/src/build/
+RUN cmake -DFLB_DEBUG=Off -DFLB_TRACE=Off -DFLB_JEMALLOC=On -DFLB_BUFFERING=On -DFLB_TLS=On -DFLB_WITHOUT_SHARED_LIB=On -DFLB_WITHOUT_EXAMPLES=On ..
+RUN make 
+RUN install bin/fluent-bit /fluent-bit/bin/
+# Configuration files
+COPY conf/fluent-bit.conf conf/parsers.conf conf/parsers_java.conf /fluent-bit/etc/
+
+FROM gcr.io/google-containers/debian-base-amd64:0.3
+MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
+LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install --no-install-recommends ca-certificates -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoclean
+COPY --from=builder /fluent-bit /fluent-bit
+
+# Entry point
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]


### PR DESCRIPTION
This is based on the work here: https://github.com/fluent/fluent-bit-docker-image/blob/master/0.12/Dockerfile
And thus I kept the maintainer statements and just bumped the source image from jessie to stretch.
This uses multistage build that was introduced in Docker 17.05 CE. The compressed image only takes up 24.7Mb because of that.
Hoping you can set up an automated build using this Dockerfile against either Docker Hub or quay.io as right now we're building our own Docker images.