### PR TITLE
test.lua: output table contents

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -27,7 +27,14 @@
 
 -- Print record to the standard output
 function cb_print(tag, timestamp, record)
-   print(tag, string.format("%f", timestamp), record)
+   output = tag .. ":  [" .. string.format("%f", timestamp) .. ", { "
+
+   for key, val in pairs(record) do
+      output = output .. string.format(" %s => %s,", key, val)
+   end
+   
+   output = string.sub(output,1,-2) .. " }]"
+   print(output)
 
    -- Record not modified so 'code' return value is 0 (first parameter)
    return 0, 0, 0


### PR DESCRIPTION
Recently, we changed the format of filter_lua, JSON -> Lua table.
So, we also need to modify cb_print to handle Lua table.

Now, cb_print doesn't output contents of table.
```shell
$ bin/fluent-bit -i mem -F lua -p script=../scripts/test.lua -p call=cb_print -m '*' -o stdout
Fluent-Bit v0.14.0
Copyright (C) Treasure Data

[2018/06/11 22:53:12] [ info] [engine] started (pid=20490)
mem.0	1528725193.000884	table: 0x41f16340
mem.0	1528725194.000263	table: 0x41f16398
mem.0	1528725195.000821	table: 0x41f1ccf0
```

My patch is to output such JSON like format.
```shell
$ bin/fluent-bit -i mem -F lua -p script=../scripts/test.lua -p call=cb_print -m '*' -o stdout
Fluent-Bit v0.14.0
Copyright (C) Treasure Data

[2018/06/11 22:48:53] [ info] [engine] started (pid=20207)
mem.0:  [1528724934.002288, {  Mem.free => 625464, Swap.free => 2064380, Swap.used => 0, Mem.used => 3294704, Mem.total => 3920168, Swap.total => 2064380 }]
mem.0:  [1528724935.001287, {  Mem.free => 625464, Swap.free => 2064380, Swap.used => 0, Mem.used => 3294704, Mem.total => 3920168, Swap.total => 2064380 }]
mem.0:  [1528724936.000483, {  Mem.free => 625464, Swap.free => 2064380, Swap.used => 0, Mem.used => 3294704, Mem.total => 3920168, Swap.total => 2064380 }]

```