### PR TITLE
Change FLB_ES_DEFAULT_TAG_KEY to flb-key from _flb-key

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -28,7 +28,7 @@
 #define FLB_ES_DEFAULT_TIME_FMT   "%Y.%m.%d"
 #define FLB_ES_DEFAULT_TIME_KEY   "@timestamp"
 #define FLB_ES_DEFAULT_TIME_KEYF  "%Y-%m-%dT%H:%M:%S"
-#define FLB_ES_DEFAULT_TAG_KEY    "_flb-key"
+#define FLB_ES_DEFAULT_TAG_KEY    "flb-key"
 
 struct flb_elasticsearch {
     /* Elasticsearch index (database) and type (table) */


### PR DESCRIPTION
Elasticsearch reserves keys starting with underscore (_) for internal
use. This is enforced in Kibana. Change the default to avoid errors.

Signed-off-by: Don Bowman <don@agilicus.com>