### PR TITLE
flb_pack: improve the buffer allocation strategy

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -670,7 +670,7 @@ int flb_msgpack_raw_to_json_str(char *buf, size_t buf_size,
         return -1;
     }
 
-    json_size = (buf_size * 1.2);
+    json_size = (buf_size * 1.8);
     json_buf = flb_calloc(1, json_size);
     if (!json_buf) {
         flb_errno();
@@ -681,7 +681,7 @@ int flb_msgpack_raw_to_json_str(char *buf, size_t buf_size,
     while (1) {
         ret = flb_msgpack_to_json(json_buf, json_size, &result.data);
         if (ret <= 0) {
-            json_size += 128;
+            json_size *= 2;
             tmp = flb_realloc(json_buf, json_size);
             if (!tmp) {
                 flb_errno();


### PR DESCRIPTION
When serialization fails, we try to add a 128-byte block to the
buffer and retry again. This strategy seemingly works fine.

Except when we have an input with high flow volume, and suddenly
the consent growth factor (128 bytes) becomes too small. And we
end up wasting time doing a ridiculous amount of recalculations:

```
| EVENTS | INITIAL [bytes] | ACTUAL [bytes] | RECALC [calls] |
| ------ | --------------- | -------------- | -------------- |
|      1 |             36  |            47  |             1  |
|     10 |            349  |           470  |             1  |
|    100 |           3483  |          4700  |            10  |
|   1000 |          34803  |         47000  |            96  |
|  10000 |         348003  |        470000  |           954  |
```

This patch fixes the issue by using an exponential growth factor,
instead of a constant one.

Also I adjusted the initial buffer size to increase the chance
of getting a complete result in the first time.

