### PR TITLE
Fix Nginx parser regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+.DS_Store
 *~
 _book/
 lib/jemalloc

--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -20,7 +20,7 @@
 [PARSER]
     Name   nginx
     Format regex
-    Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")
     Time_Key time
     Time_Format %d/%b/%Y:%H:%M:%S %z
 


### PR DESCRIPTION
The default nginx parser provided does not properly match logs from nginx. After hunting around I found [this comment](https://github.com/fluent/fluent-bit/issues/1041#issuecomment-457795464) from the fluentbit issues which after testing a bit seems to work as expected.

I think it makes sense to update the parsers list here and on the `fluent-bit-kubernetes-logging` repo.