### PR TITLE
core/upstream: flb_upstream_conn.ka_count should be initialized

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -141,6 +141,7 @@ static struct flb_upstream_conn *create_conn(struct flb_upstream *u)
 #endif
     conn->ts_created = time(NULL);
     conn->ts_available = 0;
+    conn->ka_count = 0;
 
     MK_EVENT_ZERO(&conn->event);
 


### PR DESCRIPTION
flb_upstream_conn.ka_count is not initialized and can get
random values.

This can break out_forward when it get wrong information
that tells that connection is reused, but it's not and
out_forward thinks that handshake is already done.

flb_calloc could also be used to zero init whole flb_upstream_conn 
in allocation.

Signed-off-by: Jukka Pihl <jukka.pihl@iki.fi>