### PR TITLE
out_nats: fix SIGSEGV on long topic names

### DIFF
--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -189,8 +189,8 @@ void cb_nats_flush(void *data, size_t bytes,
     }
 
     /* Compose the NATS Publish request */
-    request = flb_malloc(json_len + 32);
-    req_len = snprintf(request, json_len + 32, "PUB %s %zu\r\n",
+    request = flb_malloc(json_len + tag_len + 32);
+    req_len = snprintf(request, tag_len + 32, "PUB %s %zu\r\n",
                        tag, json_len);
 
     /* Append JSON message and ending CRLF */


### PR DESCRIPTION
This patch resolves the issue #909.

A typical NATS publish request looks like below:

    PUB <tag> <bytes>\r\n<json>

... which means that we need to allocate (tag_len + 32) bytes for
the request header, and (json_len) bytes for the payload body.

We right now allocates no more than (json_len + 32) bytes, so the
following memcpy can overrun the buffer.
