### PR TITLE
in_disk and in_netif: Fix the first output uncorrect of input plugin

### DIFF
--- a/plugins/in_disk/in_disk.h
+++ b/plugins/in_disk/in_disk.h
@@ -38,6 +38,7 @@ struct flb_in_disk_config {
     int      entry;
     int      interval_sec;
     int      interval_nsec;
+    int      first_snapshot;   /* a feild to indicate whethor or not this is the first collect*/
 };
 
 extern struct flb_input_plugin in_disk_plugin;

--- a/plugins/in_netif/in_netif.h
+++ b/plugins/in_netif/in_netif.h
@@ -51,6 +51,7 @@ struct flb_in_netif_config {
     int  interface_len;
 
     int  verbose;
+    int  first_snapshot;   /* a feild to indicate whethor or not this is the first collect */
 
     struct netif_entry *entry;
     int entry_len;


### PR DESCRIPTION
I hava find that the in_netif plugin use prev and now to indicate the previous and current correct value.
At the first collect, the prev is not exist. I think the first correct should not output, and should just assign now to prev. It should begin to output from the second collect.
So I add a feild first_snapshot to indicate current collect is the first fo not to control.

The same of in_disk.

This is reference to
How to solve Large log file leading to some input plugin abnormal #464