### PR TITLE
in_tail: adding fifo support

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -585,7 +585,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     struct mk_list *head;
     struct flb_tail_file *file;
 
-    if (!S_ISREG(st->st_mode)) {
+    if (!S_ISREG(st->st_mode) && !S_ISFIFO(st->st_mode)) {
         return -1;
     }
 
@@ -606,7 +606,11 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
 #ifdef _MSC_VER
     fd = open_file(path);
 #else
-    fd = open(path, O_RDONLY);
+    if(S_ISREG(st->st_mode)) {
+        fd = open(path, O_RDONLY);
+    } else {
+        fd = open(path, O_RDONLY | O_NONBLOCK);
+    }
 #endif
     if (fd == -1) {
         flb_errno();

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -108,7 +108,7 @@ static int tail_fs_event(struct flb_input_instance *i_ins,
         }
 
         /* Check if the file was truncated */
-        if (file->offset > st.st_size) {
+        if ((S_ISREG(st.st_mode)) && file->offset > st.st_size) {
             offset = lseek(file->fd, 0, SEEK_SET);
             if (offset == -1) {
                 flb_errno();

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -130,7 +130,7 @@ static int tail_fs_check(struct flb_input_instance *i_ins,
         flb_free(name);
 
         /* Check if the file was truncated */
-        if (file->offset > st.st_size) {
+        if (S_ISREG(st.st_mode) && file->offset > st.st_size) {
             offset = lseek(file->fd, 0, SEEK_SET);
             if (offset == -1) {
                 flb_errno();

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -251,7 +251,7 @@ int flb_tail_scan(const char *path, struct flb_tail_config *ctx)
     /* For every entry found, generate an output list */
     for (i = 0; i < globbuf.gl_pathc; i++) {
         ret = stat(globbuf.gl_pathv[i], &st);
-        if (ret == 0 && S_ISREG(st.st_mode)) {
+        if (ret == 0 && (S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode))) {
             /* Check if this file is blacklisted */
             if (tail_is_excluded(globbuf.gl_pathv[i], ctx) == FLB_TRUE) {
                 flb_debug("[in_tail] excluded=%s", globbuf.gl_pathv[i]);
@@ -305,7 +305,7 @@ int flb_tail_scan_callback(struct flb_input_instance *i_ins,
     /* For every entry found, check if is already registered or not */
     for (i = 0; i < globbuf.gl_pathc; i++) {
         ret = stat(globbuf.gl_pathv[i], &st);
-        if (ret == 0 && S_ISREG(st.st_mode)) {
+        if (ret == 0 && (S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode))) {
             /* Check if this file is blacklisted */
             if (tail_is_excluded(globbuf.gl_pathv[i], ctx) == FLB_TRUE) {
                 continue;


### PR DESCRIPTION
There could be two use cases for this, one is for testing configurations  
and the other one for parsing the stdout of some process.

There is one lseek in tail_file.c on line 759 which only seems to be
required in case of db_file support which seems safe.
The other two lseek's are used in case a file got truncated which
are checked now for file type. And opening the fifo is NON_BLOCKING.

Was not able to understand how testing works; if the change is okay
I would be happy to add some test.

Signed-off-by: RomanManz <roman.manz.fsm@googlemail.com>