### PR TITLE
in_systemd: fix nanosecond timestamp calculation

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -139,7 +139,7 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
         /* Set time */
         sd_journal_get_realtime_usec(ctx->j, &usec);
         sec = usec / 1000000;
-        nsec = (usec % 1000000) / 1000;
+        nsec = (usec % 1000000) * 1000;
         flb_time_set(&tm, sec, nsec);
 
         /* Count the number of entries in the record */


### PR DESCRIPTION
`ns = us * 1000` - nanoseconds are smaller than microseconds.

Signed-off-by: Mike Kaplinskiy <mike@ladderlife.com>