### PR TITLE
in_netif: fix uninitialized variable to malloc (#1680)

### DIFF
--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -71,13 +71,13 @@ static int init_entry_linux(struct flb_in_netif_config *ctx)
 {
     int i;
 
+    ctx->entry_len = sizeof(entry_name_linux) / sizeof(struct entry_define);
     ctx->entry = flb_malloc(sizeof(struct netif_entry) * ctx->entry_len);
     if (!ctx->entry) {
         flb_errno();
         return -1;
     }
 
-    ctx->entry_len = sizeof(entry_name_linux) / sizeof(struct entry_define);
     for(i = 0; i < ctx->entry_len; i++) {
         ctx->entry[i].name     = entry_name_linux[i].name;
         ctx->entry[i].name_len = strlen(entry_name_linux[i].name);


### PR DESCRIPTION
To fix #1680 
in_netif uses uninitialized variable `ctx->entry_len` to allocate memory.
This patch is to fix it.