### PR TITLE
 influxdb: fix timestamp types

### DIFF
--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -24,6 +24,8 @@
 #include <fluent-bit.h>
 #include "influxdb_bulk.h"
 
+static const uint64_t ONE_BILLION = 1000000000;
+ 
 static int influxdb_bulk_buffer(struct influxdb_bulk *bulk, int required)
 {
     int new_size;
@@ -178,7 +180,7 @@ int influxdb_bulk_append_timestamp(struct influxdb_bulk *bulk,
     }
 
     /* Timestamp is in Nanoseconds */
-    timestamp = (t->tm.tv_sec * 1000000000) + t->tm.tv_nsec;
+    timestamp = (t->tm.tv_sec * ONE_BILLION) + t->tm.tv_nsec;
     len = snprintf(bulk->ptr + bulk->len, 127, " %" PRIu64, timestamp);
     if (len == -1) {
         return -1;


### PR DESCRIPTION
Timestamps `tm.tv_sec` and `tm.tv_nsec` set in `src/flb_time.c` [here](https://github.com/010akv/fluent-bit/blob/master/src/flb_time.c#L36-L51) will be uint64_t or uint32_t. However, `influxdb_bulk_append_timestamp()` in influxdb plugin assumes uint64_t.  This is not always true. This causes incorrect timestamp values being computed and sent to influxdb.

Adding a global uint64_t constant to fix this issue.

Signed-off-by: Anusha Kasi Vishwanathan 010akv@gmail.com