### PR TITLE
build: Add Dockerfile.debug to allow 'shell into image'

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,8 @@
+FROM debian:stretch as builder
+ADD https://busybox.net/downloads/binaries/1.30.0-i686/busybox /bin/busybox
+RUN chmod 555 /bin/busybox \
+ && /bin/busybox --install
+
+FROM fluent/fluent-bit:latest
+COPY --from=builder /bin/ /bin/
+


### PR DESCRIPTION
Some people prefer debugging by shell'ing into a container
and having local filesystem access. This image inherits the
parent and then adds busybox (giving sh/cat/ls etc).

Signed-off-by: Don Bowman <don@agilicus.com>