### PR TITLE
Switch to dockerhub debian:9 from launcher.gcr.io/debian9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/debian9 as builder
+FROM debian:stretch as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 0


### PR DESCRIPTION
Google has deprecated `launcher.gcr.io`
(see https://cloud.google.com/marketplace/docs/container-images)

Their recommended replacement is marketplace.gcr.io, which requires
Google Cloud Platform credentials (which we don't have).

Switch to the upstream debian-maintained Dockerhub image
which derives from the same source.

Signed-off-by: Don Bowman <don@agilicus.com>