### PR TITLE
flb_pipe: add cast to character pointer type for VC++

### DIFF
--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -101,7 +101,7 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count)
     size_t total = 0;
 
     do {
-        bytes = flb_pipe_r(fd, buf + total, count - total);
+        bytes = flb_pipe_r(fd, (char *) buf + total, count - total);
         if (bytes == -1) {
             if (errno == EAGAIN) {
                 /*
@@ -132,7 +132,7 @@ ssize_t flb_pipe_write_all(int fd, void *buf, size_t count)
     size_t total = 0;
 
     do {
-        bytes = flb_pipe_w(fd, buf + total, count - total);
+        bytes = flb_pipe_w(fd, (const char *) buf + total, count - total);
         if (bytes == -1) {
             if (errno == EAGAIN) {
                 /*


### PR DESCRIPTION
This allows us to compile `flb_pipe.c` without errors on both Linux
and Windows.

Basically, we need to pass a char pointer to recv/send on Windows;
Otherwise VC++ will complain "void * unknown size" and the compilation
process fails.

Main issue link: #960