### PR TITLE
sp: add timeseries function TIMESERIES_FORECAST_R

### DIFF
--- a/include/fluent-bit/stream_processor/flb_sp_parser.h
+++ b/include/fluent-bit/stream_processor/flb_sp_parser.h
@@ -44,7 +44,10 @@
 #define FLB_SP_RECORD_TIME     21
 
 /* Timeseries functions */
-#define FLB_SP_FORECAST        30
+#define FLB_SP_TIMESERIES_START  30
+#define FLB_SP_FORECAST          30
+#define FLB_SP_FORECAST_R        31
+#define FLB_SP_TIMESERIES_END    39
 
 /* Status */
 #define FLB_SP_OK            0

--- a/src/stream_processor/parser/flb_sp_parser.c
+++ b/src/stream_processor/parser/flb_sp_parser.c
@@ -184,7 +184,7 @@ struct flb_sp_cmd_key *flb_sp_key_create(struct flb_sp_cmd *cmd, int func,
         /* Record function */
         record_func = func;
     }
-    else if (func >= FLB_SP_FORECAST && func <= FLB_SP_FORECAST) {
+    else if (func >= FLB_SP_TIMESERIES_START && func <= FLB_SP_TIMESERIES_END) {
         /* Timeseries function */
         timeseries_func = func;
     }
@@ -834,9 +834,9 @@ int flb_sp_cmd_timeseries(struct flb_sp_cmd *cmd, char *func, const char *key_al
     for (i = 0; i < TIMESERIES_FUNCTIONS_SIZE; i++)
     {
         ts_name = timeseries_functions[i];
-        if (strncmp(ts_name, func, strlen(ts_name)) == 0)
+        if (strcmp(ts_name, func) == 0)
         {
-            key = flb_sp_key_create(cmd, i + FLB_SP_FORECAST, NULL, key_alias);
+            key = flb_sp_key_create(cmd, i + FLB_SP_TIMESERIES_START, NULL, key_alias);
 
             if (!key) {
                 return -1;

--- a/src/stream_processor/parser/sql.l
+++ b/src/stream_processor/parser/sql.l
@@ -81,6 +81,7 @@ TIME                    return TIME;
 
  /* Timeseries Functions */
 TIMESERIES_FORECAST     return TIMESERIES_FORECAST;
+TIMESERIES_FORECAST_R   return TIMESERIES_FORECAST_R;
 
  /* Window Types */
 TUMBLING                return TUMBLING;

--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -46,7 +46,7 @@ void yyerror(struct flb_sp_cmd *cmd, const char *query, void *scanner,
 %token RECORD CONTAINS TIME
 
 /* Timeseries functions */
-%token TIMESERIES_FORECAST
+%token TIMESERIES_FORECAST TIMESERIES_FORECAST_R
 
 /* Time functions */
 %token NOW UNIX_TIMESTAMP
@@ -310,15 +310,26 @@ select: SELECT keys FROM source window where groupby ';'
                     flb_free($7);
                   }
                   |
-                  TIMESERIES_FORECAST '(' params ')'
+                  TIMESERIES_FORECAST '(' param ',' param ',' param ')'
                   {
                     flb_sp_cmd_timeseries(cmd, "forecast", NULL);
                   }
                   |
-                  TIMESERIES_FORECAST '(' params ')' AS alias
+                  TIMESERIES_FORECAST '(' param ',' param ',' param ')' AS alias
                   {
-                    flb_sp_cmd_timeseries(cmd, "forecast", $6);
-                    flb_free($6);
+                    flb_sp_cmd_timeseries(cmd, "forecast", $10);
+                    flb_free($10);
+                  }
+                  |
+                  TIMESERIES_FORECAST_R '(' param ',' param ',' param ',' param ')'
+                  {
+                    flb_sp_cmd_timeseries(cmd, "forecast_r", NULL);
+                  }
+                  |
+                  TIMESERIES_FORECAST_R '(' param ',' param ',' param ',' param ')' AS alias
+                  {
+                    flb_sp_cmd_timeseries(cmd, "forecast_r", $12);
+                    flb_free($12);
                   }
                   |
                   NOW '(' ')'
@@ -531,7 +542,6 @@ select: SELECT keys FROM source window where groupby ';'
                {
                  flb_sp_cmd_param_add(cmd, -1, $1);
                }
-        params: param | param ',' params
         value: INTEGER
                {
                  $$ = flb_sp_cmd_condition_integer(cmd, $1);


### PR DESCRIPTION
This pull request adds `TIMESERIES_FORECAST_R(x, y, v, maximum_x)` function, which is the same as `TIMESERIES_FORECAST_R`, but returns the forecast of number of future points for `x`, when the value of `y` becomes `v`.

To prevent returning infinity when such value is estimated to be unreachable in future (the slope of the line in Linear Regression calculation is zero or negative), the function returns `maximum_x` passed as 4th parameter.