### PR TITLE
filter_nest: Multiple wildcards and add/remove prefix options

### DIFF
--- a/plugins/filter_nest/nest.h
+++ b/plugins/filter_nest/nest.h
@@ -28,18 +28,24 @@ enum FILTER_NEST_OPERATION {
 struct filter_nest_ctx
 {
     enum FILTER_NEST_OPERATION operation;
+    char *key;
+    int key_len;
+    char *prefix;
+    int prefix_len;
     // nest
-    char *nesting_key;
-    int nesting_key_len;
-    char *wildcard;
-    int wildcard_len;
-    bool wildcard_is_dynamic;
+    struct mk_list wildcards;
+    int wildcards_cnt;
+    bool remove_prefix;
     // lift
-    char *nested_under;
-    int nested_under_len;
-    char *prefix_with;
-    int prefix_with_len;
-    bool use_prefix;
+    bool add_prefix;
+};
+
+struct filter_nest_wildcard
+{
+    char *key;
+    int key_len;
+    bool key_is_dynamic;
+    struct mk_list _head;
 };
 
 #endif


### PR DESCRIPTION
This adds support to `filter_nest` for,

 - Multiple wildcards in a single filter instance
 - `Add_prefix` for both nest and lift operations
 - `Remove_prefix` for both nest and lift operations

Signed-off-by: Michiel Kalkman <michiel@nosuchtype.com>