### PR TITLE
sds: fix excess zeros before utf8 converted string

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -303,10 +303,6 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
             else {
                 s[head->len++] = '\\';
                 s[head->len++] = 'u';
-                s[head->len++] = '0';
-                s[head->len++] = '0';
-                s[head->len++] = int2hex[ (unsigned char) ((cp & 0xf00000) >> 20)];
-                s[head->len++] = int2hex[ (unsigned char) ((cp & 0x0f0000) >> 16)];
                 s[head->len++] = int2hex[ (unsigned char) ((cp & 0xf000) >> 12)];
                 s[head->len++] = int2hex[ (unsigned char) ((cp & 0x0f00) >> 8)];
                 s[head->len++] = int2hex[ (unsigned char) ((cp & 0xf0) >> 4)];

--- a/tests/internal/sds.c
+++ b/tests/internal/sds.c
@@ -7,18 +7,30 @@
 
 static void test_sds_usage()
 {
-    flb_sds_t s;
+    flb_sds_t s1;
 
-    s = flb_sds_create("test");
-    TEST_CHECK(s != NULL);
-    TEST_CHECK(flb_sds_len(s) == 4);
-    TEST_CHECK(flb_sds_alloc(s) == 4);
-    TEST_CHECK(strcmp("test", s) == 0);
+    s1 = flb_sds_create("test");
+    TEST_CHECK(s1 != NULL);
+    TEST_CHECK(flb_sds_len(s1) == 4);
+    TEST_CHECK(flb_sds_alloc(s1) == 4);
+    TEST_CHECK(strcmp("test", s1) == 0);
 
-    s = flb_sds_cat(s, ",cat message", 12);
-    TEST_CHECK(strcmp("test,cat message", s) == 0);
+    s1 = flb_sds_cat(s1, ",cat message", 12);
+    TEST_CHECK(strcmp("test,cat message", s1) == 0);
+    flb_sds_destroy(s1);
 
-    flb_sds_destroy(s);
+
+    flb_sds_t s2;
+
+    s2 = flb_sds_create("تست");
+    TEST_CHECK(s2 != NULL);
+    TEST_CHECK(flb_sds_len(s2) == 6);
+    TEST_CHECK(flb_sds_alloc(s2) == 6);
+    TEST_CHECK(strcmp("تست", s2) == 0);
+
+    s2 = flb_sds_cat_utf8(s2, "، پیام افزوده", 24);
+    TEST_CHECK(strcmp("تست، پیام افزوده", s2) == 0);
+    flb_sds_destroy(s2);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
UTF-8 encoded characters are 1-4 bytes long.
In the changed section, it was assumed to be 8 bytes long.
I removed most significant 4 bytes from it to only keep least significant 4 bytes.

I tested the result with Japanese and Persian characters. The result was OK.
I also added a test inside tests/internal/sds directory to test flb_sds_cat_utf8 function.