### PR TITLE
es_out: trace log payload for HTTP statuses > 201

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -587,6 +587,7 @@ void cb_es_flush(const void *data, size_t bytes,
         /* The request was issued successfully, validate the 'error' field */
         flb_debug("[out_es] HTTP Status=%i URI=%s", c->resp.status, ctx->uri);
         if (c->resp.status != 200 && c->resp.status != 201) {
+            flb_trace("[es_out] payload response: %s", c->resp.payload);
             goto retry;
         }
 


### PR DESCRIPTION
This patch introduces logging of response payloads from the server when the status code is not 200 or 201.