### PR TITLE
runtime tests: Tighten executing runtime tests targets on macOS

### DIFF
--- a/ci/do-ut
+++ b/ci/do-ut
@@ -15,6 +15,12 @@ flb-rt-out_forward
 flb-rt-in_disk
 flb-rt-in_proc"
 
+# On macOS, kubernetes log directory which points to /var/log does not exist.
+if [ "$(uname)" = "Darwin" ]
+then
+    SKIP_TESTS+="flb-rt-filter_kubernetes"
+fi
+
 for skip in $SKIP_TESTS
 do
     SKIP="$SKIP -DFLB_WITHOUT_${skip}=1"

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -18,12 +18,15 @@ endmacro()
 
 # Input Plugins
 if(FLB_OUT_LIB)
-  FLB_RT_TEST(FLB_IN_CPU           "in_cpu.c")
-  FLB_RT_TEST(FLB_IN_DUMMY         "in_dummy.c")
-  FLB_RT_TEST(FLB_IN_DISK          "in_disk.c")
+  # These plugins works only on Linux
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    FLB_RT_TEST(FLB_IN_CPU           "in_cpu.c")
+    FLB_RT_TEST(FLB_IN_DISK          "in_disk.c")
+    FLB_RT_TEST(FLB_IN_MEM           "in_mem.c")
+    FLB_RT_TEST(FLB_IN_PROC          "in_proc.c")
+  endif()
   FLB_RT_TEST(FLB_IN_HEAD          "in_head.c")
-  FLB_RT_TEST(FLB_IN_MEM           "in_mem.c")
-  FLB_RT_TEST(FLB_IN_PROC          "in_proc.c")
+  FLB_RT_TEST(FLB_IN_DUMMY         "in_dummy.c")
   FLB_RT_TEST(FLB_IN_RANDOM        "in_random.c")
 endif()
 


### PR DESCRIPTION
* in_cpu/in_disk/in_mem/in_proc is written for Linux not macOS.

ref: https://github.com/fluent/fluent-bit/blob/master/plugins/CMakeLists.txt#L91-L100

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>