### PR TITLE
Revert "out_kafka: make MSVC compatible (#1179)"

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -63,7 +63,7 @@ set(FLB_OUT_STDOUT            Yes)
 set(FLB_OUT_LIB                No)
 set(FLB_OUT_NULL              Yes)
 set(FLB_OUT_FLOWCOUNTER       Yes)
-set(FLB_OUT_KAFKA             Yes)
+set(FLB_OUT_KAFKA              No)
 set(FLB_OUT_KAFKA_REST         No)
 
 # FILTER plugins

--- a/plugins/out_kafka/CMakeLists.txt
+++ b/plugins/out_kafka/CMakeLists.txt
@@ -16,6 +16,4 @@ set(src
   kafka.c)
 
 FLB_PLUGIN(out_kafka "${src}" "rdkafka")
-if (NOT MSVC)
-  target_link_libraries(flb-plugin-out_kafka -lpthread)
-endif()
+target_link_libraries(flb-plugin-out_kafka -lpthread)


### PR DESCRIPTION
This reverts commit 69fffab96630869015437a6d1d13aa1efeb0a9c7.

Bakashar Kemerbay (and many other Windows users) reports that it
causes an immediate abort on Windows environments. In particular,
it causes abort even when they does not use out_kafka.

For example, I can confirm that even the following command does
not work on a vanilla Windows server.

    $ fluent-bit.exe -i dummy -o stdout

This is because librdkafka is dependent on OpenSSL (ssleay32.dll
and libeay32.dll), which most Windows servers do not have. Hence
fluent-bit.exe always fails due to missing DLL dependencies.

So we have to revert this, and revisit it after resolving the
dependency issue.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>