### PR TITLE
config: added Parsers_dir config option (#846)

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -200,6 +200,7 @@ enum conf_type {
 #define FLB_CONF_STR_LOGFILE  "Log_File"
 #define FLB_CONF_STR_LOGLEVEL "Log_Level"
 #define FLB_CONF_STR_PARSERS_FILE "Parsers_File"
+#define FLB_CONF_STR_PARSERS_DIR  "Parsers_Dir"
 #define FLB_CONF_STR_PLUGINS_FILE "Plugins_File"
 #ifdef FLB_HAVE_HTTP_SERVER
 #define FLB_CONF_STR_HTTP_SERVER  "HTTP_Server"


### PR DESCRIPTION
This patch adds a new SERVICE option as "Parsers_dir"

Argument is path to a directory which includes parsers files ending in .conf

Only parsers ending in .conf will be loaded.

Signed-off-by: Dan Oliver <thrift24@gmail.com>