### PR TITLE
Fix timestamp in in_kmsg

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -157,7 +157,7 @@ static inline int process_line(char *line,
     tv.tv_sec  = val/1000000;
     tv.tv_usec = val - (tv.tv_sec * 1000000);
 
-    flb_time_set(&ts, ctx->boot_time.tv_sec + tv.tv_sec, tv.tv_usec);
+    flb_time_set(&ts, ctx->boot_time.tv_sec + tv.tv_sec, tv.tv_usec * 1000);
 
     /* Now process the human readable message */
     p = strchr(p, ';');

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -132,11 +132,11 @@ int tcp_conn_event(void *data)
         ret = flb_pack_json_state(conn->buf_data, conn->buf_len,
                                   &pack, &out_size, &conn->pack_state);
         if (ret == FLB_ERR_JSON_PART) {
-            flb_debug("[in_serial] JSON incomplete, waiting for more data...");
+            flb_debug("[in_tcp] JSON incomplete, waiting for more data...");
             return 0;
         }
         else if (ret == FLB_ERR_JSON_INVAL) {
-            flb_debug("[in_serial] invalid JSON message, skipping");
+            flb_debug("[in_tcp] invalid JSON message, skipping");
             flb_pack_state_reset(&conn->pack_state);
             flb_pack_state_init(&conn->pack_state);
             conn->pack_state.multiple = FLB_TRUE;


### PR DESCRIPTION
I noticed funny timestamps when collecting kernel messages using fluent-bit. The fix turned out to be straight-forward.