### PR TITLE
output: fixup for SDS alloc/free matching for TLS parameters

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -404,7 +404,7 @@ int flb_output_set_property(struct flb_output_instance *out,
         if (strcasecmp(tmp, "true") == 0 || strcasecmp(tmp, "on") == 0) {
             if ((out->flags & FLB_IO_TLS) == 0) {
                 flb_error("[config] %s don't support TLS", out->name);
-                flb_free(tmp);
+                flb_sds_destroy(tmp);
                 return -1;
             }
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -84,19 +84,19 @@ static void flb_output_free_properties(struct flb_output_instance *ins)
 
 #ifdef FLB_HAVE_TLS
     if (ins->tls_ca_path) {
-        flb_free(ins->tls_ca_path);
+        flb_sds_destroy(ins->tls_ca_path);
     }
     if (ins->tls_ca_file) {
-        flb_free(ins->tls_ca_file);
+        flb_sds_destroy(ins->tls_ca_file);
     }
     if (ins->tls_crt_file) {
-        flb_free(ins->tls_crt_file);
+        flb_sds_destroy(ins->tls_crt_file);
     }
     if (ins->tls_key_file) {
-        flb_free(ins->tls_key_file);
+        flb_sds_destroy(ins->tls_key_file);
     }
     if (ins->tls_key_passwd) {
-        flb_free(ins->tls_key_passwd);
+        flb_sds_destroy(ins->tls_key_passwd);
     }
 #endif
 }


### PR DESCRIPTION
Came across this segfault:

```
==21111== Invalid free() / delete / delete[] / realloc()
==21111==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21111==    by 0x15476A: flb_free (flb_mem.h:107)
==21111==    by 0x154BA2: flb_output_free_properties (flb_output.c:87)
==21111==    by 0x154D07: flb_output_instance_destroy (flb_output.c:141)
==21111==    by 0x154DD2: flb_output_exit (flb_output.c:170)
==21111==    by 0x15C546: flb_engine_shutdown (flb_engine.c:564)
==21111==    by 0x14499C: flb_signal_handler (fluent-bit.c:235)
==21111==    by 0x5853F1F: ??? (in /lib/x86_64-linux-gnu/libc-2.27.so)
==21111==    by 0x5936BB6: epoll_wait (epoll_wait.c:30)
==21111==    by 0x3D00EB: _mk_event_wait (mk_event_epoll.c:345)
==21111==    by 0x3D03DB: mk_event_wait (mk_event.c:163)
==21111==    by 0x15C112: flb_engine_start (flb_engine.c:486)
==21111==  Address 0x5c39de0 is 16 bytes inside a block of size 21 alloc'd
==21111==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21111==    by 0x14FE22: flb_malloc (flb_mem.h:62)
==21111==    by 0x150062: sds_alloc (flb_sds.c:39)
==21111==    by 0x15019E: flb_sds_create_size (flb_sds.c:91)
==21111==    by 0x14EC99: flb_env_var_translate (flb_env.c:177)
==21111==    by 0x1552ED: flb_output_set_property (flb_output.c:349)
==21111==    by 0x145393: flb_service_conf (fluent-bit.c:528)
==21111==    by 0x145A54: main (fluent-bit.c:807)
```
In my config:

```
[OUTPUT]
    Name http
    Format json_lines
    Match *
...
    tls.ca_path /tmp

```
Seems to be due to: [b2dba1cbbf8484ed15f6a6dfda046273493a3f9f](https://github.com/fluent/fluent-bit/commit/b2dba1cbbf8484ed15f6a6dfda046273493a3f9f)

So the fix here seems to be to match SDS alloc with SDS free.

Signed-off-by: Nigel Stewart <nigels@nigels.com>