### PR TITLE
Oauth2 and stackdriver support ipv6

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -282,6 +282,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
 {
     char *token;
     struct flb_stackdriver *ctx;
+    int io_flags = FLB_IO_TLS;
 
     /* Create config context */
     ctx = flb_stackdriver_conf_create(ins, config);
@@ -293,9 +294,14 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     /* Set context */
     flb_output_set_context(ins, ctx);
 
+    /* Network mode IPv6 */
+    if (ins->host.ipv6 == FLB_TRUE) {
+        io_flags |= FLB_IO_IPV6;
+    }
+
     /* Create Upstream context for Stackdriver Logging (no oauth2 service) */
     ctx->u = flb_upstream_create_url(config, FLB_STD_WRITE_URL,
-                                     FLB_IO_TLS, &ins->tls);
+                                     io_flags, &ins->tls);
     ctx->metadata_u = flb_upstream_create_url(config, "http://metadata.google.internal",
                                      FLB_IO_TCP, NULL);
     if (!ctx->u) {

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -321,8 +321,13 @@ char *flb_oauth2_token_get(struct flb_oauth2 *ctx)
     /* Get Token and store it in the context */
     u_conn = flb_upstream_conn_get(ctx->u);
     if (!u_conn) {
-        flb_error("[oauth2] could not get an upstream connection");
-        return NULL;
+        ctx->u->flags |= FLB_IO_IPV6;
+        u_conn = flb_upstream_conn_get(ctx->u);
+        if (!u_conn) {
+            flb_error("[oauth2] could not get an upstream connection");
+            ctx->u->flags &= ~FLB_IO_IPV6;
+            return NULL;
+        }
     }
 
     /* Create HTTP client context */


### PR DESCRIPTION
Fixes #1348 

- oauth2
When oauth2 module creates upstream to retrieve an token, if the access using ipv4 is failed, it will attempt to connect to with ipv6.

- stackdriver
Support `ipv6` param in out_stackdriver config.
If set `ipv6 on`, create upstream connection for stackdriver logging with FLB_IO_IPV6 mode.