### PR TITLE
filter_lua: port filter_lua to Windows

### DIFF
--- a/plugins/filter_lua/CMakeLists.txt
+++ b/plugins/filter_lua/CMakeLists.txt
@@ -2,4 +2,8 @@ set(src
   lua_config.c
   lua.c)
 
-FLB_PLUGIN(filter_lua "${src}" "m")
+if(MSVC)
+  FLB_PLUGIN(filter_lua "${src}" "")
+else()
+  FLB_PLUGIN(filter_lua "${src}" "m")
+endif()

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_luajit.h>

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
@@ -29,7 +30,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
 
 struct lua_filter *lua_config_create(struct flb_filter_instance *ins,


### PR DESCRIPTION
This patch sorts out non-portable stuffs in `plugins/filter_lua`
so that it's possible to use LuaJIT filter on Windows.

 1. Include "unistd.h" thorough "flb_compat.h"
 2. Don't try to link libm on Windows (that's a Linux/BSD thing)

I can confirm filter_lua is working fine on Windows with this.

Part of #960 
Depend on #1053