### PR TITLE
build: use "CMAKE_POSITION_INDEPENDENT_CODE" instead of -fpic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(fluent-bit)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Update CFLAGS
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC ")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall ")
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 else()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -77,7 +77,6 @@ endmacro()
 
 # FLB_PLUGIN: used by plugins to perform registration and linking
 macro(FLB_PLUGIN name src deps)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   add_library(flb-plugin-${name} STATIC ${src})
   add_sanitizers(flb-plugin-${name})
   target_link_libraries(flb-plugin-${name} fluent-bit-static msgpackc-static ${deps})


### PR DESCRIPTION
This patch fixes "unknown flag -fpic" warnings on VC++.

Not all compilers understand -fpic flag, so let's use the CMake's
cross-platform property instead of tweaking compiler flags manually.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>