### PR TITLE
out_http: avoid logging raw binary payload in HTTP response

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -276,9 +276,9 @@ static int http_post (struct flb_out_http *ctx,
         }
         else {
             if (c->resp.payload) {
-                flb_info("[out_http] %s:%i, HTTP status=%i\n%s",
+                flb_info("[out_http] %s:%i, HTTP status=%i (%i bytes)",
                          ctx->host, ctx->port,
-                         c->resp.status, c->resp.payload);
+                         c->resp.status, c->resp.payload_size);
             }
             else {
                 flb_info("[out_http] %s:%i, HTTP status=%i",


### PR DESCRIPTION
The endpoint HTTP server can send back non-text data as response.
For example, Fluentd will respond with empty GIF images when the
option "respond_with_empty_img" is enabled.

https://docs.fluentd.org/v1.0/articles/in_http#respond_with_empty_img

This teaches `out_http` to log the size of payloads, instead of the
raw incoming data.
