### PR TITLE
filter_lua: add new option to convert integer

### DIFF
--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -98,7 +98,7 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
     }
     
     lf->l2c_types_num = 0;
-    tmp = flb_filter_get_property("c_int_key", ins);
+    tmp = flb_filter_get_property("type_int_key", ins);
     if (tmp) {
         split = flb_utils_split(tmp, ' ', L2C_TYPES_NUM_MAX);
         mk_list_foreach_safe(head, tmp_list, split) {

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -100,7 +100,7 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
     lf->l2c_types_num = 0;
     tmp = flb_filter_get_property("c_int_key", ins);
     if (tmp) {
-        split = flb_utils_split(tmp, ' ', 1);
+        split = flb_utils_split(tmp, ' ', L2C_TYPES_NUM_MAX);
         mk_list_foreach_safe(head, tmp_list, split) {
             l2c = flb_malloc(sizeof(struct l2c_type));
 

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -21,6 +21,8 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_utils.h>
 
 #include "lua_config.h"
 
@@ -32,8 +34,14 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
 {
     int ret;
     char *tmp;
+    char *tmp_key;
     (void) config;
     struct lua_filter *lf;
+    struct mk_list *split   = NULL;
+    struct mk_list *head    = NULL;
+    struct mk_list *tmp_list= NULL;
+    struct l2c_type  *l2c   = NULL;
+    struct flb_split_entry *sentry = NULL;
 
     /* Allocate context */
     lf = flb_calloc(1, sizeof(struct lua_filter));
@@ -41,6 +49,8 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         flb_errno();
         return NULL;
     }
+
+    mk_list_init(&lf->l2c_types);
 
     /* Config: script */
     tmp = flb_filter_get_property("script", ins);
@@ -86,12 +96,36 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         lua_config_destroy(lf);
         return NULL;
     }
+    
+    lf->l2c_types_num = 0;
+    tmp = flb_filter_get_property("c_int_key", ins);
+    if (tmp) {
+        split = flb_utils_split(tmp, ' ', 1);
+        mk_list_foreach_safe(head, tmp_list, split) {
+            l2c = flb_malloc(sizeof(struct l2c_type));
+
+            sentry = mk_list_entry(head, struct flb_split_entry, _head);
+
+            tmp_key = flb_strndup(sentry->value, sentry->len);
+            l2c->key = flb_sds_create(tmp_key);
+            flb_free(tmp_key);
+
+            mk_list_add(&l2c->_head, &lf->l2c_types);
+            lf->l2c_types_num++;
+        }
+        flb_utils_split_free(split);
+    }
+
 
     return lf;
 }
 
 void lua_config_destroy(struct lua_filter *lf)
 {
+    struct mk_list  *tmp_list = NULL;
+    struct mk_list  *head     = NULL;
+    struct l2c_type *l2c      = NULL;
+
     if (!lf) {
         return;
     }
@@ -105,5 +139,18 @@ void lua_config_destroy(struct lua_filter *lf)
     if (lf->buffer) {
         flb_sds_destroy(lf->buffer);
     }
+
+    mk_list_foreach_safe(head, tmp_list, &lf->l2c_types) {
+        l2c = mk_list_entry(head, struct l2c_type, _head);
+        if (l2c) {
+            if (l2c->key) {
+                flb_sds_destroy(l2c->key);
+            }
+            mk_list_del(&l2c->_head);
+            flb_free(l2c);
+        }
+    }
+
+
     flb_free(lf);
 }

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -27,11 +27,18 @@
 
 #define LUA_BUFFER_CHUNK    1024*8  /* 8K should be enough to get started */
 
+struct l2c_type {
+    flb_sds_t key;
+    struct mk_list _head;
+};
+
 struct lua_filter {
-    flb_sds_t script;       /* lua script path */
-    flb_sds_t call;         /* function name   */
-    flb_sds_t buffer;       /* json dec buffer */
-    struct flb_luajit *lua; /* state context   */
+    flb_sds_t script;         /* lua script path */
+    flb_sds_t call;           /* function name   */
+    flb_sds_t buffer;         /* json dec buffer */
+    int    l2c_types_num;     /* number of l2c_types */
+    struct mk_list l2c_types; /* data types (lua -> C) */
+    struct flb_luajit *lua;   /* state context   */
 };
 
 struct lua_filter *lua_config_create(struct flb_filter_instance *ins,

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -32,6 +32,7 @@ struct l2c_type {
     struct mk_list _head;
 };
 
+#define L2C_TYPES_NUM_MAX 16
 struct lua_filter {
     flb_sds_t script;         /* lua script path */
     flb_sds_t call;           /* function name   */


### PR DESCRIPTION
This is an another patch to fix #641 

With this patch
* default : lua_TNUMBER is converted to `double`
* option (c_int_key) : lua_TNUMBER is converted to `int64`

## example 
lua.conf:
```python
[INPUT]
    Name cpu

[FILTER]
    Name lua
    Match *
    call  cb_append
    script append.lua
    c_int_key cpu_p cpu0.p_system lua_int

[OUTPUT]
    Name stdout
```

append.lua:
```lua
function cb_append(tag, timestamp, record)
   new_record = record
   new_record["lua_double"] = 12345
   new_record["lua_int"]    = 12345
   return 1, timestamp, new_record
end
```

`cpu_p` and `cpu0.p_system` and `lua_int` (generated in lua) are converted to integer.
Others are double.
```sh
$ bin/fluent-bit -c lua.conf 
Fluent-Bit v0.14.0
Copyright (C) Treasure Data

[2018/08/26 20:30:27] [ info] [engine] started (pid=22075)
[0] cpu.0: [1535283028.002336740, {"lua_double"=>12345.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>1.000000, "cpu_p"=>2, "cpu0.p_system"=>1, "lua_int"=>12345, "user_p"=>1.000000}]
[1] cpu.0: [1535283029.002326011, {"lua_double"=>12345.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>8.000000, "cpu0.p_user"=>7.000000, "cpu_p"=>8, "cpu0.p_system"=>1, "lua_int"=>12345, "user_p"=>7.000000}]
[2] cpu.0: [1535283030.002673387, {"lua_double"=>12345.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>8.000000, "cpu0.p_user"=>6.000000, "cpu_p"=>8, "cpu0.p_system"=>2, "lua_int"=>12345, "user_p"=>6.000000}]
[3] cpu.0: [1535283031.011747121, {"lua_double"=>12345.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>6.000000, "cpu_p"=>7, "cpu0.p_system"=>1, "lua_int"=>12345, "user_p"=>6.000000}]
^C[engine] caught signal (SIGINT)
[2018/08/26 20:30:32] [ info] [input] pausing cpu.0

```