### PR TITLE
compat: move the network-related compatibility stuff

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -25,8 +25,17 @@
 
 /* Windows compatibility utils */
 #ifdef _MSC_VER
-#include <windows.h>
 #define PATH_MAX MAX_PATH
+
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <windows.h>
+#else
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 #endif
 
 #endif

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -20,14 +20,7 @@
 #ifndef FLB_NETWORK_H
 #define FLB_NETWORK_H
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#else
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#endif
-
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_uri.h>
 
 /* Defines a host service and it properties */

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -26,18 +26,8 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#else
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#endif
-
 #include <monkey/mk_core.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_mem.h>

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -18,6 +18,7 @@
  */
 
 #include <msgpack.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_time.h>
@@ -26,7 +27,6 @@
 #  include <mach/mach.h>
 #endif
 
-#include <arpa/inet.h>
 #include <string.h>
 
 #define ONESEC_IN_NSEC 1000000000


### PR DESCRIPTION
Both Windows and Linux have their own way to name network libraries.

This patch allows you to import these libraries just with:

    #include <fluent_bit/flb_compat.h>

so you do not need to care the underlying difference.

Main issue link: #960