### PR TITLE
in_tail: use {0} instead of {} to initialize structs

### DIFF
--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -255,7 +255,7 @@ void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     size_t repl_line_len = 0;
     void *out_buf = NULL;
     size_t out_size;
-    struct flb_time out_time = {};
+    struct flb_time out_time = {0};
     time_t now = time(NULL);
 
     if (flb_sds_len(file->dmode_lastline) == 0) {

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -186,7 +186,7 @@ static int process_content(struct flb_tail_file *file, off_t *bytes)
     char *repl_line;
     size_t repl_line_len;
     time_t now = time(NULL);
-    struct flb_time out_time = {};
+    struct flb_time out_time = {0};
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
     msgpack_sbuffer *out_sbuf;


### PR DESCRIPTION
Zero-initialization with 'struct foo bar = {}' is a GCC extension and
MSVC does not support it.

Instead, we need to do 'struct foo bar = {0}' to be portable.
(To my knowledge, this is valid at least since C89)

Part of #960