### PR TITLE
parser: initialize "types" to NULL explicitly

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -411,7 +411,7 @@ int flb_parser_conf_file(char *file, struct flb_config *config)
     struct mk_rconf_section *section;
     struct mk_list *head;
     struct stat st;
-    struct flb_parser_types *types;
+    struct flb_parser_types *types = NULL;
     struct mk_list *decoders;
 
 #ifndef FLB_HAVE_STATIC_CONF


### PR DESCRIPTION
If a parser configuration does not have Types fields, the "types"
variable can be passed around without initialized. This has been
causing errors on Windows build.

Part of #960