### PR TITLE
CMakeLists.txt: disable out_gelf if zlib is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,10 @@ if(FLB_DEV)
 endif()
 
 if(FLB_OUT_GELF)
-  find_package( ZLIB REQUIRED )
+  find_package( ZLIB )
+  if ( NOT ZLIB_FOUND )
+     set(FLB_OUT_GELF 0)
+  endif()
 endif()
 
 # Macro to set definitions


### PR DESCRIPTION
out_gelf plugin needs zlib. 
If zlib is not installed, it causes compilation error. "Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)"

I modified CMakeLists.txt.
If zlib is not installed, out_gelf will be disabled.

see also #787