### PR TITLE
in_systemd: fix endless loop on reading a rotated journal

### DIFF
--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -40,6 +40,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     struct flb_config_prop *prop;
     struct flb_systemd_config *ctx;
     int journal_filter_is_and;
+    size_t size;
 
     /* Allocate space for the configuration */
     ctx = flb_calloc(1, sizeof(struct flb_systemd_config));
@@ -207,6 +208,10 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     } else {
         ctx->strip_underscores = FLB_FALSE;
     }
+
+    sd_journal_get_data_threshold(ctx->j, &size);
+    flb_debug("[in_systemd] sd_journal library may truncate values "
+        "to sd_journal_get_data_threshold() bytes: %i", size);
 
     return ctx;
 }

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -28,6 +28,7 @@
 #include <systemd/sd-journal.h>
 
 /* return values */
+#define FLB_SYSTEMD_ERROR   -1 /* Systemd journal file read error. */
 #define FLB_SYSTEMD_NONE     0
 #define FLB_SYSTEMD_OK       1
 #define FLB_SYSTEMD_MORE     2


### PR DESCRIPTION
# Description of the issue

Journald may write logs faster than fluent-bit is able to forward.
For example, the receiving part or network may be too slow.

In such situation, journald will rotate (delete) a journal file that is being read by fluent-bit.
Then, sd_journal_next() will return error (ret_j<0). The current master branch code does not address
such case. Therefore, in_systemd_collect() will be restarted in order to retry reading the very same 
deleted log file. It will never succeed, thus leaving fluent-bit in an endless loop.

The proposed PR fixes this endless loop by detecting such a case and returning an error instead of FLB_SYSTEMD_MORE.

# Steps to reproduce the issue

* setup docker logging into systemd;
* disable systemd-journald throttling
  ```bash
    cat <<EOF > /etc/systemd/journald.conf.d/0-ratelimit.conf
    [Journal]
    RateLimitBurst=10000000
    RateLimitIntervalSec=30s
    EOF
    ```
* run a few containers that log a lot of text constantly;
* configure fluent-bit with the `in_systemd` input and some slow networked output, such as `out_es`, so that FLB would save logs slower then they get generated by the container(s);
* wait for `journald` to fill up one log file and switch to the next one;
* truncate journal: `sudo journalctl --vacuum-size=1`

It may require two or three tries till FLB gets frozen.

fixes #899