### PR TITLE
parser: do not abort instantly on '%z'/'%Z' on Windows

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -209,7 +209,7 @@ struct flb_parser *flb_parser_create(char *name, char *format,
         /* Check if the format contains a timezone (%z) */
         if (strstr(p->time_fmt, "%z") || strstr(p->time_fmt, "%Z") ||
             strstr(p->time_fmt, "%SZ") || strstr(p->time_fmt, "%S.%LZ")) {
-#ifdef FLB_HAVE_GMTOFF
+#if defined(FLB_HAVE_GMTOFF) || !defined(FLB_HAVE_SYSTEM_STRPTIME)
             p->time_with_tz = FLB_TRUE;
 #else
             flb_error("[parser] timezone offset not supported");


### PR DESCRIPTION
Right now, the follwing command results in an error on startup on Windows:

    PS> .\bin\fluent-bit -R ..\conf\parsers.conf ...

This is just because flb_parser is too strict on tm_gmtoff support,
and would abort if SOME of the parser definitions include '%Z'/'%z'
in their Time_Format.

In truth, it's perfectly fine to use these parsers on Windows, since
our strptime implementation can handle %Z/%z without any problems. So
let's just relax the restriction here.

Part of #960