### PR TITLE
Switch to distroless as base image for container, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+build/**
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
       libasl-dev \
       libsasl2-dev \
       pkg-config \
+      libsystemd-dev \
       zlib1g-dev
 
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
@@ -26,15 +27,15 @@ COPY . /tmp/src/
 RUN rm -rf /tmp/src/build/*
 
 WORKDIR /tmp/src/build/
-RUN cmake -DFLB_DEBUG=On \
+RUN cmake -DFLB_DEBUG=Off \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
           -DFLB_BUFFERING=On \
           -DFLB_TLS=On \
-          -DFLB_WITHOUT_SHARED_LIB=On \
-          -DFLB_WITHOUT_EXAMPLES=On \
+          -DFLB_SHARED_LIB=Off \
+          -DFLB_EXAMPLES=Off \
           -DFLB_HTTP_SERVER=On \
-          -DFLB_SYSTEMD=Off \
+          -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On ..
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
@@ -58,6 +59,15 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+# These below are all needed for systemd
+COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libgcrypt.so* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libpcre.so* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libgpg-error.so* /lib/x86_64-linux-gnu/
+
 COPY --from=builder /fluent-bit /fluent-bit
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google-containers/debian-base-amd64:0.3.1 as builder
+FROM launcher.gcr.io/google/debian9 as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 0
@@ -8,25 +8,22 @@ ENV FLB_VERSION 0.15.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
-
-COPY . /tmp/src/
-
-RUN rm -rf /tmp/src/build/*
-
 RUN apt-get update && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
       build-essential \
       cmake \
       make \
       wget \
       unzip \
-      libsystemd-dev \
       libssl1.0-dev \
       libasl-dev \
       libsasl2-dev \
+      pkg-config \
       zlib1g-dev
+
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
+COPY . /tmp/src/
+RUN rm -rf /tmp/src/build/*
 
 WORKDIR /tmp/src/build/
 RUN cmake -DFLB_DEBUG=On \
@@ -37,8 +34,10 @@ RUN cmake -DFLB_DEBUG=On \
           -DFLB_WITHOUT_SHARED_LIB=On \
           -DFLB_WITHOUT_EXAMPLES=On \
           -DFLB_HTTP_SERVER=On \
+          -DFLB_SYSTEMD=Off \
           -DFLB_OUT_KAFKA=On ..
-RUN make
+
+RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Configuration files
@@ -50,15 +49,15 @@ COPY conf/fluent-bit.conf \
      conf/parsers_cinder.conf \
      /fluent-bit/etc/
 
-FROM gcr.io/google-containers/debian-base-amd64:0.3.1
+FROM gcr.io/distroless/cc
 MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
 LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
-RUN apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install --no-install-recommends ca-certificates libssl1.0.2 libsasl2-2 -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get autoclean
+COPY --from=builder /usr/lib/x86_64-linux-gnu/*sasl* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /fluent-bit /fluent-bit
 
 #


### PR DESCRIPTION
The copy-in of the code is moved to after the setup of the build
container to maximise cache (so no rebuild of the build packages
if the source changes).

Add a .dockerignore of .git / build / Dockerfile to maximise
cache.

Switch to gcr.io/distroless/cc as a base container for the run-time,
reducing the possibility of an 'escape' in the code.

Signed-off-by: Don Bowman <don@agilicus.com>