### PR TITLE
upstream: Do ssl_close_notify before closing the socket

### DIFF
--- a/src/flb_io_tls.c
+++ b/src/flb_io_tls.c
@@ -306,6 +306,7 @@ struct flb_tls_session *flb_tls_session_new(struct flb_tls_context *ctx)
 int flb_tls_session_destroy(struct flb_tls_session *session)
 {
     if (session) {
+        mbedtls_ssl_close_notify(&session->ssl);
         mbedtls_ssl_free(&session->ssl);
         mbedtls_ssl_config_free(&session->conf);
         flb_free(session);

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -238,16 +238,16 @@ int flb_upstream_conn_release(struct flb_upstream_conn *u_conn)
         mk_event_del(u->evl, &u_conn->event);
     }
 
-    if (u_conn->fd > 0) {
-        flb_socket_close(u_conn->fd);
-    }
-
 #ifdef FLB_HAVE_TLS
     if (u_conn->tls_session) {
         flb_tls_session_destroy(u_conn->tls_session);
         u_conn->tls_session = NULL;
     }
 #endif
+
+    if (u_conn->fd > 0) {
+        flb_socket_close(u_conn->fd);
+    }
 
     /* remove connection from the queue */
     mk_list_del(&u_conn->_head);


### PR DESCRIPTION
This fix notifies the peer that the (SSL) connection is being closed
before closing the socket.

Tested against rsyslog 8.1901.0 using GnuTLS,
"The TLS connection was non-properly terminated" errors are gone.

Signed-off-by: Joost Coelingh <joost.coelingh@eu.equinix.com>