### PR TITLE
out_http: add a proper error return to the failure path

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -352,6 +352,9 @@ static int http_gelf(struct flb_out_http *ctx,
         }
         else {
             flb_error("[out_http] error encoding to GELF");
+            msgpack_unpacked_destroy(&result);
+            flb_sds_destroy(s);
+            return FLB_RETRY;
         }
 
         flb_sds_destroy(s);


### PR DESCRIPTION
http_gelf() should return FLB_RETRY (not FLB_OK) when it fails to
serialize the payload. Otherwise, no retry will happen and the data
will slip through the cracks.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>