### PR TITLE
in_tail: use C99 macro instead of '%lu' to format 64-bit integers

### DIFF
--- a/plugins/in_tail/tail_sql.h
+++ b/plugins/in_tail/tail_sql.h
@@ -43,10 +43,10 @@
 
 #define SQL_INSERT_FILE                                             \
     "INSERT INTO in_tail_files (name, offset, inode, created)"      \
-    "  VALUES ('%s', %lu, %lu, %lu);"
+    "  VALUES ('%s', %"PRIu64", %"PRIu64", %"PRIu64");"
 
 #define SQL_UPDATE_OFFSET                               \
-    "UPDATE in_tail_files set offset=%lu WHERE id=%"PRId64";"
+    "UPDATE in_tail_files set offset=%"PRIu64" WHERE id=%"PRId64";"
 
 #define SQL_ROTATE_FILE                         \
     "UPDATE in_tail_files set name='%s',rotated=1 WHERE id=%"PRId64";"


### PR DESCRIPTION
Windows is LLP64 system, and long integers have only 32-bit width there.
However, we use '%lu' for serializing read offset numbers (and others)
in tail_sql.h assuming long has always 64-bit width.

This was causing data corruption on Windows. This patch fixes the bug by
replacing them with C99's PRIu64 macro.

*This patch is intended to be merged after v1.1 release*

Part of #960 