### PR TITLE
out_influxdb: add 'Auto_Tags' and 'Tag_Keys' options

### DIFF
--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -252,17 +252,24 @@ static char *influxdb_format(char *tag, int tag_len,
             }
         }
 
-        /* Append the timestamp */
-        ret = influxdb_bulk_append_timestamp(bulk_body, &tm);
-        if (ret == -1) {
-            flb_error("[out_influxdb] cannot append timestamp");
-            goto error;
-        }
+        /* Check have data fields */
+        if (bulk_body->len > 0) {
+            /* Append the timestamp */
+            ret = influxdb_bulk_append_timestamp(bulk_body, &tm);
+            if (ret == -1) {
+                flb_error("[out_influxdb] cannot append timestamp");
+                goto error;
+            }
 
-        /* Append collected data to final bulk */
-        if (influxdb_bulk_append_bulk(bulk, bulk_head, '\n') != 0 ||
-            influxdb_bulk_append_bulk(bulk, bulk_body, ' ') != 0) {
-            goto error;
+            /* Append collected data to final bulk */
+            if (influxdb_bulk_append_bulk(bulk, bulk_head, '\n') != 0 ||
+                influxdb_bulk_append_bulk(bulk, bulk_body, ' ') != 0) {
+                goto error;
+            }
+        } else {
+            flb_error("[out_influxdb] cannot send record, "
+                      "because all field is tagged in record");
+            /* Following records maybe ok, so continue processing */
         }
 
         /* Reset bulk_head and bulk_body */

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -42,6 +42,12 @@ struct flb_influxdb_config {
     char *seq_name;
     int seq_len;
 
+    /* auto_tags: on/off */
+    int auto_tags;
+
+    /* tag_keys: space separated list of key */
+    struct mk_list *tag_keys;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 };

--- a/plugins/out_influxdb/influxdb_bulk.h
+++ b/plugins/out_influxdb/influxdb_bulk.h
@@ -41,7 +41,12 @@ int influxdb_bulk_append_header(struct influxdb_bulk *bulk,
 int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
                             char *key, int k_len,
                             char *val, int v_len,
-                            int more, int quote);
+                            int quote);
+
+int influxdb_bulk_append_bulk(struct influxdb_bulk *bulk_to,
+                              struct influxdb_bulk *bulk_from,
+                              char separator);
+
 void influxdb_bulk_destroy(struct influxdb_bulk *bulk);
 int influxdb_bulk_append_timestamp(struct influxdb_bulk *bulk,
                                    struct flb_time *t);


### PR DESCRIPTION
These two options works like similar to 'fluent-plugin-influxdb'.
- `Auto_Tags:` On/Off *(default: Off)* Auto-tagging behaviour which makes string values as tags.
- `Tag_Keys:` Space separated list of the key names. Set this keys as tag in InfluxDB.