### PR TITLE
out_es: remove warning on not using '_' as first character of tag-key

### DIFF
--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -200,9 +200,6 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
         if (tmp) {
             ctx->tag_key = flb_strdup(tmp);
             ctx->tag_key_len = strlen(tmp);
-            if (tmp[0] != '_') {
-                flb_warn("[out_es] consider use a tag_key that starts with '_'");
-            }
         }
         else {
             ctx->tag_key = flb_strdup(FLB_ES_DEFAULT_TAG_KEY);


### PR DESCRIPTION
Elasticsearch reserves keys starting with '\_' for internal use, although it does not enforce this. Kibana does enforce it, making such keys useless to it. 'flb-key' is not internal to Elasticsearch, so it should not start with '\_', remove warning.

Signed-off-by: Don Bowman <don@agilicus.com>