### PR TITLE
luajit: windows: Use CMake when using MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,16 +499,25 @@ endif()
 # LuaJIT (Scripting Support)
 # ==========================
 if(FLB_LUAJIT)
-  set(LUA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/LuaJIT-2.1.0-beta3)
-  ExternalProject_Add(luajit
-    SOURCE_DIR ${LUA_PATH}
-    CONFIGURE_COMMAND ${LUA_PATH}/configure
-    BUILD_COMMAND $(MAKE) BUILD_MODE=static XCFLAGS="-fPIC" -C ${LUA_PATH}
-    INSTALL_COMMAND cp ${LUA_PATH}/src/libluajit.a "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
-  add_library(libluajit STATIC IMPORTED GLOBAL)
-  set_target_properties(libluajit PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
-  add_dependencies(libluajit luajit)
-  include_directories("${CMAKE_CURRENT_BINARY_DIR}/include/")
+  if(NOT MSVC)
+    set(LUA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/LuaJIT-2.1.0-beta3)
+    ExternalProject_Add(luajit
+      SOURCE_DIR ${LUA_PATH}
+      CONFIGURE_COMMAND ${LUA_PATH}/configure
+      BUILD_COMMAND $(MAKE) BUILD_MODE=static XCFLAGS="-fPIC" -C ${LUA_PATH}
+      INSTALL_COMMAND cp ${LUA_PATH}/src/libluajit.a "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
+    add_library(libluajit STATIC IMPORTED GLOBAL)
+    set_target_properties(libluajit PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
+    add_dependencies(libluajit luajit)
+    include_directories("${CMAKE_CURRENT_BINARY_DIR}/include/")
+  else()
+    # When we use MSVC, use CMakeLists.txt!
+    add_subdirectory(lib/luajit-cmake)
+    include_directories(
+      lib/LuaJIT-2.1.0-beta3
+      ${PROJECT_BINARY_DIR}/lib/LuaJIT-2.1.0-beta3
+      )
+  endif()
   FLB_DEFINITION(FLB_HAVE_LUAJIT)
 endif()
 

--- a/lib/luajit-cmake/CMakeLists.txt
+++ b/lib/luajit-cmake/CMakeLists.txt
@@ -1,0 +1,310 @@
+# Removed LUA_ADD_EXECUTABULE and adjusted for flb bundled Hiroshi Hatake <hatake@clear-code.com>
+# This CMakeLists.exe has been first taken from luv.
+# Added LUA_ADD_EXECUTABLE Ryan Phillips <ryan at trolocsis.com>
+# This CMakeLists.txt has been first taken from LuaDist
+# Copyright (C) 2007-2011 LuaDist.
+# Created by Peter Drahoš
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# Debugged and (now seriously) modified by Ronan Collobert, for Torch7
+
+SET(LUAJIT_DIR ${CMAKE_CURRENT_LIST_DIR}/../LuaJIT-2.1.0-beta3)
+
+SET(CMAKE_REQUIRED_INCLUDES
+  ${LUAJIT_DIR}
+  ${LUAJIT_DIR}/src
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+OPTION(WITH_AMALG "Build eveything in one shot (needs memory)" ON)
+
+# Ugly warnings
+IF(MSVC)
+  ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
+ENDIF()
+
+# Various includes
+INCLUDE(CheckLibraryExists)
+INCLUDE(CheckFunctionExists)
+INCLUDE(CheckCSourceCompiles)
+INCLUDE(CheckTypeSize)
+
+# LuaJIT specific
+option(LUAJIT_DISABLE_FFI "Disable FFI." OFF)
+option(LUAJIT_ENABLE_LUA52COMPAT "Enable Lua 5.2 compatibility." ON)
+option(LUAJIT_DISABLE_JIT "Disable JIT." OFF)
+option(LUAJIT_CPU_SSE2 "Use SSE2 instead of x87 instructions." ON)
+option(LUAJIT_CPU_NOCMOV "Disable NOCMOV." OFF)
+MARK_AS_ADVANCED(LUAJIT_DISABLE_FFI LUAJIT_ENABLE_LUA52COMPAT LUAJIT_DISABLE_JIT LUAJIT_CPU_SSE2 LUAJIT_CPU_NOCMOV)
+
+IF(LUAJIT_DISABLE_FFI)
+  ADD_DEFINITIONS(-DLUAJIT_DISABLE_FFI)
+ENDIF()
+
+IF(LUAJIT_ENABLE_LUA52COMPAT)
+  ADD_DEFINITIONS(-DLUAJIT_ENABLE_LUA52COMPAT)
+ENDIF()
+
+IF(LUAJIT_DISABLE_JIT)
+  ADD_DEFINITIONS(-DLUAJIT_DISABLE_JIT)
+ENDIF()
+
+IF(LUAJIT_CPU_SSE2)
+  ADD_DEFINITIONS(-DLUAJIT_CPU_SSE2)
+ENDIF()
+
+IF(LUAJIT_CPU_NOCMOV)
+  ADD_DEFINITIONS(-DLUAJIT_CPU_NOCMOV)
+ENDIF()
+######
+
+
+CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P)
+IF(SIZEOF_VOID_P EQUAL 8)
+  ADD_DEFINITIONS(-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE)
+ENDIF()
+
+if ( WIN32 AND NOT CYGWIN )
+  set ( LJVM_MODE peobj )
+elseif ( APPLE )
+  set ( CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000 ${CMAKE_EXE_LINKER_FLAGS}" )
+  set ( LJVM_MODE machasm )
+else ()
+  set ( LJVM_MODE elfasm )
+endif ()
+
+IF(NOT WIN32)
+  FIND_LIBRARY(DL_LIBRARY "dl")
+  IF(DL_LIBRARY)
+    SET(CMAKE_REQUIRED_LIBRARIES ${DL_LIBRARY})
+    LIST(APPEND LIBS ${DL_LIBRARY})
+  ENDIF(DL_LIBRARY)
+  CHECK_FUNCTION_EXISTS(dlopen LUA_USE_DLOPEN)
+  IF(NOT LUA_USE_DLOPEN)
+    MESSAGE(FATAL_ERROR "Cannot compile a useful lua.
+Function dlopen() seems not to be supported on your platform.
+Apparently you are not on a Windows platform as well.
+So lua has no way to deal with shared libraries!")
+  ENDIF(NOT LUA_USE_DLOPEN)
+ENDIF(NOT WIN32)
+
+check_library_exists(m sin "" LUA_USE_LIBM)
+if ( LUA_USE_LIBM )
+  list ( APPEND LIBS m )
+endif ()
+
+if ( CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  list ( APPEND LIBS pthread c++abi )
+endif ()
+
+## SOURCES
+MACRO(LJ_TEST_ARCH stuff)
+  CHECK_C_SOURCE_COMPILES("
+#undef ${stuff}
+#include \"lj_arch.h\"
+#if ${stuff}
+int main() { return 0; }
+#else
+#error \"not defined\"
+#endif
+" ${stuff})
+ENDMACRO()
+
+MACRO(LJ_TEST_ARCH_VALUE stuff value)
+  CHECK_C_SOURCE_COMPILES("
+#undef ${stuff}
+#include \"lj_arch.h\"
+#if ${stuff} == ${value}
+int main() { return 0; }
+#else
+#error \"not defined\"
+#endif
+" ${stuff}_${value})
+ENDMACRO()
+
+
+FOREACH(arch X64 X86 ARM ARM64 PPC PPCSPE MIPS)
+  LJ_TEST_ARCH(LJ_TARGET_${arch})
+  if(LJ_TARGET_${arch})
+    STRING(TOLOWER ${arch} TARGET_LJARCH)
+    MESSAGE(STATUS "LuaJIT Target: ${TARGET_LJARCH}")
+    BREAK()
+  ENDIF()
+ENDFOREACH()
+
+IF(NOT TARGET_LJARCH)
+  MESSAGE(FATAL_ERROR "architecture not supported")
+ELSE()
+  MESSAGE(STATUS "LuaJIT target ${TARGET_LJARCH}")
+ENDIF()
+
+FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/jit)
+FILE(GLOB jit_files ${LUAJIT_DIR}/src/jit/*.lua)
+FILE(COPY ${jit_files} DESTINATION ${CMAKE_BINARY_DIR}/jit)
+
+SET(DASM_ARCH ${TARGET_LJARCH})
+SET(DASM_FLAGS)
+SET(TARGET_ARCH)
+LIST(APPEND TARGET_ARCH "LUAJIT_TARGET=LUAJIT_ARCH_${TARGET_LJARCH}")
+LJ_TEST_ARCH_VALUE(LJ_ARCH_BITS 64)
+IF(LJ_ARCH_BITS_64)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D P64)
+ENDIF()
+LJ_TEST_ARCH_VALUE(LJ_HASJIT 1)
+IF(LJ_HASJIT_1)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D JIT)
+ENDIF()
+LJ_TEST_ARCH_VALUE(LJ_HASFFI 1)
+IF(LJ_HASFFI_1)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D FFI)
+ENDIF()
+LJ_TEST_ARCH_VALUE(LJ_DUALNUM 1)
+IF(LJ_DUALNUM_1)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D DUALNUM)
+ENDIF()
+LJ_TEST_ARCH_VALUE(LJ_ARCH_HASFPU 1)
+IF(LJ_ARCH_HASFPU_1)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D FPU)
+  LIST(APPEND TARGET_ARCH "LJ_ARCH_HASFPU=1")
+ELSE()
+  LIST(APPEND TARGET_ARCH "LJ_ARCH_HASFPU=0")
+ENDIF()
+LJ_TEST_ARCH_VALUE(LJ_ABI_SOFTFP 1)
+IF(NOT LJ_ABI_SOFTFP_1)
+  SET(DASM_FLAGS ${DASM_FLAGS} -D HFABI)
+  LIST(APPEND TARGET_ARCH "LJ_ABI_SOFTFP=0")
+ELSE()
+  LIST(APPEND TARGET_ARCH "LJ_ABI_SOFTFP=1")
+ENDIF()
+IF(WIN32)
+  SET(DASM_FLAGS ${DASM_FLAGS} -LN -D WIN)
+ENDIF()
+IF(TARGET_LJARCH STREQUAL "x86")
+  LJ_TEST_ARCH_VALUE(__SSE2__ 1)
+  IF(__SSE2__1)
+    SET(DASM_FLAGS ${DASM_FLAGS} -D SSE)
+  ENDIF()
+ENDIF()
+IF(TARGET_LJARCH STREQUAL "x64")
+  SET(DASM_ARCH "x86")
+ENDIF()
+IF(TARGET_LJARCH STREQUAL "ppc")
+  LJ_TEST_ARCH_VALUE(LJ_ARCH_SQRT 1)
+  IF(NOT LJ_ARCH_SQRT_1)
+    SET(DASM_FLAGS ${DASM_FLAGS} -D SQRT)
+  ENDIF()
+  LJ_TEST_ARCH_VALUE(LJ_ARCH_PPC64 1)
+  IF(NOT LJ_ARCH_PPC64_1)
+    SET(DASM_FLAGS ${DASM_FLAGS} -D GPR64)
+  ENDIF()
+ENDIF()
+
+add_executable(minilua ${LUAJIT_DIR}/src/host/minilua.c)
+SET_TARGET_PROPERTIES(minilua PROPERTIES COMPILE_DEFINITIONS "${TARGET_ARCH}")
+CHECK_LIBRARY_EXISTS(m sin "" MINILUA_USE_LIBM)
+if(MINILUA_USE_LIBM)
+  TARGET_LINK_LIBRARIES(minilua m)
+endif()
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildvm_arch.h
+  COMMAND minilua ${LUAJIT_DIR}/dynasm/dynasm.lua ${DASM_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/buildvm_arch.h ${LUAJIT_DIR}/src/vm_${DASM_ARCH}.dasc
+  DEPENDS ${LUAJIT_DIR}/dynasm/dynasm.lua minilua
+)
+
+## Source Lists
+SET(SRC_LJLIB
+  ${LUAJIT_DIR}/src/lib_base.c
+  ${LUAJIT_DIR}/src/lib_math.c
+  ${LUAJIT_DIR}/src/lib_bit.c
+  ${LUAJIT_DIR}/src/lib_string.c
+  ${LUAJIT_DIR}/src/lib_table.c
+  ${LUAJIT_DIR}/src/lib_io.c
+  ${LUAJIT_DIR}/src/lib_os.c
+  ${LUAJIT_DIR}/src/lib_package.c
+  ${LUAJIT_DIR}/src/lib_debug.c
+  ${LUAJIT_DIR}/src/lib_jit.c
+  ${LUAJIT_DIR}/src/lib_ffi.c
+)
+
+SET(SRC_LIBAUX
+  ${LUAJIT_DIR}/src/lib_aux.c
+  ${LUAJIT_DIR}/src/lib_init.c
+)
+file (GLOB_RECURSE SRC_LJCORE   "${LUAJIT_DIR}/src/lj_*.c")
+list (APPEND SRC_LJCORE ${SRC_LJLIB} ${SRC_LIBAUX})
+file (GLOB_RECURSE SRC_BUILDVM  "${LUAJIT_DIR}/src/host/buildvm*.c")
+list (APPEND SRC_BUILDVM ${CMAKE_CURRENT_BINARY_DIR}/buildvm_arch.h)
+
+## GENERATE
+ADD_EXECUTABLE(buildvm ${SRC_BUILDVM})
+SET_TARGET_PROPERTIES(buildvm PROPERTIES COMPILE_DEFINITIONS "${TARGET_ARCH}")
+
+macro(add_buildvm_target _target _mode)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_target}
+    COMMAND buildvm ARGS -m ${_mode} -o ${CMAKE_CURRENT_BINARY_DIR}/${_target} ${ARGN}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS buildvm ${ARGN}
+  )
+endmacro(add_buildvm_target)
+
+if (WIN32)
+  add_buildvm_target ( lj_vm.obj peobj )
+  set (LJ_VM_SRC ${CMAKE_CURRENT_BINARY_DIR}/lj_vm.obj)
+else ()
+  add_buildvm_target ( lj_vm.S ${LJVM_MODE} )
+  set (LJ_VM_SRC ${CMAKE_CURRENT_BINARY_DIR}/lj_vm.S)
+endif ()
+add_buildvm_target ( lj_ffdef.h   ffdef   ${SRC_LJLIB} )
+add_buildvm_target ( lj_bcdef.h  bcdef  ${SRC_LJLIB} )
+add_buildvm_target ( lj_folddef.h folddef ${LUAJIT_DIR}/src/lj_opt_fold.c )
+add_buildvm_target ( lj_recdef.h  recdef  ${SRC_LJLIB} )
+add_buildvm_target ( lj_libdef.h  libdef  ${SRC_LJLIB} )
+add_buildvm_target ( vmdef.lua  vmdef  ${SRC_LJLIB} )
+
+SET(DEPS
+  ${LJ_VM_SRC}
+  ${CMAKE_CURRENT_BINARY_DIR}/lj_ffdef.h
+  ${CMAKE_CURRENT_BINARY_DIR}/lj_bcdef.h
+  ${CMAKE_CURRENT_BINARY_DIR}/lj_libdef.h
+  ${CMAKE_CURRENT_BINARY_DIR}/lj_recdef.h
+  ${CMAKE_CURRENT_BINARY_DIR}/lj_folddef.h
+  ${CMAKE_CURRENT_BINARY_DIR}/vmdef.lua
+  )
+
+## COMPILE
+include_directories(
+  ${LUAJIT_DIR}/dynasm
+  ${LUAJIT_DIR}/src
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+IF(WITH_SHARED_LUA)
+    IF(WITH_AMALG)
+	add_library(luajit-5.1 SHARED ${LUAJIT_DIR}/src/ljamalg.c ${DEPS} )
+    ELSE()
+	add_library(luajit-5.1 SHARED ${SRC_LJCORE} ${DEPS} )
+    ENDIF()
+    SET_TARGET_PROPERTIES(luajit-5.1 PROPERTIES OUTPUT_NAME "lua51")
+ELSE()
+    IF(WITH_AMALG)
+	add_library(luajit-5.1 STATIC ${LUAJIT_DIR}/src/ljamalg.c ${DEPS} )
+    ELSE()
+	add_library(luajit-5.1 STATIC ${SRC_LJCORE} ${DEPS} )
+    ENDIF()
+    SET_TARGET_PROPERTIES(luajit-5.1 PROPERTIES
+	PREFIX "lib" IMPORT_PREFIX "lib" OUTPUT_NAME "luajit")
+ENDIF()
+
+target_link_libraries (luajit-5.1 ${LIBS} )
+
+IF(WIN32)
+  add_executable(luajit ${LUAJIT_DIR}/src/luajit.c)
+  target_link_libraries(luajit luajit-5.1)
+ELSE()
+  IF(WITH_AMALG)
+    add_executable(luajit ${LUAJIT_DIR}/src/luajit.c ${LUAJIT_DIR}/src/ljamalg.c ${DEPS})
+  ELSE()
+    add_executable(luajit ${LUAJIT_DIR}/src/luajit.c ${SRC_LJCORE} ${DEPS})
+  ENDIF()
+  target_link_libraries(luajit ${LIBS})
+  SET_TARGET_PROPERTIES(luajit PROPERTIES ENABLE_EXPORTS ON)
+ENDIF()


### PR DESCRIPTION
luajit-cmake/CMakeLists.txt's original license is MIT.
Can we include this MIT licensed license file?

---

When we use MSVC, we cannot execute configure, autoconf, and make.
Instead, we should generate Visual Studio solution files via cmake.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>