### PR TITLE
strptime: set up the build settings for flb_strptime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(FLB_SQLDB              "Enable SQL embedded DB"        No)
 option(FLB_HTTP_SERVER        "Enable HTTP Server"            No)
 option(FLB_BACKTRACE          "Enable stacktrace support"    Yes)
 option(FLB_LUAJIT             "Enable Lua Scripting support" Yes)
+option(FLB_SYSTEM_STRPTIME    "Use strptime in system libc"  Yes)
 option(FLB_STATIC_CONF        "Build binary using static configuration")
 option(FLB_CORO_STACK_SIZE    "Set coroutine stack size")
 
@@ -464,6 +465,11 @@ if("${GNU_HOST}" STREQUAL "")
     set(AUTOCONF_HOST_OPT "")
 else()
     set(AUTOCONF_HOST_OPT "--host=${GNU_HOST}")
+endif()
+
+# strptime(2) support
+if (FLB_SYSTEM_STRPTIME)
+  FLB_DEFINITION(FLB_HAVE_SYSTEM_STRPTIME)
 endif()
 
 # Memory Allocator

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -9,6 +9,9 @@ set(FLB_LUAJIT                Yes)
 set(FLB_EXAMPLES               No)
 set(FLB_PARSER                 No)
 
+# Windows does not support strptime(3)
+set(FLB_SYSTEM_STRPTIME        No)
+
 # INPUT plugins
 # =============
 set(FLB_IN_CPU                 No)

--- a/include/fluent-bit/flb_strptime.h
+++ b/include/fluent-bit/flb_strptime.h
@@ -1,0 +1,35 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_STRPTIME_H
+#define FLB_STRPTIME_H
+
+/* Load system strptime(3) */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
+#include <time.h>
+
+/* Override strptime if requested */
+#ifndef FLB_HAVE_SYSTEM_STRPTIME
+extern char *flb_strptime(const char *s, const char *format, struct tm *tm);
+#define strptime flb_strptime
+#endif
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,13 @@ if(FLB_STATIC_CONF)
     )
 endif()
 
+if(NOT FLB_SYSTEM_STRPTIME)
+  set(src
+    ${src}
+    "flb_strptime.c"
+    )
+endif()
+
 include(CheckSymbolExists)
 check_symbol_exists(accept4 "sys/socket.h" HAVE_ACCEPT4)
 

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -28,10 +28,10 @@
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_strptime.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <limits.h>
 #include <string.h>
 


### PR DESCRIPTION
This is a series of patches to introduce flb_strptime into the code base.

d9586753 build: set up cmake build procedures for flb_strptime.c
8670b19b parser: introduce flb_strptime.h to the codebase

The important part is that this adds a new option FLB_SYSTEM_STRPTIME
that allows us to switch between implementations of strptime(3).

    $ cmake -DFLB_SYSTEM_STRPTIME=Off ..

Right now this option is set to false only on Windows, but might be
useful on other platforms as well.

Depends on #1109
Part of #960
