### PR TITLE
build: sp: Specify onigmo library build dependency

### DIFF
--- a/src/stream_processor/parser/CMakeLists.txt
+++ b/src/stream_processor/parser/CMakeLists.txt
@@ -25,3 +25,4 @@ add_library(flb-sp-parser STATIC
 #    )
 
 add_flex_bison_dependency(lexer parser)
+add_dependencies(flb-sp-parser libonigmo)


### PR DESCRIPTION
stream_processor module should be built after building libonigmo.
Because stream_processor/parser uses `<onigmo.h>` indirectly:

```
In file included from /Users/cosmo/GitHub/fluent-bit/src/stream_processor/parser/flb_sp_parser.c:30:
In file included from /Users/cosmo/GitHub/fluent-bit/include/fluent-bit/stream_processor/flb_sp_parser.h:26:
In file included from /Users/cosmo/GitHub/fluent-bit/include/fluent-bit/stream_processor/flb_sp.h:27:
In file included from /Users/cosmo/GitHub/fluent-bit/include/fluent-bit/flb_input.h:33:
In file included from /Users/cosmo/GitHub/fluent-bit/include/fluent-bit/flb_filter.h:27:
/Users/cosmo/GitHub/fluent-bit/include/fluent-bit/flb_regex.h:33:10: fatal error: 'onigmo.h' file not found
#include <onigmo.h>
         ^~~~~~~~~~
```

I've confirmed that parallel building on Windows and macOS do not throw `<onigmo.h>` not found error.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>