### PR TITLE
The maximum broker hostname size is increased to 255 bytes

### DIFF
--- a/plugins/out_kafka/librdkafka-0.11.6/src/rdkafka_int.h
+++ b/plugins/out_kafka/librdkafka-0.11.6/src/rdkafka_int.h
@@ -147,7 +147,7 @@ struct rd_kafka_s {
 
         rd_kafka_conf_t  rk_conf;
         rd_kafka_q_t    *rk_logq;          /* Log queue if `log.queue` set */
-        char             rk_name[128];
+        char             rk_name[256];
 	rd_kafkap_str_t *rk_client_id;
         rd_kafkap_str_t *rk_group_id;    /* Consumer group id */
 

--- a/plugins/out_kafka/librdkafka-0.11.6/src/rdkafka_proto.h
+++ b/plugins/out_kafka/librdkafka-0.11.6/src/rdkafka_proto.h
@@ -450,7 +450,7 @@ int rd_kafkap_bytes_cmp_data (const rd_kafkap_bytes_t *a,
 typedef struct rd_kafka_buf_s rd_kafka_buf_t;
 
 
-#define RD_KAFKA_NODENAME_SIZE  128
+#define RD_KAFKA_NODENAME_SIZE  256
 
 
 


### PR DESCRIPTION
The maximum broker hostname size is increased to 255 bytes

Signed-off-by: akshaydubey29 <akshaydubey2912@gmail.com>