### PR TITLE
worker: fix SIGSEGV on calling loging functions on Win64

### DIFF
--- a/include/fluent-bit/flb_worker.h
+++ b/include/fluent-bit/flb_worker.h
@@ -34,7 +34,11 @@ struct flb_worker {
     pthread_t tid;             /* thread ID   */
 
     /* Logging */
+#ifdef _WIN32
+    intptr_t log[2];
+#else
     int log[2];
+#endif
 
     /* Runtime context */
     void *config;


### PR DESCRIPTION
On Windows, evutil_socket_t is an alias of intptr_t, not integer.

> libevent-2.0 > util.h > evutil_socket_t
>
> A type wide enough to hold the output of "socket()" or "accept()".
> On Windows, this is an intptr_t; elsewhere, it is an int.

Since sizeof(intptr_t) is greater than sizeof(int) on x64 MSVC,
flb_pipe_create() silently corrupts memory inside the worker struct
resulting in SIGSEGV.

This patch fixes the issue by using the correct data type on Windows.

Part of #960