### PR TITLE
Add Trace_Output to Elasticsearch output plugin

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -326,6 +326,10 @@ static char *elasticsearch_format(void *data, size_t bytes,
      * return the bulk->ptr buffer
      */
     flb_free(bulk);
+    if (ctx->trace_output) {
+        printf("%s", buf);
+        fflush(stdout);
+    }
     return buf;
 }
 

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -48,6 +48,8 @@ struct flb_elasticsearch {
      */
     int replace_dots;
 
+    int trace_output;
+
     /*
      * Logstash compatibility options
      * ==============================

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -255,6 +255,16 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     else {
         ctx->replace_dots = FLB_FALSE;
     }
+
+    /* Trace output */
+    tmp = flb_output_get_property("Trace_Output", ins);
+    if (tmp) {
+        ctx->trace_output = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->trace_output = FLB_FALSE;
+    }
+
     return ctx;
 }
 


### PR DESCRIPTION
I find it very difficult to diagnose errors logging to Elastic,
and don't want to see all messages logged at e.g. debug level,
this allows gating it on/off to print the JSON of the exchange.

Signed-off-by: Don Bowman <don@agilicus.com>