### PR TITLE
Check C11 style thread local storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,22 @@ if(NOT FLB_POSIX_TLS)
   endif()
 endif()
 
+# Pthread Local Storage for C11 (mainly for macOS)
+# ================================================
+# We test the compiler support thread local storage
+# through _Thread_local type, otherwise Fluent Bit
+# fallback to the old POSIX pthread mode (pthread_key_t).
+if(NOT FLB_C11_TLS)
+  check_c_source_compiles("
+   _Thread_local int a;
+   int main() {
+       return 0;
+   }" FLB_HAVE_C11_TLS)
+  if(FLB_HAVE_C11_TLS)
+    FLB_DEFINITION(FLB_HAVE_C11_TLS)
+  endif()
+endif()
+
 # accept(4)
 check_c_source_compiles("
     #define _GNU_SOURCE

--- a/include/fluent-bit/flb_thread_storage.h
+++ b/include/fluent-bit/flb_thread_storage.h
@@ -30,6 +30,12 @@
 #define FLB_TLS_INIT(key)          do {} while (0)
 #define FLB_TLS_DEFINE(type, name) __thread type *name;
 
+#elif FLB_HAVE_C11_TLS
+#define FLB_TLS_SET(key, val)      key=val
+#define FLB_TLS_GET(key)           key
+#define FLB_TLS_INIT(key)          do {} while (0)
+#define FLB_TLS_DEFINE(type, name) _Thread_local type *name;
+
 #else
 
 /* Fallback mode using pthread_*() for Thread-Local-Storage usage */


### PR DESCRIPTION
Otherwise, GNU style `__thread` type causes SIGSEGV on macOS in in_metrics test cases.

I digged the root cause of this issue. Then, I found that `pthread_getspecific` causes this Segfault.
macOS's clang can handle `_Thread_local` type.
This changes suppress SIGSEGV in in_metrics test cases under macOS.

Comments?