### PR TITLE
filter_modify: fix return data leak when input unmodified

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1406,10 +1406,15 @@ static int cb_modify_filter(void *data, size_t bytes,
     }
     msgpack_unpacked_destroy(&result);
 
+    if(modifications == 0) {
+        msgpack_sbuffer_destroy(&buffer);
+        return FLB_FILTER_NOTOUCH;
+    }
+
     *out_buf = buffer.data;
     *out_size = buffer.size;
 
-    return (modifications == 0) ? FLB_FILTER_NOTOUCH : FLB_FILTER_MODIFIED;
+    return FLB_FILTER_MODIFIED;
 }
 
 static int cb_modify_exit(void *data, struct flb_config *config)


### PR DESCRIPTION
filter_modify/modify.c doesn't handle return status FLB_FILTER_NOTOUCH.
It should free memory allocated for msgpack_sbuffer fore returning  FLB_FILTER_NOTOUCH status.
This  can make memory leak, I think.
Or I have understood memory handling correctly? 

Signed-off-by: Jukka Pihl <jukka.pihl@iki.fi>
