### PR TITLE
core: add missing va_end() on exception

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -349,6 +349,7 @@ int flb_service_set(flb_ctx_t *ctx, ...)
         value = va_arg(va, char *);
         if (!value) {
             /* Wrong parameter */
+            va_end(va);
             return -1;
         }
 

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -368,6 +368,7 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
                       (sizeof(msg.msg) - 2) - len,
                       fmt, args);
     if (total < 0) {
+        va_end(args);
         return;
     }
 


### PR DESCRIPTION
From the `STDARG(3)` man page:
> Note that each call to va_start() must be matched by a call to va_end(), from within the same function.