### PR TITLE
filter_record_modifier: Support wildcard for Remove_key and Whitelist_key

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -55,6 +55,12 @@ static int configure(struct record_modifier_ctx *ctx,
             }
             mod_key->key     = prop->val;
             mod_key->key_len = strlen(prop->val);
+            if (mod_key->key[mod_key->key_len-1] == '*' ) {
+                mod_key->dynamic_key = FLB_TRUE;
+                mod_key->key_len--;
+            } else {
+                mod_key->dynamic_key = FLB_FALSE;
+            }
             mk_list_add(&mod_key->_head, &ctx->remove_keys);
             ctx->remove_keys_num++;
         }
@@ -66,6 +72,12 @@ static int configure(struct record_modifier_ctx *ctx,
             }
             mod_key->key     = prop->val;
             mod_key->key_len = strlen(prop->val);
+            if (mod_key->key[mod_key->key_len-1] == '*' ) {
+                mod_key->dynamic_key = FLB_TRUE;
+                mod_key->key_len--;
+            } else {
+                mod_key->dynamic_key = FLB_FALSE;
+            }
             mk_list_add(&mod_key->_head, &ctx->whitelist_keys);
             ctx->whitelist_keys_num++;
         }
@@ -198,7 +210,13 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
             mk_list_foreach_safe(head, tmp, check) {
                 mod_key = mk_list_entry(head, struct modifier_key,  _head);
                 if (key->via.bin.size != mod_key->key_len &&
-                    key->via.str.size != mod_key->key_len) {
+                    key->via.str.size != mod_key->key_len &&
+                    mod_key->dynamic_key == FLB_FALSE ) {
+                    continue;
+                }
+                if (key->via.bin.size < (mod_key->key_len) &&
+                    key->via.str.size < (mod_key->key_len) &&
+                    mod_key->dynamic_key == FLB_TRUE) {
                     continue;
                 }
                 if ((key->type == MSGPACK_OBJECT_BIN &&

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -30,7 +30,7 @@
 #define PLUGIN_NAME "filter_record_modifier"
 
 static int configure(struct record_modifier_ctx *ctx,
-                     struct flb_filter_instance *f_ins)
+                         struct flb_filter_instance *f_ins)
 {
     struct mk_list *head = NULL;
     struct mk_list *split;
@@ -55,10 +55,11 @@ static int configure(struct record_modifier_ctx *ctx,
             }
             mod_key->key     = prop->val;
             mod_key->key_len = strlen(prop->val);
-            if (mod_key->key[mod_key->key_len-1] == '*' ) {
+            if (mod_key->key[mod_key->key_len - 1] == '*') {
                 mod_key->dynamic_key = FLB_TRUE;
                 mod_key->key_len--;
-            } else {
+            }
+            else {
                 mod_key->dynamic_key = FLB_FALSE;
             }
             mk_list_add(&mod_key->_head, &ctx->remove_keys);
@@ -72,10 +73,11 @@ static int configure(struct record_modifier_ctx *ctx,
             }
             mod_key->key     = prop->val;
             mod_key->key_len = strlen(prop->val);
-            if (mod_key->key[mod_key->key_len-1] == '*' ) {
+            if (mod_key->key[mod_key->key_len - 1] == '*') {
                 mod_key->dynamic_key = FLB_TRUE;
                 mod_key->key_len--;
-            } else {
+            }
+            else {
                 mod_key->dynamic_key = FLB_FALSE;
             }
             mk_list_add(&mod_key->_head, &ctx->whitelist_keys);
@@ -147,8 +149,8 @@ static int delete_list(struct record_modifier_ctx *ctx)
 
 
 static int cb_modifier_init(struct flb_filter_instance *f_ins,
-                        struct flb_config *config,
-                        void *data)
+                                struct flb_config *config,
+                                void *data)
 {
     struct record_modifier_ctx *ctx = NULL;
 
@@ -173,7 +175,7 @@ static int cb_modifier_init(struct flb_filter_instance *f_ins,
 }
 
 static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
-                         bool_map_t *bool_map, int map_num)
+                             bool_map_t *bool_map, int map_num)
 {
     struct mk_list *tmp;
     struct mk_list *head;
@@ -211,7 +213,7 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
                 mod_key = mk_list_entry(head, struct modifier_key,  _head);
                 if (key->via.bin.size != mod_key->key_len &&
                     key->via.str.size != mod_key->key_len &&
-                    mod_key->dynamic_key == FLB_FALSE ) {
+                    mod_key->dynamic_key == FLB_FALSE) {
                     continue;
                 }
                 if (key->via.bin.size < (mod_key->key_len) &&
@@ -221,10 +223,10 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
                 }
                 if ((key->type == MSGPACK_OBJECT_BIN &&
                      !strncasecmp(key->via.bin.ptr, mod_key->key,
-                                 mod_key->key_len)) ||
+                                  mod_key->key_len)) ||
                     (key->type == MSGPACK_OBJECT_STR &&
                      !strncasecmp(key->via.str.ptr, mod_key->key,
-                                 mod_key->key_len))
+                                  mod_key->key_len))
                     ) {
                     result = FLB_TRUE;
                     break;
@@ -241,11 +243,11 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
 }
 
 static int cb_modifier_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
-                          void **out_buf, size_t *out_size,
-                          struct flb_filter_instance *f_ins,
-                          void *context,
-                          struct flb_config *config)
+                                  char *tag, int tag_len,
+                                  void **out_buf, size_t *out_size,
+                                  struct flb_filter_instance *f_ins,
+                                  void *context,
+                                  struct flb_config *config)
 {
     struct record_modifier_ctx *ctx = context;
     char is_modified = FLB_FALSE;
@@ -286,7 +288,8 @@ static int cb_modifier_filter(void *data, size_t bytes,
             map_num = obj->via.map.size;
             removed_map_num = make_bool_map(ctx, obj,
                                             bool_map, obj->via.map.size);
-        } else {
+        }
+        else {
             continue;
         }
 

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -216,8 +216,8 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
                     mod_key->dynamic_key == FLB_FALSE) {
                     continue;
                 }
-                if (key->via.bin.size < (mod_key->key_len) &&
-                    key->via.str.size < (mod_key->key_len) &&
+                if (key->via.bin.size < mod_key->key_len &&
+                    key->via.str.size < mod_key->key_len &&
                     mod_key->dynamic_key == FLB_TRUE) {
                     continue;
                 }

--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -31,6 +31,7 @@ struct modifier_record {
 struct modifier_key {
     char *key;
     int   key_len;
+    int   dynamic_key;
     struct mk_list _head;
 };
 


### PR DESCRIPTION
Allow matching of Remove_key by wildcard after some prefix.
Example: -F record_modifier -p 'Remove_key=example*'

Allow matching of Whitelist_key by wildcard after some prefix.
Example: -F record_modifier -p 'Wildcard_key=example*'

This change may break some existing config if a key's final character is '*'.