### PR TITLE
fixup format warning - actually causing segv on arm32

### DIFF
--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <time.h>
 
 #include <fluent-bit/flb_info.h>
@@ -108,10 +109,10 @@ static void output_fcount(FILE* f, struct flb_out_fcount_config *ctx,
 {
     fprintf(f,
            "[%s] [%lu, {"
-           "\"counts\":%lu, "
-           "\"bytes\":%lu, "
-           "\"counts/%s\":%lu, "
-           "\"bytes/%s\":%lu }"
+           "\"counts\":%"PRIu64", "
+           "\"bytes\":%"PRIu64", "
+           "\"counts/%s\":%"PRIu64", "
+           "\"bytes/%s\":%"PRIu64" }"
            "]\n",
            PLUGIN_NAME, buf->until,
            buf->counts,


### PR DESCRIPTION

Hi,

I encountered SEGV faults using fluent-bit (0.13.7 deb) on a 32 bit armv7 platform with the following config:

~~~
[INPUT]
    Name          stdin
    Tag           auditflow

[OUTPUT]
    Name          flowcounter
    Match         *
    Unit          second
~~~

Gave the following output

~~~
Fluent-Bit v0.14.2
Copyright (C) Treasure Data

[2018/09/18 15:16:45] [ info] [engine] started (pid=6629)
[2018/09/18 15:16:45] [ info] [http_server] listen iface=127.0.0.1 tcp_port=2020
[out_flowcounter] [1537283805, {"counts":0, "bytes":0, "counts/(null)":0, "bytes/second":2759094127 }]
[out_flowcounter] [1537283806, {"counts":0, "bytes":0, "counts/(null)":0, "bytes/second":2759094127 }]
[out_flowcounter] [1537283807, {"counts":0, "bytes":0, "counts/(null)":0, "bytes/second":2759094127 }]
[out_flowcounter] [1537283808, {"counts":0, "bytes":0, "counts/(null)":0, "bytes/second":2759094127 }]
[out_flowcounter] [1537283809, {"counts":0, "bytes":0, "counts/(null)":0, "bytes/second":2759094127 }]
[engine] caught signal (SIGSEGV)
[out_flowcounter] [1537283810, {"counts":30, "bytes":0, "counts/
~~~

Compiling 0.14.2 gave the following warnings (and also gave a SEGV):

![fluent-bit](https://user-images.githubusercontent.com/1745970/45709743-a302ab00-bb7c-11e8-894e-3a787e263ec3.PNG)

Correcting those formatting warnings resolved the SEGV.   


