### PR TITLE
in_tail: prevent file duplication on macOS

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -641,6 +641,18 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         goto error;
     }
 
+#if defined(__APPLE__)
+    char *name = flb_tail_file_name(file);
+    if (name == NULL) {
+        goto error;
+    }
+    if (flb_tail_file_exists(name, ctx)) {
+        flb_free(name);
+        goto error;
+    }
+    flb_free(name);
+#endif
+
 #ifdef _MSC_VER
     if (get_inode(fd, &file->inode)) {
         goto error;

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -312,11 +312,14 @@ int flb_tail_scan_callback(struct flb_input_instance *i_ins,
                 continue;
             }
 
+            /* Append file to list */
+            if (flb_tail_file_append(globbuf.gl_pathv[i], &st,
+                                     FLB_TAIL_STATIC, ctx)) {
+                continue;
+            }
+
             flb_debug("[in_tail] append new file: %s", globbuf.gl_pathv[i]);
 
-            /* Append file to list */
-            flb_tail_file_append(globbuf.gl_pathv[i], &st,
-                                 FLB_TAIL_STATIC, ctx);
             count++;
         }
         else {


### PR DESCRIPTION
Call `flb_tail_file_name()` for a normalized path and then perform a
duplication chack using the returned path. We normally don't need to
do this, but we _do_ need in order to handle symlinks properly on OSX.

    $ ls -l /tmp/nginx.log
    20 Sep 26 18:15 /tmp/nginx.log -> /private/tmp/nginx.log

This patch should resolve the bug that in_tail registers the same file
again and again on macOS (#1591)

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>