### PR TITLE
build: fix unit test failures occurring on Travis (arm64/clang)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ script: |
   echo "CC = $CC, CXX = $CXX"
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
   sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
+  sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
   sudo usermod -a -G systemd-journal $(id -un)
   sudo -E su -p travis -c "PATH=$PATH ci/do-ut"
 addons:
@@ -86,5 +87,6 @@ addons:
     packages:
       - gcc-7
       - g++-7
+      - clang-6.0
       - libsystemd-dev
       - gcovr


### PR DESCRIPTION
We're right now seeing persistent test failures on Travis (arm64/clang).

 * https://travis-ci.org/fluent/fluent-bit/builds/601256615
 * https://travis-ci.org/fluent/fluent-bit/builds/602281393
 * https://travis-ci.org/fluent/fluent-bit/builds/601502335

I noticed that Travis downgraded the clang version to 3.8 since last week's
build and coincidentally the failure started to occur (Before that build,
Travis used clang 6.0.0 -- I'm not sure what made it switch).

This patch tweaks travis.yml so that Travis uses clang-6 consistently.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>