### PR TITLE
[out_forward] Don't assumed 'secure' mode just because TLS is on

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -428,15 +428,14 @@ static int forward_config_ha(char *upstream_file,
         }
         fc->secured = FLB_FALSE;
 
-        /* Is TLS enabled ? */
-        if (node->tls_enabled == FLB_TRUE) {
-            fc->secured = FLB_TRUE;
-        }
-
         /* Shared key (secure_forward) */
         tmp = flb_upstream_node_get_property("shared_key", node);
         if (tmp) {
             fc->shared_key = flb_sds_create(tmp);
+	    /* Is TLS enabled ? */
+	    if (node->tls_enabled == FLB_TRUE) {
+		fc->secured = FLB_TRUE;
+	    }
         }
         else {
             fc->shared_key = NULL;
@@ -500,7 +499,9 @@ static int forward_config_simple(struct flb_forward *ctx,
 #ifdef FLB_HAVE_TLS
     if (ins->use_tls == FLB_TRUE) {
         io_flags = FLB_IO_TLS;
-        fc->secured = FLB_TRUE;
+	if (fc->shared_key) {
+	    fc->secured = FLB_TRUE;
+	}
     }
     else {
         io_flags = FLB_IO_TCP;


### PR DESCRIPTION
If we are using fluent-bit -> fluent-bit (e.g. fwd from one
to another) we might have a TLS tunnel in the middle courtesy
of e.g. stunnel. We are secured by client-certificate, but not
by 'forward protocol secure mode'.

Signed-off-by: Don Bowman <don@agilicus.com>