### PR TITLE
Clean up EAGAIN checks on pipes

### DIFF
--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -29,11 +29,13 @@
 #define flb_sockfd_t evutil_socket_t
 #define flb_pipe_w(fd, buf, len) send(fd, buf, len, 0)
 #define flb_pipe_r(fd, buf, len) recv(fd, buf, len, 0)
+#define FLB_PIPE_WOULDBLOCK() (WSAGetLastError() == WSAEWOULDBLOCK)
 #else
 #define flb_pipefd_t int
 #define flb_sockfd_t int
 #define flb_pipe_w(fd, buf, len) write(fd, buf, len)
 #define flb_pipe_r(fd, buf, len) read(fd, buf, len)
+#define FLB_PIPE_WOULDBLOCK() (errno == EAGAIN || errno == EWOULDBLOCK)
 #endif
 
 int flb_pipe_create(flb_pipefd_t pipefd[2]);

--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -42,7 +42,6 @@ int flb_pipe_create(flb_pipefd_t pipefd[2]);
 void flb_pipe_destroy(flb_pipefd_t pipefd[2]);
 int flb_pipe_close(flb_pipefd_t fd);
 int flb_pipe_set_nonblocking(flb_pipefd_t fd);
-int flb_pipe_check_eagain(void);
 ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
 ssize_t flb_pipe_write_all(int fd, void *buf, size_t count);
 

--- a/plugins/in_tail/tail_signal.h
+++ b/plugins/in_tail/tail_signal.h
@@ -46,7 +46,7 @@ static inline int tail_signal_pending(struct flb_tail_config *ctx)
     /* Insert a dummy event into the 'pending' channel */
     n = flb_pipe_w(ctx->ch_pending[1], &val, sizeof(val));
     /* If we get EAGAIN, it simply means pending channel is full. As notification is already pending, it's safe to ignore. */
-    if (n == -1 && !flb_pipe_check_eagain()) {
+    if (n == -1 && !FLB_PIPE_WOULDBLOCK()) {
         flb_errno();
         return -1;
     }
@@ -65,11 +65,11 @@ static inline int tail_consume_pending(struct flb_tail_config *ctx)
      */
     do {
         ret = flb_pipe_r(ctx->ch_pending[0], &val, sizeof(val));
-        if (ret <= 0 && !flb_pipe_check_eagain()) {
+        if (ret <= 0 && !FLB_PIPE_WOULDBLOCK()) {
             flb_errno();
             return -1;
         }
-    } while (!flb_pipe_check_eagain());
+    } while (!FLB_PIPE_WOULDBLOCK());
 
     return 0;
 }

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -78,12 +78,6 @@ int flb_pipe_set_nonblocking(flb_pipefd_t fd)
 {
     return evutil_make_socket_nonblocking(fd);
 }
-
-int flb_pipe_check_eagain(void)
-{
-    return WSAGetLastError() == WSAEWOULDBLOCK;
-}
-
 #else
 /* All other flavors of Unix/BSD are OK */
 
@@ -114,11 +108,6 @@ int flb_pipe_set_nonblocking(flb_pipefd_t fd)
     if (flags & O_NONBLOCK)
         return 0;
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-}
-
-int flb_pipe_check_eagain(void)
-{
-    return errno == EAGAIN || errno == EWOULDBLOCK;
 }
 #endif
 

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -131,7 +131,7 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count)
     do {
         bytes = flb_pipe_r(fd, (char *) buf + total, count - total);
         if (bytes == -1) {
-            if (errno == EAGAIN) {
+            if (FLB_PIPE_WOULDBLOCK()) {
                 /*
                  * This could happen, since this function goal is not to
                  * return until all data have been read, just sleep a little
@@ -162,7 +162,7 @@ ssize_t flb_pipe_write_all(int fd, void *buf, size_t count)
     do {
         bytes = flb_pipe_w(fd, (const char *) buf + total, count - total);
         if (bytes == -1) {
-            if (errno == EAGAIN) {
+            if (FLB_PIPE_WOULDBLOCK()) {
                 /*
                  * This could happen, since this function goal is not to
                  * return until all data have been read, just sleep a little


### PR DESCRIPTION
This migrates a few remaining raw EAGAIN checks. With this merged,
all EAGAIN handlings in Fluent Bit are Windows-compatible.

I added a new macro FLB_PIPE_WOULDBOCK instead of using the existing
flb_pipe_check_eagain() here. The reason for doing this is coding coherency.

That is, previously we did:

 * for sockets, define a "macro" FLB_WOULDBLOCK to check EAGAIN.
 * for pipes, define a "function" flb_pipe_check_eagain() to check EAGAIN.

So similar problem, different solutions. I liked the design we used
for socket, so removed the function and introduced a new macro.
