### PR TITLE
out_influxdb: add backslashes escaping.

### DIFF
--- a/plugins/out_influxdb/influxdb_bulk.c
+++ b/plugins/out_influxdb/influxdb_bulk.c
@@ -36,6 +36,8 @@ static int influxdb_escape(char *out, const char *str, int size, bool quote) {
         char ch = str[i];
         if (quote ? (ch == '"') : (isspace(ch) || ch == ',' || ch == '=')) {
             out[out_size++] = '\\';
+        } else if (ch == '\\') {
+            out[out_size++] = '\\';
         }
         out[out_size++] = ch;
     }


### PR DESCRIPTION
According to the new docs of the line protocol, multiple backslashes
must be escaped.

https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_reference/#note-on-backslashes

Signed-off-by: disigma <yang.yu@disigma.org>