### PR TITLE
in_mem: fix a minor memory leak due to forgetting to free.

### DIFF
--- a/plugins/in_mem/proc.c
+++ b/plugins/in_mem/proc.c
@@ -104,6 +104,7 @@ struct proc_task *proc_stat(pid_t pid, int page_size)
     /* Compose path for /proc/PID/stat */
     ret = snprintf(pid_path, PROC_PID_SIZE, "/proc/%i/stat", pid);
     if (ret < 0) {
+        flb_free(t);
         flb_errno();
         return NULL;
     }


### PR DESCRIPTION
This adds flb_free(t) to the failure path, to reclaim memory we
allocated a few lines above but end up not using.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>