### PR TITLE
bin: enable to use long command-line options on Windows

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -589,7 +589,6 @@ int main(int argc, char **argv)
     flb_stacktrace_init(argv[0]);
 #endif
 
-#ifndef _WIN32
     /* Setup long-options */
     static const struct option long_opts[] = {
         { "storage_path",    required_argument, NULL, 'b' },
@@ -624,7 +623,6 @@ int main(int argc, char **argv)
 #endif
         { NULL, 0, NULL, 0 }
     };
-#endif
 
 #ifdef FLB_HAVE_MTRACE
     /* Start tracing malloc and free */


### PR DESCRIPTION
Our getopt emulation did not support the long options. With this patch,
we allow users to use long options on Windows, since we have the full
support for getopt.h on Windows since 32e8da9.

I can confirm long options are now working fine on our dev Windows machine.

![capture](https://user-images.githubusercontent.com/8974561/52193679-ada3af80-2893-11e9-8a4a-8c9890d5b89f.PNG)
