### PR TITLE
out_splunk: Allow user to send raw message by setting Splunk_Send_Raw On

### DIFF
--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -38,6 +38,9 @@ struct flb_splunk {
     /* Token Auth */
     flb_sds_t auth_header;
 
+    /* Send fields directly or pack data into "event" object */
+    int splunk_send_raw;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 };

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -110,6 +110,15 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* Event format, send all fields or pack into event map */
+    tmp = flb_output_get_property("splunk_send_raw", ins);
+    if (tmp) {
+        ctx->splunk_send_raw = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->splunk_send_raw = FLB_FALSE;
+    }
+
     return ctx;
 }
 


### PR DESCRIPTION
This patch adds a new toggle for the Splunk HTTP Event Collector output
plugin to allow users to specify index, sourcetype and other top level
fields when sending data to splunk.  The current behaviour sends data to
the main index by default.

When enabling the feature, the user must take care to put all log
details in the event field, and only specify fields known to splunk in
the top level event.

Example:

    Splunk_Send_Raw Off
    {"time": .., "event": {"k1": "foo", "k2": "bar", "index": "applogs"}}

    Splunk_Send_Raw On
    {"time": .., "k1": "foo", "k2": "bar", "index": "applogs"}

For up to date information about the valid keys in the top level object,
refer to the splunk documentation:

http://docs.splunk.com/Documentation/Splunk/latest/Data/AboutHEC

The patch has been tested using Splunk 6.6.1

Fixes #609