### PR TITLE
filter_modify: condition key_value_matches regex bug

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -169,7 +169,7 @@ static int setup(struct filter_modify_ctx *ctx,
             }
             else if (strcasecmp(sentry->value, "key_value_matches") == 0) {
                 condition->conditiontype = KEY_VALUE_MATCHES;
-                condition->a_is_regex = true;
+                condition->b_is_regex = true;
             }
             else if (strcasecmp(sentry->value, "key_value_does_not_match") ==
                      0) {


### PR DESCRIPTION
In configuring Condition 'Key_Value_Matches' KEY REGEX
Accidentally KEY is consired regex not REGEX parameter.
This can crash program.

Signed-off-by: Jukka Pihl <jukka.pihl@iki.fi>