### PR TITLE
flb_utils: fix out of bounds write on invalid utf-8

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -535,7 +535,6 @@ int flb_utils_write_str(char *buf, int *off, size_t size,
         return FLB_FALSE;
     }
 
-    written = *off;
     p = buf + *off;
     for (i = 0; i < str_len; i++) {
         if ((available - written) < 2) {


### PR DESCRIPTION
In flb_utils_write_str, written and *off could be set
to an incorrect large value on invalid UTF-8 input.

Later, this would lead to an out of bounds write when
nul-terminating the string:

    Invalid write of size 1
       at 0x44378B: flb_msgpack_to_json (in /build/bin/fluent-bit)
       by 0x443B78: flb_msgpack_raw_to_json_str (in /build/bin/fluent-bit)
       by 0x47576D: kafka_rest_format (in /build/bin/fluent-bit)
       by 0x4758E9: cb_kafka_flush (in /build/bin/fluent-bit)
       by 0x434A71: output_pre_cb_flush (in /build/bin/fluent-bit)
       by 0x50DF26: co_init (in /build/bin/fluent-bit)
     Address 0x4d9985e is on thread 1's stack

Input file (base64 encoded):

    MAowCjAwCjAwADAKMDAwMDAK/wowCjAwCoAK