### PR TITLE
show the message where is no short_message key present. 

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1367,7 +1367,7 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
     }
 
     if (short_message_key_found == FLB_FALSE) {
-        flb_error("[flb_msgpack_to_gelf] missing short_message key");
+        flb_error("[flb_msgpack_to_gelf] missing short_message key: %s", tmp);
         return NULL;
     }
 


### PR DESCRIPTION
Sometimes it help debugging regexp enormously