### PR TITLE
Build fix macOS

### DIFF
--- a/lib/chunkio/deps/crc32/crc32.c
+++ b/lib/chunkio/deps/crc32/crc32.c
@@ -17,8 +17,11 @@
 #include "crc32.h"     /* include the header file generated with pycrc */
 #include <stdlib.h>
 #include <stdint.h>
-#include <endian.h>
-
+#ifdef __APPLE__
+#  include <machine/endian.h>
+#else
+#  include <endian.h>
+#endif
 
 
 /**

--- a/lib/chunkio/deps/crc32/crc32.c
+++ b/lib/chunkio/deps/crc32/crc32.c
@@ -19,6 +19,11 @@
 #include <stdint.h>
 #ifdef __APPLE__
 #  include <machine/endian.h>
+#  include <libkern/OSByteOrder.h>
+#  define htobe16(x) OSSwapHostToBigInt16(x)
+#  define htole16(x) OSSwapHostToLittleInt16(x)
+#  define be16toh(x) OSSwapBigToHostInt16(x)
+#  define le16toh(x) OSSwapLittleToHostInt16(x)
 #else
 #  include <endian.h>
 #endif

--- a/lib/chunkio/src/cio_file.c
+++ b/lib/chunkio/src/cio_file.c
@@ -415,8 +415,16 @@ int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count)
             return -1;
         }
 
+        /* OSX mman does not implement mremap or MREMAP_MAYMOVE. */
+#ifndef MREMAP_MAYMOVE
+        if (munmap(cf->data_size, av_size) == -1)
+            return -1;
+
+        tmp = mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, cf->fd, 0);
+#else
         tmp = mremap(cf->map, cf->alloc_size,
                      new_size, MREMAP_MAYMOVE);
+#endif
         if (tmp == MAP_FAILED) {
             cio_errno();
             cio_log_error(ch->ctx,

--- a/lib/chunkio/src/cio_file.c
+++ b/lib/chunkio/src/cio_file.c
@@ -536,6 +536,9 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
         return 0;
     }
 
+    /* macOS does not have fallocate().
+     * So, we should use ftruncate always. */
+#ifndef __APPLE__
     if (new_size > cf->alloc_size) {
         /*
          * To increase the file size we use fallocate() since this option
@@ -547,7 +550,9 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
          */
         ret = fallocate(cf->fd, 0, 0, new_size);
     }
-    else {
+    else
+#endif
+    {
         ret = ftruncate(cf->fd, new_size);
     }
 

--- a/lib/chunkio/src/cio_meta.c
+++ b/lib/chunkio/src/cio_meta.c
@@ -132,8 +132,16 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
     if (content_av < size) {
         new_size = (size - meta_av) + cf->data_size + CIO_FILE_HEADER_MIN;
 
+        /* OSX mman does not implement mremap or MREMAP_MAYMOVE. */
+#ifndef MREMAP_MAYMOVE
+        if (munmap(cf->data_size, size) == -1)
+            return -1;
+
+        tmp = mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, cf->fd, 0);
+#else
         /* Increase memory map size */
         tmp = mremap(cf->map, cf->alloc_size, new_size, MREMAP_MAYMOVE);
+#endif
         if (tmp == MAP_FAILED) {
             cio_errno();
             cio_log_error(ch->ctx,

--- a/lib/chunkio/src/cio_os.c
+++ b/lib/chunkio/src/cio_os.c
@@ -48,6 +48,7 @@ int cio_os_isdir(const char *dir)
 int cio_os_mkpath(const char *dir, mode_t mode)
 {
     struct stat st;
+    char *dup_dir;
 
     if (!dir) {
         errno = EINVAL;
@@ -58,6 +59,8 @@ int cio_os_mkpath(const char *dir, mode_t mode)
         return 0;
     }
 
-    cio_os_mkpath(dirname(strdupa(dir)), mode);
+    dup_dir = strdup(dir);
+    cio_os_mkpath(dirname(dup_dir), mode);
+    free(dup_dir);
     return mkdir(dir, mode);
 }


### PR DESCRIPTION
I've fixed building failure on macOS.
Does anyone want to try this fixes?

---

* Use `<machine/endian.h>` instead of `<endian.h>`
* Avoid to use MREMAP_MAYMOVE and mremap
* Avoid to use fallocate
* Use OSSwapLittleToHostInt16(x) instead of le16toh(x) via macro replacing
* Avoid to use strdupa. It breaks non-gcc environment