### PR TITLE
update CMakefile to resolve issue

### DIFF
--- a/lib/tutf8e/CMakeLists.txt
+++ b/lib/tutf8e/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_C_FLAGS "-Os -Wall")
 
 include_directories(include)
 add_library(tutf8e STATIC src/tutf8e.c)
+set_property(TARGET tutf8e PROPERTY C_STANDARD 99)
 
 add_executable(tutf8e-test test/test.c)
 target_link_libraries(tutf8e-test tutf8e)

--- a/lib/tutf8e/CMakeLists.txt
+++ b/lib/tutf8e/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_C_FLAGS "-Os -Wall")
 
 include_directories(include)
 add_library(tutf8e STATIC src/tutf8e.c)
-set_property(TARGET tutf8e PROPERTY C_STANDARD 99)
 
 add_executable(tutf8e-test test/test.c)
 target_link_libraries(tutf8e-test tutf8e)

--- a/lib/tutf8e/codegen.py
+++ b/lib/tutf8e/codegen.py
@@ -80,7 +80,8 @@ with open('src/tutf8e.c', 'w') as src:
 
 int tutf8e_string_length(const uint16_t *table, const char *input, size_t *ilen, size_t *olen)
 {
-  for (const unsigned char *i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       *olen += 1;
@@ -128,7 +129,8 @@ int tutf8e_string_encode(const uint16_t *table, const char *i, char *o, size_t *
 
 int tutf8e_buffer_length(const uint16_t *table, const char *input, size_t ilen, size_t *length)
 {
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       ++*length;
@@ -157,7 +159,8 @@ int tutf8e_buffer_encode(const uint16_t *table, const char *input, size_t ilen, 
 {
   size_t left = *olen;
   unsigned char *o = (unsigned char *) output;
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       if (left<1) return TUTF8E_TOOLONG;

--- a/lib/tutf8e/src/tutf8e.c
+++ b/lib/tutf8e/src/tutf8e.c
@@ -9,7 +9,8 @@
 
 int tutf8e_string_length(const uint16_t *table, const char *input, size_t *ilen, size_t *olen)
 {
-  for (const unsigned char *i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       *olen += 1;
@@ -57,7 +58,8 @@ int tutf8e_string_encode(const uint16_t *table, const char *i, char *o, size_t *
 
 int tutf8e_buffer_length(const uint16_t *table, const char *input, size_t ilen, size_t *length)
 {
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       ++*length;
@@ -86,7 +88,8 @@ int tutf8e_buffer_encode(const uint16_t *table, const char *input, size_t ilen, 
 {
   size_t left = *olen;
   unsigned char *o = (unsigned char *) output;
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       if (left<1) return TUTF8E_TOOLONG;


### PR DESCRIPTION
1)  issue reported when compile the project
```
Scanning dependencies of target tutf8e
[  8%] Building C object lib/tutf8e/CMakeFiles/tutf8e.dir/src/tutf8e.c.o
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c: In function ‘tutf8e_string_length’:
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c:12:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (const unsigned char *i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
   ^
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c:12:3: note: use option -std=c99 or -std=gnu99 to compile your code
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c: In function ‘tutf8e_buffer_length’:
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c:60:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
   ^
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c: In function ‘tutf8e_buffer_encode’:
/home/fwang/test/fluent-bit/lib/tutf8e/src/tutf8e.c:89:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
   ^
make[2]: *** [lib/tutf8e/CMakeFiles/tutf8e.dir/src/tutf8e.c.o] Error 1
make[1]: *** [lib/tutf8e/CMakeFiles/tutf8e.dir/all] Error 2
make: *** [all] Error 2
```

2) add one line in CMakeLists.txt to resolve the issue.
3) env for reproduction.

```
[root@sdw1 build]# cmake --version
cmake version 3.15.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
[root@sdw1 build]# gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

[root@sdw1 build]# cat /etc/redhat-release
CentOS Linux release 7.3.1611 (Core)
[root@sdw1 build]#
```