### PR TITLE
Switch travis UT to 'xenial', add matrix of clang/gcc for sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,55 @@
-dist: trusty
-sudo: required
+dist: xenial
 language: c
+# The leak sanitizer uses ptrace, which doesn't work under the
+# travis container infrastructure, so we enable 'sudo'
+sudo: true
+
+git:
+  depth: 3
+
 compiler:
   - gcc
   - clang
-os:
-  - linux
-  - osx
-env:
-  - FLB_MEM="-DFLB_JEMALLOC=On"
-  - FLB_MEM="-DFLB_JEMALLOC=Off"
 
-notifications:
-  irc: "irc.freenode.net#fluent-bit"
+env:
+  - FLB_OPT="-DFLB_JEMALLOC=On"
+  - FLB_OPT="-DFLB_JEMALLOC=Off"
+  - FLB_OPT="-DSANITIZE_ADDRESS=On"
+  - FLB_OPT="-DSANITIZE_UNDEFINED=On"
+  - FLB_OPT="-DSANITIZE_MEMORY=On"
+
+# Many errors on this
+#  - FLB_OPT="-DSANITIZE_THREAD=On"
 
 before_script:
-  # Add an IPv6 config - see the corresponding Travis issue
-  # https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'; fi
 
 matrix:
-  exclude:
+  include:
     - os: osx
-      env: FLB_MEM="-DFLB_JEMALLOC=On"
+      env: FLB_OPT="-DFLB_JEMALLOC=Off"
+      script: |
+        ci/do-ut || true
+    - os: linux
+      dist: xenial
+      sudo: true
+      language: node_js
+        - "9"
+      compiler: gcc
+      env: DOCKER_BUILD=1
+      script: |
+        echo "===== BUILD DOCKER IMAGE ======="
+        docker build -t test-image -f Dockerfile .
+        npm install -g bats
 
 script: |
-    cd build
-    cmake -DFLB_ALL=On -DFLB_WITHOUT_EXAMPLES=On $FLB_FLUSH $FLB_MEM -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On ../
-    make
-    SKIP_EXTERNAL="elasticsearch|out_td|out_forward"
-    SKIP_BROKEN="filter_nest|filter_parser|in_disk|in_proc"
-    echo "Run 'internal' tests for $FLB_MEM $FLB_FLUSH"
-    for i in bin/flb-it*
-    do
-      echo "===== <<$(basename $i)>> ====="
-      $i
-    done
-    if [ "${TRAVIS_OS_NAME}" == "linux" ]
-    then
-      echo "Run select 'runtime' tests for $FLB_MEM $FLB_FLUSH"
-      for i in $(ls bin/flb-rt* | egrep -v "$SKIP_EXTERNAL|$SKIP_BROKEN")
-      do
-        echo "===== <<$(basename $i)>> ====="
-        $i
-      done
-    fi
+  echo "CC = $CC, CXX = $CXX"
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
+  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
+  ci/do-ut
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-7
+      - g++-7

--- a/ci/do-ut
+++ b/ci/do-ut
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
+
+[ -x /usr/bin/llvm-symbolizer-5.0 ] && export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-5.0
+[ -x /usr/local/clang-5.0.0/bin/llvm-symbolizer ] && export ASAN_SYMBOLIZER_PATH=/usr/local/clang-5.0.0/bin/llvm-symbolizer
+[ -x /usr/bin/llvm-symbolizer-6.0 ] && export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-6.0
+[ -x /usr/bin/llvm-symbolizer ] && export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+
+echo "use $ASAN_SYMBOLIZER_PATH"
+
+SKIP_TESTS="flb-rt-filter_parser
+flb-rt-out_elasticsearch
+flb-rt-out_td
+flb-rt-out_forward
+flb-rt-filter_nest
+flb-rt_filter_parser
+flb-rt-in_disk
+flb-rt-in_proc"
+
+for skip in $SKIP_TESTS
+do
+    SKIP="$SKIP -DFLB_WITHOUT_${skip}=1"
+done
+
+[ -f /etc/lsb-release ] && . /etc/lsb-release
+if [ "$DISTRIB_RELEASE" = "14.04" ]
+then
+    # On 'Trusty', gmtime_r doesn't parse this properly:
+    # {"generic_TZ"   , "07/18/2017 01:47:03 +05:30"  , 1500322623, 0,   0},
+    echo "Skip flb-it-parser (trusty)"
+    SKIP="$SKIP -DFLB_WITHOUT_flb-it-parser=1"
+fi
+
+# If no v6, disable that test
+[[ ! $(ip a) =~ ::1 ]] && SKIP="$SKIP -DFLB_WITHOUT_flb-it-network=1"
+
+if [ "$CC" = "gcc" ]
+then
+    if [[ "$FLB_OPT" =~ SANITIZE  ]]
+    then
+        # https://stackoverflow.com/questions/50024731/ld-unrecognized-option-push-state-no-as-needed
+        echo Set gold linker to workaround ubsan
+        LDFLAG=-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+    fi
+fi
+
+GLOBAL_OPTS="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
+set -e
+mkdir -p build
+cd build
+echo "Build unit tests for $FLB_OPT on $nparallel VCPU"
+echo cmake $LDFLAG $GLOBAL_OPTS $FLB_OPT -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On $SKIP ../
+cmake $LDFLAG $GLOBAL_OPTS $FLB_OPT -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On $SKIP ../
+make -j $nparallel
+
+echo
+echo "Run unit tests for $FLB_OPT on $nparallel VCPU"
+echo
+ctest -j $nparallel --build-run-dir $PWD --output-on-failure
+


### PR DESCRIPTION
Switch to 'xenial' from 'trusty' for unit testing since the older
binutils did not work well with the sanitizer tests for gcc.
There was also a bug in libc gmtime() which was causing faulse failures.

Add a matrix so that we run, for both gcc and clang:
- JEMALLOC on/off
- ASAN on/off
- USAN on/off
- MSAN on/off

TSAN is disabled as there are significant errors/false positives
in the code where sleep() is used to synchronise.

Infrastructure is put in place to build a test docker image
with a bash test suite prepatory to committing a 'corpus' of
input test files to compare output for system test of the
docker image.

Signed-off-by: Don Bowman <don@agilicus.com>