### PR TITLE
pipe: add flb_pipe_set_nonblocking() for portability

### DIFF
--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -39,6 +39,7 @@
 int flb_pipe_create(flb_pipefd_t pipefd[2]);
 void flb_pipe_destroy(flb_pipefd_t pipefd[2]);
 int flb_pipe_close(flb_pipefd_t fd);
+int flb_pipe_set_nonblocking(flb_pipefd_t fd);
 ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
 ssize_t flb_pipe_write_all(int fd, void *buf, size_t count);
 


### PR DESCRIPTION
The reason why need this function is that Windows does not support
O_NONBLOCK and we need to call another function (ioctlsocket) to
create a nonblocking socket.

This patch adds a portable wrapper function for that purpose.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>