### PR TITLE
Fix test failures on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ matrix:
       sudo: true
       language: c
       compiler: gcc
-      script: |
-        ci/do-ut
     - os: linux
       dist: xenial
       sudo: true


### PR DESCRIPTION
This is a minimal patch to fix the test build on Travis CI.

https://travis-ci.org/fluent/fluent-bit/jobs/462253233

Basically this patch just removes the "script" tag from the matrix,
which makes Travls CI to fall back to the default setting.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>