### PR TITLE
lib: tutf8e: C99 baseline compiler support

### DIFF
--- a/lib/tutf8e/CMakeLists.txt
+++ b/lib/tutf8e/CMakeLists.txt
@@ -1,10 +1,17 @@
 cmake_minimum_required(VERSION 2.8)
 project(tutf8e)
 
+# Not supported: -std=c90 (lacks support for inline)
+# Supported:     -std=gnu90, -std=c99 or -std=gnu99
+
 set(CMAKE_C_FLAGS "-Os -Wall")
 
 include_directories(include)
 add_library(tutf8e STATIC src/tutf8e.c)
+set_property(TARGET tutf8e PROPERTY C_STANDARD 99)
+set_property(TARGET tutf8e PROPERTY C_EXTENSIONS OFF)
 
 add_executable(tutf8e-test test/test.c)
 target_link_libraries(tutf8e-test tutf8e)
+set_property(TARGET tutf8e-test PROPERTY C_STANDARD 99)
+set_property(TARGET tutf8e-test PROPERTY C_EXTENSIONS OFF)

--- a/lib/tutf8e/codegen.py
+++ b/lib/tutf8e/codegen.py
@@ -80,7 +80,8 @@ with open('src/tutf8e.c', 'w') as src:
 
 int tutf8e_string_length(const uint16_t *table, const char *input, size_t *ilen, size_t *olen)
 {
-  for (const unsigned char *i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       *olen += 1;
@@ -128,7 +129,8 @@ int tutf8e_string_encode(const uint16_t *table, const char *i, char *o, size_t *
 
 int tutf8e_buffer_length(const uint16_t *table, const char *input, size_t ilen, size_t *length)
 {
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       ++*length;
@@ -157,7 +159,8 @@ int tutf8e_buffer_encode(const uint16_t *table, const char *input, size_t ilen, 
 {
   size_t left = *olen;
   unsigned char *o = (unsigned char *) output;
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       if (left<1) return TUTF8E_TOOLONG;

--- a/lib/tutf8e/src/tutf8e.c
+++ b/lib/tutf8e/src/tutf8e.c
@@ -9,7 +9,8 @@
 
 int tutf8e_string_length(const uint16_t *table, const char *input, size_t *ilen, size_t *olen)
 {
-  for (const unsigned char *i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; *i; ++i, (*ilen)++) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       *olen += 1;
@@ -57,7 +58,8 @@ int tutf8e_string_encode(const uint16_t *table, const char *i, char *o, size_t *
 
 int tutf8e_buffer_length(const uint16_t *table, const char *input, size_t ilen, size_t *length)
 {
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       ++*length;
@@ -86,7 +88,8 @@ int tutf8e_buffer_encode(const uint16_t *table, const char *input, size_t ilen, 
 {
   size_t left = *olen;
   unsigned char *o = (unsigned char *) output;
-  for (const unsigned char *i = (const unsigned char *) input; ilen; ++i, --ilen) {
+  const unsigned char *i;
+  for (i = (const unsigned char *) input; ilen; ++i, --ilen) {
     const uint16_t c = table[*i];
     if (c<0x80) {
       if (left<1) return TUTF8E_TOOLONG;


### PR DESCRIPTION
In relation to Issue #1753 and PR #1752 

`-std=c90` is not quite sufficent, due to `inline`