### PR TITLE
tests: modify add test case to detect issue #1077

### DIFF
--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1097,7 +1097,7 @@ static int get_output_num()
 static int callback_count(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_nest] received message: %s", data);
+        flb_debug("[test_filter_modify] received message: %s", data);
         add_output_num(size); /* success */
     }
     return 0;


### PR DESCRIPTION
I added test case to detect #1077 issue.

In this case, 3 events are pushed and fluent-bit appends key value if "cond" is "true".
```
{"cond":"false", "data": "something"}
{"cond":"true", "data": "something"}
{"data": "something"}
```

If filtered events are 3 (no events are dropped), it means #1077 is addressed.
