### PR TITLE
Add backslash escape for output_influxdb plugin

### DIFF
--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -34,7 +34,7 @@ static int influxdb_escape(char *out, const char *str, int size, bool quote) {
     int i;
     for (i = 0; i < size; ++i) {
         char ch = str[i];
-        if (quote ? (ch == '"') : (isspace(ch) || ch == ',' || ch == '=')) {
+        if (quote ? (ch == '"' || ch == '\\') : (isspace(ch) || ch == ',' || ch == '=')) {
             out[out_size++] = '\\';
         }
         out[out_size++] = ch;


### PR DESCRIPTION
Refer to influxdata git issue
https://github.com/influxdata/docs.influxdata.com/issues/1295
Although the line protocol doesn't mention about escaping backslash, however, consider using fluent-bit to process docker container logs, sample data is below
log="msg=\\\"faulty\\\"",stream="stderr",time="2019-02-15T01:56:37.53737463Z"

out-influxdb plugin will escape it to
log="msg=\\\\\"faulty\\\\\"",stream="stderr",time="2019-02-15T01:56:37.53737463Z"

If we post this data to influxdb, it will report 400 error
curl -i -XPOST 'http://127.0.0.1:8086/write?db=fluentbit' --data-binary 'faultylog log="msg=\\\\\"faulty\\\\\"",stream="stderr",time="2019-02-15T01:56:37.53737463Z"'

This fix is added to escape backslash so the correct post request will be and it can be accepted by influxdb
curl -i -XPOST 'http://127.0.0.1:8086/write?db=fluentbit' --data-binary 'faultylog log="msg=\\\\\\"faulty\\\\\\"",stream="stderr",time="2019-02-15T01:56:37.53737463Z"'