### PR TITLE
Make engine-stop grace-period settable, reduce polling in Kubernetes …

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -55,6 +55,7 @@ struct flb_config {
     int support_mode;         /* enterprise support mode ?      */
     int is_running;           /* service running ?              */
     int flush;                /* Flush timeout                  */
+    int grace;                /* Grace on shutdown              */
     flb_pipefd_t flush_fd;    /* Timer FD associated to flush   */
     int flush_method;         /* Flush method set at build time */
 
@@ -196,6 +197,7 @@ enum conf_type {
 };
 
 #define FLB_CONF_STR_FLUSH    "Flush"
+#define FLB_CONF_STR_GRACE    "Grace"
 #define FLB_CONF_STR_DAEMON   "Daemon"
 #define FLB_CONF_STR_LOGFILE  "Log_File"
 #define FLB_CONF_STR_LOGLEVEL "Log_Level"

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -45,6 +45,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, flush)},
 
+    {FLB_CONF_STR_GRACE,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, grace)},
+
     {FLB_CONF_STR_DAEMON,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, daemon)},
@@ -114,6 +118,7 @@ struct flb_config *flb_config_init()
     config->init_time    = time(NULL);
     config->kernel       = flb_kernel_info();
     config->verbose      = 3;
+    config->grace        = 5;
 
 #ifdef FLB_HAVE_HTTP_SERVER
     config->http_ctx     = NULL;

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -516,14 +516,14 @@ int flb_engine_start(struct flb_config *config)
                 if (ret == FLB_ENGINE_STOP) {
                     /*
                      * We are preparing to shutdown, we give a graceful time
-                     * of 5 seconds to process any pending event.
+                     * of (default 5) seconds to process any pending event.
                      */
                     event = &config->event_shutdown;
                     event->mask = MK_EVENT_EMPTY;
                     event->status = MK_EVENT_NONE;
-                    config->shutdown_fd = mk_event_timeout_create(evl, 5, 0, event);
+                    config->shutdown_fd = mk_event_timeout_create(evl, config->grace, 0, event);
 
-                    flb_warn("[engine] service will stop in 5 seconds");
+                    flb_warn("[engine] service will stop in %u seconds", config->grace);
                 }
                 else if (ret == FLB_ENGINE_SHUTDOWN) {
                     flb_info("[engine] service stopped");

--- a/tests/runtime/core_engine.c
+++ b/tests/runtime/core_engine.c
@@ -94,7 +94,7 @@ int check_routing(const char* tag, const char* match, bool expect)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", match, NULL);
 
-    flb_service_set(ctx, "Flush", "1", "Daemon", "false", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Daemon", "false", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -52,7 +52,7 @@ void flb_test_filter_parser_extract_fields()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace" "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
@@ -137,7 +137,7 @@ void flb_test_filter_parser_reserve_data_off()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
@@ -212,7 +212,7 @@ void flb_test_filter_parser_handle_time_key()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
@@ -288,7 +288,7 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
@@ -368,7 +368,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
@@ -443,7 +443,7 @@ void flb_test_filter_parser_preserve_original_field()
     ctx = flb_create();
 
     /* Configure service */
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "debug", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "debug", NULL);
 
     /* Input */
     in_ffd = flb_input(ctx, (char *) "lib", NULL);

--- a/tests/runtime/in_cpu.c
+++ b/tests/runtime/in_cpu.c
@@ -91,7 +91,7 @@ void flb_test_in_cpu_flush_2s_2times(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/in_disk.c
+++ b/tests/runtime/in_disk.c
@@ -91,7 +91,7 @@ void flb_test_in_disk_flush_2s_2times(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/in_dummy.c
+++ b/tests/runtime/in_dummy.c
@@ -90,7 +90,7 @@ void flb_test_in_dummy_flush_2s_2times(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/in_head.c
+++ b/tests/runtime/in_head.c
@@ -93,7 +93,7 @@ void flb_test_in_head_flush_2s_2times(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     flb_info("[test] read %s",path);
 

--- a/tests/runtime/in_mem.c
+++ b/tests/runtime/in_mem.c
@@ -92,7 +92,7 @@ void flb_test_in_mem_flush_2s_2times(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/in_proc.c
+++ b/tests/runtime/in_proc.c
@@ -95,7 +95,7 @@ void flb_test_in_proc_selfcheck(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "1", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);
@@ -142,7 +142,7 @@ void flb_test_in_proc_absent_process(void)
     TEST_CHECK(out_ffd >= 0);
     flb_output_set(ctx, out_ffd, "match", "test", NULL);
 
-    flb_service_set(ctx, "Flush", "2", NULL);
+    flb_service_set(ctx, "Flush", "2", "Grace", "1", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0); // error occurs but return value is true

--- a/tests/runtime/out_counter.c
+++ b/tests/runtime/out_counter.c
@@ -32,7 +32,7 @@ void flb_test_counter_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -66,7 +66,7 @@ void flb_test_counter_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -101,7 +101,7 @@ void flb_test_counter_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_exit.c
+++ b/tests/runtime/out_exit.c
@@ -37,7 +37,7 @@ void flb_test_exit_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -73,7 +73,7 @@ void flb_test_exit_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -108,7 +108,7 @@ void flb_test_exit_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -143,7 +143,7 @@ void flb_test_exit_keep_alive(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -44,7 +44,7 @@ void flb_test_file_json_invalid(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -89,7 +89,7 @@ void flb_test_file_json_long(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -135,7 +135,7 @@ void flb_test_file_json_small(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -181,7 +181,7 @@ void flb_test_file_format_csv(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -229,7 +229,7 @@ void flb_test_file_format_ltsv(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -278,7 +278,7 @@ void flb_test_file_format_invalid(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_flowcounter.c
+++ b/tests/runtime/out_flowcounter.c
@@ -43,7 +43,7 @@ void flb_test_flowcounter_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -77,7 +77,7 @@ void flb_test_flowcounter_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -112,7 +112,7 @@ void flb_test_flowcounter_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -147,7 +147,7 @@ void flb_test_flowcounter_unit_second(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -183,7 +183,7 @@ void flb_test_flowcounter_unit_minute(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -219,7 +219,7 @@ void flb_test_flowcounter_unit_hour(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -255,7 +255,7 @@ void flb_test_flowcounter_unit_day(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -291,7 +291,7 @@ void flb_test_flowcounter_unit_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_null.c
+++ b/tests/runtime/out_null.c
@@ -33,7 +33,7 @@ void flb_test_null_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -67,7 +67,7 @@ void flb_test_null_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -102,7 +102,7 @@ void flb_test_null_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);

--- a/tests/runtime/out_stdout.c
+++ b/tests/runtime/out_stdout.c
@@ -34,7 +34,7 @@ void flb_test_stdout_json_invalid(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -73,7 +73,7 @@ void flb_test_stdout_json_long(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -111,7 +111,7 @@ void flb_test_stdout_json_small(void)
     int out_ffd;
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);


### PR DESCRIPTION
Make engine-stop grace-period settable, reduce polling in Kubernetes test

Each unit test creates/destroys the engine, which had a fixed 5-second
delay. Make this delay settable (adding a new 'Grace' parameter).

In the filter_kubernetes test, it was doing a fixed 1-second sleep
for every line, make this wait up until 2 seconds or until
the line appears.

Signed-off-by: Don Bowman <don@agilicus.com>