### PR TITLE
Reduce non-interesting verbosity of tests

### DIFF
--- a/tests/runtime/filter_kubernetes.c
+++ b/tests/runtime/filter_kubernetes.c
@@ -213,8 +213,6 @@ static int cb_check_result(void *record, size_t size, void *data)
             fprintf(stderr, "Validator mismatch::\nTarget: <<%s>>, Suffix: <<%s>\n"
                             "Filtered record: <<%s>>\nExpected record: <<%s>>\n",
                             result->target, result->suffix, (char *)record, out);
-        } else {
-            flb_info("Log line matched expected");
         }
         TEST_CHECK(check != NULL);
         result->nmatched++;

--- a/tests/runtime/out_counter.c
+++ b/tests/runtime/out_counter.c
@@ -32,6 +32,7 @@ void flb_test_counter_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -65,6 +66,7 @@ void flb_test_counter_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -99,6 +101,7 @@ void flb_test_counter_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_exit.c
+++ b/tests/runtime/out_exit.c
@@ -37,6 +37,7 @@ void flb_test_exit_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -72,6 +73,7 @@ void flb_test_exit_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -106,6 +108,7 @@ void flb_test_exit_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -140,6 +143,7 @@ void flb_test_exit_keep_alive(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -44,6 +44,7 @@ void flb_test_file_json_invalid(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -88,6 +89,7 @@ void flb_test_file_json_long(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -133,6 +135,7 @@ void flb_test_file_json_small(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -178,6 +181,7 @@ void flb_test_file_format_csv(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -225,6 +229,7 @@ void flb_test_file_format_ltsv(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -273,6 +278,7 @@ void flb_test_file_format_invalid(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_flowcounter.c
+++ b/tests/runtime/out_flowcounter.c
@@ -43,6 +43,7 @@ void flb_test_flowcounter_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -76,6 +77,7 @@ void flb_test_flowcounter_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -110,6 +112,7 @@ void flb_test_flowcounter_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -144,6 +147,7 @@ void flb_test_flowcounter_unit_second(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -179,6 +183,7 @@ void flb_test_flowcounter_unit_minute(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -214,6 +219,7 @@ void flb_test_flowcounter_unit_hour(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -249,6 +255,7 @@ void flb_test_flowcounter_unit_day(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -284,6 +291,7 @@ void flb_test_flowcounter_unit_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_null.c
+++ b/tests/runtime/out_null.c
@@ -33,6 +33,7 @@ void flb_test_null_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -66,6 +67,7 @@ void flb_test_null_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -100,6 +102,7 @@ void flb_test_null_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_stdout.c
+++ b/tests/runtime/out_stdout.c
@@ -34,6 +34,7 @@ void flb_test_stdout_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -72,6 +73,7 @@ void flb_test_stdout_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -109,6 +111,7 @@ void flb_test_stdout_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);


### PR DESCRIPTION
Many of the tests had thousands of lines of
```
[2018/10/05 08:10:46] [ warn] lib data incomplete, waiting for more data...
```
output since they had Log_Level set to 'debug'. Change
to 'error'.

Signed-off-by: Don Bowman <don@agilicus.com>