### PR TITLE
out_http: Pass tag dynamically in header

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -310,6 +310,14 @@ int cb_http_init(struct flb_output_instance *ins, struct flb_config *config,
         }
     }
 
+    /* Tag in header */
+    tmp = flb_output_get_property("header_tag", ins);
+    if (tmp) {
+      ctx->header_tag = flb_strdup(tmp);
+      ctx->headertag_len = strlen(ctx->header_tag);
+      flb_info("[out_http] configure to pass tag in header: %s", ctx->header_tag);
+    }
+
     /* Output format */
     ctx->out_format = FLB_HTTP_OUT_MSGPACK;
     tmp = flb_output_get_property("format", ins);
@@ -411,6 +419,13 @@ void cb_http_flush(void *data, size_t bytes,
                             sizeof(FLB_HTTP_MIME_MSGPACK) - 1);
     }
 
+    if (ctx->header_tag) {
+        flb_http_add_header(c,
+                        ctx->header_tag,
+                        ctx->headertag_len,
+                        tag, tag_len);
+    }
+
     if (ctx->http_user && ctx->http_passwd) {
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
@@ -477,6 +492,7 @@ int cb_http_exit(void *data, struct flb_config *config)
     flb_free(ctx->proxy_host);
     flb_free(ctx->uri);
     flb_free(ctx->json_date_key);
+    flb_free(ctx->header_tag);
     flb_free(ctx);
 
     return 0;

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -54,6 +54,10 @@ struct flb_out_http_config {
     char *host;
     int port;
 
+    /* Include tag in header */
+    char *header_tag;
+    size_t headertag_len;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 };


### PR DESCRIPTION
The http plugin currently not sending the message's tag. The in_http
plugin of Fluentd use the URI as tag. If we want to keep the original
tag then we have to define multipe output section per tag to map it to
URI. This change send the tag in a header(the headername can define in
config file), and it's up to the receiver to parse the header and
replace the tag.

The use case is to use this plugin in place of SecureForward plugin
because it's easier to maintain and config terminating TLS at load balancer
level, which probably a part of infrastructure already, comparing
with maintain TLS per fluentd instance.