### PR TITLE
filter_nest: seg fault if output configuration fails (#1195)

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -599,7 +599,9 @@ static int cb_nest_exit(void *data, struct flb_config *config)
 {
     struct filter_nest_ctx *ctx = data;
 
-    teardown(ctx);
+    if (ctx != NULL) {
+        teardown(ctx);
+    }
     flb_free(ctx);
     return 0;
 }


### PR DESCRIPTION
With this change, nest's cleanup hook will check for a NULL context (which occurs if the output configuration fails)