### PR TITLE
in_thermal: Add thermal device detection on init.

### DIFF
--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -184,7 +184,7 @@ static int in_thermal_init(struct flb_input_instance *in,
 #endif
 
     ctx->prev_device_num = proc_temperature(ctx, info,  IN_THERMAL_N_MAX);
-    if (!ctx->prev_device_num){
+    if (!ctx->prev_device_num) {
         flb_warn("[in_thermal] thermal device file not found");
     }
 

--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -122,18 +122,6 @@ static inline int proc_temperature(struct flb_in_thermal_config *ctx, struct tem
     return i;
 }
 
-static void config_destroy(struct flb_in_thermal_config *ctx) {
-#ifdef FLB_HAVE_REGEX
-    if (ctx && ctx->name_regex) {
-        flb_regex_destroy(ctx->name_regex);
-    }
-    if (ctx && ctx->type_regex) {
-        flb_regex_destroy(ctx->type_regex);
-    }
-#endif
-    flb_free(ctx);
-}
-
 /* Init temperature input */
 static int in_thermal_init(struct flb_input_instance *in,
                        struct flb_config *config, void *data)
@@ -292,9 +280,15 @@ static int in_thermal_exit(void *data, struct flb_config *config)
 {
     (void) *config;
     struct flb_in_thermal_config *ctx = data;
-
-    config_destroy(ctx);
-    
+#ifdef FLB_HAVE_REGEX
+    if (ctx && ctx->name_regex) {
+        flb_regex_destroy(ctx->name_regex);
+    }
+    if (ctx && ctx->type_regex) {
+        flb_regex_destroy(ctx->type_regex);
+    }
+#endif
+    flb_free(ctx);
     return 0;
 }
 

--- a/plugins/in_thermal/in_thermal.h
+++ b/plugins/in_thermal/in_thermal.h
@@ -34,6 +34,7 @@ struct flb_in_thermal_config {
     int coll_fd;                  /* collector id/fd                       */
     int interval_sec;             /* interval collection time (Second)     */
     int interval_nsec;            /* interval collection time (Nanosecond) */
+    int prev_device_num;          /* number of thermal devices             */
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *name_regex; /* optional filter by name */
     struct flb_regex *type_regex; /* optional filter by type */


### PR DESCRIPTION
Some systems have no thermal device. (e.g. virtual machine / docker env)
This is a `ls` output of Ubuntu 18.04 on VMWare
```
$ ls /sys/class/thermal/
cooling_device0
$
```
In such cases, fluent-bit registers in_thermal as input plugin ,
but no records will be emitted.

My patch is to detect thermal device on `cb_init`.
If no device is found, fluent-bit doesn't register in_thermal plugin and reports error.