### PR TITLE
filter_modify:copy original event if condition is not matched(#1077)

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1382,6 +1382,7 @@ static int cb_modify_filter(const void *data, size_t bytes,
     struct filter_modify_ctx *ctx = context;
 
     int modifications = 0;
+    int total_modifications = 0;
 
     msgpack_sbuffer buffer;
     msgpack_sbuffer_init(&buffer);
@@ -1400,8 +1401,14 @@ static int cb_modify_filter(const void *data, size_t bytes,
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_ARRAY) {
-            modifications +=
+            modifications =
                 apply_modifying_rules(&packer, &result.data, ctx);
+
+            if (modifications == 0) {
+                // not matched, so copy original event.
+                msgpack_pack_object(&packer, result.data);
+            }
+            total_modifications += modifications;
         }
         else {
             msgpack_pack_object(&packer, result.data);
@@ -1409,7 +1416,7 @@ static int cb_modify_filter(const void *data, size_t bytes,
     }
     msgpack_unpacked_destroy(&result);
 
-    if(modifications == 0) {
+    if(total_modifications == 0) {
         msgpack_sbuffer_destroy(&buffer);
         return FLB_FILTER_NOTOUCH;
     }


### PR DESCRIPTION
To fix #1077 

filter_modify doesn't copy event if it is not matched at `apply_modifying_rules`. ( only logging)
```c
static inline int apply_modifying_rules(msgpack_packer * packer,
                                        msgpack_object * root,
                                        struct filter_modify_ctx *ctx)
{
    msgpack_object ts = root->via.array.ptr[0];
    msgpack_object map = root->via.array.ptr[1];

    if (!evaluate_conditions(&map, ctx)) {
        flb_debug
            ("[filter_modify] : Conditions not met, not touching record");
        return 0;
    }
```

So some events will removed by filter_modify when multiple events come and some of events are not matched.

@jesk78 's config is https://github.com/fluent/fluent-bit/issues/1077#issuecomment-463445403

In that case,  4 events are expected.
```
[0] test: [1562233919.205549498, {"mickey"=>"mouse", "do"=>"like"}]
[1] test: [1562233919.205562366, {"donald"=>"duck", "do"=>"likeaswell"}]
[2] test: [1562233919.205564829, {"mickey"=>"goofie"}]
[3] test: [1562233919.205566708, {"mickey"=>"mouse", "do"=>"like"}]
```

However, output is only 2 events.
```
[0] test: [1562232572.617520289, {"mickey"=>"mouse", "do"=>"like"}]
[1] test: [1562232572.617619277, {"mickey"=>"mouse", "do"=>"like"}]
```

My patch is to fix it as expected.