### PR TITLE
compat: add a set of macros for implementing strptime

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -32,6 +32,9 @@
 
 #define PATH_MAX MAX_PATH
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#define timezone _timezone
+#define tzname _tzname
+#define strncasecmp _strnicmp
 
 static inline int getpagesize(void)
 {


### PR DESCRIPTION
It's preparation for introducing a portable strptime function.

Since Windows calls some functions and constants differently, we
need these macros to compile the source code properly.

Part of #960