### PR TITLE
in_tcp: prevent tcp_conn_event() from truncating data

### DIFF
--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -218,6 +218,7 @@ int tcp_conn_event(void *data)
                       conn->buf_data[0]);
             consume_bytes(conn->buf_data, 1, conn->buf_len);
             conn->buf_len--;
+            conn->buf_data[conn->buf_len] = '\0';
         }
 
         /* JSON Format handler */
@@ -236,9 +237,12 @@ int tcp_conn_event(void *data)
         }
         else if (ctx->format == FLB_TCP_FMT_NONE) {
             ret_payload = parse_payload_none(conn);
-            if (ret_payload <= 0) {
+            if (ret_payload == 0) {
+                return -1;
+            }
+            else if (ret_payload == -1) {
                 conn->buf_len = 0;
-                return (int) ret_payload;
+                return -1;
             }
         }
 


### PR DESCRIPTION
Currently, the event callback discards the received data when
parse_payload_none() returns a non-positive code, whereas it actually
means "Please retry later when you received the remaining data".

This was causing data loss when in_tcp received a long line (a few
hundred kilobytes in length.). 

This patch should resolves #1702.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>