### PR TITLE
in_tail: optionally format tag based on a regex against filename

### DIFF
--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -24,6 +24,9 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_macros.h>
+#ifdef FLB_HAVE_REGEX
+#include <fluent-bit/flb_regex.h>
+#endif
 
 struct flb_tail_config {
     int fd_notify;             /* inotify fd               */
@@ -47,6 +50,9 @@ struct flb_tail_config {
 
     /* Configuration */
     int dynamic_tag;           /* dynamic tag ? e.g: abc.*     */
+#ifdef FLB_HAVE_REGEX
+    struct flb_regex *tag_regex;/* path to tag regex           */
+#endif
     int refresh_interval_sec;  /* seconds to re-scan           */
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
     int rotate_wait;           /* sec to wait on rotated files */

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -31,6 +31,10 @@
 #include "tail_config.h"
 #include "tail_file_internal.h"
 
+#ifdef FLB_HAVE_REGEX
+#define FLB_HASH_TABLE_SIZE 50
+#endif
+
 int flb_tail_file_to_event(struct flb_tail_file *file);
 int flb_tail_file_chunk(struct flb_tail_file *file);
 int flb_tail_file_append(char *path, struct stat *st, int mode,

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -290,7 +290,7 @@ int flb_hash_get(struct flb_hash *ht, char *key, int key_len,
                                     struct flb_hash_entry,
                                     _head);
 
-        if (strcmp(entry->key, key) != 0) {
+        if (strncmp(entry->key, key, key_len) != 0) {
             entry = NULL;
         }
     }


### PR DESCRIPTION
Add a new Tag_Regex option to capture named groups in the filename. Format the
tag according to the pattern set in the tag option which makes use of these
named groups.

Signed-off-by: Yann Soubeyrand <ysoubeyrand@leadformance.com>