### PR TITLE
[test filter_kubernetes] skip systemd test if journal not running

### DIFF
--- a/tests/runtime/filter_kubernetes.c
+++ b/tests/runtime/filter_kubernetes.c
@@ -440,32 +440,34 @@ void flb_test_json_logs_invalid()
 #include <systemd/sd-journal.h>
 void flb_test_systemd_logs()
 {
+    struct stat statb;
     struct kube_test *ctx;
 
-    /* Send test message to Journal. If this fails (e.g. journal is not running
-     * then skip the test
-     */
-    if (sd_journal_send(
-                    "@timestamp=2018-02-23T08:58:45.0Z",
-                    "PRIORITY=6",
-                    "CONTAINER_NAME=k8s_kairosdb_kairosdb-914055854-b63vq_default_d6c53deb-05a4-11e8-a8c4-080027435fb7_23",
-                    "CONTAINER_TAG=",
-                    "CONTAINER_ID=56e257661383",
-                    "CONTAINER_ID_FULL=56e257661383836fac4cd90a23ee8a7a02ee1538c8f35657d1a90f3de1065a22",
-                    "MESSAGE=08:58:45.839 [qtp151442075-47] DEBUG [HttpParser.java:281] - filled 157/157",
-                    "KUBE_TEST=2018",
-                    NULL) == 0)
-    {
+    if (stat("/run/systemd/journal/socket", &statb) == 0 && statb.st_mode & S_IFSOCK) {
 
-        ctx = kube_test_create(T_SYSTEMD_SIMPLE, KUBE_SYSTEMD, "", STD_PARSER,
-                               "Merge_Log", "On",
-                               NULL);
-        if (!ctx) {
-            exit(EXIT_FAILURE);
+        /* Send test message to Journal. If this fails (e.g. journal is not running
+         * then skip the test
+         */
+        if (sd_journal_send(
+                        "@timestamp=2018-02-23T08:58:45.0Z",
+                        "PRIORITY=6",
+                        "CONTAINER_NAME=k8s_kairosdb_kairosdb-914055854-b63vq_default_d6c53deb-05a4-11e8-a8c4-080027435fb7_23",
+                        "CONTAINER_TAG=",
+                        "CONTAINER_ID=56e257661383",
+                        "CONTAINER_ID_FULL=56e257661383836fac4cd90a23ee8a7a02ee1538c8f35657d1a90f3de1065a22",
+                        "MESSAGE=08:58:45.839 [qtp151442075-47] DEBUG [HttpParser.java:281] - filled 157/157",
+                        "KUBE_TEST=2018",
+                        NULL) == 0) {
+
+            ctx = kube_test_create(T_SYSTEMD_SIMPLE, KUBE_SYSTEMD, "", STD_PARSER,
+                                   "Merge_Log", "On",
+                                   NULL);
+            if (!ctx) {
+                exit(EXIT_FAILURE);
+            }
+            kube_test_destroy(ctx);
         }
-        kube_test_destroy(ctx);
     }
-
 }
 #endif
 


### PR DESCRIPTION
In a container environment systemd does not run. Skip
the test if there is no systemd journal sock.

Signe-off-by: Don Bowman <don@agilicus.com>