### PR TITLE
Add logtag field to crio logs

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -83,10 +83,10 @@
     Time_Key time
 
 [PARSER]
-    # http://rubular.com/r/izM6olvshn
+    # http://rubular.com/r/qa68kQgVWe
     Name crio
     Format Regex
-    Regex /^(?<time>.+)\b(?<stream>stdout|stderr)\b(?<log>.*)$/
+    Regex /^(?<time>.+)\b(?<stream>stdout|stderr)( (?<logtag>[A-Z]))?\b(?<log>.*)$/
     Time_Key    time
     Time_Format %Y-%m-%dT%H:%M:%S.%N%:z
     Time_Keep   On


### PR DESCRIPTION
Since 1.9.0 in november 2017 cri-o has written a log tag field before the
log message:

https://github.com/kubernetes-sigs/cri-o/blob/f58419d6cf462070a0c3727ad2dc554ef151e832/conmon/conmon.c#L499-L509

If a single character is detected, consider this the log tag for the line.
This is a part of the multiline handling for cri-o logs.

Signed-off-by: Carl Henrik Lunde <chlunde@ifi.uio.no>