### PR TITLE
in_tail: avoid double freeing the same timeout event object

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -250,8 +250,8 @@ void flb_config_exit(struct flb_config *config)
         collector = mk_list_entry(head, struct flb_input_collector, _head);
 
         if (collector->type == FLB_COLLECT_TIME) {
-            mk_event_timeout_destroy(config->evl, &collector->event);
             if (collector->fd_timer > 0) {
+                mk_event_timeout_destroy(config->evl, &collector->event);
                 mk_event_closesocket(collector->fd_timer);
             }
         } else {


### PR DESCRIPTION
If the input plugin supports cb_pause() interface, we ended up freeing
the same timeout object twice while shutdown, because of the function
flb_input_pause_all() destroying the timeout object in order to halt it.

This issue has been causing SIGSEGV on libevent backend (and probably
on select backend).

Part of #960