### PR TITLE
syslog_prot: Add a missing `#include <fluent-bit/flb_time.h>`

### DIFF
--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -21,6 +21,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_time.h>
 
 #include "syslog.h"
 #include "syslog_conn.h"


### PR DESCRIPTION
Otherwise, MSVC complains that `flb_time` is incomplete type.
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>