### PR TITLE
build: enable filter plugins on Windows by default

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -3,7 +3,7 @@
 # Not all plugins are supported on Windows yet. This file tweaks
 # the build flags so that we can compile fluent-bit on it.
 
-set(FLB_REGEX                  No)
+set(FLB_REGEX                 Yes)
 set(FLB_BACKTRACE              No)
 set(FLB_LUAJIT                Yes)
 set(FLB_EXAMPLES               No)
@@ -61,12 +61,12 @@ set(FLB_OUT_KAFKA_REST         No)
 
 # FILTER plugins
 # ==============
-set(FLB_FILTER_GREP            No)
-set(FLB_FILTER_MODIFY          No)
-set(FLB_FILTER_STDOUT          No)
+set(FLB_FILTER_GREP           Yes)
+set(FLB_FILTER_MODIFY         Yes)
+set(FLB_FILTER_STDOUT         Yes)
 set(FLB_FILTER_PARSER          No)
 set(FLB_FILTER_KUBERNETES      No)
 set(FLB_FILTER_THROTTLE        No)
 set(FLB_FILTER_NEST            No)
-set(FLB_FILTER_LUA             No)
-set(FLB_FILTER_RECORD_MODIFIER No)
+set(FLB_FILTER_LUA            Yes)
+set(FLB_FILTER_RECORD_MODIFIER Yes)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -148,9 +148,7 @@ REGISTER_OUT_PLUGIN("out_gelf")
 
 # FILTERS
 # =======
-if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
-  REGISTER_FILTER_PLUGIN("filter_grep")
-endif()
+REGISTER_FILTER_PLUGIN("filter_grep")
 REGISTER_FILTER_PLUGIN("filter_stdout")
 REGISTER_FILTER_PLUGIN("filter_throttle")
 


### PR DESCRIPTION
Since we have full Onigmo and LuaJIT support, we can just compile
and use these filter plugins on Windows.

 1. FLB_FILTER_GREP
 2. FLB_FILTER_MODIFY
 3. FLB_FILTER_STDOUT
 4. FLB_FILTER_LUA
 5. FLB_FILTER_RECORD_MODIFIER

This patch enables the compilation of these plugins on Windows by
default.

Part of #960