### PR TITLE
More on compiler warnings on MSVC

### DIFF
--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -48,7 +48,7 @@ struct flb_sds {
 
 static inline size_t flb_sds_len(flb_sds_t s)
 {
-    return FLB_SDS_HEADER(s)->len;
+    return (size_t) FLB_SDS_HEADER(s)->len;
 }
 
 static inline void flb_sds_len_set(flb_sds_t s, size_t len)
@@ -58,7 +58,7 @@ static inline void flb_sds_len_set(flb_sds_t s, size_t len)
 
 static inline size_t flb_sds_alloc(flb_sds_t s)
 {
-    return FLB_SDS_HEADER(s)->alloc;
+    return (size_t) FLB_SDS_HEADER(s)->alloc;
 }
 
 static inline size_t flb_sds_avail(flb_sds_t s)
@@ -66,7 +66,7 @@ static inline size_t flb_sds_avail(flb_sds_t s)
     struct flb_sds *h;
 
     h = FLB_SDS_HEADER(s);
-    return (h->alloc - h->len);
+    return (size_t) (h->alloc - h->len);
 }
 
 static inline int flb_sds_cmp(flb_sds_t s, char *str, int len)

--- a/include/fluent-bit/flb_thread_libco.h
+++ b/include/fluent-bit/flb_thread_libco.h
@@ -65,7 +65,7 @@ struct flb_thread {
 
 FLB_EXPORT pthread_key_t flb_thread_key;
 
-static FLB_INLINE void flb_thread_prepare()
+static FLB_INLINE void flb_thread_prepare(void)
 {
     pthread_key_create(&flb_thread_key, NULL);
 }

--- a/include/fluent-bit/flb_thread_pthreads.h
+++ b/include/fluent-bit/flb_thread_pthreads.h
@@ -79,7 +79,7 @@ struct flb_thread
     struct mk_list _head;
 };
 
-static FLB_INLINE void flb_thread_prepare()
+static FLB_INLINE void flb_thread_prepare(void)
 {
 }
 

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -65,7 +65,7 @@ static inline void flb_time_copy(struct flb_time *dst, struct flb_time *src)
 static inline void flb_time_from_double(struct flb_time *dst, double d)
 {
     dst->tm.tv_sec = (int) d;
-    dst->tm.tv_nsec = (d - dst->tm.tv_sec) * 1000000000L;
+    dst->tm.tv_nsec = (long) ((d - dst->tm.tv_sec) * 1000000000L);
 }
 
 static inline int flb_time_equal(struct flb_time *t0, struct flb_time *t1) {


### PR DESCRIPTION
This is a series of patches that fix compiler warnings on MSVC.

    Before: 873 Warnings
    After : 627 Warnings

The gist is that MSVC is rather strict on types than GCC and clang,
and we needed some explicit type casts to prevent it complaining.
