### PR TITLE
in_tail: add Docker mode for recombining log lines split by Docker

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -41,6 +41,7 @@ struct flb_pack_state {
     jsmn_parser parser;   /* parser state            */
 };
 
+int flb_json_tokenise(char *js, size_t len, struct flb_pack_state *state);
 int flb_pack_json(char *js, size_t len, char **buffer, size_t *size,
                   int *root_type);
 int flb_pack_state_init(struct flb_pack_state *s);

--- a/plugins/in_tail/CMakeLists.txt
+++ b/plugins/in_tail/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(src
   tail_file.c
   tail_multiline.c
+  tail_dockermode.c
   tail_scan.c
   tail_config.c
   tail_db.c

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -36,6 +36,7 @@
 #include "tail_scan.h"
 #include "tail_signal.h"
 #include "tail_config.h"
+#include "tail_dockermode.h"
 #include "tail_multiline.h"
 
 static inline int consume_byte(int fd)
@@ -259,6 +260,19 @@ static int in_tail_init(struct flb_input_instance *in,
                  "(parser disabled)");
     }
 
+    /* Register callback to process docker mode queued buffer */
+    if (ctx->docker_mode == FLB_TRUE) {
+        ret = flb_input_set_collector_time(in, flb_tail_dmode_pending_flush,
+                                           ctx->docker_mode_flush, 0,
+                                           config);
+        if (ret == -1) {
+            ctx->docker_mode = FLB_FALSE;
+            flb_tail_config_destroy(ctx);
+            return -1;
+        }
+        ctx->coll_fd_dmode_flush = ret;
+    }
+
     /* Register callback to process multiline queued buffer */
     if (ctx->multiline == FLB_TRUE) {
         ret = flb_input_set_collector_time(in, flb_tail_mult_pending_flush,
@@ -312,6 +326,10 @@ static void in_tail_pause(void *data, struct flb_config *config)
     flb_input_collector_pause(ctx->coll_fd_static, ctx->i_ins);
     flb_input_collector_pause(ctx->coll_fd_pending, ctx->i_ins);
 
+    if (ctx->docker_mode == FLB_TRUE) {
+        flb_input_collector_pause(ctx->coll_fd_dmode_flush, ctx->i_ins);
+    }
+
     if (ctx->multiline == FLB_TRUE) {
         flb_input_collector_pause(ctx->coll_fd_mult_flush, ctx->i_ins);
     }
@@ -326,6 +344,10 @@ static void in_tail_resume(void *data, struct flb_config *config)
 
     flb_input_collector_resume(ctx->coll_fd_static, ctx->i_ins);
     flb_input_collector_resume(ctx->coll_fd_pending, ctx->i_ins);
+
+    if (ctx->docker_mode == FLB_TRUE) {
+        flb_input_collector_resume(ctx->coll_fd_dmode_flush, ctx->i_ins);
+    }
 
     if (ctx->multiline == FLB_TRUE) {
         flb_input_collector_resume(ctx->coll_fd_mult_flush, ctx->i_ins);

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -28,6 +28,7 @@
 #include "tail_db.h"
 #include "tail_config.h"
 #include "tail_scan.h"
+#include "tail_dockermode.h"
 #include "tail_multiline.h"
 
 struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
@@ -152,6 +153,19 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
         if (ret == FLB_TRUE) {
             ctx->multiline = FLB_TRUE;
             ret = flb_tail_mult_create(ctx, i_ins, config);
+            if (ret == -1) {
+                return NULL;
+            }
+        }
+    }
+
+    /* Config: Docker mode */
+    tmp = flb_input_get_property("docker_mode", i_ins);
+    if (tmp) {
+        ret = flb_utils_bool(tmp);
+        if (ret == FLB_TRUE) {
+            ctx->docker_mode = FLB_TRUE;
+            ret = flb_tail_dmode_create(ctx, i_ins, config);
             if (ret == -1) {
                 return NULL;
             }

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -42,6 +42,7 @@ struct flb_tail_config {
     int coll_fd_scan;
     int coll_fd_rotated;
     int coll_fd_pending;
+    int coll_fd_dmode_flush;
     int coll_fd_mult_flush;
 
     /* Backend collectors */
@@ -79,6 +80,10 @@ struct flb_tail_config {
     int multiline_flush;       /* multiline flush/wait */
     struct flb_parser *mult_parser_firstline;
     struct mk_list mult_parsers;
+
+    /* Docker mode */
+    int docker_mode;           /* Docker mode enabled ?  */
+    int docker_mode_flush;     /* Docker mode flush/wait */
 
     /* Lists head for files consumed statically (read) and by events (inotify) */
     struct mk_list files_static;

--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -1,0 +1,342 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_unescape.h>
+
+#include "tail_config.h"
+#include "tail_dockermode.h"
+#include "tail_file_internal.h"
+
+int flb_tail_dmode_create(struct flb_tail_config *ctx,
+                          struct flb_input_instance *i_ins,
+                          struct flb_config *config)
+{
+    char *tmp;
+
+    if (ctx->multiline == FLB_TRUE) {
+        flb_error("[in_tail] Docker mode cannot be enabled when multiline is enabled");
+        return -1;
+    }
+
+    tmp = flb_input_get_property("docker_mode_flush", i_ins);
+    if (!tmp) {
+        ctx->docker_mode_flush = FLB_TAIL_DMODE_FLUSH;
+    }
+    else {
+        ctx->docker_mode_flush = atoi(tmp);
+        if (ctx->docker_mode_flush <= 0) {
+            ctx->docker_mode_flush = 1;
+        }
+    }
+
+    return 0;
+}
+
+static int modify_json_cond(char *js, size_t js_len,
+                            char **val, size_t *val_len,
+                            char **out, size_t *out_len,
+                            int cond(char*, size_t),
+                            int mod(char*, size_t, char**, size_t*, void*), void *data)
+{
+    int ret;
+    struct flb_pack_state state;
+    jsmntok_t *t;
+    jsmntok_t *t_val = NULL;
+    int i;
+    int i_root = -1;
+    int i_key = -1;
+    char *old_val;
+    size_t old_val_len;
+    char *new_val = NULL;
+    size_t new_val_len = 0;
+    size_t mod_len;
+
+    ret = flb_pack_state_init(&state);
+    if (ret != 0) {
+        ret = -1;
+        goto modify_json_cond_end;
+    }
+
+    ret = flb_json_tokenise(js, js_len, &state);
+    if (ret != 0 || state.tokens_count == 0) {
+        ret = -1;
+        goto modify_json_cond_end;
+    }
+
+    for (i = 0; i < state.tokens_count; i++) {
+        t = &state.tokens[i];
+
+        if (i_key >= 0) {
+            if (t->parent == i_key) {
+                if (t->type == JSMN_STRING) {
+                   t_val = t;
+                }
+                break;
+            }
+            continue;
+        }
+
+        if (t->start == 0 && t->parent == -1 && t->type == JSMN_OBJECT) {
+            i_root = i;
+            continue;
+        }
+        if (i_root == -1) {
+            continue;
+        }
+
+        if (t->parent == i_root && t->type == JSMN_STRING && t->end - t->start == 3 && strncmp(js + t->start, "log", 3) == 0) {
+            i_key = i;
+        }
+    }
+
+    if (!t_val) {
+        ret = -1;
+        goto modify_json_cond_end;
+    }
+
+    *out = js;
+    *out_len = js_len;
+
+    if (val) {
+        *val = js + t_val->start;
+    }
+    if (val_len) {
+        *val_len = t_val->end - t_val->start;
+    }
+
+    if (!cond || cond(js + t_val->start, t_val->end - t_val->start)) {
+        old_val = js + t_val->start;
+        old_val_len = t_val->end - t_val->start;
+        ret = mod(old_val, old_val_len, &new_val, &new_val_len, data);
+        if (ret != 0) {
+            ret = -1;
+            goto modify_json_cond_end;
+        }
+
+        ret = 1;
+
+        if (new_val == old_val) {
+            goto modify_json_cond_end;
+        }
+
+        mod_len = js_len + new_val_len - old_val_len;
+        *out = flb_malloc(mod_len);
+        if (!*out) {
+            flb_errno();
+            ret = -1;
+            goto modify_json_cond_end;
+        }
+        *out_len = mod_len;
+
+        memcpy(*out, js, t_val->start);
+        memcpy(*out + t_val->start, new_val, new_val_len);
+        memcpy(*out + t_val->start + new_val_len, js + t_val->end, js_len - t_val->end);
+
+        flb_free(new_val);
+    }
+
+ modify_json_cond_end:
+    flb_pack_state_reset(&state);
+    if (ret < 0) {
+        *out = NULL;
+    }
+    return ret;
+}
+
+static int unesc_ends_with_nl(char *str, size_t len)
+{
+    char* unesc;
+    int unesc_len;
+    int nl;
+
+    unesc = flb_malloc(len + 1);
+    if (!unesc) {
+        flb_errno();
+        return FLB_FALSE;
+    }
+    unesc_len = flb_unescape_string(str, len, &unesc);
+    nl = unesc[unesc_len - 1] == '\n';
+    flb_free(unesc);
+    return nl;
+}
+
+static int prepend_sds_to_str(char *str, size_t len, char **out, size_t *out_len, void *data)
+{
+    flb_sds_t sds = data;
+
+    if (flb_sds_len(sds) == 0) {
+        *out = str;
+        *out_len = len;
+        return 0;
+    }
+
+    size_t mod_len = flb_sds_len(sds) + len;
+    *out = flb_malloc(mod_len);
+    if (!*out) {
+        flb_errno();
+        return -1;
+    }
+    *out_len = mod_len;
+
+    memcpy(*out, sds, flb_sds_len(sds));
+    memcpy(*out + flb_sds_len(sds), str, len);
+    return 0;
+}
+
+static int use_sds(char *str, size_t len, char **out, size_t *out_len, void *data)
+{
+    flb_sds_t sds = data;
+    size_t mod_len = flb_sds_len(sds);
+    *out = flb_malloc(mod_len);
+    if (!*out) {
+        flb_errno();
+        return -1;
+    }
+    *out_len = mod_len;
+
+    memcpy(*out, sds, flb_sds_len(sds));
+    return 0;
+}
+
+int flb_tail_dmode_process_content(time_t now,
+                                   char* line, size_t line_len,
+                                   char **repl_line, size_t *repl_line_len,
+                                   struct flb_tail_file *file,
+                                   struct flb_tail_config *ctx)
+{
+    char* val = NULL;
+    size_t val_len;
+    int ret;
+
+    ret = modify_json_cond(line, line_len,
+                           &val, &val_len,
+                           repl_line, repl_line_len,
+                           unesc_ends_with_nl,
+                           prepend_sds_to_str, file->dmode_buf);
+    if (ret >= 0) {
+        flb_sds_len_set(file->dmode_lastline, 0);
+
+        if (ret == 0) {
+            file->dmode_buf = flb_sds_cat(file->dmode_buf, val, val_len);
+            file->dmode_lastline = flb_sds_copy(file->dmode_lastline, line, line_len);
+            file->dmode_flush_timeout = now + (ctx->docker_mode_flush - 1);
+            return ret;
+        }
+
+        flb_sds_len_set(file->dmode_buf, 0);
+        file->dmode_flush_timeout = 0;
+    }
+    return ret;
+}
+
+void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
+                          struct flb_tail_file *file, struct flb_tail_config *ctx)
+{
+    int ret;
+    char *repl_line = NULL;
+    size_t repl_line_len = 0;
+    void *out_buf = NULL;
+    size_t out_size;
+    struct flb_time out_time = {};
+    time_t now = time(NULL);
+
+    if (flb_sds_len(file->dmode_lastline) == 0) {
+        return;
+    }
+
+    flb_time_zero(&out_time);
+
+    ret = modify_json_cond(file->dmode_lastline, flb_sds_len(file->dmode_lastline),
+                           NULL, NULL,
+                           &repl_line, &repl_line_len,
+                           NULL,
+                           use_sds, file->dmode_buf);
+    if (ret < 0) {
+        return;
+    }
+
+    flb_sds_len_set(file->dmode_buf, 0);
+    flb_sds_len_set(file->dmode_lastline, 0);
+    file->dmode_flush_timeout = 0;
+
+#ifdef FLB_HAVE_REGEX
+    if (ctx->parser) {
+        ret = flb_parser_do(ctx->parser, repl_line, repl_line_len,
+                            &out_buf, &out_size, &out_time);
+        if (ret >= 0) {
+            if (flb_time_to_double(&out_time) == 0) {
+                flb_time_get(&out_time);
+            }
+            if (ctx->ignore_older > 0 && (now - ctx->ignore_older) > out_time.tm.tv_sec) {
+                goto dmode_flush_end;
+            }
+            flb_tail_pack_line_map(mp_sbuf, mp_pck, &out_time,
+                                   (char**) &out_buf, &out_size, file);
+            goto dmode_flush_end;        }
+    }
+#endif
+    flb_time_get(&out_time);
+    flb_tail_file_pack_line(mp_sbuf, mp_pck, &out_time,
+                            repl_line, repl_line_len, file);
+
+ dmode_flush_end:
+    flb_free(repl_line);
+    flb_free(out_buf);
+}
+
+int flb_tail_dmode_pending_flush(struct flb_input_instance *i_ins,
+                                 struct flb_config *config, void *context)
+{
+    time_t now;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    struct mk_list *head;
+    struct flb_tail_file *file;
+    struct flb_tail_config *ctx = context;
+
+    now = time(NULL);
+
+    /* Iterate promoted event files with pending bytes */
+    mk_list_foreach(head, &ctx->files_event) {
+        file = mk_list_entry(head, struct flb_tail_file, _head);
+
+        if (file->dmode_flush_timeout > now) {
+            continue;
+        }
+
+        if (flb_sds_len(file->dmode_lastline) == 0) {
+            continue;
+        }
+
+        msgpack_sbuffer_init(&mp_sbuf);
+        msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+        flb_tail_dmode_flush(&mp_sbuf, &mp_pck, file, ctx);
+
+        flb_input_dyntag_append_raw(i_ins,
+                                    file->tag_buf,
+                                    file->tag_len,
+                                    mp_sbuf.data,
+                                    mp_sbuf.size);
+        msgpack_sbuffer_destroy(&mp_sbuf);
+    }
+
+    return 0;
+}

--- a/plugins/in_tail/tail_dockermode.h
+++ b/plugins/in_tail/tail_dockermode.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_TAIL_DOCKERMODE_H
+#define FLB_TAIL_DOCKERMODE_H
+
+#include "tail_file.h"
+#define FLB_TAIL_DMODE_FLUSH 4
+
+int flb_tail_dmode_create(struct flb_tail_config *ctx,
+                          struct flb_input_instance *i_ins, struct flb_config *config);
+int flb_tail_dmode_process_content(time_t now,
+                                   char* line, size_t line_len,
+                                   char **repl_line, size_t *repl_line_len,
+                                   struct flb_tail_file *file,
+                                   struct flb_tail_config *ctx);
+void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
+                          struct flb_tail_file *file, struct flb_tail_config *ctx);
+int flb_tail_dmode_pending_flush(struct flb_input_instance *i_ins,
+                                 struct flb_config *config, void *context);
+
+#endif

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -57,5 +57,11 @@ char *flb_tail_file_name(struct flb_tail_file *file);
 int flb_tail_file_rotated(struct flb_tail_file *file);
 int flb_tail_file_rotated_purge(struct flb_input_instance *i_ins,
                                 struct flb_config *config, void *context);
+int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
+                           struct flb_time *time, char **data,
+                           size_t *data_size, struct flb_tail_file *file);
+int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
+                            struct flb_time *time, char *data, size_t data_size,
+                            struct flb_tail_file *file);
 
 #endif

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -21,6 +21,7 @@
 #define FLB_TAIL_INTERNAL_H
 
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_sds.h>
 
 #include "tail.h"
 #include "tail_config.h"
@@ -55,6 +56,11 @@ struct flb_tail_file {
     msgpack_sbuffer mult_sbuf;  /* temporal msgpack buffer               */
     msgpack_packer mult_pck;    /* temporal msgpack packer               */
     struct flb_time mult_time;  /* multiline time parsed from first line */
+
+    /* docker mode */
+    time_t dmode_flush_timeout; /* time when docker mode started         */
+    flb_sds_t dmode_buf;        /* buffer for docker mode                */
+    flb_sds_t dmode_lastline;   /* last incomplete line                  */
 
     /* buffering */
     off_t parsed;

--- a/plugins/in_tail/tail_multiline.h
+++ b/plugins/in_tail/tail_multiline.h
@@ -54,8 +54,4 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf,
 int flb_tail_mult_pending_flush(struct flb_input_instance *i_ins,
                                 struct flb_config *config, void *context);
 
-int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
-                            struct flb_time *time, char *data, size_t data_size,
-                            struct flb_tail_file *file);
-
 #endif

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -34,8 +34,8 @@
 
 #define try_to_write_str  flb_utils_write_str
 
-static int json_tokenise(char *js, size_t len,
-                         struct flb_pack_state *state)
+int flb_json_tokenise(char *js, size_t len,
+                      struct flb_pack_state *state)
 {
     int ret;
     int n;
@@ -191,7 +191,7 @@ int flb_pack_json(char *js, size_t len, char **buffer, size_t *size,
     if (ret != 0) {
         return -1;
     }
-    ret = json_tokenise(js, len, &state);
+    ret = flb_json_tokenise(js, len, &state);
     if (ret != 0) {
         ret = -1;
         goto flb_pack_json_end;
@@ -263,7 +263,7 @@ int flb_pack_json_state(char *js, size_t len,
     char *buf;
     jsmntok_t *t;
 
-    ret = json_tokenise(js, len, state);
+    ret = flb_json_tokenise(js, len, state);
     state->multiple = FLB_TRUE;
     if (ret == FLB_ERR_JSON_PART && state->multiple == FLB_TRUE) {
         /*


### PR DESCRIPTION
An extension to in_tail that recombines JSON-encoded log lines split by
Docker's 16k log line limit. Just add "Docker_Mode on" to in_tail's
configuration.