### PR TITLE
Set cc as default compiler (fixes building on FreeBSD)

### DIFF
--- a/lib/LuaJIT-2.1.0-beta3/src/Makefile
+++ b/lib/LuaJIT-2.1.0-beta3/src/Makefile
@@ -24,7 +24,7 @@ NODOTABIVER= 51
 # removing the '#' in front of them. Make sure you force a full recompile
 # with "make clean", followed by "make" if you change any options.
 #
-DEFAULT_CC = gcc
+DEFAULT_CC = cc
 #
 # LuaJIT builds as a native 32 or 64 bit binary by default.
 CC= $(DEFAULT_CC)

--- a/lib/chunkio/deps/crc32/crc32.c
+++ b/lib/chunkio/deps/crc32/crc32.c
@@ -29,6 +29,8 @@
 #  define htole16(x) (x)
 #  define be16toh(x) ntohs(x)
 #  define le16toh(x) (x)
+#elif defined(__FreeBSD__)
+#  include <sys/endian.h>
 #else
 #  include <endian.h>
 #endif

--- a/lib/chunkio/src/cio_file.c
+++ b/lib/chunkio/src/cio_file.c
@@ -591,7 +591,7 @@ int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
 
     /* macOS does not have fallocate().
      * So, we should use ftruncate always. */
-#ifndef __APPLE__
+#ifdef __linux__
     if (new_size > cf->alloc_size) {
         /*
          * To increase the file size we use fallocate() since this option


### PR DESCRIPTION
When building with modern FreeBSD, gcc is not installed by default, but clang is. Building with clang works fine so I don't see why we must specify exactly "gcc". cc would be a symlink to the preferred C compiler.