### PR TITLE
Improve Apache2 accesslog parser to parse potentially escaped quotes in request headers

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -8,7 +8,7 @@
 [PARSER]
     Name   apache2
     Format regex
-    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>(?:[^\\"]+|\\.)*)" "(?<agent>(?:[^\\"]+|\\.)*)")?$
     Time_Key time
     Time_Format %d/%b/%Y:%H:%M:%S %z
 


### PR DESCRIPTION
This finally parses the Apache2 access logs in case there are encoded quotes within the request headers as Apache quotes them since 2.0.46. See http://httpd.apache.org/docs/current/mod/mod_log_config.html#formats

_Format Notes  
For security reasons, starting with version 2.0.46, non-printable and other special characters in %r, %i and %o are escaped using \xhh sequences, where hh stands for the hexadecimal representation of the raw byte. Exceptions from this rule are " and \, which are escaped by prepending a backslash, and all whitespace characters, which are written in their C-style notation (\n, \t, etc). In versions prior to 2.0.46, no escaping was performed on these strings so you had to be quite careful when dealing with raw log files._

Tests: https://rubular.com/r/vZ3b0G5zvkuME0

Signed-off-by: Stefan Reimer <stefan@zero-downtime.net>