### PR TITLE
Add address/thread/memory sanitisers as option to build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake/sanitizers-cmake"]
+	path = cmake/sanitizers-cmake
+	url = git://github.com/arsenm/sanitizers-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)
 include(cmake/FindMonkey.cmake)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
+find_package(Sanitizers)
 
 # Output paths
 set(FLB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -79,6 +79,7 @@ endmacro()
 macro(FLB_PLUGIN name src deps)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   add_library(flb-plugin-${name} STATIC ${src})
+  add_sanitizers(flb-plugin-${name})
   target_link_libraries(flb-plugin-${name} fluent-bit-static msgpackc-static ${deps})
 endmacro()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,7 @@ set(FLB_DEPS
 # Shared Library
 if(FLB_SHARED_LIB)
   add_library(fluent-bit-shared SHARED ${src})
+  add_sanitizers(fluent-bit-shared)
   target_link_libraries(fluent-bit-shared ${FLB_DEPS} -lpthread)
   set_target_properties(fluent-bit-shared
     PROPERTIES OUTPUT_NAME fluent-bit)
@@ -221,6 +222,7 @@ endif()
 
 # Static Library
 add_library(fluent-bit-static STATIC ${src})
+add_sanitizers(fluent-bit-static)
 target_link_libraries(fluent-bit-static ${FLB_DEPS})
 
 if(MSVC)
@@ -242,6 +244,7 @@ endif()
 if(FLB_BINARY)
   find_package (Threads)
   add_executable(fluent-bit-bin fluent-bit.c)
+  add_sanitizers(fluent-bit-bin)
 
   if(FLB_STATIC_CONF)
     add_dependencies(fluent-bit-bin flb-static-conf)

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -51,6 +51,7 @@ foreach(source_file ${UNIT_TESTS_FILES})
     ${source_file_we}
     ${source_file}
     )
+  add_sanitizers(${source_file_we})
 
   if(FLB_JEMALLOC)
     target_link_libraries(${source_file_we} libjemalloc ${CMAKE_THREAD_LIBS_INIT})

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -67,6 +67,7 @@ foreach(source_file ${CHECK_PROGRAMS})
     ${source_file_we}
     ${source_file}
     )
+  add_sanitizers(${source_file_we})
   target_link_libraries(${source_file_we}
     fluent-bit-static
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
See [sanitizers-cmake](https://github.com/arsenm/sanitizers-cmake) for reference.

This allows e.g. building with -DSANITIZE_ADDRESS=On and then running the unit tests.

Signed-off-by: Don Bowman <don@agilicus.com>