### PR TITLE
hash: Implement EVICT_OLDER and  EVICT_LESS_USED modes in flb_hash

### DIFF
--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -179,6 +179,33 @@ static void flb_hash_evict_random(struct flb_hash *ht)
     }
 }
 
+static void flb_hash_evict_less_used(struct flb_hash *ht)
+{
+    struct mk_list *head;
+    struct flb_hash_entry *entry;
+    struct flb_hash_entry *entry_less_used = NULL;
+
+    mk_list_foreach(head, &ht->entries) {
+        entry = mk_list_entry(head, struct flb_hash_entry, _head_parent);
+        if (!entry_less_used) {
+            entry_less_used = entry;
+        }
+        else if (entry->hits < entry_less_used->hits) {
+            entry_less_used = entry;
+        }
+    }
+
+    flb_hash_entry_free(ht, entry_less_used);
+}
+
+static void flb_hash_evict_older(struct flb_hash *ht)
+{
+    struct flb_hash_entry *entry;
+
+    entry = mk_list_entry_first(&ht->entries, struct flb_hash_entry, _head_parent);
+    flb_hash_entry_free(ht, entry);
+}
+
 int flb_hash_add(struct flb_hash *ht,
                  const char *key, int key_len,
                  const char *val, size_t val_size)
@@ -197,15 +224,14 @@ int flb_hash_add(struct flb_hash *ht,
 
     /* Check capacity */
     if (ht->max_entries > 0 && ht->total_count >= ht->max_entries) {
-        /* FIXME: handle eviction mode */
         if (ht->evict_mode == FLB_HASH_EVICT_NONE) {
-
+            /* Do nothing */
         }
         else if (ht->evict_mode == FLB_HASH_EVICT_OLDER) {
-
+            flb_hash_evict_older(ht);
         }
         else if (ht->evict_mode == FLB_HASH_EVICT_LESS_USED) {
-
+            flb_hash_evict_less_used(ht);
         }
         else if (ht->evict_mode == FLB_HASH_EVICT_RANDOM) {
             flb_hash_evict_random(ht);

--- a/tests/internal/hashtable.c
+++ b/tests/internal/hashtable.c
@@ -241,6 +241,86 @@ void test_random_eviction()
     flb_hash_destroy(ht);
 }
 
+void test_less_used_eviction()
+{
+    int ret;
+    const char *out_buf;
+    size_t out_size;
+    struct flb_hash *ht;
+
+    ht = flb_hash_create(FLB_HASH_EVICT_LESS_USED, 8, 2);
+    TEST_CHECK(ht != NULL);
+
+    ret = ht_add(ht, "key1", "value1");
+    TEST_CHECK(ret != -1);
+
+    ret = ht_add(ht, "key2", "value2");
+    TEST_CHECK(ret != -1);
+
+    ret = flb_hash_get(ht, "key1", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = ht_add(ht, "key3", "value3");
+    TEST_CHECK(ret != -1);
+
+    ret = flb_hash_get(ht, "key3", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key1", 4, &out_buf, &out_size);
+    TEST_CHECK(ret == -1);
+
+    flb_hash_destroy(ht);
+}
+
+void test_older_eviction()
+{
+    int ret;
+    const char *out_buf;
+    size_t out_size;
+    struct flb_hash *ht;
+
+    ht = flb_hash_create(FLB_HASH_EVICT_OLDER, 8, 2);
+    TEST_CHECK(ht != NULL);
+
+    ret = ht_add(ht, "key2", "value2");
+    TEST_CHECK(ret != -1);
+
+    ret = ht_add(ht, "key1", "value1");
+    TEST_CHECK(ret != -1);
+
+    ret = flb_hash_get(ht, "key1", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = ht_add(ht, "key3", "value3");
+    TEST_CHECK(ret != -1);
+
+    ret = flb_hash_get(ht, "key3", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    ret = flb_hash_get(ht, "key2", 4, &out_buf, &out_size);
+    TEST_CHECK(ret == -1);
+
+    ret = flb_hash_get(ht, "key1", 4, &out_buf, &out_size);
+    TEST_CHECK(ret >= 0);
+
+    flb_hash_destroy(ht);
+}
+
 TEST_LIST = {
     { "zero_size", test_create_zero },
     { "single",    test_single },
@@ -249,5 +329,7 @@ TEST_LIST = {
     { "chaining_count", test_chaining },
     { "delete_all", test_delete_all },
     { "random_eviction", test_random_eviction },
+    { "less_used_eviction", test_less_used_eviction },
+    { "older_eviction", test_older_eviction },
     { 0 }
 };


### PR DESCRIPTION
This patch will implement the FLB_HASH_EVICT_OLDER and FLB_HASH_EVICT_LESS_USED
eviction modes where they were previously marked as Todos. FLB_HASH_EVICT_OLDER
mode will evict the oldest entry found in the hash table if the size exceed the
max_entries and FLB_HASH_EVICT_LESS_USED mode will evict the entry that has the
least number of hits if the size exceeds the max_entries.

Also adds two more unit tests to test the new eviction modes

flb_hash unit tests results:

./bin/flb-it-hashtable

Test zero_size...                               [   OK   ]
Test single...                                  [   OK   ]
Test small_table...                             [   OK   ]
Test medium_table...                            [   OK   ]
Test chaining_count...                          [   OK   ]
Test delete_all...                              [   OK   ]
Test random_eviction...                         [   OK   ]
Test less_used_eviction...                      [   OK   ]
Test older_eviction...                          [   OK   ]
SUCCESS: All unit tests have passed.

Signed-off-by: Tian Lan <tian@twosigma.com>