### PR TITLE
scripts: add scripts to override timestamp with float/integer timestamp

### DIFF
--- a/scripts/override_time.lua
+++ b/scripts/override_time.lua
@@ -1,0 +1,23 @@
+--[[
+   This Lua script is to override timestamp with integer/float epoch time.
+   https://github.com/fluent/fluent-bit/issues/662
+
+   sample input is
+   [XXXXX.XXXXX, {"KEY_OF_TIMESTAMP"=>1530239065.807368, "data"=>"sample"}]
+   
+   expected output is
+   [1530239065.807368040, {"KEY_OF_TIMESTAMP"=>1530239065.807368, "data"=>"sample"}]
+
+
+   sample configuration:
+   [FILTER]
+    Name lua
+    Match *.*
+    script override_time.lua
+    call   override_time
+]]
+
+function override_time(tag, timestamp, record)
+         -- modify KEY_OF_TIMESTAMP properly.
+         return 1, record["KEY_OF_TIMESTAMP"], record
+end


### PR DESCRIPTION
I added a lua script to override timestamp.

We can override with `Time_key` option.
However it doesn't work when the value is integer/float.
https://github.com/fluent/fluent-bit/issues/662

This script is to solve the issue.

This is an example to override with a value of `KEY_OF_TIMESTAMP` which is an integer.

a.conf
```python
[INPUT]
    Name dummy
    Tag  dummy.data
    Dummy {"KEY_OF_TIMESTAMP":1530239065, "data":"sample"}

[FILTER]
    Name lua
    Match *.*
    script override_time.lua
    call   override_time

[OUTPUT]
    Name stdout
    Match *
```

result is
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.4.0
Copyright (C) Treasure Data

[2019/10/13 07:19:28] [ info] [storage] initializing...
[2019/10/13 07:19:28] [ info] [storage] in-memory
[2019/10/13 07:19:28] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2019/10/13 07:19:28] [ info] [engine] started (pid=44427)
[2019/10/13 07:19:28] [ info] [sp] stream processor started
[0] dummy.data: [1530239065.000000000, {"data"=>"sample", "KEY_OF_TIMESTAMP"=>1530239065.000000}]
[1] dummy.data: [1530239065.000000000, {"data"=>"sample", "KEY_OF_TIMESTAMP"=>1530239065.000000}]
[2] dummy.data: [1530239065.000000000, {"data"=>"sample", "KEY_OF_TIMESTAMP"=>1530239065.000000}]
[3] dummy.data: [1530239065.000000000, {"data"=>"sample", "KEY_OF_TIMESTAMP"=>1530239065.000000}]
```