### PR TITLE
out_es: fix buffer overrun on Trace_Output=On

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -414,7 +414,7 @@ static char *elasticsearch_format(void *data, size_t bytes,
      */
     flb_free(bulk);
     if (ctx->trace_output) {
-        printf("%s", buf);
+        fwrite(buf, 1, *out_size, stdout);
         fflush(stdout);
     }
     return buf;


### PR DESCRIPTION
While testing out_es on Windows, I noticed that Fluent Bit sometimes
outputs a garbled noise that apparently is a memory dump.

It turned out that it was just because elasticsearch_format() tried
to do printf("%s", buf) where buf is actually not null-terminated.
This patch is a simple fix for it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>