### PR TITLE
out_stackdriver: add functionality to send log level info to stackdriver

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -83,4 +83,16 @@ struct flb_stackdriver {
     struct flb_config *config;
 };
 
+typedef enum {
+    EMERGENCY = 800,
+    ALERT     = 700,
+    CRITICAL  = 600,
+    ERROR     = 500,
+    WARNING   = 400,
+    NOTICE    = 300,
+    INFO      = 200,
+    DEBUG     = 100,
+    DEFAULT   = 0
+} severity_t;
+
 #endif

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -68,6 +68,7 @@ struct flb_stackdriver {
 
     /* other */
     flb_sds_t resource;
+    flb_sds_t severity_key;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -279,6 +279,11 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->resource = flb_sds_create(FLB_SDS_RESOURCE_TYPE);
     }
 
+    tmp = flb_output_get_property("severity_key", ins);
+    if (tmp) {
+        ctx->severity_key = flb_sds_create(tmp);
+    }
+
     return ctx;
 }
 
@@ -298,6 +303,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->auth_uri);
     flb_sds_destroy(ctx->token_uri);
     flb_sds_destroy(ctx->resource);
+    flb_sds_destroy(ctx->severity_key);
 
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);


### PR DESCRIPTION
As per google cloud documentation there is ability to set severity log
level information for each log entry.

https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity

This patch modifies pack entries and inserts "severity" field with one
of log levels:
- EMERGENCY
- ALERT
- CRITICAL
- ERROR
- WARNING
- NOTICE
- INFO
- DEBUG

This enables better ability to filter logs in stackdriver.

Log level information / severity level is retrived from payload object
(parsed log entry). Key for which fluent-bit looks inside payload is
configurable by "severity_key" stackdriver output option.

Example:

[OUTPUT]
    Name            stackdriver
    Match           *
    severity_key    level

With this configuration stackdriver output would look inside payload
for "level" key and compare its value with allowed severity levels,
and set it as "severity" key inside pack entries.

Example json log entry / payload:
{
  "remote_addr": "111.111.111.111",
  "remote_user": "admin",
  "request": "GET /portal/admin/jsi18n/ HTTP/1.1",
  "level": "DEBUG"
}

Signed-off-by: kantica <kantica@gmail.com>