### PR TITLE
out_stackdriver: add missing / to URI

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -23,7 +23,7 @@
 #include "stackdriver.h"
 
 /* Project ID metadata URI */
-#define FLB_STD_METADATA_PROJECT_ID_URI "computeMetadata/v1/project/numeric-project-id"
+#define FLB_STD_METADATA_PROJECT_ID_URI "/computeMetadata/v1/project/numeric-project-id"
 
 /* Zone metadata URI */
 #define FLB_STD_METADATA_ZONE_URI "/computeMetadata/v1/instance/zone"


### PR DESCRIPTION
Without this, the plugin generates an invalid request with a relative
path.