### PR TITLE
out_kafka: Make MSVC compatible

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -60,7 +60,7 @@ set(FLB_OUT_STDOUT            Yes)
 set(FLB_OUT_LIB                No)
 set(FLB_OUT_NULL              Yes)
 set(FLB_OUT_FLOWCOUNTER       Yes)
-set(FLB_OUT_KAFKA              No)
+set(FLB_OUT_KAFKA             Yes)
 set(FLB_OUT_KAFKA_REST         No)
 
 # FILTER plugins

--- a/plugins/out_kafka/CMakeLists.txt
+++ b/plugins/out_kafka/CMakeLists.txt
@@ -14,4 +14,6 @@ set(src
   kafka.c)
 
 FLB_PLUGIN(out_kafka "${src}" "rdkafka")
-target_link_libraries(flb-plugin-out_kafka -lpthread)
+if (NOT MSVC)
+  target_link_libraries(flb-plugin-out_kafka -lpthread)
+endif()


### PR DESCRIPTION
librdkafka is already compatible for MinGW and MSVC.
For MSVC, we should avoid to link libpthread.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

---

I've confirmed with the folllowing fluent-bit settings:

```ini
[INPUT]
    Name  dummy

[OUTPUT]
    Name        kafka
    Match       *
    Brokers     local-kafka-server-address:9092
    Topics      test
    Timestamp_Format iso8601 # or double
    Timestamp_Key @timestamp
    Format msgpack # or json
    rdkafka.log.connection.close false
    rdkafka.request.required.acks 1
```

Part of #960.