### PR TITLE
in_tail: don't pause scan/rotate

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -297,12 +297,8 @@ static void in_tail_pause(void *data, struct flb_config *config)
      * Pause general collectors:
      *
      * - static : static files lookup before promotion
-     * - scan   : scan path to find new files
-     * - rotated: rotate files lookup
      */
     flb_input_collector_pause(ctx->coll_fd_static, ctx->i_ins);
-    flb_input_collector_pause(ctx->coll_fd_scan, ctx->i_ins);
-    flb_input_collector_pause(ctx->coll_fd_rotated, ctx->i_ins);
     flb_input_collector_pause(ctx->coll_fd_pending, ctx->i_ins);
 
     if (ctx->multiline == FLB_TRUE) {
@@ -318,8 +314,6 @@ static void in_tail_resume(void *data, struct flb_config *config)
     struct flb_tail_config *ctx = data;
 
     flb_input_collector_resume(ctx->coll_fd_static, ctx->i_ins);
-    flb_input_collector_resume(ctx->coll_fd_scan, ctx->i_ins);
-    flb_input_collector_resume(ctx->coll_fd_rotated, ctx->i_ins);
     flb_input_collector_resume(ctx->coll_fd_pending, ctx->i_ins);
 
     if (ctx->multiline == FLB_TRUE) {

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -817,6 +817,9 @@ int flb_tail_file_rotated_purge(struct flb_input_instance *i_ins,
         file = mk_list_entry(head, struct flb_tail_file, _rotate_head);
         if ((file->rotated + ctx->rotate_wait) <= now) {
             flb_debug("[in_tail] purge rotated file %s", file->name);
+            if (file->pending_bytes > 0 && flb_input_buf_paused(i_ins)) {
+                flb_warn("[in_tail] purged rotated file while data ingestion is paused, consider increasing rotate_wait");
+            }
             flb_tail_file_remove(file);
             count++;
         }


### PR DESCRIPTION
Otherwise new files may never get ingested if heavy log volume is
causing frequent pauses.

This should be safe since no ingestion happens during scan and rotate.

Fix https://github.com/fluent/fluent-bit/issues/465