### PR TITLE
scheduler: use mk_event_closesocket() to close timer->timer_fd

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -394,7 +394,7 @@ int flb_sched_timer_cb_disable(struct flb_sched_timer *timer)
 {
     int ret;
 
-    ret = close(timer->timer_fd);
+    ret = mk_event_closesocket(timer->timer_fd);
     timer->timer_fd = -1;
     return ret;
 }


### PR DESCRIPTION
On Windows, this line fails with a segmentation fault. This is because
Windows distinguishes sockets and file descriptors strictly and we can't
use POSIX close() to close a socket.

Fix this by using monkey's wrapper function.

Part of #960