### PR TITLE
in_systemd: strip_underscores adds extra character to value

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -174,11 +174,12 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
         msgpack_pack_map(&mp_pck, entries);
         while (sd_journal_enumerate_data(ctx->j, &data, &length)) {
             key = (char *) data;
+            if (ctx->strip_underscores == FLB_TRUE && key[0] == '_') {
+                key++; 
+                length--;
+            }
             sep = strchr(key, '=');
             len = (sep - key);
-            if (ctx->strip_underscores == FLB_TRUE && key[0] == '_') {
-                key++; len--;
-            }
             msgpack_pack_str(&mp_pck, len);
             msgpack_pack_str_body(&mp_pck, key, len);
 


### PR DESCRIPTION
After stripping the leading underscore, the code adjusts string length for copying the key but doesn't adjust length for copying the value, adding a trailing character to value.  Better to strip the leading underscore before searching and extracting the key/value pair.