### PR TITLE
In tail input, on 'Exit_On_EOF' case, call flb_engine_exit()

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -139,8 +139,7 @@ static int in_tail_collect_static(struct flb_input_instance *i_ins,
         case FLB_TAIL_WAIT:
             if (file->config->exit_on_eof) {
                 flb_info("[in_tail] file=%s ended, stop", file->name);
-                flb_engine_shutdown(config);
-                exit(0);
+                flb_engine_exit(config);
             }
             /* Promote file to 'events' type handler */
             flb_debug("[in_tail] file=%s promote to TAIL_EVENT", file->name);


### PR DESCRIPTION
Formerly this was calling flb_engine_shutdown(), which had the affect of not flushing/calling through the grace period.

Signed-off-by: Don Bowman <don@agilicus.com>