### PR TITLE
Mention syslog and journald input plugins in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $ bin/fluent-bit -i cpu -o stdout
 | MQTT               | mqtt    | start a MQTT server and receive publish messages |
 | Netif              | netif   | usage of network interface |
 | Kernel Ring Buffer | kmsg    | read Linux Kernel messages, same behavior as the __dmesg__ command line program |
+| Syslog             | syslog  | read messages from a syslog daemon | 
+| Systemd/Journald   | systemd | read messages from journald, part of the systemd suite |
 | Serial Port        | serial  | read from serial port |
 | Standard Input     | stdin   | read from the standard input |
 | Head               | head    | read first part of files |


### PR DESCRIPTION
I'm guessing this omission was unintentional.
