### PR TITLE
time: add flb_time_msleep() to sleep N milliseconds

### DIFF
--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -109,7 +109,7 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count)
                  * return until all data have been read, just sleep a little
                  * bit (0.05 seconds)
                  */
-                usleep(50000);
+                flb_time_msleep(50);
                 continue;
             }
         }
@@ -140,7 +140,7 @@ ssize_t flb_pipe_write_all(int fd, void *buf, size_t count)
                  * return until all data have been read, just sleep a little
                  * bit (0.05 seconds)
                  */
-                usleep(50000);
+                flb_time_msleep(50);
                 continue;
             }
         }

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -28,6 +28,8 @@
 
 #include <arpa/inet.h>
 #include <string.h>
+#include <inttypes.h>
+#include <time.h>
 
 #define ONESEC_IN_NSEC 1000000000
 
@@ -65,6 +67,20 @@ static int _flb_time_get(struct flb_time *tm)
 int flb_time_get(struct flb_time *tm)
 {
     return _flb_time_get(tm);
+}
+
+/* A portable function to sleep N msec */
+int flb_time_msleep(uint32_t ms)
+{
+#ifdef _MSC_VER
+    Sleep((DWORD) ms);
+    return 0;
+#else
+    struct timespec ts;
+    ts.tv_sec = ms / 1000;
+    ts.tv_nsec = (ms % 1000) * 1000000;
+    return nanosleep(&ts, NULL);
+#endif
 }
 
 double flb_time_to_double(struct flb_time *tm)


### PR DESCRIPTION
This is a portable implementation to suspend execution in sub-second
precision, which should work on both Linux and Windows.

Since Windows provides neither nanosleep() nor usleep(), we need to
implement the functionality using Win32 Sleep() function here.

Main issue link: #960