### PR TITLE
Add buf_size property to exec plugin

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -39,7 +39,6 @@ static int in_exec_collect(struct flb_input_instance *i_ins,
     int ret = -1;
     size_t str_len = 0;
     FILE *cmdp = NULL;
-    char buf[DEFAULT_BUF_SIZE] = {0};
     struct flb_in_exec_config *exec_config = in_context;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
@@ -57,13 +56,13 @@ static int in_exec_collect(struct flb_input_instance *i_ins,
     }
 
     if (exec_config->parser) {
-        while (fgets(buf, DEFAULT_BUF_SIZE - 1,cmdp) != NULL) {
-            str_len = strlen(buf);
-            buf[str_len-1] = '\0'; /* chomp */
+        while (fgets(exec_config->buf, exec_config->buf_size, cmdp) != NULL) {
+            str_len = strnlen(exec_config->buf, exec_config->buf_size);
+            exec_config->buf[str_len - 1] = '\0'; /* chomp */
 
             flb_time_get(&out_time);
-            parser_ret = flb_parser_do(exec_config->parser, buf, str_len-1,
-                                &out_buf, &out_size, &out_time);
+            parser_ret = flb_parser_do(exec_config->parser, exec_config->buf, str_len - 1,
+                                       &out_buf, &out_size, &out_time);
             if (parser_ret >= 0) {
                 if (flb_time_to_double(&out_time) == 0.0) {
                     flb_time_get(&out_time);
@@ -82,12 +81,17 @@ static int in_exec_collect(struct flb_input_instance *i_ins,
                 msgpack_sbuffer_destroy(&mp_sbuf);
                 flb_free(out_buf);
             }
+            else {
+                flb_trace("[in_exec] tried to parse '%s'", exec_config->buf);
+                flb_trace("[in_exec] buf_size %zu", exec_config->buf_size);
+                flb_error("[in_exec] parser returned an error");
+            }
         }
     }
     else {
-        while (fgets(buf, DEFAULT_BUF_SIZE - 1,cmdp) != NULL) {
-            str_len = strlen(buf);
-            buf[str_len-1] = '\0'; /* chomp */
+        while (fgets(exec_config->buf, exec_config->buf_size, cmdp) != NULL) {
+            str_len = strnlen(exec_config->buf, exec_config->buf_size);
+            exec_config->buf[str_len - 1] = '\0'; /* chomp */
 
             /* Initialize local msgpack buffer */
             msgpack_sbuffer_init(&mp_sbuf);
@@ -99,9 +103,9 @@ static int in_exec_collect(struct flb_input_instance *i_ins,
 
             msgpack_pack_str(&mp_pck, 4);
             msgpack_pack_str_body(&mp_pck, "exec", 4);
-            msgpack_pack_str(&mp_pck, str_len-1);
+            msgpack_pack_str(&mp_pck, str_len - 1);
             msgpack_pack_str_body(&mp_pck,
-                                  buf, str_len-1);
+                                  exec_config->buf, str_len - 1);
 
             flb_input_chunk_append_raw(i_ins, NULL, 0,
                                        mp_sbuf.data, mp_sbuf.size);
@@ -146,6 +150,19 @@ static int in_exec_config_read(struct flb_in_exec_config *exec_config,
         }
     }
 
+    pval = flb_input_get_property("buf_size", in);
+    if (pval != NULL) {
+        exec_config->buf_size = (size_t) flb_utils_size_to_bytes(pval);
+
+        if (exec_config->buf_size == -1) {
+            flb_error("[in_exec] buffer size '%s' is invalid", pval);
+            return -1;
+        }
+    }
+    else {
+        exec_config->buf_size = DEFAULT_BUF_SIZE;
+    }
+
     /* interval settings */
     pval = flb_input_get_property("interval_sec", in);
     if (pval != NULL && atoi(pval) >= 0) {
@@ -178,6 +195,10 @@ static int in_exec_config_read(struct flb_in_exec_config *exec_config,
 static void delete_exec_config(struct flb_in_exec_config *exec_config)
 {
     if (exec_config) {
+        /* release buffer */
+        if (exec_config->buf != NULL) {
+            flb_free(exec_config->buf);
+        }
         flb_free(exec_config);
     }
 }
@@ -188,7 +209,7 @@ static int in_exec_init(struct flb_input_instance *in,
 {
     struct flb_in_exec_config *exec_config = NULL;
     int ret = -1;
-    int interval_sec  = 0;
+    int interval_sec = 0;
     int interval_nsec = 0;
 
     /* Allocate space for the configuration */
@@ -201,6 +222,12 @@ static int in_exec_init(struct flb_input_instance *in,
     /* Initialize exec config */
     ret = in_exec_config_read(exec_config, in, config, &interval_sec, &interval_nsec);
     if (ret < 0) {
+        goto init_error;
+    }
+
+    exec_config->buf = flb_malloc(exec_config->buf_size);
+    if (exec_config->buf == NULL) {
+        flb_error("could not allocate exec buffer");
         goto init_error;
     }
 

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -33,6 +33,8 @@
 struct flb_in_exec_config {
     char  *cmd;
     struct flb_parser  *parser;
+    char *buf;
+    size_t buf_size;
 };
 
 extern struct flb_input_plugin in_exec_plugin;


### PR DESCRIPTION
This is in relation to [this](https://github.com/fluent/fluent-bit/issues/1009) issue.

I used the **head** plugin as inspiration.

The idea is to be able to specify a `buf_size` property for the exec plugin to be able to handle outputs larger than 4kb.

A few things about this PR:
- the buffer is allocated once, at plugin init, exactly like the **head** plugin
- the buffer is deallocated at the exit of the plugin
- the size can be specified exactly like `mem_buf_limit` property, using human readable sizes like `1kb` or `3mb`. Fails if it doesn't understand the size.
- Added an error message and some trace messages in case the parser is specified and it fails.
- Uses `DEFAULT_BUF_SIZE` (4096) in case the `buf_size` property is not present.

Tested using this:
```bash
$ echo "{\"$(printf "%0.sa" {1..2048})\":\"$(printf "%0.sb" {1..2048})\"}" > /tmp/big-foo.json
$ wc -c /tmp/big-foo.json #    4104 /tmp/big-foo.json

$ cat /tmp/parsers.conf
[PARSER]
    Name        json
    Format      json

$ ./bin/fluent-bit -f 1 -i exec -p 'command=cat /tmp/big-foo.json' -p 'parser=json' -p 'BuF_Size=1kb' -R /tmp/parsers.conf -o stdout
# fails with this line
# [2019/02/15 18:26:52] [error] [in_exec] parser returned an error

$ ./bin/fluent-bit -f 1 -i exec -p 'command=cat /tmp/big-foo.json' -p 'parser=json' -p 'BuF_Size=5kb' -R /tmp/parsers.conf -o stdout
# works
```

Cheers!