### PR TITLE
in_mem: don't discard return value of human_readable_size(#1625)

### DIFF
--- a/plugins/in_mem/proc.c
+++ b/plugins/in_mem/proc.c
@@ -169,6 +169,11 @@ struct proc_task *proc_stat(pid_t pid, int page_size)
     /* Internal conversion */
     t->proc_rss    = (t->rss * page_size);
     t->proc_rss_hr = human_readable_size(t->proc_rss);
+    if ( t->proc_rss_hr == NULL ) {
+        flb_free(buf);
+        flb_free(t);
+        return NULL;
+    }
 
     flb_free(buf);
     return t;


### PR DESCRIPTION
To fix #1625  .

The return value of  human_readable_size() is also thrown away.
My patch is to use it.