### PR TITLE
Fix for #743 infinite loop if msgpack_unpack_next() returns error

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -261,7 +261,7 @@ static int cb_grep_filter(void *data, size_t bytes,
 
     /* Iterate each item array and apply rules */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
         if (root.type != MSGPACK_OBJECT_ARRAY) {
             continue;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -546,7 +546,7 @@ static inline int extract_meta(struct flb_kube *ctx, char *tag, int tag_len,
     if (ctx->use_journal == FLB_TRUE) {
         off = 0;
         msgpack_unpacked_init(&mp_result);
-        while (msgpack_unpack_next(&mp_result, data, data_size, &off)) {
+        while (msgpack_unpack_next(&mp_result, data, data_size, &off) == MSGPACK_UNPACK_SUCCESS) {
             root = mp_result.data;
             if (root.type != MSGPACK_OBJECT_ARRAY) {
                 continue;

--- a/plugins/filter_kubernetes/kube_property.c
+++ b/plugins/filter_kubernetes/kube_property.c
@@ -235,7 +235,7 @@ int flb_kube_prop_unpack(struct flb_kube_props *props, char *buf, size_t size)
 
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, size, &off);
-    if (ret == -1) {
+    if (ret == MSGPACK_UNPACK_PARSE_ERROR) {
         msgpack_unpacked_destroy(&result);
         return -1;
     }

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -50,7 +50,7 @@ static int is_stream_stderr(void *data, size_t bytes)
     msgpack_object k;
     msgpack_object v;
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
         if (root.type != MSGPACK_OBJECT_ARRAY) {
             continue;
@@ -500,7 +500,7 @@ static int cb_kube_filter(void *data, size_t bytes,
 
     /* Iterate each item array and append meta */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
         if (root.type != MSGPACK_OBJECT_ARRAY) {
             continue;

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -402,7 +402,7 @@ static int cb_lua_filter(void *data, size_t bytes,
     msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         msgpack_packer data_pck;
         msgpack_sbuffer data_sbuf;
 

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1396,7 +1396,7 @@ static int cb_modify_filter(void *data, size_t bytes,
     // [1123123, {"Mem.total"=>4050908, "Mem.used"=>476576, "Mem.free"=>3574332 } ]
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_ARRAY) {
             modifications +=
                 apply_modifying_rules(&packer, &result.data, ctx);

--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -566,7 +566,7 @@ static int cb_nest_filter(void *data, size_t bytes,
      */
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_ARRAY) {
             if (ctx->operation == NEST) {
                 modified_records +=

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -216,7 +216,7 @@ static int cb_parser_filter(void *data, size_t bytes,
     msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         out_buf = NULL;
         append_arr_i = 0;
 

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -275,7 +275,7 @@ static int cb_modifier_filter(void *data, size_t bytes,
 
     /* Iterate each item to know map number */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         map_num = 0;
         removed_map_num = 0;
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -55,7 +55,7 @@ static int cb_stdout_filter(void *data, size_t bytes,
     msgpack_object *p;
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         printf("[%zd] %s: [", cnt++, tag);
         flb_time_pop_from_msgpack(&tmp, &result, &p);
         printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);

--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -221,7 +221,7 @@ static int cb_throttle_filter(void *data, size_t bytes,
 
     /* Iterate each item array and apply rules */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
         if (root.type != MSGPACK_OBJECT_ARRAY) {
             continue;

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -52,7 +52,7 @@ static int in_dummy_collect(struct flb_input_instance *i_ins,
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-    while (msgpack_unpack_next(&result, pack, pack_size, &off)) {
+    while (msgpack_unpack_next(&result, pack, pack_size, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_MAP) {
             /* { map => val, map => val, map => val } */
             msgpack_pack_array(&mp_pck, 2);

--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -136,7 +136,7 @@ static int mqtt_data_append(char *topic, size_t topic_len,
 
     off = 0;
     msgpack_unpacked_init(&result);
-    if (!msgpack_unpack_next(&result, pack, out, &off)) {
+    if (msgpack_unpack_next(&result, pack, out, &off) != MSGPACK_UNPACK_SUCCESS) {
         msgpack_unpacked_destroy(&result);
         return -1;
     }

--- a/plugins/in_serial/in_serial.c
+++ b/plugins/in_serial/in_serial.c
@@ -74,7 +74,7 @@ static inline int process_pack(msgpack_packer *mp_pck,
 
     /* First pack the results, iterate concatenated messages */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, pack, size, &off)) {
+    while (msgpack_unpack_next(&result, pack, size, &off) == MSGPACK_UNPACK_SUCCESS) {
         entry = result.data;
 
         msgpack_pack_array(mp_pck, 2);

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -54,7 +54,7 @@ static inline int pack_json(msgpack_packer *mp_pck,
     /* Queue the data with time field */
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, data, data_size, &off)) {
+    while (msgpack_unpack_next(&result, data, data_size, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_MAP) {
             /* { map => val, map => val, map => val } */
             msgpack_pack_array(mp_pck, 2);

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -374,7 +374,7 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     msgpack_unpacked_init(&result);
     msgpack_unpacked_init(&cont);
 
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
         if (root.type != MSGPACK_OBJECT_MAP) {
             continue;
@@ -390,7 +390,7 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
             /* Always check if the 'next' entry is a continuation */
             total = 0;
             if (i + 1 == root.via.map.size) {
-                while (msgpack_unpack_next(&cont, data, bytes, &next_off)) {
+                while (msgpack_unpack_next(&cont, data, bytes, &next_off) == MSGPACK_UNPACK_SUCCESS) {
                     next = cont.data;
                     if (next.type != MSGPACK_OBJECT_STR) {
                         break;
@@ -411,7 +411,7 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                  * value field.
                  */
                 next_off = off;
-                while (msgpack_unpack_next(&cont, data, bytes, &next_off)) {
+                while (msgpack_unpack_next(&cont, data, bytes, &next_off) == MSGPACK_UNPACK_SUCCESS) {
                     next = cont.data;
                     if (next.type != MSGPACK_OBJECT_STR) {
                         break;

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -48,7 +48,7 @@ static inline int process_pack(struct tcp_conn *conn,
 
     /* First pack the results, iterate concatenated messages */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, pack, size, &off)) {
+    while (msgpack_unpack_next(&result, pack, size, &off) == MSGPACK_UNPACK_SUCCESS) {
         entry = result.data;
 
         msgpack_pack_array(&mp_pck, 2);

--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -69,7 +69,7 @@ int azure_format(void *in_buf, size_t in_bytes,
 
     /* Count number of items */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off)) {
+    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -81,7 +81,7 @@ int azure_format(void *in_buf, size_t in_bytes,
     msgpack_pack_array(&mp_pck, array_size);
 
     off = 0;
-    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off)) {
+    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
 
         /* Get timestamp */

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -328,7 +328,7 @@ static int bigquery_format(void *data, size_t bytes,
 
     /* Count number of records */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -359,7 +359,7 @@ static int bigquery_format(void *data, size_t bytes,
     msgpack_pack_array(&mp_pck, array_size);
 
     off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Get timestamp */
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -156,7 +156,7 @@ static char *elasticsearch_format(void *data, size_t bytes,
 
     /* Perform some format validation */
     ret = msgpack_unpack_next(&result, data, bytes, &off);
-    if (!ret) {
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
         msgpack_unpacked_destroy(&result);
         return NULL;
     }
@@ -200,7 +200,7 @@ static char *elasticsearch_format(void *data, size_t bytes,
                              ctx->index, ctx->type);
     }
 
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }
@@ -395,7 +395,7 @@ static int elasticsearch_error_check(struct flb_http_client *c)
     /* Lookup error field */
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, out_buf, out_size, &off);
-    if (!ret) {
+    if (ret == MSGPACK_UNPACK_SUCCESS) {
         return FLB_TRUE;
     }
 

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -237,7 +237,7 @@ static void cb_file_flush(void *data, size_t bytes,
      * of the map to use as a data point.
      */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         alloc_size = (off - last_off) + 128; /* JSON is larger than msgpack */
         last_off = off;
 

--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -194,7 +194,7 @@ static void out_fcount_flush(void *data, size_t bytes,
     (void) config;
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&tm, &result, &obj);
 
         if (ctx->event_based == FLB_FALSE) {

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -613,7 +613,7 @@ static int data_compose(void *data, size_t bytes,
         msgpack_sbuffer_init(&mp_sbuf);
         msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-        while (msgpack_unpack_next(&result, data, bytes, &off)) {
+        while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
             /* Gather time */
             flb_time_pop_from_msgpack(&tm, &result, &mp_obj);
 
@@ -625,7 +625,7 @@ static int data_compose(void *data, size_t bytes,
         }
     }
     else {
-        while (msgpack_unpack_next(&result, data, bytes, &off)) {
+        while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
             entries++;
         }
     }

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -283,7 +283,7 @@ void cb_gelf_flush(void *data, size_t bytes,
 
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         size = off - prev_off;
         prev_off = off;
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -62,7 +62,7 @@ static char *msgpack_to_json(struct flb_out_http *ctx, char *data, uint64_t byte
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -74,7 +74,7 @@ static char *msgpack_to_json(struct flb_out_http *ctx, char *data, uint64_t byte
     msgpack_pack_array(&tmp_pck, array_size);
 
     off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Each array must have two entries: time and record */
         root = result.data;
         if (root.via.array.size != 2) {
@@ -321,7 +321,7 @@ static int http_gelf(struct flb_out_http *ctx,
 
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         size = off - prev_off;
         prev_off = off;
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -127,7 +127,7 @@ static char *influxdb_format(char *tag, int tag_len,
     off = 0;
     msgpack_unpacked_destroy(&result);
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -276,7 +276,7 @@ static void cb_kafka_flush(void *data, size_t bytes,
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 
         ret = produce_message(&tms, obj, ctx, config);

--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -66,7 +66,7 @@ static char *kafka_rest_format(void *data, size_t bytes,
     msgpack_unpacked_init(&result);
 
     /* Count number of entries */
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         arr_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -81,7 +81,7 @@ static char *kafka_rest_format(void *data, size_t bytes,
 
     /* Iterate and compose array content */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
 
         map = root.via.array.ptr[1];

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -128,7 +128,7 @@ static void out_lib_flush(void *data, size_t bytes,
     (void) tag_len;
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (ctx->max_records > 0 && count >= ctx->max_records) {
             break;
         }

--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -96,7 +96,7 @@ static int msgpack_to_json(void *data, size_t bytes,
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -108,7 +108,7 @@ static int msgpack_to_json(void *data, size_t bytes,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
     msgpack_pack_array(&mp_pck, array_size);
 
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }

--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -108,7 +108,7 @@ static void cb_plot_flush(void *data, size_t bytes,
      * of the map to use as a data point.
      */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&atime, &result, &map);
 
         /*

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -74,7 +74,7 @@ int splunk_format(void *in_buf, size_t in_bytes,
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off)) {
+    while (msgpack_unpack_next(&result, in_buf, in_bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
 
         /* Get timestamp */

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -328,7 +328,7 @@ static int stackdriver_format(void *data, size_t bytes,
 
     /* Count number of records */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -377,7 +377,7 @@ static int stackdriver_format(void *data, size_t bytes,
     msgpack_pack_array(&mp_pck, array_size);
 
     off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Get timestamp */
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -52,7 +52,7 @@ static char *msgpack_to_json(struct flb_out_stdout_config *ctx,
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         array_size++;
     }
     msgpack_unpacked_destroy(&result);
@@ -64,7 +64,7 @@ static char *msgpack_to_json(struct flb_out_stdout_config *ctx,
     msgpack_pack_array(&tmp_pck, array_size);
 
     off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Each array must have two entries: time and record */
         root = result.data;
         if (root.via.array.size != 2) {
@@ -238,7 +238,7 @@ static void cb_stdout_flush(void *data, size_t bytes,
         memcpy(buf, tag, tag_len);
         buf[tag_len] = '\0';
         msgpack_unpacked_init(&result);
-        while (msgpack_unpack_next(&result, data, bytes, &off)) {
+        while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
             printf("[%zd] %s: [", cnt++, buf);
             flb_time_pop_from_msgpack(&tmp, &result, &p);
             printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -70,7 +70,7 @@ static char *td_format(void *data, size_t bytes, int *out_size)
 
     /* Perform some format validation */
     ret = msgpack_unpack_next(&result, data, bytes, &off);
-    if (!ret) {
+    if (ret == MSGPACK_UNPACK_CONTINUE) {
         return NULL;
     }
 
@@ -98,7 +98,7 @@ static char *td_format(void *data, size_t bytes, int *out_size)
     off = 0;
     msgpack_unpacked_destroy(&result);
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -39,7 +39,7 @@ static inline int mp_count(void *data, size_t bytes, msgpack_zone *zone)
         t = zone;
     }
 
-    while (msgpack_unpack(data, bytes, &off, t, &obj)) {
+    while (msgpack_unpack(data, bytes, &off, t, &obj) == MSGPACK_UNPACK_SUCCESS) {
         c++;
     }
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -360,7 +360,7 @@ void flb_pack_print(char *data, size_t bytes)
     size_t off = 0, cnt = 0;
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off)) {
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Check if we are processing an internal Fluent Bit record */
         ret = pack_print_fluent_record(cnt, result);
         if (ret == 0) {
@@ -667,7 +667,7 @@ int flb_msgpack_raw_to_json_str(char *buf, size_t buf_size,
 
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, buf_size, &off);
-    if (ret == -1) {
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
         return -1;
     }
 
@@ -732,7 +732,7 @@ int flb_msgpack_expand_map(char *map_data, size_t map_size,
     }
 
     msgpack_unpacked_init(&result);
-    if (!(i=msgpack_unpack_next(&result, map_data, map_size, &off))){
+    if ( (i=msgpack_unpack_next(&result, map_data, map_size, &off)) != MSGPACK_UNPACK_SUCCESS ){
         return -1;
     }
     if (result.data.type != MSGPACK_OBJECT_MAP) {
@@ -1381,7 +1381,7 @@ flb_sds_t flb_msgpack_raw_to_gelf(char *buf, size_t buf_size,
 
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, buf_size, &off);
-    if (ret == -1) {
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
         return NULL;
     }
 

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -64,7 +64,7 @@ int flb_parser_json_do(struct flb_parser *parser,
 
     /* Make sure object is a map */
     msgpack_unpacked_init(&result);
-    if (msgpack_unpack_next(&result, mp_buf, mp_size, &off)) {
+    if (msgpack_unpack_next(&result, mp_buf, mp_size, &off) == MSGPACK_UNPACK_SUCCESS) {
         map = result.data;
         if (map.type != MSGPACK_OBJECT_MAP) {
             flb_free(mp_buf);

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -144,7 +144,7 @@ void test_json_pack_mult()
 
     /* Validate output buffer */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, out_buf, out_size, &off)) {
+    while (msgpack_unpack_next(&result, out_buf, out_size, &off) == MSGPACK_UNPACK_SUCCESS) {
         maps++;
         root = result.data;
         TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
@@ -221,7 +221,7 @@ void test_json_pack_mult_iter()
             off = 0;
             maps = 0;
             msgpack_unpacked_init(&result);
-            while (msgpack_unpack_next(&result, out_buf, out_size, &off)) {
+            while (msgpack_unpack_next(&result, out_buf, out_size, &off) == MSGPACK_UNPACK_SUCCESS) {
                 root = result.data;
                 TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
                 maps++;
@@ -310,7 +310,7 @@ void test_json_pack_bug342()
 
         size_t coff = 0;
         msgpack_unpacked_init(&result);
-        while (msgpack_unpack_next(&result, out, out_size, &coff)) {
+        while (msgpack_unpack_next(&result, out, out_size, &coff) == MSGPACK_UNPACK_SUCCESS) {
             records++;
         }
         msgpack_unpacked_destroy(&result);


### PR DESCRIPTION
Fix for #743.
msgpack_unpack_next() may return 
```
    MSGPACK_UNPACK_SUCCESS              =  2,
    MSGPACK_UNPACK_EXTRA_BYTES          =  1,
    MSGPACK_UNPACK_CONTINUE             =  0,
    MSGPACK_UNPACK_PARSE_ERROR          = -1,
    MSGPACK_UNPACK_NOMEM_ERROR          = -2
```
Of those only MSGPACK_UNPACK_CONTINUE casts to `false`. All error codes are converted also to boolean `true`. Therefore `while` loop may hit error, cast negative integer to `true` and continue the loop forever.
Instead, one must compare if msgpack_unpack_next() returns MSGPACK_UNPACK_SUCCESS, which is by chance defined as equal to 2 at the moment. All other values are some sort of error or end of msgpack, and should end a loop.
This PR also pulls in the similar fix from @g7 in [ts-way fork](https://github.com/ts-way/fluent-bit/commit/8900100d4bff47510e51778fc90c03dd0a8ddcf1), which is also signed-off.