### PR TITLE
socket: introduce FLB_WOULDBLOCK to handle nonblocking IO portably

### DIFF
--- a/include/fluent-bit/flb_socket.h
+++ b/include/fluent-bit/flb_socket.h
@@ -29,6 +29,7 @@
 #define flb_socket_close(fd) evutil_closesocket(fd)
 #define flb_socket_error(fd) evutil_socket_geterror(fd)
 #define FLB_EINPROGRESS(e)   ((e) == WSAEWOULDBLOCK)
+#define FLB_WOULDBLOCK()     (WSAGetLastError() == WSAEWOULDBLOCK)
 #else
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -36,6 +37,7 @@
 #define flb_socket_close(fd) close(fd)
 #define flb_socket_error(fd) errno
 #define FLB_EINPROGRESS(e)   ((e) == EINTR || (e) == EINPROGRESS)
+#define FLB_WOULDBLOCK()     (errno == EAGAIN || errno == EWOULDBLOCK)
 #endif
 
 #endif

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -218,7 +218,7 @@ static int net_io_write(struct flb_upstream_conn *u_conn,
     while (total < len) {
         ret = send(u_conn->fd, (char *) data + total, len - total, 0);
         if (ret == -1) {
-            if (errno == EAGAIN) {
+            if (FLB_WOULDBLOCK()) {
                 /*
                  * FIXME: for now we are handling this in a very lazy way,
                  * just sleep for a second and retry (for a max of 30 tries).
@@ -286,7 +286,7 @@ static FLB_INLINE int net_io_write_async(struct flb_thread *th,
 #endif
 
     if (bytes == -1) {
-        if (errno == EAGAIN) {
+        if (FLB_WOULDBLOCK()) {
             u_conn->thread = th;
             ret = mk_event_add(u->evl,
                                u_conn->fd,
@@ -402,7 +402,7 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_thread *th,
 
     ret = read(u_conn->fd, buf, len);
     if (ret == -1) {
-        if (errno == EAGAIN) {
+        if (FLB_WOULDBLOCK()) {
             u_conn->thread = th;
             ret = mk_event_add(u->evl,
                                u_conn->fd,


### PR DESCRIPTION
This is a series of patches that introduces `FLB_WOULDBLOCK` to detect
`EWOULDBLOCK` portably.

bc6c97be io: perform EAGAIN checks using FLB_WOULDBLOCK()
3b3b4caf socket: introduce FLB_WOULDBLOCK to handle nonblocking IO portably

With this patch applied, we can handle temporal socket errors reliably both
on UNIX and Windows.

Part of #960 