### PR TITLE
utils: avoid overflowing string buffer in flb_utils_write_str()

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -585,7 +585,7 @@ int flb_utils_write_str(char *buf, int *off, size_t size,
         }
         else if (c >= 0x80 && c <= 0xFFFF) {
             hex_bytes = flb_utf8_len(str + i);
-            if ((available - written) < (2 + hex_bytes)) {
+            if ((available - written) < 6) {
                 return FLB_FALSE;
             }
 


### PR DESCRIPTION
When we encode a multi-byte character in UTF-8 strings, we encode
each character in the format of '\\uXXXX' (e.g. 'à' => "\\u00e0").
Hence we use 6 bytes per character.

However, we previously did:

    hex_bytes = flb_utf8_len(str + i);
    if ((available - written) < (2 + hex_bytes)) {
        return FLB_FALSE;
    }

to see if the buffer has an enough space, and it almost always
miscalculated the byte size required; For instance, (2 + hex_bytes)
would evaluate to 4 (instead of 6) for 'à'.

This fixes the bug and should make flb-it-pack run fine on arm64.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>