### PR TITLE
scheduler: fix multiple SIGSEGV issues on Windows

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -257,7 +257,6 @@ int flb_sched_request_destroy(struct flb_config *config,
     mk_list_del(&req->_head);
 
     timer = req->timer;
-    flb_pipe_close(req->fd);
 
     /*
      * We invalidate the timer since in the same event loop round
@@ -266,6 +265,9 @@ int flb_sched_request_destroy(struct flb_config *config,
      * the event loop round finish.
      */
     flb_sched_timer_invalidate(timer);
+
+    /* Close pipe after invalidating timer */
+    flb_pipe_close(req->fd);
 
     /* Remove request */
     flb_free(req);

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -257,9 +257,6 @@ int flb_sched_request_destroy(struct flb_config *config,
     mk_list_del(&req->_head);
 
     timer = req->timer;
-    if (config->evl && timer->event.mask != MK_EVENT_EMPTY) {
-        mk_event_del(config->evl, &timer->event);
-    }
     flb_pipe_close(req->fd);
 
     /*


### PR DESCRIPTION
This is a series of patches that sorts out `flb_sched_request_destroy()`
so that it does not fail with segmentation faults on Windows.

a2b49aa6 scheduler: close communication pipe after invalidating timer
90903a16 scheduler: fix double free of timer->event

Part of #960 