### PR TITLE
config: fix SIGSEGV errors on shutdown of input plugins

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -248,13 +248,14 @@ void flb_config_exit(struct flb_config *config)
     /* Collectors */
     mk_list_foreach_safe(head, tmp, &config->collectors) {
         collector = mk_list_entry(head, struct flb_input_collector, _head);
-        mk_event_del(config->evl, &collector->event);
 
         if (collector->type == FLB_COLLECT_TIME) {
             mk_event_timeout_destroy(config->evl, &collector->event);
             if (collector->fd_timer > 0) {
                 close(collector->fd_timer);
             }
+        } else {
+            mk_event_del(config->evl, &collector->event);
         }
 
         mk_list_del(&collector->_head);


### PR DESCRIPTION
The point is that we do not need to call both `mk_event_del()` and
`mk_event_timeout_destroy()` on the same event object. In fact,
calling both  can lead to SIGSEGV in some backend (e.g. libevent).

This patch fixies the issue by moving the call of mk_event_del() to
the "else" block.

Part of #960