### PR TITLE
in_cpu: remove unnecessary pointer dereference

### DIFF
--- a/plugins/in_cpu/cpu.c
+++ b/plugins/in_cpu/cpu.c
@@ -206,7 +206,7 @@ static inline double proc_cpu_pid_load(pid_t pid, struct cpu_stats *cstats)
 
     /* skip first two values (after process name) */
     p = line;
-    while (*p != ')') *p++;
+    while (*p != ')') p++;
 
     ret = sscanf(p,
                  fmt,


### PR DESCRIPTION
Value of expression `*p++` is not used.