### PR TITLE
out_http: Support ISO8601 format for json date

### DIFF
--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -24,6 +24,10 @@
 #define FLB_HTTP_OUT_JSON           1
 #define FLB_HTTP_OUT_JSON_STREAM    2
 
+#define FLB_JSON_DATE_DOUBLE      0
+#define FLB_JSON_DATE_ISO8601     1
+#define FLB_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
 #define FLB_HTTP_CONTENT_TYPE   "Content-Type"
 #define FLB_HTTP_MIME_MSGPACK   "application/msgpack"
 #define FLB_HTTP_MIME_JSON      "application/json"
@@ -40,6 +44,8 @@ struct flb_out_http_config {
 
     /* Output format */
     int out_format;
+
+    int json_date_format;
     char *json_date_key;
     size_t json_date_key_len;
 


### PR DESCRIPTION
This PR adds support for the ISO8601 timestamp format to the `http` output plugin.
The immediate purpose for this is to be able to have Loggly recognize log timestamps: Loggly requires messages to have a field named `timestamp` in this format. Otherwise it uses the ingestion timestamp instead of the timestamp in the original log message.

This new format is optional -- the original `double` format is kept as the default.
To use the new format, specify it like this:

```
Json_Date_Key    timestamp
Json_Date_Format iso8601
```

@brandoncole This might be of interest to you.