### PR TITLE
out_forward: don't handshake when the connection has been used

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1020,8 +1020,9 @@ static void cb_forward_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    /* Shared Key */
-    if (fc->shared_key) {
+    /* Shared Key
+     * if ka_count > 0 it means the handshake has already been done lately */
+    if (fc->shared_key && u_conn->ka_count == 0) {
         ret = secure_forward_handshake(u_conn, fc, ctx);
         flb_debug("[out_fw] handshake status = %i", ret);
         if (ret == -1) {

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -338,6 +338,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
 
         flb_debug("[upstream] KA connection #%i to %s:%i is now available",
                   conn->fd, conn->u->tcp_host, conn->u->tcp_port);
+        conn->ka_count++;
         return 0;
     }
 


### PR DESCRIPTION
The forward plugin shouldn't try to do the secure handshake if it
already used the connection kept open by the keepalive. It only applies
if the user sets the share_key setting.

The plugin was waiting for the HELO message forever from the server.