### PR TITLE
Kubernetes filter: Fix memory leak

### DIFF
--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -464,6 +464,8 @@ static int cb_kube_filter(void *data, size_t bytes,
                                     data + pre, off - pre,
                                     &cache_buf, &cache_size, &meta, &props);
             if (ret == -1) {
+                msgpack_sbuffer_destroy(&tmp_sbuf);
+                msgpack_unpacked_destroy(&result);
                 flb_kube_prop_destroy(&props);
                 return FLB_FILTER_NOTOUCH;
             }


### PR DESCRIPTION
In case the message didn't come from a pod, we would leak the message.