### PR TITLE
log: check localtime_r(2) is not NULL

### DIFF
--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -347,6 +347,11 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
     now = time(NULL);
     current = localtime_r(&now, &result);
 
+    if (current == NULL) {
+        va_end(args);
+        return;
+    }
+
     len = snprintf(msg.msg, sizeof(msg.msg) - 1,
                    "%s[%s%i/%02i/%02i %02i:%02i:%02i%s]%s [%s%5s%s] ",
                    /*      time     */                    /* type */


### PR DESCRIPTION
Return value of a function 'localtime_r' is dereferenced from 356 line

without checking whether the return value of localtime_r(2) is NULL or not

Signed-off-by: aniketoss <aniketoss@naver.com>