### PR TITLE
in_netif: don't discard return value of init_entry_linux

### DIFF
--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -144,9 +144,7 @@ static int configure(struct flb_in_netif_config *ctx,
 
     ctx->first_snapshot = FLB_TRUE;    /* assign first_snapshot with FLB_TRUE */
 
-    init_entry_linux(ctx);
-
-    return 0;
+    return init_entry_linux(ctx);
 }
 
 static inline int is_specific_interface(struct flb_in_netif_config *ctx,


### PR DESCRIPTION
8b36716e277ea2ec75fdba9de93626bcaefc7880 fixed to return error value.
But the return value is thrown away.

My patch is to use the return value.