### PR TITLE
[out_datadog] allow remapping entry to `message` key

### DIFF
--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -31,6 +31,8 @@
 #define FLB_DATADOG_DD_SOURCE_KEY     "ddsource"
 #define FLB_DATADOG_DD_SERVICE_KEY    "service"
 #define FLB_DATADOG_DD_TAGS_KEY       "ddtags"
+#define FLB_DATADOG_DD_MESSAGE_KEY    "message"
+#define FLB_DATADOG_DD_LOG_KEY        "log"
 
 #define FLB_DATADOG_CONTENT_TYPE   "Content-Type"
 #define FLB_DATADOG_MIME_JSON      "application/json"
@@ -52,6 +54,7 @@ struct flb_out_datadog {
     flb_sds_t dd_source;
     flb_sds_t dd_service;
     flb_sds_t dd_tags;
+    flb_sds_t dd_message_key;
 
     /* Upstream connection to the backend server */
     struct flb_upstream *upstream;

--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -103,6 +103,11 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
         ctx->dd_tags = flb_sds_create(tmp);
     }
 
+    tmp = flb_output_get_property("dd_message_key", ins);
+    if (tmp) {
+        ctx->dd_message_key = flb_sds_create(tmp);
+    }
+
     ctx->uri = flb_sds_create("/v1/input/");
     if (!ctx->uri) {
         flb_error("[out_datadog] error on uri generation");
@@ -187,6 +192,9 @@ int flb_datadog_conf_destroy(struct flb_out_datadog *ctx)
     }
     if (ctx->dd_tags) {
         flb_sds_destroy(ctx->dd_tags);
+    }
+    if (ctx->dd_message_key) {
+        flb_sds_destroy(ctx->dd_message_key);
     }
     if (ctx->upstream) {
         flb_upstream_destroy(ctx->upstream);


### PR DESCRIPTION
Datadog Http(s) logs API required to send application logs into the
JSON key `message`. By default, the plugin searches for the key `log` and
remap the value to the key `message`.
If never the application logs are associated with another key than `log`
you can specify it with the parameter: `dd_message_key`
