### PR TITLE
Setting Generate_Id with ES output creates corrupted JSON output #1308

### DIFF
--- a/plugins/out_es/es_bulk.h
+++ b/plugins/out_es/es_bulk.h
@@ -24,8 +24,8 @@
 #include <inttypes.h>
 
 #define ES_BULK_CHUNK      4096  /* Size of buffer chunks    */
-#define ES_BULK_HEADER      128  /* ES Bulk API prefix line  */
-#define ES_BULK_INDEX_FMT   "{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\"}}\n"
+#define ES_BULK_HEADER      165  /* ES Bulk API prefix line  */
+#define ES_BULK_INDEX_FMT    "{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\"}}\n"
 #define ES_BULK_INDEX_FMT_ID "{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}\n"
 
 struct es_bulk {


### PR DESCRIPTION
Setting Generate_Id with ES output creates corrupted JSON output #1308

When the UUID was expanded to 37 to include dashes the header size was not incremented accordingly ...

Can this get merged quickly so we can use yum to update our severs.  I opened #1308 weeks ago and ended up debugging and fixing this for you.