### PR TITLE
build: use /W3 for MSVC to get less warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Update CFLAGS
 if (MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()


### PR DESCRIPTION
Right now, we get 3000+ warnings while building fluent-bit on MSVC.
Roughly 80% of them comes from dependent libraries. For example,
msgpack alone contributes more than 2000 warnings.

    Built with /W4 : 3804 warnings
    Built with /W3 :  828 warnings

I believe /W4 is too overwhelming to provide any insight on the specific
code lines of Fluent Bit. Let's reduce the verbosity level by one.

After this patch, I'm planning to work on the remaining 828 warnings to
make our Windows build process less clunky.