### PR TITLE
Fix several salient warnings on MSVC

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -369,7 +369,7 @@ static FLB_INLINE void input_params_set(struct flb_thread *th,
     co_switch(th->callee);
 }
 
-static FLB_INLINE void input_pre_cb_collect()
+static FLB_INLINE void input_pre_cb_collect(void)
 {
     struct flb_input_collector *coll = libco_in_param.coll;
     struct flb_config *config = libco_in_param.config;

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -436,7 +436,7 @@ static inline void flb_input_return(struct flb_thread *th) {
      * We put together the return value with the task_id on the 32 bits at right
      */
     val = FLB_BITS_U64_SET(3 /* FLB_ENGINE_IN_THREAD */, in_th->id);
-    n = flb_pipe_w(in_th->config->ch_manager[1], &val, sizeof(val));
+    n = flb_pipe_w(in_th->config->ch_manager[1], (void *) &val, sizeof(val));
     if (n == -1) {
         flb_errno();
     }

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -443,7 +443,7 @@ static inline void flb_output_return(int ret, struct flb_thread *th) {
     set = FLB_TASK_SET(ret, task->id, out_th->id);
     val = FLB_BITS_U64_SET(2 /* FLB_ENGINE_TASK */, set);
 
-    n = flb_pipe_w(task->config->ch_manager[1], &val, sizeof(val));
+    n = flb_pipe_w(task->config->ch_manager[1], (void *) &val, sizeof(val));
     if (n == -1) {
         flb_errno();
     }

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -292,7 +292,7 @@ static FLB_INLINE void output_params_set(struct flb_thread *th,
     co_switch(th->callee);
 }
 
-static FLB_INLINE void output_pre_cb_flush()
+static FLB_INLINE void output_pre_cb_flush(void)
 {
     void *data   = libco_param.data;
     size_t bytes = libco_param.bytes;


### PR DESCRIPTION
This fixes a couple of type mismatch warnings on MSVC

 * Cast the argument explicitly to avoid "incompatibe type" warnings
 * Add `void` argument to functions which we pass to co_create().

The reason why I call these warnings as "salient" is that they are cloned
to other files by `#include`, resulting tons of warnings in count.