### PR TITLE
Additional parsers spec.

### DIFF
--- a/conf/parsers_cinder.conf
+++ b/conf/parsers_cinder.conf
@@ -1,0 +1,10 @@
+
+[PARSER]
+    # http://rubular.com/r/IvZVElTgNl
+    Name ceph
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep Off
+    Time_Key log_time
+

--- a/conf/parsers_extra.conf
+++ b/conf/parsers_extra.conf
@@ -1,0 +1,78 @@
+# Extra set of common parsers
+
+[PARSER]
+    # http://rubular.com/r/cCVd1HLCAO
+    Name crowbar
+    Format regex
+    Regex ^.*\[(?<log_time>[^ ][-.\d\+:]+T[:\d]*)([^\]])*?\]\s+?(?<severity>[^ ]\w+)([\s-]*):?\s+(?<message>.*)
+    Time_Format %Y-%m-%dT%H:%M:%S
+    Time_Keep Off
+    Time_Key log_time
+
+[PARSER]
+    # http://rubular.com/r/frDgnElXW9 
+    Name chefclient
+    Format regex
+    Regex ^\[(?<log_time>[^ ][-.\d\+:]+T[:\d]*)([^\]])*?\]\s+(?<severity>[^ ]\w+):\s+(?<message>.*)$
+    Time_Format %Y-%m-%dT%H:%M:%S
+    Time_Keep Off
+    Time_Key log_time
+
+[PARSER]
+    Name mysql_error
+    Format regex
+    #Regex ^(?<log_time>[^ +][ -:0-9TZ]+|[[:upper:]][[:lower:]]{2})(\+\d+:\d+[TZ]*){0,1}\s*(?<myid>[^ ]\d+)\s+\[(?<severity>[^ ]\w+)\](\s+(?<subsystem>[^ ]\w+):){0,1}\s+(?<message>.*)$
+    Regex ^(?<log_time>[^ +][-\d]+[\ T]*[:\dZ]+)\s*(?<myid>[^ ]\d+)\s+\[(?<severity>[^ ]\w+)\](\s+(?<subsystem>[^ ]\w+):){0,1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name mysql_slow
+    Format regex
+    Regex ^# User\@Host:\s+(?<user>[^\@][\w\[\]]+)[@\s]+(?<dbhost>[^ ][-.\w]+)\s+(\[(?<dbhost_address>[.\d]+)\]){0,1}\s+(?<message>.*)$
+
+[PARSER]
+    Name pacemaker
+    Format regex
+    Regex ^\s*(?<log_time>[^ ]* {1,2}[^ ]* [^ ]*) \[(?<pid>\d+)\] (?<node>[\-\w]*)\s*(?<component>\w*):\s+(?<severity>\w+):\s+(?<message>.*)$
+    #Time_Format %Y-%m-%dT%H:%M:%S
+    Time_Format %b %d %H:%M:%S
+    Time_Keep   Off
+    Time_Key log_time
+    #Types pid:integer
+
+[PARSER]
+    Name rabbitmq
+    Format regex
+    Regex ^=(?<severity>[^ ]\w+)\s+REPORT[=\s]*(?<log_time>[^ =][-:.\d\w]+)[\s=]+(?<message>.*)$
+    Time_Format %d-%b-%Y::%H:%M:%S
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name http_statement
+    Format regex
+    Regex ^.*((?<req_method>GET|POST|PUT|DELETE|CONNECT|OPTIONS|HEAD[^ ]\w+)\s*(?<req_path>[^ ][-._?=%&\/[:alnum:]]*)\s*(?<req_protocol>[^ ][.\/\dHTFSP]+){0,1})(['"\s]*){0,1}((\s*status:\s*(?<req_status>[^ ]\d+)){0,1}(\s*len:\ (?<req_len>[^ ]\d+)){0,1}(\s*time:\s*(?<req_log_time>[^ ][.\d]+)){0,1}(\s*microversion:\s*(?<req_mver>[^ ][.\d]+)){0,1}){0,1}$
+
+[PARSER]
+    Name universal
+    Format regex
+    Regex ^(?<message>.*)$
+
+[PARSER]
+    Name uuid
+    Format regex
+    Regex (?<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})
+#UUID v1 :
+#/^[0-9A-F]{8}-[0-9A-F]{4}-[1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+#UUID v2 :
+#/^[0-9A-F]{8}-[0-9A-F]{4}-[2][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+#UUID v3 :
+#/^[0-9A-F]{8}-[0-9A-F]{4}-[3][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+#UUID v4 :
+#/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+#UUID v5 :
+#/^[0-9A-F]{8}-[0-9A-F]{4}-[5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+
+

--- a/conf/parsers_openstack.conf
+++ b/conf/parsers_openstack.conf
@@ -1,0 +1,53 @@
+# Example openstack parsers, see source for recent updates:
+# https://github.com/salt-formulas/salt-formula-fluentbit/tree/master/metadata/service/config/parser
+
+# Take these parsers as an example, as they may not fully fit all possible
+# openstack deployments from all vendors, etc..
+
+[PARSER]
+    Name cinder
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name glance
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name heat
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name keystone
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name neutron
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time
+
+[PARSER]
+    Name nova
+    Format regex
+    Regex ^(?<log_time>[^ ][-.\d\+:T]+[ ]*[.:\d]*)\s+(?<pid>[^ ]\d+)\s+(?<severity>[^ ][.-_\w]+)\s+(?<component>[^ ][.-_\w]+)(\s+\[(-|(?<req_id>[^ ][-\w]*) (?<req_user>[^ ][-\w]*) (?<req_project>[^ ][-\w]*) (?<req_domain>[^ ][-\w]*) (?<req_user_domain>[^ ][-\w]*) (?<req_project_domain>[^ ][-\w]*))\]){1}\s+(?<message>.*)$
+    Time_Format %Y-%m-%d %H:%M:%S.%L
+    Time_Keep   Off
+    Time_Key log_time


### PR DESCRIPTION
I was not sure whether to contribute to parsers.conf directly but finally I follow the current practice add additional files that are not enabled by default.

Default parsers enabled has a reasoning if they are really general, thus format/time match most of the platforms.

Log_time regex, as well as some other parts, could be written better, but instead of expensive re-do I am keeping this for others to update as needed.