### PR TITLE
in_winlog: listen to 'Application' channel by deafult

### DIFF
--- a/plugins/in_winlog/in_winlog.c
+++ b/plugins/in_winlog/in_winlog.c
@@ -92,10 +92,8 @@ static int in_winlog_init(struct flb_input_instance *in,
     /* Open channels */
     tmp = flb_input_get_property("channels", in);
     if (!tmp) {
-        flb_error("[in_winlog] no input 'channels' given");
-        flb_free(ctx->buf);
-        flb_free(ctx);
-        return -1;
+        flb_debug("[in_winlog] no channel provided. listening to 'Application'");
+        tmp = "Application";
     }
 
     ctx->active_channel = winlog_open_all(tmp);


### PR DESCRIPTION
This is the default behaviour of Windows and very likely what users
expect. Let's just follow the convention here.

For details, read the official manual page of OpenEventLog().

    lpSourceName

    The name of the log. If you specify a custom log and it cannot
    be found, the event logging service opens the Application log;

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>