### PR TITLE
filter_kubernetes: Fix leak of 'meta dir' on destroy

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -297,6 +297,9 @@ void flb_kube_conf_destroy(struct flb_kube *ctx)
         return;
     }
 
+    if (ctx->meta_preload_cache_dir) {
+        flb_free(ctx->meta_preload_cache_dir);
+    }
     if (ctx->hash_table) {
         flb_hash_destroy(ctx->hash_table);
     }


### PR DESCRIPTION
Signed-off-by: Don Bowman <don@agilicus.com>