### PR TITLE
parser: mysql quoted decoder

### DIFF
--- a/include/fluent-bit/flb_parser_decoder.h
+++ b/include/fluent-bit/flb_parser_decoder.h
@@ -33,6 +33,7 @@
 #define FLB_PARSER_DEC_JSON          0  /* decode_json()    */
 #define FLB_PARSER_DEC_ESCAPED       1  /* decode_escaped() */
 #define FLB_PARSER_DEC_ESCAPED_UTF8  2  /* decode_escaped_utf8() */
+#define FLB_PARSER_DEC_MYSQL_QUOTED  3  /* decode_mysql_quoted() */
 
 /* Decoder actions */
 #define FLB_PARSER_ACT_NONE     0

--- a/include/fluent-bit/flb_unescape.h
+++ b/include/fluent-bit/flb_unescape.h
@@ -23,5 +23,6 @@
 
 int flb_unescape_string(const char *buf, int buf_len, char **unesc_buf);
 int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf);
+int flb_mysql_unquote_string(char *buf, int buf_len, char **unesc_buf);
 
 #endif

--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -259,3 +259,56 @@ int flb_unescape_string(const char *buf, int buf_len, char **unesc_buf)
     p[j] = '\0';
     return j;
 }
+
+
+/* mysql unquote */
+int flb_mysql_unquote_string(char *buf, int buf_len, char **unesc_buf)
+{
+    int i = 0;
+    int j = 0;
+    char *p;
+    char n;
+
+    p = *unesc_buf;
+    while (i < buf_len) {
+        if ((n = buf[i++]) != '\\') {
+            p[j++] = n;
+        } else if(i >= buf_len) {
+            p[j++] = n;
+        } else {
+            n = buf[i++];
+            switch(n) {
+            case 'n':
+                p[j++] = '\n';
+                break;
+            case 'r':
+                p[j++] = '\r';
+                break;
+            case 't':
+                p[j++] = '\t';
+                break;
+            case '\\':
+                p[j++] = '\\';
+                break;
+            case '\'':
+                p[j++] = '\'';
+                break;
+            case '\"':
+                p[j++] = '\"';
+                break;
+            case '0':
+                p[j++] = 0;
+                break;
+            case 'Z':
+                p[j++] = 0x1a;
+                break;
+            default:
+                p[j++] = '\\';
+                p[j++] = n;
+                break;
+            }
+        }
+    }
+    p[j] = '\0';
+    return j;
+}

--- a/tests/internal/data/parser/regex.conf
+++ b/tests/internal/data/parser/regex.conf
@@ -204,3 +204,18 @@
     Time_Key    time
     Time_Format %a %b %d %H:%M:%S.%L %Y
     Time_Keep   On
+
+
+
+# Parser: mysql_quoted_stuff
+# ====================
+# Apache error log time format
+#
+[PARSER]
+    Name        mysql_quoted_stuff
+    Format      regex
+    Regex       ^(?<time>.*?),(?<key001>.*)$
+    Time_Key    time
+    Time_Format %Y-%M-%S %H:%M:%S
+    Time_Keep   On
+    Decode_Field_As   mysql_quoted key001


### PR DESCRIPTION
New decoder "mysql_quoted" to decode mysql/mariadb quoted 'xxx' strings.

```
[PARSER]
    Format regex
    ...
    # decoders
    Decode_Field_As   mysql_quoted    field

```