### PR TITLE
out_kafka: Add support to setting the time key format for kafka.

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -94,9 +94,6 @@ int produce_message(struct flb_time *tms, msgpack_object *map,
         size = map->via.map.size + 1;
         msgpack_pack_map(&mp_pck, size);
 
-        /* Pack timestamp */
-        msgpack_pack_str(&mp_pck, ctx->timestamp_key_len);
-
         if (ctx->time_key_format) {
           gmtime_r(&(*tms).tm.tv_sec, &tm);
           s = strftime(time_formatted, sizeof(time_formatted) - 1,
@@ -108,6 +105,8 @@ int produce_message(struct flb_time *tms, msgpack_object *map,
           msgpack_pack_str_body(&mp_pck, time_formatted, s);
         }
         else {
+          /* Pack timestamp */
+          msgpack_pack_str(&mp_pck, ctx->timestamp_key_len);
           msgpack_pack_str_body(&mp_pck,
                                ctx->timestamp_key, ctx->timestamp_key_len);
           msgpack_pack_double(&mp_pck, flb_time_to_double(tm));

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -254,6 +254,10 @@ int flb_kafka_conf_destroy(struct flb_kafka *ctx)
         flb_free(ctx->message_key);
     }
 
+    if (ctx->time_key_format) {
+      flb_free(ctx->time_key_format);
+    }
+
     flb_sds_destroy(ctx->gelf_fields.timestamp_key);
     flb_sds_destroy(ctx->gelf_fields.host_key);
     flb_sds_destroy(ctx->gelf_fields.short_message_key);

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -180,6 +180,16 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
     if (tmp) {
         ctx->gelf_fields.level_key = flb_sds_create(tmp);
     }
+    /* Config: Time_Key_Format */
+    tmp = flb_output_get_property("time_key_format", ins);
+    if(tmp){
+        ctx->time_key_format = flb_strdup(tmp);
+        ctx->time_key_format_len = strlen(tmp);
+    }
+    else {
+       ctx->time_key_format = NULL;
+       ctx->time_key_format_len = 0;
+    }
 
     /* Kafka Producer */
     ctx->producer = rd_kafka_new(RD_KAFKA_PRODUCER, ctx->conf,

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -52,6 +52,10 @@ struct flb_kafka {
     int timestamp_key_len;
     char *timestamp_key;
 
+    /* time key format */
+    int time_key_format_len;
+    char *time_key_format;
+
     int message_key_len;
     char *message_key;
 


### PR DESCRIPTION
This change keeps the UNIX timestamp as default.

```
[OUTPUT]
    Name        kafka
    Match       *
    Brokers     192.168.1.3:9092
    Topics      test
    Time_Key_Format %Y-%m-%dT%H:%M:%S
```

Signed-off-by: Miguel Perez <mperez@squarespace.com>