### PR TITLE
adding inotify-disabled flavour for Docker images (#1777)

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,8 +1,15 @@
+ARG inotify_mode=inotify_on
+
 FROM debian:stretch as builder
 COPY --from=amd64/busybox:1.31.0 /bin/busybox /bin/busybox
 RUN chmod 555 /bin/busybox \
  && /bin/busybox --install
 
-FROM fluent/fluent-bit:1.3
+
+FROM fluent/fluent-bit:1.3 AS inotify_on
+
+FROM fluent/fluent-bit-inotify-disabled:1.3 AS inotify_off
+
+FROM $inotify_mode
 COPY --from=builder /bin/ /bin/
 

--- a/docker-image-build.sh
+++ b/docker-image-build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+VERSION="1.3"
+IMAGE_NAME="fluent/fluent-bit"
+
+docker build --build-arg inotify_mode=inotify_on -t ${IMAGE_NAME}:${VERSION} -f ./Dockerfile .
+docker build --build-arg inotify_mode=inotify_on -t ${IMAGE_NAME}:${VERSION}-debug -f ./Dockerfile.debug .
+
+docker build --build-arg inotify_mode=inotify_off -t ${IMAGE_NAME}-inotify-disabled:${VERSION} -f ./Dockerfile .
+docker build --build-arg inotify_mode=inotify_off -t ${IMAGE_NAME}-inotify-disabled:${VERSION}-debug -f ./Dockerfile.debug .

--- a/docker-image-check.sh
+++ b/docker-image-check.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+VERSION="1.3"
+IMAGE_NAMES=("fluent/fluent-bit" "fluent/fluent-bit-inotify-disabled")
+
+for imageName in "${IMAGE_NAMES[@]}"
+do
+	echo "==> Checking Fluent-Bit reported version by '${imageName}' image:"
+
+	docker run -ti ${imageName}:${VERSION} /fluent-bit/bin/fluent-bit --version
+	docker run -ti ${imageName}:${VERSION}-debug /fluent-bit/bin/fluent-bit --version
+	
+	echo "==> Checking INOTIFY flag presence in '${imageName}' Fluent-Bit image:" 
+	
+	# for full debug only:
+	#docker run -ti ${imageName}:${VERSION} /fluent-bit/bin/fluent-bit --sosreport
+	#docker run -ti ${imageName}:${VERSION}-debug /fluent-bit/bin/fluent-bit --sosreport
+	
+	docker run -ti ${imageName}:${VERSION} /fluent-bit/bin/fluent-bit --sosreport | grep "INOTIFY"
+	docker run -ti ${imageName}:${VERSION}-debug /fluent-bit/bin/fluent-bit --sosreport | grep "INOTIFY"
+	
+	# for full debug only:
+	#docker run -ti ${imageName}:${VERSION} /fluent-bit/bin/fluent-bit --help
+	#docker run -ti ${imageName}:${VERSION}-debug /fluent-bit/bin/fluent-bit --help
+	
+	docker run -ti ${imageName}:${VERSION} /fluent-bit/bin/fluent-bit --help | grep "INOTIFY"
+	docker run -ti ${imageName}:${VERSION}-debug /fluent-bit/bin/fluent-bit --help | grep "INOTIFY"
+done
+
+echo "Checking finished"


### PR DESCRIPTION
Proposed solution for #1777 which enabled building Fluent-Bit Docker images also with "inotify-disabled" flavour, which turns _FLB_INOTIFY_ to _Off_ making e.g. in_tail plugin use stat instead of inotify - might be useful as a workaround for random "Too many open files" error when tailing files most likely connected with _inotify_ in this case.

An example _docker-image-build.sh_ builds all 4 Docker images (inotify on or off, debug and non-debug) and _docker-image-check.sh_ checks what build-in flags Fluent-Bit from those images is reporting.