### PR TITLE
Implement precise time obtaining mechanism on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,21 @@ if(FLB_HAVE_TIMESPEC_GET)
   FLB_DEFINITION(FLB_HAVE_TIMESPEC_GET)
 endif()
 
+# clock_get_time() support for macOS.
+check_c_source_compiles("
+  #include <mach/clock.h>
+  #include <mach/mach.h>
+  int main() {
+      clock_serv_t cclock;
+      mach_timespec_t mts;
+      host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+      clock_get_time(cclock, &mts);
+      return mach_port_deallocate(mach_task_self(), cclock);
+  }" FLB_HAVE_CLOCK_GET_TIME)
+if(FLB_HAVE_CLOCK_GET_TIME)
+  FLB_DEFINITION(FLB_HAVE_CLOCK_GET_TIME)
+endif()
+
 # Build tools/xxd-c
 add_subdirectory(tools/xxd-c)
 

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -29,11 +29,6 @@ struct flb_time {
     struct timespec tm;
 };
 
-#undef FLB_TIME_FORCE_FMT_INT
-#ifdef TARGET_OS_MAC
-#define FLB_TIME_FORCE_FMT_INT /* FIXME */
-#endif
-
 /*
    to represent eventtime of fluentd
    see also

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -21,6 +21,10 @@
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_time.h>
+#ifdef FLB_HAVE_CLOCK_GET_TIME
+#  include <mach/clock.h>
+#  include <mach/mach.h>
+#endif
 
 #include <arpa/inet.h>
 #include <string.h>
@@ -45,6 +49,14 @@ static int _flb_time_get(struct flb_time *tm)
 #elif defined FLB_HAVE_TIMESPEC_GET
     /* C11 supported! */
     return timespec_get(&tm->tm, TIME_UTC);
+#elif defined FLB_CLOCK_GET_TIME
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    tm->tv_sec = mts.tv_sec;
+    tm->tv_nsec = mts.tv_nsec;
+    return mach_port_deallocate(mach_task_self(), cclock);
 #else /* __STDC_VERSION__ */
     return clock_gettime(CLOCK_REALTIME, &tm->tm);
 #endif


### PR DESCRIPTION
macOS does not have `clock_gettime()`.
Instead, we can use `clock_get_time()` which is originated from Mach.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>