### PR TITLE
out_forward: make Shared_Key usable without TLS (and vice versa)

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -209,7 +209,7 @@ static int secure_forward_ping(struct flb_upstream_conn *u_conn,
 
     msgpack_sbuffer_destroy(&mp_sbuf);
 
-    if (ret == 0 && bytes_sent > 0) {
+    if (ret > -1 && bytes_sent > 0) {
         return 0;
     }
 


### PR DESCRIPTION
Right now, Fluent Bit forces us to set up a common secret (Shared_Key)
if TLS/SSL encryption is in use. The opposite is also true and we can't
use a common secret on a plain-text connection.

Since these two features are not actually depending each other, Fluent
Bit should allow users to set up them independently. This fixes it.

### Example

For example, this allows users to set up the configuration as follows:

      [Output]
      Name forward
      Host 127.0.0.1
      Self_Hostname example.com
      Shared_Key some-secret-key

### Testing

I have tested this patch with Fluentd v1.4.2, and confirmed it works
fine on the following patterns.

No  | Test Pattern           |  Working?  |
--- | ---------------------- | ---------- |
 1  | TLS + Shared_Key       |  OK        |
 2  | TCP + Shared_Key       |  OK        |
 3  | TLS without Shared Key |  OK        |
 4  | TCP without Shared_key |  OK        |
