### PR TITLE
compat: add Windows compatibility functions

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -38,6 +38,14 @@ static inline int getpagesize(void)
     GetSystemInfo(&info);
     return info.dwPageSize;
 }
+
+static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
+{
+    if (gmtime_s(result, timep))
+        return NULL;
+    return result;
+}
+
 #else
 #include <netdb.h>
 #include <netinet/in.h>

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -31,6 +31,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <windows.h>
+
+static inline int getpagesize(void)
+{
+    SYSTEM_INFO info;
+    GetSystemInfo(&info);
+    return info.dwPageSize;
+}
 #else
 #include <netdb.h>
 #include <netinet/in.h>


### PR DESCRIPTION
This is a series of patches to provide a set of functions that we do not have on Windows.

23797a00 compat: add a function to get memory page size on Windows
ffd5b111 compat: implement gmtime_r() function for MSVS

Part of #960
