### PR TITLE
input: return a unique ffd for each input plugin instance

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -61,7 +61,7 @@ static inline int instance_id(struct flb_input_plugin *p,
 
     mk_list_foreach(head, &config->inputs) {
         entry = mk_list_entry(head, struct flb_input_instance, _head);
-        if (entry->p == p) {
+        if (entry->id == c) {
             c++;
         }
     }


### PR DESCRIPTION
Currently, using the flb_input.c function flb_input() returns an input ffd that can be
used to configure the plugin instance with subsequent calls to flb_input_set(). However,
the function instance_id() in flb_input.c will only return a unique ffd for input plugin
instances that are the same type; if instance_id() is called twice with two different
plugin types, it will return the same ffd both times. This patch fixes the issue by examining
all currently assigned ffds rather than checking plugin type.

Signed-off-by: Robert LaMarre <robert.lamarre@viasat.com>