### PR TITLE
build: make LuaJIT compilable on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,16 +504,7 @@ endif()
 # LuaJIT (Scripting Support)
 # ==========================
 if(FLB_LUAJIT)
-  set(LUA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/LuaJIT-2.1.0-beta3)
-  ExternalProject_Add(luajit
-    SOURCE_DIR ${LUA_PATH}
-    CONFIGURE_COMMAND ${LUA_PATH}/configure
-    BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} BUILD_MODE=static XCFLAGS="-fPIC" -C ${LUA_PATH}
-    INSTALL_COMMAND cp ${LUA_PATH}/src/libluajit.a "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
-  add_library(libluajit STATIC IMPORTED GLOBAL)
-  set_target_properties(libluajit PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/lib/libluajit.a")
-  add_dependencies(libluajit luajit)
-  include_directories("${CMAKE_CURRENT_BINARY_DIR}/include/")
+  include(cmake/luajit.cmake)
   FLB_DEFINITION(FLB_HAVE_LUAJIT)
 endif()
 

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -1,0 +1,44 @@
+# This file provides 'libluajit' target for both UNIX and Windows.
+#
+# To enable LuaJIT, include this file and link the build target:
+#
+#    include(cmake/luajit.cmake)
+#    target_link_libraries(fluent-bit libluajit)
+
+add_library(libluajit STATIC IMPORTED GLOBAL)
+
+# Global Settings
+set(LUAJIT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/lib/LuaJIT-2.1.0-beta3)
+set(LUAJIT_DEST ${CMAKE_CURRENT_BINARY_DIR})
+
+# luajit (UNIX)
+# =============
+ExternalProject_Add(luajit
+  BUILD_IN_SOURCE TRUE
+  EXCLUDE_FROM_ALL TRUE
+  SOURCE_DIR ${LUAJIT_SRC}
+  CONFIGURE_COMMAND ./configure
+  BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} BUILD_MODE=static XCFLAGS="-fPIC"
+  INSTALL_COMMAND cp src/libluajit.a "${LUAJIT_DEST}/lib/libluajit.a")
+
+# luajit (Windows)
+# ================
+ExternalProject_Add(luajit-windows
+  BUILD_IN_SOURCE TRUE
+  EXCLUDE_FROM_ALL TRUE
+  SOURCE_DIR ${LUAJIT_SRC}/src
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ./msvcbuild.bat static
+  INSTALL_COMMAND cmake -E copy lua51.lib "${LUAJIT_DEST}/lib/libluajit.lib")
+
+# Hook the buld definition to 'libluajit' target
+if(MSVC)
+  add_dependencies(libluajit luajit-windows)
+  set(LUAJIT_STATIC_LIB "${LUAJIT_DEST}/lib/libluajit.lib")
+else()
+  add_dependencies(libluajit luajit)
+  set(LUAJIT_STATIC_LIB "${LUAJIT_DEST}/lib/libluajit.a")
+endif()
+
+set_target_properties(libluajit PROPERTIES IMPORTED_LOCATION "${LUAJIT_STATIC_LIB}")
+include_directories("${LUAJIT_DEST}/include/")

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -5,7 +5,7 @@
 
 set(FLB_REGEX                  No)
 set(FLB_BACKTRACE              No)
-set(FLB_LUAJIT                 No)
+set(FLB_LUAJIT                Yes)
 set(FLB_EXAMPLES               No)
 
 # INPUT plugins


### PR DESCRIPTION
With this change LuaJIT can be compiled and linked on MSVC.

It turned out that the Windows support was fairly streight forward
since LuaJIT already provided a working build script (msvcbuild.bat).
So what I basically did was to tell cmake to invoke this bat file,
and it just worked fine.

Part of #960