### PR TITLE
Use line-delimited JSON for HTTP json_stream output plugin

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -120,8 +120,10 @@ static char *msgpack_to_json(struct flb_out_http_config *ctx, char *data, uint64
                     level++;
                 else if (*p == '}')
                     level--;
-                else if ((*p == '[' || *p == ']' || *p == ',') && level == 0)
+                else if ((*p == '[' || *p == ']') && level == 0)
                     *p=' ';
+                else if (*p == ',' && level == 0)
+                    *p='\n';
             }
         }
     }


### PR DESCRIPTION
The `json_stream` format in the `http` output plugin currently delimits JSON records with a space.
Some consumers, such as Loggly, require newline-separated records.
This patch changes the current behavior to use a newline as a delimiter instead of a space. This format seems more common and I can't see any obvious downside to this. If needed, I can change this to keep the current behavior as a default but adds the option to specify the delimiter via a configuration option.