### PR TITLE
in_stdin: prevent double free / use after free of msgpack buffer

### DIFF
--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -195,7 +195,7 @@ static int in_stdin_collect(struct flb_input_instance *i_ins,
                 flb_free(out_buf);
                 flb_input_chunk_append_raw(i_ins, NULL, 0,
                                            mp_sbuf.data, mp_sbuf.size);
-                msgpack_sbuffer_destroy(&mp_sbuf);
+                msgpack_sbuffer_clear(&mp_sbuf);
             }
             else {
                 /* we need more data ? */


### PR DESCRIPTION
Currently the msgpack sbuffer is destroyed instead of cleared after constructing the msgpack objects. This is changed to clear the buffer instead, so re-using it does not refer to deallocated memory.

Alternatively the buffer could be re-initialized after destroying it, but since the memory which would be used is effectively bound to the stdin buffer size, clearing it should be the better approach here.