### PR TITLE
Build: Adding upstart init system support

### DIFF
--- a/init/systemd.in
+++ b/init/systemd.in
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c @CMAKE_INSTALL_SYSCONFDIR@/@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c @CMAKE_INSTALL_SYSCONFDIR@@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
 Restart=always
 
 [Install]

--- a/init/upstart.in
+++ b/init/upstart.in
@@ -1,0 +1,10 @@
+# td-agent-bit - ligtweight log shipping for fluent
+
+description "@FLB_PROG_NAME@"
+
+# start in normal runlevels when disks are mounted and networking is available
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+exec @CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c @CMAKE_INSTALL_SYSCONFDIR@@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,15 +273,23 @@ if(FLB_BINARY)
     ENABLE_EXPORTS ON)
   install(TARGETS fluent-bit-bin RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 
-  # Detect init system, install systemd or init.d script
-  if(IS_DIRECTORY /lib/systemd/system)
+  # Detect init system, install upstart, systemd or init.d script
+  if(IS_DIRECTORY /usr/share/upstart)
+    set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")
+    configure_file(
+      "${PROJECT_SOURCE_DIR}/init/upstart.in"
+      ${FLB_UPSTART_SCRIPT}
+      )
+    install(FILES ${FLB_UPSTART_SCRIPT} DESTINATION /etc/init)
+    install(DIRECTORY DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}${FLB_OUT_NAME}/")
+  elseif(IS_DIRECTORY /lib/systemd/system)
     set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
     configure_file(
       "${PROJECT_SOURCE_DIR}/init/systemd.in"
       ${FLB_SYSTEMD_SCRIPT}
       )
     install(FILES ${FLB_SYSTEMD_SCRIPT} DESTINATION /lib/systemd/system)
-    install(DIRECTORY DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
+    install(DIRECTORY DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}${FLB_OUT_NAME}/")
   else()
     # FIXME: should we support Sysv init script ?
   endif()


### PR DESCRIPTION
This patch provides an upstart job file to be passed to the build process;
The job's config mimics the behaviour of the systemd service.
CMake config modified to handle the above.
Also, there was some duplication of '/' in the resulting package's
paths, that is fixed as well.

Build tested with modified 'fluent-bit-packaging' project;
Resulting package tested on Ubuntu 14.04.

Signed-off-by: Zsolt Kulcsar <zskulcsar@gmail.com>