### PR TITLE
Fix reference to nonexistent path (introduced in commit 7584ee5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN install bin/fluent-bit /fluent-bit/bin/
 COPY conf/fluent-bit.conf \
      conf/parsers.conf \
      conf/parsers_java.conf \
-     conf/parsers_mult.conf \
+     conf/parsers_extra.conf \
      conf/parsers_openstack.conf \
      conf/parsers_cinder.conf \
      /fluent-bit/etc/


### PR DESCRIPTION
In commit 7584ee58 (@edsiper), the path conf/parsers_mult.conf was added to the Dockerfile. However, that path doesn't exist in the repo (but conf/parsers_extra.conf does).