### PR TITLE
out_http: fix support ISO8601 format for json date

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -173,6 +173,7 @@ int cb_http_init(struct flb_output_instance *ins, struct flb_config *config,
     int io_flags = 0;
     char *uri = NULL;
     char *tmp;
+    char *json_date_format;
     struct flb_upstream *upstream;
     struct flb_out_http_config *ctx = NULL;
     (void)data;
@@ -350,9 +351,12 @@ int cb_http_init(struct flb_output_instance *ins, struct flb_config *config,
     ctx->json_date_format = FLB_JSON_DATE_DOUBLE;
     tmp = flb_output_get_property("json_date_format", ins);
     if (tmp) {
-        if (strcasecmp(tmp, "iso8601") == 0) {
+        json_date_format= flb_strdup(tmp);
+        if (strcasecmp(json_date_format, "iso8601") == 0) {
             ctx->json_date_format = FLB_JSON_DATE_ISO8601;
         }
+
+        flb_free(json_date_format);
     }
 
     /* Date key for JSON output */


### PR DESCRIPTION
Hello,

In the `http output` plugin  setting the value of `Json_Date_Format` property to `iso8601` has no effect. The `double` format is allways used.

Configuration:
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    trace 
    Log_File     /fluent-bit/log/fluent-bit.log
    Parsers_File parsers.conf

[INPUT]
    Name          random
    Samples      -1
    Interval_Sec  1
    Interval_NSec 0
    Tag aa

[OUTPUT]
    Name  http 
    Match *
    Host 127.0.0.1 
    Port 8080
    URI /v1/sendlogs
    tls.verify off
    tls off
    Format json_stream
    json_date_format iso8601 

```
**Actual result:**
```
{"date":1527599027.002163, "rand_value":16995394648344596114} 
```

**Expected Result:**
```
{"date":"2018-05-30T09:39:52.000681Z", "rand_value":8547899446852466802}
```
The bug seems to be  [here](https://github.com/fluent/fluent-bit/blob/master/plugins/out_http/http.c#L353)

Best Regards