### PR TITLE
parser: remove typo of Time_Format in syslog-rfc3164 parser config

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -81,7 +81,6 @@
     Format      regex
     Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
     Time_Key    time
-    Time_Format %b %d %H:%M:%S
     Time_Format %Y-%m-%dT%H:%M:%S.%L
     Time_Keep   On
 


### PR DESCRIPTION
The `Time_Format` should not appear twice in syslog-rfc3164 parser config, and it seems that the first one is a typo?