### PR TITLE
appveyor: Re-setup AppVeyor to build with Visual C++ 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
-version: 0.11-winbuild-{build}
+version: v1-winbuild-{build}
+
+image: Visual Studio 2017
 
 platform:
   - Win32
@@ -9,10 +11,11 @@ configuration:
   - Release
 
 before_build:
-  - cmd: if "%platform%"=="Win32" set msvc=Visual Studio 14 2015
-  - cmd: if "%platform%"=="x64"   set msvc=Visual Studio 14 2015 Win64
+  - cmd: if "%platform%"=="Win32" set msvc=Visual Studio 15 2017
+  - cmd: if "%platform%"=="x64"   set msvc=Visual Studio 15 2017 Win64
 
 build_script:
+  - mkdir build
   - cd build
-  - cmake -G "%msvc%" -DCMAKE_BUILD_TYPE=%configuration% -DFLB_WITHOUT_SHARED_LIB=On -DFLB_WITHOUT_EXAMPLES=On ..
+  - cmake -G "%msvc%" -DCMAKE_BUILD_TYPE=%configuration% -DFLB_WITHOUT_SHARED_LIB=On -DFLB_WITHOUT_EXAMPLES=On -DCIO_BACKEND_FILESYSTEM=Off ..
   - cmake --build .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,11 @@ platform:
 
 configuration:
   - Debug
-  - Release
+  # - Release # TODO
 
 before_build:
   - cmd: if "%platform%"=="Win32" set msvc=Visual Studio 15 2017
   - cmd: if "%platform%"=="x64"   set msvc=Visual Studio 15 2017 Win64
 
 build_script:
-  - mkdir build
-  - cd build
-  - cmake -G "%msvc%" -DCMAKE_BUILD_TYPE=%configuration% -DFLB_WITHOUT_SHARED_LIB=On -DFLB_WITHOUT_EXAMPLES=On -DCIO_BACKEND_FILESYSTEM=Off ..
-  - cmake --build .
+  - powershell ".\ci\do-ut.ps1;exit $LASTEXITCODE"

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -1,0 +1,26 @@
+$SKIP_TESTS=@("flb-rt-out_elasticsearch",
+              "flb-rt-out_td",
+              "flb-rt-out_forward",
+              "flb-rt-in_disk",
+              "flb-rt-in_proc",
+              "flb-it-http_client",
+              "flb-it-network",
+              "flb-it-pack")
+
+$SKIP=""
+
+foreach ($SKIP_TEST in $SKIP_TESTS) {
+    $SKIP += " -DFLB_WITHOUT_${SKIP_TEST}=1"
+}
+
+$GLOBAL_OPTS="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_ALL=On -DFLB_DEBUG=On -DFLB_EXAMPLES=Off"
+mkdir build
+cd build
+Write-Host cmake -G """$ENV:msvc""" -DCMAKE_BUILD_TYPE="$ENV:configuration" $GLOBAL_OPTS -DFLB_TESTS_INTERNAL=On -DCIO_BACKEND_FILESYSTEM=Off $SKIP ../
+# Use Start-Process to pass 9 or more arguments
+# TODO: Enable -DFLB_TESTS_RUNTIME=On
+$build = Start-Process cmake -ArgumentList "-G ""$ENV:msvc"" -DCMAKE_BUILD_TYPE=""$ENV:configuration"" $GLOBAL_OPTS -DFLB_TESTS_INTERNAL=On -DCIO_BACKEND_FILESYSTEM=Off $SKIP ../" -NoNewWindow -PassThru
+Wait-Process -InputObject $build
+cmake --build .
+
+ctest -C "$ENV:configuration" --build-run-dir $PWD --output-on-failure

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -2,11 +2,15 @@ $SKIP_TESTS=@("flb-rt-out_elasticsearch",
               "flb-rt-out_td",
               "flb-rt-out_forward",
               "flb-rt-in_disk",
-              "flb-rt-in_proc",
+              "flb-rt-in_proc")
+$TODO_TESTS=@("flb-it-pipe",
+              "flb-it-parser",
+              "flb-it-unit_sizes"
               "flb-it-http_client",
               "flb-it-network",
               "flb-it-pack")
 
+$SKIP_TESTS = $SKIP_TESTS + $TODO_TESTS
 $SKIP=""
 
 foreach ($SKIP_TEST in $SKIP_TESTS) {

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -18,7 +18,7 @@ foreach ($SKIP_TEST in $SKIP_TESTS) {
 }
 
 $GLOBAL_OPTS="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_ALL=On -DFLB_DEBUG=On -DFLB_EXAMPLES=Off"
-mkdir build
+mkdir build -Force
 cd build
 Write-Host cmake -G """$ENV:msvc""" -DCMAKE_BUILD_TYPE="$ENV:configuration" $GLOBAL_OPTS -DFLB_TESTS_INTERNAL=On -DCIO_BACKEND_FILESYSTEM=Off $SKIP ../
 # Use Start-Process to pass 9 or more arguments


### PR DESCRIPTION
Currently, Windows support is targeted to build with Visual Studio 2017 and w/o chunkio filesystem backend.

This PR contains just building and minimal testing fluent-bit on Windows with Visual Studio 2017.
~~Compiling and running unit tests is on AppVeyor not yet.~~ Done. :muscle:

---

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

Part of #960