### PR TITLE
Fix leak on cleanup of throttle

### DIFF
--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -257,6 +257,8 @@ static int cb_throttle_exit(void *data, struct flb_config *config)
 {
     struct flb_filter_throttle_ctx *ctx = data;
 
+    flb_free(ctx->hash->table);
+    flb_free(ctx->hash);
     flb_free(ctx);
     return 0;
 }


### PR DESCRIPTION
The hash table and window were leaked in the destructor.

Signed-off-by: Don Bowman <don@agilicus.com>