### PR TITLE
Improve GitLab CICD Pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,25 +1,75 @@
+include:
+  - local: '/.gitlab/ci-templates.yml'
+
 stages:
   - build
   - docker-build
 
-build:
+"gcc DFLB_JEMALLOC=On":
   stage: build
   image: gcc
   variables:
-      FLB_OPT: "-DFLB_JEMALLOC=On -DFLB_JEMALLOC=Off -DSANITIZE_ADDRESS=On -DSANITIZE_UNDEFINED=On -DFLB_COVERAGE=On"
+      FLB_OPT: "-DFLB_JEMALLOC=On"
+  extends: .gcc-template
   script:
-    - echo "CC = $CC, CXX = $CXX"
-    - apt-get update -y
-    - apt-get install cmake flex bison -y
-    #- update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
-    #- update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
-    #- usermod -a -G systemd-journal $(id -un)
     - sh ci/do-ut
   cache:
     key: "$CI_COMMIT_REF_SLUG"
     paths:
       - ./build
 
+"gcc DFLB_JEMALLOC=Off":
+  stage: build
+  image: gcc
+  variables:
+      FLB_OPT: "-DFLB_JEMALLOC=Off"
+  extends: .gcc-template
+  script:
+    - sh ci/do-ut
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - ./build
+
+"gcc DSANITIZE_ADDRESS=On":
+  stage: build
+  image: gcc
+  variables:
+      FLB_OPT: "-DSANITIZE_ADDRESS=On"
+  extends: .gcc-template
+  script:
+    - sh ci/do-ut
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - ./build
+
+"gcc DSANITIZE_UNDEFINED=On":
+  stage: build
+  image: gcc
+  variables:
+      FLB_OPT: "-DSANITIZE_UNDEFINED=On"
+  extends: .gcc-template
+  script:
+    - sh ci/do-ut
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - ./build
+
+"gcc DFLB_COVERAGE=On":
+  stage: build
+  image: gcc
+  variables:
+      FLB_OPT: "-DFLB_COVERAGE=On"
+  extends: .gcc-template
+  script:
+    - sh ci/do-ut
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - ./build
+      
 docker-build:
   stage: docker-build
   image: docker:stable
@@ -35,4 +85,4 @@ docker-build:
       - ./build
   script:
     - echo "===== BUILD DOCKER IMAGE ======="
-    - docker build -t test-image -f ./Dockerfile .
+    - docker build -t test-image -f ./build/Dockerfile .

--- a/.gitlab/ci-templates.yml
+++ b/.gitlab/ci-templates.yml
@@ -1,0 +1,5 @@
+.gcc-template:
+  before_script:
+    - export CC=gcc
+    - apt-get update -y
+    - apt-get install cmake flex bison -y


### PR DESCRIPTION
This merge request modified the GitLab CICD Process to take advantage of templates. Thus cleaning code up. In addition it adds in the additional build targets.

It does not add in a Clang build target. The reason for this is no supported clang docker image has been selected. Once it has been, A new merge request should be done to add support for clang.