### PR TITLE
out_lib: fix "data size is unknown" error on MSVC

### DIFF
--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -143,7 +143,7 @@ static void out_lib_flush(void *data, size_t bytes,
                 FLB_OUTPUT_RETURN(FLB_ERROR);
             }
 
-            memcpy(data_for_user, data + last_off, alloc_size);
+            memcpy(data_for_user, (char *) data + last_off, alloc_size);
             data_size = alloc_size;
             break;
         case FLB_OUT_LIB_FMT_JSON:


### PR DESCRIPTION
Right now, VC++ fails to compile out_lib due to the following error.

    C2036: 'void *' unknown size

This patch fixes it by adding a explicit type cast to a char pointer.

Main issue link: #960