### PR TITLE
in_stdin: Restore documented JSON array handling

### DIFF
--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -57,16 +57,12 @@ static inline int process_pack(msgpack_packer *mp_pck,
     while (msgpack_unpack_next(&result, data, data_size, &off) == MSGPACK_UNPACK_SUCCESS) {
         entry = result.data;
 
-        msgpack_pack_array(mp_pck, 2);
-        flb_pack_time_now(mp_pck);
-
         if (entry.type == MSGPACK_OBJECT_MAP) {
+            msgpack_pack_array(mp_pck, 2);
+            flb_pack_time_now(mp_pck);
             msgpack_pack_object(mp_pck, entry);
         }
         else if (entry.type == MSGPACK_OBJECT_ARRAY) {
-            msgpack_pack_map(mp_pck, 1);
-            msgpack_pack_str(mp_pck, 3);
-            msgpack_pack_str_body(mp_pck, "log", 3);
             msgpack_pack_object(mp_pck, entry);
         }
         else {


### PR DESCRIPTION
As reported in Issue #1733 - stdin input plugin adds timestamp unconditionally

According to the documentation the following format is supported:
https://docs.fluentbit.io/manual/input/stdin

```
2. [ time, { map => val, map => val, map => val } ]
```

This change ensures that JSON array data is passed through without modification.

Last observed to work in `1.13.8`, still seems like a reasonable and useful behaviour.