### PR TITLE
utils: fix buffer overrun on invalid UTF-8 characters

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -585,8 +585,11 @@ int flb_utils_write_str(char *buf, int *off, size_t size,
         }
         else if (c >= 0x80 && c <= 0xFFFF) {
             hex_bytes = flb_utf8_len(str + i);
-            if ((available - written) < 6) {
+            if (available - written < 6) {
                 return FLB_FALSE;
+            }
+            if (i + hex_bytes > str_len) {
+                break; /* skip truncated UTF-8 */
             }
 
             state = FLB_UTF8_ACCEPT;
@@ -612,8 +615,11 @@ int flb_utils_write_str(char *buf, int *off, size_t size,
         }
         else if (c > 0xFFFF) {
             hex_bytes = flb_utf8_len(str + i);
-            if ((available - written) < (4 + hex_bytes)) {
+            if (available - written < 6) {
                 return FLB_FALSE;
+            }
+            if (i + hex_bytes > str_len) {
+                break; /* skip truncated UTF-8 */
             }
 
             state = FLB_UTF8_ACCEPT;

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -110,8 +110,43 @@ void test_url_split()
     }
 }
 
+void test_write_str()
+{
+    char buf[10];
+    int size = sizeof(buf);
+    int off;
+    int ret;
+
+    off = 0;
+    ret = flb_utils_write_str(buf, &off, size, "a", 1);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK(memcmp(buf, "a", off) == 0);
+
+    off = 0;
+    ret = flb_utils_write_str(buf, &off, size, "\n", 1);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK(memcmp(buf, "\\n", off) == 0);
+
+    off = 0;
+    ret = flb_utils_write_str(buf, &off, size, "\xe3\x81\x82", 3);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK(memcmp(buf, "\\u3042", off) == 0);
+
+    // Truncated bytes
+    off = 0;
+    ret = flb_utils_write_str(buf, &off, size, "\xe3\x81\x82\xe3", 1);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK(memcmp(buf, "\\u3042", off) == 0);
+
+    // Error: buffer too small
+    off = 0;
+    ret = flb_utils_write_str(buf, &off, size, "aaaaaaaaaaa", 11);
+    TEST_CHECK(ret == FLB_FALSE);
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "url_split", test_url_split },
+    { "write_str", test_write_str },
     { 0 }
 };


### PR DESCRIPTION
This fixes the memory issue pointed out by https://github.com/fluent/fluent-bit/pull/1633#issuecomment-539936507.

The current flb_utils_write_str() tries to read "ahead" to decode
a multibyte UTF-8 sequence. While doing so, it never checks the
boundary of the input buffer.

This means that if we pass a truncated UTF-8 string like "\xe3",
it will read _beyond_ the boundary of the buffer and potentially
cause a crash.

This fixes the bug, and also add corresponding test cases for it.
