### PR TITLE
filter_parser: fix return value(#700)

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -185,6 +185,7 @@ static int cb_parser_filter(void *data, size_t bytes,
     msgpack_object_kv *kv;
     int i;
     int ret = FLB_FILTER_NOTOUCH;
+    int parse_ret = -1;
     int map_num;
     char *key_str;
     int key_len;
@@ -254,10 +255,10 @@ static int cb_parser_filter(void *data, size_t bytes,
                     mk_list_foreach(head, &ctx->parsers) {
                         fp = mk_list_entry(head, struct filter_parser, _head);
 
-                        ret = flb_parser_do(fp->parser, val_str, val_len,
+                        parse_ret = flb_parser_do(fp->parser, val_str, val_len,
                                             (void **) &out_buf, &out_size,
                                             &parsed_time);
-                        if (ret >= 0) {
+                        if (parse_ret >= 0) {
                             if (flb_time_to_double(&parsed_time) != 0) {
                                 flb_time_copy(&tm, &parsed_time);
                             }


### PR DESCRIPTION
To fix #700 

## root cause

In some cases, `cb_parser_filter` returns -1.
cb_filter should return 1 or 2
```
#define FLB_FILTER_MODIFIED 1
#define FLB_FILTER_NOTOUCH  2
```

The variable `ret` is diverted as return value of `flb_parser_do`.
If flb_parser_do returns -1, it will be returned from cb_parser_filter.
The buffer will not be released at `flb_filter_do`, if return value is not 1 

## how to reproduce the problem
```
$ ../bin/fluent-bit -c out_forward.conf  -f 1
$ valgrind --tool=massif ../bin/fluent-bit -c in_forward.conf
```
### in_forward side
in_forward.conf:
```python
[SERVICE]                                      
    Flush        1                             
    Daemon       Off                           
    Log_Level    debug
    Parsers_File ./parsers.conf  
    HTTP_Server  On                            
    HTTP_Listen  0.0.0.0                       
    HTTP_PORT    2020                        

[INPUT]                                        
    Name Forward                               
#    Listen 127.0.0.1                           
    Port 24224                                 
    Buffer_Max_Size 128M                       
    Mem_Buf_Limit 128M                         
    Chunk_Size 64M                             
[FILTER]                                       
    Name parser                                
    Match *              
    Key_Name log
    Parser proxy                       
[OUTPUT]
    Name null
#    Match *
```

parsers.conf:
```python
[PARSER]
    Name proxy
    Format regex
    Regex ^time:(?<time>[^\s]*)\s*remote_addr:(?<remote_addr>[^\s]*)\s*request_method:(?<request_method>[^\s]*)\s*request_length:(?<request_length>[^\s]*)\s*request_uri:(?<request_uri>[^\s]*)\s*https:(?<https>[^\s]*)\s*uri:(?<uri>[^\s]*)\s*query_string:(?<query_string>[^\s]*)\s*status:(?<status>[^\s]*)\s*bytes_sent:(?<bytes_sent>[^\s]*)\s*body_bytes_sent:(?<body_bytes_sent>[^\s]*)\s*referer:(?<referer>[^\s]*)\s*useragent:(?<useragent>[^\s].*)\s*forwardedfor:(?<forwardedfor>[^\s]*)\s*request_time:(?<request_time>[^\s]*)\s*upstream_response_time:(?<upstream_response_time>[^\s]*)\s*upstream_addr:(?<upstream_addr>[^\s]*)
    Time_Key time
    Time_Format %Y-%m-%dT%H:%M:%S%z
```

### out_forward side
out_forward.conf:
```python
[INPUT] 
   Name dummy
   dummy {"log":"time:2018-08-01T23:00:49+09:00  remote_addr:10.114.99.27        request_method:GET     request_length:58       request_uri:/   https:  uri:/   query_string:-status:200       bytes_sent:11428        body_bytes_sent:11250   referer:-     useragent:-      forwardedfor:-  request_time:0.101      upstream_response_time:0.100, 0.001    upstream_addr:**.***.***.**:*****, **.***.***.**:*****"}
   rate 100000

[OUTPUT]
   Name forward
   Match *
```

## result

### without this patch

over half GB.
```
$ ms_print leak_massif 

    MB
624.6^                                                                       #
     |                                                                       #
     |                                                                       #
     |                                                                      @#
     |                                                                  :@::@#
     |                                              @@::::: @@:::@@::::::@::@#
     |                                   :::@@::::::@ :: : :@ : :@ :: :::@::@#
     |                              @@:::: :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                             :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                          ::::@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                        :::: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                     @::: :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                    @@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |                 :::@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |               @@: :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |               @ : :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |               @ : :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |               @ : :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |          :::@@@ : :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
     |  ::::::::: :@ @ : :@@: : :: :@ :: : :@ ::: : @ :: : :@ : :@ :: :::@::@#
   0 +----------------------------------------------------------------------->Gi
     0                                                                   48.86
```

### fixed case

under 50MB
```
$ ms_print massif.out.26609 

    MB
40.85^                                                               #        
     |                                                              @#        
     |                                                              @#        
     |                        @@                                   :@#        
     |                        @                                   ::@#        
     |                       :@                                   ::@#        
     |                      @:@                                   ::@#        
     |                      @:@                                   ::@#        
     |                     @@:@                                :  ::@#        
     |                 @   @@:@                          @    :: :::@#        
     |                 @   @@:@                          @   ::: :::@#        
     |           @  :  @   @@:@         :            :   @  :::: :::@#        
     |           @ ::: @  :@@:@        ::            :   @  ::::::::@#        
     |       ::: @ ::: @  :@@:@        ::            : : @::::::::::@#        
     |      :: : @ ::: @:::@@:@        ::     :      : ::@: ::::::::@#        
     |    : :: ::@ ::::@: :@@:@    ::  ::     ::: :  ::::@: ::::::::@#     : :
     |    :::: ::@:::::@: :@@:@    ::  ::  ::::: ::::::::@: ::::::::@#    ::@:
     |   ::::: ::@:::::@: :@@:@  : ::::::  ::::: ::: ::::@: ::::::::@#  : ::@:
     | ::::::: ::@:::::@: :@@:@  ::::::::  ::::: ::: ::::@: ::::::::@#::::::@:
     | : ::::: ::@:::::@: :@@:@ :::::::::::::::: ::: ::::@: ::::::::@#::::::@:
   0 +----------------------------------------------------------------------->Gi
     0                                                                   53.35

```