### PR TITLE
build: suppress excessive warnings on Windows/MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@ project(fluent-bit)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Update CFLAGS
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall ")
+if (MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+endif()
+
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 else()


### PR DESCRIPTION
Right now, we receive lots of vogus warnings on Windows from system
headers (e.g. "padding added after construct X in windows.h").

This patch tweaks the compiler flag to use -W4 (instead of -Wall) on
MSVC. This should reduce quite a lot of unhelpful warnings.

**Note** See [mbedtls/CmakeLists.txt](https://github.com/fluent/fluent-bit/blob/master/lib/mbedtls-2.14.1/CMakeLists.txt#L153) for similar tweaking.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>