### PR TITLE
filter_modify: Add new operations, conditionals

### DIFF
--- a/plugins/filter_modify/modify.h
+++ b/plugins/filter_modify/modify.h
@@ -20,20 +20,53 @@
 #ifndef FLB_FILTER_MODIFY_H
 #define FLB_FILTER_MODIFY_H
 
+enum FLB_FILTER_MODIFY_RULETYPE {
+  RENAME,
+  HARD_RENAME,
+  ADD,
+  SET,
+  REMOVE,
+  REMOVE_WILDCARD,
+  COPY,
+  HARD_COPY
+};
+
+enum FLB_FILTER_MODIFY_CONDITIONTYPE {
+  KEY_EXISTS,
+  KEY_DOES_NOT_EXIST,
+  KEY_VALUE_EQUALS,
+  KEY_VALUE_DOES_NOT_EQUAL
+};
+
 struct filter_modify_ctx
 {
-    int add_key_rules_cnt;
-    int rename_key_rules_cnt;
-    struct mk_list add_key_rules;
-    struct mk_list rename_key_rules;
+  int rules_cnt;
+  struct mk_list rules;
+  int conditions_cnt;
+  struct mk_list conditions;
 };
 
 struct modify_rule
 {
-    int key_len;
-    int val_len;
-    char *key;
-    char *val;
-    struct mk_list _head;
+  enum FLB_FILTER_MODIFY_RULETYPE ruletype;
+  int key_len;
+  int val_len;
+  char *key;
+  char *val;
+  char *raw_k;
+  char *raw_v;
+  struct mk_list _head;
+};
+
+struct modify_condition
+{
+  enum FLB_FILTER_MODIFY_CONDITIONTYPE conditiontype;
+  int a_len;
+  int b_len;
+  char *a;
+  char *b;
+  char *raw_k;
+  char *raw_v;
+  struct mk_list _head;
 };
 #endif


### PR DESCRIPTION
This extends the number of operations the modify filter can perform to,

-   RENAME
-   HARD_RENAME
-   ADD
-   SET
-   REMOVE
-   REMOVE_WILDCARD
-   COPY
-   HARD_COPY

In addition, this also adds the option to add conditions that have to be met for a filter instance's rules to be applied.

The possible conditions are,

-   KEY_EXISTS
-   KEY_DOES_NOT_EXIST
-   KEY_VALUE_EQUALS
-   KEY_VALUE_DOES_NOT_EQUAL

Example configuration,
```
[FILTER]
    Name    modify
    Match   *

    Set sourcetype memstats

[FILTER]
    Name    modify
    Match   *

    # Multiple conditions are possible, all have to be met
    Condition Key_Value_Does_Not_Equal sourcetype memstats
    Condition Key_Value_Equals sourcetype memstats

    Add sourcetypeX memstatsX
    Copy sourcetypeX sourcetype_copy
    Rename sourcetypeX new_sourcetype
    Set all_done true
```