### PR TITLE
Apache2 Parser config: Allow \" in the user-agent

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Name   apache2
     Format regex
-    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
     Time_Key time
     Time_Format %d/%b/%Y:%H:%M:%S %z
 


### PR DESCRIPTION
The user-agent comes from the client and we cannot prevent \" within it, so certain entries wont be parsed.
User-Agent is the last column in access.log so we cannot miss anything afterwards anyways.
eg. x.x.x.x - - [16/Apr/2018:16:19:20 +0000] "POST /myURL HTTP/1.1" 200 8073 "-" "Dalvik/2.1.0 (Linux; U; Android 5.1; Alba 10\" Build/LMY47I)"