### PR TITLE
build: enable FLB_PARSER on Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -7,7 +7,7 @@ set(FLB_REGEX                 Yes)
 set(FLB_BACKTRACE              No)
 set(FLB_LUAJIT                Yes)
 set(FLB_EXAMPLES               No)
-set(FLB_PARSER                 No)
+set(FLB_PARSER                Yes)
 
 # Windows does not support strptime(3)
 set(FLB_SYSTEM_STRPTIME        No)


### PR DESCRIPTION
We have migrated flb_parser to Windows on 1ace90224, so this patch
enables the build option by default on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>