### PR TITLE
in_mqtt: properly encode packet identifier

### DIFF
--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -269,8 +269,8 @@ static int mqtt_handle_publish(struct mqtt_conn *conn)
             mqtt_packet_header(MQTT_PUBREC, 2 , (char *) &buf);
         }
         /* Set the identifier that we are replying to */
-        buf[2] = (packet_id & 0xf0) >> 4;
-        buf[3] = (packet_id & 0xf);
+        buf[2] = (packet_id >> 8) & 0xff;
+        buf[3] = (packet_id & 0xff);
         write(conn->event.fd, buf, 4);
     }
 


### PR DESCRIPTION
This fixes how packet identifiers are encoded in acknowledgements to publish events with a QoS > 0.

Fixes #1464

Signed-off-by: Jan Willem Janssen <j.w.janssen@lxtreme.nl>