### PR TITLE
out_stackdriver: support k8s resource types

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -937,11 +937,26 @@ int flb_kube_dummy_meta_get(char **out_buf, size_t *out_size)
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-    msgpack_pack_map(&mp_pck, 1);
+    msgpack_pack_map(&mp_pck, 4);
     msgpack_pack_str(&mp_pck, 5 /* dummy */ );
     msgpack_pack_str_body(&mp_pck, "dummy", 5);
     msgpack_pack_str(&mp_pck, len);
     msgpack_pack_str_body(&mp_pck, stime, len);
+
+    msgpack_pack_str(&mp_pck, 14 /* container_name */ );
+    msgpack_pack_str_body(&mp_pck, "container_name", 14);
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "dummy-container", 15);
+
+    msgpack_pack_str(&mp_pck, 8 /* pod_name */ );
+    msgpack_pack_str_body(&mp_pck, "pod_name", 8);
+    msgpack_pack_str(&mp_pck, 9);
+    msgpack_pack_str_body(&mp_pck, "dummy-pod", 9);
+
+    msgpack_pack_str(&mp_pck, 14 /* namespace_name */ );
+    msgpack_pack_str_body(&mp_pck, "namespace_name", 14);
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "dummy-namespace", 15);
 
     *out_buf = mp_sbuf.data;
     *out_size = mp_sbuf.size;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -68,6 +68,8 @@ struct flb_stackdriver {
 
     /* other */
     flb_sds_t resource;
+    flb_sds_t location;
+    flb_sds_t cluster_name;
     flb_sds_t severity_key;
 
     /* oauth2 context */


### PR DESCRIPTION
If k8s_cluster is specified for resource type, set type and labels
appropriately based on the data emitted from the kube filter.

Signed-off-by: arabustams <g.smatsubara@gmail.com>