### PR TITLE
in_mem: clean up the buffer handling in proc.c

### DIFF
--- a/plugins/in_mem/proc.c
+++ b/plugins/in_mem/proc.c
@@ -51,7 +51,7 @@ static char *human_readable_size(long size)
 }
 
 /* Read file content into a memory buffer */
-static char *file_to_buffer(const char *path, long *read_size)
+static char *file_to_buffer(const char *path)
 {
     FILE *fp;
     char *buffer;
@@ -61,13 +61,12 @@ static char *file_to_buffer(const char *path, long *read_size)
         return NULL;
     }
 
-    buffer = flb_malloc(PROC_STAT_BUF_SIZE);
+    buffer = flb_calloc(1, PROC_STAT_BUF_SIZE);
     if (!buffer) {
         fclose(fp);
         flb_errno();
         return NULL;
     }
-    memset(buffer, 0, PROC_STAT_BUF_SIZE);
 
     fread(buffer, PROC_STAT_BUF_SIZE, 1, fp);
     if (ferror(fp) || !feof(fp)) {
@@ -75,7 +74,6 @@ static char *file_to_buffer(const char *path, long *read_size)
         fclose(fp);
         return NULL;
     }
-    *read_size = PROC_STAT_BUF_SIZE;
 
     fclose(fp);
     return buffer;
@@ -85,7 +83,6 @@ static char *file_to_buffer(const char *path, long *read_size)
 struct proc_task *proc_stat(pid_t pid, int page_size)
 {
     int ret;
-    long read_size = 0;
     char *p, *q;
     char *buf;
     char pid_path[PROC_PID_SIZE];
@@ -105,8 +102,8 @@ struct proc_task *proc_stat(pid_t pid, int page_size)
         return NULL;
     }
 
-    buf = file_to_buffer(pid_path, &read_size);
-    if (!buf || read_size == 0) {
+    buf = file_to_buffer(pid_path);
+    if (!buf) {
         flb_free(t);
         return NULL;
     }
@@ -124,12 +121,11 @@ struct proc_task *proc_stat(pid_t pid, int page_size)
     p++;
 
     /* seek from tail of file.  */
-    q = buf + (read_size-1);
-    while (*q != ')' && read_size > 0) {
+    q = buf + (PROC_STAT_BUF_SIZE - 1);
+    while (*q != ')' && p < q) {
         q--;
-        read_size--;
     }
-    if (p==q || read_size == 0) {
+    if (p >= q) {
         flb_free(buf);
         flb_free(t);
         return NULL;


### PR DESCRIPTION
Right now, `proc_stat()` tries to find out the buffer size by asking
`file_to_buffer()` about it. This is totally unnecessary, because the
size is actually a globally-accessible constant.

This patch removes the meaningless hustle surrounding `read_size` and
simplifies the logic of `proc_stat()`.

Also `file_to_buffer()` now just uses `flb_calloc()`, instead of allocating
memory and initialize it with `memset()` by hand.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>