### PR TITLE
compat: add an explicit declaration for localtime_r()

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -46,6 +46,9 @@ static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
     return result;
 }
 
+/* mk_utils.c exposes localtime_r */
+extern struct tm *localtime_r(const time_t *timep, struct tm * result);
+
 #else
 #include <netdb.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Without this, MSVC wrongly assumes that the return value of localtime_r()
is an integer while it's actually a pointer (struct tm*).

> warning C4013: 'localtime_r' undefined; assuming extern returning int

This has been causing SIGSEGV in flb_log_print() on Win64, since Windows
improperly truncates the returned pointer in order to fit the pointer
address into 4 bytes.

Part of #960