### PR TITLE
core: use _fullpath in place of realpath on Windows

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -349,7 +349,11 @@ static int flb_service_conf_path_set(struct flb_config *config, char *file)
     char *end;
     char path[PATH_MAX + 1];
 
+#ifdef _MSC_VER
+    p = _fullpath(path, file, PATH_MAX + 1);
+#else
     p = realpath(file, path);
+#endif
     if (!p) {
         return -1;
     }


### PR DESCRIPTION
Windows does not support realpath(3); so added ifdefs to switch to
_fullpath on VC++.

Main issue link: #960