### PR TITLE
CI: remove `bats` and nodejs from Docker canary build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,16 @@ matrix:
         sudo usermod -a -G systemd-journal $(id -un)
         sudo -E su -p travis -c "PATH=$PATH ci/do-ut"
     - os: linux
+      services:
+        - docker
       dist: xenial
       sudo: true
-      language: node_js
-        - "9"
+      language: c
       compiler: gcc
       env: DOCKER_BUILD=1
       script: |
         echo "===== BUILD DOCKER IMAGE ======="
         docker build -t test-image -f Dockerfile .
-        npm install -g bats
       addons:
         apt:
           sources: {}


### PR DESCRIPTION
This needs https://github.com/fluent/fluent-bit/pull/1271 merged first.
E.g. this will show a failure in CI that was being masked, the above MR will resolve the underlying failure.

Remove `bats` which was vestigal, not in use
Add explicit docker service need

Signed-off-by: Don Bowman <don@agilicus.com>