### PR TITLE
tail: fix SIGSEGV due to the incompatible type length (int/intptr_t)

### DIFF
--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -38,8 +38,13 @@
 
 struct flb_tail_config {
     int fd_notify;             /* inotify fd               */
+#ifdef _WIN32
+    intptr_t ch_manager[2];    /* pipe: channel manager    */
+    intptr_t ch_pending[2];    /* pipe: pending events     */
+#else
     int ch_manager[2];         /* pipe: channel manager    */
     int ch_pending[2];         /* pipe: pending events     */
+#endif
 
     /* Buffer Config */
     size_t buf_chunk_size;     /* allocation chunks        */


### PR DESCRIPTION
This is essentially the same fix as 13166dfb.

Since these pipe fds are actually sockets on Windows, we need to
use a 64-bit type (intptr_t) instead of 32-bit one (int) to hold
the descriptor properly.

Otherwise memory can silently get corrupt due to the type-length
mismatch, resulting in SIGSEGV.

Part of #960