### PR TITLE
README: Fix build steps in "Quick Start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ http://fluentbit.io/documentation
 ## Quick Start
 
 ```
+$ git submodule update --init
 $ cd build
 $ cmake ..
 $ make


### PR DESCRIPTION
Since 69eee3f, we need to initialize the submodule before calling
cmake. Otherwise, cmake would fail with the following error:

    Unknown CMake command "add_sanitizers".

This patch is a quick fix for the issue.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>