### PR TITLE
build: avoid including Windows-specific build definitions

### DIFF
--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -23,13 +23,15 @@ ExternalProject_Add(luajit
 
 # luajit (Windows)
 # ================
-ExternalProject_Add(luajit-windows
-  BUILD_IN_SOURCE TRUE
-  EXCLUDE_FROM_ALL TRUE
-  SOURCE_DIR ${LUAJIT_SRC}/src
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ./msvcbuild.bat static
-  INSTALL_COMMAND cmake -E copy lua51.lib "${LUAJIT_DEST}/lib/libluajit.lib")
+if (MSVC)
+  ExternalProject_Add(luajit-windows
+    BUILD_IN_SOURCE TRUE
+    EXCLUDE_FROM_ALL TRUE
+    SOURCE_DIR ${LUAJIT_SRC}/src
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ./msvcbuild.bat static
+    INSTALL_COMMAND cmake -E copy lua51.lib "${LUAJIT_DEST}/lib/libluajit.lib")
+endif()
 
 # Hook the buld definition to 'libluajit' target
 if(MSVC)

--- a/cmake/onigmo.cmake
+++ b/cmake/onigmo.cmake
@@ -31,14 +31,16 @@ ExternalProject_Add(onigmo
 
 # Onigmo (Windows)
 # ================
-ExternalProject_Add(onigmo-windows
-  BUILD_IN_SOURCE TRUE
-  EXCLUDE_FROM_ALL TRUE
-  SOURCE_DIR ${ONIGMO_SRC}
-  CONFIGURE_COMMAND cmake -E copy win32/Makefile win32/config.h ${ONIGMO_SRC}
-  BUILD_COMMAND nmake ARCH=${ONIGMO_ARCH}
-  INSTALL_COMMAND cmake -E copy build_${ONIGMO_ARCH}/onigmo_s.lib ${ONIGMO_DEST}/lib/libonigmo.lib
-          COMMAND cmake -E copy onigmo.h ${ONIGMO_DEST}/include/)
+if(MSVC)
+  ExternalProject_Add(onigmo-windows
+    BUILD_IN_SOURCE TRUE
+    EXCLUDE_FROM_ALL TRUE
+    SOURCE_DIR ${ONIGMO_SRC}
+    CONFIGURE_COMMAND cmake -E copy win32/Makefile win32/config.h ${ONIGMO_SRC}
+    BUILD_COMMAND nmake ARCH=${ONIGMO_ARCH}
+    INSTALL_COMMAND cmake -E copy build_${ONIGMO_ARCH}/onigmo_s.lib ${ONIGMO_DEST}/lib/libonigmo.lib
+            COMMAND cmake -E copy onigmo.h ${ONIGMO_DEST}/include/)
+endif()
 
 # Hook the buld definition to 'libonigmo' target
 if(MSVC)


### PR DESCRIPTION
The problem was that older cmake versions (2.x) didn't recognize
EXCLUDE_FROM_ALL setting. Since cmake would add external projects
into "make all" target by default, it has been causing compilation
errors on non-Windows systems.

This patch fixes the issue by not including the build definitions
on platforms other than Windows.

Part of #960
Related to #1071 