### PR TITLE
decoder_utf8: do not read escaped newline (#615)

### DIFF
--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -131,6 +131,7 @@ static inline bool is_json_escape(char *c)
         (*c == '\"') || // double-quote
         (*c == '\'') || // single-quote
         (*c == '\\') || // solidus
+        (*c == 'n')  || // new-line
         (*c == '/')     // reverse-solidus
       );
 }


### PR DESCRIPTION
In the UTF-8 decoder, it tries to read escaped char for general
purpose. Escaping a new-line is valid in JSON encoding, if it
lines a UTF-8 decoder and then a JSON decoder, the JSON decoder
will fail, as the escaped new-line is treated as a real newline
in the first UTF-8 decoder.

This fixes the issue in #615

Signed-off-by: Richard Meng <mengangr@foxmail.com>