### PR TITLE
In filter_kubernetes, don't destroy regex if it was not created

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -302,7 +302,7 @@ void flb_kube_conf_destroy(struct flb_kube *ctx)
     }
 
     /* Destroy regex content only if a parser was not defined */
-    if (ctx->parser == NULL) {
+    if (ctx->parser == NULL && ctx->regex) {
         flb_regex_destroy(ctx->regex);
     }
 


### PR DESCRIPTION
In the event the user specifies a Regex_Parser that is invalid
in filter_kubernetes, it would be null. Don't delete this
on cleanup.

Signed-off-by: Don Bowman <don@agilicus.com>