### PR TITLE
in_tail: use flb_compat.h instead of unistd.h

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -20,11 +20,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_error.h>

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -20,11 +20,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <time.h>
 #include <libgen.h>
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_parser.h>

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -23,8 +23,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_input.h>
 
 #include "tail.h"

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -20,12 +20,12 @@
 
 #define _DEFAULT_SOURCE
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "tail_file.h"
 #include "tail_db.h"

--- a/plugins/in_tail/tail_scan.c
+++ b/plugins/in_tail/tail_scan.c
@@ -20,10 +20,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <glob.h>
 #include <fnmatch.h>
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_utils.h>
 

--- a/plugins/in_tail/tail_signal.h
+++ b/plugins/in_tail/tail_signal.h
@@ -22,7 +22,6 @@
 #define FLB_TAIL_SIGNAL_H
 
 #include "tail_config.h"
-#include <unistd.h>
 
 static inline int tail_signal_manager(struct flb_tail_config *ctx)
 {


### PR DESCRIPTION
We need this in order to make the source tree compilable on Windows.
    
Since Windows lacks unistd.h, we need to include it indirectly though
flb_compat.h.
    


Part of #960