### PR TITLE
Some changes make the influxdb output work properly

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -72,6 +72,10 @@ static inline void flb_time_from_double(struct flb_time *dst, double d)
     dst->tm.tv_nsec = (d - dst->tm.tv_sec) * 1000000000L;
 }
 
+static inline int flb_time_equal(struct flb_time *t0, struct flb_time *t1) {
+    return t0->tm.tv_sec == t1->tm.tv_sec && t0->tm.tv_nsec == t1->tm.tv_nsec;
+}
+
 int flb_time_get(struct flb_time *tm);
 double flb_time_to_double(struct flb_time *tm);
 int flb_time_diff(struct flb_time *time1,

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -371,6 +371,9 @@ int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *config,
     if (!tmp) {
         ctx->seq_name = flb_strdup("_seq");
     }
+    else if (strcmp(tmp, "off") == 0) {
+        ctx->seq_name = flb_strdup("");
+    }
     else {
         ctx->seq_name = flb_strdup(tmp);
     }

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -456,11 +456,11 @@ void cb_influxdb_flush(void *data, size_t bytes,
         if (c->resp.status != 200 && c->resp.status != 204) {
             if (c->resp.payload_size > 0) {
                 flb_error("[out_influxdb] http_status=%i\n%s",
-                          ret, c->resp.status, c->resp.payload);
+                          c->resp.status, c->resp.payload);
             }
             else {
                 flb_debug("[out_influxdb] http_status=%i",
-                          ret, c->resp.status);
+                          c->resp.status);
             }
         }
         flb_debug("[out_influxdb] http_do=%i OK", ret);

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -231,7 +231,7 @@ static char *influxdb_format(char *tag, int tag_len,
                 ret = influxdb_bulk_append_kv(bulk_head,
                                               key, key_len,
                                               val, val_len,
-                                              quote);
+                                              false);
             }
             else {
                 /* Append key/value data into the bulk_body */

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -42,6 +42,22 @@ static int is_tagged_key(struct flb_influxdb_config *ctx,
                          char *key, int kl, int type);
 
 /*
+ * Increments the timestamp when it is duplicated
+ */
+static void influxdb_tsmod(struct flb_time *ts, struct flb_time *dupe,
+                           struct flb_time *last) {
+    if (flb_time_equal(ts, last) || flb_time_equal(ts, dupe)) {
+        ++dupe->tm.tv_nsec;
+        flb_time_copy(last, ts);
+        flb_time_copy(ts, dupe);
+    }
+    else {
+        flb_time_copy(last, ts);
+        flb_time_copy(dupe, ts);
+    }
+}
+
+/*
  * Convert the internal Fluent Bit data representation to the required one
  * by InfluxDB.
  */
@@ -254,6 +270,8 @@ static char *influxdb_format(char *tag, int tag_len,
 
         /* Check have data fields */
         if (bulk_body->len > 0) {
+            /* Modify timestamp in avoidance of duplication */
+            influxdb_tsmod(&tm, &ctx->ts_dupe, &ctx->ts_last);
             /* Append the timestamp */
             ret = influxdb_bulk_append_timestamp(bulk_body, &tm);
             if (ret == -1) {
@@ -408,6 +426,9 @@ int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *config,
     }
     ctx->u   = upstream;
     ctx->seq = 0;
+
+    flb_time_zero(&ctx->ts_dupe);
+    flb_time_zero(&ctx->ts_last);
 
     flb_debug("[out_influxdb] host=%s port=%i", ins->host.name, ins->host.port);
     flb_output_set_context(ins, ctx);

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -21,6 +21,7 @@
 #define FLB_OUT_INFLUXDB_H
 
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_time.h>
 
 #define FLB_INFLUXDB_HOST "127.0.0.1"
 #define FLB_INFLUXDB_PORT 8086
@@ -50,6 +51,10 @@ struct flb_influxdb_config {
 
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
+
+    /* used for incrementing identical timestamps */
+    struct flb_time ts_dupe;
+    struct flb_time ts_last;
 };
 
 #endif

--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -112,18 +112,20 @@ int influxdb_bulk_append_header(struct influxdb_bulk *bulk,
     memcpy(bulk->ptr + bulk->len, tag, tag_len);
     bulk->len += tag_len;
 
-    bulk->ptr[bulk->len] = ',';
-    bulk->len++;
+    if (seq_len != 0) {
+        bulk->ptr[bulk->len] = ',';
+        bulk->len++;
 
-    /* Sequence number */
-    memcpy(bulk->ptr + bulk->len, seq, seq_len);
-    bulk->len += seq_len;
+        /* Sequence number */
+        memcpy(bulk->ptr + bulk->len, seq, seq_len);
+        bulk->len += seq_len;
 
-    bulk->ptr[bulk->len] = '=';
-    bulk->len++;
+        bulk->ptr[bulk->len] = '=';
+        bulk->len++;
 
-    ret = snprintf(bulk->ptr + bulk->len, 32, "%" PRIu64, seq_n);
-    bulk->len += ret;
+        ret = snprintf(bulk->ptr + bulk->len, 32, "%" PRIu64, seq_n);
+        bulk->len += ret;
+    }
 
     /* Add a NULL byte for debugging purposes */
     bulk->ptr[bulk->len] = '\0';

--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -20,12 +20,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include <fluent-bit.h>
+#include "influxdb.h"
 #include "influxdb_bulk.h"
 
 static const uint64_t ONE_BILLION = 1000000000;
- 
+
+static int influxdb_escape(char *out, const char *str, int size) {
+    int out_size = 0;
+    int i;
+    for (i = 0; i < size; ++i) {
+        char ch = str[i];
+        if (isspace(ch) || ch == ',' || ch == '=' || ch == '"') {
+            out[out_size++] = '\\';
+        }
+        out[out_size++] = ch;
+    }
+    return out_size;
+}
+
 static int influxdb_bulk_buffer(struct influxdb_bulk *bulk, int required)
 {
     int new_size;
@@ -124,7 +139,8 @@ int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
     int ret;
     int required;
 
-    required = k_len + 1 + v_len + 1 + 1;
+    /* Reserve double space for keys and values in case of escaping */
+    required = k_len * 2 + 1 + v_len * 2 + 1 + 1;
     if (quote) {
         required += 2;
     }
@@ -141,8 +157,7 @@ int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
     }
 
     /* key */
-    memcpy(bulk->ptr + bulk->len, key, k_len);
-    bulk->len += k_len;
+    bulk->len += influxdb_escape(bulk->ptr + bulk->len, key, k_len);
 
     /* separator */
     bulk->ptr[bulk->len] = '=';
@@ -153,8 +168,7 @@ int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
         bulk->ptr[bulk->len] = '"';
         bulk->len++;
     }
-    memcpy(bulk->ptr + bulk->len, val, v_len);
-    bulk->len += v_len;
+    bulk->len += influxdb_escape(bulk->ptr + bulk->len, val, v_len);
     if (quote) {
         bulk->ptr[bulk->len] = '"';
         bulk->len++;


### PR DESCRIPTION
When I used the Influxdb output to test the fluency, I found it unusable.

* Crash when an error occurs when writing to Influxdb.
* There is no escaping in the kv field, so the write fails when the field contains a space.
* The written data will be overwritten by other data with the same timestamp.
* The `sequence_tag` produces too many series.

So I committed some changes and fixed the above problem. Now when I use influxdb as the output, everything works fine.
