### PR TITLE
[core/out_http/out_stdout] De-duplicate msgpack to json

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -186,7 +186,7 @@ struct flb_config {
 
 struct flb_config *flb_config_init();
 void flb_config_exit(struct flb_config *config);
-char *flb_config_prop_get(char *key, struct mk_list *list);
+char *flb_config_prop_get(const char *key, struct mk_list *list);
 int flb_config_set_property(struct flb_config *config,
                             char *k, char *v);
 #ifdef FLB_HAVE_STATIC_CONF

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -40,6 +40,7 @@
 #include <fluent-bit/flb_thread.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_pack.h>
 
 #ifdef FLB_HAVE_REGEX
 #include <fluent-bit/flb_regex.h>
@@ -490,7 +491,9 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
                                            char *output, void *data);
 
 int flb_output_set_property(struct flb_output_instance *out, char *k, char *v);
-char *flb_output_get_property(char *key, struct flb_output_instance *o_ins);
+char *flb_output_get_property(const char *key, struct flb_output_instance *o_ins);
+flb_date_format_t flb_output_get_date_format(const char *key,
+                                             struct flb_output_instance *o_ins);
 void flb_output_net_default(char *host, int port,
                             struct flb_output_instance *o_ins);
 void flb_output_pre_run(struct flb_config *config);

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -21,6 +21,18 @@
 #ifndef FLB_PACK_H
 #define FLB_PACK_H
 
+typedef enum {
+    FLB_DATE_FORMAT_DOUBLE,
+    FLB_DATE_FORMAT_ISO8601,
+    FLB_DATE_FORMAT_EPOCH
+} flb_date_format_t;
+
+typedef enum {
+    FLB_JSON_FORMAT_JSON,
+    FLB_JSON_FORMAT_STREAM,
+    FLB_JSON_FORMAT_LINES
+} flb_json_format_t;
+
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_time.h>
@@ -42,6 +54,12 @@ struct flb_pack_state {
     jsmn_parser parser;   /* parser state            */
 };
 
+char *flb_msgpack_to_json_with_date(char *data,
+                                    uint64_t bytes,
+                                    uint64_t *out_size,
+                                    const char *date_key,
+                                    flb_date_format_t date_format,
+				    flb_json_format_t out_format);
 int flb_json_tokenise(char *js, size_t len, struct flb_pack_state *state);
 int flb_pack_json(char *js, size_t len, char **buffer, size_t *size,
                   int *root_type);

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -22,13 +22,13 @@
 #define FLB_TIME_H
 
 #include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_time_utils.h>
 
 #include <time.h>
 #include <msgpack.h>
 struct flb_time {
     struct timespec tm;
 };
+#include <fluent-bit/flb_time_utils.h>
 
 /*
    to represent eventtime of fluentd

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -39,142 +39,6 @@
 
 struct flb_output_plugin out_http_plugin;
 
-static char *msgpack_to_json(struct flb_out_http *ctx, char *data, uint64_t bytes, uint64_t *out_size)
-{
-    int i;
-    int ret;
-    int len;
-    int array_size = 0;
-    int map_size;
-    size_t off = 0;
-    char *json_buf;
-    size_t json_size;
-    char time_formatted[32];
-    size_t s;
-    msgpack_unpacked result;
-    msgpack_object root;
-    msgpack_object map;
-    msgpack_sbuffer tmp_sbuf;
-    msgpack_packer tmp_pck;
-    msgpack_object *obj;
-    struct tm tm;
-    struct flb_time tms;
-
-    /* Iterate the original buffer and perform adjustments */
-    msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
-        array_size++;
-    }
-    msgpack_unpacked_destroy(&result);
-    msgpack_unpacked_init(&result);
-
-    /* Create temporal msgpack buffer */
-    msgpack_sbuffer_init(&tmp_sbuf);
-    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
-    msgpack_pack_array(&tmp_pck, array_size);
-
-    off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
-        /* Each array must have two entries: time and record */
-        root = result.data;
-        if (root.via.array.size != 2) {
-            continue;
-        }
-
-        flb_time_pop_from_msgpack(&tms, &result, &obj);
-        map = root.via.array.ptr[1];
-
-        map_size = map.via.map.size;
-        msgpack_pack_map(&tmp_pck, map_size + 1);
-
-        /* Append date key */
-        msgpack_pack_str(&tmp_pck, ctx->json_date_key_len);
-        msgpack_pack_str_body(&tmp_pck, ctx->json_date_key, ctx->json_date_key_len);
-
-        /* Append date value */
-        switch (ctx->json_date_format) {
-            case FLB_JSON_DATE_DOUBLE:
-                msgpack_pack_double(&tmp_pck, flb_time_to_double(&tms));
-                break;
-
-            case FLB_JSON_DATE_ISO8601:
-                /* Format the time; use microsecond precision (not nanoseconds). */
-                gmtime_r(&tms.tm.tv_sec, &tm);
-                s = strftime(time_formatted, sizeof(time_formatted) - 1,
-                             FLB_JSON_DATE_ISO8601_FMT, &tm);
-
-                len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
-                               ".%06" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec / 1000);
-                s += len;
-
-                msgpack_pack_str(&tmp_pck, s);
-                msgpack_pack_str_body(&tmp_pck, time_formatted, s);
-                break;
-
-            case FLB_JSON_DATE_EPOCH:
-                msgpack_pack_uint64(&tmp_pck, (long long unsigned)(tms.tm.tv_sec));
-                break;
-        }
-
-        for (i = 0; i < map_size; i++) {
-            msgpack_object *k = &map.via.map.ptr[i].key;
-            msgpack_object *v = &map.via.map.ptr[i].val;
-
-            msgpack_pack_object(&tmp_pck, *k);
-            msgpack_pack_object(&tmp_pck, *v);
-        }
-    }
-
-    /* Release msgpack */
-    msgpack_unpacked_destroy(&result);
-
-    /* Format to JSON */
-    ret = flb_msgpack_raw_to_json_str(tmp_sbuf.data, tmp_sbuf.size,
-                                      &json_buf, &json_size);
-    if (ret != 0) {
-        msgpack_sbuffer_destroy(&tmp_sbuf);
-        return NULL;
-    }
-
-    /* Optionally convert to JSON stream from JSON array */
-    if ((ctx->out_format == FLB_HTTP_OUT_JSON_STREAM) ||
-        (ctx->out_format == FLB_HTTP_OUT_JSON_LINES)) {
-        char *p;
-        char *end = json_buf + json_size;
-        int level = 0;
-        int in_string = FLB_FALSE;
-        int in_escape = FLB_FALSE;
-        char separator = ' ';
-        if (ctx->out_format == FLB_HTTP_OUT_JSON_LINES) {
-            separator = '\n';
-        }
-
-        for (p = json_buf; p!=end; p++) {
-            if (in_escape)
-                in_escape = FLB_FALSE;
-            else if (*p == '\\')
-                in_escape = FLB_TRUE;
-            else if (*p == '"')
-                in_string = !in_string;
-            else if (!in_string) {
-                if (*p == '{')
-                    level++;
-                else if (*p == '}')
-                    level--;
-                else if ((*p == '[' || *p == ']') && level == 0)
-                    *p = ' ';
-                else if (*p == ',' && level == 0)
-                    *p = separator;
-            }
-        }
-    }
-
-    msgpack_sbuffer_destroy(&tmp_sbuf);
-
-    *out_size = json_size;
-    return json_buf;
-}
-
 static int cb_http_init(struct flb_output_instance *ins,
                         struct flb_config *config, void *data)
 {
@@ -384,7 +248,18 @@ static void cb_http_flush(void *data, size_t bytes,
     if ((ctx->out_format == FLB_HTTP_OUT_JSON) ||
         (ctx->out_format == FLB_HTTP_OUT_JSON_STREAM) ||
         (ctx->out_format == FLB_HTTP_OUT_JSON_LINES)) {
-        body = msgpack_to_json(ctx, data, bytes, &body_len);
+
+        flb_json_format_t out_format = FLB_JSON_FORMAT_JSON;
+        if (ctx->out_format == FLB_JSON_FORMAT_STREAM) {
+            out_format = FLB_JSON_FORMAT_STREAM;
+        } else if (ctx->out_format == FLB_JSON_FORMAT_LINES) {
+            out_format = FLB_JSON_FORMAT_LINES;
+        }
+
+        body = flb_msgpack_to_json_with_date(data, bytes, &body_len,
+                                   ctx->json_date_key,
+                                   ctx->json_date_format,
+                                   out_format);
         if (body != NULL) {
             ret = http_post(ctx, body, body_len, tag, tag_len);
             flb_free(body);

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -49,9 +49,8 @@ struct flb_out_http {
     /* Output format */
     int out_format;
 
-    int json_date_format;
+    flb_date_format_t json_date_format;
     char *json_date_key;
-    size_t json_date_key_len;
 
     /* HTTP URI */
     char *uri;

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -211,21 +211,11 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     }
 
     /* Date format for JSON output */
-    ctx->json_date_format = FLB_JSON_DATE_DOUBLE;
-    tmp = flb_output_get_property("json_date_format", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "iso8601") == 0) {
-            ctx->json_date_format = FLB_JSON_DATE_ISO8601;
-        }
-        if (strcasecmp(tmp, "epoch") == 0) {
-            ctx->json_date_format = FLB_JSON_DATE_EPOCH;
-        }
-    }
+    ctx->json_date_format = flb_output_get_date_format("json_date_format", ins);
 
     /* Date key for JSON output */
     tmp = flb_output_get_property("json_date_key", ins);
     ctx->json_date_key = flb_strdup(tmp ? tmp : "date");
-    ctx->json_date_key_len = strlen(ctx->json_date_key);
 
     /* Config Gelf_Timestamp_Key */
     tmp = flb_output_get_property("gelf_timestamp_key", ins);

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -27,136 +27,6 @@
 
 #include "stdout.h"
 
-static char *msgpack_to_json(struct flb_out_stdout_config *ctx,
-                             char *data, uint64_t bytes,
-                             uint64_t *out_size)
-{
-    int i;
-    int ret;
-    int len;
-    int array_size = 0;
-    int map_size;
-    size_t off = 0;
-    char *json_buf;
-    size_t json_size;
-    char time_formatted[32];
-    size_t s;
-    msgpack_unpacked result;
-    msgpack_object root;
-    msgpack_object map;
-    msgpack_sbuffer tmp_sbuf;
-    msgpack_packer tmp_pck;
-    msgpack_object *obj;
-    struct tm tm;
-    struct flb_time tms;
-
-    /* Iterate the original buffer and perform adjustments */
-    msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
-        array_size++;
-    }
-    msgpack_unpacked_destroy(&result);
-    msgpack_unpacked_init(&result);
-
-    /* Create temporal msgpack buffer */
-    msgpack_sbuffer_init(&tmp_sbuf);
-    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
-    msgpack_pack_array(&tmp_pck, array_size);
-
-    off = 0;
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
-        /* Each array must have two entries: time and record */
-        root = result.data;
-        if (root.via.array.size != 2) {
-            continue;
-        }
-
-        flb_time_pop_from_msgpack(&tms, &result, &obj);
-        map = root.via.array.ptr[1];
-
-        map_size = map.via.map.size;
-        msgpack_pack_map(&tmp_pck, map_size + 1);
-
-        /* Append date key */
-        msgpack_pack_str(&tmp_pck, ctx->json_date_key_len);
-        msgpack_pack_str_body(&tmp_pck, ctx->json_date_key, ctx->json_date_key_len);
-
-        /* Append date value */
-        switch (ctx->json_date_format) {
-            case FLB_STDOUT_JSON_DATE_DOUBLE:
-                msgpack_pack_double(&tmp_pck, flb_time_to_double(&tms));
-                break;
-
-            case FLB_STDOUT_JSON_DATE_ISO8601:
-                /* Format the time; use microsecond precision (not nanoseconds). */
-                gmtime_r(&tms.tm.tv_sec, &tm);
-                s = strftime(time_formatted, sizeof(time_formatted) - 1,
-                             FLB_STDOUT_JSON_DATE_ISO8601_FMT, &tm);
-
-                len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
-                               ".%06" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec / 1000);
-                s += len;
-
-                msgpack_pack_str(&tmp_pck, s);
-                msgpack_pack_str_body(&tmp_pck, time_formatted, s);
-                break;
-        }
-
-        for (i = 0; i < map_size; i++) {
-            msgpack_object *k = &map.via.map.ptr[i].key;
-            msgpack_object *v = &map.via.map.ptr[i].val;
-
-            msgpack_pack_object(&tmp_pck, *k);
-            msgpack_pack_object(&tmp_pck, *v);
-        }
-    }
-
-    /* Release msgpack */
-    msgpack_unpacked_destroy(&result);
-
-    /* Format to JSON */
-    ret = flb_msgpack_raw_to_json_str(tmp_sbuf.data, tmp_sbuf.size,
-                                      &json_buf, &json_size);
-
-    /* Convert to JSON lines from JSON array */
-    {
-        char *p;
-        char *end = json_buf + json_size;
-        int level = 0;
-        int in_string = FLB_FALSE;
-        int in_escape = FLB_FALSE;
-        char separator = '\n';
-
-        for (p = json_buf; p!=end; p++) {
-            if (in_escape)
-                in_escape = FLB_FALSE;
-            else if (*p == '\\')
-                in_escape = FLB_TRUE;
-            else if (*p == '"')
-                in_string = !in_string;
-            else if (!in_string) {
-                if (*p == '{')
-                    level++;
-                else if (*p == '}')
-                    level--;
-                else if ((*p == '[' || *p == ']') && level == 0)
-                    *p = ' ';
-                else if (*p == ',' && level == 0)
-                    *p = separator;
-            }
-        }
-    }
-
-    msgpack_sbuffer_destroy(&tmp_sbuf);
-    if (ret != 0) {
-        return NULL;
-    }
-
-    *out_size = json_size;
-    return json_buf;
-}
-
-
 static int cb_stdout_init(struct flb_output_instance *ins,
                           struct flb_config *config, void *data)
 {
@@ -187,18 +57,11 @@ static int cb_stdout_init(struct flb_output_instance *ins,
     }
 
     /* Date format for JSON output */
-    ctx->json_date_format = FLB_STDOUT_JSON_DATE_DOUBLE;
-    tmp = flb_output_get_property("json_date_format", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "iso8601") == 0) {
-            ctx->json_date_format = FLB_STDOUT_JSON_DATE_ISO8601;
-        }
-    }
+    ctx->json_date_format = flb_output_get_date_format("json_date_format", ins);
 
     /* Date key for JSON output */
     tmp = flb_output_get_property("json_date_key", ins);
     ctx->json_date_key = flb_strdup(tmp ? tmp : "date");
-    ctx->json_date_key_len = strlen(ctx->json_date_key);
 
     flb_output_set_context(ins, ctx);
     return 0;
@@ -223,7 +86,10 @@ static void cb_stdout_flush(void *data, size_t bytes,
     msgpack_object *p;
 
     if (ctx->out_format == FLB_STDOUT_OUT_JSON_LINES) {
-        json = msgpack_to_json(ctx, data, bytes, &json_len);
+        json = flb_msgpack_to_json_with_date(data, bytes, &json_len,
+                                             ctx->json_date_key,
+                                             ctx->json_date_format,
+                                             FLB_JSON_FORMAT_LINES);
         printf("%s\n", json);
         flb_free(json);
         fflush(stdout);

--- a/plugins/out_stdout/stdout.h
+++ b/plugins/out_stdout/stdout.h
@@ -24,16 +24,11 @@
 #define FLB_STDOUT_OUT_MSGPACK      0
 #define FLB_STDOUT_OUT_JSON_LINES   1
 
-#define FLB_STDOUT_JSON_DATE_DOUBLE      0
-#define FLB_STDOUT_JSON_DATE_ISO8601     1
-#define FLB_STDOUT_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
-
 struct flb_out_stdout_config {
     int out_format;
 
-    int json_date_format;
+    flb_date_format_t json_date_format;
     char *json_date_key;
-    size_t json_date_key_len;
 };
 
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -305,7 +305,7 @@ void flb_config_exit(struct flb_config *config)
     flb_free(config);
 }
 
-char *flb_config_prop_get(char *key, struct mk_list *list)
+char *flb_config_prop_get(const char *key, struct mk_list *list)
 {
     struct mk_list *head;
     struct flb_config_prop *p;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -475,9 +475,27 @@ char *flb_output_name(struct flb_output_instance *in)
     return in->name;
 }
 
-char *flb_output_get_property(char *key, struct flb_output_instance *o_ins)
+char *flb_output_get_property(const char *key, struct flb_output_instance *o_ins)
 {
     return flb_config_prop_get(key, &o_ins->properties);
+}
+
+flb_date_format_t flb_output_get_date_format(const char *key,
+                                             struct flb_output_instance *o_ins)
+{
+    flb_date_format_t format = FLB_DATE_FORMAT_DOUBLE;
+    char *tmp = flb_config_prop_get(key, &o_ins->properties);
+    if (tmp) {
+        if (strcasecmp(tmp, "iso8601") == 0) {
+            format = FLB_DATE_FORMAT_ISO8601;
+        } else if (strcasecmp(tmp, "epoch") == 0) {
+            format = FLB_DATE_FORMAT_EPOCH;
+        } else if (strcasecmp(tmp, "double") == 0) {
+            format = FLB_DATE_FORMAT_DOUBLE;
+        }
+        free(tmp);
+    }
+    return format;
 }
 
 /* Trigger the output plugins setup callbacks to prepare them. */


### PR DESCRIPTION
There were 2 identical functions msgpack_to_json()
in out_http and out_stdout. Refactor to flb_pack as a
library function.

Signed-off-by: Don Bowman <don@agilicus.com>