### PR TITLE
build: add a new FLB_PARSER build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ option(FLB_ALL                "Enable all features"           No)
 option(FLB_DEBUG              "Build with debug symbols"      No)
 option(FLB_COVERAGE           "Build with code-coverage"      No)
 option(FLB_JEMALLOC           "Build with Jemalloc support"   No)
-option(FLB_REGEX              "Build wiht Regex support"     Yes)
+option(FLB_REGEX              "Build with Regex support"     Yes)
+option(FLB_PARSER             "Build with Parser support"    Yes)
 option(FLB_TLS                "Build with SSL/TLS support"    No)
 option(FLB_BINARY             "Build executable binary"      Yes)
 option(FLB_EXAMPLES           "Build examples"               Yes)
@@ -211,6 +212,12 @@ endmacro()
 # Enable Debug symbols if specified
 if(FLB_DEBUG)
   set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+if(FLB_PARSER)
+  FLB_DEFINITION(FLB_HAVE_PARSER)
+  message("Enabling FLB_REGEX since FLB_PARSER requires")
+  set(FLB_REGEX On)
 endif()
 
 # Is sanitize_address defined ?

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -7,6 +7,7 @@ set(FLB_REGEX                  No)
 set(FLB_BACKTRACE              No)
 set(FLB_LUAJIT                 No)
 set(FLB_EXAMPLES               No)
+set(FLB_PARSER                 No)
 
 # INPUT plugins
 # =============

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ include_directories(
   ${extra_headers}
   )
 
-if(FLB_REGEX)
+if(FLB_PARSER)
   set(src
     ${src}
     flb_parser.c

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -393,7 +393,7 @@ int flb_config_set_property(struct flb_config *config,
                 }
             }
             else if (!strncasecmp(key, FLB_CONF_STR_PARSERS_FILE, 32)) {
-#ifdef FLB_HAVE_REGEX
+#ifdef FLB_HAVE_PARSER
                 tmp = flb_env_var_translate(config->env, v);
                 ret = flb_parser_conf_file(tmp, config);
                 flb_free(tmp);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -520,7 +520,7 @@ int flb_engine_shutdown(struct flb_config *config)
     /* router */
     flb_router_exit(config);
 
-#ifdef FLB_HAVE_REGEX
+#ifdef FLB_HAVE_PARSER
     /* parsers */
     flb_parser_exit(config);
 #endif

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -135,7 +135,9 @@ static void flb_help(int rc, struct flb_config *config)
     printf("  -m, --match=MATCH\tset plugin match, same as '-p match=abc'\n");
     printf("  -o, --output=OUTPUT\tset an output\n");
     printf("  -p, --prop=\"A=B\"\tset plugin configuration property\n");
+#ifdef FLB_HAVE_PARSER
     printf("  -R, --parser=FILE\tspecify a parser configuration file\n");
+#endif
     printf("  -e, --plugin=FILE\tload an external plugin (shared lib)\n");
     printf("  -l, --log_file=FILE\twrite log info to a file\n");
     printf("  -t, --tag=TAG\t\tset plugin tag, same as '-p tag=abc'\n");
@@ -603,7 +605,9 @@ int main(int argc, char **argv)
         { "match",           required_argument, NULL, 'm' },
         { "output",          required_argument, NULL, 'o' },
         { "filter",          required_argument, NULL, 'F' },
+#ifdef FLB_HAVE_PARSER
         { "parser",          required_argument, NULL, 'R' },
+#endif
         { "prop",            required_argument, NULL, 'p' },
         { "plugin",          required_argument, NULL, 'e' },
         { "tag",             required_argument, NULL, 't' },
@@ -709,7 +713,7 @@ int main(int argc, char **argv)
             }
             last_plugin = PLUGIN_OUTPUT;
             break;
-#ifdef FLB_HAVE_REGEX
+#ifdef FLB_HAVE_PARSER
         case 'R':
             ret = flb_parser_conf_file(optarg, config);
             if (ret != 0) {


### PR DESCRIPTION
The effect of this patch is that we can disable the parser feature
while enabling the FLB_REGEX flag.

This is needed in order to compile and use filter plugins on Windows,
where we don't have the parser support yet.

Part of #960 