### PR TITLE
in_mqtt: fix ping response

### DIFF
--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -291,7 +291,7 @@ static int mqtt_handle_ping(struct mqtt_conn *conn)
     int ret;
     char buf[2] = {0, 0};
 
-    mqtt_packet_header(MQTT_PINGRESP, 2 , (char *) &buf);
+    mqtt_packet_header(MQTT_PINGRESP, 0 , (char *) &buf);
 
     /* write PINGRESP message */
     ret = write(conn->event.fd, buf, 2);


### PR DESCRIPTION
A ping response has no payload, but it was encoded with a payload length of 2, confusing many MQTT clients and causing connection timeouts/drops.

Fixes #1469.

Signed-off-by: Jan Willem Janssen <j.w.janssen@lxtreme.nl>