### PR TITLE
in_forward: implement basic TLS support

### DIFF
--- a/include/fluent-bit/ssl/flb_ssl.h
+++ b/include/fluent-bit/ssl/flb_ssl.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_SSL_H
+#define FLB_SSL_H
+
+#define FLB_SSL_WANT_POLLIN  -2
+#define FLB_SSL_WANT_POLLOUT -3
+
+struct flb_ssl_config;
+
+struct flb_ssl;
+
+struct flb_ssl *flb_ssl_server(void);
+
+void flb_ssl_free(struct flb_ssl *ctx);
+
+int flb_ssl_bind(struct flb_ssl *ctx, const char *ip, const char *port);
+
+int flb_ssl_getfd(struct flb_ssl *ctx);
+
+int flb_ssl_accept(struct flb_ssl *ctx, struct flb_ssl **cctx);
+
+int flb_ssl_read(struct flb_ssl *ctx, char *buf, int len);
+
+int flb_ssl_configure(struct flb_ssl *ctx, struct flb_ssl_config *config);
+
+/* flb_ssl_config */
+struct flb_ssl_config *flb_ssl_config_new(void);
+
+void flb_ssl_config_free(struct flb_ssl_config *config);
+
+void flb_ssl_config_set_verify(struct flb_ssl_config *config);
+
+void flb_ssl_config_set_insecure_noverify(struct flb_ssl_config *config);
+
+void flb_ssl_config_set_debug(struct flb_ssl_config *config);
+
+void flb_ssl_config_set_nodebug(struct flb_ssl_config *config);
+
+void flb_ssl_config_set_ca_path(struct flb_ssl_config *config, const char *path);
+
+void flb_ssl_config_set_ca_file(struct flb_ssl_config *config, const char *file);
+
+void flb_ssl_config_set_cert_file(struct flb_ssl_config *config, const char *file);
+
+void flb_ssl_config_set_key_file(struct flb_ssl_config *config, const char *file, const char *passwd);
+#endif

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -24,6 +24,10 @@
 #include <msgpack.h>
 #include <fluent-bit/flb_input.h>
 
+#ifdef FLB_HAVE_TLS
+#include <fluent-bit/ssl/flb_ssl.h>
+#endif
+
 struct flb_in_fw_config {
     int server_fd;               /* TCP server file descriptor  */
     size_t buffer_max_size;      /* Max Buffer size             */
@@ -39,6 +43,15 @@ struct flb_in_fw_config {
     struct mk_list connections;    /* List of active connections */
     struct mk_event_loop *evl;     /* Event loop file descriptor */
     struct flb_input_instance *in; /* Input plugin instace       */
+
+#ifdef FLB_HAVE_TLS
+    const char *tls_crt_file;
+    const char *tls_key_file;
+    const char *tls_key_passwd;
+
+    struct flb_ssl *ssl;
+    struct flb_ssl_config *ssl_config;
+#endif
 };
 
 #endif

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -93,6 +93,24 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         flb_debug("[in_fw] Listen='%s' TCP_Port=%s",
                   config->listen, config->tcp_port);
     }
+
+#ifdef FLB_HAVE_TLS
+    p = flb_input_get_property("tls.crt_file", i_ins);
+    if (p) {
+        config->tls_crt_file = p;
+    }
+
+    p = flb_input_get_property("tls.key_file", i_ins);
+    if (p) {
+        config->tls_key_file = p;
+    }
+
+    p = flb_input_get_property("tls.key_passwd", i_ins);
+    if (p) {
+        config->tls_key_passwd = p;
+    }
+#endif
+
     return config;
 }
 

--- a/plugins/in_forward/fw_conn.h
+++ b/plugins/in_forward/fw_conn.h
@@ -49,6 +49,10 @@ struct fw_conn {
     struct flb_in_fw_config *ctx;    /* Plugin configuration context      */
 
     struct mk_list _head;
+
+#ifdef FLB_HAVE_TLS
+    struct flb_ssl *ssl;
+#endif
 };
 
 struct fw_conn *fw_conn_add(int fd, struct flb_in_fw_config *ctx);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,13 @@ if(FLB_TLS)
     ${extra_libs}
     "mbedtls"
     )
+
+  add_subdirectory(ssl)
+
+  set(FLB_DEPS
+    ${FLB_DEPS}
+    flb-ssl
+    )
 endif()
 
 if(FLB_PROXY_GO)

--- a/src/ssl/CMakeLists.txt
+++ b/src/ssl/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+project(flb-ssl)
+
+set(src
+  flb_ssl.c
+  flb_ssl_config.c)
+
+add_library(flb-ssl STATIC ${src})
+
+if(FLB_JEMALLOC)
+  target_link_libraries(flb-ssl libjemalloc)
+endif()

--- a/src/ssl/README.md
+++ b/src/ssl/README.md
@@ -1,0 +1,87 @@
+Fluent Bit SSL Interface
+========================
+
+`flb_ssl` is a simple interface for creating TLS connections, both for
+servers and clients.
+
+The interface is loosely based on libtls (https://www.libressl.org/),
+and intended to make it easier to use TLS/SSL.
+
+HOW TO CREATE A TLS SERVER
+--------------------------
+
+First, create a new config object.
+
+ * Call `flb_ssl_config()` to create a config object.
+ * Call `flb_ssl_set_key_file()` and `flb_ssl_set_cert_file()`.
+
+Then create a server context.
+
+ * Call `flb_ssl_server()` to create a new server context.
+ * Call `flb_ssl_configure()` to configure the context
+ * Call `flb_ssl_bind()` to bind to ip:port
+
+Now you can accept a new connection.
+
+ * Call `flb_ssl_accept()` to accept a new connection.
+ * Call `flb_ssl_read()` or `flb_ssl_write()` on the connection context.
+ * Call `flb_ssl_free()` to clean up the connection.
+
+On exit:
+
+ * Call `flb_ssl_free()` to clean up the listening socket.
+ * Call `flb_ssl_config_free()` to cean up the config object.
+
+EXAMPLE SERVER
+--------------
+
+```
+#include <fluent-bit/ssl/flb_ssl.h>
+
+int main(void) {
+    struct flb_ssl *ctx = NULL;
+    struct flb_ssl *cctx = NULL;
+    struct flb_ssl_config *config = NULL;
+    char buf = "Hello World!";
+    int bytes;
+    int ret;
+
+    /* Configure */
+    config = flb_ssl_config_new();
+    if (config == NULL)
+        goto exit;
+
+    flb_ssl_set_cert_file(config, "/etc/fluent.crt");
+    flb_ssl_set_key_file(config, "/etc/fluent.key", "password");
+
+    /* Create server */
+    ctx = flb_ssl_server();
+    if (ctx == NULL)
+        goto exit;
+
+    if (flb_ssl_configure(ctx, config))
+        goto exit;
+
+    if (flb_ssl_bind(ctx, host, port))
+        goto exit;
+
+    /* Listening ... */
+    while (1) {
+        if (flb_ssl_accept(ctx, &cctx))
+            goto exit;
+
+        bytes = 0;
+        while (bytes < strlen(buf)) {
+            n = flb_ssl_write(cctx, buf + bytes, strlen(buf) - bytes);
+            if (n < 0) {
+                break;
+            bytes += n;
+        }
+        flb_ssl_free(cctx);
+    }
+exit:
+    flb_ssl_config_free(config);
+    flb_ssl_free(ctx);
+    return 0;
+}
+```

--- a/src/ssl/flb_ssl.c
+++ b/src/ssl/flb_ssl.c
@@ -1,0 +1,287 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/* This module is loosely inspired by libtls */
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
+
+#include <fluent-bit/ssl/flb_ssl.h>
+#include "flb_ssl_internal.h"
+
+static struct flb_ssl *flb_ssl_new(void)
+{
+    struct flb_ssl *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct flb_ssl));
+    if (ctx == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    mbedtls_ssl_init(&ctx->mbed_ssl);
+    mbedtls_ssl_config_init(&ctx->mbed_config);
+    mbedtls_entropy_init(&ctx->mbed_entropy);
+    mbedtls_ctr_drbg_init(&ctx->mbed_ctr_drbg);
+    mbedtls_x509_crt_init(&ctx->mbed_ca_cert);
+    mbedtls_x509_crt_init(&ctx->mbed_cert);
+    mbedtls_pk_init(&ctx->mbed_key);
+    mbedtls_net_init(&ctx->mbed_conn);
+
+    return ctx;
+}
+
+struct flb_ssl *flb_ssl_server(void)
+{
+    struct flb_ssl *ctx = flb_ssl_new();
+
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    ctx->flags |= FLB_SSL_SERVER;
+
+    return ctx;
+}
+
+struct flb_ssl *flb_ssl_server_conn(struct flb_ssl *ctx)
+{
+    struct flb_ssl *cctx = flb_ssl_new();
+
+    if (cctx == NULL) {
+        return NULL;
+    }
+
+    cctx->config = ctx->config;
+
+    cctx->flags |= FLB_SSL_SERVER_CONN;
+
+    return cctx;
+}
+
+void flb_ssl_free(struct flb_ssl *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+    mbedtls_ssl_close_notify(&ctx->mbed_ssl);
+    mbedtls_net_free(&ctx->mbed_conn);
+    mbedtls_ssl_free(&ctx->mbed_ssl);
+    mbedtls_entropy_free(&ctx->mbed_entropy);
+    mbedtls_ctr_drbg_free(&ctx->mbed_ctr_drbg);
+    mbedtls_ssl_config_free(&ctx->mbed_config);
+    mbedtls_x509_crt_free(&ctx->mbed_cert);
+    mbedtls_pk_free(&ctx->mbed_key);
+    flb_free(ctx);
+}
+
+int flb_ssl_bind(struct flb_ssl *ctx, const char *ip, const char *port)
+{
+    int ret;
+
+    ret = mbedtls_net_bind(&ctx->mbed_conn, ip, port, MBEDTLS_NET_PROTO_TCP);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    return 0;
+}
+
+int flb_ssl_getfd(struct flb_ssl *ctx)
+{
+    return ctx->mbed_conn.fd;
+}
+
+int flb_ssl_accept(struct flb_ssl *ctx, struct flb_ssl **cctx)
+{
+    int ret;
+
+    *cctx = flb_ssl_server_conn(ctx);
+    if (*cctx == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = mbedtls_ssl_setup(&(*cctx)->mbed_ssl, &ctx->mbed_config);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    ret = mbedtls_net_accept(&ctx->mbed_conn, &(*cctx)->mbed_conn,
+                             NULL, 0, NULL);
+    if (ret) {
+        flb_ssl_error(ret);
+        flb_ssl_free(*cctx);
+        return -1;
+    }
+
+    mbedtls_ssl_set_bio(&(*cctx)->mbed_ssl, &(*cctx)->mbed_conn,
+                        mbedtls_net_send, mbedtls_net_recv, NULL);
+
+    return 0;
+}
+
+int flb_ssl_handshake(struct flb_ssl *ctx)
+{
+    int ret;
+
+    ret = mbedtls_ssl_handshake(&ctx->mbed_ssl);
+    if (ret == MBEDTLS_ERR_SSL_WANT_READ) {
+        return FLB_SSL_WANT_POLLIN;
+    }
+    if (ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+        return FLB_SSL_WANT_POLLOUT;
+    }
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+    ctx->state |= FLB_SSL_HANDSHAKE_COMPLETE;
+    return 0;
+}
+
+int flb_ssl_read(struct flb_ssl *ctx, char *buf, int len)
+{
+    int ret;
+
+    if ((ctx->state & FLB_SSL_HANDSHAKE_COMPLETE) == 0) {
+        ret = flb_ssl_handshake(ctx);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    ret = mbedtls_ssl_read(&ctx->mbed_ssl, (unsigned char *) buf, len);
+
+    if (ret == MBEDTLS_ERR_SSL_WANT_READ) {
+        return FLB_SSL_WANT_POLLIN;
+    }
+    if (ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+        return FLB_SSL_WANT_POLLOUT;
+    }
+    if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+        return 0;
+    }
+    if (ret < 0) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+    return ret;
+}
+
+int flb_ssl_configure(struct flb_ssl *ctx, struct flb_ssl_config *config)
+{
+    int ret;
+
+    ctx->config = config;
+
+    ret = mbedtls_ctr_drbg_seed(&ctx->mbed_ctr_drbg,
+                                mbedtls_entropy_func,
+                                &ctx->mbed_entropy,
+                                NULL,
+                                0);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    mbedtls_ssl_conf_rng(&ctx->mbed_config,
+                         mbedtls_ctr_drbg_random,
+                         &ctx->mbed_ctr_drbg);
+
+    if (config->debug > -1) {
+        mbedtls_debug_set_threshold(config->debug);
+        mbedtls_ssl_conf_dbg(&ctx->mbed_config, flb_ssl_debug, NULL);
+    }
+
+    if (ctx->flags & FLB_SSL_SERVER) {
+        return flb_ssl_configure_server(ctx);
+    }
+
+    return 0;
+}
+
+int flb_ssl_configure_server(struct flb_ssl *ctx)
+{
+    int ret;
+
+    if (ctx->config->cert_file == NULL || ctx->config->key_file == NULL)  {
+        flb_error("[SSL] must set both cert and key");
+        return -1;
+    }
+
+    ret = mbedtls_ssl_config_defaults(&ctx->mbed_config,
+                                      MBEDTLS_SSL_IS_SERVER,
+                                      MBEDTLS_SSL_TRANSPORT_STREAM,
+                                      MBEDTLS_SSL_PRESET_DEFAULT);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    if (ctx->config->verify_client) {
+        mbedtls_ssl_conf_authmode(&ctx->mbed_config,
+                                  MBEDTLS_SSL_VERIFY_REQUIRED);
+    }
+    else {
+        mbedtls_ssl_conf_authmode(&ctx->mbed_config, MBEDTLS_SSL_VERIFY_NONE);
+    }
+
+    ret = mbedtls_x509_crt_parse_file(&ctx->mbed_cert,
+                                      ctx->config->cert_file);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    ret = mbedtls_pk_parse_keyfile(&ctx->mbed_key,
+                                   ctx->config->key_file,
+                                   ctx->config->key_passwd);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    ret = mbedtls_ssl_conf_own_cert(&ctx->mbed_config,
+                                    &ctx->mbed_cert,
+                                    &ctx->mbed_key);
+    if (ret) {
+        flb_ssl_error(ret);
+        return -1;
+    }
+
+    return 0;
+}
+
+void flb_ssl_debug(void *ctx, int level, const char *file, int line,
+                   const char *str)
+{
+    (void) level;
+    flb_debug("[ssl] %s %04d: %.*s", file, line, strlen(str) - 1, str);
+}
+
+void flb_ssl_error_internal(int ret, char *file, int line)
+{
+    char buf[72];
+    mbedtls_strerror(ret, buf, sizeof(buf));
+    flb_error("[ssl] %s:%04d: %s", file, line, buf);
+}

--- a/src/ssl/flb_ssl_config.c
+++ b/src/ssl/flb_ssl_config.c
@@ -1,0 +1,102 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/ssl/flb_ssl.h>
+#include <fluent-bit/flb_mem.h>
+#include "flb_ssl_internal.h"
+
+struct flb_ssl_config *flb_ssl_config_new(void)
+{
+    struct flb_ssl_config *config;
+
+    config = flb_calloc(1, sizeof(struct flb_ssl_config));
+    if (config == NULL) {
+        return NULL;
+    }
+
+    flb_ssl_config_set_verify(config);
+    flb_ssl_config_set_nodebug(config);
+
+    return config;
+}
+
+void flb_ssl_config_free(struct flb_ssl_config *config)
+{
+    if (config == NULL) {
+        return;
+    }
+    flb_free(config);
+}
+
+void flb_ssl_config_set_verify(struct flb_ssl_config *config)
+{
+    config->verify = 1;
+}
+
+void flb_ssl_config_set_insecure_noverify(struct flb_ssl_config *config)
+{
+    config->verify = 0;
+}
+
+void flb_ssl_config_set_verify_client(struct flb_ssl_config *config)
+{
+    config->verify_client = 1;
+}
+
+void flb_ssl_config_set_noverify_client(struct flb_ssl_config *config)
+{
+    config->verify_client = 0;
+}
+
+void flb_ssl_config_set_debug(struct flb_ssl_config *config)
+{
+    config->debug = 5;
+}
+
+void flb_ssl_config_set_nodebug(struct flb_ssl_config *config)
+{
+    config->debug = -1;
+}
+
+void flb_ssl_config_set_ca_path(struct flb_ssl_config *config,
+                                const char *path)
+{
+    config->ca_path = path;
+}
+
+void flb_ssl_config_set_ca_file(struct flb_ssl_config *config,
+                                const char *file)
+{
+    config->ca_file = file;
+}
+
+void flb_ssl_config_set_cert_file(struct flb_ssl_config *config,
+                                  const char *file)
+{
+    config->cert_file = file;
+}
+
+void flb_ssl_config_set_key_file(struct flb_ssl_config *config,
+                                 const char *file,
+                                 const char *passwd)
+{
+    config->key_file = file;
+    config->key_passwd = passwd;
+}

--- a/src/ssl/flb_ssl_internal.h
+++ b/src/ssl/flb_ssl_internal.h
@@ -1,0 +1,73 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_SSL_INTERNAL_H
+#define FLB_SSL_INTERNAL_H
+
+#include <mbedtls/net.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/error.h>
+
+#define FLB_SSL_CLIENT      1
+#define FLB_SSL_SERVER      2
+#define FLB_SSL_SERVER_CONN 4
+
+#define FLB_SSL_CONNECTED           1
+#define FLB_SSL_HANDSHAKE_COMPLETE  2
+
+struct flb_ssl_config {
+    const char *ca_path;
+    const char *ca_file;
+    int verify;
+    int verify_client;
+    int debug;
+    const char *cert_file;
+    const char *key_file;
+    const char *key_passwd;
+};
+
+struct flb_ssl {
+    struct flb_ssl_config *config;
+    unsigned int flags;
+    unsigned int state;
+    mbedtls_ssl_context mbed_ssl;
+    mbedtls_ssl_config mbed_config;
+    mbedtls_entropy_context mbed_entropy;
+    mbedtls_ctr_drbg_context mbed_ctr_drbg;
+    mbedtls_x509_crt mbed_ca_cert;
+    mbedtls_x509_crt mbed_cert;
+    mbedtls_pk_context mbed_key;
+    mbedtls_net_context mbed_conn;
+};
+
+int flb_ssl_handshake(struct flb_ssl *ctx);
+int flb_ssl_configure_server(struct flb_ssl *ctx);
+
+void flb_ssl_debug(void *ctx, int level, const char *file, int line,
+                   const char *str);
+
+void flb_ssl_error_internal(int ret, char *file, int line);
+
+#define flb_ssl_error(ret) flb_ssl_error_internal(ret, __FILE__, __LINE__)
+
+#endif

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -84,6 +84,10 @@ foreach(source_file ${UNIT_TESTS_FILES})
       target_link_libraries(${source_file_we} flb-sp)
     endif()
 
+    if(FLB_HAVE_TLS)
+      target_link_libraries(${source_file_we} flb-ssl)
+    endif()
+
     target_link_libraries(${source_file_we} fluent-bit-static)
 
     add_test(NAME ${source_file_we}


### PR DESCRIPTION
This patch implements SSL/TLS support on in_forward and enables it to
accept secure connections.

You can set up a secure forward server using the following configuration:

    [INPUT]
      Name forward
      tls.crt_file /etc/ssl/fluent.crt
      tls.key_file /etc/ssl/fluent.key
      tls.key_passwd password

To ease the task of managing TLS server, I added `flb_ssl` family functions
that provides a set of simpler interface to establish TLS connections (loosely
based on the design of libtls, OpenBSD's SSL/TLS API).

With this patch merged, I can confirm that Fluent Bit can receive records
from Fluentd (or Fluent Bit) through TLS.