### PR TITLE
docker: replace deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY conf/fluent-bit.conf \
      /fluent-bit/etc/
 
 FROM gcr.io/distroless/cc
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
+LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
 LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
 COPY --from=builder /usr/lib/x86_64-linux-gnu/*sasl* /usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
`MAINTAINER` is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile

We should use `LABEL` instruction like `LABEL maintainer=""`