### PR TITLE
output: initialize match_regex conditionally

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -271,7 +271,9 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->data        = data;
     instance->upstream    = NULL;
     instance->match       = NULL;
+#ifdef FLB_HAVE_REGEX
     instance->match_regex = NULL;
+#endif
     instance->retry_limit = 1;
     instance->host.name   = NULL;
 


### PR DESCRIPTION
The attribute `match_regex` does not exist if FLB_REGEX is turned
off at compile time, so we need special care not to touch it in
such case.

Main issue link: #960