### PR TITLE
Clarify info, debug and trace logging modes for fluent-bit CLI

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -145,7 +145,10 @@ static void flb_help(int rc, struct flb_config *config)
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     printf("  -T, --sp-task=SQL\tdefine a stream processor task\n");
 #endif
-    printf("  -v, --verbose\t\tenable verbose mode\n");
+    printf("  -v, --verbose\t\tincrease logging verbosity (default: info)\n");
+#ifdef FLB_HAVE_TRACE
+    printf("  -vv\t\t\ttrace mode (available)\n");
+#endif
 #ifdef FLB_HAVE_HTTP_SERVER
     printf("  -H, --http\t\tenable monitoring HTTP server\n");
     printf("  -P, --port\t\tset HTTP server TCP port (default: %s)\n",


### PR DESCRIPTION
Signed-off-by: Nigel Stewart <nigels@nigels.com>

As a follow-up to https://github.com/fluent/fluent-bit/pull/1198

Clarify how to get trace logging, if available.

```
$ bin/fluent-bit -h
Usage: fluent-bit [OPTION]

Available Options
  -b  --storage_path=PATH	specify a storage buffering path
  -c  --config=FILE	specify an optional configuration file
  -d, --daemon		run Fluent Bit in background mode
  -f, --flush=SECONDS	flush timeout in seconds (default: 5)
  -F  --filter=FILTER	 set a filter
  -i, --input=INPUT	set an input
  -m, --match=MATCH	set plugin match, same as '-p match=abc'
  -o, --output=OUTPUT	set an output
  -p, --prop="A=B"	set plugin configuration property
  -R, --parser=FILE	specify a parser configuration file
  -e, --plugin=FILE	load an external plugin (shared lib)
  -l, --log_file=FILE	write log info to a file
  -t, --tag=TAG		set plugin tag, same as '-p tag=abc'
  -T, --sp-task=SQL	define a stream processor task
  -v, --verbose		increase logging verbosity (default: info)
  -vv			trace mode (available)
  -s, --coro_stack_size	Set coroutines stack size in bytes (default: 24576)
  -q, --quiet		quiet mode
  -S, --sosreport	support report for Enterprise customers
  -V, --version		show version number
  -h, --help		print this help
```