### PR TITLE
sp: Make buildable stream_processor on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
     - os: osx
       env: FLB_OPT="-DFLB_JEMALLOC=Off"
       script: |
+        brew update
+        brew install bison flex || true
         ci/do-ut || true
     - os: linux
       env: FLB_OPT="-DFLB_COVERAGE=On"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,20 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   include(cmake/windows-setup.cmake)
 endif()
 
+# Tweak build targets for macOS
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+    COMMAND brew --prefix
+    RESULT_VARIABLE HOMEBREW
+    OUTPUT_VARIABLE HOMEBREW_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (HOMEBREW EQUAL 0 AND EXISTS "${HOMEBREW_PREFIX}")
+    message(STATUS "Found Homebrew at ${HOMEBREW_PREFIX}")
+    include(cmake/homebrew.cmake)
+  endif()
+endif()
+
 if(FLB_COVERAGE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
   set(CMAKE_BUILD_TYPE "Debug")

--- a/cmake/homebrew.cmake
+++ b/cmake/homebrew.cmake
@@ -1,0 +1,22 @@
+# Search homebrewed keg-only versions of Bison and Flex on macOS.
+execute_process(
+  COMMAND brew --prefix bison
+  RESULT_VARIABLE HOMEBREW_BISON
+  OUTPUT_VARIABLE HOMEBREW_BISON_PREFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if (HOMEBREW_BISON EQUAL 0 AND EXISTS "${HOMEBREW_BISON_PREFIX}")
+  message(STATUS "Using bison keg installed by Homebrew at ${HOMEBREW_BISON_PREFIX}")
+  set(BISON_EXECUTABLE "${HOMEBREW_BISON_PREFIX}/bin/bison")
+endif()
+
+execute_process(
+  COMMAND brew --prefix flex
+  RESULT_VARIABLE HOMEBREW_FLEX
+  OUTPUT_VARIABLE HOMEBREW_FLEX_PREFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if (HOMEBREW_FLEX EQUAL 0 AND EXISTS "${HOMEBREW_FLEX_PREFIX}")
+  message(STATUS "Using flex keg installed by Homebrew at ${HOMEBREW_FLEX_PREFIX}")
+  set(FLEX_EXECUTABLE "${HOMEBREW_FLEX_PREFIX}/bin/flex")
+endif()


### PR DESCRIPTION
Otherwise, default provided bison on macOS is too old (still in bison 2.3!) to build stream processor.

```log
sql.y:1.9-16: syntax error, unexpected identifier, expecting string
make[2]: *** [src/stream_processor/parser/sql_parser.c] Error 1
make[1]: *** [src/stream_processor/parser/CMakeFiles/flb-sp-parser.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

---

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>