### PR TITLE
in_tail: include libgen.h though flb_compat.h for portability

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -79,6 +79,7 @@ extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <libgen.h>
 #endif
 
 #endif

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -22,7 +22,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
-#include <libgen.h>
 
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>


### PR DESCRIPTION
This moves the include statement for libgen.h (the header for basename
and dirname) to flb_compat.h.

This is just for portability; Since Windows does not provide libgen.h,
we need to include it only on UNIX systems.

Part of #960 