### PR TITLE
in_syslog: add 'Unix_Perm' option

### DIFF
--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -45,6 +45,7 @@ struct flb_syslog {
     /* Unix socket (UDP/TCP)*/
     int server_fd;
     char *unix_path;
+    unsigned int unix_perm;
 
     /* UDP buffer, data length and buffer size */
     char *buffer_data;

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -98,11 +98,18 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
         }
     }
 
-    /* Unix socket path */
+    /* Unix socket path and permission */
     if (ctx->mode == FLB_SYSLOG_UNIX_UDP || ctx->mode == FLB_SYSLOG_UNIX_TCP) {
         tmp = flb_input_get_property("path", i_ins);
         if (tmp) {
             ctx->unix_path = flb_strdup(tmp);
+        }
+
+        tmp = flb_input_get_property("unix_perm", i_ins);
+        if (tmp) {
+            ctx->unix_perm = strtol(tmp, NULL, 8) & 07777;
+        } else {
+            ctx->unix_perm = 0644;
         }
     }
 


### PR DESCRIPTION
It solves a common pain point when using the `in_syslog` plugin. Here
is an example usage:

    [INPUT]
      Name      syslog
      Tag       syslog_data
      Parser    syslog-rfc3164
      Path      /tmp/fluent-bit.sock
      Mode      unix_udp
      Unix_Perm 0777

Without this, users are required to keep track of restarts of fluent-bit
and manually set file permission on the UNIX socket it creates. Let's
just make it work seamlessly without such manual interventions.

This resolves the user reports #1479 and #1493.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>