### PR TITLE
core: add const in functions signatures and limit casts

### DIFF
--- a/include/fluent-bit/flb_api.h
+++ b/include/fluent-bit/flb_api.h
@@ -25,7 +25,7 @@
 #include <fluent-bit/flb_output.h>
 
 struct flb_api {
-    char *(*output_get_property) (char *, void *);
+    const char *(*output_get_property) (const char *, struct flb_output_instance *);
 };
 
 #ifdef FLB_CORE

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -197,11 +197,11 @@ struct flb_config {
 
 struct flb_config *flb_config_init();
 void flb_config_exit(struct flb_config *config);
-char *flb_config_prop_get(char *key, struct mk_list *list);
+const char *flb_config_prop_get(const char *key, struct mk_list *list);
 int flb_config_set_property(struct flb_config *config,
-                            char *k, char *v);
+                            const char *k, const char *v);
 #ifdef FLB_HAVE_STATIC_CONF
-struct mk_rconf *flb_config_static_open(char *file);
+struct mk_rconf *flb_config_static_open(const char *file);
 #endif
 
 struct flb_service_config {

--- a/include/fluent-bit/flb_env.h
+++ b/include/fluent-bit/flb_env.h
@@ -29,8 +29,8 @@ struct flb_env {
 
 struct flb_env *flb_env_create();
 void flb_env_destroy(struct flb_env *env);
-int flb_env_set(struct flb_env *env, char *key, char *val);
-char *flb_env_get(struct flb_env *env, char *key);
-char *flb_env_var_translate(struct flb_env *env, char *value);
+int flb_env_set(struct flb_env *env, const char *key, const char *val);
+const char *flb_env_get(struct flb_env *env, const char *key);
+char *flb_env_var_translate(struct flb_env *env, const char *value);
 
 #endif

--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -48,7 +48,8 @@ struct flb_filter_plugin {
 
     /* Callbacks */
     int (*cb_init) (struct flb_filter_instance *, struct flb_config *, void *);
-    int (*cb_filter) (void *, size_t, char *, int,
+    int (*cb_filter) (const void *, size_t,
+                      const char *, int,
                       void **, size_t *,
                       struct flb_filter_instance *,
                       void *, struct flb_config *);
@@ -79,17 +80,18 @@ struct flb_filter_instance {
     struct flb_config *config;
 };
 
-int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v);
-char *flb_filter_get_property(char *key, struct flb_filter_instance *i);
+int flb_filter_set_property(struct flb_filter_instance *filter,
+                            const char *k, const char *v);
+const char *flb_filter_get_property(const char *key, struct flb_filter_instance *i);
 
 struct flb_filter_instance *flb_filter_new(struct flb_config *config,
-                                           char *filter, void *data);
+                                           const char *filter, void *data);
 void flb_filter_exit(struct flb_config *config);
 void flb_filter_do(struct flb_input_chunk *ic,
-                   void *data, size_t bytes,
-                   char *tag, int tag_len,
+                   const void *data, size_t bytes,
+                   const char *tag, int tag_len,
                    struct flb_config *config);
-char *flb_filter_name(struct flb_filter_instance *in);
+const char *flb_filter_name(struct flb_filter_instance *in);
 void flb_filter_initialize_all(struct flb_config *config);
 void flb_filter_set_context(struct flb_filter_instance *ins, void *context);
 

--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -62,12 +62,15 @@ struct flb_hash {
 struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries);
 void flb_hash_destroy(struct flb_hash *ht);
 
-int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
-                 char *val, size_t val_size);
-int flb_hash_get(struct flb_hash *ht, char *key, int key_len,
-                 char **out_buf, size_t *out_size);
-int flb_hash_get_by_id(struct flb_hash *ht, int id, char *key, char **out_buf,
-                       size_t *out_size);
-int flb_hash_del(struct flb_hash *ht, char *key);
+int flb_hash_add(struct flb_hash *ht,
+                 const char *key, int key_len,
+                 const char *val, size_t val_size);
+int flb_hash_get(struct flb_hash *ht,
+                 const char *key, int key_len,
+                 const char **out_buf, size_t *out_size);
+int flb_hash_get_by_id(struct flb_hash *ht, int id,
+                       const char *key,
+                       const char **out_buf, size_t *out_size);
+int flb_hash_del(struct flb_hash *ht, const char *key);
 
 #endif

--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -78,7 +78,7 @@ struct flb_http_response {
 struct flb_http_proxy {
     int type;               /* One of FLB_HTTP_PROXY_ macros */
     int port;               /* TCP Port */
-    char *host;             /* Proxy Host */
+    const char *host;       /* Proxy Host */
 };
 
 /* Set a request type */
@@ -94,7 +94,7 @@ struct flb_http_client {
     char *header_buf;
 
     int body_len;
-    char *body_buf;
+    const char *body_buf;
 
     /* Proxy */
     struct flb_http_proxy proxy;
@@ -104,15 +104,16 @@ struct flb_http_client {
 };
 
 struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
-                                        int method, char *uri,
-                                        char *body, size_t body_len,
-                                        char *host, int port,
-                                        char *proxy, int flags);
+                                        int method, const char *uri,
+                                        const char *body, size_t body_len,
+                                        const char *host, int port,
+                                        const char *proxy, int flags);
 
 int flb_http_add_header(struct flb_http_client *c,
-                        char *key, size_t key_len,
-                        char *val, size_t val_len);
-int flb_http_basic_auth(struct flb_http_client *c, char *user, char *passwd);
+                        const char *key, size_t key_len,
+                        const char *val, size_t val_len);
+int flb_http_basic_auth(struct flb_http_client *c,
+                        const char *user, const char *passwd);
 int flb_http_do(struct flb_http_client *c, size_t *bytes);
 void flb_http_client_destroy(struct flb_http_client *c);
 int flb_http_buffer_size(struct flb_http_client *c, size_t size);

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -461,10 +461,11 @@ static inline void FLB_INPUT_RETURN()
 
 int flb_input_register_all(struct flb_config *config);
 struct flb_input_instance *flb_input_new(struct flb_config *config,
-                                         char *input, void *data,
+                                         const char *input, void *data,
                                          int public_only);
-int flb_input_set_property(struct flb_input_instance *in, char *k, char *v);
-char *flb_input_get_property(char *key, struct flb_input_instance *i);
+int flb_input_set_property(struct flb_input_instance *in,
+                           const char *k, const char *v);
+const char *flb_input_get_property(const char *key, struct flb_input_instance *i);
 
 int flb_input_check(struct flb_config *config);
 void flb_input_set_context(struct flb_input_instance *in, void *context);
@@ -505,6 +506,6 @@ void flb_input_exit_all(struct flb_config *config);
 
 void *flb_input_flush(struct flb_input_instance *i_ins, size_t *size);
 int flb_input_pause_all(struct flb_config *config);
-char *flb_input_name(struct flb_input_instance *in);
+const char *flb_input_name(struct flb_input_instance *in);
 
 #endif

--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -38,22 +38,22 @@ struct flb_input_chunk {
 };
 
 struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
-                                               char *tag, int tag_len);
+                                               const char *tag, int tag_len);
 int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del);
 void flb_input_chunk_destroy_all(struct flb_input_instance *in);
 int flb_input_chunk_write(void *data, const char *buf, size_t len);
 int flb_input_chunk_write_at(void *data, off_t offset,
                              const char *buf, size_t len);
 int flb_input_chunk_append_obj(struct flb_input_instance *in,
-                               char *tag, int tag_len,
+                               const char *tag, int tag_len,
                                msgpack_object data);
 int flb_input_chunk_append_raw(struct flb_input_instance *in,
-                               char *tag, size_t tag_len,
-                               void *buf, size_t buf_size);
-void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size);
+                               const char *tag, size_t tag_len,
+                               const void *buf, size_t buf_size);
+const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size);
 int flb_input_chunk_release_lock(struct flb_input_chunk *ic);
 int flb_input_chunk_get_tag(struct flb_input_chunk *ic,
-                            char **tag_buf, int *tag_len);
+                            const char **tag_buf, int *tag_len);
 ssize_t flb_input_chunk_get_size(struct flb_input_chunk *ic);
 size_t flb_input_chunk_set_limits(struct flb_input_instance *in);
 size_t flb_input_chunk_total_size(struct flb_input_instance *in);

--- a/include/fluent-bit/flb_io.h
+++ b/include/fluent-bit/flb_io.h
@@ -44,7 +44,7 @@
 int flb_io_net_connect(struct flb_upstream_conn *u_conn,
                        struct flb_thread *th);
 
-int flb_io_net_write(struct flb_upstream_conn *u, void *data,
+int flb_io_net_write(struct flb_upstream_conn *u, const void *data,
                      size_t len, size_t *out_len);
 ssize_t flb_io_net_read(struct flb_upstream_conn *u, void *buf, size_t len);
 

--- a/include/fluent-bit/flb_io_tls_rw.h
+++ b/include/fluent-bit/flb_io_tls_rw.h
@@ -32,7 +32,7 @@
 int flb_io_tls_net_read(struct flb_thread *th, struct flb_upstream_conn *u_conn,
                         void *buf, size_t len);
 int flb_io_tls_net_write(struct flb_thread *th, struct flb_upstream_conn *u_conn,
-                         void *data, size_t len, size_t *out_len);
+                         const void *data, size_t len, size_t *out_len);
 
 #endif
 

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -42,9 +42,9 @@ typedef struct flb_lib_ctx         flb_ctx_t;
 
 FLB_EXPORT flb_ctx_t *flb_create();
 FLB_EXPORT void flb_destroy(flb_ctx_t *ctx);
-FLB_EXPORT int flb_input(flb_ctx_t *ctx, char *input, void *data);
-FLB_EXPORT int flb_output(flb_ctx_t *ctx, char *output, void *data);
-FLB_EXPORT int flb_filter(flb_ctx_t *ctx, char *filter, void *data);
+FLB_EXPORT int flb_input(flb_ctx_t *ctx, const char *input, void *data);
+FLB_EXPORT int flb_output(flb_ctx_t *ctx, const char *output, void *data);
+FLB_EXPORT int flb_filter(flb_ctx_t *ctx, const char *filter, void *data);
 FLB_EXPORT int flb_input_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_output_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_filter_set(flb_ctx_t *ctx, int ffd, ...);
@@ -57,7 +57,7 @@ FLB_EXPORT int flb_start(flb_ctx_t *ctx);
 FLB_EXPORT int flb_stop(flb_ctx_t *ctx);
 
 /* data ingestion for "lib" input instance */
-FLB_EXPORT int flb_lib_push(flb_ctx_t *ctx, int ffd, void *data, size_t len);
-FLB_EXPORT int flb_lib_config_file(flb_ctx_t *ctx, char *path);
+FLB_EXPORT int flb_lib_push(flb_ctx_t *ctx, int ffd, const void *data, size_t len);
+FLB_EXPORT int flb_lib_config_file(flb_ctx_t *ctx, const char *path);
 
 #endif

--- a/include/fluent-bit/flb_meta.h
+++ b/include/fluent-bit/flb_meta.h
@@ -24,6 +24,6 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 
-int flb_meta_run(struct flb_config *ctx, char *cmd, char *params);
+int flb_meta_run(struct flb_config *ctx, const char *cmd, const char *params);
 
 #endif

--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -53,11 +53,11 @@ struct flb_metrics {
     struct mk_list list;   /* Head of metrics list */
 };
 
-struct flb_metrics *flb_metrics_create(char *title);
-int flb_metrics_title(char *title, struct flb_metrics *metrics);
+struct flb_metrics *flb_metrics_create(const char *title);
+int flb_metrics_title(const char *title, struct flb_metrics *metrics);
 
 struct flb_metric *flb_metrics_get_id(int id, struct flb_metrics *metrics);
-int flb_metrics_add(int id, char *title, struct flb_metrics *metrics);
+int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics);
 int flb_metrics_sum(int id, size_t val, struct flb_metrics *metrics);
 int flb_metrics_print(struct flb_metrics *metrics);
 int flb_metrics_dump_values(char **out_buf, size_t *out_size,

--- a/include/fluent-bit/flb_mp.h
+++ b/include/fluent-bit/flb_mp.h
@@ -23,7 +23,7 @@
 
 #include <msgpack.h>
 
-int flb_mp_count(void *data, size_t bytes);
-int flb_mp_count_zone(void *data, size_t bytes, msgpack_zone *zone);
+int flb_mp_count(const void *data, size_t bytes);
+int flb_mp_count_zone(const void *data, size_t bytes, msgpack_zone *zone);
 
 #endif

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -39,7 +39,7 @@ struct flb_net_host {
 #endif
 
 /* Generic functions */
-int flb_net_host_set(char *plugin_name, struct flb_net_host *host, char *address);
+int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address);
 
 /* TCP options */
 int flb_net_socket_reset(flb_sockfd_t fd);
@@ -50,11 +50,11 @@ int flb_net_socket_tcp_fastopen(flb_sockfd_t sockfd);
 /* Socket handling */
 flb_sockfd_t flb_net_socket_create(int family, int nonblock);
 flb_sockfd_t flb_net_socket_create_udp(int family, int nonblock);
-flb_sockfd_t flb_net_tcp_connect(char *host, unsigned long port);
-flb_sockfd_t flb_net_udp_connect(char *host, unsigned long port);
-int flb_net_tcp_fd_connect(flb_sockfd_t fd, char *host, unsigned long port);
-flb_sockfd_t flb_net_server(char *port, char *listen_addr);
-flb_sockfd_t flb_net_server_udp(char *port, char *listen_addr);
+flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port);
+flb_sockfd_t flb_net_udp_connect(const char *host, unsigned long port);
+int flb_net_tcp_fd_connect(flb_sockfd_t fd, const char *host, unsigned long port);
+flb_sockfd_t flb_net_server(const char *port, const char *listen_addr);
+flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr);
 int flb_net_bind(flb_sockfd_t fd, const struct sockaddr *addr,
                  socklen_t addrlen, int backlog);
 int flb_net_bind_udp(flb_sockfd_t fd, const struct sockaddr *addr,

--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -57,16 +57,16 @@ struct flb_oauth2 {
 };
 
 struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
-                                     char *auth_url, int expire_sec);
+                                     const char *auth_url, int expire_sec);
 void flb_oauth2_destroy(struct flb_oauth2 *ctx);
 int flb_oauth2_token_len(struct flb_oauth2 *ctx);
 int flb_oauth2_payload_append(struct flb_oauth2 *ctx,
-                              char *key_str, int key_len,
-                              char *val_str, int val_len);
+                              const char *key_str, int key_len,
+                              const char *val_str, int val_len);
 char *flb_oauth2_token_get(struct flb_oauth2 *ctx);
 int flb_oauth2_token_expired(struct flb_oauth2 *ctx);
 
-int flb_oauth2_parse_json_response(char *json_data, size_t json_size,
+int flb_oauth2_parse_json_response(const char *json_data, size_t json_size,
                         struct flb_oauth2 *ctx);
 
 #endif

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -92,8 +92,8 @@ struct flb_output_plugin {
     int (*cb_pre_run) (void *, struct flb_config *);
 
     /* Flush callback */
-    void (*cb_flush) (void *, size_t,
-                      char *, int,
+    void (*cb_flush) (const void *, size_t,
+                      const char *, int,
                       struct flb_input_instance *,
                       void *,
                       struct flb_config *);
@@ -194,7 +194,7 @@ struct flb_output_instance {
 
 struct flb_output_thread {
     int id;                            /* out-thread ID      */
-    void *buffer;                      /* output buffer      */
+    const void *buffer;                /* output buffer      */
     struct flb_task *task;             /* Parent flb_task    */
     struct flb_config *config;         /* FLB context        */
     struct flb_output_instance *o_ins; /* output instance    */
@@ -259,9 +259,9 @@ static FLB_INLINE void cb_output_thread_destroy(void *data)
  * that achieve the same stuff.
  */
 struct flb_libco_out_params {
-    void  *data;
+    const void  *data;
     size_t bytes;
-    char *tag;
+    const char *tag;
     int tag_len;
     struct flb_input_instance *i_ins;
     void *out_context;
@@ -273,8 +273,8 @@ struct flb_libco_out_params {
 struct flb_libco_out_params libco_param;
 
 static FLB_INLINE void output_params_set(struct flb_thread *th,
-                              void *data, size_t bytes,
-                              char *tag, int tag_len,
+                              const void *data, size_t bytes,
+                              const char *tag, int tag_len,
                               struct flb_input_instance *i_ins,
                               struct flb_output_plugin *out_plugin,
                               void *out_context, struct flb_config *config)
@@ -295,10 +295,10 @@ static FLB_INLINE void output_params_set(struct flb_thread *th,
 
 static FLB_INLINE void output_pre_cb_flush(void)
 {
-    void *data   = libco_param.data;
-    size_t bytes = libco_param.bytes;
-    char *tag    = libco_param.tag;
-    int tag_len  = libco_param.tag_len;
+    const void *data                 = libco_param.data;
+    size_t bytes                     = libco_param.bytes;
+    const char *tag                  = libco_param.tag;
+    int tag_len                      = libco_param.tag_len;
     struct flb_input_instance *i_ins = libco_param.i_ins;
     struct flb_output_plugin *out_p  = libco_param.out_plugin;
     void *out_context                = libco_param.out_context;
@@ -321,8 +321,8 @@ struct flb_thread *flb_output_thread(struct flb_task *task,
                                      struct flb_input_instance *i_ins,
                                      struct flb_output_instance *o_ins,
                                      struct flb_config *config,
-                                     void *buf, size_t size,
-                                     char *tag, int tag_len)
+                                     const void *buf, size_t size,
+                                     const char *tag, int tag_len)
 {
     size_t stack_size;
     struct flb_output_thread *out_th;
@@ -383,8 +383,8 @@ struct flb_thread *flb_output_thread(struct flb_task *task,
                                      struct flb_input_instance *i_ins,
                                      struct flb_output_instance *o_ins,
                                      struct flb_config *config,
-                                     void *buf, size_t size,
-                                     char *tag, int tag_len)
+                                     const void *buf, size_t size,
+                                     const char *tag, int tag_len)
 {
     struct flb_thread *th;
 
@@ -488,11 +488,12 @@ static inline void flb_output_return_do(int x)
     return
 
 struct flb_output_instance *flb_output_new(struct flb_config *config,
-                                           char *output, void *data);
+                                           const char *output, void *data);
 
-int flb_output_set_property(struct flb_output_instance *out, char *k, char *v);
-char *flb_output_get_property(char *key, struct flb_output_instance *o_ins);
-void flb_output_net_default(char *host, int port,
+int flb_output_set_property(struct flb_output_instance *out,
+                            const char *k, const char *v);
+const char *flb_output_get_property(const char *key, struct flb_output_instance *o_ins);
+void flb_output_net_default(const char *host, int port,
                             struct flb_output_instance *o_ins);
 void flb_output_pre_run(struct flb_config *config);
 void flb_output_exit(struct flb_config *config);

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -42,24 +42,24 @@ struct flb_pack_state {
     jsmn_parser parser;   /* parser state            */
 };
 
-int flb_json_tokenise(char *js, size_t len, struct flb_pack_state *state);
-int flb_pack_json(char *js, size_t len, char **buffer, size_t *size,
+int flb_json_tokenise(const char *js, size_t len, struct flb_pack_state *state);
+int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size,
                   int *root_type);
 int flb_pack_state_init(struct flb_pack_state *s);
 void flb_pack_state_reset(struct flb_pack_state *s);
 
-int flb_pack_json_state(char *js, size_t len,
+int flb_pack_json_state(const char *js, size_t len,
                         char **buffer, int *size,
                         struct flb_pack_state *state);
-int flb_pack_json_valid(char *json, size_t len);
+int flb_pack_json_valid(const char *json, size_t len);
 
-void flb_pack_print(char *data, size_t bytes);
+void flb_pack_print(const char *data, size_t bytes);
 int flb_msgpack_to_json(char *json_str, size_t str_len,
-                        msgpack_object *obj);
-char* flb_msgpack_to_json_str(size_t size, msgpack_object *obj);
-int flb_msgpack_raw_to_json_str(char *buf, size_t buf_size,
+                        const msgpack_object *obj);
+char* flb_msgpack_to_json_str(size_t size, const msgpack_object *obj);
+int flb_msgpack_raw_to_json_str(const char *buf, size_t buf_size,
                                 char **out_buf, size_t *out_size);
-flb_sds_t flb_msgpack_raw_to_json_sds(void *in_buf, size_t in_size);
+flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size);
 
 int flb_pack_time_now(msgpack_packer *pck);
 int flb_msgpack_expand_map(char *map_data, size_t map_size,

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -86,29 +86,29 @@ static inline time_t flb_parser_tm2time(const struct tm *src)
 }
 
 
-struct flb_parser *flb_parser_create(char *name, char *format,
-                                     char *p_regex,
-                                     char *time_fmt, char *time_key,
-                                     char *time_offset,
+struct flb_parser *flb_parser_create(const char *name, const char *format,
+                                     const char *p_regex,
+                                     const char *time_fmt, const char *time_key,
+                                     const char *time_offset,
                                      int time_keep,
                                      struct flb_parser_types *types,
                                      int types_len,
                                      struct mk_list *decoders,
                                      struct flb_config *config);
-int flb_parser_conf_file(char *file, struct flb_config *config);
+int flb_parser_conf_file(const char *file, struct flb_config *config);
 void flb_parser_destroy(struct flb_parser *parser);
-struct flb_parser *flb_parser_get(char *name, struct flb_config *config);
-int flb_parser_do(struct flb_parser *parser, char *buf, size_t length,
+struct flb_parser *flb_parser_get(const char *name, struct flb_config *config);
+int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
                   void **out_buf, size_t *out_size, struct flb_time *out_time);
 
 void flb_parser_exit(struct flb_config *config);
-int flb_parser_tzone_offset(char *str, int len, int *tmdiff);
-int flb_parser_frac(char *str, int len, double *frac, char **end);
-int flb_parser_time_lookup(char *time, size_t tsize, time_t now,
+int flb_parser_tzone_offset(const char *str, int len, int *tmdiff);
+int flb_parser_frac(const char *str, int len, double *frac, const char **end);
+int flb_parser_time_lookup(const char *time, size_t tsize, time_t now,
                            struct flb_parser *parser,
                            struct tm *tm, double *ns);
-int flb_parser_typecast(char *key, int key_len,
-                        char *val, int val_len,
+int flb_parser_typecast(const char *key, int key_len,
+                        const char *val, int val_len,
                         msgpack_packer *pck,
                         struct flb_parser_types *types,
                         int types_len);

--- a/include/fluent-bit/flb_parser_decoder.h
+++ b/include/fluent-bit/flb_parser_decoder.h
@@ -61,7 +61,7 @@ struct flb_parser_dec {
 struct mk_list *flb_parser_decoder_list_create(struct mk_rconf_section *section);
 int flb_parser_decoder_list_destroy(struct mk_list *list);
 int flb_parser_decoder_do(struct mk_list *decoders,
-                          char *in_buf, size_t in_size,
+                          const char *in_buf, size_t in_size,
                           char **out_buf, size_t *out_size);
 
 #endif

--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -43,6 +43,6 @@ void flb_pipe_destroy(flb_pipefd_t pipefd[2]);
 int flb_pipe_close(flb_pipefd_t fd);
 int flb_pipe_set_nonblocking(flb_pipefd_t fd);
 ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
-ssize_t flb_pipe_write_all(int fd, void *buf, size_t count);
+ssize_t flb_pipe_write_all(int fd, const void *buf, size_t count);
 
 #endif

--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -78,6 +78,6 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
 struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
                                                  struct flb_config *config);
 int flb_plugin_proxy_load_all(struct flb_config *config);
-int flb_plugin_proxy_conf_file(char *file, struct flb_config *config);
+int flb_plugin_proxy_conf_file(const char *file, struct flb_config *config);
 
 #endif

--- a/include/fluent-bit/flb_regex.h
+++ b/include/fluent-bit/flb_regex.h
@@ -33,27 +33,26 @@
 #include <onigmo.h>
 
 struct flb_regex {
-    unsigned char *pattern;
     OnigRegex regex;
 };
 
 struct flb_regex_search {
     int last_pos;
     OnigRegion *region;
-    unsigned char *str;
-    void (*cb_match) (unsigned char *,          /* name  */
-                      unsigned char *, size_t,  /* value */
+    const char *str;
+    void (*cb_match) (const char *,          /* name  */
+                      const char *, size_t,  /* value */
                       void *);                  /* caller data */
     void *data;
 };
 
 int flb_regex_init();
-struct flb_regex *flb_regex_create(unsigned char *pattern);
-ssize_t flb_regex_do(struct flb_regex *r, unsigned char *str, size_t slen,
+struct flb_regex *flb_regex_create(const char *pattern);
+ssize_t flb_regex_do(struct flb_regex *r, const char *str, size_t slen,
                      struct flb_regex_search *result);
 int flb_regex_parse(struct flb_regex *r, struct flb_regex_search *result,
-                    void (*cb_match) (unsigned char *,          /* name  */
-                                      unsigned char *, size_t,  /* value */
+                    void (*cb_match) (const char *,          /* name  */
+                                      const char *, size_t,  /* value */
                                       void *),                  /* caller data */
                     void *data);
 int flb_regex_destroy(struct flb_regex *r);

--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -69,7 +69,7 @@ static inline size_t flb_sds_avail(flb_sds_t s)
     return (size_t) (h->alloc - h->len);
 }
 
-static inline int flb_sds_cmp(flb_sds_t s, char *str, int len)
+static inline int flb_sds_cmp(flb_sds_t s, const char *str, int len)
 {
     if (flb_sds_len(s) != len) {
         return -1;
@@ -78,13 +78,13 @@ static inline int flb_sds_cmp(flb_sds_t s, char *str, int len)
     return strncmp(s, str, len);
 }
 
-flb_sds_t flb_sds_create(char *str);
-flb_sds_t flb_sds_create_len(char *str, int len);
+flb_sds_t flb_sds_create(const char *str);
+flb_sds_t flb_sds_create_len(const char *str, int len);
 flb_sds_t flb_sds_create_size(size_t size);
-flb_sds_t flb_sds_cat(flb_sds_t s, char *str, int len);
-flb_sds_t flb_sds_cat_utf8(flb_sds_t *s, char *str, int len);
+flb_sds_t flb_sds_cat(flb_sds_t s, const char *str, int len);
+flb_sds_t flb_sds_cat_utf8(flb_sds_t *s, const char *str, int len);
 flb_sds_t flb_sds_increase(flb_sds_t s, size_t len);
-flb_sds_t flb_sds_copy(flb_sds_t s, char *str, int len);
+flb_sds_t flb_sds_copy(flb_sds_t s, const char *str, int len);
 void flb_sds_destroy(flb_sds_t s);
 flb_sds_t flb_sds_printf(flb_sds_t *s, const char *fmt, ...);
 

--- a/include/fluent-bit/flb_slist.h
+++ b/include/fluent-bit/flb_slist.h
@@ -30,7 +30,7 @@ struct flb_slist_entry {
 };
 
 int flb_slist_create(struct mk_list *list);
-int flb_slist_add(struct mk_list *head, char *str);
+int flb_slist_add(struct mk_list *head, const char *str);
 void flb_slist_destroy(struct mk_list *list);
 
 #endif

--- a/include/fluent-bit/flb_sqldb.h
+++ b/include/fluent-bit/flb_sqldb.h
@@ -34,11 +34,11 @@ struct flb_sqldb {
     struct mk_list _head;     /* Link to config->sqldb_list    */
 };
 
-struct flb_sqldb *flb_sqldb_open(char *path, const char *desc,
+struct flb_sqldb *flb_sqldb_open(const char *path, const char *desc,
                                  struct flb_config *config);
 int flb_sqldb_close(struct flb_sqldb *db);
 
-int flb_sqldb_query(struct flb_sqldb *db, char *sql,
+int flb_sqldb_query(struct flb_sqldb *db, const char *sql,
                     int (*callback) (void *, int, char **, char **),
                     void *data);
 int64_t flb_sqldb_last_id(struct flb_sqldb *db);

--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -83,7 +83,7 @@ struct flb_task {
     int destinations;                   /* number of output dests    */
     char *tag;                          /* record tag                */
     int tag_len;                        /* tag length                */
-    char *buf;                          /* buffer                    */
+    const char *buf;                    /* buffer                    */
     size_t size;                        /* buffer data size          */
     void *ic;                           /* input chunk */
     struct flb_input_dyntag *dt;        /* dyntag node (if applies)      */
@@ -100,11 +100,11 @@ struct flb_task {
 };
 
 struct flb_task *flb_task_create(uint64_t ref_id,
-                                 char *buf,
+                                 const char *buf,
                                  size_t size,
                                  struct flb_input_instance *i_ins,
                                  void *ic,
-                                 char *tag_buf, int tag_len,
+                                 const char *tag_buf, int tag_len,
                                  struct flb_config *config);
 void flb_task_add_thread(struct flb_thread *thread,
                          struct flb_task *task);
@@ -118,11 +118,11 @@ int flb_task_retry_clean(struct flb_task *task, void *data);
 
 
 struct flb_task *flb_task_chunk_create(uint64_t ref_id,
-                                       char *buf,
+                                       const char *buf,
                                        size_t size,
                                        struct flb_input_instance *i_ins,
                                        void *ic,
-                                       char *tag_buf, int tag_len,
+                                       const char *tag_buf, int tag_len,
                                        struct flb_config *config);
 
 #endif

--- a/include/fluent-bit/flb_tls.h
+++ b/include/fluent-bit/flb_tls.h
@@ -28,7 +28,7 @@
 #include <fluent-bit/flb_upstream.h>
 
 int net_io_tls_write(struct flb_thread *th, struct flb_upstream_conn *u_conn,
-                     void *data, size_t len, size_t *out_len);
+                     const void *data, size_t len, size_t *out_len);
 int net_io_tls_read(struct flb_thread *th, struct flb_upstream_conn *u_conn,
                     void *buf, size_t len);
 

--- a/include/fluent-bit/flb_unescape.h
+++ b/include/fluent-bit/flb_unescape.h
@@ -21,7 +21,7 @@
 #ifndef FLB_UNESCAPE_H
 #define FLB_UNESCAPE_H
 
-int flb_unescape_string(char *buf, int buf_len, char **unesc_buf);
-int flb_unescape_string_utf8(char *in_buf, int sz, char *out_buf);
+int flb_unescape_string(const char *buf, int buf_len, char **unesc_buf);
+int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf);
 
 #endif

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -114,10 +114,11 @@ struct flb_upstream_conn {
 };
 
 struct flb_upstream *flb_upstream_create(struct flb_config *config,
-                                         char *host, int port, int flags,
+                                         const char *host, int port, int flags,
                                          void *tls);
 struct flb_upstream *flb_upstream_create_url(struct flb_config *config,
-                                             char *url, int flags, void *tls);
+                                             const char *url, int flags,
+                                             void *tls);
 
 int flb_upstream_destroy(struct flb_upstream *u);
 

--- a/include/fluent-bit/flb_upstream_ha.h
+++ b/include/fluent-bit/flb_upstream_ha.h
@@ -32,12 +32,12 @@ struct flb_upstream_ha {
     struct mk_list nodes;      /* List of available nodes */
 };
 
-struct flb_upstream_ha *flb_upstream_ha_create(char *name);
+struct flb_upstream_ha *flb_upstream_ha_create(const char *name);
 void flb_upstream_ha_destroy(struct flb_upstream_ha *ctx);
 void flb_upstream_ha_node_add(struct flb_upstream_ha *ctx,
                               struct flb_upstream_node *node);
 struct flb_upstream_node *flb_upstream_ha_node_get(struct flb_upstream_ha *ctx);
-struct flb_upstream_ha *flb_upstream_ha_from_file(char *file,
+struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
                                                   struct flb_config *config);
 
 #endif

--- a/include/fluent-bit/flb_upstream_node.h
+++ b/include/fluent-bit/flb_upstream_node.h
@@ -63,19 +63,19 @@ struct flb_upstream_node {
 };
 
 
-struct flb_upstream_node *flb_upstream_node_create(char *name, char *host,
-                                                   char *port,
+struct flb_upstream_node *flb_upstream_node_create(const char *name, const char *host,
+                                                   const char *port,
                                                    int tls, int tls_verify,
                                                    int tls_debug,
-                                                   char *tls_ca_path,
-                                                   char *tls_ca_file,
-                                                   char *tls_crt_file,
-                                                   char *tls_key_file,
-                                                   char *tls_key_passwd,
+                                                   const char *tls_ca_path,
+                                                   const char *tls_ca_file,
+                                                   const char *tls_crt_file,
+                                                   const char *tls_key_file,
+                                                   const char *tls_key_passwd,
                                                    struct flb_hash *ht,
                                                    struct flb_config *config);
-char *flb_upstream_node_get_property(char *prop,
-                                     struct flb_upstream_node *node);
+const char *flb_upstream_node_get_property(const char *prop,
+                                           struct flb_upstream_node *node);
 
 static inline void flb_upstream_node_set_data(void *data,
                                               struct flb_upstream_node *node)

--- a/include/fluent-bit/flb_uri.h
+++ b/include/fluent-bit/flb_uri.h
@@ -40,7 +40,7 @@ struct flb_uri {
 };
 
 struct flb_uri_field *flb_uri_get(struct flb_uri *uri, int pos);
-struct flb_uri *flb_uri_create(char *full_uri);
+struct flb_uri *flb_uri_create(const char *full_uri);
 void flb_uri_destroy(struct flb_uri *uri);
 void flb_uri_dump(struct flb_uri *uri);
 

--- a/include/fluent-bit/flb_utf8.h
+++ b/include/fluent-bit/flb_utf8.h
@@ -39,7 +39,7 @@ static const char trailingBytesForUTF8[256] = {
 };
 
 /* returns length of next utf-8 sequence */
-static inline int flb_utf8_len(char *s)
+static inline int flb_utf8_len(const char *s)
 {
     return trailingBytesForUTF8[(unsigned int)(unsigned char)s[0]] + 1;
 }
@@ -87,7 +87,7 @@ static inline uint32_t flb_utf8_decode(uint32_t *state, uint32_t *codep,
 }
 
 
-static inline void flb_utf8_print(uint8_t *s) {
+static inline void flb_utf8_print(const uint8_t *s) {
     uint32_t codepoint;
     uint32_t state = 0;
 

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -35,7 +35,7 @@ struct flb_split_entry {
 void flb_utils_error(int err);
 void flb_utils_error_c(const char *msg);
 void flb_utils_warn_c(const char *msg);
-void flb_message(int type, char *file, int line, const char *fmt, ...);
+void flb_message(int type, const char *file, int line, const char *fmt, ...);
 
 #ifdef FLB_HAVE_FORK
 int flb_utils_set_daemon();
@@ -43,22 +43,23 @@ int flb_utils_set_daemon();
 
 void flb_utils_print_setup(struct flb_config *config);
 
-struct mk_list *flb_utils_split(char *line, int separator, int max_split);
+struct mk_list *flb_utils_split(const char *line, int separator, int max_split);
 
 void flb_utils_split_free(struct mk_list *list);
 int flb_utils_timer_consume(flb_pipefd_t fd);
-int64_t flb_utils_size_to_bytes(char *size);
-int flb_utils_time_to_seconds(char *time);
+int64_t flb_utils_size_to_bytes(const char *size);
+int flb_utils_time_to_seconds(const char *time);
 int flb_utils_pipe_byte_consume(flb_pipefd_t fd);
-int flb_utils_bool(char *val);
+int flb_utils_bool(const char *val);
 void flb_utils_bytes_to_human_readable_size(size_t bytes,
                                             char *out_buf, size_t size);
-int flb_utils_time_split(char *time, int *sec, long *nsec);
+int flb_utils_time_split(const char *time, int *sec, long *nsec);
 int flb_utils_write_str(char *buf, int *off, size_t size,
-                        char *str, size_t str_len);
-int flb_utils_write_str_buf(char *str, size_t str_len, char **out, size_t *out_size);
+                        const char *str, size_t str_len);
+int flb_utils_write_str_buf(const char *str, size_t str_len,
+                            char **out, size_t *out_size);
 
-int flb_utils_url_split(char *in_url, char **out_protocol,
+int flb_utils_url_split(const char *in_url, char **out_protocol,
                         char **out_host, char **out_port, char **out_uri);
 
 #endif

--- a/include/fluent-bit/http_server/flb_hs.h
+++ b/include/fluent-bit/http_server/flb_hs.h
@@ -52,7 +52,7 @@ struct flb_hs {
     char *ep_root_buf;
 };
 
-struct flb_hs *flb_hs_create(char *listen, char *tcp_port,
+struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config);
 int flb_hs_push_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_destroy(struct flb_hs *ctx);

--- a/include/fluent-bit/stream_processor/flb_sp.h
+++ b/include/fluent-bit/stream_processor/flb_sp.h
@@ -108,16 +108,16 @@ struct flb_sp *flb_sp_create(struct flb_config *config);
 void flb_sp_destroy(struct flb_sp *sp);
 
 int flb_sp_do(struct flb_sp *sp, struct flb_input_instance *in,
-              char *tag, int tag_len,
-              char *buf_data, size_t buf_size);
+              const char *tag, int tag_len,
+              const char *buf_data, size_t buf_size);
 int flb_sp_test_do(struct flb_sp *sp, struct flb_sp_task *task,
-                   char *tag, int tag_len,
-                   char *buf_data, size_t buf_size,
+                   const char *tag, int tag_len,
+                   const char *buf_data, size_t buf_size,
                    char **out_data, size_t *out_size);
 int flb_sp_test_fd_event(struct flb_sp_task *task, char **out_data, size_t *out_size);
 
-struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, char *name,
-                                       char *query);
+struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
+                                       const char *query);
 int flb_sp_fd_event(int fd, struct flb_sp *sp);
 void flb_sp_task_destroy(struct flb_sp_task *task);
 void flb_sp_aggr_node_destroy(struct aggr_node *aggr_node);

--- a/include/fluent-bit/stream_processor/flb_sp_func_record.h
+++ b/include/fluent-bit/stream_processor/flb_sp_func_record.h
@@ -25,7 +25,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/stream_processor/flb_sp_parser.h>
 
-int flb_sp_func_record(char *tag, int tag_len, struct flb_time *tms,
+int flb_sp_func_record(const char *tag, int tag_len, struct flb_time *tms,
                        msgpack_packer *mp_pck, struct flb_sp_cmd_key *cmd_key);
 
 #endif

--- a/include/fluent-bit/stream_processor/flb_sp_parser.h
+++ b/include/fluent-bit/stream_processor/flb_sp_parser.h
@@ -178,20 +178,20 @@ struct flb_exp_val {
     sp_val val;
 };
 
-struct flb_sp_cmd *flb_sp_cmd_create(char *sql);
+struct flb_sp_cmd *flb_sp_cmd_create(const char *sql);
 void flb_sp_cmd_destroy(struct flb_sp_cmd *cmd);
 
 /* Stream */
-int flb_sp_cmd_stream_new(struct flb_sp_cmd *cmd, char *stream_name);
-int flb_sp_cmd_stream_prop_add(struct flb_sp_cmd *cmd, char *key, char *val);
+int flb_sp_cmd_stream_new(struct flb_sp_cmd *cmd, const char *stream_name);
+int flb_sp_cmd_stream_prop_add(struct flb_sp_cmd *cmd, const char *key, const char *val);
 void flb_sp_cmd_stream_prop_del(struct flb_sp_cmd_prop *prop);
-char *flb_sp_cmd_stream_prop_get(struct flb_sp_cmd *cmd, char *key);
+const char *flb_sp_cmd_stream_prop_get(struct flb_sp_cmd *cmd, const char *key);
 
 /* Selection keys */
 int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func,
-                       char *key_name, char *key_alias);
+                       const char *key_name, const char *key_alias);
 void flb_sp_cmd_key_del(struct flb_sp_cmd_key *key);
-int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, char *source);
+int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, const char *source);
 void flb_sp_cmd_dump(struct flb_sp_cmd *cmd);
 
 void flb_sp_cmd_window(struct flb_sp_cmd *cmd,
@@ -204,18 +204,18 @@ struct flb_exp *flb_sp_cmd_operation(struct flb_sp_cmd *cmd,
 struct flb_exp *flb_sp_cmd_comparison(struct flb_sp_cmd *cmd,
                                       struct flb_exp *key, struct flb_exp *val,
                                       int operation);
-struct flb_exp *flb_sp_cmd_condition_key(struct flb_sp_cmd *cmd, char *key);
+struct flb_exp *flb_sp_cmd_condition_key(struct flb_sp_cmd *cmd, const char *key);
 struct flb_exp *flb_sp_cmd_condition_integer(struct flb_sp_cmd *cmd,
                                              int integer);
 struct flb_exp *flb_sp_cmd_condition_float(struct flb_sp_cmd *cmd, float fval);
 struct flb_exp *flb_sp_cmd_condition_string(struct flb_sp_cmd *cmd,
-                                            char *string);
+                                            const char *string);
 struct flb_exp *flb_sp_cmd_condition_boolean(struct flb_sp_cmd *cmd,
                                              bool boolean);
 
 void flb_sp_cmd_condition_free(struct flb_sp_cmd *cmd);
 
-int flb_sp_cmd_gb_key_add(struct flb_sp_cmd *cmd, char *key);
+int flb_sp_cmd_gb_key_add(struct flb_sp_cmd *cmd, const char *key);
 void flb_sp_cmd_gb_key_del(struct flb_sp_cmd_gb_key *key);
 
 #endif

--- a/include/fluent-bit/stream_processor/flb_sp_stream.h
+++ b/include/fluent-bit/stream_processor/flb_sp_stream.h
@@ -30,11 +30,11 @@ struct flb_sp_stream {
     void *in;             /* input instance context */
 };
 
-int flb_sp_stream_create(char *name, struct flb_sp_task *task,
+int flb_sp_stream_create(const char *name, struct flb_sp_task *task,
                          struct flb_sp *sp);
 void flb_sp_stream_destroy(struct flb_sp_stream *stream, struct flb_sp *sp);
 
-int flb_sp_stream_append_data(char *buf_data, size_t buf_size,
+int flb_sp_stream_append_data(const char *buf_data, size_t buf_size,
                               struct flb_sp_stream *stream);
 
 #endif

--- a/include/fluent-bit/stream_processor/flb_sp_window.h
+++ b/include/fluent-bit/stream_processor/flb_sp_window.h
@@ -22,5 +22,5 @@
 #define FLB_SP_WINDOW_TUMBLING  1
 
 void flb_sp_window_prune(struct flb_sp_task *task);
-int flb_sp_window_populate(struct flb_sp_task *task, char *buf_data,
+int flb_sp_window_populate(struct flb_sp_task *task, const char *buf_data,
                            size_t buf_size);

--- a/lib/chunkio/include/chunkio/chunkio.h
+++ b/lib/chunkio/include/chunkio/chunkio.h
@@ -66,9 +66,9 @@ void cio_set_log_callback(struct cio_ctx *ctx, void (*log_cb));
 int cio_set_log_level(struct cio_ctx *ctx, int level);
 
 
-int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size);
-int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);
-int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len);
+int cio_meta_write(struct cio_chunk *ch, const char *buf, size_t size);
+int cio_meta_cmp(struct cio_chunk *ch, const char *meta_buf, int meta_len);
+int cio_meta_read(struct cio_chunk *ch, const char **meta_buf, int *meta_len);
 
 ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
 

--- a/lib/chunkio/include/chunkio/cio_chunk.h
+++ b/lib/chunkio/include/chunkio/cio_chunk.h
@@ -45,7 +45,7 @@ int cio_chunk_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_chunk_write_at(struct cio_chunk *ch, off_t offset,
                        const void *buf, size_t count);
 int cio_chunk_sync(struct cio_chunk *ch);
-int cio_chunk_get_content(struct cio_chunk *ch, char **buf, size_t *size);
+int cio_chunk_get_content(struct cio_chunk *ch, const char **buf, size_t *size);
 ssize_t cio_chunk_get_content_size(struct cio_chunk *ch);
 ssize_t cio_chunk_get_real_size(struct cio_chunk *ch);
 size_t cio_chunk_get_content_end_pos(struct cio_chunk *ch);

--- a/lib/chunkio/include/chunkio/cio_file.h
+++ b/lib/chunkio/include/chunkio/cio_file.h
@@ -47,7 +47,7 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
                                size_t size);
 void cio_file_close(struct cio_chunk *ch, int delete);
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
-int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
+int cio_file_write_metadata(struct cio_chunk *ch, const char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);
 int cio_file_fs_size_change(struct cio_file *cf, size_t new_size);
 int cio_file_close_stream(struct cio_stream *st);

--- a/lib/chunkio/include/chunkio/cio_meta.h
+++ b/lib/chunkio/include/chunkio/cio_meta.h
@@ -23,8 +23,8 @@
 #include <chunkio/cio_file.h>
 #include <chunkio/cio_chunk.h>
 
-int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size);
-int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len);
-int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);
+int cio_meta_write(struct cio_chunk *ch, const char *buf, size_t size);
+int cio_meta_read(struct cio_chunk *ch, const char **meta_buf, int *meta_len);
+int cio_meta_cmp(struct cio_chunk *ch, const char *meta_buf, int meta_len);
 
 #endif

--- a/lib/chunkio/src/cio_chunk.c
+++ b/lib/chunkio/src/cio_chunk.c
@@ -164,7 +164,7 @@ int cio_chunk_sync(struct cio_chunk *ch)
     return ret;
 }
 
-int cio_chunk_get_content(struct cio_chunk *ch, char **buf, size_t *size)
+int cio_chunk_get_content(struct cio_chunk *ch, const char **buf, size_t *size)
 {
     int ret = 0;
     int type;

--- a/lib/chunkio/src/cio_file.c
+++ b/lib/chunkio/src/cio_file.c
@@ -656,7 +656,7 @@ int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count)
     return 0;
 }
 
-int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size)
+int cio_file_write_metadata(struct cio_chunk *ch, const char *buf, size_t size)
 {
     int ret;
     char *meta;

--- a/lib/chunkio/src/cio_meta.c
+++ b/lib/chunkio/src/cio_meta.c
@@ -43,7 +43,7 @@
  * empty metadata with specific sizes.
  */
 
-int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
+int cio_meta_write(struct cio_chunk *ch, const char *buf, size_t size)
 {
     struct cio_memfs *mf;
 
@@ -72,7 +72,7 @@ int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size)
     return -1;
 }
 
-int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
+int cio_meta_read(struct cio_chunk *ch, const char **meta_buf, int *meta_len)
 {
     int len;
     char *meta;
@@ -112,7 +112,7 @@ int cio_meta_read(struct cio_chunk *ch, char **meta_buf, int *meta_len)
 
 }
 
-int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len)
+int cio_meta_cmp(struct cio_chunk *ch, const char *meta_buf, int meta_len)
 {
     int len;
     char *meta;

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -103,7 +103,7 @@ static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
         flb_utils_split_free(split);
 
         /* Convert string to regex pattern */
-        rule->regex = flb_regex_create((unsigned char *) rule->regex_pattern);
+        rule->regex = flb_regex_create(rule->regex_pattern);
         if (!rule->regex) {
             delete_rules(ctx);
             flb_free(rule);
@@ -123,8 +123,8 @@ static inline int grep_filter_data(msgpack_object map, struct grep_ctx *ctx)
     int i;
     int klen;
     int vlen;
-    char *key;
-    char *val;
+    const char *key;
+    const char *val;
     ssize_t ret;
     msgpack_object *k;
     msgpack_object *v;
@@ -145,11 +145,11 @@ static inline int grep_filter_data(msgpack_object map, struct grep_ctx *ctx)
             }
 
             if (k->type == MSGPACK_OBJECT_STR) {
-                key  = (char *) k->via.str.ptr;
+                key  = k->via.str.ptr;
                 klen = k->via.str.size;
             }
             else {
-                key = (char *) k->via.bin.ptr;
+                key = k->via.bin.ptr;
                 klen = k->via.bin.size;
             }
 
@@ -176,11 +176,11 @@ static inline int grep_filter_data(msgpack_object map, struct grep_ctx *ctx)
 
         /* a value must be a string */
         if (v->type == MSGPACK_OBJECT_STR) {
-            val  = (char *)v->via.str.ptr;
+            val  = v->via.str.ptr;
             vlen = v->via.str.size;
         }
         else if(v->type == MSGPACK_OBJECT_BIN) {
-            val  = (char *)v->via.bin.ptr;
+            val  = v->via.bin.ptr;
             vlen = v->via.bin.size;
         }
         else {
@@ -190,7 +190,7 @@ static inline int grep_filter_data(msgpack_object map, struct grep_ctx *ctx)
         struct flb_regex_search result;
 
         ret = flb_regex_do(rule->regex,
-                           (unsigned char *) val, vlen, &result);
+                           val, vlen, &result);
         if (ret != 0) { /* no match */
             if (rule->type == GREP_REGEX) {
                 return GREP_RET_EXCLUDE;
@@ -236,8 +236,8 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_grep_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static int cb_grep_filter(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           void **out_buf, size_t *out_size,
                           struct flb_filter_instance *f_ins,
                           void *context,

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -40,9 +40,9 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
 {
     int off;
     int ret;
-    char *url;
-    char *tmp;
-    char *p;
+    const char *url;
+    const char *tmp;
+    const char *p;
     struct flb_kube *ctx;
 
     ctx = flb_calloc(1, sizeof(struct flb_kube));

--- a/plugins/filter_kubernetes/kube_meta.h
+++ b/plugins/filter_kubernetes/kube_meta.h
@@ -56,10 +56,11 @@ struct flb_kube_meta {
 
 int flb_kube_meta_init(struct flb_kube *ctx, struct flb_config *config);
 int flb_kube_meta_fetch(struct flb_kube *ctx);
+int flb_kube_dummy_meta_get(char **out_buf, size_t *out_size);
 int flb_kube_meta_get(struct flb_kube *ctx,
-                      char *tag, int tag_len,
-                      char *data, size_t data_size,
-                      char **out_buf, size_t *out_size,
+                      const char *tag, int tag_len,
+                      const char *data, size_t data_size,
+                      const char **out_buf, size_t *out_size,
                       struct flb_kube_meta *meta,
                       struct flb_kube_props *props);
 int flb_kube_meta_release(struct flb_kube_meta *meta);

--- a/plugins/filter_kubernetes/kube_property.c
+++ b/plugins/filter_kubernetes/kube_property.c
@@ -28,7 +28,8 @@
 #include "kube_meta.h"
 #include "kube_property.h"
 
-static inline int prop_cmp(const char *key, size_t keylen, const char *property, size_t proplen)
+static inline int prop_cmp(const char *key, size_t keylen,
+                           const char *property, size_t proplen)
 {
     return strncmp(key, property, keylen < proplen ? keylen : proplen) == 0;
 }
@@ -45,7 +46,7 @@ static inline const char *strnchr(const char *s, char c, size_t len)
     return 0;
 }
 
-static inline void prop_not_allowed(char *prop, struct flb_kube_meta *meta)
+static inline void prop_not_allowed(const char *prop, struct flb_kube_meta *meta)
 {
     flb_warn("[filter_kube] annotation '%s' not allowed "
              "(ns='%s' pod_name='%s')",
@@ -55,8 +56,8 @@ static inline void prop_not_allowed(char *prop, struct flb_kube_meta *meta)
 /* Property: parser */
 static int prop_set_parser(struct flb_kube *ctx, struct flb_kube_meta *meta,
                            const char *container, size_t container_len,
-                           char *stream, size_t stream_len,
-                           char *val_buf, size_t val_len,
+                           const char *stream, size_t stream_len,
+                           const char *val_buf, size_t val_len,
                            struct flb_kube_props *props)
 {
     char *tmp;
@@ -104,7 +105,7 @@ static int prop_set_parser(struct flb_kube *ctx, struct flb_kube_meta *meta,
 }
 
 static int prop_set_exclude(struct flb_kube *ctx, struct flb_kube_meta *meta,
-                            char *val_buf, size_t val_len,
+                            const char *val_buf, size_t val_len,
                             struct flb_kube_props *props)
 {
     char *tmp;
@@ -134,8 +135,8 @@ static int prop_set_exclude(struct flb_kube *ctx, struct flb_kube_meta *meta,
 #define FLB_UNIFIED_PARSER_ANNOTATION  "parser"
 
 int flb_kube_prop_set(struct flb_kube *ctx, struct flb_kube_meta *meta,
-                      char *prop, int prop_len,
-                      char *val_buf, size_t val_len,
+                      const char *prop, int prop_len,
+                      const char *val_buf, size_t val_len,
                       struct flb_kube_props *props)
 {
     // Parser can be:
@@ -223,7 +224,8 @@ int flb_kube_prop_pack(struct flb_kube_props *props,
     return 0;
 }
 
-int flb_kube_prop_unpack(struct flb_kube_props *props, char *buf, size_t size)
+int flb_kube_prop_unpack(struct flb_kube_props *props,
+                         const char *buf, size_t size)
 {
     int ret;
     size_t off = 0;
@@ -247,7 +249,7 @@ int flb_kube_prop_unpack(struct flb_kube_props *props, char *buf, size_t size)
         props->stdout_parser = NULL;
     }
     else {
-        props->stdout_parser = flb_sds_create_len((char *) o.via.str.ptr, o.via.str.size);
+        props->stdout_parser = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
     }
 
     /* Index 1: stderr_parser */
@@ -256,7 +258,7 @@ int flb_kube_prop_unpack(struct flb_kube_props *props, char *buf, size_t size)
         props->stderr_parser = NULL;
     }
     else {
-        props->stderr_parser = flb_sds_create_len((char *) o.via.str.ptr, o.via.str.size);
+        props->stderr_parser = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
     }
 
     /* Index 2: Exclude */

--- a/plugins/filter_kubernetes/kube_property.h
+++ b/plugins/filter_kubernetes/kube_property.h
@@ -25,12 +25,12 @@
 #include "kube_props.h"
 
 int flb_kube_prop_set(struct flb_kube *ctx, struct flb_kube_meta *meta,
-                      char *prop, int prop_len,
-                      char *val_buf, size_t val_len,
+                      const char *prop, int prop_len,
+                      const char *val_buf, size_t val_len,
                       struct flb_kube_props *props);
 int flb_kube_prop_pack(struct flb_kube_props *props,
                        void **out_buf, size_t *out_size);
-int flb_kube_prop_unpack(struct flb_kube_props *props, char *buf, size_t size);
+int flb_kube_prop_unpack(struct flb_kube_props *props, const char *buf, size_t size);
 void flb_kube_prop_destroy(struct flb_kube_props *props);
 
 #endif

--- a/plugins/filter_kubernetes/kube_regex.c
+++ b/plugins/filter_kubernetes/kube_regex.c
@@ -29,10 +29,10 @@ int flb_kube_regex_init(struct flb_kube *ctx)
     /* If a custom parser is not set, use the defaults */
     if (!ctx->parser) {
         if (ctx->use_journal == FLB_TRUE) {
-            ctx->regex = flb_regex_create((unsigned char *) KUBE_JOURNAL_TO_REGEX);
+            ctx->regex = flb_regex_create(KUBE_JOURNAL_TO_REGEX);
         }
         else {
-            ctx->regex = flb_regex_create((unsigned char *) KUBE_TAG_TO_REGEX);
+            ctx->regex = flb_regex_create(KUBE_TAG_TO_REGEX);
         }
     }
 

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -60,15 +60,15 @@ static void lua_pushmsgpack(lua_State *l, msgpack_object *o)
             break;
 
         case MSGPACK_OBJECT_STR:
-            lua_pushlstring(l, (char*)o->via.str.ptr, o->via.str.size);
+            lua_pushlstring(l, o->via.str.ptr, o->via.str.size);
             break;
 
         case MSGPACK_OBJECT_BIN:
-            lua_pushlstring(l, (char*)o->via.bin.ptr, o->via.bin.size);
+            lua_pushlstring(l, o->via.bin.ptr, o->via.bin.size);
             break;
 
         case MSGPACK_OBJECT_EXT:
-            lua_pushlstring(l, (char*)o->via.ext.ptr, o->via.ext.size);
+            lua_pushlstring(l, o->via.ext.ptr, o->via.ext.size);
             break;
 
         case MSGPACK_OBJECT_ARRAY:
@@ -374,8 +374,8 @@ static int pack_result (double ts, msgpack_packer *pck, msgpack_sbuffer *sbuf,
     return FLB_TRUE;
 }
 
-static int cb_lua_filter(void *data, size_t bytes,
-                         char *tag, int tag_len,
+static int cb_lua_filter(const void *data, size_t bytes,
+                         const char *tag, int tag_len,
                          void **out_buf, size_t *out_bytes,
                          struct flb_filter_instance *f_ins,
                          void *filter_context,

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -36,10 +36,10 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
                                      struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     char *tmp_key;
     char buf[PATH_MAX];
-    char *script = NULL;
+    const char *script = NULL;
     (void) config;
     struct stat st;
     struct lua_filter *lf;

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -234,7 +234,7 @@ static int setup(struct filter_modify_ctx *ctx,
                         ("[filter_modify] Creating regex for condition A : %s %s : %s",
                          condition->raw_k, condition->raw_v, condition->a);
                     condition->a_regex =
-                        flb_regex_create((unsigned char *) condition->a);
+                        flb_regex_create(condition->a);
                 }
             }
 
@@ -252,7 +252,7 @@ static int setup(struct filter_modify_ctx *ctx,
                         ("[filter_modify] Creating regex for condition B : %s %s : %s",
                          condition->raw_k, condition->raw_v, condition->b);
                     condition->b_regex =
-                        flb_regex_create((unsigned char *) condition->b);
+                        flb_regex_create(condition->b);
                 }
             }
 
@@ -354,7 +354,7 @@ static int setup(struct filter_modify_ctx *ctx,
             }
             else {
                 rule->key_regex =
-                    flb_regex_create((unsigned char *) rule->key);
+                    flb_regex_create(rule->key);
             }
 
             if (rule->val_is_regex && rule->val_len == 0) {
@@ -365,7 +365,7 @@ static int setup(struct filter_modify_ctx *ctx,
             }
             else {
                 rule->val_regex =
-                    flb_regex_create((unsigned char *) rule->val);
+                    flb_regex_create(rule->val);
             }
 
             mk_list_add(&rule->_head, &ctx->rules);
@@ -388,7 +388,7 @@ static inline bool helper_msgpack_object_matches_regex(msgpack_object * obj,
                                                        struct flb_regex
                                                        *regex)
 {
-    char *key;
+    const char *key;
     int len;
     struct flb_regex_search result;
 
@@ -396,14 +396,14 @@ static inline bool helper_msgpack_object_matches_regex(msgpack_object * obj,
         return false;
     }
     else if (obj->type == MSGPACK_OBJECT_STR) {
-        key = (char *) obj->via.str.ptr;
+        key = obj->via.str.ptr;
         len = obj->via.str.size;
     }
     else {
         return false;
     }
 
-    return (flb_regex_do(regex, (unsigned char *) key, len, &result) == 0);
+    return (flb_regex_do(regex, key, len, &result) == 0);
 }
 
 static inline bool kv_key_matches_regex(msgpack_object_kv * kv,
@@ -488,13 +488,13 @@ static inline bool helper_msgpack_object_matches_wildcard(msgpack_object *
                                                           obj, char *str,
                                                           int len)
 {
-    char *key;
+    const char *key;
 
     if (obj->type == MSGPACK_OBJECT_BIN) {
-        key = (char *) obj->via.bin.ptr;
+        key = obj->via.bin.ptr;
     }
     else if (obj->type == MSGPACK_OBJECT_STR) {
-        key = (char *) obj->via.str.ptr;
+        key = obj->via.str.ptr;
     }
     else {
         return false;
@@ -585,15 +585,15 @@ static inline bool helper_msgpack_object_matches_str(msgpack_object * obj,
                                                      char *str, int len)
 {
 
-    char *key;
+    const char *key;
     int klen;
 
     if (obj->type == MSGPACK_OBJECT_BIN) {
-        key = (char *) obj->via.bin.ptr;
+        key = obj->via.bin.ptr;
         klen = obj->via.bin.size;
     }
     else if (obj->type == MSGPACK_OBJECT_STR) {
-        key = (char *) obj->via.str.ptr;
+        key = obj->via.str.ptr;
         klen = obj->via.str.size;
     }
     else {
@@ -1368,8 +1368,8 @@ static int cb_modify_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_modify_filter(void *data, size_t bytes,
-                            char *tag, int tag_len,
+static int cb_modify_filter(const void *data, size_t bytes,
+                            const char *tag, int tag_len,
                             void **out_buf, size_t * out_size,
                             struct flb_filter_instance *f_ins,
                             void *context, struct flb_config *config)

--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -267,7 +267,7 @@ static inline bool is_kv_to_nest(msgpack_object_kv * kv,
                                  struct filter_nest_ctx *ctx)
 {
 
-    char *key;
+    const char *key;
     int klen;
 
     msgpack_object *obj = &kv->key;
@@ -277,11 +277,11 @@ static inline bool is_kv_to_nest(msgpack_object_kv * kv,
     struct filter_nest_wildcard *wildcard;
 
     if (obj->type == MSGPACK_OBJECT_BIN) {
-        key = (char *) obj->via.bin.ptr;
+        key = obj->via.bin.ptr;
         klen = obj->via.bin.size;
     }
     else if (obj->type == MSGPACK_OBJECT_STR) {
-        key = (char *) obj->via.str.ptr;
+        key = obj->via.str.ptr;
         klen = obj->via.str.size;
     }
     else {
@@ -322,18 +322,18 @@ static inline bool is_kv_to_lift(msgpack_object_kv * kv,
                                  struct filter_nest_ctx *ctx)
 {
 
-    char *key;
+    const char *key;
     int klen;
     bool match;
 
     msgpack_object *obj = &kv->key;
 
     if (obj->type == MSGPACK_OBJECT_BIN) {
-        key = (char *) obj->via.bin.ptr;
+        key = obj->via.bin.ptr;
         klen = obj->via.bin.size;
     }
     else if (obj->type == MSGPACK_OBJECT_STR) {
-        key = (char *) obj->via.str.ptr;
+        key = obj->via.str.ptr;
         klen = obj->via.str.size;
     }
     else {
@@ -535,8 +535,8 @@ static int cb_nest_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_nest_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static int cb_nest_filter(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           void **out_buf, size_t * out_size,
                           struct flb_filter_instance *f_ins,
                           void *context, struct flb_config *config)

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -32,17 +32,17 @@
 #include "filter_parser.h"
 
 static int msgpackobj2char(msgpack_object *obj,
-                           char **ret_char, int *ret_char_size)
+                           const char **ret_char, int *ret_char_size)
 {
     int ret = -1;
 
     if (obj->type == MSGPACK_OBJECT_STR) {
-        *ret_char      = (char*)obj->via.str.ptr;
+        *ret_char      = obj->via.str.ptr;
         *ret_char_size = obj->via.str.size;
         ret = 0;
     }
     else if (obj->type == MSGPACK_OBJECT_BIN) {
-        *ret_char      = (char*)obj->via.bin.ptr;
+        *ret_char      = obj->via.bin.ptr;
         *ret_char_size = obj->via.bin.size;
         ret = 0;
     }
@@ -50,7 +50,7 @@ static int msgpackobj2char(msgpack_object *obj,
     return ret;
 }
 
-static int add_parser(char *parser, struct filter_parser_ctx *ctx,
+static int add_parser(const char *parser, struct filter_parser_ctx *ctx,
                        struct flb_config *config)
 {
     struct flb_parser *p;
@@ -94,7 +94,7 @@ static int configure(struct filter_parser_ctx *ctx,
                      struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     struct mk_list *head;
     struct flb_config_prop *p;
 
@@ -174,8 +174,8 @@ static int cb_parser_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_parser_filter(void *data, size_t bytes,
-                            char *tag, int tag_len,
+static int cb_parser_filter(const void *data, size_t bytes,
+                            const char *tag, int tag_len,
                             void **ret_buf, size_t *ret_bytes,
                             struct flb_filter_instance *f_ins,
                             void *context,
@@ -195,9 +195,9 @@ static int cb_parser_filter(void *data, size_t bytes,
     int ret = FLB_FILTER_NOTOUCH;
     int parse_ret = -1;
     int map_num;
-    char *key_str;
+    const char *key_str;
     int key_len;
-    char *val_str;
+    const char *val_str;
     int val_len;
     char *out_buf;
     size_t out_size;

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -243,12 +243,12 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
     return ret;
 }
 
-static int cb_modifier_filter(void *data, size_t bytes,
-                                  char *tag, int tag_len,
-                                  void **out_buf, size_t *out_size,
-                                  struct flb_filter_instance *f_ins,
-                                  void *context,
-                                  struct flb_config *config)
+static int cb_modifier_filter(const void *data, size_t bytes,
+                              const char *tag, int tag_len,
+                              void **out_buf, size_t *out_size,
+                              struct flb_filter_instance *f_ins,
+                              void *context,
+                              struct flb_config *config)
 {
     struct record_modifier_ctx *ctx = context;
     char is_modified = FLB_FALSE;

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -37,8 +37,8 @@ static int cb_stdout_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_stdout_filter(void *data, size_t bytes,
-                            char *tag, int tag_len,
+static int cb_stdout_filter(const void *data, size_t bytes,
+                            const char *tag, int tag_len,
                             void **out_buf, size_t *out_bytes,
                             struct flb_filter_instance *f_ins,
                             void *filter_context,

--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -101,7 +101,7 @@ static inline int throttle_data(struct flb_filter_throttle_ctx *ctx)
 
 static int configure(struct flb_filter_throttle_ctx *ctx, struct flb_filter_instance *f_ins)
 {
-    char *str = NULL;
+    const char *str = NULL;
     double val  = 0;
     char *endp;
 
@@ -140,7 +140,7 @@ static int configure(struct flb_filter_throttle_ctx *ctx, struct flb_filter_inst
     return 0;
 }
 
-static int parse_duration(char *interval)
+static int parse_duration(const char *interval)
 {
     double seconds = 0.0;
     double s;
@@ -196,12 +196,12 @@ static int cb_throttle_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
-static int cb_throttle_filter(void *data, size_t bytes,
-                          char *tag, int tag_len,
-                          void **out_buf, size_t *out_size,
-                          struct flb_filter_instance *f_ins,
-                          void *context,
-                          struct flb_config *config)
+static int cb_throttle_filter(const void *data, size_t bytes,
+                              const char *tag, int tag_len,
+                              void **out_buf, size_t *out_size,
+                              struct flb_filter_instance *f_ins,
+                              void *context,
+                              struct flb_config *config)
 {
     int ret;
     int old_size = 0;

--- a/plugins/filter_throttle/throttle.h
+++ b/plugins/filter_throttle/throttle.h
@@ -34,7 +34,7 @@
 struct flb_filter_throttle_ctx {
     double    max_rate;
     unsigned int    window_size;
-    char  *slide_interval;
+    const char  *slide_interval;
     int print_status;
 
     /* internal */

--- a/plugins/in_cpu/in_cpu.c
+++ b/plugins/in_cpu/in_cpu.c
@@ -164,7 +164,7 @@ static int in_cpu_init(struct flb_input_instance *in,
     int ret;
     struct flb_in_cpu_config *ctx;
     (void) data;
-    char *pval = NULL;
+    const char *pval = NULL;
 
     /* Allocate space for the configuration */
     ctx = flb_calloc(1, sizeof(struct flb_in_cpu_config));

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -214,7 +214,7 @@ static int configure(struct flb_in_disk_config *disk_config,
                                struct flb_input_instance *in)
 {
     (void) *in;
-    char *pval = NULL;
+    const char *pval = NULL;
     int entry = 0;
     int i;
 

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -82,7 +82,7 @@ static int configure(struct flb_in_dummy_config *ctx,
                      struct flb_input_instance *in,
                                  struct timespec *tm)
 {
-    char *str = NULL;
+    const char *str = NULL;
     int root_type;
     int  ret = -1;
     long val  = 0;

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -132,8 +132,8 @@ static int in_exec_config_read(struct flb_in_exec_config *exec_config,
                                int *interval_nsec
 )
 {
-    char *cmd = NULL;
-    char *pval = NULL;
+    const char *cmd = NULL;
+    const char *pval = NULL;
 
     /* filepath setting */
     cmd = flb_input_get_property("command", in);

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -32,7 +32,7 @@
 #define DEFAULT_INTERVAL_NSEC 0
 
 struct flb_in_exec_config {
-    char  *cmd;
+    const char  *cmd;
     struct flb_parser  *parser;
     char *buf;
     size_t buf_size;

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -28,10 +28,10 @@
 struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
 {
     char tmp[16];
-    char *listen;
-    char *buffer_size;
-    char *chunk_size;
-    char *p;
+    const char *listen;
+    const char *buffer_size;
+    const char *chunk_size;
+    const char *p;
     struct flb_in_fw_config *config;
 
     config = flb_calloc(1, sizeof(struct flb_in_fw_config));

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -33,7 +33,7 @@
 #define EACH_RECV_SIZE 32
 
 static int fw_process_array(struct flb_input_instance *in,
-                            char *tag, int tag_len,
+                            const char *tag, int tag_len,
                             msgpack_object *arr)
 {
     int i;
@@ -101,7 +101,7 @@ int fw_prot_process(struct fw_conn *conn)
     int ret;
     int stag_len;
     int c = 0;
-    char *stag;
+    const char *stag;
     size_t bytes;
     size_t buf_off = 0;
     size_t recv_len;
@@ -191,7 +191,7 @@ int fw_prot_process(struct fw_conn *conn)
                 return -1;
             }
 
-            stag     = (char *) tag.via.str.ptr;
+            stag     = tag.via.str.ptr;
             stag_len = tag.via.str.size;
 
             entry = root.via.array.ptr[1];
@@ -230,15 +230,15 @@ int fw_prot_process(struct fw_conn *conn)
             else if (entry.type == MSGPACK_OBJECT_STR ||
                      entry.type == MSGPACK_OBJECT_BIN) {
                 /* PackedForward Mode */
-                char *data = NULL;
+                const char *data = NULL;
                 size_t len = 0;
 
                 if (entry.type == MSGPACK_OBJECT_STR) {
-                    data = (char *) entry.via.str.ptr;
+                    data = entry.via.str.ptr;
                     len = entry.via.str.size;
                 }
                 else if (entry.type == MSGPACK_OBJECT_BIN) {
-                    data = (char *) entry.via.bin.ptr;
+                    data = entry.via.bin.ptr;
                     len = entry.via.bin.size;
                 }
 

--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -255,8 +255,8 @@ static int in_head_collect(struct flb_input_instance *i_ins,
 static int in_head_config_read(struct flb_in_head_config *head_config,
                                struct flb_input_instance *in)
 {
-    char *filepath = NULL;
-    char *pval = NULL;
+    const char *filepath = NULL;
+    const char *pval = NULL;
 
     /* filepath setting */
     filepath = flb_input_get_property("file", in);

--- a/plugins/in_head/in_head.h
+++ b/plugins/in_head/in_head.h
@@ -31,22 +31,22 @@
 #define DEFAULT_INTERVAL_NSEC 0
 
 struct flb_in_head_config {
-    size_t    buf_size; /* size of buf */
-    ssize_t   buf_len;  /* read size */
-    char     *buf;      /* read buf */
-    char     *key;
-    int      key_len;
+    size_t       buf_size; /* size of buf */
+    ssize_t      buf_len;  /* read size */
+    char         *buf;      /* read buf */
+    const char   *key;
+    int          key_len;
 
-    char     *filepath; /* to read */
+    const char   *filepath; /* to read */
 
-    char     add_path; /* add path mode */
-    size_t   path_len;
+    char         add_path; /* add path mode */
+    size_t       path_len;
 
-    int      lines; /* line num to read */
-    int      split_line;
+    int          lines; /* line num to read */
+    int          split_line;
 
-    int      interval_sec;
-    int      interval_nsec;
+    int          interval_sec;
+    int          interval_nsec;
 };
 
 extern struct flb_input_plugin in_head_plugin;

--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -133,7 +133,7 @@ static int in_health_init(struct flb_input_instance *in,
                           struct flb_config *config, void *data)
 {
     int ret;
-    char *pval;
+    const char *pval;
     struct flb_in_health_config *ctx;
     (void) data;
 

--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -106,7 +106,7 @@ static int boot_time(struct timeval *boot_time)
     return 0;
 }
 
-static inline int process_line(char *line,
+static inline int process_line(const char *line,
                                struct flb_input_instance *i_ins,
                                struct flb_in_kmsg_config *ctx)
 {
@@ -115,7 +115,7 @@ static inline int process_line(char *line,
     struct timeval tv;       /* time value                  */
     int line_len;
     uint64_t val;
-    char *p = line;
+    const char *p = line;
     char *end = NULL;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
@@ -213,7 +213,7 @@ static inline int process_line(char *line,
               ts,
               (long int) tv.tv_sec,
               (long int) tv.tv_usec,
-              (const char *) p);
+              p);
 
     return 0;
 

--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -134,10 +134,10 @@ static int in_mem_init(struct flb_input_instance *in,
                        struct flb_config *config, void *data)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     struct flb_in_mem_config *ctx;
     (void) data;
-    char *pval = NULL;
+    const char *pval = NULL;
 
     /* Initialize context */
     ctx = flb_malloc(sizeof(struct flb_in_mem_config));

--- a/plugins/in_mqtt/mqtt_config.c
+++ b/plugins/in_mqtt/mqtt_config.c
@@ -28,7 +28,7 @@
 struct flb_in_mqtt_config *mqtt_config_init(struct flb_input_instance *i_ins)
 {
     char tmp[16];
-    char *listen;
+    const char *listen;
     struct flb_in_mqtt_config *config;
 
     config = flb_calloc(1, sizeof(struct flb_in_mqtt_config));

--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -96,7 +96,7 @@ static int configure(struct flb_in_netif_config *ctx,
                      int *interval_sec,
                      int *interval_nsec)
 {
-    char *pval = NULL;
+    const char *pval = NULL;
     ctx->map_num = 0;
 
     /* interval settings */

--- a/plugins/in_netif/in_netif.h
+++ b/plugins/in_netif/in_netif.h
@@ -48,7 +48,7 @@ struct netif_entry {
 };
 
 struct flb_in_netif_config {
-    char *interface;
+    const char *interface;
     int  interface_len;
 
     int  verbose;

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -143,8 +143,8 @@ static pid_t get_pid_from_procname_linux(const char* proc)
         cmdname[FLB_CMD_LEN-1] = '\0';
         bname = basename(cmdname);
 
-        if (strncmp(proc, (const char*)bname, FLB_CMD_LEN) == 0) {
-            sscanf((const char*)glb.gl_pathv[i],"/proc/%ld/cmdline",&ret_scan);
+        if (strncmp(proc, bname, FLB_CMD_LEN) == 0) {
+            sscanf(glb.gl_pathv[i],"/proc/%ld/cmdline",&ret_scan);
             ret = (pid_t)ret_scan;
             close(fd);
             break;
@@ -158,7 +158,7 @@ static pid_t get_pid_from_procname_linux(const char* proc)
 static int configure(struct flb_in_proc_config *ctx,
                      struct flb_input_instance *in)
 {
-    char *pval = NULL;
+    const char *pval = NULL;
 
     /* interval settings */
     pval = flb_input_get_property("interval_sec", in);

--- a/plugins/in_random/random.c
+++ b/plugins/in_random/random.c
@@ -109,7 +109,7 @@ static int in_random_collect(struct flb_input_instance *i_ins,
 static int in_random_config_read(struct flb_in_random_config *random_config,
                                  struct flb_input_instance *in)
 {
-    char *val = NULL;
+    const char *val = NULL;
 
     /* samples */
     val = flb_input_get_property("samples", in);

--- a/plugins/in_serial/in_serial.c
+++ b/plugins/in_serial/in_serial.c
@@ -42,7 +42,7 @@
 #include "in_serial.h"
 #include "in_serial_config.h"
 
-static inline int process_line(msgpack_packer *mp_pck, char *line, int len,
+static inline int process_line(msgpack_packer *mp_pck, const char *line, int len,
                                struct flb_in_serial_config *ctx)
 {
 
@@ -58,8 +58,7 @@ static inline int process_line(msgpack_packer *mp_pck, char *line, int len,
     msgpack_pack_str(mp_pck, len);
     msgpack_pack_str_body(mp_pck, line, len);
 
-    flb_debug("[in_serial] message '%s'",
-              (const char *) line);
+    flb_debug("[in_serial] message '%s'", line);
 
     return 0;
 }

--- a/plugins/in_serial/in_serial_config.c
+++ b/plugins/in_serial/in_serial_config.c
@@ -29,11 +29,11 @@ struct flb_in_serial_config *serial_config_read(struct flb_in_serial_config *con
                                                 struct flb_input_instance *i_ins)
 {
     uint64_t min_bytes;
-    char *file;
-    char *bitrate;
-    char *separator;
-    char *tmp;
-    char *format;
+    const char *file;
+    const char *bitrate;
+    const char *separator;
+    const char *tmp;
+    const char *format;
 
     /* Get input properties */
     file      = flb_input_get_property("file", i_ins);

--- a/plugins/in_serial/in_serial_config.h
+++ b/plugins/in_serial/in_serial_config.h
@@ -39,12 +39,12 @@ struct flb_in_serial_config {
 
     /* config */
     int min_bytes;
-    char *file;
-    char *bitrate;
+    const char *file;
+    const char *bitrate;
 
     /* separator */
     int sep_len;
-    char *separator;
+    const char *separator;
 
     /* Incoming format: JSON only for now */
     int format;

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -231,7 +231,7 @@ static int in_stdin_init(struct flb_input_instance *in,
 {
     int fd;
     int ret;
-    char *tmp;
+    const char *tmp;
     struct flb_in_stdin_config *ctx;
     (void) data;
 

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -33,7 +33,7 @@
 struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
                                       struct flb_config *config)
 {
-    char *tmp;
+    const char *tmp;
     char port[16];
     struct flb_syslog *ctx;
 

--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -31,11 +31,11 @@
 #define pack_uint32(buf, d) _msgpack_store32(buf, (uint32_t) d)
 
 /* tag composer */
-static int tag_compose(char *tag, char *unit_name,
+static int tag_compose(const char *tag, const char *unit_name,
                        int unit_size, char **out_buf, size_t *out_size)
 {
     int len;
-    char *p;
+    const char *p;
     char *buf = *out_buf;
     size_t buf_s = 0;
 
@@ -82,9 +82,9 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
     uint8_t h;
     uint64_t usec;
     size_t length;
-    char *sep;
-    char *key;
-    char *val;
+    const char *sep;
+    const char *key;
+    const char *val;
     char *tmp;
     char *cursor = NULL;
     char *tag;
@@ -128,7 +128,7 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
             ret = sd_journal_get_data(ctx->j, "_SYSTEMD_UNIT", &data, &length);
             if (ret == 0) {
                 tag = new_tag;
-                tag_compose(ctx->i_ins->tag, (char *) data + 14, length - 14,
+                tag_compose(ctx->i_ins->tag, (const char *) data + 14, length - 14,
                             &tag, &tag_len);
             }
             else {
@@ -199,7 +199,7 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
         entries = 0;
         while (sd_journal_enumerate_data(ctx->j, &data, &length) > 0 &&
                entries < ctx->max_fields) {
-            key = (char *) data;
+            key = (const char *) data;
             if (ctx->strip_underscores == FLB_TRUE && key[0] == '_') {
                 key++;
                 length--;

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -34,7 +34,8 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
                                                      struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
+    char *cursor = NULL;
     struct stat st;
     struct mk_list *head;
     struct flb_config_prop *prop;
@@ -186,11 +187,11 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
 
     /* Check if we have a cursor in our database */
     if (ctx->db) {
-        tmp = flb_systemd_db_get_cursor(ctx);
-        if (tmp) {
-            ret = sd_journal_seek_cursor(ctx->j, tmp);
+        cursor = flb_systemd_db_get_cursor(ctx);
+        if (cursor) {
+            ret = sd_journal_seek_cursor(ctx->j, cursor);
             if (ret == 0) {
-                flb_info("[in_systemd] seek_cursor=%.40s... OK", tmp);
+                flb_info("[in_systemd] seek_cursor=%.40s... OK", cursor);
 
                 /* Skip the first entry, already processed */
                 sd_journal_next_skip(ctx->j, 1);
@@ -198,7 +199,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
             else {
                 flb_warn("[in_systemd] seek_cursor failed");
             }
-            flb_free(tmp);
+            flb_free(cursor);
         }
     }
 

--- a/plugins/in_systemd/systemd_db.c
+++ b/plugins/in_systemd/systemd_db.c
@@ -42,7 +42,8 @@ static int cb_cursor_check(void *data, int argc, char **argv, char **cols)
     return 0;
 }
 
-struct flb_sqldb *flb_systemd_db_open(char *path, struct flb_input_instance *in,
+struct flb_sqldb *flb_systemd_db_open(const char *path,
+                                      struct flb_input_instance *in,
                                       struct flb_config *config)
 {
     int ret;
@@ -71,7 +72,7 @@ int flb_systemd_db_close(struct flb_sqldb *db)
     return 0;
 }
 
-int flb_systemd_db_set_cursor(struct flb_systemd_config *ctx, char *cursor)
+int flb_systemd_db_set_cursor(struct flb_systemd_config *ctx, const char *cursor)
 {
     int ret;
     char query[PATH_MAX];

--- a/plugins/in_systemd/systemd_db.h
+++ b/plugins/in_systemd/systemd_db.h
@@ -43,10 +43,11 @@
 #define SQL_UPDATE_CURSOR \
     "UPDATE in_systemd_cursor SET cursor='%s', updated=%lu;"
 
-struct flb_sqldb *flb_systemd_db_open(char *path, struct flb_input_instance *in,
+struct flb_sqldb *flb_systemd_db_open(const char *path,
+                                      struct flb_input_instance *in,
                                       struct flb_config *config);
 int flb_systemd_db_close(struct flb_sqldb *db);
-int flb_systemd_db_set_cursor(struct flb_systemd_config *ctx, char *cursor);
+int flb_systemd_db_set_cursor(struct flb_systemd_config *ctx, const char *cursor);
 char *flb_systemd_db_get_cursor(struct flb_systemd_config *ctx);
 
 #endif

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -43,7 +43,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
     int i;
     long nsec;
     ssize_t bytes;
-    char *tmp;
+    const char *tmp;
     struct flb_tail_config *ctx;
 
     ctx = flb_calloc(1, sizeof(struct flb_tail_config));
@@ -265,7 +265,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *i_ins,
 #ifdef FLB_HAVE_REGEX
     tmp = flb_input_get_property("tag_regex", i_ins);
     if (tmp) {
-        ctx->tag_regex = flb_regex_create((unsigned char *) tmp);
+        ctx->tag_regex = flb_regex_create(tmp);
         if (ctx->tag_regex) {
             ctx->dynamic_tag = FLB_TRUE;
         }

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -72,9 +72,9 @@ struct flb_tail_config {
     int rotate_wait;           /* sec to wait on rotated files */
     int ignore_older;          /* ignore fields older than X seconds        */
     time_t last_pending;       /* last time a 'pending signal' was emitted' */
-    char *path;                /* lookup path (glob)           */
-    char *exclude_path;        /* exclude path                 */
-    char *path_key;            /* key name of file path        */
+    const char *path;          /* lookup path (glob)           */
+    const char *exclude_path;  /* exclude path                 */
+    const char *path_key;      /* key name of file path        */
     int   path_key_len;        /* length of key name           */
     char *key;                 /* key for unstructured record  */
     int   key_len;             /* length of key ^              */

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -34,7 +34,7 @@ struct query_status {
 };
 
 /* Open or create database required by tail plugin */
-struct flb_sqldb *flb_tail_db_open(char *path,
+struct flb_sqldb *flb_tail_db_open(const char *path,
                                    struct flb_input_instance *in,
                                    struct flb_tail_config *ctx,
                                    struct flb_config *config)
@@ -148,7 +148,7 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
 }
 
 /* Mark a file as rotated */
-int flb_tail_db_file_rotate(char *new_name,
+int flb_tail_db_file_rotate(const char *new_name,
                             struct flb_tail_file *file,
                             struct flb_tail_config *ctx)
 {

--- a/plugins/in_tail/tail_db.h
+++ b/plugins/in_tail/tail_db.h
@@ -26,7 +26,7 @@
 
 #include "tail_file.h"
 
-struct flb_sqldb *flb_tail_db_open(char *path,
+struct flb_sqldb *flb_tail_db_open(const char *path,
                                    struct flb_input_instance *in,
                                    struct flb_tail_config *ctx,
                                    struct flb_config *config);
@@ -36,7 +36,7 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
                          struct flb_tail_config *ctx);
 int flb_tail_db_file_offset(struct flb_tail_file *file,
                             struct flb_tail_config *ctx);
-int flb_tail_db_file_rotate(char *new_name,
+int flb_tail_db_file_rotate(const char *new_name,
                             struct flb_tail_file *file,
                             struct flb_tail_config *ctx);
 

--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -29,7 +29,7 @@ int flb_tail_dmode_create(struct flb_tail_config *ctx,
                           struct flb_input_instance *i_ins,
                           struct flb_config *config)
 {
-    char *tmp;
+    const char *tmp;
 
     if (ctx->multiline == FLB_TRUE) {
         flb_error("[in_tail] Docker mode cannot be enabled when multiline is enabled");

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -91,8 +91,8 @@ static int open_file(const char *path)
 #endif
 
 static int unpack_and_pack(msgpack_packer *pck, msgpack_object *root,
-                           char *key, size_t key_len,
-                           char *val, size_t val_len)
+                           const char *key, size_t key_len,
+                           const char *val, size_t val_len)
 {
     int i;
     int size = root->via.map.size;
@@ -117,8 +117,8 @@ static int unpack_and_pack(msgpack_packer *pck, msgpack_object *root,
 }
 
 static int append_record_to_map(char **data, size_t *data_size,
-                                char *key,  size_t key_len,
-                                char *val,  size_t val_len)
+                                const char *key, size_t key_len,
+                                const char *val, size_t val_len)
 {
     int ret;
     msgpack_unpacked result;
@@ -395,17 +395,17 @@ static inline void drop_bytes(char *buf, size_t len, int pos, int bytes)
 }
 
 #ifdef FLB_HAVE_REGEX
-static void cb_results(unsigned char *name, unsigned char *value,
+static void cb_results(const char *name, const char *value,
                        size_t vlen, void *data)
 {
     struct flb_hash *ht = data;
     char *p;
 
-    while ((p = strchr((char *) value, '.'))) {
+    while ((p = strchr(value, '.'))) {
         *p = '_';
     }
 
-    flb_hash_add(ht, (char *) name, strlen((char *) name), (char *) value, vlen);
+    flb_hash_add(ht, name, strlen(name), value, vlen);
 }
 #endif
 
@@ -427,13 +427,13 @@ static int tag_compose(char *tag, char *fname, char **out_buf, size_t *out_size)
     char *beg;
     char *end;
     int ret;
-    char *tmp;
+    const char *tmp;
     size_t tmp_s;
 #endif
 
 #ifdef FLB_HAVE_REGEX
     if (tag_regex) {
-        n = flb_regex_do(tag_regex, (unsigned char *) fname, strlen(fname), &result);
+        n = flb_regex_do(tag_regex, fname, strlen(fname), &result);
         if (n <= 0) {
             flb_error("[in_tail] invalid pattern for given file %s", fname);
             return -1;

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -46,7 +46,7 @@ int flb_tail_mult_create(struct flb_tail_config *ctx,
                          struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     struct mk_list *head;
     struct flb_parser *parser;
     struct flb_config_prop *p;

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -42,7 +42,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 
-static char *expand_tilde(char *path)
+static char *expand_tilde(const char *path)
 {
     int len;
     char user[256];
@@ -119,7 +119,6 @@ static inline int do_glob(const char *pattern, int flags,
     (void) not_used;
 
     /* Save current values */
-    tmp = (char *) pattern;
     new_flags = flags;
 
     if (flags & GLOB_TILDE) {
@@ -133,13 +132,12 @@ static inline int do_glob(const char *pattern, int flags,
          *
          * the workaround is to do our own tilde expansion in a temporary buffer.
          */
-        char *p;
 
         /* Look for a tilde */
-        p = expand_tilde((char *) pattern);
-        if (p != pattern) {
+        tmp = expand_tilde(pattern);
+        if (tmp != pattern) {
             /* the path was expanded */
-            tmp = p;
+            pattern = tmp;
         }
 
         /* remove unused flag */
@@ -148,10 +146,10 @@ static inline int do_glob(const char *pattern, int flags,
     }
 
     /* invoke glob with new parameters */
-    ret = glob(tmp, new_flags, NULL, pglob);
+    ret = glob(pattern, new_flags, NULL, pglob);
 
     /* remove temporary buffer */
-    if (tmp != pattern) {
+    if (tmp != NULL) {
         flb_free(tmp);
     }
 

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -28,9 +28,9 @@
 struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *i_ins)
 {
     char tmp[16];
-    char *listen;
-    char *buffer_size;
-    char *chunk_size;
+    const char *listen;
+    const char *buffer_size;
+    const char *chunk_size;
     struct flb_in_tcp_config *config;
 
     config = flb_malloc(sizeof(struct flb_in_tcp_config));

--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -45,9 +45,9 @@ static int cb_azure_init(struct flb_output_instance *ins,
     return 0;
 }
 
-int azure_format(void *in_buf, size_t in_bytes,
-                  char **out_buf, size_t *out_size,
-                  struct flb_azure *ctx)
+int azure_format(const void *in_buf, size_t in_bytes,
+                 char **out_buf, size_t *out_size,
+                 struct flb_azure *ctx)
 {
     int i;
     int array_size = 0;
@@ -234,11 +234,11 @@ static int build_headers(struct flb_http_client *c,
     return 0;
 }
 
-static void cb_azure_flush(void *data, size_t bytes,
-                            char *tag, int tag_len,
-                            struct flb_input_instance *i_ins,
-                            void *out_context,
-                            struct flb_config *config)
+static void cb_azure_flush(const void *data, size_t bytes,
+                           const char *tag, int tag_len,
+                           struct flb_input_instance *i_ins,
+                           void *out_context,
+                           struct flb_config *config)
 {
     int ret;
     size_t b_sent;

--- a/plugins/out_azure/azure_conf.c
+++ b/plugins/out_azure/azure_conf.c
@@ -29,8 +29,8 @@ struct flb_azure *flb_azure_conf_create(struct flb_output_instance *ins,
     int ret;
     size_t size;
     size_t olen;
-    char *tmp;
-    char *cid = NULL;
+    const char *tmp;
+    const char *cid = NULL;
     struct flb_upstream *upstream;
     struct flb_azure *ctx;
 

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -310,8 +310,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static int bigquery_format(void *data, size_t bytes,
-                           char *tag, size_t tag_len,
+static int bigquery_format(const void *data, size_t bytes,
+                           const char *tag, size_t tag_len,
                            char **out_data, size_t *out_size,
                            struct flb_bigquery *ctx)
 {
@@ -408,8 +408,8 @@ static void set_authorization_header(struct flb_http_client *c,
     flb_http_add_header(c, "Authorization", 13, header, len);
 }
 
-static void cb_bigquery_flush(void *data, size_t bytes,
-                              char *tag, int tag_len,
+static void cb_bigquery_flush(const void *data, size_t bytes,
+                              const char *tag, int tag_len,
                               struct flb_input_instance *i_ins,
                               void *out_context,
                               struct flb_config *config)

--- a/plugins/out_bigquery/bigquery_conf.c
+++ b/plugins/out_bigquery/bigquery_conf.c
@@ -171,7 +171,7 @@ struct flb_bigquery *flb_bigquery_conf_create(struct flb_output_instance *ins,
                                               struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     struct flb_bigquery *ctx;
     struct flb_bigquery_oauth_credentials *creds;
 
@@ -260,11 +260,8 @@ struct flb_bigquery *flb_bigquery_conf_create(struct flb_output_instance *ins,
     }
     else {
        if (creds->project_id) {
-            tmp = flb_sds_create(creds->project_id);
-            if (tmp) {
-                ctx->project_id = tmp;
-            }
-            else {
+            ctx->project_id = flb_sds_create(creds->project_id);
+            if (!ctx->project_id) {
                 flb_error("[out_bigquery] failed extracting 'project_id' from credentials.");
                 flb_bigquery_conf_destroy(ctx);
                 return NULL;

--- a/plugins/out_counter/counter.c
+++ b/plugins/out_counter/counter.c
@@ -56,8 +56,8 @@ int cb_counter_init(struct flb_output_instance *ins,
     return 0;
 }
 
-void cb_counter_flush(void *data, size_t bytes,
-                      char *tag, int tag_len,
+void cb_counter_flush(const void *data, size_t bytes,
+                      const char *tag, int tag_len,
                       struct flb_input_instance *i_ins,
                       void *out_context,
                       struct flb_config *config)

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -52,15 +52,15 @@ static inline int es_pack_map_content(msgpack_packer *tmp_pck,
         ptr_key = NULL;
 
         /* Store key */
-        char *key_ptr = NULL;
+        const char *key_ptr = NULL;
         size_t key_size = 0;
 
         if (k->type == MSGPACK_OBJECT_BIN) {
-            key_ptr  = (char *) k->via.bin.ptr;
+            key_ptr  = k->via.bin.ptr;
             key_size = k->via.bin.size;
         }
         else if (k->type == MSGPACK_OBJECT_STR) {
-            key_ptr  = (char *) k->via.str.ptr;
+            key_ptr  = k->via.str.ptr;
             key_size = k->via.str.size;
         }
 
@@ -128,8 +128,8 @@ static inline int es_pack_map_content(msgpack_packer *tmp_pck,
  *
  * 'Sadly' this process involves to convert from Msgpack to JSON.
  */
-static char *elasticsearch_format(void *data, size_t bytes,
-                                  char *tag, int tag_len, int *out_size,
+static char *elasticsearch_format(const void *data, size_t bytes,
+                                  const char *tag, int tag_len, int *out_size,
                                   struct flb_elasticsearch *ctx)
 {
     int ret;
@@ -537,8 +537,8 @@ static int elasticsearch_error_check(struct flb_http_client *c)
     return check;
 }
 
-void cb_es_flush(void *data, size_t bytes,
-                 char *tag, int tag_len,
+void cb_es_flush(const void *data, size_t bytes,
+                 const char *tag, int tag_len,
                  struct flb_input_instance *i_ins, void *out_context,
                  struct flb_config *config)
 {

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -32,8 +32,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
 
     int io_flags = 0;
     ssize_t ret;
-    char *tmp;
-    char *path;
+    const char *tmp;
+    const char *path;
     struct flb_uri *uri = ins->host.uri;
     struct flb_uri_field *f_index = NULL;
     struct flb_uri_field *f_type = NULL;
@@ -239,7 +239,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     /* Elasticsearch: Path */
     path = flb_output_get_property("path", ins);
     if (!path) {
-        path = flb_strdup("");
+        path = "";
     }
 
     /* Elasticsearch: Pipeline */
@@ -250,8 +250,6 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     else {
         snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/_bulk", path);
     }
-
-    flb_free(path);
 
     /* Generate _id */
     tmp = flb_output_get_property("generate_id", ins);

--- a/plugins/out_exit/exit.c
+++ b/plugins/out_exit/exit.c
@@ -36,7 +36,7 @@ static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *conf
 {
     (void) config;
     (void) data;
-    char *tmp;
+    const char *tmp;
     struct flb_exit *ctx;
 
     ctx = flb_malloc(sizeof(struct flb_exit));
@@ -60,8 +60,8 @@ static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *conf
     return 0;
 }
 
-static void cb_exit_flush(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static void cb_exit_flush(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -39,13 +39,13 @@
 #endif
 
 struct flb_file_conf {
-    char *out_file;
-    char *delimiter;
-    char *label_delimiter;
+    const char *out_file;
+    const char *delimiter;
+    const char *label_delimiter;
     int  format;
 };
 
-static char* check_delimiter(char *str)
+static char* check_delimiter(const char *str)
 {
     if (str == NULL) {
         return NULL;
@@ -69,7 +69,7 @@ static int cb_file_init(struct flb_output_instance *ins,
                         struct flb_config *config,
                         void *data)
 {
-    char *tmp;
+    const char *tmp;
     char *ret_str;
     (void) config;
     (void) data;
@@ -199,8 +199,8 @@ static int plain_output(FILE *fp, msgpack_object *obj, size_t alloc_size)
     return 0;
 }
 
-static void cb_file_flush(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static void cb_file_flush(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)
@@ -212,7 +212,7 @@ static void cb_file_flush(void *data, size_t bytes,
     size_t last_off = 0;
     size_t alloc_size = 0;
     size_t total;
-    char *out_file;
+    const char *out_file;
     char *buf;
     char *tag_buf;
     msgpack_object *obj;

--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -53,7 +53,7 @@ static int configure(struct flb_out_fcount_config *ctx,
                      struct flb_output_instance   *ins,
                      struct flb_config *config)
 {
-    char* pval = NULL;
+    const char* pval = NULL;
     int i;
     time_t base = time(NULL);
 
@@ -175,11 +175,11 @@ static struct flb_out_fcount_buffer* seek_buffer(time_t t,
 
 
 
-static void out_fcount_flush(void *data, size_t bytes,
-                     char *tag, int tag_len,
-                     struct flb_input_instance *i_ins,
-                     void *out_context,
-                     struct flb_config *config)
+static void out_fcount_flush(const void *data, size_t bytes,
+                             const char *tag, int tag_len,
+                             struct flb_input_instance *i_ins,
+                             void *out_context,
+                             struct flb_config *config)
 {
     msgpack_unpacked result;
     msgpack_object *obj;

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -252,8 +252,8 @@ static int gelf_send_udp(struct flb_out_gelf_config *ctx, char *msg,
   return 0;
 }
 
-void cb_gelf_flush(void *data, size_t bytes,
-                   char *tag, int tag_len,
+void cb_gelf_flush(const void *data, size_t bytes,
+                   const char *tag, int tag_len,
                    struct flb_input_instance *i_ins,
                    void *out_context,
                    struct flb_config *config)
@@ -350,7 +350,7 @@ int cb_gelf_init(struct flb_output_instance *ins, struct flb_config *config,
 {
     int ret;
     int fd;
-    char *tmp;
+    const char *tmp;
     struct flb_out_gelf_config *ctx = NULL;
 
 

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -39,7 +39,7 @@
 
 struct flb_output_plugin out_http_plugin;
 
-static char *msgpack_to_json(struct flb_out_http *ctx, char *data, uint64_t bytes, uint64_t *out_size)
+static char *msgpack_to_json(struct flb_out_http *ctx, const char *data, uint64_t bytes, uint64_t *out_size)
 {
     int i;
     int ret;
@@ -193,8 +193,8 @@ static int cb_http_init(struct flb_output_instance *ins,
 }
 
 static int http_post (struct flb_out_http *ctx,
-                      void *body, size_t body_len,
-                      char *tag, int tag_len)
+                      const void *body, size_t body_len,
+                      const char *tag, int tag_len)
 {
     int ret;
     int out_ret = FLB_OK;
@@ -309,7 +309,7 @@ static int http_post (struct flb_out_http *ctx,
 }
 
 static int http_gelf(struct flb_out_http *ctx,
-                     char *data, uint64_t bytes, char *tag, int tag_len)
+                     const char *data, uint64_t bytes, const char *tag, int tag_len)
 {
     flb_sds_t s;
     flb_sds_t tmp;
@@ -369,8 +369,8 @@ static int http_gelf(struct flb_out_http *ctx,
     return FLB_OK;
 }
 
-static void cb_http_flush(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static void cb_http_flush(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -42,7 +42,7 @@ struct flb_out_http {
     char *http_passwd;
 
     /* Proxy */
-    char *proxy;
+    const char *proxy;
     char *proxy_host;
     int proxy_port;
 

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -34,7 +34,8 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     int len;
     int io_flags = 0;
     char *uri = NULL;
-    char *tmp;
+    char *tmp_uri = NULL;
+    const char *tmp;
     struct flb_upstream *upstream;
     struct flb_out_http *ctx = NULL;
     struct mk_list *head;
@@ -156,12 +157,12 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     }
     else if (uri[0] != '/') {
         ulen = strlen(uri);
-        tmp = flb_malloc(ulen + 2);
-        tmp[0] = '/';
-        memcpy(tmp + 1, uri, ulen);
-        tmp[ulen + 1] = '\0';
+        tmp_uri = flb_malloc(ulen + 2);
+        tmp_uri[0] = '/';
+        memcpy(tmp_uri + 1, uri, ulen);
+        tmp_uri[ulen + 1] = '\0';
         flb_free(uri);
-        uri = tmp;
+        uri = tmp_uri;
     }
 
     /* HTTP Auth */

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -33,14 +33,14 @@
 /*
  * Returns FLB_TRUE if the specified value is true, otherwise FLB_FALSE
  */
-static int bool_value(char *v);
+static int bool_value(const char *v);
 
 /*
  * Returns FLB_TRUE when the specified key is in Tag_Keys list,
  * otherwise FLB_FALSE
  */
 static int is_tagged_key(struct flb_influxdb_config *ctx,
-                         char *key, int kl, int type);
+                         const char *key, int kl, int type);
 
 /*
  * Increments the timestamp when it is duplicated
@@ -62,8 +62,8 @@ static void influxdb_tsmod(struct flb_time *ts, struct flb_time *dupe,
  * Convert the internal Fluent Bit data representation to the required one
  * by InfluxDB.
  */
-static char *influxdb_format(char *tag, int tag_len,
-                             void *data, size_t bytes, int *out_size,
+static char *influxdb_format(const char *tag, int tag_len,
+                             const void *data, size_t bytes, int *out_size,
                              struct flb_influxdb_config *ctx)
 {
     int i;
@@ -170,19 +170,19 @@ static char *influxdb_format(char *tag, int tag_len,
             int quote = FLB_FALSE;
 
             /* key */
-            char *key = NULL;
+            const char *key = NULL;
             int key_len;
 
             /* val */
-            char *val = NULL;
+            const char *val = NULL;
             int val_len;
 
             if (k->type == MSGPACK_OBJECT_STR) {
-                key = (char *) k->via.str.ptr;
+                key = k->via.str.ptr;
                 key_len = k->via.str.size;
             }
             else {
-                key = (char *) k->via.bin.ptr;
+                key = k->via.bin.ptr;
                 key_len = k->via.bin.size;
             }
 
@@ -216,13 +216,13 @@ static char *influxdb_format(char *tag, int tag_len,
             else if (v->type == MSGPACK_OBJECT_STR) {
                 /* String value */
                 quote   = FLB_TRUE;
-                val     = (char *) v->via.str.ptr;
+                val     = v->via.str.ptr;
                 val_len = v->via.str.size;
             }
             else if (v->type == MSGPACK_OBJECT_BIN) {
                 /* Bin value */
                 quote   = FLB_TRUE;
-                val     = (char *) v->via.bin.ptr;
+                val     = v->via.bin.ptr;
                 val_len = v->via.bin.size;
             }
 
@@ -330,7 +330,7 @@ int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *config,
                      void *data)
 {
     int io_flags = 0;
-    char *tmp;
+    const char *tmp;
     struct flb_upstream *upstream;
     struct flb_influxdb_config *ctx;
 
@@ -440,8 +440,8 @@ int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *config,
     return 0;
 }
 
-void cb_influxdb_flush(void *data, size_t bytes,
-                       char *tag, int tag_len,
+void cb_influxdb_flush(const void *data, size_t bytes,
+                       const char *tag, int tag_len,
                        struct flb_input_instance *i_ins,
                        void *out_context,
                        struct flb_config *config)
@@ -526,7 +526,7 @@ int cb_influxdb_exit(void *data, struct flb_config *config)
     return 0;
 }
 
-int bool_value(char *v)
+int bool_value(const char *v)
 {
     if (strcasecmp(v, "true") == 0) {
         return FLB_TRUE;
@@ -541,7 +541,7 @@ int bool_value(char *v)
     return FLB_FALSE;
 }
 
-int is_tagged_key(struct flb_influxdb_config *ctx, char *key, int kl, int type)
+int is_tagged_key(struct flb_influxdb_config *ctx, const char *key, int kl, int type)
 {
     if (type == MSGPACK_OBJECT_STR) {
         if (ctx->auto_tags) {

--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -95,8 +95,8 @@ void influxdb_bulk_destroy(struct influxdb_bulk *bulk)
 }
 
 int influxdb_bulk_append_header(struct influxdb_bulk *bulk,
-                                char *tag, int tag_len,
-                                uint64_t seq_n, char *seq, int seq_len)
+                                const char *tag, int tag_len,
+                                uint64_t seq_n, const char *seq, int seq_len)
 {
     int ret;
     int required;
@@ -135,8 +135,8 @@ int influxdb_bulk_append_header(struct influxdb_bulk *bulk,
 }
 
 int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
-                            char *key, int k_len,
-                            char *val, int v_len,
+                            const char *key, int k_len,
+                            const char *val, int v_len,
                             int quote)
 {
     int ret;

--- a/plugins/out_influxdb/influxdb_bulk.h
+++ b/plugins/out_influxdb/influxdb_bulk.h
@@ -36,12 +36,12 @@ struct influxdb_bulk {
 struct influxdb_bulk *influxdb_bulk_create();
 
 int influxdb_bulk_append_header(struct influxdb_bulk *bulk,
-                                char *tag, int tag_len,
-                                uint64_t seq_n, char *seq, int seq_len);
+                                const char *tag, int tag_len,
+                                uint64_t seq_n, const char *seq, int seq_len);
 
 int influxdb_bulk_append_kv(struct influxdb_bulk *bulk,
-                            char *key, int k_len,
-                            char *val, int v_len,
+                            const char *key, int k_len,
+                            const char *val, int v_len,
                             int quote);
 
 int influxdb_bulk_append_bulk(struct influxdb_bulk *bulk_to,

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -137,7 +137,7 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
         if (ctx->topic_key && !topic && val.type == MSGPACK_OBJECT_STR) {
             if (key.via.str.size == ctx->topic_key_len &&
                 strncmp(key.via.str.ptr, ctx->topic_key, ctx->topic_key_len) == 0) {
-                topic = flb_kafka_topic_lookup((char *) val.via.str.ptr,
+                topic = flb_kafka_topic_lookup(val.via.str.ptr,
                                                val.via.str.size,
                                                ctx);
             }
@@ -251,8 +251,8 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     return FLB_OK;
 }
 
-static void cb_kafka_flush(void *data, size_t bytes,
-                           char *tag, int tag_len,
+static void cb_kafka_flush(const void *data, size_t bytes,
+                           const char *tag, int tag_len,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -31,7 +31,7 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
                                         struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     char errstr[512];
     struct mk_list *head;
     struct mk_list *topics;

--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -33,8 +33,8 @@
  * Convert the internal Fluent Bit data representation to the required
  * one by Kafka REST Proxy.
  */
-static char *kafka_rest_format(void *data, size_t bytes,
-                               char *tag, int tag_len, size_t *out_size,
+static char *kafka_rest_format(const void *data, size_t bytes,
+                               const char *tag, int tag_len, size_t *out_size,
                                struct flb_kafka_rest *ctx)
 {
     int i;
@@ -190,8 +190,8 @@ static int cb_kafka_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_kafka_flush(void *data, size_t bytes,
-                           char *tag, int tag_len,
+static void cb_kafka_flush(const void *data, size_t bytes,
+                           const char *tag, int tag_len,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)

--- a/plugins/out_kafka_rest/kafka_conf.c
+++ b/plugins/out_kafka_rest/kafka_conf.c
@@ -31,7 +31,7 @@ struct flb_kafka_rest *flb_kr_conf_create(struct flb_output_instance *ins,
 {
     long part;
     int io_flags = 0;
-    char *tmp;
+    const char *tmp;
     char *endptr;
     struct flb_upstream *upstream;
     struct flb_kafka_rest *ctx;

--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -34,7 +34,7 @@
 static int configure(struct flb_out_lib_config *ctx,
                      struct flb_output_instance *ins)
 {
-    char *tmp;
+    const char *tmp;
 
     tmp = flb_output_get_property("format", ins);
     if (!tmp) {
@@ -102,8 +102,8 @@ static int out_lib_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void out_lib_flush(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static void out_lib_flush(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)

--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -73,8 +73,8 @@ int cb_nats_init(struct flb_output_instance *ins, struct flb_config *config,
     return 0;
 }
 
-static int msgpack_to_json(void *data, size_t bytes,
-                           char *tag, int tag_len,
+static int msgpack_to_json(const void *data, size_t bytes,
+                           const char *tag, int tag_len,
                            char **out_json, size_t *out_size)
 {
     int i;
@@ -151,8 +151,8 @@ static int msgpack_to_json(void *data, size_t bytes,
     return 0;
 }
 
-void cb_nats_flush(void *data, size_t bytes,
-                   char *tag, int tag_len,
+void cb_nats_flush(const void *data, size_t bytes,
+                   const char *tag, int tag_len,
                    struct flb_input_instance *i_ins,
                    void *out_context,
                    struct flb_config *config)

--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -31,8 +31,8 @@ int cb_null_init(struct flb_output_instance *ins,
     return 0;
 }
 
-void cb_null_flush(void *data, size_t bytes,
-                   char *tag, int tag_len,
+void cb_null_flush(const void *data, size_t bytes,
+                   const char *tag, int tag_len,
                    struct flb_input_instance *i_ins,
                    void *out_context,
                    struct flb_config *config)

--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -29,8 +29,8 @@
 #include <msgpack.h>
 
 struct flb_plot_conf {
-    char *out_file;
-    char *key_name;
+    const char *out_file;
+    const char *key_name;
     int key_len;
 };
 
@@ -38,7 +38,7 @@ static int cb_plot_init(struct flb_output_instance *ins,
                         struct flb_config *config,
                         void *data)
 {
-    char *tmp;
+    const char *tmp;
     (void) config;
     (void) data;
     struct flb_plot_conf *conf;
@@ -68,8 +68,8 @@ static int cb_plot_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_plot_flush(void *data, size_t bytes,
-                          char *tag, int tag_len,
+static void cb_plot_flush(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)
@@ -79,7 +79,7 @@ static void cb_plot_flush(void *data, size_t bytes,
     struct flb_time atime;
     msgpack_unpacked result;
     size_t off = 0;
-    char *out_file;
+    const char *out_file;
     msgpack_object *map;
     msgpack_object *key = NULL;
     msgpack_object *val = NULL;

--- a/plugins/out_retry/retry.c
+++ b/plugins/out_retry/retry.c
@@ -37,7 +37,7 @@ int cb_retry_init(struct flb_output_instance *ins,
 {
     (void) config;
     (void) data;
-    char *tmp;
+    const char *tmp;
     struct retry_ctx *ctx;
 
     ctx = flb_malloc(sizeof(struct retry_ctx));
@@ -58,8 +58,8 @@ int cb_retry_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_retry_flush(void *data, size_t bytes,
-                           char *tag, int tag_len,
+static void cb_retry_flush(const void *data, size_t bytes,
+                           const char *tag, int tag_len,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -44,7 +44,7 @@ static int cb_splunk_init(struct flb_output_instance *ins,
     return 0;
 }
 
-int splunk_format(void *in_buf, size_t in_bytes,
+int splunk_format(const void *in_buf, size_t in_bytes,
                   char **out_buf, size_t *out_size,
                   struct flb_splunk *ctx)
 {
@@ -149,8 +149,8 @@ int splunk_format(void *in_buf, size_t in_bytes,
     return 0;
 }
 
-static void cb_splunk_flush(void *data, size_t bytes,
-                            char *tag, int tag_len,
+static void cb_splunk_flush(const void *data, size_t bytes,
+                            const char *tag, int tag_len,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -28,7 +28,7 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
                                           struct flb_config *config)
 {
     int io_flags = 0;
-    char *tmp;
+    const char *tmp;
     flb_sds_t t;
     struct flb_upstream *upstream;
     struct flb_splunk *ctx;

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -324,8 +324,8 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static int stackdriver_format(void *data, size_t bytes,
-                              char *tag, size_t tag_len,
+static int stackdriver_format(const void *data, size_t bytes,
+                              const char *tag, size_t tag_len,
                               char **out_data, size_t *out_size,
                               struct flb_stackdriver *ctx)
 {
@@ -491,11 +491,11 @@ static void set_authorization_header(struct flb_http_client *c,
     flb_http_add_header(c, "Authorization", 13, header, len);
 }
 
-static void cb_stackdriver_flush(void *data, size_t bytes,
-                            char *tag, int tag_len,
-                            struct flb_input_instance *i_ins,
-                            void *out_context,
-                            struct flb_config *config)
+static void cb_stackdriver_flush(const void *data, size_t bytes,
+                                 const char *tag, int tag_len,
+                                 struct flb_input_instance *i_ins,
+                                 void *out_context,
+                                 struct flb_config *config)
 {
     (void) i_ins;
     (void) config;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -30,7 +30,7 @@
 #include "stackdriver.h"
 #include "stackdriver_conf.h"
 
-static inline int key_cmp(char *str, int len, char *cmp) {
+static inline int key_cmp(const char *str, int len, const char *cmp) {
 
     if (strlen(cmp) != len) {
         return -1;
@@ -39,7 +39,7 @@ static inline int key_cmp(char *str, int len, char *cmp) {
     return strncasecmp(str, cmp, len);
 }
 
-static int validate_resource(char *res)
+static int validate_resource(const char *res)
 {
     if (strcasecmp(res, "global") != 0 &&
         strcasecmp(res, "gce_instance") != 0) {
@@ -49,7 +49,7 @@ static int validate_resource(char *res)
     return 0;
 }
 
-static int read_credentials_file(char *creds, struct flb_stackdriver *ctx)
+static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
 {
     int i;
     int ret;
@@ -179,7 +179,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                                               struct flb_config *config)
 {
     int ret;
-    char *tmp;
+    const char *tmp;
     struct flb_stackdriver *ctx;
 
     /* Allocate config context */

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -28,7 +28,7 @@
 #include "stdout.h"
 
 static char *msgpack_to_json(struct flb_out_stdout_config *ctx,
-                             char *data, uint64_t bytes,
+                             const char *data, uint64_t bytes,
                              uint64_t *out_size)
 {
     int i;
@@ -160,7 +160,7 @@ static char *msgpack_to_json(struct flb_out_stdout_config *ctx,
 static int cb_stdout_init(struct flb_output_instance *ins,
                           struct flb_config *config, void *data)
 {
-    char *tmp;
+    const char *tmp;
     struct flb_out_stdout_config *ctx = NULL;
     (void) ins;
     (void) config;
@@ -204,8 +204,8 @@ static int cb_stdout_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_stdout_flush(void *data, size_t bytes,
-                            char *tag, int tag_len,
+static void cb_stdout_flush(const void *data, size_t bytes,
+                            const char *tag, int tag_len,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -44,7 +44,7 @@ struct flb_output_plugin out_td_plugin;
  * This function returns a new msgpack buffer and store the bytes length
  * in the out_size variable.
  */
-static char *td_format(void *data, size_t bytes, int *out_size)
+static char *td_format(const void *data, size_t bytes, int *out_size)
 {
     int i;
     int ret;
@@ -177,8 +177,8 @@ int cb_td_init(struct flb_output_instance *ins, struct flb_config *config,
     return 0;
 }
 
-static void cb_td_flush(void *data, size_t bytes,
-                        char *tag, int tag_len,
+static void cb_td_flush(const void *data, size_t bytes,
+                        const char *tag, int tag_len,
                         struct flb_input_instance *i_ins,
                         void *out_context,
                         struct flb_config *config)

--- a/plugins/out_td/td_config.c
+++ b/plugins/out_td/td_config.c
@@ -25,10 +25,10 @@
 
 struct flb_out_td_config *td_config_init(struct flb_output_instance *o_ins)
 {
-    char *tmp;
-    char *api;
-    char *db_name;
-    char *db_table;
+    const char *tmp;
+    const char *api;
+    const char *db_name;
+    const char *db_table;
     struct flb_out_td_config *config;
 
     /* Validate TD section keys */

--- a/plugins/out_td/td_config.h
+++ b/plugins/out_td/td_config.h
@@ -30,9 +30,9 @@
 struct flb_out_td_config {
     int fd;           /* Socket to destination/backend */
     int region;       /* TD Region end-point */
-    char *api;
-    char *db_name;
-    char *db_table;
+    const char *api;
+    const char *db_name;
+    const char *db_table;
 
     struct flb_upstream *u;
 };

--- a/src/flb_api.c
+++ b/src/flb_api.c
@@ -34,7 +34,7 @@ struct flb_api *flb_api_create()
         return NULL;
     }
 
-    api->output_get_property = (char * (*)(char *, void *)) flb_output_get_property;
+    api->output_get_property = flb_output_get_property;
     return api;
 }
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -324,7 +324,7 @@ void flb_config_exit(struct flb_config *config)
     flb_free(config);
 }
 
-char *flb_config_prop_get(char *key, struct mk_list *list)
+const char *flb_config_prop_get(const char *key, struct mk_list *list)
 {
     struct mk_list *head;
     struct flb_config_prop *p;
@@ -339,7 +339,7 @@ char *flb_config_prop_get(char *key, struct mk_list *list)
     return NULL;
 }
 
-static inline int prop_key_check(char *key, char *kv, int k_len)
+static inline int prop_key_check(const char *key, const char *kv, int k_len)
 {
     size_t len;
 
@@ -350,7 +350,7 @@ static inline int prop_key_check(char *key, char *kv, int k_len)
     return -1;
 }
 
-static int set_log_level(struct flb_config *config, char *v_str)
+static int set_log_level(struct flb_config *config, const char *v_str)
 {
     if (v_str != NULL) {
         if (strcasecmp(v_str, "error") == 0) {
@@ -378,7 +378,7 @@ static int set_log_level(struct flb_config *config, char *v_str)
     return 0;
 }
 
-static inline int atobool(char*v)
+static inline int atobool(const char *v)
 {
     return  (strcasecmp("true", v) == 0 ||
              strcasecmp("on", v) == 0 ||
@@ -388,7 +388,7 @@ static inline int atobool(char*v)
 }
 
 int flb_config_set_property(struct flb_config *config,
-                            char *k, char *v)
+                            const char *k, const char *v)
 {
     int i=0;
     int ret = -1;

--- a/src/flb_config_static.c
+++ b/src/flb_config_static.c
@@ -152,15 +152,14 @@ static int flb_config_static_read(struct mk_rconf *conf,
     char *section = NULL;
     char *indent = NULL;
     char *key, *val;
-    char *cfg_file = (char *) fname;
     size_t off;
     struct mk_rconf_file *file;
     struct mk_rconf_section *current = NULL;
 
     /* Check this file have not been included before */
-    ret = is_file_included(conf, cfg_file);
+    ret = is_file_included(conf, fname);
     if (ret == MK_TRUE) {
-        mk_err("[config] file already included %s", cfg_file);
+        mk_err("[config] file already included %s", fname);
         return -1;
     }
 
@@ -175,7 +174,7 @@ static int flb_config_static_read(struct mk_rconf *conf,
 
     /* looking for configuration directives */
     off = 0;
-    while (static_fgets(buf, MK_RCONF_KV_SIZE, (char *) data, &off)) {
+    while (static_fgets(buf, MK_RCONF_KV_SIZE, data, &off)) {
         len = strlen(buf);
         if (buf[len - 1] == '\n') {
             buf[--len] = 0;
@@ -361,14 +360,14 @@ struct mk_rconf *flb_config_static_open(char *file)
 {
     int i;
     int ret;
-    char *k;
-    char *v;
+    const char *k;
+    const char *v;
     struct mk_rconf *conf = NULL;
 
     /* Iterate static array and lookup the file name */
     for (i = 0; i < flb_config_files_size; i++) {
-        k = (char *) flb_config_files[i][0];
-        v = (char *) flb_config_files[i][1];
+        k = flb_config_files[i][0];
+        v = flb_config_files[i][1];
 
         if (strcmp(k, file) == 0) {
             break;

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -119,9 +119,9 @@ int flb_engine_dispatch(uint64_t id, struct flb_input_instance *in,
                         struct flb_config *config)
 {
     int ret;
-    char *buf_data;
+    const char *buf_data;
     size_t buf_size = 0;
-    char *tag_buf;
+    const char *tag_buf;
     int tag_len;
     struct mk_list *tmp;
     struct mk_list *head;

--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -33,7 +33,7 @@ struct flb_buf {
     size_t len;
 };
 
-static inline int buf_append(struct flb_buf *buf, char *str, int len)
+static inline int buf_append(struct flb_buf *buf, const char *str, int len)
 {
     size_t av;
     size_t new_size;
@@ -118,12 +118,12 @@ void flb_env_destroy(struct flb_env *env)
     flb_free(env);
 }
 
-int flb_env_set(struct flb_env *env, char *key, char *val)
+int flb_env_set(struct flb_env *env, const char *key, const char *val)
 {
     int id;
     int klen;
     int vlen;
-    char *out_buf;
+    const char *out_buf;
     size_t out_size;
 
     /* Get lengths */
@@ -142,11 +142,11 @@ int flb_env_set(struct flb_env *env, char *key, char *val)
     return id;
 }
 
-char *flb_env_get(struct flb_env *env, char *key)
+const char *flb_env_get(struct flb_env *env, const char *key)
 {
     int len;
     int ret;
-    char *out_buf;
+    const char *out_buf;
     size_t out_size;
 
     if (!key) {
@@ -175,7 +175,7 @@ char *flb_env_get(struct flb_env *env, char *key)
  * Given a 'value', lookup for variables, if found, return a new composed
  * string.
  */
-char *flb_env_var_translate(struct flb_env *env, char *value)
+char *flb_env_var_translate(struct flb_env *env, const char *value)
 {
     int i;
     int len;
@@ -183,7 +183,7 @@ char *flb_env_var_translate(struct flb_env *env, char *value)
     int e_len;
     int pre_var;
     int have_var = FLB_FALSE;
-    char *env_var = NULL;
+    const char *env_var = NULL;
     char *v_start = NULL;
     char *v_end = NULL;
     char tmp[64];

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -40,7 +40,7 @@ static inline int instance_id(struct flb_config *config)
     return (entry->id + 1);
 }
 
-static inline int prop_key_check(char *key, char *kv, int k_len)
+static inline int prop_key_check(const char *key, const char *kv, int k_len)
 {
     int len;
 
@@ -53,8 +53,8 @@ static inline int prop_key_check(char *key, char *kv, int k_len)
 }
 
 void flb_filter_do(struct flb_input_chunk *ic,
-                   void *data, size_t bytes,
-                   char *tag, int tag_len,
+                   const void *data, size_t bytes,
+                   const char *tag, int tag_len,
                    struct flb_config *config)
 {
     int ret;
@@ -64,7 +64,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
     int diff = 0;
 #endif
     char *ntag;
-    char *work_data;
+    const char *work_data;
     size_t work_size;
     void *out_buf;
     size_t cur_size;
@@ -87,7 +87,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
     ntag[tag_len] = '\0';
 
 
-    work_data = (char *) data;
+    work_data = (const char *) data;
     work_size = bytes;
 
     /* Count number of incoming records */
@@ -186,7 +186,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
     flb_free(ntag);
 }
 
-int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v)
+int flb_filter_set_property(struct flb_filter_instance *filter,
+                            const char *k, const char *v)
 {
     int len;
     char *tmp;
@@ -201,7 +202,7 @@ int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v
     /* Check if the key is a known/shared property */
 #ifdef FLB_HAVE_REGEX
     if (prop_key_check("match_regex", k, len) == 0) {
-        filter->match_regex = flb_regex_create((unsigned char *) tmp);
+        filter->match_regex = flb_regex_create(tmp);
     }
     else
 #endif
@@ -227,7 +228,7 @@ int flb_filter_set_property(struct flb_filter_instance *filter, char *k, char *v
     return 0;
 }
 
-char *flb_filter_get_property(char *key, struct flb_filter_instance *i)
+const char *flb_filter_get_property(const char *key, struct flb_filter_instance *i)
 {
     return flb_config_prop_get(key, &i->properties);
 }
@@ -289,7 +290,7 @@ void flb_filter_exit(struct flb_config *config)
 }
 
 struct flb_filter_instance *flb_filter_new(struct flb_config *config,
-                                           char *filter, void *data)
+                                           const char *filter, void *data)
 {
     int id;
     struct mk_list *head;
@@ -341,7 +342,7 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
 }
 
 /* Return an instance name or alias */
-char *flb_filter_name(struct flb_filter_instance *in)
+const char *flb_filter_name(struct flb_filter_instance *in)
 {
     if (in->alias) {
         return in->alias;
@@ -355,7 +356,7 @@ void flb_filter_initialize_all(struct flb_config *config)
 {
     int ret;
 #ifdef FLB_HAVE_METRICS
-    char *name;
+    const char *name;
 #endif
     struct mk_list *tmp;
     struct mk_list *head;

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -179,8 +179,9 @@ static void flb_hash_evict_random(struct flb_hash *ht)
     }
 }
 
-int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
-                 char *val, size_t val_size)
+int flb_hash_add(struct flb_hash *ht,
+                 const char *key, int key_len,
+                 const char *val, size_t val_size)
 {
     int id;
     unsigned int hash;
@@ -270,8 +271,9 @@ int flb_hash_add(struct flb_hash *ht, char *key, int key_len,
     return id;
 }
 
-int flb_hash_get(struct flb_hash *ht, char *key, int key_len,
-                 char **out_buf, size_t * out_size)
+int flb_hash_get(struct flb_hash *ht,
+                 const char *key, int key_len,
+                 const char **out_buf, size_t * out_size)
 {
     int id;
     unsigned int hash;
@@ -336,8 +338,9 @@ int flb_hash_get(struct flb_hash *ht, char *key, int key_len,
  * Get an entry based in the table id. Note that a table id might have multiple
  * entries so the 'key' parameter is required to get an exact match.
  */
-int flb_hash_get_by_id(struct flb_hash *ht, int id, char *key, char **out_buf,
-                       size_t * out_size)
+int flb_hash_get_by_id(struct flb_hash *ht, int id,
+                       const char *key,
+                       const char **out_buf, size_t * out_size)
 {
     struct mk_list *head;
     struct flb_hash_entry *entry = NULL;
@@ -372,7 +375,7 @@ int flb_hash_get_by_id(struct flb_hash *ht, int id, char *key, char **out_buf,
     return 0;
 }
 
-int flb_hash_del(struct flb_hash *ht, char *key)
+int flb_hash_del(struct flb_hash *ht, const char *key)
 {
     int id;
     int len;

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -54,8 +54,8 @@ static int header_available(struct flb_http_client *c, int bytes)
 
 /* Try to find a header value in the buffer */
 static int header_lookup(struct flb_http_client *c,
-                         char *header, int header_len,
-                         char **out_val, int *out_len)
+                         const char *header, int header_len,
+                         const char **out_val, int *out_len)
 {
     char *p;
     char *crlf;
@@ -98,7 +98,7 @@ static int check_chunked_encoding(struct flb_http_client *c)
 {
     int ret;
     int len;
-    char *header = NULL;
+    const char *header = NULL;
 
     ret = header_lookup(c, "Transfer-Encoding: ", 19,
                         &header, &len);
@@ -123,7 +123,7 @@ static int check_content_length(struct flb_http_client *c)
 {
     int ret;
     int len;
-    char *header;
+    const char *header;
     char tmp[256];
 
     if (c->resp.status == 204) {
@@ -365,14 +365,14 @@ static int process_data(struct flb_http_client *c)
     return FLB_HTTP_MORE;
 }
 
-static int proxy_parse(char *proxy, struct flb_http_client *c)
+static int proxy_parse(const char *proxy, struct flb_http_client *c)
 {
     int len;
     int port;
     int off = 0;
-    char *s;
-    char *e;
-    char *host;
+    const char *s;
+    const char *e;
+    const char *host;
 
     len = strlen(proxy);
     if (len < 7) {
@@ -429,10 +429,10 @@ static int proxy_parse(char *proxy, struct flb_http_client *c)
 }
 
 struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
-                                        int method, char *uri,
-                                        char *body, size_t body_len,
-                                        char *host, int port,
-                                        char *proxy, int flags)
+                                        int method, const char *uri,
+                                        const char *body, size_t body_len,
+                                        const char *host, int port,
+                                        const char *proxy, int flags)
 {
     int ret;
     char *buf = NULL;
@@ -653,8 +653,8 @@ int flb_http_buffer_increase(struct flb_http_client *c, size_t size,
 
 /* Append a custom HTTP header to the request */
 int flb_http_add_header(struct flb_http_client *c,
-                        char *key, size_t key_len,
-                        char *val, size_t val_len)
+                        const char *key, size_t key_len,
+                        const char *val, size_t val_len)
 {
     int required;
     int new_size;
@@ -707,7 +707,8 @@ int flb_http_add_header(struct flb_http_client *c,
     return 0;
 }
 
-int flb_http_basic_auth(struct flb_http_client *c, char *user, char *passwd)
+int flb_http_basic_auth(struct flb_http_client *c,
+                        const char *user, const char *passwd)
 {
     int ret;
     int len_u;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -36,7 +36,7 @@
 
 #define protcmp(a, b)  strncasecmp(a, b, strlen(a))
 
-static int check_protocol(char *prot, char *output)
+static int check_protocol(const char *prot, const char *output)
 {
     int len;
 
@@ -87,7 +87,7 @@ static int collector_id(struct flb_input_instance *in)
 
 /* Create an input plugin instance */
 struct flb_input_instance *flb_input_new(struct flb_config *config,
-                                         char *input, void *data,
+                                         const char *input, void *data,
                                          int public_only)
 {
     int id;
@@ -180,7 +180,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
     return instance;
 }
 
-static inline int prop_key_check(char *key, char *kv, int k_len)
+static inline int prop_key_check(const char *key, const char *kv, int k_len)
 {
     int len;
 
@@ -194,7 +194,8 @@ static inline int prop_key_check(char *key, char *kv, int k_len)
 }
 
 /* Override a configuration property for the given input_instance plugin */
-int flb_input_set_property(struct flb_input_instance *in, char *k, char *v)
+int flb_input_set_property(struct flb_input_instance *in,
+                           const char *k, const char *v)
 {
     int len;
     ssize_t limit;
@@ -260,13 +261,13 @@ int flb_input_set_property(struct flb_input_instance *in, char *k, char *v)
     return 0;
 }
 
-char *flb_input_get_property(char *key, struct flb_input_instance *i)
+const char *flb_input_get_property(const char *key, struct flb_input_instance *i)
 {
     return flb_config_prop_get(key, &i->properties);
 }
 
 /* Return an instance name or alias */
-char *flb_input_name(struct flb_input_instance *in)
+const char *flb_input_name(struct flb_input_instance *in)
 {
     if (in->alias) {
         return in->alias;
@@ -329,7 +330,7 @@ int flb_input_instance_init(struct flb_input_instance *in,
                             struct flb_config *config)
 {
     int ret;
-    char *name;
+    const char *name;
     struct flb_input_plugin *p = in->p;
 
     /* Skip pseudo input plugins */

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -68,7 +68,7 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
 {
     int ret;
     int records;
-    char *buf_data;
+    const char *buf_data;
     size_t buf_size;
     struct flb_input_chunk *ic;
 
@@ -103,7 +103,7 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
 }
 
 struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
-                                               char *tag, int tag_len)
+                                               const char *tag, int tag_len)
 {
     int ret;
     char name[256];
@@ -165,7 +165,7 @@ int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del)
 }
 
 /* Return or create an available chunk to write data */
-static struct flb_input_chunk *input_chunk_get(char *tag, int tag_len,
+static struct flb_input_chunk *input_chunk_get(const char *tag, int tag_len,
                                                struct flb_input_instance *in)
 {
     struct mk_list *head;
@@ -355,8 +355,8 @@ int flb_input_chunk_set_up(struct flb_input_chunk *ic)
 
 /* Append a RAW MessagPack buffer to the input instance */
 int flb_input_chunk_append_raw(struct flb_input_instance *in,
-                               char *tag, size_t tag_len,
-                               void *buf, size_t buf_size)
+                               const char *tag, size_t tag_len,
+                               const void *buf, size_t buf_size)
 {
     int ret;
     size_t size;
@@ -436,7 +436,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     }
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     else if (in->config->stream_processor_ctx) {
-        char *c_data;
+        const char *c_data;
         size_t c_size;
 
         /* Retrieve chunk (filtered) output content */
@@ -475,10 +475,10 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 }
 
 /* Retrieve a raw buffer from a dyntag node */
-void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
+const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
 {
     int ret;
-    char *buf = NULL;
+    const char *buf = NULL;
 
     if (cio_chunk_is_up(ic->chunk) == CIO_FALSE) {
         ret = cio_chunk_up(ic->chunk);
@@ -521,7 +521,7 @@ int flb_input_chunk_release_lock(struct flb_input_chunk *ic)
 }
 
 int flb_input_chunk_get_tag(struct flb_input_chunk *ic,
-                            char **tag_buf, int *tag_len)
+                            const char **tag_buf, int *tag_len)
 {
     return cio_meta_read(ic->chunk, tag_buf, tag_len);
 

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -200,7 +200,7 @@ FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
 }
 
 static int net_io_write(struct flb_upstream_conn *u_conn,
-                        void *data, size_t len, size_t *out_len)
+                        const void *data, size_t len, size_t *out_len)
 {
     int ret;
     int tries = 0;
@@ -251,7 +251,7 @@ static int net_io_write(struct flb_upstream_conn *u_conn,
  */
 static FLB_INLINE int net_io_write_async(struct flb_thread *th,
                                          struct flb_upstream_conn *u_conn,
-                                         void *data, size_t len, size_t *out_len)
+                                         const void *data, size_t len, size_t *out_len)
 {
     int ret = 0;
     int error;
@@ -429,7 +429,7 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_thread *th,
 }
 
 /* Write data to an upstream connection/server */
-int flb_io_net_write(struct flb_upstream_conn *u_conn, void *data,
+int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
                      size_t len, size_t *out_len)
 {
     int ret = -1;

--- a/src/flb_io_tls.c
+++ b/src/flb_io_tls.c
@@ -225,16 +225,10 @@ static void flb_tls_debug(void *ctx, int level,
                           const char *file, int line,
                           const char *str)
 {
-    int len;
-    char *p;
-    ((void) level);
+    (void) level;
 
-    len = strlen(str);
-    p = (char *) str;
-    p[len - 1] = '\0';
-
-    flb_debug("[io_tls] %s %04d: %s", file + sizeof(FLB_SOURCE_DIR) - 1,
-              line, str);
+    flb_debug("[io_tls] %s %04d: %.*s", file + sizeof(FLB_SOURCE_DIR) - 1,
+              line, strlen(str), str);
 }
 
 struct flb_tls_session *flb_tls_session_new(struct flb_tls_context *ctx)
@@ -428,7 +422,7 @@ int flb_io_tls_net_read(struct flb_thread *th, struct flb_upstream_conn *u_conn,
 }
 
 int flb_io_tls_net_write(struct flb_thread *th, struct flb_upstream_conn *u_conn,
-                         void *data, size_t len, size_t *out_len)
+                         const void *data, size_t len, size_t *out_len)
 {
     int ret;
     size_t total = 0;

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -87,7 +87,7 @@ static inline struct flb_output_instance *out_instance_get(flb_ctx_t *ctx,
 }
 
 static inline struct flb_filter_instance *filter_instance_get(flb_ctx_t *ctx,
-                                                         int ffd)
+                                                              int ffd)
 {
     struct mk_list *head;
     struct flb_filter_instance *f_ins;
@@ -198,7 +198,7 @@ void flb_destroy(flb_ctx_t *ctx)
 }
 
 /* Defines a new input instance */
-int flb_input(flb_ctx_t *ctx, char *input, void *data)
+int flb_input(flb_ctx_t *ctx, const char *input, void *data)
 {
     struct flb_input_instance *i_ins;
 
@@ -211,7 +211,7 @@ int flb_input(flb_ctx_t *ctx, char *input, void *data)
 }
 
 /* Defines a new output instance */
-int flb_output(flb_ctx_t *ctx, char *output, void *data)
+int flb_output(flb_ctx_t *ctx, const char *output, void *data)
 {
     struct flb_output_instance *o_ins;
 
@@ -224,7 +224,7 @@ int flb_output(flb_ctx_t *ctx, char *output, void *data)
 }
 
 /* Defines a new filter instance */
-int flb_filter(flb_ctx_t *ctx, char *filter, void *data)
+int flb_filter(flb_ctx_t *ctx, const char *filter, void *data)
 {
     struct flb_filter_instance *f_ins;
 
@@ -364,7 +364,7 @@ int flb_service_set(flb_ctx_t *ctx, ...)
 }
 
 /* Load a configuration file that may be used by the input or output plugin */
-int flb_lib_config_file(struct flb_lib_ctx *ctx, char *path)
+int flb_lib_config_file(struct flb_lib_ctx *ctx, const char *path)
 {
     if (access(path, R_OK) != 0) {
         perror("access");
@@ -392,7 +392,7 @@ int flb_lib_free(void* data)
 
 
 /* Push some data into the Engine */
-int flb_lib_push(flb_ctx_t *ctx, int ffd, void *data, size_t len)
+int flb_lib_push(flb_ctx_t *ctx, int ffd, const void *data, size_t len)
 {
     int ret;
     struct flb_input_instance *i_ins;

--- a/src/flb_meta.c
+++ b/src/flb_meta.c
@@ -35,7 +35,7 @@
  */
 
 /* @SET command: register a key/value as a configuration variable */
-static int meta_cmd_set(struct flb_config *ctx, char *params)
+static int meta_cmd_set(struct flb_config *ctx, const char *params)
 {
     int ret;
     int len;
@@ -70,7 +70,7 @@ static int meta_cmd_set(struct flb_config *ctx, char *params)
 }
 
 /* Run a specific command */
-int flb_meta_run(struct flb_config *ctx, char *cmd, char *params)
+int flb_meta_run(struct flb_config *ctx, const char *cmd, const char *params)
 {
     if (strcasecmp(cmd, "SET") == 0) {
         return meta_cmd_set(ctx, params);

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -74,7 +74,7 @@ struct flb_metric *flb_metrics_get_id(int id, struct flb_metrics *metrics)
     return NULL;
 }
 
-struct flb_metrics *flb_metrics_create(char *title)
+struct flb_metrics *flb_metrics_create(const char *title)
 {
     int ret;
     struct flb_metrics *metrics;
@@ -99,7 +99,7 @@ struct flb_metrics *flb_metrics_create(char *title)
     return metrics;
 }
 
-int flb_metrics_title(char *title, struct flb_metrics *metrics)
+int flb_metrics_title(const char *title, struct flb_metrics *metrics)
 {
     int ret;
 
@@ -112,7 +112,7 @@ int flb_metrics_title(char *title, struct flb_metrics *metrics)
     return 0;
 }
 
-int flb_metrics_add(int id, char *title, struct flb_metrics *metrics)
+int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
 {
     int ret;
     struct flb_metric *m;

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -22,7 +22,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
-static inline int mp_count(void *data, size_t bytes, msgpack_zone *zone)
+static inline int mp_count(const void *data, size_t bytes, msgpack_zone *zone)
 {
     int c = 0;
     int ret;
@@ -58,12 +58,12 @@ static inline int mp_count(void *data, size_t bytes, msgpack_zone *zone)
     return c;
 }
 
-int flb_mp_count(void *data, size_t bytes)
+int flb_mp_count(const void *data, size_t bytes)
 {
     return mp_count(data, bytes, NULL);
 }
 
-int flb_mp_count_zone(void *data, size_t bytes, msgpack_zone *zone)
+int flb_mp_count_zone(const void *data, size_t bytes, msgpack_zone *zone)
 {
     return mp_count(data, bytes, zone);
 }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -42,7 +42,7 @@
 #endif
 
 /* Copy a sub-string in a new memory buffer */
-static char *copy_substr(char *str, int s)
+static char *copy_substr(const char *str, int s)
 {
     char *buf;
 
@@ -53,11 +53,11 @@ static char *copy_substr(char *str, int s)
     return buf;
 }
 
-int flb_net_host_set(char *plugin_name, struct flb_net_host *host, char *address)
+int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address)
 {
     int len;
     int olen;
-    char *s, *e, *u;
+    const char *s, *e, *u;
 
     memset(host, '\0', sizeof(struct flb_net_host));
 
@@ -199,7 +199,7 @@ flb_sockfd_t flb_net_socket_create_udp(int family, int nonblock)
 }
 
 /* Connect to a TCP socket server and returns the file descriptor */
-flb_sockfd_t flb_net_tcp_connect(char *host, unsigned long port)
+flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port)
 {
     flb_sockfd_t fd = -1;
     int ret;
@@ -244,7 +244,7 @@ flb_sockfd_t flb_net_tcp_connect(char *host, unsigned long port)
 }
 
 /* "Connect" to a UDP socket server and returns the file descriptor */
-flb_sockfd_t flb_net_udp_connect(char *host, unsigned long port)
+flb_sockfd_t flb_net_udp_connect(const char *host, unsigned long port)
 {
     flb_sockfd_t fd = -1;
     int ret;
@@ -289,7 +289,7 @@ flb_sockfd_t flb_net_udp_connect(char *host, unsigned long port)
 }
 
 /* Connect to a TCP socket server and returns the file descriptor */
-int flb_net_tcp_fd_connect(flb_sockfd_t fd, char *host, unsigned long port)
+int flb_net_tcp_fd_connect(flb_sockfd_t fd, const char *host, unsigned long port)
 {
     int ret;
     struct addrinfo hints;
@@ -314,7 +314,7 @@ int flb_net_tcp_fd_connect(flb_sockfd_t fd, char *host, unsigned long port)
     return ret;
 }
 
-flb_sockfd_t flb_net_server(char *port, char *listen_addr)
+flb_sockfd_t flb_net_server(const char *port, const char *listen_addr)
 {
     flb_sockfd_t fd = -1;
     int ret;
@@ -360,7 +360,7 @@ flb_sockfd_t flb_net_server(char *port, char *listen_addr)
     return fd;
 }
 
-flb_sockfd_t flb_net_server_udp(char *port, char *listen_addr)
+flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr)
 {
     flb_sockfd_t fd = -1;
     int ret;
@@ -424,7 +424,7 @@ int flb_net_bind(flb_sockfd_t fd, const struct sockaddr *addr,
 }
 
 int flb_net_bind_udp(flb_sockfd_t fd, const struct sockaddr *addr,
-                 socklen_t addrlen)
+                     socklen_t addrlen)
 {
     int ret;
 

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -42,7 +42,7 @@
         flb_free(uri);                          \
     }
 
-static inline int key_cmp(char *str, int len, char *cmp) {
+static inline int key_cmp(const char *str, int len, const char *cmp) {
 
     if (strlen(cmp) != len) {
         return -1;
@@ -51,16 +51,16 @@ static inline int key_cmp(char *str, int len, char *cmp) {
     return strncasecmp(str, cmp, len);
 }
 
-int flb_oauth2_parse_json_response(char *json_data, size_t json_size,
-                               struct flb_oauth2 *ctx)
+int flb_oauth2_parse_json_response(const char *json_data, size_t json_size,
+                                   struct flb_oauth2 *ctx)
 {
     int i;
     int ret;
     int key_len;
     int val_len;
     int tokens_size = 32;
-    char *key;
-    char *val;
+    const char *key;
+    const char *val;
     jsmn_parser parser;
     jsmntok_t *t;
     jsmntok_t *tokens;
@@ -131,7 +131,7 @@ int flb_oauth2_parse_json_response(char *json_data, size_t json_size,
 }
 
 struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
-                                     char *auth_url, int expire_sec)
+                                     const char *auth_url, int expire_sec)
 {
     int ret;
     char *prot = NULL;
@@ -241,8 +241,8 @@ struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
 
 /* Append a key/value to the request body */
 int flb_oauth2_payload_append(struct flb_oauth2 *ctx,
-                              char *key_str, int key_len,
-                              char *val_str, int val_len)
+                              const char *key_str, int key_len,
+                              const char *val_str, int val_len)
 {
     int size;
     flb_sds_t tmp;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -37,7 +37,7 @@
 #include <fluent-bit/flb_plugin_proxy.h>
 
 /* Validate the the output address protocol */
-static int check_protocol(char *prot, char *output)
+static int check_protocol(const char *prot, const char *output)
 {
     int len;
     char *p;
@@ -201,7 +201,7 @@ static inline int instance_id(struct flb_config *config)
  * proper type and if valid, populate the global config.
  */
 struct flb_output_instance *flb_output_new(struct flb_config *config,
-                                           char *output, void *data)
+                                           const char *output, void *data)
 {
     int ret = -1;
     int mask_id;
@@ -334,7 +334,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     return instance;
 }
 
-static inline int prop_key_check(char *key, char *kv, int k_len)
+static inline int prop_key_check(const char *key, const char *kv, int k_len)
 {
     int len;
 
@@ -347,7 +347,8 @@ static inline int prop_key_check(char *key, char *kv, int k_len)
 }
 
 /* Override a configuration property for the given input_instance plugin */
-int flb_output_set_property(struct flb_output_instance *out, char *k, char *v)
+int flb_output_set_property(struct flb_output_instance *out,
+                            const char *k, const char *v)
 {
     int len;
     char *tmp;
@@ -368,7 +369,7 @@ int flb_output_set_property(struct flb_output_instance *out, char *k, char *v)
     }
 #ifdef FLB_HAVE_REGEX
     else if (prop_key_check("match_regex", k, len) == 0) {
-        out->match_regex = flb_regex_create((unsigned char *) tmp);
+        out->match_regex = flb_regex_create(tmp);
         flb_free(tmp);
     }
 #endif
@@ -471,7 +472,7 @@ int flb_output_set_property(struct flb_output_instance *out, char *k, char *v)
 }
 
 /* Configure a default hostname and TCP port if they are not set */
-void flb_output_net_default(char *host, int port,
+void flb_output_net_default(const char *host, const int port,
                             struct flb_output_instance *o_ins)
 {
     /* Set default network configuration */
@@ -484,7 +485,7 @@ void flb_output_net_default(char *host, int port,
 }
 
 /* Return an instance name or alias */
-char *flb_output_name(struct flb_output_instance *in)
+const char *flb_output_name(struct flb_output_instance *in)
 {
     if (in->alias) {
         return in->alias;
@@ -493,7 +494,7 @@ char *flb_output_name(struct flb_output_instance *in)
     return in->name;
 }
 
-char *flb_output_get_property(char *key, struct flb_output_instance *o_ins)
+const char *flb_output_get_property(const char *key, struct flb_output_instance *o_ins)
 {
     return flb_config_prop_get(key, &o_ins->properties);
 }
@@ -502,7 +503,7 @@ char *flb_output_get_property(char *key, struct flb_output_instance *o_ins)
 int flb_output_init(struct flb_config *config)
 {
     int ret;
-    char *name;
+    const char *name;
     struct mk_list *tmp;
     struct mk_list *head;
     struct flb_output_instance *ins;

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -84,29 +84,29 @@ static unsigned u64_to_str(uint64_t value, char* dst) {
 }
 
 int flb_parser_regex_do(struct flb_parser *parser,
-                        char *buf, size_t length,
+                        const char *buf, size_t length,
                         void **out_buf, size_t *out_size,
                         struct flb_time *out_time);
 
 int flb_parser_json_do(struct flb_parser *parser,
-                       char *buf, size_t length,
+                       const char *buf, size_t length,
                        void **out_buf, size_t *out_size,
                        struct flb_time *out_time);
 
 int flb_parser_ltsv_do(struct flb_parser *parser,
-                       char *buf, size_t length,
+                       const char *buf, size_t length,
                        void **out_buf, size_t *out_size,
                        struct flb_time *out_time);
 
 int flb_parser_logfmt_do(struct flb_parser *parser,
-                         char *buf, size_t length,
+                         const char *buf, size_t length,
                          void **out_buf, size_t *out_size,
                          struct flb_time *out_time);
 
-struct flb_parser *flb_parser_create(char *name, char *format,
-                                     char *p_regex,
-                                     char *time_fmt, char *time_key,
-                                     char *time_offset,
+struct flb_parser *flb_parser_create(const char *name, const char *format,
+                                     const char *p_regex,
+                                     const char *time_fmt, const char *time_key,
+                                     const char *time_offset,
                                      int time_keep,
                                      struct flb_parser_types *types,
                                      int types_len,
@@ -166,7 +166,7 @@ struct flb_parser *flb_parser_create(char *name, char *format,
             return NULL;
         }
 
-        regex = flb_regex_create((unsigned char *) p_regex);
+        regex = flb_regex_create(p_regex);
         if (!regex) {
             flb_error("[parser:%s] Invalid regex pattern %s", name, p_regex);
             flb_free(p);
@@ -337,11 +337,12 @@ void flb_parser_exit(struct flb_config *config)
     }
 }
 
-static int proc_types_str(char *types_str, struct flb_parser_types **types)
+static int proc_types_str(const char *types_str, struct flb_parser_types **types)
 {
     int i = 0;
     int types_num = 0;
     char *type_str = NULL;
+    size_t len;
     struct mk_list *split;
     struct mk_list *head;
     struct flb_split_entry *sentry;
@@ -363,10 +364,9 @@ static int proc_types_str(char *types_str, struct flb_parser_types **types)
             i++;
             continue;
         }
-        *type_str = '\0'; /* for strdup */
-        (*types)[i].key = flb_strdup(sentry->value);
-        (*types)[i].key_len = strlen(sentry->value);
-        *types_str = ':';
+        len = type_str - sentry->value;
+        (*types)[i].key = flb_strndup(sentry->value, len);
+        (*types)[i].key_len = len;
 
         type_str++;
         if (!strcasecmp(type_str, "integer")) {
@@ -392,11 +392,11 @@ static int proc_types_str(char *types_str, struct flb_parser_types **types)
 }
 
 /* Load parsers from a configuration file */
-int flb_parser_conf_file(char *file, struct flb_config *config)
+int flb_parser_conf_file(const char *file, struct flb_config *config)
 {
     int ret;
     char tmp[PATH_MAX + 1];
-    char *cfg = NULL;
+    const char *cfg = NULL;
     char *name;
     char *format;
     char *regex;
@@ -569,7 +569,7 @@ int flb_parser_conf_file(char *file, struct flb_config *config)
     return -1;
 }
 
-struct flb_parser *flb_parser_get(char *name, struct flb_config *config)
+struct flb_parser *flb_parser_get(const char *name, struct flb_config *config)
 {
     struct mk_list *head;
     struct flb_parser *parser;
@@ -585,7 +585,7 @@ struct flb_parser *flb_parser_get(char *name, struct flb_config *config)
     return NULL;
 }
 
-int flb_parser_do(struct flb_parser *parser, char *buf, size_t length,
+int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
                   void **out_buf, size_t *out_size, struct flb_time *out_time)
 {
 
@@ -610,13 +610,13 @@ int flb_parser_do(struct flb_parser *parser, char *buf, size_t length,
 }
 
 /* Given a timezone string, return it numeric offset */
-int flb_parser_tzone_offset(char *str, int len, int *tmdiff)
+int flb_parser_tzone_offset(const char *str, int len, int *tmdiff)
 {
     int neg;
     long hour;
     long min;
-    char *end;
-    char *p = str;
+    const char *end;
+    const char *p = str;
 
     /* Check timezones */
     if (*p == 'Z') {
@@ -658,7 +658,7 @@ int flb_parser_tzone_offset(char *str, int len, int *tmdiff)
     return 0;
 }
 
-int flb_parser_time_lookup(char *time_str, size_t tsize,
+int flb_parser_time_lookup(const char *time_str, size_t tsize,
                            time_t now,
                            struct flb_parser *parser,
                            struct tm *tm, double *ns)
@@ -670,7 +670,7 @@ int flb_parser_time_lookup(char *time_str, size_t tsize,
     char *p = NULL;
     char *fmt;
     int time_len = tsize;
-    char *time_ptr = time_str;
+    const char *time_ptr = time_str;
     char tmp[64];
     char fs_tmp[32];
     struct tm tmy;
@@ -765,19 +765,21 @@ int flb_parser_time_lookup(char *time_str, size_t tsize,
     return -1;
 }
 
-int flb_parser_frac(char *str, int len, double *frac, char **end)
+int flb_parser_frac(const char *str, int len, double *frac, const char **end)
 {
     int ret = 0;
     char *p;
     double d;
-    char *pstr;
+    const char *pstr;
+    char *tmp = NULL;
 
     /* Fractional seconds */
     /* Normalize the fractional seperator to be '.' since that's what strtod()
      * expects in standard C locale */
     if (*str == ',') {
-        pstr = flb_strdup(str);
-        pstr[0] = '.';
+        tmp = flb_strdup(str);
+        tmp[0] = '.';
+        pstr = tmp;
     }
     else {
         pstr = str;
@@ -792,21 +794,21 @@ int flb_parser_frac(char *str, int len, double *frac, char **end)
     *end = str + (p - pstr);
 
 free_and_return:
-    if (pstr != str) {
-        flb_free(pstr);
+    if (tmp != NULL) {
+        flb_free(tmp);
     }
     return ret;
 }
 
-int flb_parser_typecast(char *key, int key_len,
-                        char *val, int val_len,
+int flb_parser_typecast(const char *key, int key_len,
+                        const char *val, int val_len,
                         msgpack_packer *pck,
                         struct flb_parser_types *types,
                         int types_len)
 {
     int i;
     int error = FLB_FALSE;
-    char tmp_char;
+    char *tmp_str;
     int casted = FLB_FALSE;
 
     for(i=0; i<types_len; i++){
@@ -825,24 +827,20 @@ int flb_parser_typecast(char *key, int key_len,
                     long long lval;
 
                     /* msgpack char is not null terminated.
-                       So backup and fill null char,
-                       convert int,
-                       rewind char.
+                       So make a temporary copy.
                      */
-                    tmp_char = val[val_len];
-                    val[val_len] = '\0';
-                    lval = atoll(val);
-                    val[val_len] = tmp_char;
+                    tmp_str = flb_strndup(val, val_len);
+                    lval = atoll(tmp_str);
+                    flb_free(tmp_str);
                     msgpack_pack_int64(pck, lval);
                 }
                 break;
             case FLB_PARSER_TYPE_HEX:
                 {
                     unsigned long long lval;
-                    tmp_char = val[val_len];
-                    val[val_len] = '\0';
-                    lval = strtoull(val, NULL, 16);
-                    val[val_len] = tmp_char;
+                    tmp_str = flb_strndup(val, val_len);
+                    lval = strtoull(tmp_str, NULL, 16);
+                    flb_free(tmp_str);
                     msgpack_pack_uint64(pck, lval);
                 }
                 break;
@@ -850,10 +848,9 @@ int flb_parser_typecast(char *key, int key_len,
             case FLB_PARSER_TYPE_FLOAT:
                 {
                     double dval;
-                    tmp_char = val[val_len];
-                    val[val_len] = '\0';
-                    dval = atof(val);
-                    val[val_len] = tmp_char;
+                    tmp_str = flb_strndup(val, val_len);
+                    dval = atof(tmp_str);
+                    flb_free(tmp_str);
                     msgpack_pack_double(pck, dval);
                 }
                 break;

--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -33,7 +33,7 @@
 
 /* Decode a stringified JSON message */
 static int decode_json(struct flb_parser_dec *dec,
-                       char *in_buf, size_t in_size,
+                       const char *in_buf, size_t in_size,
                        char **out_buf, size_t *out_size, int *out_type)
 {
     int len;
@@ -70,7 +70,7 @@ static int decode_json(struct flb_parser_dec *dec,
 }
 
 static int decode_escaped(struct flb_parser_dec *dec,
-                          char *in_buf, size_t in_size,
+                          const char *in_buf, size_t in_size,
                           char **out_buf, size_t *out_size, int *out_type)
 {
     int len;
@@ -85,8 +85,8 @@ static int decode_escaped(struct flb_parser_dec *dec,
 }
 
 static int decode_escaped_utf8(struct flb_parser_dec *dec,
-                          char *in_buf, size_t in_size,
-                          char **out_buf, size_t *out_size, int *out_type)
+                               const char *in_buf, size_t in_size,
+                               char **out_buf, size_t *out_size, int *out_type)
 {
     int len;
 
@@ -98,8 +98,8 @@ static int decode_escaped_utf8(struct flb_parser_dec *dec,
     return 0;
 }
 
-static int merge_record_and_extra_keys(char *in_buf, size_t in_size,
-                                       char *extra_buf, size_t extra_size,
+static int merge_record_and_extra_keys(const char *in_buf, size_t in_size,
+                                       const char *extra_buf, size_t extra_size,
                                        char **out_buf, size_t *out_size)
 {
     int i;
@@ -165,7 +165,7 @@ static int merge_record_and_extra_keys(char *in_buf, size_t in_size,
  * a new msgpack buffer.
  */
 int flb_parser_decoder_do(struct mk_list *decoders,
-                          char *in_buf, size_t in_size,
+                          const char *in_buf, size_t in_size,
                           char **out_buf, size_t *out_size)
 {
     int i;
@@ -223,7 +223,7 @@ int flb_parser_decoder_do(struct mk_list *decoders,
         /* Try to match this key name with decoder's rule */
         mk_list_foreach(head, decoders) {
             dec = mk_list_entry(head, struct flb_parser_dec, _head);
-            if (flb_sds_cmp(dec->key, (char *) k.via.str.ptr,
+            if (flb_sds_cmp(dec->key, k.via.str.ptr,
                             k.via.str.size) == 0) {
                 /* we have a match, stop the check */
                 matched = i;
@@ -285,7 +285,7 @@ int flb_parser_decoder_do(struct mk_list *decoders,
         /* Lookup for decoders associated to the current 'key' */
         mk_list_foreach(head, decoders) {
             dec = mk_list_entry(head, struct flb_parser_dec, _head);
-            if (flb_sds_cmp(dec->key, (char *) k.via.str.ptr,
+            if (flb_sds_cmp(dec->key, k.via.str.ptr,
                             k.via.str.size) == 0) {
                 break;
             }
@@ -312,7 +312,7 @@ int flb_parser_decoder_do(struct mk_list *decoders,
         }
 
         /* Copy original content */
-        tmp_sds = flb_sds_copy(data_sds, (char *) v.via.str.ptr,
+        tmp_sds = flb_sds_copy(data_sds, v.via.str.ptr,
                                v.via.str.size);
         if (tmp_sds != data_sds) {
             data_sds = tmp_sds;
@@ -495,7 +495,7 @@ int flb_parser_decoder_do(struct mk_list *decoders,
  * Iterate decoders list and lookup for an existing context for 'key_name',
  * if it does not exists, create and link a new one
  */
-static struct flb_parser_dec *get_decoder_key_context(char *key_name, int key_len,
+static struct flb_parser_dec *get_decoder_key_context(const char *key_name, int key_len,
                                                       struct mk_list *list)
 {
     struct mk_list *head;

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -27,7 +27,7 @@
 #include <fluent-bit/flb_parser_decoder.h>
 
 int flb_parser_json_do(struct flb_parser *parser,
-                       char *in_buf, size_t in_size,
+                       const char *in_buf, size_t in_size,
                        void **out_buf, size_t *out_size,
                        struct flb_time *out_time)
 {
@@ -154,7 +154,7 @@ int flb_parser_json_do(struct flb_parser *parser,
     }
 
     /* Lookup time */
-    ret = flb_parser_time_lookup((char *) v->via.str.ptr, v->via.str.size,
+    ret = flb_parser_time_lookup(v->via.str.ptr, v->via.str.size,
                                  0, parser, &tm, &tmfrac);
     if (ret == -1) {
         len = v->via.str.size;

--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -62,7 +62,7 @@ static char ident_byte[256] = {
 };
 
 static int logfmt_parser(struct flb_parser *parser,
-                         char *in_buf, size_t in_size,
+                         const char *in_buf, size_t in_size,
                          msgpack_packer *tmp_pck,
                          char *time_key, size_t time_key_len,
                          time_t *time_lookup, double *tmfrac,
@@ -70,12 +70,12 @@ static int logfmt_parser(struct flb_parser *parser,
 {
     int ret;
     struct tm tm = {0};
-    unsigned char *key = NULL;
+    const unsigned char *key = NULL;
     size_t key_len = 0;
-    unsigned char *value = NULL;
+    const unsigned char *value = NULL;
     size_t value_len = 0;
-    unsigned char *c = (unsigned char *)in_buf;
-    unsigned char *end = c + in_size;
+    const unsigned char *c = (const unsigned char *)in_buf;
+    const unsigned char *end = c + in_size;
     int last_byte;
     int do_pack = FLB_TRUE;
     int value_escape = FLB_FALSE;
@@ -144,9 +144,9 @@ static int logfmt_parser(struct flb_parser *parser,
 
             if (parser->time_fmt && key_len == time_key_len &&
                 value_len > 0 &&
-                !strncmp((char *)key, time_key, key_len)) {
+                !strncmp((const char *)key, time_key, key_len)) {
                 if (do_pack) {
-                    ret = flb_parser_time_lookup((char *) value, value_len,
+                    ret = flb_parser_time_lookup((const char *) value, value_len,
                                                   0, parser, &tm, tmfrac);
                     if (ret == -1) {
                        flb_error("[parser:%s] Invalid time format %s.",
@@ -161,15 +161,15 @@ static int logfmt_parser(struct flb_parser *parser,
             if (time_found == FLB_FALSE || parser->time_keep == FLB_TRUE) {
                 if (do_pack) {
                     if (parser->types_len != 0) {
-                        flb_parser_typecast((char*) key, key_len,
-                                            (char*) value, value_len,
+                        flb_parser_typecast((const char*) key, key_len,
+                                            (const char*) value, value_len,
                                             tmp_pck,
                                             parser->types,
                                             parser->types_len);
                     }
                     else {
                         msgpack_pack_str(tmp_pck, key_len);
-                        msgpack_pack_str_body(tmp_pck, (char *)key, key_len);
+                        msgpack_pack_str_body(tmp_pck, (const char *)key, key_len);
                         if (value_len == 0) {
                             msgpack_pack_true(tmp_pck);
                         }
@@ -184,14 +184,14 @@ static int logfmt_parser(struct flb_parser *parser,
                                     return -1;
                                 }
                                 out_str[0] = 0;
-                                flb_unescape_string_utf8((char *)value,
+                                flb_unescape_string_utf8((const char *)value,
                                                           value_len,
                                                           out_str);
                                 out_len = strlen(out_str);
 
                                 msgpack_pack_str(tmp_pck, out_len);
                                 msgpack_pack_str_body(tmp_pck,
-                                                      (char *)out_str,
+                                                      out_str,
                                                       out_len);
 
                                 flb_free(out_str);
@@ -199,7 +199,7 @@ static int logfmt_parser(struct flb_parser *parser,
                             else {
                                 msgpack_pack_str(tmp_pck, value_len);
                                 msgpack_pack_str_body(tmp_pck,
-                                                      (char *)value,
+                                                      (const char *)value,
                                                       value_len);
                             }
                         }
@@ -230,13 +230,13 @@ static int logfmt_parser(struct flb_parser *parser,
             break;
         }
     }
-    last_byte = (char *)c - in_buf;
+    last_byte = (const char *)c - in_buf;
 
     return last_byte;
 }
 
 int flb_parser_logfmt_do(struct flb_parser *parser,
-                        char *in_buf, size_t in_size,
+                        const char *in_buf, size_t in_size,
                         void **out_buf, size_t *out_size,
                         struct flb_time *out_time)
 {

--- a/src/flb_parser_ltsv.c
+++ b/src/flb_parser_ltsv.c
@@ -81,7 +81,7 @@ static char ltvs_field[256] = {
 
 
 static int ltsv_parser(struct flb_parser *parser,
-                       char *in_buf, size_t in_size,
+                       const char *in_buf, size_t in_size,
                        msgpack_packer *tmp_pck,
                        char *time_key, size_t time_key_len,
                        time_t *time_lookup, double *tmfrac,
@@ -89,12 +89,12 @@ static int ltsv_parser(struct flb_parser *parser,
 {
     int ret;
     struct tm tm = {0};
-    unsigned char *label = NULL;
+    const unsigned char *label = NULL;
     size_t label_len = 0;
-    unsigned char *field = NULL;
+    const unsigned char *field = NULL;
     size_t field_len = 0;
-    unsigned char *c = (unsigned char *)in_buf;
-    unsigned char *end = c + in_size;
+    const unsigned char *c = (const unsigned char *)in_buf;
+    const unsigned char *end = c + in_size;
     int last_byte;
     int do_pack = FLB_TRUE;
 
@@ -131,9 +131,9 @@ static int ltsv_parser(struct flb_parser *parser,
 
             if (parser->time_fmt && label_len == time_key_len &&
                 field_len > 0 &&
-                !strncmp((char *)label, time_key, label_len)) {
+                !strncmp((const char *)label, time_key, label_len)) {
                 if (do_pack) {
-                    ret = flb_parser_time_lookup((char *) field, field_len,
+                    ret = flb_parser_time_lookup((const char *) field, field_len,
                                                   0, parser, &tm, tmfrac);
                     if (ret == -1) {
                        flb_error("[parser:%s] Invalid time format %s.",
@@ -148,17 +148,17 @@ static int ltsv_parser(struct flb_parser *parser,
             if (time_found == FLB_FALSE || parser->time_keep == FLB_TRUE) {
                 if (do_pack) {
                     if (parser->types_len != 0) {
-                        flb_parser_typecast((char*) label, label_len,
-                                            (char*) field, field_len,
+                        flb_parser_typecast((const char*) label, label_len,
+                                            (const char*) field, field_len,
                                             tmp_pck,
                                             parser->types,
                                             parser->types_len);
                     }
                     else {
                         msgpack_pack_str(tmp_pck, label_len);
-                        msgpack_pack_str_body(tmp_pck, (char *)label, label_len);
+                        msgpack_pack_str_body(tmp_pck, (const char *)label, label_len);
                         msgpack_pack_str(tmp_pck, field_len);
-                        msgpack_pack_str_body(tmp_pck, (char *)field, field_len);
+                        msgpack_pack_str_body(tmp_pck, (const char *)field, field_len);
                     }
                 }
                 else {
@@ -192,13 +192,13 @@ static int ltsv_parser(struct flb_parser *parser,
             break;
         }
     }
-    last_byte = (char *)c - in_buf;
+    last_byte = (const char *)c - in_buf;
 
     return last_byte;
 }
 
 int flb_parser_ltsv_do(struct flb_parser *parser,
-                       char *in_buf, size_t in_size,
+                       const char *in_buf, size_t in_size,
                        void **out_buf, size_t *out_size,
                        struct flb_time *out_time)
 {

--- a/src/flb_parser_regex.c
+++ b/src/flb_parser_regex.c
@@ -42,7 +42,7 @@ struct regex_cb_ctx {
     msgpack_packer *pck;
 };
 
-static void cb_results(unsigned char *name, unsigned char *value,
+static void cb_results(const char *name, const char *value,
                        size_t vlen, void *data)
 {
     int len;
@@ -60,7 +60,7 @@ static void cb_results(unsigned char *name, unsigned char *value,
         return;
     }
 
-    len = strlen((char *) name);
+    len = strlen(name);
 
     /* Check if there is a time lookup field */
     if (parser->time_fmt) {
@@ -71,9 +71,9 @@ static void cb_results(unsigned char *name, unsigned char *value,
             time_key = "time";
         }
 
-        if (strcmp((char *) name, time_key) == 0) {
+        if (strcmp(name, time_key) == 0) {
             /* Lookup time */
-            ret = flb_parser_time_lookup((char *) value, vlen,
+            ret = flb_parser_time_lookup(value, vlen,
                                          pcb->time_now, parser, &tm, &frac);
             if (ret == -1) {
                 if (vlen > sizeof(tmp) - 1) {
@@ -98,22 +98,22 @@ static void cb_results(unsigned char *name, unsigned char *value,
     }
 
     if (parser->types_len != 0) {
-        flb_parser_typecast((char*)name, len,
-                            (char*)value, vlen,
+        flb_parser_typecast(name, len,
+                            value, vlen,
                             pcb->pck,
                             parser->types,
                             parser->types_len);
     }
     else {
         msgpack_pack_str(pcb->pck, len);
-        msgpack_pack_str_body(pcb->pck, (char *) name, len);
+        msgpack_pack_str_body(pcb->pck, name, len);
         msgpack_pack_str(pcb->pck, vlen);
-        msgpack_pack_str_body(pcb->pck, (char *) value, vlen);
+        msgpack_pack_str_body(pcb->pck, value, vlen);
     }
 }
 
 int flb_parser_regex_do(struct flb_parser *parser,
-                        char *buf, size_t length,
+                        const char *buf, size_t length,
                         void **out_buf, size_t *out_size,
                         struct flb_time *out_time)
 {
@@ -130,7 +130,7 @@ int flb_parser_regex_do(struct flb_parser *parser,
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
 
-    n = flb_regex_do(parser->regex, (unsigned char *) buf, length, &result);
+    n = flb_regex_do(parser->regex, buf, length, &result);
     if (n <= 0) {
         return -1;
     }

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -143,7 +143,7 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count)
 }
 
 /* Blocking write until send 'count bytes */
-ssize_t flb_pipe_write_all(int fd, void *buf, size_t count)
+ssize_t flb_pipe_write_all(int fd, const void *buf, size_t count)
 {
     ssize_t bytes;
     size_t total = 0;

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -42,8 +42,8 @@
 /* Proxies */
 #include "proxy/go/go.h"
 
-static void flb_proxy_cb_flush(void *data, size_t bytes,
-                               char *tag, int tag_len,
+static void flb_proxy_cb_flush(const void *data, size_t bytes,
+                               const char *tag, int tag_len,
                                struct flb_input_instance *i_ins,
                                void *out_context,
                                struct flb_config *config)
@@ -232,11 +232,11 @@ struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
 }
 
 /* Load plugins from a configuration file */
-int flb_plugin_proxy_conf_file(char *file, struct flb_config *config)
+int flb_plugin_proxy_conf_file(const char *file, struct flb_config *config)
 {
     int ret;
     char tmp[PATH_MAX + 1];
-    char *cfg = NULL;
+    const char *cfg = NULL;
     struct mk_rconf *fconf;
     struct mk_rconf_section *section;
     struct mk_rconf_entry *entry;

--- a/src/flb_router.c
+++ b/src/flb_router.c
@@ -42,9 +42,9 @@ static inline int router_match(const char *tag, int tag_len,
     int n;
     if (match_regex) {
         n = onig_match(match_regex->regex,
-                       (unsigned char *) tag,
-                       (unsigned char *) tag + tag_len,
-                       (unsigned char *) tag, 0,
+                       (const unsigned char *) tag,
+                       (const unsigned char *) tag + tag_len,
+                       (const unsigned char *) tag, 0,
                        ONIG_OPTION_NONE);
         if (n > 0) {
             return 1;

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -52,7 +52,7 @@ static flb_sds_t sds_alloc(size_t size)
     return s;
 }
 
-flb_sds_t flb_sds_create_len(char *str, int len)
+flb_sds_t flb_sds_create_len(const char *str, int len)
 {
     flb_sds_t s;
     struct flb_sds *head;
@@ -72,7 +72,7 @@ flb_sds_t flb_sds_create_len(char *str, int len)
     return s;
 }
 
-flb_sds_t flb_sds_create(char *str)
+flb_sds_t flb_sds_create(const char *str)
 {
     size_t len;
 
@@ -118,7 +118,7 @@ flb_sds_t flb_sds_increase(flb_sds_t s, size_t len)
     return out;
 }
 
-flb_sds_t flb_sds_cat(flb_sds_t s, char *str, int len)
+flb_sds_t flb_sds_cat(flb_sds_t s, const char *str, int len)
 {
     size_t avail;
     struct flb_sds *head;
@@ -141,7 +141,7 @@ flb_sds_t flb_sds_cat(flb_sds_t s, char *str, int len)
     return s;
 }
 
-flb_sds_t flb_sds_copy(flb_sds_t s, char *str, int len)
+flb_sds_t flb_sds_copy(flb_sds_t s, const char *str, int len)
 {
     size_t avail;
     struct flb_sds *head;
@@ -164,7 +164,7 @@ flb_sds_t flb_sds_copy(flb_sds_t s, char *str, int len)
     return s;
 }
 
-flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, char *str, int str_len)
+flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
 {
     static const char int2hex[] = "0123456789abcdef";
     int i;
@@ -174,7 +174,7 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, char *str, int str_len)
     uint32_t cp;
     uint32_t state = 0;
     uint32_t c;
-    uint8_t *p;
+    const uint8_t *p;
     struct flb_sds *head;
     flb_sds_t tmp;
     flb_sds_t s;
@@ -255,7 +255,7 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, char *str, int str_len)
             state = FLB_UTF8_ACCEPT;
             cp = 0;
             for (b = 0; b < hex_bytes; b++) {
-                p = (unsigned char *) str + i + b;
+                p = (const unsigned char *) str + i + b;
                 ret = flb_utf8_decode(&state, &cp, *p);
                 if (ret == 0) {
                     break;
@@ -288,7 +288,7 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, char *str, int str_len)
             state = FLB_UTF8_ACCEPT;
             cp = 0;
             for (b = 0; b < hex_bytes; b++) {
-                p = (unsigned char *) str + i + b;
+                p = (const unsigned char *) str + i + b;
                 ret = flb_utf8_decode(&state, &cp, *p);
                 if (ret == 0) {
                     break;

--- a/src/flb_slist.c
+++ b/src/flb_slist.c
@@ -31,7 +31,7 @@ int flb_slist_create(struct mk_list *list)
 }
 
 /* Append string as a new node into the list */
-int flb_slist_add(struct mk_list *head, char *str)
+int flb_slist_add(struct mk_list *head, const char *str)
 {
     struct flb_slist_entry *e;
 

--- a/src/flb_sqldb.c
+++ b/src/flb_sqldb.c
@@ -27,7 +27,7 @@
  * Open or create a new database. Note that this function will always try to
  * use an open database and share it handler in as a new context.
  */
-struct flb_sqldb *flb_sqldb_open(char *path, const char *desc,
+struct flb_sqldb *flb_sqldb_open(const char *path, const char *desc,
                                  struct flb_config *config)
 {
     int ret;
@@ -110,7 +110,7 @@ int flb_sqldb_close(struct flb_sqldb *db)
     return 0;
 }
 
-int flb_sqldb_query(struct flb_sqldb *db, char *sql,
+int flb_sqldb_query(struct flb_sqldb *db, const char *sql,
                     int (*callback) (void *, int, char **, char **),
                     void *data)
 {

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -85,8 +85,8 @@ int flb_storage_input_create(struct cio_ctx *cio,
                              struct flb_input_instance *in)
 {
     int type;
-    char *tmp;
-    char *name;
+    const char *tmp;
+    const char *name;
     struct flb_storage_input *si;
     struct cio_stream *stream;
 

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -203,11 +203,11 @@ static struct flb_task *task_alloc(struct flb_config *config)
 
 /* Create an engine task to handle the output plugin flushing work */
 struct flb_task *flb_task_create(uint64_t ref_id,
-                                 char *buf,
+                                 const char *buf,
                                  size_t size,
                                  struct flb_input_instance *i_ins,
                                  void *ic,
-                                 char *tag_buf, int tag_len,
+                                 const char *tag_buf, int tag_len,
                                  struct flb_config *config)
 {
     int count = 0;

--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -67,7 +67,7 @@ static int u8_wc_toutf8(char *dest, uint32_t ch)
 
 /* assumes that src points to the character after a backslash
    returns number of input characters processed */
-static int u8_read_escape_sequence(char *str, uint32_t *dest)
+static int u8_read_escape_sequence(const char *str, uint32_t *dest)
 {
     uint32_t ch;
     char digs[9]="\0\0\0\0\0\0\0\0";
@@ -122,26 +122,26 @@ static int u8_read_escape_sequence(char *str, uint32_t *dest)
     return i;
 }
 
-static inline int is_json_escape(char *c)
+static inline int is_json_escape(char c)
 {
     return (
-            (*c == '\"') || /* double-quote    */
-            (*c == '\'') || /* single-quote    */
-            (*c == '\\') || /* solidus         */
-            (*c == 'n')  || /* new-line        */
-            (*c == 'r')  || /* carriage return */
-            (*c == 't')  || /* horizontal tab  */
-            (*c == 'b')  || /* backspace       */
-            (*c == 'f')  || /* form feed       */
-            (*c == '/')     /* reverse-solidus */
+            (c == '\"') || /* double-quote    */
+            (c == '\'') || /* single-quote    */
+            (c == '\\') || /* solidus         */
+            (c == 'n')  || /* new-line        */
+            (c == 'r')  || /* carriage return */
+            (c == 't')  || /* horizontal tab  */
+            (c == 'b')  || /* backspace       */
+            (c == 'f')  || /* form feed       */
+            (c == '/')     /* reverse-solidus */
             );
 }
 
-int flb_unescape_string_utf8(char *in_buf, int sz, char *out_buf)
+int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf)
 {
     uint32_t ch;
     char temp[4];
-    char *next;
+    const char *next;
 
     int count_out = 0;
     int count_in = 0;
@@ -150,7 +150,7 @@ int flb_unescape_string_utf8(char *in_buf, int sz, char *out_buf)
 
     while (*in_buf && count_in < sz) {
         next = in_buf + 1;
-        if (*in_buf == '\\' && !is_json_escape(next)) {
+        if (*in_buf == '\\' && !is_json_escape(*next)) {
             esc_in = u8_read_escape_sequence((in_buf + 1), &ch) + 1;
         }
         else {
@@ -177,7 +177,7 @@ int flb_unescape_string_utf8(char *in_buf, int sz, char *out_buf)
     return count_out;
 }
 
-int flb_unescape_string(char *buf, int buf_len, char **unesc_buf)
+int flb_unescape_string(const char *buf, int buf_len, char **unesc_buf)
 {
     int i = 0;
     int j = 0;

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -30,7 +30,7 @@
 
 /* Creates a new upstream context */
 struct flb_upstream *flb_upstream_create(struct flb_config *config,
-                                         char *host, int port, int flags,
+                                         const char *host, int port, int flags,
                                          void *tls)
 {
     struct flb_upstream *u;
@@ -60,7 +60,8 @@ struct flb_upstream *flb_upstream_create(struct flb_config *config,
 
 /* Create an upstream context using a valid URL (protocol, host and port) */
 struct flb_upstream *flb_upstream_create_url(struct flb_config *config,
-                                             char *url, int flags, void *tls)
+                                             const char *url, int flags,
+                                             void *tls)
 {
     int ret;
     int tmp_port = 0;

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -32,7 +32,7 @@
 #include <sys/stat.h>
 
 /* Creates an Upstream HA Context */
-struct flb_upstream_ha *flb_upstream_ha_create(char *name)
+struct flb_upstream_ha *flb_upstream_ha_create(const char *name)
 {
     struct flb_upstream_ha *ctx;
 
@@ -260,12 +260,12 @@ static struct flb_upstream_node *create_node(int id,
 }
 
 /* Read an upstream file and generate the context */
-struct flb_upstream_ha *flb_upstream_ha_from_file(char *file,
+struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
                                                   struct flb_config *config)
 {
     int c = 0;
     int ret;
-    char *cfg = NULL;
+    const char *cfg = NULL;
     char *tmp;
     char path[PATH_MAX + 1];
     struct mk_rconf_section *u_section;

--- a/src/flb_upstream_node.c
+++ b/src/flb_upstream_node.c
@@ -26,15 +26,15 @@
 #include <fluent-bit/flb_upstream_node.h>
 
 /* Create a new Upstream Node context */
-struct flb_upstream_node *flb_upstream_node_create(char *name, char *host,
-                                                   char *port,
+struct flb_upstream_node *flb_upstream_node_create(const char *name, const char *host,
+                                                   const char *port,
                                                    int tls, int tls_verify,
                                                    int tls_debug,
-                                                   char *tls_ca_path,
-                                                   char *tls_ca_file,
-                                                   char *tls_crt_file,
-                                                   char *tls_key_file,
-                                                   char *tls_key_passwd,
+                                                   const char *tls_ca_path,
+                                                   const char *tls_ca_file,
+                                                   const char *tls_crt_file,
+                                                   const char *tls_key_file,
+                                                   const char *tls_key_passwd,
                                                    struct flb_hash *ht,
                                                    struct flb_config *config)
 {
@@ -164,12 +164,12 @@ struct flb_upstream_node *flb_upstream_node_create(char *name, char *host,
     return node;
 }
 
-char *flb_upstream_node_get_property(char *prop,
+const char *flb_upstream_node_get_property(const char *prop,
                                      struct flb_upstream_node *node)
 {
     int ret;
     int len;
-    char *value;
+    const char *value;
     size_t size;
 
     len = strlen(prop);

--- a/src/flb_uri.c
+++ b/src/flb_uri.c
@@ -42,7 +42,7 @@ struct flb_uri_field *flb_uri_get(struct flb_uri *uri, int pos)
  * Given a 'URI' string, split the strings separated by a slash and create a
  * context.
  */
-struct flb_uri *flb_uri_create(char *full_uri)
+struct flb_uri *flb_uri_create(const char *full_uri)
 {
     int end;
     unsigned int len;

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -201,7 +201,7 @@ void flb_utils_print_setup(struct flb_config *config)
     }
 }
 
-struct mk_list *flb_utils_split(char *line, int separator, int max_split)
+struct mk_list *flb_utils_split(const char *line, int separator, int max_split)
 {
     int i = 0;
     int count = 0;
@@ -337,7 +337,7 @@ int flb_utils_pipe_byte_consume(flb_pipefd_t fd)
     return 0;
 }
 
-int64_t flb_utils_size_to_bytes(char *size)
+int64_t flb_utils_size_to_bytes(const char *size)
 {
     int i;
     int len;
@@ -403,7 +403,7 @@ int64_t flb_utils_size_to_bytes(char *size)
     return val;
 }
 
-int flb_utils_time_to_seconds(char *time)
+int flb_utils_time_to_seconds(const char *time)
 {
     int len;
     size_t val;
@@ -425,7 +425,7 @@ int flb_utils_time_to_seconds(char *time)
     return val;
 }
 
-int flb_utils_bool(char *val)
+int flb_utils_bool(const char *val)
 {
     if (strcasecmp(val, "true") == 0 ||
         strcasecmp(val, "on") == 0 ||
@@ -437,7 +437,7 @@ int flb_utils_bool(char *val)
 }
 
 /* Convert a 'string' time seconds.nanoseconds to int and long values */
-int flb_utils_time_split(char *time, int *sec, long *nsec)
+int flb_utils_time_split(const char *time, int *sec, long *nsec)
 {
     char *p;
     char *end;
@@ -501,7 +501,7 @@ void flb_utils_bytes_to_human_readable_size(size_t bytes,
 }
 
 
-static inline void encoded_to_buf(char *out, char *in, int len)
+static inline void encoded_to_buf(char *out, const char *in, int len)
 {
     int i;
     char *p = out;
@@ -517,7 +517,7 @@ static inline void encoded_to_buf(char *out, char *in, int len)
  * representation.
  */
 int flb_utils_write_str(char *buf, int *off, size_t size,
-                        char *str, size_t str_len)
+                        const char *str, size_t str_len)
 {
     int i;
     int b;
@@ -651,7 +651,7 @@ int flb_utils_write_str(char *buf, int *off, size_t size,
 }
 
 
-int flb_utils_write_str_buf(char *str, size_t str_len, char **out, size_t *out_size)
+int flb_utils_write_str_buf(const char *str, size_t str_len, char **out, size_t *out_size)
 {
     int ret;
     int off;
@@ -690,7 +690,7 @@ int flb_utils_write_str_buf(char *str, size_t str_len, char **out, size_t *out_s
     return 0;
 }
 
-int flb_utils_url_split(char *in_url, char **out_protocol,
+int flb_utils_url_split(const char *in_url, char **out_protocol,
                         char **out_host, char **out_port, char **out_uri)
 {
     char *protocol = NULL;

--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -213,11 +213,11 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
                 mv = sv.via.map.ptr[m].val;
 
                 sds = flb_sds_cat(sds, "fluentbit_", 10);
-                sds = flb_sds_cat(sds, (char *) k.via.str.ptr, k.via.str.size);
+                sds = flb_sds_cat(sds, k.via.str.ptr, k.via.str.size);
                 sds = flb_sds_cat(sds, "_", 1);
-                sds = flb_sds_cat(sds, (char *) mk.via.str.ptr, mk.via.str.size);
+                sds = flb_sds_cat(sds, mk.via.str.ptr, mk.via.str.size);
                 sds = flb_sds_cat(sds, "_total{name=\"", 13);
-                sds = flb_sds_cat(sds, (char *) sk.via.str.ptr, sk.via.str.size);
+                sds = flb_sds_cat(sds, sk.via.str.ptr, sk.via.str.size);
                 sds = flb_sds_cat(sds, "\"} ", 3);
 
                 len = snprintf(tmp, sizeof(tmp) - 1,

--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -43,7 +43,7 @@ int flb_hs_push_metrics(struct flb_hs *hs, void *data, size_t size)
 }
 
 /* Create ROOT endpoints */
-struct flb_hs *flb_hs_create(char *listen, char *tcp_port,
+struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config)
 {
     int vid;

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -59,8 +59,8 @@ struct flbgo_output_plugin {
     struct flb_plugin_proxy_context *context;
 
     int (*cb_init)();
-    int (*cb_flush)(void *, size_t, char *);
-    int (*cb_flush_ctx)(void *, void *, size_t, char *);
+    int (*cb_flush)(const void *, size_t, const char *);
+    int (*cb_flush_ctx)(void *, const void *, size_t, char *);
     int (*cb_exit)(void *);
 };
 /*------------------------EOF------------------------------------------------*/
@@ -128,8 +128,9 @@ int proxy_go_init(struct flb_plugin_proxy *proxy)
     return ret;
 }
 
-int proxy_go_flush(struct flb_plugin_proxy_context *ctx, void *data, size_t size,
-                   char *tag, int tag_len)
+int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
+                   const void *data, size_t size,
+                   const char *tag, int tag_len)
 {
     int ret;
     char *buf;

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -29,7 +29,8 @@ int proxy_go_register(struct flb_plugin_proxy *proxy,
 
 int proxy_go_init(struct flb_plugin_proxy *proxy);
 
-int proxy_go_flush(struct flb_plugin_proxy_context  *ctx, void *data, size_t size,
-                   char *tag, int tag_len);
+int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
+                   const void *data, size_t size,
+                   const char *tag, int tag_len);
 
 #endif

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -53,12 +53,12 @@
 
 /* Read and process file system configuration file */
 static int sp_config_file(struct flb_config *config, struct flb_sp *sp,
-                          char *file)
+                          const char *file)
 {
     int ret;
     char *name;
     char *exec;
-    char *cfg = NULL;
+    const char *cfg = NULL;
     char tmp[PATH_MAX + 1];
     struct stat st;
     struct mk_rconf *fconf;
@@ -235,7 +235,7 @@ static int sp_cmd_aggregated_keys(struct flb_sp_cmd *cmd)
  * - if output number is a float, 'd' is set and returns FLB_STR_FLOAT
  * - if no conversion is possible (not a number), returns -1
  */
-static int string_to_number(char *str, int len, int64_t *i, double *d)
+static int string_to_number(const char *str, int len, int64_t *i, double *d)
 {
     int c;
     int dots = 0;
@@ -443,8 +443,8 @@ static void aggr_max(struct aggr_num *nums, int key_id, int64_t i, double d)
     }
 }
 
-struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, char *name,
-                                       char *query)
+struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
+                                       const char *query)
 {
     int fd;
     int ret;
@@ -779,7 +779,7 @@ static struct flb_exp_val *key_to_value(struct flb_exp_key *ekey,
         val = map->via.map.ptr[i].val;
 
         /* Compare by length and by key name */
-        if (flb_sds_cmp(ckey, (char *) key.via.str.ptr,
+        if (flb_sds_cmp(ckey, key.via.str.ptr,
             key.via.str.size) != 0) {
             continue;
         }
@@ -809,7 +809,7 @@ static struct flb_exp_val *key_to_value(struct flb_exp_key *ekey,
         }
         else if (val.type == MSGPACK_OBJECT_STR) {
             result->type = FLB_EXP_STRING;
-            result->val.string = flb_sds_create_len((char *) val.via.str.ptr,
+            result->val.string = flb_sds_create_len(val.via.str.ptr,
                                                     val.via.str.size);
             return result;
         }
@@ -1187,7 +1187,7 @@ static struct flb_exp_val *reduce_expression(struct flb_exp *expression,
 }
 
 
-static void package_results(char *tag, int tag_len,
+static void package_results(const char *tag, int tag_len,
                             char **out_buf, size_t *out_size,
                             struct flb_sp_task *task)
 {
@@ -1352,8 +1352,8 @@ static void package_results(char *tag, int tag_len,
  * Process data, task and it defined command involves the call of aggregation
  * functions (AVG, SUM, COUNT, MIN, MAX).
  */
-static int sp_process_data_aggr(char *buf_data, size_t buf_size,
-                                char *tag, int tag_len,
+static int sp_process_data_aggr(const char *buf_data, size_t buf_size,
+                                const char *tag, int tag_len,
                                 struct flb_sp_task *task,
                                 struct flb_sp *sp)
 {
@@ -1433,7 +1433,7 @@ static int sp_process_data_aggr(char *buf_data, size_t buf_size,
                 mk_list_foreach(head, &cmd->gb_keys) {
                     gb_key = mk_list_entry(head, struct flb_sp_cmd_gb_key,
                                            _head);
-                    if (flb_sds_cmp(gb_key->name, (char *) key.via.str.ptr,
+                    if (flb_sds_cmp(gb_key->name, key.via.str.ptr,
                                     key.via.str.size) != 0) {
                         key_id++;
                         continue;
@@ -1444,7 +1444,7 @@ static int sp_process_data_aggr(char *buf_data, size_t buf_size,
                     if (ret == -1 && val.type == MSGPACK_OBJECT_STR) {
                         gb_nums[key_id].type = FLB_SP_STRING;
                         gb_nums[key_id].string =
-                            flb_sds_create_len((char *) val.via.str.ptr,
+                            flb_sds_create_len(val.via.str.ptr,
                                                 val.via.str.size);
                         continue;
                     }
@@ -1546,7 +1546,7 @@ static int sp_process_data_aggr(char *buf_data, size_t buf_size,
                     continue;
                 }
 
-                if (flb_sds_cmp(ckey->name, (char *) key.via.str.ptr,
+                if (flb_sds_cmp(ckey->name, key.via.str.ptr,
                                 key.via.str.size) != 0) {
                     key_id++;
                     continue;
@@ -1594,7 +1594,7 @@ static int sp_process_data_aggr(char *buf_data, size_t buf_size,
                         nums[key_id].type = FLB_SP_STRING;
                         if (nums[key_id].string == NULL) {
                             nums[key_id].string =
-                                flb_sds_create_len((char *) val.via.str.ptr,
+                                flb_sds_create_len(val.via.str.ptr,
                                                    val.via.str.size);
                         }
                     }
@@ -1626,8 +1626,8 @@ static int sp_process_data_aggr(char *buf_data, size_t buf_size,
 /*
  * Data processing (no aggregation functions)
  */
-static int sp_process_data(char *tag, int tag_len,
-                           char *buf_data, size_t buf_size,
+static int sp_process_data(const char *tag, int tag_len,
+                           const char *buf_data, size_t buf_size,
                            char **out_buf, size_t *out_size,
                            struct flb_sp_task *task,
                            struct flb_sp *sp)
@@ -1822,8 +1822,8 @@ static int sp_process_data(char *tag, int tag_len,
  * results on out_data/out_size variables.
  */
 int flb_sp_test_do(struct flb_sp *sp, struct flb_sp_task *task,
-                   char *tag, int tag_len,
-                   char *buf_data, size_t buf_size,
+                   const char *tag, int tag_len,
+                   const char *buf_data, size_t buf_size,
                    char **out_data, size_t *out_size)
 {
     int ret;
@@ -1886,8 +1886,8 @@ int flb_sp_test_do(struct flb_sp *sp, struct flb_sp_task *task,
 
 /* Iterate and find input chunks to process */
 int flb_sp_do(struct flb_sp *sp, struct flb_input_instance *in,
-              char *tag, int tag_len,
-              char *buf_data, size_t buf_size)
+              const char *tag, int tag_len,
+              const char *buf_data, size_t buf_size)
 
 {
     int ret;

--- a/src/stream_processor/flb_sp_func_record.c
+++ b/src/stream_processor/flb_sp_func_record.c
@@ -25,7 +25,7 @@
 
 static inline void pack_key(msgpack_packer *mp_pck,
                             struct flb_sp_cmd_key *cmd_key,
-                            char *name, int len)
+                            const char *name, int len)
 {
     if (cmd_key->alias) {
         msgpack_pack_str(mp_pck, flb_sds_len(cmd_key->alias));
@@ -38,7 +38,7 @@ static inline void pack_key(msgpack_packer *mp_pck,
     }
 }
 
-static int func_tag(char *tag, int tag_len,
+static int func_tag(const char *tag, int tag_len,
                     msgpack_packer *mp_pck, struct flb_sp_cmd_key *cmd_key)
 {
     pack_key(mp_pck, cmd_key, "RECORD_TAG()", 12);
@@ -64,7 +64,7 @@ static int func_time(struct flb_time *tms, msgpack_packer *mp_pck,
  * Wrapper to handle record functions, returns the number of entries added
  * to the map.
  */
-int flb_sp_func_record(char *tag, int tag_len, struct flb_time *tms,
+int flb_sp_func_record(const char *tag, int tag_len, struct flb_time *tms,
                        msgpack_packer *mp_pck, struct flb_sp_cmd_key *cmd_key)
 {
     switch (cmd_key->record_func) {

--- a/src/stream_processor/flb_sp_func_time.c
+++ b/src/stream_processor/flb_sp_func_time.c
@@ -25,7 +25,7 @@
 
 static inline void pack_key(msgpack_packer *mp_pck,
                             struct flb_sp_cmd_key *cmd_key,
-                            char *name, int len)
+                            const char *name, int len)
 {
     if (cmd_key->alias) {
         msgpack_pack_str(mp_pck, flb_sds_len(cmd_key->alias));

--- a/src/stream_processor/flb_sp_stream.c
+++ b/src/stream_processor/flb_sp_stream.c
@@ -29,11 +29,11 @@
 #include <fluent-bit/stream_processor/flb_sp_stream.h>
 
 /* Function defined in plugins/in_stream_processor/sp.c */
-int in_stream_processor_add_chunk(char *buf_data, size_t buf_size,
+int in_stream_processor_add_chunk(const char *buf_data, size_t buf_size,
                                   struct flb_input_instance *in);
 
 /* Check if a given stream name already exists */
-static int sp_stream_name_exists(char *name, struct flb_config *config)
+static int sp_stream_name_exists(const char *name, struct flb_config *config)
 {
     struct mk_list *head;
     struct flb_input_instance *in;
@@ -54,11 +54,11 @@ static int sp_stream_name_exists(char *name, struct flb_config *config)
     return FLB_FALSE;
 }
 
-int flb_sp_stream_create(char *name, struct flb_sp_task *task,
+int flb_sp_stream_create(const char *name, struct flb_sp_task *task,
                          struct flb_sp *sp)
 {
     int ret;
-    char *tag;
+    const char *tag;
     struct flb_input_instance *in;
     struct flb_sp_stream *stream;
 
@@ -157,7 +157,7 @@ int flb_sp_stream_create(char *name, struct flb_sp_task *task,
     return 0;
 }
 
-int flb_sp_stream_append_data(char *buf_data, size_t buf_size,
+int flb_sp_stream_append_data(const char *buf_data, size_t buf_size,
                               struct flb_sp_stream *stream)
 {
     return in_stream_processor_add_chunk(buf_data, buf_size, stream->in);

--- a/src/stream_processor/flb_sp_window.c
+++ b/src/stream_processor/flb_sp_window.c
@@ -46,7 +46,7 @@ void flb_sp_window_prune(struct flb_sp_task *task)
     }
 }
 
-int flb_sp_window_populate(struct flb_sp_task *task, char *buf_data,
+int flb_sp_window_populate(struct flb_sp_task *task, const char *buf_data,
                            size_t buf_size)
 {
     switch (task->window.type) {

--- a/src/stream_processor/parser/flb_sp_parser.c
+++ b/src/stream_processor/parser/flb_sp_parser.c
@@ -98,7 +98,7 @@ void flb_sp_cmd_gb_key_del(struct flb_sp_cmd_gb_key *key)
 }
 
 int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func,
-                       char *key_name, char *key_alias)
+                       const char *key_name, const char *key_alias)
 {
     int aggr_func = 0;
     int time_func = 0;
@@ -172,7 +172,7 @@ int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func,
     return 0;
 }
 
-int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, char *source)
+int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, const char *source)
 {
     cmd->source_type = type;
     cmd->source_name = flb_sds_create(source);
@@ -207,7 +207,7 @@ void flb_sp_cmd_dump(struct flb_sp_cmd *cmd)
     printf("'%s'\n", cmd->source_name);
 }
 
-struct flb_sp_cmd *flb_sp_cmd_create(char *sql)
+struct flb_sp_cmd *flb_sp_cmd_create(const char *sql)
 {
     int ret;
     yyscan_t scanner;
@@ -256,7 +256,7 @@ struct flb_sp_cmd *flb_sp_cmd_create(char *sql)
     return cmd;
 }
 
-int flb_sp_cmd_stream_new(struct flb_sp_cmd *cmd, char *stream_name)
+int flb_sp_cmd_stream_new(struct flb_sp_cmd *cmd, const char *stream_name)
 {
     cmd->stream_name = flb_sds_create(stream_name);
     if (!cmd->stream_name) {
@@ -267,7 +267,7 @@ int flb_sp_cmd_stream_new(struct flb_sp_cmd *cmd, char *stream_name)
     return 0;
 }
 
-int flb_sp_cmd_stream_prop_add(struct flb_sp_cmd *cmd, char *key, char *val)
+int flb_sp_cmd_stream_prop_add(struct flb_sp_cmd *cmd, const char *key, const char *val)
 {
     struct flb_sp_cmd_prop *prop;
 
@@ -305,7 +305,7 @@ void flb_sp_cmd_stream_prop_del(struct flb_sp_cmd_prop *prop)
     flb_free(prop);
 }
 
-char *flb_sp_cmd_stream_prop_get(struct flb_sp_cmd *cmd, char *key)
+const char *flb_sp_cmd_stream_prop_get(struct flb_sp_cmd *cmd, const char *key)
 {
     int len;
     struct mk_list *head;
@@ -395,7 +395,7 @@ struct flb_exp *flb_sp_cmd_comparison(struct flb_sp_cmd *cmd,
 }
 
 struct flb_exp *flb_sp_cmd_condition_key(struct flb_sp_cmd *cmd,
-                                         char *identifier)
+                                         const char *identifier)
 {
     struct flb_exp_key *key;
 
@@ -463,7 +463,7 @@ struct flb_exp *flb_sp_cmd_condition_float(struct flb_sp_cmd *cmd, float fval)
 }
 
 struct flb_exp *flb_sp_cmd_condition_string(struct flb_sp_cmd *cmd,
-                                            char *string)
+                                            const char *string)
 {
     struct flb_exp_val *val;
 
@@ -503,7 +503,7 @@ void flb_sp_cmd_condition_add(struct flb_sp_cmd *cmd, struct flb_exp *e)
     cmd->condition = e;
 }
 
-int flb_sp_cmd_gb_key_add(struct flb_sp_cmd *cmd, char *key)
+int flb_sp_cmd_gb_key_add(struct flb_sp_cmd *cmd, const char *key)
 {
     struct flb_sp_cmd_gb_key *gb_key;
 

--- a/src/stream_processor/parser/sql.l
+++ b/src/stream_processor/parser/sql.l
@@ -5,7 +5,7 @@
 #include <fluent-bit/flb_str.h>
 #include "sql_parser.h"
 
-static inline char *remove_dup_qoutes(char *s, size_t n)
+static inline char *remove_dup_qoutes(const char *s, size_t n)
 {
     char *str;
     int dups;

--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -1,6 +1,6 @@
 %define api.pure full
 %parse-param { struct flb_sp_cmd *cmd };
-%parse-param { char *query };
+%parse-param { const char *query };
 %lex-param   { void *scanner }
 %parse-param { void *scanner }
 
@@ -19,7 +19,7 @@
 
 extern int yylex();
 
-void yyerror(struct flb_sp_cmd *cmd, char *query, void *scanner,
+void yyerror(struct flb_sp_cmd *cmd, const char *query, void *scanner,
              const char *str)
 {
     flb_error("[sp] %s at '%s'", str, query);

--- a/tests/internal/hashtable.c
+++ b/tests/internal/hashtable.c
@@ -57,7 +57,7 @@ static int ht_add(struct flb_hash *ht, char *key, char *val)
   int idn;
   int klen;
   int vlen;
-  char *out_buf;
+  const char *out_buf;
   size_t out_size;
 
   klen = strlen(key);
@@ -87,7 +87,7 @@ void test_create_zero()
 void test_single()
 {
     int ret;
-    char *out_buf;
+    const char *out_buf;
     size_t out_size;
     struct flb_hash *ht;
 
@@ -219,7 +219,7 @@ void test_delete_all()
 void test_random_eviction()
 {
     int ret;
-    char *out_buf;
+    const char *out_buf;
     size_t out_size;
     struct flb_hash *ht;
 


### PR DESCRIPTION
Adding const to pointer arguments of functions which do not modify the pointed
values is a good practice. But more importantly, doing cast to discard
constness of values is a bad practice which prevents compilers from doing
static analysis to warn about program incorectness.