### PR TITLE
Support fractional seconds with UNIX timestamp

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -204,7 +204,11 @@ struct flb_parser *flb_parser_create(char *name, char *format,
             tmp = strstr(p->time_fmt, "%S.%L");
         }
         else {
-            tmp = strstr(p->time_fmt_year, "%S.%L");
+            tmp = strstr(p->time_fmt_year, "%s.%L");
+
+            if (tmp == NULL) {
+                tmp = strstr(p->time_fmt_year, "%S.%L");
+            }
         }
         if (tmp) {
             tmp[2] = '\0';


### PR DESCRIPTION
This change allows to use `%L` format option after `%s` in addition to already existing `%S`.

Essentially this allows to parse unix timestamp followed by microseconds (`1509575121.648`).

This is useful because not all systems are capable of logging with sub-second precision in human readable form. Nginx is a good example of such case, neither of [`$time_iso8601`](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_time_iso8601) or [`$time_local`](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_time_local) will include milliseconds. However, [`$msec`](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_msec) does write a unix timestamp with milliseconds resolution (`1509575121.648`), hence by adding support for `%s.%L` it would be possible to parse nginx logs with sub-second precision.