### PR TITLE
Stream processor on MSYS2ed Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,12 @@ platform:
 configuration:
   - Release
 
+install:
+  - if %PLATFORM%==x86 (set MSYS2_MSYSTEM=MINGW32) else set MSYS2_MSYSTEM=MINGW64
+  - if %PLATFORM%==x86 (set MSYS2_PREFIX=C:\msys64\mingw32) else set MSYS2_PREFIX=C:\msys64\mingw64
+  - cmd: set PATH=%MSYS2_PREFIX%\bin;C:\msys64\usr\bin;%PATH%
+  - cmd: C:\msys64\usr\bin\pacman -Su --noconfirm bison flex
+
 before_build:
   - cmd: if "%platform%"=="Win32" set msvc=Visual Studio 15 2017
   - cmd: if "%platform%"=="x64"   set msvc=Visual Studio 15 2017 Win64

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -15,7 +15,6 @@ cmake -G "$ENV:msvc" -DCMAKE_BUILD_TYPE="$ENV:configuration" `
                      -D FLB_WITHOUT_flb-it-http_client=On `
                      -D FLB_WITHOUT_flb-it-network=On `
                      -D FLB_WITHOUT_flb-it-pack=On `
-                     -D FLB_WITHOUT_flb-it-stream_processor=On `
                      ../
 
 # COMPILE

--- a/lib/rbtree/rbtree.h
+++ b/lib/rbtree/rbtree.h
@@ -33,7 +33,11 @@ extern "C" {
 /**
  * The tagged branch is unlikely to be taken
  */
+#ifdef _MSC_VER
+#define RB_UNLIKELY(x) (!!(x))
+#else
 #define RB_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#endif
 /**@}*/
 
 /** \defgroup rb_tree_state State Structures

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -577,12 +577,18 @@ static void test_select_keys()
     struct flb_config *config;
     struct flb_sp *sp;
     struct flb_sp_task *task;
+#ifdef _WIN32
+    WSADATA wsa_data;
+#endif
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
         flb_errno();
         return;
     }
+#ifdef _WIN32
+    WSAStartup(0x0201, &wsa_data);
+#endif
     mk_list_init(&config->inputs);
     mk_list_init(&config->stream_processor_tasks);
 
@@ -640,6 +646,9 @@ static void test_select_keys()
     flb_sp_destroy(sp);
     mk_event_loop_destroy(config->evl);
     flb_free(config);
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }
 
 static void cb_window_5_second(int id, struct task_check *check,
@@ -689,12 +698,18 @@ static void test_window()
     struct flb_config *config;
     struct flb_sp *sp;
     struct flb_sp_task *task;
+#ifdef _WIN32
+    WSADATA wsa_data;
+#endif
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
         flb_errno();
         return;
     }
+#ifdef _WIN32
+    WSAStartup(0x0201, &wsa_data);
+#endif
     mk_list_init(&config->inputs);
     mk_list_init(&config->stream_processor_tasks);
     config->evl = mk_event_loop_create(256);
@@ -760,6 +775,9 @@ static void test_window()
     flb_sp_destroy(sp);
     mk_event_loop_destroy(config->evl);
     flb_free(config);
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }
 
 TEST_LIST = {


### PR DESCRIPTION
Enable stream_processor feature on MSYS2ed Windows.
Also enable stream_processor test case on AppVeyor.