### PR TITLE
compat: keep "flb_compat.h" lean by moving inline functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,13 @@ if(FLB_PARSER)
     )
 endif()
 
+if(MSVC)
+  set(src
+    ${src}
+    "compat/msvc.c"
+    )
+endif()
+
 # Fluent Bit have TLS support
 if(FLB_TLS)
   # Register the TLS interface and functions

--- a/src/compat/msvc.c
+++ b/src/compat/msvc.c
@@ -18,32 +18,18 @@
  *  limitations under the License.
  */
 
-#ifndef FLB_COMPAT_H
-#define FLB_COMPAT_H
+#include <fluent-bit/flb_compat.h>
 
-/* libmonkey exposes compat macros for <unistd.h> */
-#include <monkey/mk_core.h>
+int getpagesize(void)
+{
+    SYSTEM_INFO info;
+    GetSystemInfo(&info);
+    return info.dwPageSize;
+}
 
-#ifdef _MSC_VER
-#define PATH_MAX MAX_PATH
-
-#define WIN32_LEAN_AND_MEAN
-#include <winsock2.h>
-#include <windows.h>
-
-/* compat/msvc.c */
-extern int getpagesize(void);
-extern struct tm *gmtime_r(const time_t *timep, struct tm *result);
-
-/* mk_utils.c */
-extern struct tm *localtime_r(const time_t *timep, struct tm * result);
-#endif
-
-#ifndef _MSC_VER
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#endif
-#endif
+struct tm *gmtime_r(const time_t *timep, struct tm *result)
+{
+    if (gmtime_s(result, timep))
+        return NULL;
+    return result;
+}


### PR DESCRIPTION
This moves functions to a separate file "compat/msvc.c", leaving only
extern declarations in the compat header.

Considering almost all source files includes this header, this commit
should prevent the remaining binary from being bloated (and also
be good to economy of compilation).

Part of #960