### PR TITLE
lib: monkey: Fix file descriptor leak in _mk_event_timeout_create

### DIFF
--- a/lib/monkey/mk_core/mk_event_epoll.c
+++ b/lib/monkey/mk_core/mk_event_epoll.c
@@ -187,6 +187,7 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
     ret = timerfd_settime(timer_fd, TFD_TIMER_ABSTIME, &its, NULL);
     if (ret < 0) {
+        close(timer_fd);
         mk_libc_error("timerfd_settime");
         return -1;
     }


### PR DESCRIPTION
If the call to timerfd_settime fails the file descriptor created by the
previous call to timerfd_create is not closed.

Potentially an additional fix for #798 which is about
running out of file descriptors.

```
Signed-off-by: Jonas Fonseca <jonas.fonseca@gmail.com>
```

---

We ran into an issue which looks like fluent/fluent-bit#798, however, the cause was that the HTTP basic auth credentials used for sending logs to Elasticsearch was not good and Fluent Bit kept retrying and eventually the call to `timerfd_settime` would fail.