### PR TITLE
Maintain double escapes in json strings

### DIFF
--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -212,6 +212,10 @@ int flb_unescape_string(char *buf, int buf_len, char **unesc_buf)
                     p[j++] = '\r';
                     i++;
                 }
+                else if (n == '\\') {
+                    p[j++] = '\\';
+                    i++;
+                }
                 i++;
                 continue;
             }


### PR DESCRIPTION
Maintain double escapes in order to allow quote characters in stringed json values.

For example:
```
{\"log\": "test \\\"message\\\"\"}
```
to
```
{"log": "test \"message\""}
```

fix: #615