### PR TITLE
out_forward: initialize the array with `{0}` not `{}`.

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -218,7 +218,7 @@ static int secure_forward_ping(struct flb_upstream_conn *u_conn,
 static int secure_forward_pong(char *buf, int buf_size)
 {
     int ret;
-    char msg[32] = {};
+    char msg[32] = {0};
     size_t off = 0;
     msgpack_unpacked result;
     msgpack_object root;


### PR DESCRIPTION
Namely C99 requires programmers to use `{0}` to initialize an array.

The syntax `{}` is only for C++ and causes an compilation error on
VC++ (GCC accepts it, though).

Main issue link: #960