### PR TITLE
parsers: Support CRI-O and containerd

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -85,11 +85,10 @@
 [PARSER]
     # http://rubular.com/r/tjUt3Awgg4
     Name cri
-    Format Regex
+    Format regex
     Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%N%:z
-    Time_Keep   On
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 
 [PARSER]
     Name    kube-custom

--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -83,10 +83,10 @@
     Time_Key time
 
 [PARSER]
-    # http://rubular.com/r/izM6olvshn
-    Name crio
+    # http://rubular.com/r/tjUt3Awgg4
+    Name cri
     Format Regex
-    Regex /^(?<time>.+)\b(?<stream>stdout|stderr)\b(?<log>.*)$/
+    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
     Time_Key    time
     Time_Format %Y-%m-%dT%H:%M:%S.%N%:z
     Time_Keep   On


### PR DESCRIPTION
See #876 and #873 
If a single character is detected, consider this the log tag for the line.
This is a part of the multiline handling for cri-o logs.

Example Fluent-bit log line on disk:

```
root@fluent-bit-29xjh:/# more /var/log/containers/fluent-bit-29xjh_dev-eeva-logging_fluent-bit-0db128860717a93c7d219425c9d49f4445c2d6c6e5fed3f4dc4298f03c582378.log 
2018-10-31T21:54:45.45487617Z stderr F Fluent-Bit v0.14.4
2018-10-31T21:54:45.454938595Z stderr F Copyright (C) Treasure Data
2018-10-31T21:54:45.454946545Z stderr F 
2018-10-31T21:54:45.455512949Z stderr F [2018/10/31 21:54:45] [ info] [engine] started (pid=1)
2018-10-31T21:54:48.837184585Z stderr F [2018/10/31 21:54:48] [ info] [filter_kube] https=1 host=kubernetes.default.svc.cluster.local port=443
2018-10-31T21:54:48.837218858Z stderr F [2018/10/31 21:54:48] [ info] [filter_kube] local POD info OK
2018-10-31T21:54:48.837226848Z stderr F [2018/10/31 21:54:48] [ info] [filter_kube] testing connectivity with API server...
2018-10-31T21:54:49.036009069Z stderr F [2018/10/31 21:54:49] [ info] [filter_kube] API server connectivity OK
2018-10-31T21:54:49.036783868Z stderr F [2018/10/31 21:54:49] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
```
Example Elasticsearch JSON document:
```
{
  "_index": "logstash-2018.11.03",
  "_type": "flb_type",
  "_id": "sdIP22YBrbPWNMRHKBwz",
  "_version": 1,
  "_score": null,
  "_source": {
    "time": "2018-11-03T19:31:10.000Z",
    "stream": "stderr",
    "logtag": "F",
    "message": "\u001b[1mFluent-Bit v0.14.6\u001b[0m",
    "kubernetes": {
      "pod_name": "fluent-bit-wjnfq",
      "namespace_name": "dev-logging",
      "pod_id": "0293ad2d-df9f-11e8-8914-2e491e409191",
      "labels": {
        "controller-revision-hash": "1569803976",
        "k8s-app": "fluent-bit-logging",
        "kubernetes_io/cluster-service": "true",
        "pod-template-generation": "1",
        "version": "v1"
      },
      "annotations": {
        "prometheus_io/path": "/api/v1/metrics/prometheus",
        "prometheus_io/port": "2020",
        "prometheus_io/scrape": "true"
      },
      "host": "10.63.56.245",
      "container_name": "fluent-bit",
      "docker_id": "013362a984722805ede9cf323e34919890ea44ea0004897d3ed93178116676a2"
    }
  },
  "fields": {
    "time": [
      "2018-11-03T19:31:10.000Z"
    ]
  },
  "sort": [
    1541273470000
  ]
}
```