### PR TITLE
Add optimisation / partial-work-around for non-JSON in 'Merge_Log' case

### DIFF
--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -152,7 +152,10 @@ static int merge_log_handler(msgpack_object o,
             return MERGE_PARSED;
         }
     }
-    else {
+    else if (ctx->unesc_buf[0] == '[' || ctx->unesc_buf[0] == '{') {
+        /* Optimisation: avoid trying to pack if it cannot be a valid JSON
+         * object
+         */
         ret = flb_pack_json(ctx->unesc_buf, unesc_len,
                             (char **) out_buf, out_size);
     }


### PR DESCRIPTION
In the case we are using Kubernetes and Merge_Log = On, if a message
is logged in which the first character is a valid token, but it is not 
itself a valid JSON object, the parser will lock up. E.g. if a message
of '----' is logged, the first char will pass the tokenisation test
in jsmn, and tokens!=NULL since the outer 'docker' format is JSON
and mid-parse. This in turn means the flb_pack_json will never finish
and the input will lock up. Add a simple check for '[' or '{' which
are the only valid start-of-object characters. Note: this is only
a partial work-around, since a message could be { ... w/o closing }.
More work is needed, we need a separate jsmn parser for the inner.
