### PR TITLE
in_tail: Add Exit_On_EOF option to tail input

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -144,6 +144,11 @@ static int in_tail_collect_static(struct flb_input_instance *i_ins,
                           file->name);
                 flb_tail_file_remove(file);
             }
+            if (file->config->exit_on_eof) {
+                flb_info("[in_tail] file=%s ended, stop", file->name);
+                flb_engine_shutdown(config);
+                exit(0);
+            }
             break;
         }
     }

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -136,6 +136,11 @@ static int in_tail_collect_static(struct flb_input_instance *i_ins,
             active++;
             continue;
         case FLB_TAIL_WAIT:
+            if (file->config->exit_on_eof) {
+                flb_info("[in_tail] file=%s ended, stop", file->name);
+                flb_engine_shutdown(config);
+                exit(0);
+            }
             /* Promote file to 'events' type handler */
             flb_debug("[in_tail] file=%s promote to TAIL_EVENT", file->name);
             ret = flb_tail_file_to_event(file);
@@ -143,11 +148,6 @@ static int in_tail_collect_static(struct flb_input_instance *i_ins,
                 flb_debug("[in_tail] file=%s cannot promote, unregistering",
                           file->name);
                 flb_tail_file_remove(file);
-            }
-            if (file->config->exit_on_eof) {
-                flb_info("[in_tail] file=%s ended, stop", file->name);
-                flb_engine_shutdown(config);
-                exit(0);
             }
             break;
         }

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -211,6 +211,12 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
         ctx->skip_long_lines = flb_utils_bool(tmp);
     }
 
+    /* Config: Exit on EOF (for testing) */
+    tmp = flb_input_get_property("exit_on_eof", i_ins);
+    if (tmp) {
+        ctx->exit_on_eof = flb_utils_bool(tmp);
+    }
+
     /* Validate buffer limit */
     if (ctx->buf_chunk_size > ctx->buf_max_size) {
         flb_error("[in_tail] buffer_max_size must be >= buffer_chunk");

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -65,6 +65,7 @@ struct flb_tail_config {
     char *key;                 /* key for unstructured record  */
     int   key_len;             /* length of key ^              */
     int   skip_long_lines;     /* skip long lines              */
+    int   exit_on_eof;         /* exit fluent-bit on EOF, test */
 
     /* Database */
     struct flb_sqldb *db;


### PR DESCRIPTION
The rationale is to allow writing a simple test which
takes an input file, runs to completion (perhaps writing
to stdout or output file) and then exits.

Signed-off-by: Don Bowman <don@agilicus.com>