### PR TITLE
out_http: Add configuration for the date key when output is JSON

### DIFF
--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -39,6 +39,8 @@ struct flb_out_http_config {
 
     /* Output format */
     int out_format;
+    char *json_date_key;
+    size_t json_date_key_len;
 
     /* HTTP URI */
     char *uri;


### PR DESCRIPTION
In the existing implementation the "date" key is hardcoded.

This defaults to the existing key of "date" to ensure backwards compatibility.