### PR TITLE
mem input: Treat buffer/cache memory as available, rather than used

### DIFF
--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -57,36 +57,6 @@ struct flb_input_plugin in_mem_plugin;
 
 static int in_mem_collect(struct flb_input_instance *i_ins,
                           struct flb_config *config, void *in_context);
-#if 0
-/* Locate a specific key into the buffer */
-static char *field(char *data, char *field)
-{
-    char *p;
-    char *q;
-    char *sep;
-    char *value;
-    int len = strlen(field);
-
-    p = strstr(data, field);
-    if (!p) {
-        return NULL;
-    }
-
-    sep = strchr(p, ':');
-    p = ++sep;
-    p++;
-
-    while (*p == ' ') p++;
-
-    q = strchr(p, ' ');
-    len = q - p;
-    value = flb_malloc(len + 1);
-    strncpy(value, p, len);
-    value[len] = '\0';
-
-    return value;
-}
-#endif
 
 static uint64_t calc_kb(unsigned long amount, unsigned int unit)
 {
@@ -119,7 +89,7 @@ static int mem_calc(struct flb_in_mem_info *m_info)
 
     /* This value seems to be MemAvailable if it is supported */
     /*     or MemFree on legacy linux */
-    m_info->mem_free      = calc_kb(info.freeram, info.mem_unit);
+    m_info->mem_free      = calc_kb(info.freeram + info.bufferram, info.mem_unit);
 
     m_info->mem_used      = m_info->mem_total - m_info->mem_free;
 


### PR DESCRIPTION
Signed-off-by: Nigel Stewart <nigels@nigels.com>

I noticed this in the course of testing with a Raspberry Pi 1 with only half a GiB of RAM.

While `free` is reporting a smallish about of used and free memory, a good portion is used for buffering and caching.  `fluent-bit` is reporting this "bufferram" as used, rather than available.
```
$ free
              total        used        free      shared  buff/cache   available
Mem:         443844       92616       71456        5260      279772      281844
Swap:        102396       14592       87804
```

```
[0] memory: [1570365689.889683667, {"Mem.total"=>443844, "Mem.used"=>365440, "Mem.free"=>78404, "Swap.total"=>102396, "Swap.used"=>14592, "Swap.free"=>87804}]
```