### PR TITLE
Change the default _type to be _doc

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -24,7 +24,7 @@
 #define FLB_ES_DEFAULT_HOST       "127.0.0.1"
 #define FLB_ES_DEFAULT_PORT       92000
 #define FLB_ES_DEFAULT_INDEX      "fluent-bit"
-#define FLB_ES_DEFAULT_TYPE       "flb_type"
+#define FLB_ES_DEFAULT_TYPE       "_doc"
 #define FLB_ES_DEFAULT_PREFIX     "logstash"
 #define FLB_ES_DEFAULT_TIME_FMT   "%Y.%m.%d"
 #define FLB_ES_DEFAULT_TIME_KEY   "@timestamp"


### PR DESCRIPTION
In order to be compatible with the new versions of ElasticSearch which effectively are getting rid of
_type, we should change the default type to be "_doc"

As per the ElasticSearch forum discussion at:

https://discuss.elastic.co/t/7-0-1-template-with-geo-point-geoip-processor-in-pipeline-bulk-crash/182039/3

this seems to be due to not specifying a _type when creating the mapping, at which point it defaults
to "_doc".

Later when performing a bulk operation (indexing) we specifying that _type is "flb_type" which then
causes the error to be thrown about multiple types not being allowed:

"Rejecting mapping update to [logs-2019.11.16] as the final mapping would have more than 1 type: [_doc, flb_type]"

Another possible solution to this issue might be to use the "flb_type" when creating the index (and mappings)
initially, however I'm not sure whether this type is being used for anything (we are not filtering or querying
based on it).

Issue(s): #1359