### PR TITLE
compat: implement strptime(3) for Windows

### DIFF
--- a/include/fluent-bit/win32/langinfo.h
+++ b/include/fluent-bit/win32/langinfo.h
@@ -1,0 +1,138 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/* This is a dumb implementation of langinfo.h for Windows, which only
+ * supports LC_TIME and always returns C locale.
+ */
+
+#ifndef LANGINFO_H
+#define LANGINFO_H
+
+typedef int nl_item;
+
+#define D_T_FMT  0x00
+#define D_FMT    0x01
+#define T_FMT    0x02
+
+#define DAY_1    0x03
+#define DAY_2    0x04
+#define DAY_3    0x05
+#define DAY_4    0x06
+#define DAY_5    0x07
+#define DAY_6    0x08
+#define DAY_7    0x09
+
+#define ABDAY_1  0x0A
+#define ABDAY_2  0x0B
+#define ABDAY_3  0x0C
+#define ABDAY_4  0x0D
+#define ABDAY_5  0x0E
+#define ABDAY_6  0x0F
+#define ABDAY_7  0x10
+
+#define MON_1    0x11
+#define MON_2    0x12
+#define MON_3    0x13
+#define MON_4    0x14
+#define MON_5    0x15
+#define MON_6    0x16
+#define MON_7    0x17
+#define MON_8    0x18
+#define MON_9    0x19
+#define MON_10   0x1A
+#define MON_11   0x1B
+#define MON_12   0x1C
+
+#define ABMON_1  0x1D
+#define ABMON_2  0x1E
+#define ABMON_3  0x1F
+#define ABMON_4  0x20
+#define ABMON_5  0x21
+#define ABMON_6  0x22
+#define ABMON_7  0x23
+#define ABMON_8  0x24
+#define ABMON_9  0x25
+#define ABMON_10 0x26
+#define ABMON_11 0x27
+#define ABMON_12 0x28
+
+#define AM_STR     0x29
+#define PM_STR     0x2A
+#define T_FMT_AMPM 0x2B
+
+static const char *lc_time_c[] = {
+    "%a %b %e %H:%M:%S %Y", /* D_T_FMT */
+    "%m/%d/%y",    /* D_FMT */
+    "%H:%M:%S",    /* T_FMT */
+
+    "Sunday",      /* DAY_1 */
+    "Monday",      /* DAY_2 */
+    "Tuesday",     /* DAY_3 */
+    "Wednesday",   /* DAY_4 */
+    "Thursday",    /* DAY_5 */
+    "Friday",      /* DAY_6 */
+    "Saturday",    /* DAY_7 */
+
+    "Sun",         /* ABDAY_1 */
+    "Mon",         /* ABDAY_2 */
+    "Tue",         /* ABDAY_3 */
+    "Wed",         /* ABDAY_4 */
+    "Thu",         /* ABDAY_5 */
+    "Fri",         /* ABDAY_6 */
+    "Sat",         /* ABDAY_7 */
+
+    "January",     /* MON_1 */
+    "February",    /* MON_2 */
+    "March",       /* MON_3 */
+    "April",       /* MON_4 */
+    "May",         /* MON_5 */
+    "June",        /* MON_6 */
+    "July",        /* MON_7 */
+    "August",      /* MON_8 */
+    "September",   /* MON_9 */
+    "October",     /* MON_10 */
+    "November",    /* MON_11 */
+    "December",    /* MON_12 */
+
+    "Jan",         /* ABMON_1 */
+    "Feb",         /* ABMON_2 */
+    "Mar",         /* ABMON_3 */
+    "Apr",         /* ABMON_4 */
+    "May",         /* ABMON_5 */
+    "Jun",         /* ABMON_6 */
+    "Jul",         /* ABMON_7 */
+    "Aug",         /* ABMON_8 */
+    "Sep",         /* ABMON_9 */
+    "Oct",         /* ABMON_10 */
+    "Nov",         /* ABMON_11 */
+    "Dec",         /* ABMON_12 */
+
+    "AM",          /* AM_STR */
+    "PM",          /* PM_STR */
+    "%I:%M:%S %p", /* T_FMT_AMPM */
+};
+
+static inline const char *nl_langinfo(nl_item item)
+{
+    if (item < 0 || 0x2B < item)
+        return "";
+    return lc_time_c[item];
+}
+#endif

--- a/include/fluent-bit/win32/strptime.h
+++ b/include/fluent-bit/win32/strptime.h
@@ -1,0 +1,245 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/* This file implements strptime(3) for Windows. I created this implementation
+ * based on the works of musl libc.
+ *
+ * ----
+ * Copyright © 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef STRPTIME_H
+#define STRPTIME_H
+
+#include <stdlib.h>
+#include <time.h>
+#include <ctype.h>
+#include <stddef.h>
+#include <string.h>
+#include "langinfo.h"
+
+static nl_item list_abday[] = {ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4,
+                               ABDAY_5, ABDAY_6, ABDAY_7};
+
+static nl_item list_abmon[] = {ABMON_1, ABMON_2, ABMON_3, ABMON_4,
+                               ABMON_5, ABMON_6, ABMON_7, ABMON_8,
+                               ABMON_9, ABMON_10, ABMON_11, ABMON_12};
+
+static char *strptime(const char *s, const char *f, struct tm *tm)
+{
+	int i, w, neg, adj, min, range, *dest, dummy;
+    nl_item *src;
+	const char *ex;
+	size_t len;
+	int want_century = 0, century = 0, relyear = 0;
+	while (*f) {
+		if (*f != '%') {
+			if (isspace(*f)) for (; *s && isspace(*s); s++);
+			else if (*s != *f) return 0;
+			else s++;
+			f++;
+			continue;
+		}
+		f++;
+		if (*f == '+') f++;
+		if (isdigit(*f)) {
+			char *new_f;
+			w=strtoul(f, &new_f, 10);
+			f = new_f;
+		} else {
+			w=-1;
+		}
+		adj=0;
+		switch (*f++) {
+		case 'a': case 'A':
+			dest = &tm->tm_wday;
+			src = list_abday;
+			range = 7;
+			goto symbolic_range;
+		case 'b': case 'B': case 'h':
+			dest = &tm->tm_mon;
+			src = list_abmon;
+			range = 12;
+			goto symbolic_range;
+		case 'c':
+			s = strptime(s, nl_langinfo(D_T_FMT), tm);
+			if (!s) return 0;
+			break;
+		case 'C':
+			dest = &century;
+			if (w<0) w=2;
+			want_century |= 2;
+			goto numeric_digits;
+		case 'd': case 'e':
+			dest = &tm->tm_mday;
+			min = 1;
+			range = 31;
+			goto numeric_range;
+		case 'D':
+			s = strptime(s, "%m/%d/%y", tm);
+			if (!s) return 0;
+			break;
+		case 'H':
+			dest = &tm->tm_hour;
+			min = 0;
+			range = 24;
+			goto numeric_range;
+		case 'I':
+			dest = &tm->tm_hour;
+			min = 1;
+			range = 12;
+			goto numeric_range;
+		case 'j':
+			dest = &tm->tm_yday;
+			min = 1;
+			range = 366;
+			adj = 1;
+			goto numeric_range;
+		case 'm':
+			dest = &tm->tm_mon;
+			min = 1;
+			range = 12;
+			adj = 1;
+			goto numeric_range;
+		case 'M':
+			dest = &tm->tm_min;
+			min = 0;
+			range = 60;
+			goto numeric_range;
+		case 'n': case 't':
+			for (; *s && isspace(*s); s++);
+			break;
+		case 'p':
+			ex = nl_langinfo(AM_STR);
+			len = strlen(ex);
+			if (!_strnicmp(s, ex, len)) {
+				tm->tm_hour %= 12;
+				s += len;
+				break;
+			}
+			ex = nl_langinfo(PM_STR);
+			len = strlen(ex);
+			if (!_strnicmp(s, ex, len)) {
+				tm->tm_hour %= 12;
+				tm->tm_hour += 12;
+				s += len;
+				break;
+			}
+			return 0;
+		case 'r':
+			s = strptime(s, nl_langinfo(T_FMT_AMPM), tm);
+			if (!s) return 0;
+			break;
+		case 'R':
+			s = strptime(s, "%H:%M", tm);
+			if (!s) return 0;
+			break;
+		case 'S':
+			dest = &tm->tm_sec;
+			min = 0;
+			range = 61;
+			goto numeric_range;
+		case 'T':
+			s = strptime(s, "%H:%M:%S", tm);
+			if (!s) return 0;
+			break;
+		case 'U':
+		case 'W':
+			/* Throw away result, for now. (FIXME?) */
+			dest = &dummy;
+			min = 0;
+			range = 54;
+			goto numeric_range;
+		case 'w':
+			dest = &tm->tm_wday;
+			min = 0;
+			range = 7;
+			goto numeric_range;
+		case 'x':
+			s = strptime(s, nl_langinfo(D_FMT), tm);
+			if (!s) return 0;
+			break;
+		case 'X':
+			s = strptime(s, nl_langinfo(T_FMT), tm);
+			if (!s) return 0;
+			break;
+		case 'y':
+			dest = &relyear;
+			w = 2;
+			want_century |= 1;
+			goto numeric_digits;
+		case 'Y':
+			dest = &tm->tm_year;
+			if (w<0) w=4;
+			adj = 1900;
+			want_century = 0;
+			goto numeric_digits;
+		case '%':
+			if (*s++ != '%') return 0;
+			break;
+		default:
+			return 0;
+		numeric_range:
+			if (!isdigit(*s)) return 0;
+			*dest = 0;
+			for (i=1; i<=min+range && isdigit(*s); i*=10)
+				*dest = *dest * 10 + *s++ - '0';
+			if (*dest - min >= (unsigned)range) return 0;
+			*dest -= adj;
+			switch((char *)dest - (char *)tm) {
+			case offsetof(struct tm, tm_yday):
+				;
+			}
+			goto update;
+		numeric_digits:
+			neg = 0;
+			if (*s == '+') s++;
+			else if (*s == '-') neg=1, s++;
+			if (!isdigit(*s)) return 0;
+			for (*dest=i=0; i<w && isdigit(*s); i++)
+				*dest = *dest * 10 + *s++ - '0';
+			if (neg) *dest = -*dest;
+			*dest -= adj;
+			goto update;
+		symbolic_range:
+			for (i=0; i<range; i++) {
+				ex = nl_langinfo(src[i]);
+				len = strlen(ex);
+				if (_strnicmp(s, ex, len)) continue;
+				s += len;
+				*dest = i % range;
+				break;
+			}
+			if (i<0) return 0;
+			goto update;
+		update:
+			//FIXME
+			;
+		}
+	}
+	if (want_century) {
+		tm->tm_year = relyear;
+		if (want_century & 2) tm->tm_year += century * 100 - 1900;
+		else if (tm->tm_year <= 68) tm->tm_year += 100;
+	}
+	return (char *)s;
+}
+#endif


### PR DESCRIPTION
This is a series of patches to make strptime(3) usable on Windows.

bcc55f04 compat: implement strptime(3) for Windows
9815a495 compat: implement langinfo.h for Windows

Note that the implementation is based on the one of musl libc
(I tweaked it so that it works on Windows without problems).
The license is MIT/X, so it should be compatible with fluent-bit.
