### PR TITLE
filter_nest: copy original event if condition is not mached

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -557,6 +557,7 @@ static int cb_nest_filter(const void *data, size_t bytes,
 
     struct filter_nest_ctx *ctx = context;
     int modified_records = 0;
+    int total_modified_records = 0;
 
     msgpack_sbuffer buffer;
     msgpack_sbuffer_init(&buffer);
@@ -576,15 +577,23 @@ static int cb_nest_filter(const void *data, size_t bytes,
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+        modified_records = 0;
         if (result.data.type == MSGPACK_OBJECT_ARRAY) {
             if (ctx->operation == NEST) {
-                modified_records +=
+                modified_records =
                     apply_nesting_rules(&packer, &result.data, ctx);
             }
             else {
-                modified_records +=
+                modified_records =
                     apply_lifting_rules(&packer, &result.data, ctx);
             }
+
+            
+            if (modified_records == 0) {
+                // not matched, so copy original event.
+                msgpack_pack_object(&packer, result.data);
+            }
+            total_modified_records += modified_records;
         }
         else {
             flb_debug("[filter_nest] Record is NOT an array, skipping");
@@ -596,7 +605,7 @@ static int cb_nest_filter(const void *data, size_t bytes,
     *out_buf = buffer.data;
     *out_size = buffer.size;
 
-    if (modified_records == 0) {
+    if (total_modified_records == 0) {
         return FLB_FILTER_NOTOUCH;
     }
     else {

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -5,18 +5,53 @@
 
 pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 char *output = NULL;
+int  num_output = 0;
 
 /* Test data */
 
 /* Test functions */
 void flb_test_filter_nest_single(void);
-
+void flb_test_filter_nest_multi_nest(void);
 /* Test list */
 TEST_LIST = {
     {"single", flb_test_filter_nest_single },
+    {"multiple events are not dropped(nest)", flb_test_filter_nest_multi_nest},
     {NULL, NULL}
 };
 
+
+void add_output_num()
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output++;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+void clear_output_num()
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = 0;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+int callback_count(void* data, size_t size, void* cb_data)
+{
+    if (size > 0) {
+        flb_debug("[test_filter_nest] received message: %s", data);
+        add_output_num(size); /* success */
+    }
+    return 0;
+}
 
 void set_output(char *val)
 {
@@ -43,6 +78,80 @@ int callback_test(void* data, size_t size, void* cb_data)
         set_output(data); /* success */
     }
     return 0;
+}
+
+void flb_test_filter_nest_multi_nest(void)
+{
+    int ret;
+    int bytes;
+    char *p;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    int count = 0; // should be number of events.
+    int expected = 2;
+
+    clear_output_num();
+    
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "1",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_count;
+    cb_data.data = NULL;
+
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "nest", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "Operation", "nest",
+                         "Wildcard", "to_nest",
+                         "Nest_under", "nested_key",
+                         NULL);
+
+    TEST_CHECK(ret == 0);
+
+
+    /* Output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    p = "[1448403340, {\"to_nest\":\"This is the data to nest\", \"extra\":\"Some more data\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    p = "[1448403341, {\"not_nest\":\"dummy data\", \"extra\":\"dummy more data\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+    count = get_output_num();
+
+    TEST_CHECK_(count == expected, "Expected number of events %d, got %d", expected, count );
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
 }
 
 void flb_test_filter_nest_single(void)

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -50,7 +50,7 @@ int callback_count(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
         flb_debug("[test_filter_nest] received message: %s", data);
-        add_output_num(size); /* success */
+        add_output_num(); /* success */
     }
     return 0;
 }

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -12,10 +12,12 @@ int  num_output = 0;
 /* Test functions */
 void flb_test_filter_nest_single(void);
 void flb_test_filter_nest_multi_nest(void);
+void flb_test_filter_nest_multi_lift(void);
 /* Test list */
 TEST_LIST = {
     {"single", flb_test_filter_nest_single },
     {"multiple events are not dropped(nest)", flb_test_filter_nest_multi_nest},
+    {"multiple events are not dropped(lift)", flb_test_filter_nest_multi_lift},
     {NULL, NULL}
 };
 
@@ -138,6 +140,79 @@ void flb_test_filter_nest_multi_nest(void)
     TEST_CHECK(ret == 0);
 
     p = "[1448403340, {\"to_nest\":\"This is the data to nest\", \"extra\":\"Some more data\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    p = "[1448403341, {\"not_nest\":\"dummy data\", \"extra\":\"dummy more data\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+    count = get_output_num();
+
+    TEST_CHECK_(count == expected, "Expected number of events %d, got %d", expected, count );
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_filter_nest_multi_lift(void)
+{
+    int ret;
+    int bytes;
+    char *p;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    int count = 0; // should be number of events.
+    int expected = 2;
+
+    clear_output_num();
+    
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "1",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_count;
+    cb_data.data = NULL;
+
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "nest", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "Operation", "lift",
+                         "Nested_under", "nested",
+                         NULL);
+
+    TEST_CHECK(ret == 0);
+
+
+    /* Output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    p = "[1448403340, {\"nested\": {\"child\":\"nested data\"}, \"not_nestd\":\"not nested data\" }]";
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 


### PR DESCRIPTION
To fix #1434 

The issue #1434 is similar to #1077 .
filter plugin drops some events if they are not matched condition.

test data:
```
$ for i in `seq 6 1 10`;do echo '{"key'$i'": "somevalue"}';done | tee bad_batch.log
{"key6": "somevalue"}
{"key7": "somevalue"}
{"key8": "somevalue"}
{"key9": "somevalue"}
{"key10": "somevalue"}
```

Execute from cmdline. filter_nest checks `key6`.
```
fluent-bit -v -R ../../conf/parsers.conf   -i tail -p path=./bad_batch.log -p "Parser=json" -F nest  -p 'Operation=nest' -p 'Wildcard=key6' -p "Nest_under=nested" -m '*' -o stdout
```

Result: (only 1 event. Other events which doesn't have `key6` are dropped.)
```
[0] tail.0: [1562767117.577847002, {"nested"=>{"key6"=>"somevalue"}}]
```

Expected: 
```
[0] tail.0: [1562978400.221393545, {"nested"=>{"key6"=>"somevalue"}}]
[1] tail.0: [1562978400.221400067, {"key7"=>"somevalue"}]
[2] tail.0: [1562978400.221402562, {"key8"=>"somevalue"}]
[3] tail.0: [1562978400.221404586, {"key9"=>"somevalue"}]
[4] tail.0: [1562978400.221406550, {"key10"=>"somevalue"}]
```