### PR TITLE
compat: Implement a couple of functions/macros for Windows

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -26,11 +26,12 @@
 
 /* Windows compatibility utils */
 #ifdef _MSC_VER
-#define PATH_MAX MAX_PATH
-
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <windows.h>
+
+#define PATH_MAX MAX_PATH
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 
 static inline int getpagesize(void)
 {

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -51,6 +51,21 @@ static inline time_t timegm(struct tm *tm)
     return _mkgmtime(tm);
 }
 
+static inline char* basename(const char *path)
+{
+    char drive[_MAX_DRIVE];
+    char dir[_MAX_DIR];
+    char fname[_MAX_FNAME];
+    char ext[_MAX_EXT];
+    static char buf[_MAX_PATH];
+
+    _splitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR,
+                       fname, _MAX_FNAME, ext, _MAX_EXT);
+
+    _makepath_s(buf, _MAX_PATH, "", "", fname, ext);
+    return buf;
+}
+
 /* mk_utils.c exposes localtime_r */
 extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -46,6 +46,11 @@ static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
     return result;
 }
 
+static inline time_t timegm(struct tm *tm)
+{
+    return _mkgmtime(tm);
+}
+
 /* mk_utils.c exposes localtime_r */
 extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 


### PR DESCRIPTION
This is a series of patches to add functions and macros that are missing on Windows.
We need them in order to port in_tail to Windows.

569c5521 compat: implement timegm(3) for Windows
96abb9c6 compat: implement basename(3) for Windows
2f276993 compat: define S_ISREG macro for Windows
