### PR TITLE
sp: Make buildable with msys2ed windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -70,3 +70,14 @@ set(FLB_FILTER_THROTTLE        No)
 set(FLB_FILTER_NEST            No)
 set(FLB_FILTER_LUA            Yes)
 set(FLB_FILTER_RECORD_MODIFIER Yes)
+
+# Search bison and flex executables
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  find_package(FLEX)
+  find_package(BISON)
+
+  if (NOT (${FLEX_FOUND} AND ${BISON_FOUND}))
+    message(STATUS "flex and bison not found. Disable stream_processor building.")
+    set(FLB_STREAM_PROCESSOR No)
+  endif()
+endif()

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -46,6 +46,13 @@ static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
     return result;
 }
 
+#include <monkey/mk_core/mk_sleep.h>
+
+static inline int usleep(LONGLONG usec)
+{
+    return nanosleep(usec * 1000);
+}
+
 /* mk_utils.c exposes localtime_r */
 extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -37,7 +37,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 /* Aggr num type */
 #define FLB_SP_NUM_I64       0

--- a/src/stream_processor/parser/CMakeLists.txt
+++ b/src/stream_processor/parser/CMakeLists.txt
@@ -7,6 +7,11 @@ set(sources
   flb_sp_parser.c
   )
 
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  FLB_DEFINITION(YY_NO_UNISTD_H)
+  message(STATUS "Specifying YY_NO_UNISTD_H")
+endif()
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/stream_processor/parser/sql.l
+++ b/src/stream_processor/parser/sql.l
@@ -85,11 +85,11 @@ UNIX_TIMESTAMP          return UNIX_TIMESTAMP;
 RECORD_TAG              return RECORD_TAG;
 RECORD_TIME             return RECORD_TIME;
 
-"true"                  { yylval->boolean = true;  return BOOLEAN; };
-"false"                 { yylval->boolean = false;  return BOOLEAN; };
+"true"                  { yylval->boolean = true;  return BOOLTYPE; };
+"false"                 { yylval->boolean = false;  return BOOLTYPE; };
 
 -?[1-9][0-9]*           { yylval->integer = atoi(yytext);  return INTEGER; }
--?[1-9][0-9]*\.[0-9]+   { yylval->fval = atof(yytext); return FLOAT; }
+-?[1-9][0-9]*\.[0-9]+   { yylval->fval = atof(yytext); return FLOATING; }
 \'([^']|'{2})*\'        { yylval->string = remove_dup_qoutes(yytext + 1, yyleng - 2); return STRING; }
 [A-Za-z][A-Za-z0-9_]*	{ yylval->string = flb_strdup(yytext); return IDENTIFIER; }
 

--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -43,7 +43,7 @@ void yyerror (struct flb_sp_cmd *cmd, void *scanner, const char *str)
 %token RECORD_TAG RECORD_TIME
 
 /* Value types */
-%token INTEGER FLOAT STRING BOOLEAN
+%token INTEGER FLOATING STRING BOOLTYPE
 
 /* Logical operation tokens */
 %token AND OR NOT LT LTE GT GTE
@@ -69,9 +69,9 @@ void yyerror (struct flb_sp_cmd *cmd, void *scanner, const char *str)
 
 %type <string>     IDENTIFIER
 %type <integer>    INTEGER
-%type <fval>       FLOAT
+%type <fval>       FLOATING
 %type <string>     STRING
-%type <boolean>    BOOLEAN
+%type <boolean>    BOOLTYPE
 %type <string>     record_keys
 %type <string>     record_key
 %type <string>     alias
@@ -352,7 +352,7 @@ select: SELECT keys FROM source ';'
                      $$ = flb_sp_cmd_condition_integer(cmd, $1);
                    }
                |
-               FLOAT
+               FLOATING
                    {
                      $$ = flb_sp_cmd_condition_float(cmd, $1);
                    }
@@ -363,7 +363,7 @@ select: SELECT keys FROM source ';'
                      flb_free($1);
                    }
                |
-               BOOLEAN
+               BOOLTYPE
                    {
                      $$ = flb_sp_cmd_condition_boolean(cmd, $1);
                    }

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -31,7 +31,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <fluent-bit/flb_compat.h>
+#else
 #include <unistd.h>
+#endif
 
 #define DATA_SAMPLES FLB_TESTS_DATA_PATH "/data/stream_processor/samples.mp"
 


### PR DESCRIPTION
* Avoid to include unistd.h in stream processor code on Windows
* Avoid to include unistd.h in generated code with bison/flex on Windows
* Avoid to use BOOLEAN/FLOAT which are used in WPI32 API types to prevent typedef collisions  
* Don't build stream processor module when bison&flex are not found in the building system

---

~~And also it needs to use the patch https://github.com/fluent/fluent-bit/pull/1215/commits/31fcad7cc861d99fea60933350b2394f4b1ce5ac to build Windows on clean building.~~

The above issue is onigmo.h installation race condition on building.
This should be treated on another PR.

---

I've confirmed that stream processor functionality is working on Windows:

```ini
[INPUT]
  Name dummy
  alias raw
  tag debug

[OUTPUT]
  Name stdout

[SERVICE]
  Flush        5
  Log_Level    info
  Streams_File stream_processor.conf
```

stream_processor.conf:
```ini
[STREAM_TASK]
  Name  simple_select
  Exec  SELECT message FROM STREAM:raw;
```

---

```log
PS build> .\bin\Debug\fluent-bit.exe -c .\fluent.conf
Fluent Bit v1.1.0
Copyright (C) Treasure Data

[2019/03/22 16:45:38] [ info] [storage] initializing...
[2019/03/22 16:45:38] [ info] [storage] in-memory
[2019/03/22 16:45:38] [ info] [storage] normal synchronization mode, checksum disabled
[2019/03/22 16:45:38] [ info] [engine] started (pid=11968)
[2019/03/22 16:45:38] [ info] [sp] stream processor started
[2019/03/22 16:45:38] [ info] [sp] registered task: simple_select
[0] [1553240739.493229, {"message"=>"dummy"}]
[0] [1553240740.493296, {"message"=>"dummy"}]
[0] [1553240741.484982, {"message"=>"dummy"}]
[0] [1553240742.488085, {"message"=>"dummy"}]
[0] [1553240743.488142, {"message"=>"dummy"}]
[0] debug: [1553240739.493229300, {"message"=>"dummy"}]
[1] debug: [1553240740.493296400, {"message"=>"dummy"}]
[2] debug: [1553240741.484981600, {"message"=>"dummy"}]
[3] debug: [1553240742.488084600, {"message"=>"dummy"}]
[4] debug: [1553240743.488142400, {"message"=>"dummy"}]
```