### PR TITLE
Add initial Issue Template for Feature Requests and Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
+
+Please post all questions and issues on https://slack.fluentd.org/ on the fluent-bit before opening a Github Issue. Your questions will reach a wider audience there,
+and if we confirm that there is a bug, then you can open a new issue.
+
+Check the other issue templates if you are trying to submit a bug report, feature request, or question
+Search open/closed issues before submitting since someone might have asked the same thing before!
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+
+---
+
+## Bug Report
+
+**Describe the bug**
+<!--- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+- Rubular link if applicable:
+- Example log message if applicable:
+```
+{"log":"YOUR LOG MESSAGE HERE","stream":"stdout","time":"2018-06-11T14:37:30.681701731Z"}
+```
+- Steps to reproduce the problem:
+
+**Expected behavior**
+<!--- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!--- If applicable, add screenshots to help explain your problem. -->
+
+**Your Environment**
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Configuration:
+* Environment name and version (e.g. Kubernetes? What version?):
+* Server type and version:
+* Operating System and version:
+* Filters and plugins:
+
+**Additional context**
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!--- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<!--- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
This Pull Request [adds initial Issue Templates for this repository](https://help.github.com/articles/about-issue-and-pull-request-templates/). Using the template builder, you can specify a title and description for each template, add the template content, and either commit the template to the default branch or open a pull request in the repository. The template builder automatically adds the YAML front matter markup that is required for the template to show on the new issue page. For more information, see "Creating issue templates for your repository."