### PR TITLE
flb_hash: fix del to compare key

### DIFF
--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -396,7 +396,11 @@ int flb_hash_del(struct flb_hash *ht, char *key)
     table = &ht->table[id];
     if (table->count == 1) {
         entry = mk_list_entry_first(&table->chains,
-                                    struct flb_hash_entry, _head);
+                                    struct flb_hash_entry,
+                                    _head);
+        if (strcmp(entry->key, key) != 0) {
+            entry = NULL;
+        }
     }
     else {
         mk_list_foreach(head, &table->chains) {


### PR DESCRIPTION
Improve `flb_hash_del` to check also the key when there is only one element in a table.