### PR TITLE
router: check the end of tag/match (#967)

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -61,6 +61,7 @@ struct flb_filter_instance {
     char name[32];                 /* numbered name            */
     char *alias;                   /* alias name               */
     char *match;                   /* match rule based on Tags */
+    int  match_len;
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *match_regex; /* match rule (regex) based on Tags */
 #endif

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -123,6 +123,7 @@ struct flb_output_instance {
     int retry_limit;                     /* max of retries allowed       */
     int use_tls;                         /* bool, try to use TLS for I/O */
     char *match;                         /* match rule for tag/routing   */
+    int  match_len;
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *match_regex;       /* match rule (regex) based on Tags */
 #endif

--- a/include/fluent-bit/flb_router.h
+++ b/include/fluent-bit/flb_router.h
@@ -31,9 +31,11 @@ struct flb_router_path {
 #ifdef FLB_HAVE_REGEX
 #include <fluent-bit/flb_regex.h>
 int flb_router_match(const char *tag, int tag_len,
-                     const char *match, struct flb_regex *match_regex);
+                     const char *match, int match_len, 
+                     struct flb_regex *match_regex);
 #else
-int flb_router_match(const char *tag, int tag_len, const char *match);
+int flb_router_match(const char *tag, int tag_len,
+                     const char *match, int match_len);
 #endif
 int flb_router_io_set(struct flb_config *config);
 void flb_router_exit(struct flb_config *config);

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -83,7 +83,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
     /* Iterate filters */
     mk_list_foreach(head, &config->filters) {
         f_ins = mk_list_entry(head, struct flb_filter_instance, _head);
-        if (flb_router_match(tag, tag_len, f_ins->match
+        if (flb_router_match(tag, tag_len, f_ins->match, f_ins->match_len
 #ifdef FLB_HAVE_REGEX
         , f_ins->match_regex
 #endif
@@ -176,6 +176,7 @@ int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v
 #endif
     if (prop_key_check("match", k, len) == 0) {
         filter->match = tmp;
+        filter->match_len = strlen(tmp);
     }
     else if (prop_key_check("alias", k, len) == 0 && tmp) {
         filter->alias = tmp;
@@ -300,6 +301,7 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
     instance->p     = plugin;
     instance->data  = data;
     instance->match = NULL;
+    instance->match_len = 0;
 #ifdef FLB_HAVE_REGEX
     instance->match_regex = NULL;
 #endif

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -271,6 +271,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->data        = data;
     instance->upstream    = NULL;
     instance->match       = NULL;
+    instance->match_len   = 0;
     instance->match_regex = NULL;
     instance->retry_limit = 1;
     instance->host.name   = NULL;
@@ -344,6 +345,7 @@ int flb_output_set_property(struct flb_output_instance *out, char *k, char *v)
     /* Check if the key is a known/shared property */
     if (prop_key_check("match", k, len) == 0) {
         out->match = tmp;
+        out->match_len = strlen(tmp);
     }
 #ifdef FLB_HAVE_REGEX
     else if (prop_key_check("match_regex", k, len) == 0) {

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -230,7 +230,8 @@ struct flb_task *flb_task_create(uint64_t ref_id,
         o_ins = mk_list_entry(o_head,
                               struct flb_output_instance, _head);
 
-        if (flb_router_match(task->tag, task->tag_len, o_ins->match
+        if (flb_router_match(task->tag, task->tag_len,
+                             o_ins->match, o_ins->match_len
 #ifdef FLB_HAVE_REGEX
                              , o_ins->match_regex
 #endif

--- a/tests/internal/router.c
+++ b/tests/internal/router.c
@@ -20,22 +20,27 @@ struct check route_checks[] = {
     {"cpu.rpi"        , "*.rpi"      , FLB_TRUE},
     {"cpu.rpi"        , "mem.*"      , FLB_FALSE},
     {"cpu.rpi"        , "*u.r*"      , FLB_TRUE},
-    {"hoge"           , "hogeeeeeee" , FLB_FALSE}
+    {"hoge"           , "hogeeeeeee" , FLB_FALSE},
+    {"hogeeeeee"      , "hoge"       , FLB_FALSE},
+    {"hoge"           , "AhogeA"     , FLB_FALSE}
 };
 
 void test_router_wildcard()
 {
     int i;
     int ret;
-    int len;
+    int tag_len;
+    int match_len;
     int checks = 0;
     struct check *c;
 
     checks = sizeof(route_checks) / sizeof(struct check);
     for (i = 0; i < checks; i++) {
         c = &route_checks[i];
-        len = strlen(c->tag);
-        ret = flb_router_match(c->tag, len, c->match, NULL);
+        tag_len = strlen(c->tag);
+        match_len = strlen(c->match);
+        printf("tag:%s match:%s\n",c->tag, c->match);
+        ret = flb_router_match(c->tag, tag_len, c->match, match_len, NULL);
         TEST_CHECK(ret == c->matched);
     }
 }


### PR DESCRIPTION
Note: this is a patch to 87c4dff07e6474f01fadda1b5c92e5ea2708af52 and it conflicts at master...

This PR is to be able to handle non-NULL terminated 'tag' and 'match'.
I fixed to check if the end of 'tag'/'match'.

