### PR TITLE
tail_file: open the target file in binary mode

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -553,7 +553,15 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         }
     }
 
+#ifdef _MSC_VER
+    /*
+     * We need O_BINARY here in order to avoid count errors due to
+     * Windows treating '\r\n' as 1 byte in text mode.
+     */
+    fd = _open(path, _O_RDONLY | _O_BINARY);
+#else
     fd = open(path, O_RDONLY);
+#endif
     if (fd == -1) {
         flb_errno();
         flb_error("[in_tail] could not open %s", path);


### PR DESCRIPTION
Unless we open the file with O_BINARY, Windows will treat "\r\n" as
1 byte. This has been causing in_tail malfunctioning on Windows, due
to the read count never reaching the actual file size.

Part of #960