### PR TITLE
in_tail: allow firstline to end with an int

### DIFF
--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -58,6 +58,7 @@ struct flb_tail_file {
     /* multiline status */
     time_t mult_flush_timeout;  /* time when multiline started           */
     int mult_firstline;         /* bool: mult firstline found ?          */
+    int mult_firstline_append;  /* bool: mult firstline appendable ?     */
     int mult_skipping;          /* skipping because ignode_older than ?  */
     int mult_keys;              /* total number of buffered keys         */
     msgpack_sbuffer mult_sbuf;  /* temporal msgpack buffer               */

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -294,12 +294,14 @@ int flb_tail_mult_process_content(time_t now,
          * will be possible.
          */
         ret = is_last_key_val_string(out_buf, out_size);
-        if (ret == FLB_TRUE) {
-            flb_tail_mult_process_first(now, out_buf, out_size, &out_time,
-                                        file, ctx);
-            return FLB_TAIL_MULT_MORE;
-        }
-        flb_free(out_buf);
+        if (ret == FLB_TRUE)
+            file->mult_firstline_append = FLB_TRUE;
+        else
+            file->mult_firstline_append = FLB_FALSE;
+
+        flb_tail_mult_process_first(now, out_buf, out_size, &out_time,
+                                    file, ctx);
+        return FLB_TAIL_MULT_MORE;
     }
 
     if (file->mult_skipping == FLB_TRUE) {
@@ -334,7 +336,7 @@ int flb_tail_mult_process_content(time_t now,
          * If no parser was found means the string log must be appended
          * to the last structured field.
          */
-        if (file->mult_firstline == FLB_TRUE) {
+        if (file->mult_firstline == FLB_TRUE && file->mult_firstline_append == FLB_TRUE) {
             flb_tail_mult_append_raw(buf, len, file, ctx);
         }
         else {


### PR DESCRIPTION
The fix for #1368, applied in 826c84f forbids the firstline to end with an integer. This is required if the continuation line does not match any parser.
In cases where the line is not appended to the parent, we are save to process the line, even if the first line does not end with an string.

Signed-off-by: Thomas Berger <loki@lokis-chaos.de>