### PR TITLE
go plugin: Added minimal changes to set and call `FLBPluginExit`

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -172,8 +172,12 @@ void flb_output_exit(struct flb_config *config)
 
         /* Check a exit callback */
         if (p->cb_exit) {
-            p->cb_exit(ins->context, config);
-        }
+            if(!p->proxy) {
+                p->cb_exit(ins->context, config);
+            } else {
+                p->cb_exit(ins->p, config);
+            }
+        } 
 
         if (ins->upstream) {
             flb_upstream_destroy(ins->upstream);

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -175,7 +175,7 @@ void flb_output_exit(struct flb_config *config)
             if(!p->proxy) {
                 p->cb_exit(ins->context, config);
             } else {
-                p->cb_exit(ins->p, config);
+                p->cb_exit(p, ins->context);
             }
         } 
 

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -77,9 +77,9 @@ static void flb_proxy_cb_exit(struct flb_output_plugin *instance,
     struct flbgo_output_plugin *plugin;
     plugin = (struct flbgo_output_plugin *) inst;
 
-    flb_warn("[GO] running exit callback");
+    flb_debug("[GO] running exit callback");
 
-    plugin->cb_exit(context->remote_context);
+    plugin->cb_exit();
 }
 
 static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -67,7 +67,7 @@ static void flb_proxy_cb_flush(const void *data, size_t bytes,
 
 
 static void flb_proxy_cb_exit(struct flb_output_plugin *instance,
-                           struct flb_config *config) 
+                              struct flb_plugin_proxy_context *context) 
 {
     struct flb_plugin_proxy *proxy = (instance->proxy);
     void *inst;
@@ -78,7 +78,8 @@ static void flb_proxy_cb_exit(struct flb_output_plugin *instance,
     plugin = (struct flbgo_output_plugin *) inst;
 
     flb_warn("[GO] running exit callback");
-    plugin->cb_exit(plugin->context->remote_context);
+
+    plugin->cb_exit(context->remote_context);
 }
 
 static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -77,8 +77,8 @@ static void flb_proxy_cb_exit(struct flb_output_plugin *instance,
     struct flbgo_output_plugin *plugin;
     plugin = (struct flbgo_output_plugin *) inst;
 
-    plugin->cb_exit(NULL);
-    //go_plugin->cb_exit(NULL);
+    flb_warn("[GO] running exit callback");
+    plugin->cb_exit(plugin->context->remote_context);
 }
 
 static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -66,6 +66,21 @@ static void flb_proxy_cb_flush(const void *data, size_t bytes,
 }
 
 
+static void flb_proxy_cb_exit(struct flb_output_plugin *instance,
+                           struct flb_config *config) 
+{
+    struct flb_plugin_proxy *proxy = (instance->proxy);
+    void *inst;
+
+    inst = proxy->data;
+
+    struct flbgo_output_plugin *plugin;
+    plugin = (struct flbgo_output_plugin *) inst;
+
+    plugin->cb_exit(NULL);
+    //go_plugin->cb_exit(NULL);
+}
+
 static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
                                      struct flb_plugin_proxy_def *def,
                                      struct flb_config *config)
@@ -92,6 +107,7 @@ static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
      * we put our proxy-middle callbacks to do the translation properly.
      */
     out->cb_flush = flb_proxy_cb_flush;
+    out->cb_exit = flb_proxy_cb_exit;
     return 0;
 }
 

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -24,6 +24,18 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_plugin_proxy.h>
 
+struct flbgo_output_plugin {
+    char *name;
+    void *api;
+    void *o_ins;
+    struct flb_plugin_proxy_context *context;
+
+    int (*cb_init)();
+    int (*cb_flush)(const void *, size_t, const char *);
+    int (*cb_flush_ctx)(void *, const void *, size_t, char *);
+    int (*cb_exit)(void *);
+};
+
 int proxy_go_register(struct flb_plugin_proxy *proxy,
                       struct flb_plugin_proxy_def *def);
 

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -33,7 +33,7 @@ struct flbgo_output_plugin {
     int (*cb_init)();
     int (*cb_flush)(const void *, size_t, const char *);
     int (*cb_flush_ctx)(void *, const void *, size_t, char *);
-    int (*cb_exit)(void *);
+    int (*cb_exit)();
 };
 
 int proxy_go_register(struct flb_plugin_proxy *proxy,


### PR DESCRIPTION
Fixes: #1421 

Currently in `flb_plugin_proxy.c`, only the `cb_flush` handler is set on the proxy plugin instance that is managed by fluent-bit, with the init and register callbacks begin invoked in `go.c`  itself.

For certain cases such as writing a GZip stream - the invocation of the exit handler is *essential* so that the plugin can close the current GZip stream - else the currently written file would not be a valid GZip file, and extraction of already written data would require additional work.

Signed-off-by: Sriduth Jayhari <sriduth.jayhari@juspay.in>