### PR TITLE
pack: fixed double's json packing precision

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -450,7 +450,7 @@ static int msgpack2json(char *buf, int *off, size_t left,
     case MSGPACK_OBJECT_FLOAT64:
         {
             char temp[32] = {0};
-            i = snprintf(temp, sizeof(temp)-1, "%f", o->via.f64);
+            i = snprintf(temp, sizeof(temp)-1, "%.16g", o->via.f64);
             ret = try_to_write(buf, off, left, temp, i);
         }
         break;


### PR DESCRIPTION
Floating point numbers when unpacked are stored as double type,
though when packing to json is stored with %f which stores only
6 digits after point. Double has precision of 15 digits, hence
changed to %.16g which is most compact representation of number
without losing precision.

The patch has been tested in kubernetes locally, it proven to
push numbers like 15,000.08883478 to elastic, whilst previously
it pushed 15,000.088835 instead.

Signed-off-by: Maxim Vorobjov <maxim.vorobjov@gmail.com>