### PR TITLE
engine: fix SIGSEGV while flb_shutdown() on select/libevent backend

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -231,6 +231,11 @@ static FLB_INLINE int flb_engine_handle_event(flb_pipefd_t fd, int mask,
 {
     int ret;
 
+    /* flb_engine_shutdown was already initiated */
+    if (config->is_running == FLB_FALSE) {
+        return 0;
+    }
+
     if (mask & MK_EVENT_READ) {
         /* Check if we need to flush */
         if (config->flush_fd == fd) {
@@ -506,7 +511,9 @@ int flb_engine_start(struct flb_config *config)
         }
 
         /* Cleanup functions associated to events and timers */
-        flb_sched_timer_cleanup(config->sched);
+        if (config->is_running == FLB_TRUE) {
+            flb_sched_timer_cleanup(config->sched);
+        }
     }
 }
 
@@ -556,8 +563,6 @@ int flb_engine_exit(struct flb_config *config)
 {
     int ret;
     uint64_t val = FLB_ENGINE_EV_STOP;
-
-    config->is_running = FLB_FALSE;
 
     flb_input_pause_all(config);
 


### PR DESCRIPTION
The root problem was that `flb_shutdown()` could emit an event while
closing ch_manager pipes, because `select(2)` would consider a closed
socket as "ready to read".

Since many resources has been deallocated already at that point, the
event callback dives directly into SIGSEGV and crashes.

This patch tries to fix the issue by skipping event processing if
`flb_shutdown()` has been already initiated.

Part of #960