### PR TITLE
log: add a missing FLB_TLS_INIT call for flb_log_ctx

### DIFF
--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -111,6 +111,7 @@ static void log_worker_collector(void *data)
     struct mk_event *event = NULL;
     struct flb_log *log = data;
 
+    FLB_TLS_INIT(flb_log_ctx);
     FLB_TLS_SET(flb_log_ctx, log);
 
     /* Signal the caller */


### PR DESCRIPTION
Without this fluent-bit tries to manipulates the thread-local storage
using an uninitialized key, which was causing a series of memory
corruptions.

**NOTE:** the reason this bug hasn't been evident was that GCC and clang
have native `__thread` support so we do not need to prepare the data
key manually; Unfortunately, it's not the case with MSVC.

Part of #960