### PR TITLE
cmake: fix FLB_OPTION cmake macro

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -6,5 +6,5 @@ macro(FLB_DEFINITION var)
 endmacro()
 
 macro(FLB_OPTION option value)
-  set(${option} ${value} CACHE "" INTERNAL FORCE)
+  set(${option} ${value} CACHE INTERNAL "" FORCE)
 endmacro()


### PR DESCRIPTION
`FLB_OPTION` in `macros.cmake` sets variable with invalid order of arguments and it generates some warning errors like below.
```plain
CMake Warning (dev) at cmake/macros.cmake:9 (set):
  implicitly converting '' to 'STRING' type.
Call Stack (most recent call first):
  CMakeLists.txt:313 (FLB_OPTION)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

According to cmake document, we should put `type` first and then docstring but `FLB_OPTION` does opposite.

cmake2: https://cmake.org/cmake/help/v2.8.12/cmake.html
cmake3: https://cmake.org/cmake/help/latest/command/set.html