### PR TITLE
out_stdout: call fflush(stdout) at the end of cb_stdout_flush()

### DIFF
--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -248,6 +248,7 @@ static void cb_stdout_flush(void *data, size_t bytes,
         msgpack_unpacked_destroy(&result);
         flb_free(buf);
     }
+    fflush(stdout);
 
     FLB_OUTPUT_RETURN(FLB_OK);
 }


### PR DESCRIPTION
Some terminal programs buffer stdout in memory before printing, so
emitted records may not appear on the screen promptly.

This is very confusing especially when debugging ("Is there something
wrong with my fix? Or is it just due to buffering of I/O?).

Let's flush stdout in each cb_flush call to avoid confusion.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>