### PR TITLE
[filter_kubernetes] Fix issue with >1 container in pod diff parser type

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -595,7 +595,10 @@ static inline int extract_meta(struct flb_kube *ctx, char *tag, int tag_len,
 
     /* Compose API server cache key */
     if (meta->podname && meta->namespace) {
-        meta->cache_key_len = meta->podname_len + meta->namespace_len + 1;
+        meta->cache_key_len = meta->podname_len + meta->namespace_len + meta->container_name_len + 1;
+        if (meta->container_name) {
+            meta->cache_key_len += meta->container_name_len + 2;
+        }
         meta->cache_key = flb_malloc(meta->cache_key_len + 1);
         if (!meta->cache_key) {
             flb_errno();
@@ -612,6 +615,14 @@ static inline int extract_meta(struct flb_kube *ctx, char *tag, int tag_len,
         /* Copy podname */
         memcpy(meta->cache_key + off, meta->podname, meta->podname_len);
         off += meta->podname_len;
+
+        if (meta->container_name) {
+            /* Separator */
+            meta->cache_key[off++] = ':';
+            memcpy(meta->cache_key + off, meta->container_name, meta->container_name_len);
+            off += meta->container_name_len;
+        }
+
         meta->cache_key[off] = '\0';
     }
     else {


### PR DESCRIPTION
If there was more than 1 container in a pod with different parser
types, it was matching the first one each time. Separate the hash-key
by container-name.

Signed-off-by: Don Bowman <don@agilicus.com>