### PR TITLE
dockerfile: fix ls in debug Docker image

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM debian:stretch as builder
-ADD https://busybox.net/downloads/binaries/1.30.0-i686/busybox /bin/busybox
+COPY --from=amd64/busybox:1.31.0 /bin/busybox /bin/busybox
 RUN chmod 555 /bin/busybox \
  && /bin/busybox --install
 


### PR DESCRIPTION
ls failed on the debug docker images with the following message:

```
$ ls
ls: can't open '.': Value too large for defined data type
```

This patch changes the Busybox version to Glibc and bumps it
from 1.30.0 to 1.31.0.

Upstream issues:

- https://github.com/GoogleContainerTools/distroless/issues/225
- https://bugs.busybox.net/show_bug.cgi?id=11651

Signed-off-by: Mario Marín <mmfmarin@gmail.com>