### PR TITLE
flb_pack: fix sigsegv error while packing in GELF format

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1177,7 +1177,7 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                 if (full_message_key_found == FLB_TRUE) continue;
                 full_message_key_found = FLB_TRUE;
                 key = "full_message";
-                key_len = 13;
+                key_len = 12;
             }
             else if ((key_len == 2)  && !strncmp(key, "id", 2)) {
                 /* _id key not allowed */


### PR DESCRIPTION
The string "full_message" is 12 char length, not 13.

This subtle error creates a classical "off-by-one" situation and
results in SIGSEGV when someone tries to output long messages.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>