### PR TITLE
lib: monkey: Add meaningful error message

### DIFF
--- a/lib/monkey/mk_core/mk_rconf.c
+++ b/lib/monkey/mk_core/mk_rconf.c
@@ -237,7 +237,9 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
                 buf[--len] = 0;
             }
         }
-
+        else {
+            mk_config_error(path, line, "Length of content has execeded limit");
+        }
         /* Line number */
         line++;
 


### PR DESCRIPTION
When the content of one line in config file has exceed the value of the Macro MK_RCONF_KV_SIZE, which is 4096 now. It will show error message like "Invalid indentation level".  This PR has added an ELSE branch to give out a meaningful error message. Related to issue https://github.com/fluent/fluent-bit/issues/1149 .