### PR TITLE
tail: remove libgen.h from the list of headers to include

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -22,7 +22,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
-#include <libgen.h>
 
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>


### PR DESCRIPTION
We don't need this since this header file is automatically included
via flb_compat.h (on UNIX platforms).

So just remove it to make the source code compatible with Windows.

Part of #960