### PR TITLE
parser: Add FLB_HAVE_GMTOFF to detect tm_gmtoff support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,18 @@ if(FLB_HAVE_TIMESPEC_GET)
   FLB_DEFINITION(FLB_HAVE_TIMESPEC_GET)
 endif()
 
+# gmtoff support
+check_c_source_compiles("
+  #include <time.h>
+  int main() {
+     struct tm tm;
+     tm.tm_gmtoff = 0;
+     return 0;
+  }" FLB_HAVE_GMTOFF)
+if(FLB_HAVE_GMTOFF)
+  FLB_DEFINITION(FLB_HAVE_GMTOFF)
+endif()
+
 # clock_get_time() support for macOS.
 check_c_source_compiles("
   #include <mach/clock.h>

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -74,9 +74,15 @@ enum {
 static inline time_t flb_parser_tm2time(const struct tm *src)
 {
     struct tm tmp;
+    time_t res;
 
     tmp = *src;
-    return timegm(&tmp) - src->tm_gmtoff;
+#ifdef FLB_HAVE_GMTOFF
+    res = timegm(&tmp) - src->tm_gmtoff;
+#else
+    res = timegm(&tmp);
+#endif
+    return res;
 }
 
 

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -209,7 +209,14 @@ struct flb_parser *flb_parser_create(char *name, char *format,
         /* Check if the format contains a timezone (%z) */
         if (strstr(p->time_fmt, "%z") || strstr(p->time_fmt, "%Z") ||
             strstr(p->time_fmt, "%SZ") || strstr(p->time_fmt, "%S.%LZ")) {
+#ifdef FLB_HAVE_GMTOFF
             p->time_with_tz = FLB_TRUE;
+#else
+            flb_error("[parser] timezone offset not supported");
+            flb_error("[parser] you cannot use %%z/%%Z on this platform");
+            flb_free(p);
+            return NULL;
+#endif
         }
 
         /*
@@ -746,9 +753,11 @@ int flb_parser_time_lookup(char *time_str, size_t tsize,
             }
         }
 
+#ifdef FLB_HAVE_GMTOFF
         if (parser->time_with_tz == FLB_FALSE) {
             tm->tm_gmtoff = parser->time_offset;
         }
+#endif
 
         return 0;
     }


### PR DESCRIPTION
This is a GNU extension and not all standard C libraries support it
(the notable example is Windows/VC++).

This allows us to compile the source code on such platforms.

Part of #960