### PR TITLE
Introduce flb_strlcpy to resolve "unsafe function" warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,17 @@ if(FLB_HAVE_UNIX_SOCKET)
   FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
 endif()
 
+check_c_source_compiles("
+  #include <string.h>
+  int main() {
+     char buf[8];
+     strlcpy(buf, \"aiueo\", 8);
+     return 0;
+  }" FLB_HAVE_STRLCPY)
+if(FLB_HAVE_STRLCPY)
+  FLB_DEFINITION(FLB_HAVE_STRLCPY)
+endif()
+
 # Build tools/xxd-c
 add_subdirectory(tools/xxd-c)
 

--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -28,6 +28,38 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * Copy as much as possible from src to dst. It always null-terminates
+ * the destination buffer, assuming the buffer size is dsize.
+ *
+ * Return value is strlen(src). Use it to detect a truncation:
+ *
+ *    if (strlcpy(dst, src, dsize) >= dsize) {
+ *       // some truncation occured
+ *    }
+ */
+#ifndef FLB_HAVE_STRLCPY
+static inline size_t flb_strlcpy(char *dst, const char *src, size_t dsize)
+{
+    size_t len = strlen(src);
+
+    if (!dsize) {
+        return len;
+    }
+
+    if (len < dsize) {
+        memcpy(dst, src, len);
+        dst[len] = '\0';
+    } else {
+        memcpy(dst, src, dsize - 1);
+        dst[dsize - 1] = '\0';
+    }
+    return len;
+}
+#else
+#define flb_strlcpy strlcpy
+#endif
+
 static inline char *flb_strdup(const char *s)
 {
     int len;
@@ -38,9 +70,7 @@ static inline char *flb_strdup(const char *s)
     if (!str) {
         return NULL;
     }
-    strncpy(str, s, len);
-    str[len] = '\0';
-
+    flb_strlcpy(str, s, len + 1);
     return str;
 }
 
@@ -52,9 +82,7 @@ static inline char *flb_strndup(const char *s, size_t n)
     if (!str) {
         return NULL;
     }
-    strncpy(str, s, n);
-    str[n] = '\0';
-
+    flb_strlcpy(str, s, n + 1);
     return str;
 }
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TESTS_FILES
   pack.c
   pipe.c
   sds.c
+  str.c
   router.c
   parser.c
   network.c

--- a/tests/internal/str.c
+++ b/tests/internal/str.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_str.h>
+
+#include "flb_tests_internal.h"
+
+static void test_strlcpy()
+{
+    char buf[16];
+    size_t n;
+
+    /* Normal case */
+    n = flb_strlcpy(buf, "aiueo", 6);
+    TEST_CHECK(memcmp(buf, "aiueo", 6) == 0);
+    TEST_CHECK(n == 5);
+
+    /* Enough buffer */
+    n = flb_strlcpy(buf, "aiueo", 16);
+    TEST_CHECK(memcmp(buf, "aiueo", 6) == 0);
+    TEST_CHECK(n == 5);
+
+    /* Buffer short by one */
+    n = flb_strlcpy(buf, "aiueo", 5);
+    TEST_CHECK(memcmp(buf, "aiue", 5) == 0);
+    TEST_CHECK(n == 5);
+
+    /* Buffer short by two */
+    n = flb_strlcpy(buf, "aiueo", 4);
+    TEST_CHECK(memcmp(buf, "aiu", 4) == 0);
+    TEST_CHECK(n == 5);
+
+    /* No buffer */
+    n = flb_strlcpy(buf, "aiueo", 0);
+    TEST_CHECK(n == 5);
+}
+
+TEST_LIST = {
+    { "strlcpy", test_strlcpy},
+    { 0 }
+};


### PR DESCRIPTION
The main motivation behind this patch is to elimiate "unsafe function"
warnings on Windows.

> warning C4996: 'strncpy': This function or variable may be unsafe.

In order to address these warnings, this introduces "flb_strlcpy" that
is a safer replacement for strncpy.

```c
size_t flb_strlcpy(char *dst, const char *src, size_t dsize)

    Copy as much as possible from src to dst. It always null-terminates
    the destination buffer, assuming the buffer size is dsize.
```

It has the exact same interface with BSD's strlcpy (in fact, it default
to strlcpy if available in the system). Also I added a series of test
cases to ensure its compatibility, too.
