### PR TITLE
plugin_proxy: pass ctx to remote plugins

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -57,6 +57,14 @@ struct flb_plugin_proxy {
     struct mk_list _head;     /* link to parent config->proxies              */
 };
 
+/* This is the context for proxy plugins */
+struct flb_plugin_proxy_context {
+    /* This context is set by the remote init and is passed to remote flush */
+    void *remote_context;
+    /* A proxy ptr is needed to detect the proxy type/lang (OUTPUT/GOLANG) */
+    struct flb_plugin_proxy *proxy;
+};
+
 void *flb_plugin_proxy_symbol(struct flb_plugin_proxy *proxy,
                               const char *symbol);
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -272,7 +272,17 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
         instance->context = NULL;
     }
     else {
-        instance->context = plugin->proxy;
+        struct flb_plugin_proxy_context *ctx;
+
+        ctx = flb_calloc(1, sizeof(struct flb_plugin_proxy_context));
+        if (!ctx) {
+            perror("calloc");
+            return NULL;
+        }
+
+        ctx->proxy = plugin->proxy;
+
+        instance->context = ctx;
     }
 
     instance->alias       = NULL;

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -49,18 +49,18 @@ static void flb_proxy_cb_flush(void *data, size_t bytes,
                                struct flb_config *config)
 {
     int ret = FLB_ERROR;
-    struct flb_plugin_proxy *p = out_context;
+    struct flb_plugin_proxy_context *ctx = out_context;
     (void) tag_len;
     (void) i_ins;
     (void) config;
 
 #ifdef FLB_HAVE_PROXY_GO
-    if (p->proxy == FLB_PROXY_GOLANG) {
+    if (ctx->proxy->proxy == FLB_PROXY_GOLANG) {
         flb_trace("[GO] entering go_flush()");
-        ret = proxy_go_flush(p, data, bytes, tag, tag_len);
+        ret = proxy_go_flush(ctx, data, bytes, tag, tag_len);
     }
 #else
-    (void) p;
+    (void) ctx;
 #endif
 
     if (ret != FLB_OK && ret != FLB_RETRY && ret != FLB_ERROR) {

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -29,7 +29,7 @@ int proxy_go_register(struct flb_plugin_proxy *proxy,
 
 int proxy_go_init(struct flb_plugin_proxy *proxy);
 
-int proxy_go_flush(struct flb_plugin_proxy *proxy, void *data, size_t size,
+int proxy_go_flush(struct flb_plugin_proxy_context  *ctx, void *data, size_t size,
                    char *tag, int tag_len);
 
 #endif


### PR DESCRIPTION
plugin_proxy: pass ctx to remote plugins (#1000)

This change is intended to allow for the flush functions of Go plugins to be able to determine what output plugin instance they are flushing messages for. Currently, this is not possible as the existing flush function does not receive a context.

This change introduces a new struct called flb_plugin_proxy_context. This context is used as the instance context. The flb_plugin_proxy_context contains a pointer to a context set by the init function of the Go plugin. The remote Go plugin can set whatever value they want for their context and fluent-bit will pass it into the remote FLBPluginFlushCtx. FLBPluginFlush behaviour remains the
same.

This change is backwards compatible with plugins that are already compiled. It was manually tested with Go plugins that were unaware of these changes. This change should also have no impact on the de-facto ABI.

This change enables this PR: https://github.com/fluent/fluent-bit-go/pull/15

Signed-off-by: Jason Keene <jkeene@pivotal.io>
@jasonkeene