### PR TITLE
scripts: new script to append tag to each record

### DIFF
--- a/scripts/append_tag.lua
+++ b/scripts/append_tag.lua
@@ -1,0 +1,5 @@
+function append_tag(tag, timestamp, record)
+    new_record = record
+    new_record["tag"] = tag
+    return 1, timestamp, new_record
+end


### PR DESCRIPTION
This simple lua script is  to append tag to each record.

This is an example.
```
$ bin/fluent-bit -i dummy  -F lua -m '*' -p script=../scripts/append_tag.lua -p call=append_tag -o stdout
Fluent-Bit v0.14.0
Copyright (C) Treasure Data

[2018/06/14 22:53:14] [ info] [engine] started (pid=10266)
[0] dummy.0: [1528984395.001862049, {"message"=>"dummy", "tag"=>"dummy.0"}]
[1] dummy.0: [1528984396.000606536, {"message"=>"dummy", "tag"=>"dummy.0"}]
[2] dummy.0: [1528984397.000774860, {"message"=>"dummy", "tag"=>"dummy.0"}]
```