### PR TITLE
Resolve GitLab-CI Missing Dockerfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,4 +85,4 @@ docker-build:
       - ./build
   script:
     - echo "===== BUILD DOCKER IMAGE ======="
-    - docker build -t test-image -f ./build/Dockerfile .
+    - docker build -t test-image -f ./Dockerfile .


### PR DESCRIPTION
This points to the correct Dockerfile to fix failing builds.