### PR TITLE
build: don't try to link pthread on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,9 +231,15 @@ endif()
 if(FLB_SHARED_LIB)
   add_library(fluent-bit-shared SHARED ${src})
   add_sanitizers(fluent-bit-shared)
-  target_link_libraries(fluent-bit-shared ${FLB_DEPS} -lpthread)
   set_target_properties(fluent-bit-shared
     PROPERTIES OUTPUT_NAME fluent-bit)
+
+  # Windows doesn't provide pthread (see winpthreads.c in mk_core).
+  if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    target_link_libraries(fluent-bit-shared ${FLB_DEPS})
+  else()
+    target_link_libraries(fluent-bit-shared ${FLB_DEPS} -lpthread)
+  endif()
 
   # Library install routines
   install(TARGETS fluent-bit-shared


### PR DESCRIPTION
Fluent Bit uses "pthread" to manage logging workers, both on Unix and
Windows. However, since Windows does not have a native pthread support,
we instead use the emulation layer in mk_core/external/winpthreads.c.

This means we should not try to link pthread by -lpthread on MSVC, or
the linker will emit the following warnings.

    warning LNK4044: unrecognized option '/lpthread'; ignored

*This patch is intended to be merged after v1.1 release.*

Part of #960 