### PR TITLE
tests: internal: fix a compilation error on FLB_STREAM_PROCESSOR=Off

### DIFF
--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -13,8 +13,14 @@ set(UNIT_TESTS_FILES
   hashtable.c
   http_client.c
   utils.c
-  stream_processor.c
   )
+
+if(FLB_STREAM_PROCESSOR)
+  set(UNIT_TESTS_FILES
+    ${UNIT_TESTS_FILES}
+    stream_processor.c
+    )
+endif()
 
 if(FLB_METRICS)
   set(UNIT_TESTS_FILES


### PR DESCRIPTION
Right now, the following command fails with a compile error.

    $ cmake -DFLB_DEV=On -DFLB_STREAM_PROCESSOR=Off ..
    $ make
    ...
    error: struct flb_config’ has no member named ‘stream_processor_tasks

This is just due to cmake trying to compile the test suite for stream
processor even when the feature is not available (FLB_STREAM_PROCESSOR=Off).
This fixes it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>