### PR TITLE
in_tail: migrate pipe operations to flb_pipe_* functions

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -46,7 +46,7 @@ static inline int consume_byte(int fd)
     uint64_t val;
 
     /* We need to consume the byte */
-    ret = read(fd, &val, sizeof(val));
+    ret = flb_pipe_r(fd, &val, sizeof(val));
     if (ret <= 0) {
         flb_errno();
         return -1;


### PR DESCRIPTION
The reason we need this patch is that Windows does not support pipe(2),
which in_tail uses for internal communication (e.g. for notifying file
rotations).

This patch migrates all these non-portable calls to flb_pipe_*() and
make the internal communication working properly on Windows.

Part of #960