### PR TITLE
Fix AppVeyor build failure on v1.3.4

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -47,6 +47,9 @@
 #define PATH_MAX MAX_PATH
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 
+/* monkey exposes a broken vsnprintf macro. Undo it  */
+#undef vsnprintf
+
 /*
  * Windows prefer to add an underscore to each POSIX function.
  * To suppress compiler warnings, we need these trivial macros.

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -23,6 +23,7 @@
  * SDS library created by Antirez at https://github.com/antirez/sds.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>


### PR DESCRIPTION
The commit 2eef4071 introduced a change that breaks the AppVeyor build.

    Test project C:/projects/fluent-bit-2e87g/build
          Start  1: flb-it-pipe
     1/11 Test  #1: flb-it-pipe ......................   Passed    0.02 sec
          Start  2: flb-it-sds
     2/11 Test  #2: flb-it-sds .......................***Failed    0.02 sec
    Test sds_usage...                               [   OK   ]
    Test sds_printf...                              [ FAILED ]
    
      sds.c:35: Check tmp == s... failed
      sds.c:36: Check flb_sds_len(s) == len... failed
     

Due to this, AppVayor has been failing to generate Windows installers.
This is why we are unable to download v1.3.4 installers.

This patch fixes it.
