### PR TITLE
fix SIGSEGV of runtime tests

### DIFF
--- a/tests/runtime/core_engine.c
+++ b/tests/runtime/core_engine.c
@@ -58,10 +58,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -75,6 +75,10 @@ int check_routing(const char* tag, const char* match, bool expect)
     flb_ctx_t    *ctx    = NULL;
     char         *str    = (char*)"[1, {\"key\":\"value\"}]";
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -86,7 +90,7 @@ int check_routing(const char* tag, const char* match, bool expect)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", tag, NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", match, NULL);
 

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -25,7 +25,7 @@ char *get_output(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
         flb_debug("[test_filter_parser] received message: %s", data);
@@ -44,6 +44,10 @@ void flb_test_filter_parser_extract_fields()
     int out_ffd;
     int filter_ffd;
     struct flb_parser *parser;
+
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
 
     ctx = flb_create();
 
@@ -76,7 +80,7 @@ void flb_test_filter_parser_extract_fields()
     TEST_CHECK(ret == 0);
 
     /* Output */
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd,
                    "Match", "*",
@@ -126,6 +130,10 @@ void flb_test_filter_parser_reserve_data_off()
     int filter_ffd;
     struct flb_parser *parser;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     ctx = flb_create();
 
     /* Configure service */
@@ -156,7 +164,7 @@ void flb_test_filter_parser_reserve_data_off()
     TEST_CHECK(ret == 0);
 
     /* Output */
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd,
                    "Match", "*",
@@ -197,6 +205,10 @@ void flb_test_filter_parser_handle_time_key()
     int filter_ffd;
     struct flb_parser *parser;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     ctx = flb_create();
 
     /* Configure service */
@@ -228,7 +240,7 @@ void flb_test_filter_parser_handle_time_key()
     TEST_CHECK(ret == 0);
 
     /* Output */
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd,
                    "Match", "*",
@@ -273,6 +285,10 @@ void flb_test_filter_parser_ignore_malformed_time()
     int filter_ffd;
     struct flb_parser *parser;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     ctx = flb_create();
 
     /* Configure service */
@@ -303,7 +319,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     TEST_CHECK(ret == 0);
 
     /* Output */
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd,
                    "Match", "*",
@@ -344,6 +360,10 @@ void flb_test_filter_parser_preserve_original_field()
     int filter_ffd;
     struct flb_parser *parser;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     ctx = flb_create();
 
     /* Configure service */
@@ -375,7 +395,7 @@ void flb_test_filter_parser_preserve_original_field()
     TEST_CHECK(ret == 0);
 
     /* Output */
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd,
                    "Match", "*",

--- a/tests/runtime/in_cpu.c
+++ b/tests/runtime/in_cpu.c
@@ -56,10 +56,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -72,6 +72,10 @@ void flb_test_in_cpu_flush_2s_2times(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -83,7 +87,7 @@ void flb_test_in_cpu_flush_2s_2times(void)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_disk.c
+++ b/tests/runtime/in_disk.c
@@ -56,7 +56,7 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
         flb_lib_free(data);
@@ -72,6 +72,10 @@ void flb_test_in_disk_flush_2s_2times(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -83,7 +87,7 @@ void flb_test_in_disk_flush_2s_2times(void)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_dummy.c
+++ b/tests/runtime/in_dummy.c
@@ -55,10 +55,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void *cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true);/* success */
     }
     return 0;
@@ -71,6 +71,10 @@ void flb_test_in_dummy_flush_2s_2times(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -82,7 +86,7 @@ void flb_test_in_dummy_flush_2s_2times(void)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test", "rate", "1", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_head.c
+++ b/tests/runtime/in_head.c
@@ -56,10 +56,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -73,6 +73,10 @@ void flb_test_in_head_flush_2s_2times(void)
     int out_ffd;
     char  path[] = "/dev/urandom";
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -85,7 +89,7 @@ void flb_test_in_head_flush_2s_2times(void)
     flb_input_set(ctx, in_ffd, "tag", "test",
                   "Interval_Sec", "1", "File", path,NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_mem.c
+++ b/tests/runtime/in_mem.c
@@ -56,10 +56,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void *cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -73,6 +73,10 @@ void flb_test_in_mem_flush_2s_2times(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -84,7 +88,7 @@ void flb_test_in_mem_flush_2s_2times(void)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_proc.c
+++ b/tests/runtime/in_proc.c
@@ -58,10 +58,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -73,6 +73,10 @@ void flb_test_in_proc_selfcheck(void)
     flb_ctx_t    *ctx    = NULL;
     int in_ffd;
     int out_ffd;
+
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
 
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
@@ -87,7 +91,7 @@ void flb_test_in_proc_selfcheck(void)
                   "interval_sec", "1", "proc_name", "flb_test_in_proc",
                   "alert", "true", "mem", "on", "fd", "on", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
@@ -122,6 +126,10 @@ void flb_test_in_proc_absent_process(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     ctx = flb_create();
 
     in_ffd = flb_input(ctx, (char *) "proc", NULL);
@@ -130,7 +138,7 @@ void flb_test_in_proc_absent_process(void)
                   "interval_sec", "1", "proc_name", "",
                   "alert", "true", "mem", "on", "fd", "on", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 

--- a/tests/runtime/in_random.c
+++ b/tests/runtime/in_random.c
@@ -56,10 +56,10 @@ bool get_result(void)
     return val;
 }
 
-int callback_test(void* data, size_t size)
+int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        free(data);
+        flb_lib_free(data);
         set_result(true); /* success */
     }
     return 0;
@@ -72,6 +72,10 @@ void flb_test_in_random_flush_5s(void)
     int in_ffd;
     int out_ffd;
 
+    struct flb_lib_out_cb cb;
+    cb.cb   = callback_test;
+    cb.data = NULL;
+
     /* initialize */
     ret = pthread_mutex_init(&result_mutex, NULL);
     TEST_CHECK(ret == 0);
@@ -83,7 +87,7 @@ void flb_test_in_random_flush_5s(void)
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test", NULL);
 
-    out_ffd = flb_output(ctx, (char *) "lib", (void*)callback_test);
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 


### PR DESCRIPTION
out_lib api was updated and it broke some runtime tests.
(Now, we should pass `struct flb_lib_out_cb` to out_lib_init)

I fixed some tests to use new api.
