### PR TITLE
Additional json_lines Format for HTTP Output

### DIFF
--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -23,6 +23,7 @@
 #define FLB_HTTP_OUT_MSGPACK        0
 #define FLB_HTTP_OUT_JSON           1
 #define FLB_HTTP_OUT_JSON_STREAM    2
+#define FLB_HTTP_OUT_JSON_LINES     3
 
 #define FLB_HTTP_CONTENT_TYPE   "Content-Type"
 #define FLB_HTTP_MIME_MSGPACK   "application/msgpack"


### PR DESCRIPTION
This is an attempt to provide a simple option that allows JSON logs to be sent to services that require each log entry be on a separate line.  An example is Loggly.  Currently testing this do no not merge yet but would love some feedback from anyone interested.

This is to address the items mentioned in #579 

```
  outputs.conf: |
    [OUTPUT]
        Name            http
        Match           *
        Host            logs-01.loggly.com
        Port            443
        URI             /bulk/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/tag/testing/
        Format          json_lines
        tls             On
        tls.verify      On
```

This closes #579 