### PR TITLE
output: Explicit cast to fix a build error on macOS

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -305,7 +305,7 @@ static FLB_INLINE void output_params_set(struct flb_thread *th,
 {
     struct flb_libco_out_params *params;
 
-    params = FLB_TLS_GET(flb_libco_params);
+    params = (struct flb_libco_out_params *) FLB_TLS_GET(flb_libco_params);
     if (!params) {
         params = (struct flb_libco_out_params *)
             flb_malloc(sizeof(struct flb_libco_out_params));
@@ -343,7 +343,7 @@ static FLB_INLINE void output_pre_cb_flush(void)
     struct flb_thread *th;
     struct flb_libco_out_params *params;
 
-    params = FLB_TLS_GET(flb_libco_params);
+    params = (struct flb_libco_out_params *) FLB_TLS_GET(flb_libco_params);
     if (!params) {
         flb_error("[output] no co-routines params defined, unexpected");
         return;


### PR DESCRIPTION
```
[ 98%] Built target hello_world
[ 98%] Building CXX object examples/hello_world_cpp/CMakeFiles/hello_world_cpp.dir/hello_world.cc.o
In file included from /Users/hli/src/fluent-bit/examples/hello_world_cpp/hello_world.cc:20:
In file included from /Users/hli/src/fluent-bit/include/fluent-bit.h:39:
/Users/hli/src/fluent-bit/include/fluent-bit/flb_output.h:308:14: error: assigning to 'struct flb_libco_out_params *' from incompatible type 'void * _Nullable'
    params = FLB_TLS_GET(flb_libco_params);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/hli/src/fluent-bit/include/fluent-bit/flb_thread_storage.h:37:36: note: expanded from macro 'FLB_TLS_GET'
#define FLB_TLS_GET(key)           pthread_getspecific(key)
                                   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /Users/hli/src/fluent-bit/examples/hello_world_cpp/hello_world.cc:20:
In file included from /Users/hli/src/fluent-bit/include/fluent-bit.h:39:
/Users/hli/src/fluent-bit/include/fluent-bit/flb_output.h:346:14: error: assigning to 'struct flb_libco_out_params *' from incompatible type 'void * _Nullable'
    params = FLB_TLS_GET(flb_libco_params);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/hli/src/fluent-bit/include/fluent-bit/flb_thread_storage.h:37:36: note: expanded from macro 'FLB_TLS_GET'
#define FLB_TLS_GET(key)           pthread_getspecific(key)
                                   ^~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
make[2]: *** [examples/hello_world_cpp/CMakeFiles/hello_world_cpp.dir/hello_world.cc.o] Error 1
make[1]: *** [examples/hello_world_cpp/CMakeFiles/hello_world_cpp.dir/all] Error 2
make: *** [all] Error 2
❯ cc --version
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Signed-off-by: Haitao Li <lihaitao@gmail.com>