### PR TITLE
in_systemd: add strip_underscores configuration

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -176,6 +176,9 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
             key = (char *) data;
             sep = strchr(key, '=');
             len = (sep - key);
+            if (ctx->strip_underscores && key[0] == '_') {
+                key++; len--;
+            }
             msgpack_pack_str(&mp_pck, len);
             msgpack_pack_str_body(&mp_pck, key, len);
 

--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -176,7 +176,7 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
             key = (char *) data;
             sep = strchr(key, '=');
             len = (sep - key);
-            if (ctx->strip_underscores && key[0] == '_') {
+            if (ctx->strip_underscores == FLB_TRUE && key[0] == '_') {
                 key++; len--;
             }
             msgpack_pack_str(&mp_pck, len);

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -185,6 +185,13 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
         }
     }
 
+    tmp = flb_input_get_property("strip_underscores", i_ins);
+    if (tmp != NULL && flb_utils_bool(tmp)) {
+        ctx->strip_underscores = FLB_TRUE;
+    } else {
+        ctx->strip_underscores = FLB_FALSE;
+    }
+
     return ctx;
 }
 

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -53,6 +53,7 @@ struct flb_systemd_config {
     int coll_fd_pending;       /* pending records          */
     int dynamic_tag;
     int max_entries;
+    int strip_underscores;
     struct flb_sqldb *db;
     struct flb_input_instance *i_ins;
 };


### PR DESCRIPTION
Add an option to strip leading underscores when reading systemd keys.

Elasticsearch has reserved fields beginning with underscore for internal
use. Kibana enforces this by not allowing these fields in filter.
See https://github.com/elastic/kibana/issues/2551.

This configuration option will make it easier to work with in_systemd
together with out_es.

Fix #638

Signed-off-by: Patrik Karlström <jp.karlstrom@gmail.com>