### PR TITLE
warn on wrong gelf-level

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1174,6 +1174,19 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                 level_key_found = FLB_TRUE;
                 key = "level";
                 key_len = 5;
+                if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                        if ( v->via.u64 > 7 ) {
+                            flb_error("[flb_msgpack_to_gelf] level is %" PRIu64 ", but should be in 0..6", v->via.u64);
+                            return NULL;
+                        }
+                } else if (v->type == MSGPACK_OBJECT_STR){
+                    val     = (char *) v->via.str.ptr;
+                    val_len = v->via.str.size;
+                    if ( val_len != 1 || val[0] < '0' || val[0] > '6' ) {
+                            flb_error("[flb_msgpack_to_gelf] level is '%s', but should be in 0..6", val);
+                            return NULL;
+                    }
+                }
             }
             else if ((key_len == full_message_key_len) &&
                      !strncmp(key, full_message_key, full_message_key_len)) {


### PR DESCRIPTION
According to GELF-protocol "the *level* equal to the standard syslog levels; optional, default is 1 (ALERT)", otherwise messages will be silently dropped by graylog.
Here we checking the *level* field to have a correct value, informing otherwise.

http://docs.graylog.org/en/2.4/pages/gelf.html
