### PR TITLE
Add parser decoder for escaped utf8 strings

### DIFF
--- a/include/fluent-bit/flb_parser_decoder.h
+++ b/include/fluent-bit/flb_parser_decoder.h
@@ -29,8 +29,9 @@
 #define FLB_PARSER_DEC_AS       1  /* results replace current key/value */
 
 /* Decoder Backend */
-#define FLB_PARSER_DEC_JSON     0  /* decode_json()    */
-#define FLB_PARSER_DEC_ESCAPED  1  /* decode_escaped() */
+#define FLB_PARSER_DEC_JSON          0  /* decode_json()    */
+#define FLB_PARSER_DEC_ESCAPED       1  /* decode_escaped() */
+#define FLB_PARSER_DEC_ESCAPED_UTF8  2  /* decode_escaped_utf8() */
 
 /* Decoder actions */
 #define FLB_PARSER_ACT_NONE     0

--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -29,6 +29,152 @@
 #define TYPE_OUT_STRING  0  /* unstructured text         */
 #define TYPE_OUT_OBJECT  1  /* structured msgpack object */
 
+static int octal_digit(char c)
+{
+    return (c >= '0' && c <= '7');
+}
+
+static int hex_digit(char c)
+{
+    return ((c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'F') ||
+            (c >= 'a' && c <= 'f'));
+}
+
+static int u8_wc_toutf8(char *dest, u_int32_t ch)
+{
+    if (ch < 0x80) {
+        dest[0] = (char)ch;
+        return 1;
+    }
+    if (ch < 0x800) {
+        dest[0] = (ch>>6) | 0xC0;
+        dest[1] = (ch & 0x3F) | 0x80;
+        return 2;
+    }
+    if (ch < 0x10000) {
+        dest[0] = (ch>>12) | 0xE0;
+        dest[1] = ((ch>>6) & 0x3F) | 0x80;
+        dest[2] = (ch & 0x3F) | 0x80;
+        return 3;
+    }
+    if (ch < 0x110000) {
+        dest[0] = (ch>>18) | 0xF0;
+        dest[1] = ((ch>>12) & 0x3F) | 0x80;
+        dest[2] = ((ch>>6) & 0x3F) | 0x80;
+        dest[3] = (ch & 0x3F) | 0x80;
+        return 4;
+    }
+    return 0;
+}
+
+/* assumes that src points to the character after a backslash
+   returns number of input characters processed */
+static int u8_read_escape_sequence(char *str, u_int32_t *dest)
+{
+    u_int32_t ch;
+    char digs[9]="\0\0\0\0\0\0\0\0";
+    int dno=0, i=1;
+
+    ch = (u_int32_t)str[0];    /* take literal character */
+
+    if (str[0] == 'n')
+        ch = L'\n';
+    else if (str[0] == 't')
+        ch = L'\t';
+    else if (str[0] == 'r')
+        ch = L'\r';
+    else if (str[0] == 'b')
+        ch = L'\b';
+    else if (str[0] == 'f')
+        ch = L'\f';
+    else if (str[0] == 'v')
+        ch = L'\v';
+    else if (str[0] == 'a')
+        ch = L'\a';
+    else if (octal_digit(str[0])) {
+        i = 0;
+        do {
+            digs[dno++] = str[i++];
+        } while (octal_digit(str[i]) && dno < 3);
+        ch = strtol(digs, NULL, 8);
+    }
+    else if (str[0] == 'x') {
+        while (hex_digit(str[i]) && dno < 2) {
+            digs[dno++] = str[i++];
+        }
+        if (dno > 0)
+            ch = strtol(digs, NULL, 16);
+    }
+    else if (str[0] == 'u') {
+        while (hex_digit(str[i]) && dno < 4) {
+            digs[dno++] = str[i++];
+        }
+        if (dno > 0)
+            ch = strtol(digs, NULL, 16);
+    }
+    else if (str[0] == 'U') {
+        while (hex_digit(str[i]) && dno < 8) {
+            digs[dno++] = str[i++];
+        }
+        if (dno > 0)
+            ch = strtol(digs, NULL, 16);
+    }
+    *dest = ch;
+
+    return i;
+}
+
+static inline bool is_json_escape(char *c)
+{
+  return (
+        (*c == '\"') || // double-quote
+        (*c == '\'') || // single-quote
+        (*c == '\\') || // solidus
+        (*c == '/')     // reverse-solidus
+      );
+}
+
+int unescape_string_utf8(char *buf, int sz, char *src)
+{
+    u_int32_t ch;
+    char temp[4];
+    char *next;
+
+    int count_out = 0;
+    int count_in = 0;
+    int esc_in = 0;
+    int esc_out = 0;
+
+    while (*src && count_in < sz) {
+        next = src + 1;
+        if (*src == '\\' && !is_json_escape(next)) {
+            esc_in = u8_read_escape_sequence((src + 1), &ch) + 1;
+        }
+        else {
+            ch = (u_int32_t)*src;
+            esc_in = 1;
+        }
+
+        src += esc_in;
+        count_in += esc_in;
+
+        esc_out = u8_wc_toutf8(temp, ch);
+
+        if (esc_out > sz-count_out) {
+            flb_error("Crossing over string boundary");
+            break;
+        }
+        memcpy(&buf[count_out], temp, esc_out);
+        count_out += esc_out;
+    }
+    if (count_in < sz) {
+        flb_error("Not at boundary but still NULL terminating : %d - '%s'", sz, src);
+    }
+    buf[count_in - 1] = '\0';
+    return count_out;
+}
+
 static int unescape_string(char *buf, int buf_len, char **unesc_buf)
 {
     int i = 0;
@@ -135,6 +281,19 @@ static int decode_escaped(struct flb_parser_dec *dec,
     return 0;
 }
 
+static int decode_escaped_utf8(struct flb_parser_dec *dec,
+                          char *in_buf, size_t in_size,
+                          char **out_buf, size_t *out_size, int *out_type)
+{
+    int len;
+
+    len = unescape_string_utf8(in_buf, in_size, &dec->buffer);
+    *out_buf = dec->buffer;
+    *out_size = len;
+    *out_type = TYPE_OUT_STRING;
+
+    return 0;
+}
 
 static int merge_record_and_extra_keys(char *in_buf, size_t in_size,
                                        char *extra_buf, size_t extra_size,
@@ -412,6 +571,11 @@ int flb_parser_decoder_do(struct mk_list *decoders,
                                      (char *) data_sds, flb_sds_len(data_sds),
                                      &dec_buf, &dec_size, &dec_type);
             }
+            else if (rule->backend == FLB_PARSER_DEC_ESCAPED_UTF8) {
+                ret = decode_escaped_utf8(dec,
+                                     (char *) data_sds, flb_sds_len(data_sds),
+                                     &dec_buf, &dec_size, &dec_type);
+            }
 
             /* Check decoder status */
             if (ret == -1) {
@@ -654,6 +818,9 @@ struct mk_list *flb_parser_decoder_list_create(struct mk_rconf_section *section)
         }
         else if (strcasecmp(decoder->value, "escaped") == 0) {
             backend = FLB_PARSER_DEC_ESCAPED;
+        }
+        else if (strcasecmp(decoder->value, "escaped_utf8") == 0) {
+            backend = FLB_PARSER_DEC_ESCAPED_UTF8;
         }
         else {
             flb_error("[parser] field decoder '%s' unknown", decoder->value);


### PR DESCRIPTION
This adds a parser decoder that unescapes JSON-safe UTF8 escaped strings.

Example input,

    {"log":"\u0009\u0009Starting app ..\n","stream":"stdout","time":"2018-02-19T23:25:31.0679529Z"}

File `main.conf`,

    [SERVICE]
        Parsers_File fluent-bit-parsers.conf
    
    [INPUT]
        Name        tail
        Parser      docker
        Path        /path/to/log.log

    [OUTPUT]
        Name   stdout
        Match  *

File `fluent-bit-parsers.conf`

    [PARSER]
        Name        docker
        Format      json
        Time_Key    time
        Time_Format %Y-%m-%dT%H:%M:%S %z
        Decode_Field_as escaped_utf8 log
