### PR TITLE
build: add LIBRARY and ARCHIVE as installation targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,7 +209,9 @@ if(FLB_SHARED_LIB)
     PROPERTIES OUTPUT_NAME fluent-bit)
 
   # Library install routines
-  install(TARGETS fluent-bit-shared LIBRARY DESTINATION lib)
+  install(TARGETS fluent-bit-shared
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 # Static Library


### PR DESCRIPTION
We need this in order to get cmake working on Windows without
failing with "no RUNTIME DESTINATION" errors.

See `cmake-commands(7)` for details:

> For DLL platforms the DLL part of a shared library is treated as
> a RUNTIME target and the corresponding import library is treated
> as an ARCHIVE target. All Windows-based sys‐tems including Cygwin
> are DLL platforms.

Issue Link: #960 

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>