### PR TITLE
out_es: Fix elasticsearch_error_check, add trace_error output

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -50,6 +50,7 @@ struct flb_elasticsearch {
     int replace_dots;
 
     int trace_output;
+    int trace_error;
 
     /*
      * Logstash compatibility options

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -288,6 +288,13 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     else {
         ctx->trace_output = FLB_FALSE;
     }
+    tmp = flb_output_get_property("Trace_Error", ins);
+    if (tmp) {
+        ctx->trace_error = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->trace_error = FLB_FALSE;
+    }
 
     return ctx;
 }


### PR DESCRIPTION
This change does two things. In elasticsearch_error_check()
it was incorrectly returning 'was an error' all the time
(e.g. whenever the response msgpack *could* be unpacked).

Add a 'trace_error' flag to elasticsearch output to get
a raw dump of the json messages that cause a failure, in order
to debug why the failure occurred.

Signed-off-by: Don Bowman <don@agilicus.com>