### PR TITLE
Set log level from env var FLB_LOG_LEVEL

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -187,6 +187,7 @@ void flb_config_exit(struct flb_config *config);
 const char *flb_config_prop_get(const char *key, struct mk_list *list);
 int flb_config_set_property(struct flb_config *config,
                             const char *k, const char *v);
+int set_log_level_from_env(struct flb_config *config);
 #ifdef FLB_HAVE_STATIC_CONF
 struct mk_rconf *flb_config_static_open(const char *file);
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -43,6 +43,8 @@
 #include <fluent-bit/flb_plugin.h>
 #include <fluent-bit/flb_utils.h>
 
+const char *FLB_CONF_ENV_LOGLEVEL = "FLB_LOG_LEVEL";
+
 int flb_regex_init();
 
 struct flb_service_config service_configs[] = {
@@ -384,6 +386,16 @@ static int set_log_level(struct flb_config *config, const char *v_str)
     return 0;
 }
 
+int set_log_level_from_env(struct flb_config *config)
+{
+    const char *val = NULL;
+    val = flb_env_get(config->env, FLB_CONF_ENV_LOGLEVEL);
+    if (val) {
+        return set_log_level(config, val);
+    }
+    return -1;
+}
+
 int flb_config_set_property(struct flb_config *config,
                             const char *k, const char *v)
 {
@@ -399,15 +411,21 @@ int flb_config_set_property(struct flb_config *config,
     while (key != NULL) {
         if (prop_key_check(key, k,len) == 0) {
             if (!strncasecmp(key, FLB_CONF_STR_LOGLEVEL, 256)) {
-                tmp = flb_env_var_translate(config->env, v);
-                if (tmp) {
-                    ret = set_log_level(config, tmp);
-                    flb_sds_destroy(tmp);
-                    tmp = NULL;
+                #ifndef FLB_HAVE_STATIC_CONF
+                if (set_log_level_from_env(config) < 0) {
+                #endif
+                    tmp = flb_env_var_translate(config->env, v);
+                    if (tmp) {
+                        ret = set_log_level(config, tmp);
+                        flb_sds_destroy(tmp);
+                        tmp = NULL;
+                    }
+                    else {
+                        ret = set_log_level(config, v);
+                    }
+                #ifndef FLB_HAVE_STATIC_CONF
                 }
-                else {
-                    ret = set_log_level(config, v);
-                }
+                #endif
             }
             else if (!strncasecmp(key, FLB_CONF_STR_PARSERS_FILE, 32)) {
 #ifdef FLB_HAVE_PARSER

--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -143,7 +143,6 @@ const char *flb_env_get(struct flb_env *env, const char *key)
     /* If it was not found, try to get it from the real environment */
     out_buf = getenv(key);
     if (!out_buf) {
-        flb_warn("[env] variable ${%s} is used but not set", key);
         return NULL;
     }
 
@@ -226,6 +225,8 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
             if (s != buf) {
                 buf = s;
             }
+        } else {
+            flb_warn("[env] variable ${%s} is used but not set", tmp);
         }
         i += (v_start - (value + i)) + v_len;
     }

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -795,6 +795,8 @@ int main(int argc, char **argv)
     }
 #endif /* !FLB_HAVE_STATIC_CONF */
 
+    set_log_level_from_env(config);
+
     if (config->verbose != FLB_LOG_OFF) {
         flb_banner();
     }


### PR DESCRIPTION
#1769 

Previously, log level could be set with the following precedence:
1. Via `Log_Level` in the [SERVICE] section of a config file
2. Command Line args `-q` and `-v` 

Now the options and precedence are:
1. Value of the Env Var `FLB_LOG_LEVEL`
2. Via `Log_Level` in the [SERVICE] section of a config file
3. Command Line args `-q` and `-v` 