### PR TITLE
utils: Protect flb_utils_split() from null input

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -212,6 +212,10 @@ struct mk_list *flb_utils_split(char *line, int separator, int max_split)
     struct mk_list *list;
     struct flb_split_entry *new;
 
+    if (!line) {
+        return NULL;
+    }
+
     list = flb_malloc(sizeof(struct mk_list));
     if (!list) {
         flb_errno();


### PR DESCRIPTION
flb_utils_split() can be called with a null line
in the case where e.g. an environment variable is used
that is not set. For example:

```
[OUTPUT]
    Match *
    Name  http
    Host   127.0.0.1
    Port   8000
    URI    ${URI}
```

if URI is not set in the environment.

Signed-off-by: Don Bowman <don@agilicus.com>