### PR TITLE
pipe: add a portable function to check EAGAIN

### DIFF
--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -40,6 +40,7 @@ int flb_pipe_create(flb_pipefd_t pipefd[2]);
 void flb_pipe_destroy(flb_pipefd_t pipefd[2]);
 int flb_pipe_close(flb_pipefd_t fd);
 int flb_pipe_set_nonblocking(flb_pipefd_t fd);
+int flb_pipe_check_eagain(void);
 ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
 ssize_t flb_pipe_write_all(int fd, void *buf, size_t count);
 

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -79,6 +79,11 @@ int flb_pipe_set_nonblocking(flb_pipefd_t fd)
     return evutil_make_socket_nonblocking(fd);
 }
 
+int flb_pipe_check_eagain(void)
+{
+    return WSAGetLastError() == WSAEWOULDBLOCK;
+}
+
 #else
 /* All other flavors of Unix/BSD are OK */
 
@@ -111,6 +116,10 @@ int flb_pipe_set_nonblocking(flb_pipefd_t fd)
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 }
 
+int flb_pipe_check_eagain(void)
+{
+    return errno == EAGAIN || errno == EWOULDBLOCK;
+}
 #endif
 
 /* Blocking read until receive 'count' bytes */


### PR DESCRIPTION
Since Windows has a different way to check what happend in the last
nonblocking read, it's convenient have a wrapper function for it.

We will use this function to port plugin/in_tail to Windows.

Part of #960