### PR TITLE
in_tail: free memory if allocated by expand_tilde

### DIFF
--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -152,8 +152,10 @@ static inline int do_glob(const char *pattern, int flags,
     /* invoke glob with new parameters */
     ret = glob(pattern, new_flags, NULL, pglob);
 
-    /* remove temporary buffer */
-    if (tmp != NULL) {
+    /* remove temporary buffer, if allocated by expand_tilde above.
+     * Note that this buffer is only used for libc implementations
+     * that do not support the GLOB_TILDE flag, like musl. */
+    if (tmp != NULL && tmp != pattern) {
         flb_free(tmp);
     }
 


### PR DESCRIPTION
Only free memory when it is actually allocated by expand_tilde, otherwise we're freeing memory that shouldn't be freed (at least not here).

Verified that fix is working on a musl-based ARMv7 system.

Signed-off-by: Jan Willem Janssen <j.w.janssen@lxtreme.nl>