### PR TITLE
tail plugin on win: don't repeatedly add symlinks to scan queue

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -979,7 +979,12 @@ int flb_tail_file_to_event(struct flb_tail_file *file)
         return -1;
     }
 
-    if (flb_tail_file_name_cmp(name, file) != 0) {
+    /*
+     * flb_tail_target_file_name_cmp is a deeper compare than
+     * flb_tail_file_name_cmp. If applicable, it compares to the underlying
+     * real_name of the file.
+     */
+    if (flb_tail_target_file_name_cmp(name, file) != 0) {
         ret = stat(name, &st_rotated);
         if (ret == -1) {
             flb_free(name);

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -42,6 +42,18 @@ static inline int flb_tail_file_name_cmp(char *name,
 #if defined(__linux__)
     return strcmp(name, file->name);
 #elif defined(FLB_SYSTEM_WINDOWS)
+    return _stricmp(name, file->name);
+#else
+    return strcmp(name, file->name);
+#endif
+}
+
+static inline int flb_tail_target_file_name_cmp(char *name,
+                                                struct flb_tail_file *file)
+{
+#if defined(__linux__)
+    return strcmp(name, file->name);
+#elif defined(FLB_SYSTEM_WINDOWS)
     return _stricmp(name, file->real_name);
 #else
     return strcmp(name, file->real_name);

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -123,8 +123,12 @@ static int tail_fs_check(struct flb_input_instance *i_ins,
          * Check if file still exists. This method requires explicity that the
          * user is using an absolute path, otherwise we will be rotating the
          * wrong file.
+         *
+         * flb_tail_target_file_name_cmp is a deeper compare than
+         * flb_tail_file_name_cmp. If applicable, it compares to the underlying
+         * real_name of the file.
          */
-        if (flb_tail_file_name_cmp(name, file) != 0) {
+        if (flb_tail_target_file_name_cmp(name, file) != 0) {
             flb_tail_file_rotated(file);
         }
         flb_free(name);


### PR DESCRIPTION
Fixes #1806

When deciding whether a path should be added to the scan queue or not, a superficial comparison on path/name is the correct behavior for all OSes. Only operations that actually touch the files in question may need to do a deeper comparison that accounts for `real_name` on applicable OSes. 

cc @fujimotos 