### PR TITLE
Add timestamp_format to kafka output

### DIFF
--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -152,6 +152,15 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
         ctx->timestamp_key_len = strlen(FLB_KAFKA_TS_KEY);
     }
 
+    /* Config: Timestamp_Format */
+    ctx->timestamp_format = FLB_JSON_DATE_DOUBLE;
+    tmp = flb_output_get_property("timestamp_format", ins);
+    if (tmp) {
+        if (strcasecmp(tmp, "iso8601") == 0) {
+            ctx->timestamp_format = FLB_JSON_DATE_ISO8601;
+        }
+    }
+
     /* Config Gelf_Timestamp_Key */
     tmp = flb_output_get_property("gelf_timestamp_key", ins);
     if (tmp) {

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -34,6 +34,10 @@
 #define FLB_KAFKA_TOPIC     "fluent-bit"
 #define FLB_KAFKA_TS_KEY    "@timestamp"
 
+#define FLB_JSON_DATE_DOUBLE      0
+#define FLB_JSON_DATE_ISO8601     1
+#define FLB_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
 struct flb_kafka_topic {
     int name_len;
     char *name;
@@ -52,6 +56,7 @@ struct flb_kafka {
 
     int timestamp_key_len;
     char *timestamp_key;
+    int timestamp_format;
 
     int message_key_len;
     char *message_key;


### PR DESCRIPTION
This allows using iso8601 in the JSON output format if desired
rather than double.

Signed-off-by: Don Bowman <don@agilicus.com>