### PR TITLE
sds: use "pack" pragma instead of __attribute__(__packed__)

### DIFF
--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -35,11 +35,13 @@
 
 typedef char *flb_sds_t;
 
+#pragma pack(push, 1)
 struct flb_sds {
     uint64_t len;        /* used */
     uint64_t alloc;      /* excluding the header and null terminator */
     char buf[];
-} __attribute__ ((__packed__));
+};
+#pragma pack(pop)
 
 #define FLB_SDS_HEADER(s)  ((struct flb_sds *) (s - FLB_SDS_HEADER_SIZE))
 


### PR DESCRIPTION
We need this to build flb_sds.c on MSVS without errors.

Note that GCC and clang also support the Microsoft `#pragma pack` feature,
so we can use Microsoft's syntax here without breaking portability.

* https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Structure-Layout-Pragmas.html
* http://releases.llvm.org/3.8.0/tools/clang/docs/UsersManual.html

Main issue link: #960