### PR TITLE
cmake: don't build flb_http_client/flb_oauth2 when FLB_TLS=Off

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,6 @@ set(src
   flb_upstream_ha.c
   flb_upstream_node.c
   flb_router.c
-  flb_oauth2.c
-  flb_http_client.c
   flb_worker.c
   flb_time.c
   flb_sosreport.c
@@ -68,6 +66,8 @@ if(FLB_TLS)
   set(src
     ${src}
     "flb_io_tls.c"
+    "flb_oauth2.c"
+    "flb_http_client.c"
     )
 
   # Make sure our output targets links to the TLS library


### PR DESCRIPTION
This fixes the "cannot open mbedtls/base64.h" error at compile
time when FLB_TLS is disabled.

Essentially, both source files depend on mbedtls and cannot be
compiled without TLS support.

Main issue link: #960