### PR TITLE
flb_pack: fix a minor memory leak in flb_msgpack_to_gelf()

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1203,8 +1203,10 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
 
                 tmp = flb_msgpack_gelf_flatten (s, v,
                                                 prefix, prefix_len, FLB_FALSE);
-
-                if (tmp == NULL) return NULL;
+                if (tmp == NULL) {
+                    flb_free(prefix);
+                    return NULL;
+                }
                 *s = tmp;
                 flb_free(prefix);
 


### PR DESCRIPTION
This adds free() to the failure path, to prevent memory we allocated
for the prefix string from leaking.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>