### PR TITLE
OpenEmbedded/Yocto: update Bitbake recipe for cross-compiling.

### DIFF
--- a/fluent-bit_git.bb
+++ b/fluent-bit_git.bb
@@ -12,11 +12,12 @@ SECTION = "net"
 
 SRC_URI = "git://github.com/fluent/fluent-bit.git"
 
-PR = "r0"
-PV = "0.1.0"
+PV = "0.14+git${SRCPV}"
+SRCREV = "master"
 
 S = "${WORKDIR}/git"
-SRCREV = "master"
-EXTRA_OECMAKE = "-DFLB_XBEE=1"
+HOST_SYS_ARCH = "${HOST_ARCH}"
+HOST_SYS_TRIPLE = "${HOST_SYS_ARCH}-unknown-linux"
+EXTRA_OECMAKE = "-DGNU_HOST=${HOST_SYS_TRIPLE} -DFLB_WITHOUT_EXAMPLES=On -DFLB_LUAJIT=Off -DFLB_FILTER_LUA=Off"
 
 inherit cmake


### PR DESCRIPTION
The original Bitbake recipe did not cross-compile to ARM architecture.
That should be fixed now, though without an additional patch to FindMonkey,
the build (which happens out of the project tree in Yocto) will still fail
at do_configure. Lua support is disabled by default here because it does
not appear to cross-compile successfully.

Partial solution to issue #839 
