### PR TITLE
out_es: add Logstash_Prefix_Key support

### DIFF
--- a/conf/kube_elasticsearch.conf
+++ b/conf/kube_elasticsearch.conf
@@ -16,7 +16,8 @@
     Match  kube.*
 
 [OUTPUT]
-    Name            es
-    Match           *
-    Logstash_Format On
-    Retry_Limit     False
+    Name                es
+    Match               *
+    Logstash_Format     On
+    Retry_Limit         False
+    Logstash_Prefix_Key es_index

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -145,6 +145,11 @@ static char *elasticsearch_format(void *data, size_t bytes,
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
     uint16_t hash[8];
+    const char *es_index_custom;
+    int es_index_custom_len;
+    int i;
+    msgpack_object key;
+    msgpack_object val;
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
@@ -217,6 +222,34 @@ static char *elasticsearch_format(void *data, size_t bytes,
         map   = root.via.array.ptr[1];
         map_size = map.via.map.size;
 
+        es_index_custom_len = 0;
+        if (ctx->logstash_prefix_key_len != 0) {
+            for (i = 0; i < map_size; i++) {
+                key = map.via.map.ptr[i].key;
+                if (key.type != MSGPACK_OBJECT_STR) {
+                    continue;
+                }
+                if (key.via.str.size != ctx->logstash_prefix_key_len) {
+                    continue;
+                }
+                if (strncmp(key.via.str.ptr, ctx->logstash_prefix_key, ctx->logstash_prefix_key_len) != 0) {
+                    continue;
+                }
+                val = map.via.map.ptr[i].val;
+                if (val.type != MSGPACK_OBJECT_STR) {
+                    continue;
+                }
+                if (val.via.str.size >= 128) {
+                    continue;
+                }
+                es_index_custom = val.via.str.ptr;
+                es_index_custom_len = val.via.str.size;
+                memcpy(logstash_index, es_index_custom, es_index_custom_len);
+                logstash_index[es_index_custom_len] = '\0';
+                break;
+            }
+        }
+
         /* Create temporal msgpack buffer */
         msgpack_sbuffer_init(&tmp_sbuf);
         msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
@@ -246,7 +279,11 @@ static char *elasticsearch_format(void *data, size_t bytes,
         es_index = ctx->index;
         if (ctx->logstash_format == FLB_TRUE) {
             /* Compose Index header */
-            p = logstash_index + ctx->logstash_prefix_len;
+            if (es_index_custom_len > 0) {
+                p = logstash_index + es_index_custom_len;
+            } else {
+                p = logstash_index + ctx->logstash_prefix_len;
+            }
             *p++ = '-';
 
             len = p - logstash_index;

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -55,6 +55,10 @@ struct flb_elasticsearch {
     int logstash_prefix_len;
     char *logstash_prefix;
 
+    /* prefix key */
+    int logstash_prefix_key_len;
+    char *logstash_prefix_key;
+
     /* date format */
     int logstash_dateformat_len;
     char *logstash_dateformat;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -152,6 +152,13 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
         ctx->logstash_prefix_len = sizeof(FLB_ES_DEFAULT_PREFIX) - 1;
     }
 
+    /* Logstash_Prefix_Key */
+    tmp = flb_output_get_property("logstash_prefix_key", ins);
+    if (tmp) {
+        ctx->logstash_prefix_key = flb_strdup(tmp);
+        ctx->logstash_prefix_key_len = strlen(tmp);
+    }
+
     /* Logstash_DateFormat */
     tmp = flb_output_get_property("logstash_dateformat", ins);
     if (tmp) {
@@ -265,6 +272,10 @@ int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 
     if (ctx->include_tag_key) {
         flb_free(ctx->tag_key);
+    }
+
+    if (ctx->logstash_prefix_key) {
+        flb_free(ctx->logstash_prefix_key);
     }
 
     flb_upstream_destroy(ctx->u);


### PR DESCRIPTION
ConfigMap example for k8s:

```
  output-elasticsearch.conf: |
    [OUTPUT]
        Name                es
        Match               *
        Host                ${FLUENT_ELASTICSEARCH_HOST}
        Port                ${FLUENT_ELASTICSEARCH_PORT}
        Logstash_Format     On
        Logstash_Prefix     k8s   
        Logstash_Prefix_Key es_index
```

log example

```
{"es_index":"service-liveness-probe","func":"ProbeService","level":"info","method":"TcpPort","msg":"okay","port":0,"prob_name":"http","svc":"service_name.ns","time":"2018-07-31T11:11:18+08:00"}
```

ElasticSearch result:

![wx20180731-112309](https://user-images.githubusercontent.com/2338699/43435808-38d8f0f2-94b4-11e8-9182-84059d2eed66.png)
