### PR TITLE
Output proxy go windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,12 +453,8 @@ else()
   set(FLB_OUT_NAME "fluent-bit")
 endif()
 
-if(FLB_PROXY_GO AND (NOT CMAKE_SYSTEM_NAME MATCHES "Windows"))
+if(FLB_PROXY_GO)
   FLB_DEFINITION(FLB_HAVE_PROXY_GO)
-else()
-  if(FLB_PROXY_GO)
-    unset(FLB_PROXY_GO CACHE)
-  endif()
 endif()
 
 if("${GNU_HOST}" STREQUAL "")

--- a/include/fluent-bit/flb_dlfcn_win32.h
+++ b/include/fluent-bit/flb_dlfcn_win32.h
@@ -1,0 +1,25 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define RTLD_LAZY 0
+
+void *dlopen(const char *filename, int _flag);
+char *dlerror(void);
+void *dlsym(void *handle, const char *symbol);
+int dlclose(void *handle);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,13 @@ set(src
   flb_sosreport.c
   )
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+set(src
+  ${src}
+  flb_dlfcn_win32.c
+  )
+endif()
+
 include_directories(
   .
   ../lib/

--- a/src/flb_dlfcn_win32.c
+++ b/src/flb_dlfcn_win32.c
@@ -1,0 +1,102 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_compat.h>
+
+static LPSTR errbuf;
+static CHAR *currerr;
+static char dlerrorbuf[65536];
+
+static void store_error(void)
+{
+    DWORD err = GetLastError();
+    if (err == NO_ERROR) {
+        return;
+    }
+
+    if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                       FORMAT_MESSAGE_FROM_SYSTEM |
+                       FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL,
+                       err,
+                       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                       (LPTSTR) &errbuf,
+                       _countof(errbuf), NULL))
+        errbuf[0] = '\0';
+    currerr = errbuf;
+}
+
+__declspec(noinline)
+void *dlopen(const char *filename, int _flag)
+{
+    HMODULE handle;
+
+    handle = LoadLibrary(filename);
+    if (handle == NULL) {
+        store_error();
+        return NULL;
+    }
+    return (void *)handle;
+}
+
+char *dlerror(void)
+{
+    char *errorptr = dlerrorbuf;
+
+    if (currerr == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(errorptr, currerr, strlen(currerr) + 1);
+
+    currerr = NULL;
+
+    return errorptr;
+}
+
+__declspec(noinline)
+void *dlsym(void *handle, const char *name)
+{
+    FARPROC *symbol;
+    symbol = NULL;
+
+    symbol = GetProcAddress((HMODULE) handle, name);
+    if (symbol == NULL) {
+        store_error();
+        return NULL;
+    }
+
+    return (void *)symbol;
+}
+
+int dlclose(void *handle)
+{
+    BOOL result;
+
+    result = FreeLibrary((HMODULE) handle);
+    if (!result)
+        store_error();
+
+    /* dlcose(3) returns 0 on success, and nonzero on error. */
+    /* FreeLibrary returns nonzero on success, and 0 on error. */
+    /* ref:
+     * https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary */
+    return !result;
+}

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -22,7 +22,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <fluent-bit/flb_dlfcn_win32.h>
+#else
 #include <dlfcn.h>
 #endif
 
@@ -103,18 +105,11 @@ void *flb_plugin_proxy_symbol(struct flb_plugin_proxy *proxy,
 {
     void *s;
 
-#ifdef _WIN32
-    s = GetProcAddress(proxy->dso_handler, symbol);
-    if (GetLastError() != NO_ERROR) {
-        return NULL;
-    }
-#else
     dlerror();
     s = dlsym(proxy->dso_handler, symbol);
     if (dlerror() != NULL) {
         return NULL;
     }
-#endif
     return s;
 }
 
@@ -198,60 +193,28 @@ int flb_plugin_proxy_init(struct flb_plugin_proxy *proxy,
 struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
                                                  struct flb_config *config)
 {
-#ifdef _WIN32
-    HMODULE handle;
-    DWORD err;
-    LPSTR errbuf = NULL;
-#else
     void *handle;
-#endif
     struct flb_plugin_proxy *proxy;
 
     /* Load shared library */
-#ifdef _WIN32
-    handle = LoadLibrary(dso_path);
-    if (!handle) {
-        err = GetLastError();
-        if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                           FORMAT_MESSAGE_FROM_SYSTEM |
-                           FORMAT_MESSAGE_IGNORE_INSERTS,
-                           NULL,
-                           err,
-                           MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                           (LPTSTR) &errbuf,
-                           _countof(errbuf), NULL))
-            errbuf[0] = '\0';
-        fprintf(stderr, "[proxy] error opening plugin %s: \"%s\"\n", dso_path, errbuf);
-        return NULL;
-    }
-#else
     handle = dlopen(dso_path, RTLD_LAZY);
     if (!handle) {
         fprintf(stderr, "[proxy] error opening plugin %s: \"%s\"\n", dso_path, dlerror());
         return NULL;
     }
-#endif
 
     /* Proxy Context */
     proxy = flb_malloc(sizeof(struct flb_plugin_proxy));
     if (!proxy) {
         flb_errno();
-#ifdef _WIN32
-        FreeLibrary(handle);
-#else
         dlclose(handle);
-#endif
         return NULL;
     }
 
     /* API Context */
     proxy->api = flb_api_create();
     if (!proxy->api) {
-#ifdef _WIN32
-        FreeLibrary(handle);
-#else
         dlclose(handle);
-#endif
         flb_free(proxy);
         return NULL;
     }
@@ -335,11 +298,7 @@ int flb_plugin_proxy_conf_file(char *file, struct flb_config *config)
 void flb_plugin_proxy_destroy(struct flb_plugin_proxy *proxy)
 {
     /* cleanup */
-#ifdef _WIN32
-    FreeLibrary(proxy->dso_handler);
-#else
     dlclose(proxy->dso_handler);
-#endif
     mk_list_del(&proxy->_head);
     flb_free(proxy);
 }


### PR DESCRIPTION
This PR adds output plugin proxy Golang support for Windows.

I've confirmed with fluent-bit-go (out_gstdout).

```log
~\GitHub\fluent-bit-go\examples\out_gstdout [master ≡ +3 ~1 -0 !]> make
go build -buildmode=c-shared -o out_gstdout.so .
```
And then I copied `out_gstdout.so` into fluent-bit.exe located folder.

```log
PS> .\bin\Debug\fluent-bit.exe -e .\\bin\\Debug\\out_gstdout.so -i dummy -p tag=debug -o gstdout
```

Fluent-Bit can handle windows dynamic link library (This example uses `.so` but it should use `.dll`):

```log
Fluent Bit v1.1.0
Copyright (C) Treasure Data

[2019/03/14 18:05:43] [ info] [storage] initializing...
[2019/03/14 18:05:43] [ info] [storage] in-memory
[2019/03/14 18:05:43] [ info] [storage] normal synchronization mode, checksum disabled
[2019/03/14 18:05:43] [ info] [engine] started (pid=34020)
[flb-go] plugin parameter = ''
[0] debug: [2019-03-14 18:05:44.5061336 +0900 JST, {"message": [100 117 109 109 121], }
[1] debug: [2019-03-14 18:05:45.4944399 +0900 JST, {"message": [100 117 109 109 121], }
[2] debug: [2019-03-14 18:05:46.5038502 +0900 JST, {"message": [100 117 109 109 121], }
[3] debug: [2019-03-14 18:05:47.4914434 +0900 JST, {"message": [100 117 109 109 121], }
```