### PR TITLE
http_client: fix empty body response

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -346,9 +346,10 @@ static int process_data(struct flb_http_client *c)
                 return FLB_HTTP_OK;
             }
         }
-    }
-    else if (c->resp.headers_end && c->resp.content_length <= 0) {
-        return FLB_HTTP_OK;
+        else if (c->resp.content_length < 0) {
+            // empty body
+            return FLB_HTTP_OK;
+        }
     }
 
     return FLB_HTTP_MORE;


### PR DESCRIPTION
If the HTTP request returns with empty body, the `process_data` function handled incorrect way.

This fix is triggering another problem, that i don't do fix in easy way. Currently if i run `fluent-bit` with `influxdb` output (maybe another HTTP transaction is also triggering this error) with random input (Interval_Sec=1), only generate ONE record per 5 sec ([SERVICE]:Flush = 5).

Bonus: The first 4 record processed correctly, but after the program thinking about a 16 sec for sending next record.

*config file*
```
[SERVICE]
    Flush           5

[INPUT]
    Name            random
    Tag             rnd
    Interval_Sec    1

[OUTPUT]
    Name            influxdb
    Match           *
    Host            influxdb.local
    Port            3306
    Database        fluent-bit
    Sequence_Tag    @seq
```

*SOS*
```
Fluent Bit Enterprise - SOS Report
==================================
The following report aims to be used by Fluent Bit and Fluentd Enterprise
Customers of Treasure Data. For more details visit:

    https://fluentd.treasuredata.com


[Fluent Bit]
    Edition             Community Edition
    Version             0.13.0
    Built Flags          JSMN_PARENT_LINKS JSMN_STRICT FLB_HAVE_TLS FLB_HAVE_SQLDB FLB_HAVE_FLUSH_LIBCO FLB_HAVE_VALGRIND FLB_HAVE_FORK FLB_HAVE_TIMESPEC_GET FLB_HAVE_PROXY_GO FLB_HAVE_REGEX FLB_HAVE_C_TLS
FLB_HAVE_ACCEPT4 FLB_HAVE_INOTIFY

[Operating System]
    Name                Linux
    Release             4.4.0-43-Microsoft
    Version             #1-Microsoft Wed Dec 31 14:42:53 PST 2014

[Hardware]
    Architecture        x86_64
    Processors          4

[Built Plugins]
    Inputs              cpu mem kmsg tail proc disk netif dummy head exec health serial stdin tcp mqtt lib forward random syslog
    Filters             grep stdout throttle kubernetes parser record_modifier
    Outputs             counter es exit file forward http influxdb kafka-rest nats null plot stdout td lib flowcounter

[SERVER] Runtime configuration
    Flush               5
    Daemon              Off
    Log_Level           Trace

[INPUT] Instance
    Name                random.0 (random, id=0)
    Flags
    Threaded            No
    Tag                 rnd
    Interval_Sec        1
    Routes              influxdb.0


[OUTPUT] Instance
    Name                influxdb.0 (influxdb, mask_id=1)
    Match               *
    TLS Active          No
    Retry Limit         1
    Host.TCP_Port       3306
    Host.Name           influxdb.local
    Database            fluent-bit
    Sequence_Tag        @seq
```