### PR TITLE
in_tail: use stricmp() to compare two paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(fluent-bit)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Define macro to identify Windows system (without Cygwin)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set(FLB_SYSTEM_WINDOWS On)
+  add_definitions(-DFLB_SYSTEM_WINDOWS)
+endif()
+
 # Update CFLAGS
 if (MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -39,8 +39,10 @@
 static inline int flb_tail_file_name_cmp(char *name,
                                         struct flb_tail_file *file)
 {
-#ifdef __linux__
+#if defined(__linux__)
     return strcmp(name, file->name);
+#elif defined(__MSC_VER)
+    return _stricmp(name, file->real_name);
 #else
     return strcmp(name, file->real_name);
 #endif

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -41,7 +41,7 @@ static inline int flb_tail_file_name_cmp(char *name,
 {
 #if defined(__linux__)
     return strcmp(name, file->name);
-#elif defined(__MSC_VER)
+#elif defined(FLB_SYSTEM_WINDOWS)
     return _stricmp(name, file->real_name);
 #else
     return strcmp(name, file->real_name);


### PR DESCRIPTION
Windows API is designed to be case insensitive. This means that the
following two paths refer to the same file:

    C:\Users\Alice\README.TXT
    C:\Users\Alice\readme.txt

This patch reflect this design and fixes flb_tail_file_name_cmp() to
use strnicmp() (= strcasecmp() in POSIX) to compare two file paths.

*This patch is intended to be merged after v1.1 release*

Part of #960 
