### PR TITLE
hash: remove duplicate assignment

### DIFF
--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -120,7 +120,6 @@ struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries)
     mk_list_init(&ht->entries);
     ht->evict_mode = evict_mode;
     ht->max_entries = max_entries;
-    ht->total_count = 0;
     ht->size = size;
     ht->total_count = 0;
     ht->table = flb_calloc(1, sizeof(struct flb_hash_table) * size);


### PR DESCRIPTION
`ht->total_count` is assigned 0 twice consecutively.

https://github.com/fluent/fluent-bit/blob/262267287641d6d54bb62f0a0ada1c76a5bd40b4/src/flb_hash.c#L123-L125