### PR TITLE
build: don't build nest/modify filter plugins if FLB_REGEX=Off

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -157,6 +157,8 @@ REGISTER_FILTER_PLUGIN("filter_throttle")
 if(FLB_REGEX)
   REGISTER_FILTER_PLUGIN("filter_kubernetes")
   REGISTER_FILTER_PLUGIN("filter_parser")
+  REGISTER_FILTER_PLUGIN("filter_nest")
+  REGISTER_FILTER_PLUGIN("filter_modify")
 endif()
 
 if(FLB_LUAJIT)
@@ -164,8 +166,6 @@ if(FLB_LUAJIT)
 endif()
 
 REGISTER_FILTER_PLUGIN("filter_record_modifier")
-REGISTER_FILTER_PLUGIN("filter_nest")
-REGISTER_FILTER_PLUGIN("filter_modify")
 
 # Register external input and output plugins
 if(EXT_IN_PLUGINS)


### PR DESCRIPTION
This fixes the compilation error on FLB_REGEX=Off; Both plugins
depend on onigmo.h, so we really should not try to build them in
such situations.

This patch is part of #960.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>