### PR TITLE
in_series: Fix typo in_ => cb_

### DIFF
--- a/plugins/in_serial/in_serial.c
+++ b/plugins/in_serial/in_serial.c
@@ -327,7 +327,7 @@ static int cb_serial_init(struct flb_input_instance *in,
 #else
     /* Set our collector based on a timer event */
     ret = flb_input_set_collector_time(in,
-                                       in_serial_collect,
+                                       cb_serial_collect,
                                        IN_SERIAL_COLLECT_SEC,
                                        IN_SERIAL_COLLECT_NSEC,
                                        config);


### PR DESCRIPTION
This fixes a build issue on macOS.

```
[ 78%] Building C object plugins/in_serial/CMakeFiles/flb-plugin-in_serial.dir/in_serial.c.o
/Users/<>/src/fluent/fluent-bit/plugins/in_serial/in_serial.c:330:40: error: use of undeclared identifier 'in_serial_collect'; did you
      mean 'cb_serial_collect'?
                                       in_serial_collect,
                                       ^~~~~~~~~~~~~~~~~
                                       cb_serial_collect
/Users/<>/src/fluent/fluent-bit/plugins/in_serial/in_serial.c:99:12: note: 'cb_serial_collect' declared here
static int cb_serial_collect(struct flb_input_instance *in,
           ^
1 error generated.
```