### PR TITLE
build: create a simple ZIP archive for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,8 +615,8 @@ endif()
 # Installer Generation (Cpack)
 # ============================
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CPACK_GENERATOR "NSIS")
+if(FLB_SYSTEM_WINDOWS)
+  set(CPACK_GENERATOR "NSIS" "ZIP")
 else()
   set(CPACK_GENERATOR "RPM")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,5 @@ build_script:
 artifacts:
   - path: build/td-agent-bit-*.exe
     name: td-agent-bit
+  - path: build/td-agent-bit-*.zip
+    name: td-agent-bit-zip


### PR DESCRIPTION
This teaches cmake to create a ZIP archive that contains a full set
of binaries of fluent-bit. Here is how a ZIP archive looks like:

    td-agent-bit-1.2.0-win32.zip
    ├── bin
    │   ├── fluent-bit.dll
    │   └── fluent-bit.exe
    ├── conf
    │   ├── fluent-bit.conf
    │   ├── parsers.conf
    │   └── plugins.conf
    └── include
        └── fluent-bit.h

This makes running fluent-bit trivial for Windows users, since all
one needs is just to download the archive and unzip it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>