### PR TITLE
core: allow use of relative paths in configuration files on Windows

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -31,6 +31,7 @@
 #include <windows.h>
 #include <Wincrypt.h>
 
+#define FLB_DIRCHAR '\\'
 #define PATH_MAX MAX_PATH
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #define timezone _timezone
@@ -89,6 +90,8 @@ static inline int usleep(LONGLONG usec)
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <libgen.h>
+
+#define FLB_DIRCHAR '/'
 #endif
 
 #endif

--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -72,6 +72,14 @@ static inline char* basename(const char *path)
     return buf;
 }
 
+static inline char* realpath(char *path, char *buf)
+{
+    if (buf != NULL) {
+        return NULL;  /* Read BUGS in realpath(3) */
+    }
+    return _fullpath(NULL, path, 0);
+}
+
 /* mk_utils.c exposes localtime_r */
 extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -352,28 +352,25 @@ static void flb_service_conf_err(struct mk_rconf_section *section, char *key)
 
 static int flb_service_conf_path_set(struct flb_config *config, char *file)
 {
-    char *p;
     char *end;
-    char path[PATH_MAX + 1];
+    char *path;
 
-#ifdef _MSC_VER
-    p = _fullpath(path, file, PATH_MAX + 1);
-#else
-    p = realpath(file, path);
-#endif
-    if (!p) {
+    path = realpath(file, NULL);
+    if (!path) {
         return -1;
     }
 
     /* lookup path ending and truncate */
-    end = strrchr(path, '/');
+    end = strrchr(path, FLB_DIRCHAR);
     if (!end) {
+        free(path);
         return -1;
     }
 
     end++;
     *end = '\0';
     config->conf_path = flb_strdup(path);
+    free(path);
 
     return 0;
 }


### PR DESCRIPTION
Fluent Bit has a feature that allows users to use a relative path
in the main configuration file. For example, if you have the
following files in the same directory:

    PS > ls C:\Program Files\td-agent\conf\
    parsers.conf fluent-bit.conf

Then you can just set "parsers.conf" to Parser_File as below:

    [SERVICE]
      Flush       5
      Daemon      Off
      Parser_File parsers.conf

Previously this feature did not work properly on Windows, due to
its path schema being incompatible with Unix. This fixes it.