### PR TITLE
Fix hard-coded value in TLS error message.

### DIFF
--- a/src/flb_io_tls.c
+++ b/src/flb_io_tls.c
@@ -118,7 +118,7 @@ struct flb_tls_context *flb_tls_context_new(int verify,
         ret = mbedtls_x509_crt_parse_path(&ctx->ca_cert, ca_path);
         if (ret < 0) {
             io_tls_error(ret);
-            flb_error("[TLS] error reading certificates from /etc/ssl/certs/");
+            flb_error("[TLS] error reading certificates from %s", ca_path);
             goto error;
         }
     }


### PR DESCRIPTION
Changing the hard-coded value `/etc/ssl/certs` to the variable `ca_path`. The user could enter a different value for `ca_path` in the `.conf` file. When this happens, this error displays incorrect path.

Signed-off-by: Anusha Kasi Vishwanathan 010akv@gmail.com