### PR TITLE
Add map support for out_Influxdb plugin

### DIFF
--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -34,7 +34,7 @@ static int influxdb_escape(char *out, const char *str, int size, bool quote) {
     int i;
     for (i = 0; i < size; ++i) {
         char ch = str[i];
-        if (quote ? (ch == '"') : (isspace(ch) || ch == ',' || ch == '=')) {
+        if (quote ? (ch == '"' || ch == '\\') : (isspace(ch) || ch == ',' || ch == '=')) {
             out[out_size++] = '\\';
         }
         out[out_size++] = ch;


### PR DESCRIPTION
out_Influxdb doesn't support adding map object to influxdb, this PR will convert map object to string so out_influxdb can insert it to influxdb with line protocol.