### PR TITLE
out_http: Add arbitrary HTTP headers

### DIFF
--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -61,6 +61,18 @@ struct flb_out_http_config {
 
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
+
+    /* Arbitrary HTTP headers */
+    struct mk_list headers;
+    int headers_cnt;
+};
+
+struct out_http_header {
+    char *key;
+    int key_len;
+    char *val;
+    int val_len;
+    struct mk_list _head;
 };
 
 #endif


### PR DESCRIPTION
This adds a new configuration option '`Header`', which will add an
arbitrary key/value pair as HTTP header to outgoing HTTP requests.

Signed-off-by: Michiel Kalkman <michiel@nosuchtype.com>