### PR TITLE
in_exec: allow for long-running commands

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_stats.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_macros.h>
 #include <msgpack.h>
 
 #include <fcntl.h>
@@ -230,10 +231,10 @@ static int in_exec_config_read(struct flb_in_exec_config *exec_config,
     follow = flb_input_get_property("follow", in);
     if (follow != NULL) {
         if (strcasecmp(follow, "true") == 0) {
-            exec_config->follow = 1;
+            exec_config->follow = FLB_TRUE;
         }
         else if (strcasecmp(follow, "false") == 0) {
-            exec_config->follow = 0;
+            exec_config->follow = FLB_FALSE;
         }
         else {
             flb_error("[in_exec] property 'follow' should be either 'true' or 'false'");

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -79,7 +79,8 @@ int in_exec_spawn_child(int pipefd[], struct flb_in_exec_config *config)
         return 1;
     }
 
-    for (int otherfd = 3; otherfd < rlp.rlim_cur; otherfd++) {
+    int otherfd;
+    for (otherfd = 3; otherfd < rlp.rlim_cur; otherfd++) {
         close(otherfd);
     }
 
@@ -218,7 +219,8 @@ static int in_exec_config_read(struct flb_in_exec_config *exec_config,
     }
 
     /* split into an argv array */
-    for (char *arg = strtok_r(cmd, " ", &cmd); arg != NULL; arg = strtok_r(NULL, " ", &cmd)) {
+    char *arg = NULL;
+    for (arg = strtok_r(cmd, " ", &cmd); arg != NULL; arg = strtok_r(NULL, " ", &cmd)) {
         exec_config->argv = flb_realloc(exec_config->argv, (argc + 2) * sizeof(char *));
         exec_config->argv[argc++] = arg;
     }

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -31,8 +31,11 @@
 #define DEFAULT_INTERVAL_NSEC 0
 
 struct flb_in_exec_config {
-    char  *cmd;
+    char **argv;
     struct flb_parser  *parser;
+    pid_t  pid;
+    FILE  *cmdp;
+    bool   follow;
 };
 
 extern struct flb_input_plugin in_exec_plugin;


### PR DESCRIPTION
Add a boolean option (follow) to in_exec plugin to read the spawned
process output using non-blocking I/O, this way Fluent-bit can capture
the output of commands that never exit, for example `vmstat -S M 10`.

Signed-off-by: Joost Molenaar <jjm@j0057.nl>