### PR TITLE
build: fix "cannot open rt.lib" error on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,7 +160,7 @@ else()
 endif()
 
 # Link timer library
-if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(FLB_DEPS
     ${FLB_DEPS}
     rt


### PR DESCRIPTION
This is a trivial fix for the following compilation error.

    LINK : fatal error LNK1104: cannot open "rt.lib"

Since librt normally does not exist except on Linux (and some other
Unix systems), we really should not try to link it on Windows.

Main issue link: #960