### PR TITLE
Add kafka debug configuration option

### DIFF
--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -61,6 +61,16 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
         flb_error("[out_kafka] cannot configure client.id");
     }
 
+
+    tmp = flb_output_get_property("debug", ins);
+    if (tmp) {
+        ret = rd_kafka_conf_set(ctx->conf, "debug", tmp,
+                                errstr, sizeof(errstr));
+        if (ret != RD_KAFKA_CONF_OK) {
+            flb_error("[out_kafka] cannot configure client.id");
+        }
+    }
+
     /* Config: Brokers */
     tmp = flb_output_get_property("brokers", ins);
     if (tmp) {


### PR DESCRIPTION
We are running fluent-bit to connect to a Kafka cluster and we have the following error on fluent-bit output:

```
[2018/06/05 15:48:38] [error] [out_kafka] fluent-bit#producer-1: [<REDACTED>]: <REDACTED>/2: Receive failed: Disconnected
[2018/06/05 20:06:47] [error] [out_kafka] fluent-bit#producer-1: [<REDACTED>]: <REDACTED>/4: Connection closed
```

Our problem is that we do not have sufficient context to allow us to know what shall we do to fix our problem.

To understand what is going on, we had to change the code (c.f. https://github.com/tjamet/fluent-bit/tree/debug), as suggested in https://github.com/edenhill/librdkafka/issues/1572.

This PR adds the ability to forward the debug options to Kafka, thus allowing debugging without changing the code

