### PR TITLE
gzip: fix compilation errors on Microsoft Viasual C++

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -87,7 +87,7 @@ int flb_gzip_compress(void *in_data, size_t in_len,
     gzip_header(out_buf);
 
     /* Header offset */
-    pb = out_buf + FLB_GZIP_HEADER_OFFSET;
+    pb = (char *) out_buf + FLB_GZIP_HEADER_OFFSET;
 
     flush = Z_NO_FLUSH;
     while (1) {
@@ -116,7 +116,7 @@ int flb_gzip_compress(void *in_data, size_t in_len,
 
     /* Construct the gzip checksum (CRC32 footer) */
     footer_start = FLB_GZIP_HEADER_OFFSET + *out_len;
-    pb = out_buf + footer_start;
+    pb = (char *) out_buf + footer_start;
 
     crc = mz_crc32(MZ_CRC32_INIT, in_data, in_len);
     *pb++ = crc & 0xFF;
@@ -175,7 +175,7 @@ int flb_gzip_uncompress(void *in_data, size_t in_len,
     }
 
     /* Map zip content */
-    zip_data = in_data + FLB_GZIP_HEADER_OFFSET;
+    zip_data = (char *) in_data + FLB_GZIP_HEADER_OFFSET;
     zip_len = in_len - (FLB_GZIP_HEADER_OFFSET + 8);
 
     mz_stream stream;


### PR DESCRIPTION
Incrementing a void pointer is GCC extension and not allowed in the
standard C. To be portable, we need to cast the pointer to `(char *)`.

This should fix the testing failure occurring on AppVeyor.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>