### PR TITLE
in_cpu: extend to support sec.nanosecond for sub-second sample rate

### DIFF
--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -180,9 +180,23 @@ static int in_cpu_init(struct flb_input_instance *in,
 
     /* Collection time setting */
     pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && flb_utils_time_split(pval, &ctx->interval_sec, &ctx->interval_nsec) == 0) {
+    if (pval != NULL && atoi(pval) >= 0) {
+        ctx->interval_sec = atoi(pval);
     }
     else {
+        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
+    }
+
+    pval = flb_input_get_property("interval_nsec", in);
+    if (pval != NULL && atoi(pval) >= 0) {
+        ctx->interval_nsec = atoi(pval);
+    }
+    else {
+        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
+    }
+
+    if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
+        /* Illegal settings. Override them. */
         ctx->interval_sec = DEFAULT_INTERVAL_SEC;
         ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
     }

--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -180,13 +180,12 @@ static int in_cpu_init(struct flb_input_instance *in,
 
     /* Collection time setting */
     pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) > 0) {
-        ctx->interval_sec = atoi(pval);
+    if (pval != NULL && flb_utils_time_split(pval, &ctx->interval_sec, &ctx->interval_nsec) == 0) {
     }
     else {
         ctx->interval_sec = DEFAULT_INTERVAL_SEC;
+        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
     }
-    ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
 
     /* Initialize buffers for CPU stats */
     ret = snapshots_init(ctx->n_processors, &ctx->cstats);

--- a/plugins/in_cpu/in_cpu.h
+++ b/plugins/in_cpu/in_cpu.h
@@ -73,7 +73,7 @@ struct flb_in_cpu_config {
     int cpu_ticks;      /* CPU ticks (Kernel setting) */
     int coll_fd;        /* collector id/fd            */
     int interval_sec;   /* interval collection time (Second) */
-    long interval_nsec; /* interval collection time (Nanosecond) */
+    int interval_nsec;  /* interval collection time (Nanosecond) */
     struct cpu_stats cstats;
     struct flb_input_instance *i_ins;
 };

--- a/plugins/in_cpu/in_cpu.h
+++ b/plugins/in_cpu/in_cpu.h
@@ -72,8 +72,8 @@ struct flb_in_cpu_config {
     int n_processors;   /* number of core processors  */
     int cpu_ticks;      /* CPU ticks (Kernel setting) */
     int coll_fd;        /* collector id/fd            */
-    int interval_sec;    /* interval collection time (Second) */
-    int interval_nsec;   /* interval collection time (Nanosecond) */
+    int interval_sec;   /* interval collection time (Second) */
+    long interval_nsec; /* interval collection time (Nanosecond) */
     struct cpu_stats cstats;
     struct flb_input_instance *i_ins;
 };
@@ -107,7 +107,7 @@ static inline double CPU_METRIC_SYS_AVERAGE(unsigned long pre, unsigned long now
     }
 
     diff = ULL_ABS(now, pre);
-    total = (((diff / ctx->cpu_ticks) * 100) / ctx->n_processors) / ctx->interval_sec;
+    total = (((diff / ctx->cpu_ticks) * 100) / ctx->n_processors) / (ctx->interval_sec + 1e-9*ctx->interval_nsec);
 
     return total;
 }
@@ -124,7 +124,7 @@ static inline double CPU_METRIC_USAGE(unsigned long pre, unsigned long now,
     }
 
     diff = ULL_ABS(now, pre);
-    total = ((diff * 100) / ctx->cpu_ticks) / ctx->interval_sec;
+    total = ((diff * 100) / ctx->cpu_ticks) / (ctx->interval_sec + 1e-9*ctx->interval_nsec);
     return total;
 }
 


### PR DESCRIPTION
Seems like extending the CPU Usage input plugin to sub-second sampling interval is a straight-forward sort of change.

For example:

```
$ fluent-bit -i cpu -p interval_sec=0.500000000 -F record_modifier -m '*' -p 'Whitelist_key=cpu_p' -o stdout -p format=json_lines -p json_date_format=iso8601  -m '*'
...
 {"date":"2019-02-20T11:40:22.500103Z", "cpu_p":12.500000}
 {"date":"2019-02-20T11:40:23.000148Z", "cpu_p":10.000000}
 {"date":"2019-02-20T11:40:23.500153Z", "cpu_p":5.000000}
 {"date":"2019-02-20T11:40:24.000157Z", "cpu_p":5.000000}
...
```

It would be nicer to have another utility function for accepting an optional unit such as 'ms', 'milis', 'micros' or 'nanos' as a suffix to a floating-point interval?