### PR TITLE
Adding `dropped` metrics for input plugins.

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -211,13 +211,6 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
                      "retrying in one second");
 
             /*
-             * If the queue is full, first make sure to discard any further
-             * flush request from the engine. This means 'the caller will
-             * issue a retry at a later time'.
-             */
-            ctx->blocked = FLB_TRUE;
-
-            /*
              * Next step is to give it some time to the background rdkafka
              * library to do it own work. By default rdkafka wait 1 second
              * or up to 10000 messages to be enqueued before delivery.
@@ -227,6 +220,7 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
              * issue a full retry of the data chunk.
              */
             flb_time_sleep(1000, config);
+            rd_kafka_poll(ctx->producer, 0);
 
             /* Issue a re-try */
             queue_full_retries++;
@@ -237,7 +231,6 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
         flb_debug("[out_kafka] enqueued message (%zd bytes) for topic '%s'",
                   out_size, rd_kafka_topic_name(topic->tp));
     }
-    ctx->blocked = FLB_FALSE;
 
     rd_kafka_poll(ctx->producer, 0);
     if (ctx->format == FLB_KAFKA_FMT_JSON) {
@@ -264,15 +257,6 @@ static void cb_kafka_flush(void *data, size_t bytes,
     struct flb_time tms;
     msgpack_object *obj;
     msgpack_unpacked result;
-
-    /*
-     * If the context is blocked, means rdkafka queue is full and no more
-     * messages can be appended. For our called (Fluent Bit engine) means
-     * that is not possible to work on this now and it need to 'retry'.
-     */
-    if (ctx->blocked == FLB_TRUE) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -45,7 +45,6 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
         flb_errno();
         return NULL;
     }
-    ctx->blocked = FLB_FALSE;
 
     /* rdkafka config context */
     ctx->conf = rd_kafka_conf_new();

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -67,18 +67,6 @@ struct flb_kafka {
     /* Head of defined topics by configuration */
     struct mk_list topics;
 
-    /*
-     * Blocked Status: since rdkafka have it own buffering queue, there is a
-     * chance that the queue becomes full, when that happens our default
-     * behavior is the following:
-     *
-     * - out_kafka yields and try to continue every second until it succeed. In
-     *   the meanwhile blocked flag gets FLB_TRUE value.
-     * - when flushing more records and blocked == FLB_TRUE, issue
-     *   a retry.
-     */
-    int blocked;
-
     /* Internal */
     rd_kafka_t *producer;
     rd_kafka_conf_t *conf;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -345,6 +345,7 @@ int flb_input_instance_init(struct flb_input_instance *in,
     /* Create the metrics context */
     in->metrics = flb_metrics_create(name);
     if (in->metrics) {
+        flb_metrics_add(FLB_METRIC_N_DROPPED, "dropped", in->metrics);
         flb_metrics_add(FLB_METRIC_N_RECORDS, "records", in->metrics);
         flb_metrics_add(FLB_METRIC_N_BYTES, "bytes", in->metrics);
     }


### PR DESCRIPTION
In some cases, when input plugin tries to add a message, it could be
dropped due to few reasons (e.g. Mem_Buf_Limit or some error in record).
This change captures such events by incrementing a counter.
This counter could then be visualised in prometheus/metrics_server.