### PR TITLE
build: enable "filter_nest" on Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -74,7 +74,7 @@ set(FLB_FILTER_STDOUT         Yes)
 set(FLB_FILTER_PARSER         Yes)
 set(FLB_FILTER_KUBERNETES      No)
 set(FLB_FILTER_THROTTLE        No)
-set(FLB_FILTER_NEST            No)
+set(FLB_FILTER_NEST           Yes)
 set(FLB_FILTER_LUA            Yes)
 set(FLB_FILTER_RECORD_MODIFIER Yes)
 


### PR DESCRIPTION
We received a bug report that pointed out "filter_nest" being absent
from Windows build.

A basic testing reveals the plugin was already Windows-compatible
and all we needed was to turn on the compile flag on Windows. This
patch contains that changeset.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>