### PR TITLE
plugin: include flb_compat.h for Windows compatibility

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -31,6 +31,9 @@
 #include <windows.h>
 #include <Wincrypt.h>
 
+#include <monkey/mk_core/mk_sleep.h>
+#include <fluent-bit/flb_dlfcn_win32.h>
+
 #define FLB_DIRCHAR '\\'
 #define PATH_MAX MAX_PATH
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
@@ -83,8 +86,6 @@ static inline char* realpath(char *path, char *buf)
 /* mk_utils.c exposes localtime_r */
 extern struct tm *localtime_r(const time_t *timep, struct tm * result);
 
-#include <monkey/mk_core/mk_sleep.h>
-
 static inline int usleep(LONGLONG usec)
 {
     // Convert into 100ns unit.
@@ -98,6 +99,7 @@ static inline int usleep(LONGLONG usec)
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <libgen.h>
+#include <dlfcn.h>
 
 #define FLB_DIRCHAR '/'
 #endif

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
@@ -28,9 +29,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
-#include <dlfcn.h>
-#include <libgen.h>
 
 #define PLUGIN_PREFIX           "flb-"
 #define PLUGIN_EXTENSION        ".so"

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -22,11 +22,6 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef _WIN32
-#include <fluent-bit/flb_dlfcn_win32.h>
-#else
-#include <dlfcn.h>
-#endif
 
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_compat.h>


### PR DESCRIPTION
Since MSVC does not provide dlfcn.h, we need to use a stub
implementation in flb_dlfcn_win32.c on Windows.

This patch allows flb_compat.h to abstract away the difference,
and should make flb_plugin.c compilable on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>
