### PR TITLE
build: don't build out_kafka on Windows by default

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -63,7 +63,7 @@ set(FLB_OUT_STDOUT            Yes)
 set(FLB_OUT_LIB                No)
 set(FLB_OUT_NULL              Yes)
 set(FLB_OUT_FLOWCOUNTER       Yes)
-set(FLB_OUT_KAFKA             Yes)
+set(FLB_OUT_KAFKA              No)
 set(FLB_OUT_KAFKA_REST         No)
 
 # FILTER plugins


### PR DESCRIPTION
69fffab inadvertently introduced dependency on OpenSSL (via librdkafka),
which made it impossible to run Fluent Bit on many Windows platforms where
ssleay32.dll and libeay32.dll do not exist.

This is a simple patch for the issue and should fix the "Program can't
start because SSLEAY32.dll is missing" error (#1646 and https://github.com/fluent/fluent-bit/issues/960#issuecomment-526455732)

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>