### PR TITLE
filter_kubernetes: allow user to decide whether they want to include labels

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -52,6 +52,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     }
     ctx->config = config;
     ctx->merge_log = FLB_FALSE;
+    ctx->labels = FLB_TRUE;
     ctx->annotations = FLB_TRUE;
     ctx->dummy_meta = FLB_FALSE;
     ctx->tls_debug = -1;
@@ -201,6 +202,12 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;
+    }
+
+    /* Include Kubernetes Labels in the final record */
+    tmp = flb_filter_get_property("labels", i);
+    if (tmp) {
+        ctx->labels = flb_utils_bool(tmp);
     }
 
     /* Include Kubernetes Annotations in the final record */

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -63,6 +63,7 @@ struct flb_kube {
     int api_port;
     int api_https;
     int use_journal;
+    int labels;
     int annotations;
     int dummy_meta;
     int tls_debug;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -403,7 +403,9 @@ static int merge_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
         }
         else if (size == 6 && strncmp(ptr, "labels", 6) == 0) {
             have_labels = i;
-            map_size++;
+            if (ctx->labels == FLB_TRUE) {
+                map_size++;
+            }
         }
 
         else if (size == 11 && strncmp(ptr, "annotations", 11) == 0) {
@@ -455,7 +457,7 @@ static int merge_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
         msgpack_pack_object(&mp_pck, v);
     }
 
-    if (have_labels >= 0) {
+    if (have_labels >= 0 && ctx->labels == FLB_TRUE) {
         k = meta_val.via.map.ptr[have_labels].key;
         v = meta_val.via.map.ptr[have_labels].val;
 


### PR DESCRIPTION
[#440](https://github.com/fluent/fluent-bit/pull/440) makes possible to exclude the `Annotations` from the extra metadata. This PR does the same for kubernetes `Labels`.