### PR TITLE
tests: make input plugin testing run more stable on Travis CI

### DIFF
--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -53,6 +53,7 @@ static inline int64_t time_in_ms()
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
+        flb_info("[test] flush triggered");
         flb_lib_free(data);
         set_result(time_in_ms()); /* success */
     }
@@ -62,7 +63,6 @@ int callback_test(void* data, size_t size, void* cb_data)
 void do_test(char *system, ...)
 {
     int64_t ret;
-    int64_t start;
     flb_ctx_t    *ctx    = NULL;
     int in_ffd;
     int out_ffd;
@@ -95,50 +95,55 @@ void do_test(char *system, ...)
     TEST_CHECK(out_ffd >= 0);
     TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "test", NULL) == 0);
 
-    TEST_CHECK(flb_service_set(ctx, "Flush", "2",
+    TEST_CHECK(flb_service_set(ctx, "Flush", "3",
                                     "Grace", "1",
                                     NULL) == 0);
 
+    /* The following test tries to check if an input plugin generates
+     * data in a timely manner.
+     *
+     *    0  1  2  3  4  5  6  7  8 (sec)
+     *    |--C--*--F--C--*--F--C--|
+     *
+     *    F ... Flush (3 sec interval)
+     *    C ... Condition checks
+     *
+     * Since CI servers can be sometimes very slow, we wait slightly a
+     * little more (1 sec) before checking the condition.
+     */
 
-    start = time_in_ms();
+    /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* start test */
-    ret = get_result(); /* No data should be flushed */
-    TEST_CHECK(ret == false);
-
-    while ( (ret = get_result()) == 0 && (time_in_ms() - start < 4000))
-        usleep(10);
-
-    /* We allow some slop. It should not be less than 2 seconds.
-     * But ... the CI system might be slow etc, so allow up
-     * to 4 seconds
-     */
-    TEST_CHECK(ret > start + 900 && ret < start + 4000);
-    set_result(0); /* clear flag */
-    start = time_in_ms();
-
-    usleep(0.5e06);
-    ret = get_result(); /* 1sec passed, no data should be flushed */
+    /* 1 sec passed. No data should be flushed */
+    sleep(1);
+    flb_info("[test] check status 1");
+    ret = get_result();
     TEST_CHECK(ret == 0);
 
-    while ( (ret = get_result()) == 0 && (time_in_ms() - start < 4000))
-        usleep(10);
-    ret = get_result(); /* 1sec passed, data should be flushed */
-    TEST_CHECK(ret > start + 900 && ret < start + 4000);
+    /* 4 sec passed. It must have flushed once */
+    sleep(3);
+    flb_info("[test] check status 2");
+    ret = get_result();
+    TEST_CHECK(ret > 0);
 
-    /* finalize */
+    /* 7 sec passed. It must have flushed again */
+    sleep(3);
+    flb_info("[test] check status 3");
+    ret = get_result();
+    TEST_CHECK(ret > 0);
+
     flb_stop(ctx);
     flb_destroy(ctx);
 }
 
-void flb_test_in_disk_flush_2s_2times()
+void flb_test_in_disk_flush()
 {
     do_test("disk",
-            "interval_sec", "0",
+            "interval_sec", "1",
             NULL);
 }
-void flb_test_in_proc_flush_2s_2times()
+void flb_test_in_proc_flush()
 {
     do_test("proc",
             "interval_sec", "1",
@@ -148,26 +153,26 @@ void flb_test_in_proc_flush_2s_2times()
             "fd", "on",
             NULL);
 }
-void flb_test_in_head_flush_2s_2times()
+void flb_test_in_head_flush()
 {
     do_test("head", 
             "Interval_Sec", "1",
             "File", "/dev/urandom",
             NULL);
 }
-void flb_test_in_cpu_flush_2s_2times()
+void flb_test_in_cpu_flush()
 {
     do_test("cpu", NULL);
 }
-void flb_test_in_random_flush_2s_2times()
+void flb_test_in_random_flush()
 {
     do_test("random", NULL);
 }
-void flb_test_in_dummy_flush_2s_2times()
+void flb_test_in_dummy_flush()
 {
     do_test("dummy", NULL);
 }
-void flb_test_in_mem_flush_2s_2times()
+void flb_test_in_mem_flush()
 {
     do_test("mem", NULL);
 }
@@ -209,26 +214,26 @@ void flb_test_in_proc_absent_process(void)
 /* Test list */
 TEST_LIST = {
 #ifdef in_disk
-    {"disk_flush_2s_2times",    flb_test_in_disk_flush_2s_2times },
+    {"disk_flush",    flb_test_in_disk_flush},
 #endif
 #ifdef in_proc
-    {"proc_flush_2s_2times",    flb_test_in_proc_flush_2s_2times },
-    {"proc_absent_process",     flb_test_in_proc_absent_process },
+    {"proc_flush",    flb_test_in_proc_flush},
+    {"proc_absent_process",     flb_test_in_proc_absent_process},
 #endif
 #ifdef in_head
-    {"head_flush_2s_2times",    flb_test_in_head_flush_2s_2times },
+    {"head_flush",    flb_test_in_head_flush},
 #endif
 #ifdef in_cpu
-    {"cpu_flush_2s_2times",     flb_test_in_cpu_flush_2s_2times },
+    {"cpu_flush",     flb_test_in_cpu_flush},
 #endif
 #ifdef in_random
-    {"random_flush_2s_2times",  flb_test_in_random_flush_2s_2times },
+    {"random_flush",  flb_test_in_random_flush},
 #endif
 #ifdef in_dummy
-    {"dummy_flush_2s_2times",   flb_test_in_dummy_flush_2s_2times },
+    {"dummy_flush",   flb_test_in_dummy_flush},
 #endif
 #ifdef in_mem
-    {"mem_flush_2s_2times",     flb_test_in_mem_flush_2s_2times },
+    {"mem_flush",     flb_test_in_mem_flush},
 #endif
     {NULL, NULL}
 };

--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -95,41 +95,35 @@ void do_test(char *system, ...)
     TEST_CHECK(out_ffd >= 0);
     TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "test", NULL) == 0);
 
-    TEST_CHECK(flb_service_set(ctx, "Flush", "3",
+    TEST_CHECK(flb_service_set(ctx, "Flush", "0.5",
                                     "Grace", "1",
                                     NULL) == 0);
 
     /* The following test tries to check if an input plugin generates
      * data in a timely manner.
      *
-     *    0  1  2  3  4  5  6  7  8 (sec)
-     *    |--C--*--F--C--*--F--C--|
+     *    0     1     2     3     4   (sec)
+     *    |--F--F--F--C--F--F--F--C--|
      *
-     *    F ... Flush (3 sec interval)
+     *    F ... Flush (0.5 sec interval)
      *    C ... Condition checks
      *
      * Since CI servers can be sometimes very slow, we wait slightly a
-     * little more (1 sec) before checking the condition.
+     * little more before checking the condition.
      */
 
     /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* 1 sec passed. No data should be flushed */
-    sleep(1);
+    /* 2 sec passed. It must have flushed */
+    sleep(2);
     flb_info("[test] check status 1");
-    ret = get_result();
-    TEST_CHECK(ret == 0);
-
-    /* 4 sec passed. It must have flushed once */
-    sleep(3);
-    flb_info("[test] check status 2");
     ret = get_result();
     TEST_CHECK(ret > 0);
 
-    /* 7 sec passed. It must have flushed again */
-    sleep(3);
-    flb_info("[test] check status 3");
+    /* 4 sec passed. It must have flushed */
+    sleep(2);
+    flb_info("[test] check status 2");
     ret = get_result();
     TEST_CHECK(ret > 0);
 
@@ -140,13 +134,15 @@ void do_test(char *system, ...)
 void flb_test_in_disk_flush()
 {
     do_test("disk",
-            "interval_sec", "1",
+            "interval_sec", "0",
+            "interval_nsec", "500000000",
             NULL);
 }
 void flb_test_in_proc_flush()
 {
     do_test("proc",
-            "interval_sec", "1",
+            "interval_sec", "0",
+            "interval_nsec", "500000000",
             "proc_name", "flb_test_in_proc",
             "alert", "true",
             "mem", "on",
@@ -156,7 +152,8 @@ void flb_test_in_proc_flush()
 void flb_test_in_head_flush()
 {
     do_test("head", 
-            "Interval_Sec", "1",
+            "interval_sec", "0",
+            "interval_nsec", "500000000",
             "File", "/dev/urandom",
             NULL);
 }


### PR DESCRIPTION
Previously we used a few clever tricks in order to make our test
cases run robustly on slow servers (e.g. use while loop to absorb
random delays). Still we saw occasional failures on CI servers.

My opinion is that the old implementation was thinking too complex,
ended up introducing another fragility itself. I do not think adding
another pile of tricks would improve the overall situation.

Instead, this patch simplifies the test code significantly (e.g.
use a fixed sleep interval instead of a wait loop), and improve
the stability by making sure each test has enough cushion for
absorbing random delays.

In a nutshell, the new version tests the event generation using the
following schedule:

    0  1  2  3  4  5  6  7  8 (sec)
    |--C--*--F--C--*--F--C--|

    F ... Flush (3 sec interval)
    C ... Check if any data has been generated

... and should ensure that each input plugin generates events in a
timely manner.

Issue Link: #1231