### PR TITLE
out_stackdrvier: added support of metadata server and gce_instance resource.

### DIFF
--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -66,4 +66,7 @@ int flb_oauth2_payload_append(struct flb_oauth2 *ctx,
 char *flb_oauth2_token_get(struct flb_oauth2 *ctx);
 int flb_oauth2_token_expired(struct flb_oauth2 *ctx);
 
+int flb_oauth2_parse_json_response(char *json_data, size_t json_size,
+                        struct flb_oauth2 *ctx);
+
 #endif

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(src
+  gce_metadata.c
   stackdriver_conf.c
   stackdriver.c
   )

--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -1,0 +1,188 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_oauth2.h>
+
+#include <msgpack.h>
+
+#include "gce_metadata.h"
+#include "stackdriver.h"
+#include "stackdriver_conf.h"
+
+
+static int fetch_metadata(struct flb_upstream *ctx, char *uri,
+                          char *payload) {
+  int ret;
+  int ret_code;
+  size_t b_sent;
+  struct flb_upstream_conn *metadata_conn;
+  struct flb_http_client *c;
+
+  /* Get metadata connection */
+  metadata_conn = flb_upstream_conn_get(ctx);
+  if (!metadata_conn) {
+    flb_error("[out_stackdriver] failed to create metadata connection");
+    return -1;
+  }
+
+  /* Compose HTTP Client request */
+  c = flb_http_client(metadata_conn, FLB_HTTP_GET, uri,
+                      "", 0, NULL, 0, NULL, 0);
+
+  flb_http_buffer_size(c, 4096);
+
+  flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+  flb_http_add_header(c, "Content-Type", 12, "application/text", 20);
+  flb_http_add_header(c, "Metadata-Flavor", 15, "Google", 6);
+
+  /* Send HTTP request */
+  ret = flb_http_do(c, &b_sent);
+
+  /* validate response */
+  if (ret != 0) {
+    flb_warn("[out_stackdriver] http_do=%i", ret);
+    ret_code = -1;
+  }
+  else {
+    /* The request was issued successfully, validate the 'error' field */
+    flb_debug("[out_stackdriver] HTTP Status=%i", c->resp.status);
+    if (c->resp.status == 200) {
+      ret_code = 0;
+      flb_sds_copy(payload, c->resp.payload, c->resp.payload_size);
+    }
+    else {
+      if (c->resp.payload_size > 0) {
+        /* we got an error */
+        flb_warn("[out_stackdriver] error\n%s", c->resp.payload);
+      }
+      else {
+        flb_debug("[out_stackdriver] response\n%s", c->resp.payload);
+      }
+      ret_code = -1;
+    }
+  }
+
+  /* Cleanup */
+  flb_http_client_destroy(c);
+  flb_upstream_conn_release(metadata_conn);
+  return ret_code;
+}
+
+int gce_metadata_read_token(struct flb_stackdriver *ctx) {
+  int ret;
+  flb_sds_t uri = flb_sds_create(FLB_STD_METADATA_SERVICE_ACCOUNT_URI);
+  flb_sds_t payload = flb_sds_create_size(4096);
+
+  uri = flb_sds_cat(uri, ctx->client_email, flb_sds_len(ctx->client_email));
+  uri = flb_sds_cat(uri, "/token", 6);
+  ret = fetch_metadata(ctx->metadata_u, uri, payload);
+  if (ret != 0) {
+    flb_error("[out_stackdriver] can't fetch token from the metadata server");
+    flb_sds_destroy(payload);
+    return -1;
+  }
+
+  ret = flb_oauth2_parse_json_response(payload, flb_sds_len(payload), ctx->o);
+  flb_sds_destroy(payload);
+  if (ret != 0) {
+    flb_error("[out_stackdriver] unable to parse token body");
+    return -1;
+  }
+  ctx->o->expires = time(NULL) + ctx->o->expires_in;
+  return 0;
+}
+
+int gce_metadata_read_zone(struct flb_stackdriver *ctx) {
+  int ret;
+  int i;
+  int j;
+  int part = 0;
+  flb_sds_t payload = flb_sds_create_size(4096);
+  flb_sds_t zone;
+
+  ret = fetch_metadata(ctx->metadata_u, FLB_STD_METADATA_ZONE_URI, payload);
+  if (ret != 0) {
+    flb_error("[out_stackdriver] can't fetch zone from the metadata server");
+    flb_sds_destroy(payload);
+    return -1;
+  }
+
+  /* Data returned in the format projects/{project-id}/zones/{name} */
+  for (i = 0; i < flb_sds_len(payload); ++i) {
+    if (payload[i] == '/') {
+      part++;
+    }
+    if (part == 3) {
+      i++;
+      break;
+    }
+  }
+  if (part != 3) {
+    flb_error("[out_stackdriver] wrong format of zone response");
+    flb_sds_destroy(payload);
+    return -1;
+  }
+  zone = flb_sds_create_size(flb_sds_len(payload) - i);
+  j = 0;
+  while (i != flb_sds_len(payload)) {
+    zone[j] = payload[i];
+    i++;
+    j++;
+  }
+  ctx->zone = flb_sds_create(zone);
+  flb_sds_destroy(zone);
+  flb_sds_destroy(payload);
+  return 0;
+}
+
+int gce_metadata_read_project_id(struct flb_stackdriver *ctx) {
+  int ret;
+  flb_sds_t payload = flb_sds_create_size(4096);
+
+  ret = fetch_metadata(ctx->metadata_u, FLB_STD_METADATA_PROJECT_ID_URI, payload);
+  if (ret != 0) {
+    flb_error("[out_stackdriver] can't fetch project id from the metadata server");
+    flb_sds_destroy(payload);
+    return -1;
+  }
+  ctx->project_id = flb_sds_create(payload);
+  flb_sds_destroy(payload);
+  return 0;
+}
+
+int gce_metadata_read_instance_id(struct flb_stackdriver *ctx) {
+  int ret;
+  flb_sds_t payload = flb_sds_create_size(4096);
+
+  ret = fetch_metadata(ctx->metadata_u, FLB_STD_METADATA_INSTANCE_ID_URI, payload);
+  if (ret != 0) {
+    flb_error("[out_stackdriver] can't fetch instance id from the metadata server");
+    flb_sds_destroy(payload);
+    return -1;
+  }
+  ctx->instance_id = flb_sds_create(payload);
+  flb_sds_destroy(payload);
+  return 0;
+}

--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLUENT_BIT_GCE_METADATA_H
+#define FLUENT_BIT_GCE_METADATA_H
+
+#include "stackdriver.h"
+
+/* Project ID metadata URI */
+#define FLB_STD_METADATA_PROJECT_ID_URI "computeMetadata/v1/project/numeric-project-id"
+
+/* Zone metadata URI */
+#define FLB_STD_METADATA_ZONE_URI "/computeMetadata/v1/instance/zone"
+
+/* Instance ID metadata URI */
+#define FLB_STD_METADATA_INSTANCE_ID_URI "/computeMetadata/v1/instance/id"
+
+/* Service account metadata URI */
+#define FLB_STD_METADATA_SERVICE_ACCOUNT_URI "/computeMetadata/v1/instance/service-accounts/"
+
+int gce_metadata_read_token(struct flb_stackdriver *ctx);
+int gce_metadata_read_zone(struct flb_stackdriver *ctx);
+int gce_metadata_read_project_id(struct flb_stackdriver *ctx);
+int gce_metadata_read_instance_id(struct flb_stackdriver *ctx);
+
+#endif //FLUENT_BIT_GCE_METADATA_H

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -28,6 +28,7 @@
 
 #include <msgpack.h>
 
+#include "gce_metadata.h"
 #include "stackdriver.h"
 #include "stackdriver_conf.h"
 #include <mbedtls/base64.h>
@@ -68,6 +69,7 @@ int jwt_base64_url_encode(unsigned char *out_buf, size_t out_size,
     *olen = i;
     return 0;
 }
+
 
 static int jwt_encode(char *payload, char *secret,
                       char **out_signature, size_t *out_size)
@@ -195,6 +197,18 @@ static int get_oauth2_token(struct flb_stackdriver *ctx)
     time_t expires;
     char payload[1024];
 
+    /* Create oauth2 context */
+    ctx->o = flb_oauth2_create(ctx->config, FLB_STD_AUTH_URL, 3000);
+    if (!ctx->o) {
+      flb_error("[out_stackdriver] cannot create oauth2 context");
+      return -1;
+    }
+
+    /* In case of using metadata server, fetch token from there */
+    if (ctx->metadata_server_auth) {
+        return gce_metadata_read_token(ctx);
+    }
+
     /* JWT encode for oauth2 */
     issued = time(NULL);
     expires = issued + FLB_STD_TOKEN_REFRESH;
@@ -212,16 +226,7 @@ static int get_oauth2_token(struct flb_stackdriver *ctx)
         flb_error("[out_stackdriver] JWT signature generation failed");
         return -1;
     }
-
     flb_debug("[out_stackdriver] JWT signature:\n%s", sig_data);
-
-    /* Create oauth2 context */
-    ctx->o = flb_oauth2_create(ctx->config, FLB_STD_AUTH_URL, 3000);
-    if (!ctx->o) {
-        flb_sds_destroy(sig_data);
-        flb_error("[out_stackdriver] cannot create oauth2 context");
-        return -1;
-    }
 
     ret = flb_oauth2_payload_append(ctx->o,
                                     "grant_type", -1,
@@ -291,8 +296,17 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     /* Create Upstream context for Stackdriver Logging (no oauth2 service) */
     ctx->u = flb_upstream_create_url(config, FLB_STD_WRITE_URL,
                                      FLB_IO_TLS, &ins->tls);
+    ctx->metadata_u = flb_upstream_create_url(config, "http://metadata.google.internal",
+                                     FLB_IO_TCP, NULL);
+    ctx->u->flags &= ~FLB_IO_ASYNC;
+    ctx->metadata_u->flags &= ~FLB_IO_ASYNC;
+
     if (!ctx->u) {
         flb_error("[out_stackdriver] upstream creation failed");
+        return -1;
+    }
+    if (!ctx->metadata_u) {
+        flb_error("[out_stackdriver] metadata upstream creation failed");
         return -1;
     }
 
@@ -301,7 +315,11 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     if (!token) {
         flb_warn("[out_stackdriver] token retrieval failed");
     }
-
+    if (ctx->metadata_server_auth) {
+      gce_metadata_read_project_id(ctx);
+      gce_metadata_read_zone(ctx);
+      gce_metadata_read_instance_id(ctx);
+    }
     return 0;
 }
 
@@ -359,16 +377,38 @@ static int stackdriver_format(void *data, size_t bytes,
     msgpack_pack_str_body(&mp_pck, ctx->resource,
                           flb_sds_len(ctx->resource));
 
-    /* labels (we only append 'project_id' at the moment) */
     msgpack_pack_str(&mp_pck, 6);
     msgpack_pack_str_body(&mp_pck, "labels", 6);
 
-    msgpack_pack_map(&mp_pck, 1);
-    msgpack_pack_str(&mp_pck, 10);
-    msgpack_pack_str_body(&mp_pck, "project_id", 10);
-    msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-    msgpack_pack_str_body(&mp_pck,
-                          ctx->project_id, flb_sds_len(ctx->project_id));
+    if (strcmp(ctx->resource, "global") == 0) {
+      /* global resource has field project_id */
+      msgpack_pack_map(&mp_pck, 1);
+      msgpack_pack_str(&mp_pck, 10);
+      msgpack_pack_str_body(&mp_pck, "project_id", 10);
+      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+      msgpack_pack_str_body(&mp_pck,
+                            ctx->project_id, flb_sds_len(ctx->project_id));
+    } else if (strcmp(ctx->resource, "gce_instance") == 0) {
+      /* gce_instance resource has fields project_id, zone, instance_id */
+      msgpack_pack_map(&mp_pck, 3);
+
+      msgpack_pack_str(&mp_pck, 10);
+      msgpack_pack_str_body(&mp_pck, "project_id", 10);
+      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+      msgpack_pack_str_body(&mp_pck,
+                            ctx->project_id, flb_sds_len(ctx->project_id));
+
+      msgpack_pack_str(&mp_pck, 4);
+      msgpack_pack_str_body(&mp_pck, "zone", 4);
+      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->zone));
+      msgpack_pack_str_body(&mp_pck, ctx->zone, flb_sds_len(ctx->zone));
+
+      msgpack_pack_str(&mp_pck, 11);
+      msgpack_pack_str_body(&mp_pck, "instance_id", 11);
+      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->instance_id));
+      msgpack_pack_str_body(&mp_pck,
+                            ctx->instance_id, flb_sds_len(ctx->instance_id));
+    }
 
     msgpack_pack_str(&mp_pck, 7);
     msgpack_pack_str_body(&mp_pck, "entries", 7);
@@ -391,7 +431,6 @@ static int stackdriver_format(void *data, size_t bytes,
          * }
          */
         msgpack_pack_map(&mp_pck, 3);
-
 
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -59,11 +59,12 @@ struct flb_stackdriver {
     flb_sds_t client_id;
     flb_sds_t auth_uri;
     flb_sds_t token_uri;
+    bool metadata_server_auth;
 
     /* metadata server (GCP specific, WIP) */
     flb_sds_t zone;
-    flb_sds_t vm_id;
-    flb_sds_t vm_name;
+    flb_sds_t instance_id;
+    flb_sds_t instance_name;
 
     /* other */
     flb_sds_t resource;
@@ -73,6 +74,9 @@ struct flb_stackdriver {
 
     /* upstream context for stackdriver write end-point */
     struct flb_upstream *u;
+
+    /* upstream context for metadata end-point */
+    struct flb_upstream *metadata_u;
 
     /* Fluent Bit context */
     struct flb_config *config;

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -51,7 +51,7 @@ static inline int key_cmp(char *str, int len, char *cmp) {
     return strncasecmp(str, cmp, len);
 }
 
-static int parse_json_response(char *json_data, size_t json_size,
+int flb_oauth2_parse_json_response(char *json_data, size_t json_size,
                                struct flb_oauth2 *ctx)
 {
     int i;
@@ -362,7 +362,8 @@ char *flb_oauth2_token_get(struct flb_oauth2 *ctx)
 
     /* Extract token */
     if (c->resp.payload_size > 0 && c->resp.status == 200) {
-        ret = parse_json_response(c->resp.payload, c->resp.payload_size, ctx);
+        ret = flb_oauth2_parse_json_response(c->resp.payload,
+                                             c->resp.payload_size, ctx);
         if (ret == 0) {
             flb_info("[oauth2] access token from '%s:%s' retrieved",
                      ctx->host, ctx->port);


### PR DESCRIPTION
This PR adds basic support of GCE metadata server to fluentbit. Now plugin can read next fields: project_id, zone and instance_id from the metadata server (happens once during plugin init phase).

In case if private key wasn't provided, plugin assumes that it runs in GCE environment and token can be fetched from the metadata server. If client_email wasn't provided too "default" is used.

Combining project_id, zone and instance_id allows us to add support of gce_instance resource.