### PR TITLE
build: fix cmake to include FLB_PATH_LIB_CO properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ endif()
 
 FLB_DEFINITION(FLB_HAVE_FLUSH_LIBCO)
 if(NOT TARGET co)
-  add_subdirectory(${FLB_PATH_LIB_SQLITE})
+  add_subdirectory(${FLB_PATH_LIB_CO})
 endif()
 
 if(NOT TARGET rbtree)


### PR DESCRIPTION
Right now, running cmake in a clean fluent-bit repository fails with
the following error.

    $ git clone https://github.com/fluent/fluent-bit
    $ cd build
    $ cmake ..
    CMake Error at CMakeLists.txt:334 (add_subdirectory):

... which is just because of cmake trying include sqlite3 instead
of libco wrongly. This is a trivial fix for the bug.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>