### PR TITLE
tools: xxd-c: include getopt.h through <mk_getopt.h> for portability

### DIFF
--- a/tools/xxd-c/xxd-c.c
+++ b/tools/xxd-c/xxd-c.c
@@ -27,8 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
-#include <unistd.h>
+#include <monkey/mk_core/mk_getopt.h>
 
 #define XXDC_CHUNK    1024
 


### PR DESCRIPTION
I can confirm this patch fixes compile errors within tools/xxd-c.c,
and allows us to use xxd-c.exe on Windows.

    % .\bin\debug\xxd-c.exe -i test.conf
    ...
    static unsigned char __test_conf[] = {
        0x61, 0x69, 0x75, 0x65, 0x6f,
    };

Part of #960 