### PR TITLE
Add a replace_dots option for filter kubernetes

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -223,6 +223,15 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *i,
         ctx->annotations = flb_utils_bool(tmp);
     }
 
+    /* Replace dots with underscores in keys */
+    tmp = flb_filter_get_property("replace_dots", i);
+    if (tmp) {
+        ctx->replace_dots = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->replace_dots = FLB_FALSE;
+    }
+
     /*
      * The Application may 'propose' special configuration keys
      * to the logging agent (Fluent Bit) through the annotations

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -80,6 +80,9 @@ struct flb_kube {
     /* Merge Log feature */
     int merge_log;             /* old merge_json_log */
 
+    /* Replace dots with underscores */
+    int replace_dots;
+
     /* Temporal buffer to unescape strings */
     size_t unesc_buf_size;
     size_t unesc_buf_len;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -379,11 +379,10 @@ static int pack_map_content(msgpack_packer *pck, msgpack_sbuffer *sbuf,
         }
 
         if (ctx->replace_dots == FLB_TRUE) {
-          char *p   = ptr_key;
           char *end = ptr_key + key_size;
-          while (p != end) {
-            if (*p == '.') *p = '_';
-            p++;
+          while (ptr_key != end) {
+            if (*ptr_key == '.') *ptr_key = '_';
+            ptr_key++;
           }
         }
 


### PR DESCRIPTION
Hi,

I'll like to help about issue #1134 but I have no skills in C so I tried to copy the implementation of the `replace_dots` option of [Elasticsearch output plugin](https://github.com/fluent/fluent-bit/blob/b99898292f42669c5023c286bb41dd0653a7764e/plugins/out_es/es.c#L90).

Feel free to dump this PR to trash if it's not good code or suggest any changes, but I'll like to have this feature implemented on filter Kubernetes :)