### PR TITLE
core: use mk_event_closesocket() instead of plain close(2)

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -220,28 +220,28 @@ void flb_config_exit(struct flb_config *config)
 
     /* release resources */
     if (config->ch_event.fd) {
-        close(config->ch_event.fd);
+        mk_event_closesocket(config->ch_event.fd);
     }
 
     /* Pipe */
     if (config->ch_data[0]) {
-        close(config->ch_data[0]);
-        close(config->ch_data[1]);
+        mk_event_closesocket(config->ch_data[0]);
+        mk_event_closesocket(config->ch_data[1]);
     }
 
     /* Channel manager */
     if (config->ch_manager[0] > 0) {
-        close(config->ch_manager[0]);
+        mk_event_closesocket(config->ch_manager[0]);
         if (config->ch_manager[0] != config->ch_manager[1]) {
-            close(config->ch_manager[1]);
+            mk_event_closesocket(config->ch_manager[1]);
         }
     }
 
     /* Channel notifications */
     if (config->ch_notif[0] > 0) {
-        close(config->ch_notif[0]);
+        mk_event_closesocket(config->ch_notif[0]);
         if (config->ch_notif[0] != config->ch_notif[1]) {
-            close(config->ch_notif[1]);
+            mk_event_closesocket(config->ch_notif[1]);
         }
     }
 
@@ -252,7 +252,7 @@ void flb_config_exit(struct flb_config *config)
         if (collector->type == FLB_COLLECT_TIME) {
             mk_event_timeout_destroy(config->evl, &collector->event);
             if (collector->fd_timer > 0) {
-                close(collector->fd_timer);
+                mk_event_closesocket(collector->fd_timer);
             }
         } else {
             mk_event_del(config->evl, &collector->event);
@@ -276,7 +276,7 @@ void flb_config_exit(struct flb_config *config)
     if (config->evl) {
         mk_event_del(config->evl, &config->event_flush);
     }
-    close(config->flush_fd);
+    mk_event_closesocket(config->flush_fd);
 
     /* Release scheduler */
     flb_sched_exit(config);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -569,7 +569,7 @@ static int collector_start(struct flb_input_collector *coll,
                            MK_EVENT_READ, event);
         if (ret == -1) {
             flb_error("[input collector] COLLECT_EVENT registration failed");
-            close(coll->fd_event);
+            mk_event_closesocket(coll->fd_event);
             coll->running = FLB_FALSE;
             return -1;
         }
@@ -684,7 +684,7 @@ int flb_input_collector_pause(int coll_id, struct flb_input_instance *in)
          * one can be created.
          */
         mk_event_timeout_destroy(config->evl, &coll->event);
-        close(coll->fd_timer);
+        mk_event_closesocket(coll->fd_timer);
         coll->fd_timer = -1;
     }
     else if (coll->type & (FLB_COLLECT_FD_SERVER | FLB_COLLECT_FD_EVENT)) {


### PR DESCRIPTION
This is a series of patches to fix SIGSEGV on closing sockets on Windows.

21bcd10b lib: monkey: sync Windows support changes
50325994 core: use mk_event_closesocket() instead of plain close(2)

Since this patch depends on the function added in monkey/monkey/pull/294,
it syncs lib/monkey with the latest master HEAD.

Part of #960.
