### PR TITLE
Avoid using reserved keyword delete

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -36,7 +36,7 @@ struct flb_input_chunk {
 
 struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
                                                char *tag, int tag_len);
-int flb_input_chunk_destroy(struct flb_input_chunk *ic, int delete);
+int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del);
 void flb_input_chunk_destroy_all(struct flb_input_instance *in);
 int flb_input_chunk_write(void *data, const char *buf, size_t len);
 int flb_input_chunk_write_at(void *data, off_t offset,

--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -108,7 +108,7 @@ struct flb_task *flb_task_create(uint64_t ref_id,
 void flb_task_add_thread(struct flb_thread *thread,
                          struct flb_task *task);
 
-void flb_task_destroy(struct flb_task *task, int delete);
+void flb_task_destroy(struct flb_task *task, int del);
 
 struct flb_task_retry *flb_task_retry_create(struct flb_task *task,
                                              void *data);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -151,9 +151,9 @@ struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
     return ic;
 }
 
-int flb_input_chunk_destroy(struct flb_input_chunk *ic, int delete)
+int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del)
 {
-    cio_chunk_close(ic->chunk, delete);
+    cio_chunk_close(ic->chunk, del);
     mk_list_del(&ic->_head);
     flb_free(ic);
 

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -263,7 +263,7 @@ struct flb_task *flb_task_create(uint64_t ref_id,
     return task;
 }
 
-void flb_task_destroy(struct flb_task *task, int delete)
+void flb_task_destroy(struct flb_task *task, int del)
 {
     struct mk_list *tmp;
     struct mk_list *head;
@@ -286,7 +286,7 @@ void flb_task_destroy(struct flb_task *task, int delete)
     mk_list_del(&task->_head);
 
     /* destroy chunk */
-    flb_input_chunk_destroy(task->ic, delete);
+    flb_input_chunk_destroy(task->ic, del);
 
     /* Remove 'retries' */
     mk_list_foreach_safe(head, tmp, &task->retries) {


### PR DESCRIPTION
Unbreak build on CentOS 7/x86_64 using gcc 4.8.5 by renaming `delete` to just `del`.
```
In file included from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_input.h:24:0,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_engine.h:26,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_output.h:37,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit.h:38,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/examples/hello_world_cpp/hello_world.cc:20:
/builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_input_chunk.h:39:61: error: expected ',' or '...' before 'delete'
 int flb_input_chunk_destroy(struct flb_input_chunk *ic, int delete);
                                                             ^
In file included from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_output.h:38:0,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit.h:38,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/examples/hello_world_cpp/hello_world.cc:20:
/builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_task.h:111:50: error: expected ',' or '...' before 'delete'
 void flb_task_destroy(struct flb_task *task, int delete);
                                                  ^
make[2]: *** [examples/hello_world_cpp/CMakeFiles/hello_world_cpp.dir/hello_world.cc.o] Error 1
make[2]: Leaving directory `/builddir/build/BUILD/fluent-bit-1.0.0/build'
make[1]: *** [examples/hello_world_cpp/CMakeFiles/hello_world_cpp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_input.h:24:0,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_engine.h:26,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_output.h:37,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit.h:38,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/examples/td_cpp/td.cc:21:
/builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_input_chunk.h:39:61: error: expected ',' or '...' before 'delete'
 int flb_input_chunk_destroy(struct flb_input_chunk *ic, int delete);
                                                             ^
In file included from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_output.h:38:0,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit.h:38,
                 from /builddir/build/BUILD/fluent-bit-1.0.0/examples/td_cpp/td.cc:21:
/builddir/build/BUILD/fluent-bit-1.0.0/include/fluent-bit/flb_task.h:111:50: error: expected ',' or '...' before 'delete'
 void flb_task_destroy(struct flb_task *task, int delete);
                                                  ^
make[2]: *** [examples/td_cpp/CMakeFiles/td.dir/td.cc.o] Error 1
make[2]: Leaving directory `/builddir/build/BUILD/fluent-bit-1.0.0/build'
make[1]: *** [examples/td_cpp/CMakeFiles/td.dir/all] Error 2
```