### PR TITLE
in_tail: emulate inodes on Windows

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -41,6 +41,28 @@
 #include "tail_multiline.h"
 #include "tail_scan.h"
 
+#ifdef _MSC_VER
+static int get_inode(int fd, uint64_t *inode)
+{
+    HANDLE h;
+    BY_HANDLE_FILE_INFORMATION info;
+
+    h = _get_osfhandle(fd);
+    if (h == INVALID_HANDLE_VALUE) {
+        flb_error("[in_tail] cannot convert fd:%i into HANDLE", fd);
+        return -1;
+    }
+
+    if (GetFileInformationByHandle(h, &info) == 0) {
+        flb_error("[in_tail] cannot get file info for fd:%i", fd);
+        return -1;
+    }
+    *inode = (uint64_t) info.nFileIndexHigh;
+    *inode = *inode << 32 | info.nFileIndexLow;
+    return 0;
+}
+#endif
+
 static inline void consume_bytes(char *buf, int bytes, int length)
 {
     memmove(buf, buf + bytes, length - bytes);
@@ -597,8 +619,16 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         return -1;
     }
 
-    file->offset    = 0;
+#ifdef _MSC_VER
+    if (get_inode(fd, &file->inode)) {
+        close(fd);
+        flb_free(file);
+        return -1;
+    }
+#else
     file->inode     = st->st_ino;
+#endif
+    file->offset    = 0;
     file->size      = st->st_size;
     file->buf_len   = 0;
     file->parsed    = 0;

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -36,7 +36,11 @@ struct flb_tail_file {
     off_t size;
     off_t offset;
     off_t last_line;
+#ifdef _MSC_VER
+    uint64_t inode;
+#else
     ino_t inode;
+#endif
     char *name;                 /* target file name given by scan routine */
 #if !defined(__linux)
     char *real_name;            /* real file name in the file system */


### PR DESCRIPTION
in_tail uses inodes to identify files in a SQLite DB. The problem
was that Windows did not support inode and always set st_ino to 0
on stat(3) calls. Because of such, the offset storing feature was
not working properly on Windows.

This patch adds a simple emulation of inodes for Windows, and
enables Windows users to retain the read offset between restarts.

*This patch is intended to be merged after v1.1 relelase*

Part of #960