### PR TITLE
out_http: add epoch option for json_date_format

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -110,6 +110,10 @@ static char *msgpack_to_json(struct flb_out_http *ctx, char *data, uint64_t byte
                 msgpack_pack_str(&tmp_pck, s);
                 msgpack_pack_str_body(&tmp_pck, time_formatted, s);
                 break;
+
+            case FLB_JSON_DATE_EPOCH:
+                msgpack_pack_uint64(&tmp_pck, (long long unsigned)(tms.tm.tv_sec));
+                break;
         }
 
         for (i = 0; i < map_size; i++) {

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -29,6 +29,7 @@
 
 #define FLB_JSON_DATE_DOUBLE      0
 #define FLB_JSON_DATE_ISO8601     1
+#define FLB_JSON_DATE_EPOCH       2
 #define FLB_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
 
 #define FLB_HTTP_CONTENT_TYPE   "Content-Type"

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -217,6 +217,9 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         if (strcasecmp(tmp, "iso8601") == 0) {
             ctx->json_date_format = FLB_JSON_DATE_ISO8601;
         }
+        if (strcasecmp(tmp, "epoch") == 0) {
+            ctx->json_date_format = FLB_JSON_DATE_EPOCH;
+        }
     }
 
     /* Date key for JSON output */


### PR DESCRIPTION
I am working with an API that expects the timestamp format to be an integer. Previously I've been able to work around this by using a Lua script, but it would be nicer if this could be accomplished inside the plugin since it's already handling timestamp fields.

I do not have a ton of experience working with C, so any feedback or direction would be much appreciated!