### PR TITLE
router: Conditional inclusion of onigmo.h for regex support

### DIFF
--- a/src/flb_router.c
+++ b/src/flb_router.c
@@ -25,7 +25,10 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_router.h>
+
+#ifdef FLB_HAVE_REGEX
 #include <onigmo.h>
+#endif
 
 #include <string.h>
 


### PR DESCRIPTION
Needed this little build fixup for `-DFLB_REGEX=No -DFLB_PARSER=No` to work.

Otherwise:

```
$ cmake -DFLB_REGEX=No -DFLB_PARSER=No ..
..
$ make -j4
...
[ 49%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_upstream.c.o
[ 49%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_upstream_ha.c.o
[ 49%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_upstream_node.c.o
[ 50%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_router.c.o
[ 50%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_worker.c.o
/home/nigels/dev/fluent-bit/src/flb_router.c:28:10: fatal error: onigmo.h: No such file or directory
 #include <onigmo.h>
          ^~~~~~~~~~
compilation terminated.
src/CMakeFiles/fluent-bit-static.dir/build.make:782: recipe for target 'src/CMakeFiles/fluent-bit-static.dir/flb_router.c.o' failed
make[2]: *** [src/CMakeFiles/fluent-bit-static.dir/flb_router.c.o] Error 1
```