### PR TITLE
include k8s nginx ingress parser

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -27,7 +27,7 @@
 [PARSER]
     Name        k8s-nginx-ingress
     Format      regex
-    Regex       ^(?<host>[^ ]*) - \[(?<real_ip>)[^ ]*\] - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<last>[^$]*)
+    Regex       ^(?<host>[^ ]*) - \[(?<real_ip>[^ ]*)\] - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<last>[^$]*)
     Time_Key    time
     Time_Format %d/%b/%Y:%H:%M:%S %z
 

--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -25,6 +25,13 @@
     Time_Format %d/%b/%Y:%H:%M:%S %z
 
 [PARSER]
+    Name        k8s-nginx-ingress
+    Format      regex
+    Regex       ^(?<host>[^ ]*) - \[(?<real_ip>)[^ ]*\] - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<last>[^$]*)
+    Time_Key    time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
     Name   json
     Format json
     Time_Key time


### PR DESCRIPTION
Seeing that `fluent-bit` and NGINX ingress controller are widely used in k8s, it seems like a good idea to include a parser out of the box.

Thanks to @donbowman https://blog.donbowman.ca/2018/09/13/increasing-the-usefulness-of-your-kubernetes-ingress-logging/ for creating the parser.