### PR TITLE
conf: docker parser escapes utf8 by default

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -43,10 +43,11 @@
     Time_Key     time
     Time_Format  %Y-%m-%dT%H:%M:%S.%L
     Time_Keep    On
-    # Command      |  Decoder | Field | Optional Action
-    # =============|==================|=================
-    Decode_Field_As   escaped    log
-    Decode_Field_As   escaped    stream
+    # Command      |     Decoder   | Field | Optional Action
+    # =============|===============|=======|================
+    Decode_Field_As   escaped_utf8   log        do_next
+    Decode_Field_As   escaped        log
+    Decode_Field_As   escaped        stream
 
 [PARSER]
     Name        docker-daemon


### PR DESCRIPTION
Signed-off-by: huanggze <“loganhuang@yunify.com”>