### PR TITLE
in_mqtt: fix incorrect MQTT length handling

### DIFF
--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -382,7 +382,6 @@ int mqtt_prot_parser(struct mqtt_conn *conn)
                 }
             } while (1);
 
-            conn->buf_pos += bytes - 1;
             conn->packet_length = length;
 
             /* At this point we have a full control packet in place */


### PR DESCRIPTION
While parsing the length of a MQTT packet, the buf_pos is already
incremented, making it no longer necessary to do it once more once the
length is determined.

Fixes #672.

Signed-off-by: Jan Willem Janssen <j.w.janssen@lxtreme.nl>