### PR TITLE
Add FLB_COVERAGE to calculate test-code coverage, add summary to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,14 @@ matrix:
       script: |
         ci/do-ut || true
     - os: linux
+      env: FLB_OPT="-DFLB_COVERAGE=On"
+      dist: xenial
+      sudo: true
+      language: c
+      compiler: gcc
+      script: |
+        ci/do-ut
+    - os: linux
       dist: xenial
       sudo: true
       language: node_js
@@ -63,3 +71,4 @@ addons:
     packages:
       - gcc-7
       - g++-7
+      - gcovr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(FLB_VERSION_STR "${FLB_VERSION_MAJOR}.${FLB_VERSION_MINOR}.${FLB_VERSION_PAT
 # Build Options
 option(FLB_ALL                "Enable all features"           No)
 option(FLB_DEBUG              "Build with debug symbols"      No)
+option(FLB_COVERAGE           "Build with code-coverage"      No)
 option(FLB_JEMALLOC           "Build with Jemalloc support"   No)
 option(FLB_REGEX              "Build wiht Regex support"     Yes)
 option(FLB_TLS                "Build with SSL/TLS support"    No)
@@ -170,6 +171,11 @@ if(FLB_DEV)
   set(FLB_METRICS        On)
   set(FLB_HTTP_SERVER    On)
   set(FLB_TESTS_INTERNAL On)
+endif()
+
+if(FLB_COVERAGE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+  set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 if(FLB_OUT_GELF)

--- a/ci/do-ut
+++ b/ci/do-ut
@@ -55,3 +55,15 @@ echo
 echo "Run unit tests for $FLB_OPT on $nparallel VCPU"
 echo
 ctest -j $nparallel --build-run-dir $PWD --output-on-failure
+res=$?
+
+if [[ "$FLB_OPT" =~ COVERAGE  ]]
+then
+    mkdir -p coverage
+    find lib -name "*.gcda" -o -name "*.gcno" -print0 | xargs -0 -r rm
+    gcovr -p -r .. . | cut -c1-100
+    gcovr --html --html-details -p -r .. -o coverage/index.html .
+    echo
+    echo "See coverage/index.html for code-coverage details"
+fi
+exit $res


### PR DESCRIPTION
The new option, FLB_COVERAGE enables code-coverage analysis
during testing. Since there are multiple test executables,
it leaves the summarisation of these out of the cmake. This
is in turn performed in the CI.

To see coverage, run

    gcovr --html --html-details -p -r ..  -o coverage/index.html .

from the build directory.

Signed-off-by: Don Bowman <don@agilicus.com>