### PR TITLE
in_syslog: do check the return value of flb_utils_size_to_bytes()

### DIFF
--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -35,6 +35,7 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
 {
     const char *tmp;
     char port[16];
+    int64_t size;
     struct flb_syslog *ctx;
 
     ctx = flb_calloc(1, sizeof(struct flb_syslog));
@@ -119,7 +120,13 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *i_ins,
         ctx->buffer_chunk_size = FLB_SYSLOG_CHUNK; /* 32KB */
     }
     else {
-        ctx->buffer_chunk_size = flb_utils_size_to_bytes(tmp);
+        size = flb_utils_size_to_bytes(tmp);
+        if (size < 1) {
+            flb_error("[in_syslog] invalid buffer_chunk_size '%s'", tmp);
+            syslog_conf_destroy(ctx);
+            return NULL;
+        }
+        ctx->buffer_chunk_size = size;
     }
 
     /* Buffer Max Size */


### PR DESCRIPTION
The point is that flb_utils_size_to_bytes() can return -1 if an invalid
numeric string is given. In that case, buffer_chunk_size becomes a
gigantic number due to the implicit conversion of -1 into size_t.

This has been causing opaque "cannot allocate memory" errors when some
users fail to supply a valid value to the 'Buffer_Chunk_Size' option (#1685).

Let's check the return value explicitly here, and notify users promptly
if buffer_chunk_size is clearly wrong.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>