### PR TITLE
Plugin: record_modifier: Suffix_Type modification for keys

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -39,6 +39,7 @@ struct record_modifier_ctx {
     int records_num;
     int remove_keys_num;
     int whitelist_keys_num;
+    int suffix_type;
     struct mk_list records;
     struct mk_list remove_keys;
     struct mk_list whitelist_keys;


### PR DESCRIPTION
This patch adds an option to record_modifier plugin that modifies
record key names by suffixing a type identifier.

It is activated with the boolean option Suffix_Type (default False).

For example if processing a JSON log message like:

{"port":8000,"app":"myapp","ssl":true}

it would generate key names: port_i, app_s and ssl_b

This is useful primarily for JSON structured log aggregation output
to Elasticsearch. Once the data type for a key is set for an index it
can't be changed, which can lead to conflicts if different data types
are used for the same key in a large application or across different
applications.

With this patch {"port":"8000"} and {"port":8000} result in different
key names (port_s and port_i) respectively, which prevents data type
conflicts.

Signed-off-by: Rory Douglas <rory1douglas@gmail.com>