### PR TITLE
Fixed Dockerfile, zlib1g-dev missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && \
       libsystemd-dev \
       libssl1.0-dev \
       libasl-dev \
-      libsasl2-dev
+      libsasl2-dev \
+      zlib1g-dev
 
 WORKDIR /tmp/src/build/
 RUN cmake -DFLB_DEBUG=On \


### PR DESCRIPTION
Fixed "Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)" error during the Dockerfile build