### PR TITLE
ci: avoid using ld.gold to fix "ELF section name out of range" error

### DIFF
--- a/ci/do-ut
+++ b/ci/do-ut
@@ -38,16 +38,6 @@ fi
 # If no v6, disable that test
 [[ ! $(ip a) =~ ::1 ]] && SKIP="$SKIP -DFLB_WITHOUT_flb-it-network=1"
 
-if [ "$CC" = "gcc" ]
-then
-    if [[ "$FLB_OPT" =~ SANITIZE  ]]
-    then
-        # https://stackoverflow.com/questions/50024731/ld-unrecognized-option-push-state-no-as-needed
-        echo Set gold linker to workaround ubsan
-        LDFLAG=-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
-    fi
-fi
-
 GLOBAL_OPTS="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
 set -e
 mkdir -p build


### PR DESCRIPTION
We are seeing unit test failures on Travis CI.

> /usr/bin/ld.gold: fatal error: ../../library/libflb-plugin-out_plot.a: ELF section name out of range
> collect2: error: ld returned 1 exit status

It looks to me that these failures are occurring only on ARM systems
with sanitizers enabled. The possible cause is we're using a different
linker when sanitizers enabled.

This commit removes the relevant part in the unit test script.