### PR TITLE
Add build directory and generated headers to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ _book/
 lib/jemalloc
 lib/onigmo
 tests/internal/flb_tests_internal.h
+build/*
+include/fluent-bit/flb_info.h
+include/fluent-bit/flb_plugins.h
+include/fluent-bit/flb_version.h
+init/fluent-bit.service
+lib/monkey/monkey.service
+lib/monkey/include/monkey/mk_core/mk_core_info.h


### PR DESCRIPTION
Add various generated files for in-tree builds to .gitignore

Signed-off-by: Don Bowman <db@donbowman.ca>