### PR TITLE
compat: include <unistd.h> through monkey/mk_core.h

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -17,7 +17,6 @@
  *  limitations under the License.
  */
 
-#include <unistd.h>
 #include <fluent-bit.h>
 #include <msgpack.h>
 

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -17,28 +17,10 @@
  *  limitations under the License.
  */
 
-#ifndef FLB_PIPE_H
-#define FLB_PIPE_H
+#ifndef FLB_COMPAT_H
+#define FLB_COMPAT_H
 
-#include <fluent-bit/flb_compat.h>
-
-#ifdef _WIN32
-#include <event.h>
-#define flb_pipefd_t evutil_socket_t
-#define flb_sockfd_t evutil_socket_t
-#define flb_pipe_w(fd, buf, len) send(fd, buf, len, 0)
-#define flb_pipe_r(fd, buf, len) recv(fd, buf, len, 0)
-#else
-#define flb_pipefd_t int
-#define flb_sockfd_t int
-#define flb_pipe_w(fd, buf, len) write(fd, buf, len)
-#define flb_pipe_r(fd, buf, len) read(fd, buf, len)
-#endif
-
-int flb_pipe_create(flb_pipefd_t pipefd[2]);
-void flb_pipe_destroy(flb_pipefd_t pipefd[2]);
-int flb_pipe_close(flb_pipefd_t fd);
-ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
-ssize_t flb_pipe_write_all(int fd, void *buf, size_t count);
+/* libmonkey exposes compat macros for <unistd.h> */
+#include <monkey/mk_core.h>
 
 #endif

--- a/include/fluent-bit/flb_regex.h
+++ b/include/fluent-bit/flb_regex.h
@@ -20,12 +20,10 @@
 #ifndef FLB_REGEX_H
 #define FLB_REGEX_H
 
+#include <fluent-bit/flb_compat.h>
+
 #include <stdlib.h>
 #include <stddef.h>
-
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <onigmo.h>
 

--- a/include/fluent-bit/flb_socket.h
+++ b/include/fluent-bit/flb_socket.h
@@ -20,6 +20,8 @@
 #ifndef FLB_SOCKET_H
 #define FLB_SOCKET_H
 
+#include <fluent-bit/flb_compat.h>
+
 #ifdef _WIN32
 #include <event.h>
 #define flb_sockfd_t         evutil_socket_t
@@ -29,7 +31,6 @@
 #else
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <unistd.h>
 #define flb_sockfd_t         int
 #define flb_socket_close(fd) close(fd)
 #define flb_socket_error(fd) errno

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_unescape.h>
 
@@ -24,7 +25,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "stackdriver.h"
 #include "stackdriver_conf.h"

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -36,6 +36,7 @@
  * is not a socket.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_pipe.h>
 #include <fluent-bit/flb_log.h>
 
@@ -73,7 +74,6 @@ int flb_pipe_close(flb_pipefd_t fd)
 #else
 /* All other flavors of Unix/BSD are OK */
 
-#include <unistd.h>
 #include <stdint.h>
 
 int flb_pipe_create(flb_pipefd_t pipefd[2])

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -21,10 +21,10 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <dlfcn.h>
 
 #include <monkey/mk_core.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>

--- a/src/flb_sosreport.c
+++ b/src/flb_sosreport.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
@@ -26,7 +27,6 @@
 #include <fluent-bit/flb_version.h>
 #include <fluent-bit/flb_utils.h>
 
-#include <unistd.h>
 #include <sys/utsname.h>
 
 static void print_key(char *key)

--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -17,12 +17,12 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <inttypes.h>
 
 static int octal_digit(char c)

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
@@ -28,7 +29,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 /* Creates an Upstream HA Context */
 struct flb_upstream_ha *flb_upstream_ha_create(char *name)


### PR DESCRIPTION
Windows platforms do not have `<unistd.h>`, thus including it directly
on each program file causes a compilation error on MSVC.

This patch avoids the issue by importing `<monkey/mk_core.h>` instead.
See "mk_core/mk_unistd.h" for how it fixes the problem.

#### Note for reviewers

This patch introduces a new header file "flb_compat.h". We're
planning to accumulate platform-dependent stuffs to this file to
keep the source tree clean.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>