### PR TITLE
out_datadog: use 'unsigned int' instead of 'uint'

### DIFF
--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -49,7 +49,7 @@ static void dd_remap_move_to_tags(const char* tag_name, msgpack_object attr_valu
 static void dd_remap_container_name(const char* tag_name, msgpack_object attr_value, flb_sds_t dd_tags)
 {
     /* remove the first / if present */
-    uint adjust = attr_value.via.str.ptr[0] == '/' ? 1 : 0;
+    unsigned int adjust = attr_value.via.str.ptr[0] == '/' ? 1 : 0;
     flb_sds_t buf = flb_sds_create_len(attr_value.via.str.ptr + adjust, attr_value.via.str.size - adjust);
     dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags);
     flb_sds_destroy(buf);


### PR DESCRIPTION
`uint` is not a standard type and many compilers do not recognize it.

This should fix the testing failure occurring on AppVeyor.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>