### PR TITLE
out_forward: add support for user-based authentication

### DIFF
--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -72,4 +72,11 @@ struct flb_forward {
     struct mk_list configs;
 };
 
+struct flb_forward_ping {
+    const char *nonce;
+    int nonce_len;
+    const char *auth;
+    int auth_len;
+    int keepalive;
+};
 #endif

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -49,6 +49,8 @@ struct flb_forward_config {
     int require_ack_response; /* Require acknowledge for "chunk" */
     int send_options;         /* send options in messages */
 
+    const char *username;
+    const char *password;
 
     /* mbedTLS specifics */
     unsigned char shared_key_salt[16];


### PR DESCRIPTION
Fluentd has support for username/password authentication in addition
to the shared secret (shared_key). This teaches Fluent Bit about it.

To enable the support, put the following to your configuration.

    [OUTPUT]
      Name       forward
      Shared_Key some-shared-key
      Username   fluent-bit
      Password   password

This patch should resolve the issue #596.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>