### PR TITLE
compat: define PATH_MAX for Windows

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -23,4 +23,10 @@
 /* libmonkey exposes compat macros for <unistd.h> */
 #include <monkey/mk_core.h>
 
+/* Windows compatibility utils */
+#ifdef _MSC_VER
+#include <windows.h>
+#define PATH_MAX MAX_PATH
+#endif
+
 #endif

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -26,6 +26,7 @@
 #include <signal.h>
 
 #include <monkey/mk_core.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_env.h>
 #include <fluent-bit/flb_macros.h>


### PR DESCRIPTION
Windows defines the maximum path length as `MAX_PATH`, while
Linux calls the same constant `PATH_MAX`.

This patch adds a compatibility macro for them (and is part of #960).

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>