### PR TITLE
Fix for issue #1840

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -133,7 +133,7 @@ int flb_output_instance_destroy(struct flb_output_instance *ins)
 #endif
 
 #ifdef FLB_HAVE_TLS
-    if (ins->flags & FLB_IO_TLS) {
+    if (ins->use_tls == FLB_TRUE) {
         if (ins->tls.context) {
             flb_tls_context_destroy(ins->tls.context);
         }

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -587,7 +587,7 @@ int flb_output_init(struct flb_config *config)
 #endif
 
 #ifdef FLB_HAVE_TLS
-        if (ins->flags & FLB_IO_TLS) {
+        if (ins->use_tls == FLB_TRUE) {
             ins->tls.context = flb_tls_context_new(ins->tls_verify,
                                                    ins->tls_debug,
                                                    ins->tls_vhost,


### PR DESCRIPTION
There are multiple cases
1. Plugin doesn't support TLS.
2. Plugin supports TLS but TLS isn't configurable.
3. Plugin support TLS but is configurable.

flb_output.c:

In all cases, the use_tls gets set to appropriate value. But not the instance flags.
318     else if (flags & FLB_IO_OPT_TLS) {
319         /* TLS must be enabled manually in the config */
320         instance->use_tls = FLB_FALSE;
321         instance->flags |= FLB_IO_TLS;
322     }
In the above snippet we can see that flags is set to FLB_IO_TLS irrespective of the configuration. So this flag alone doesn't tell us if the configuration has tls enabled or not.
But the use_tls gets updated based on the configuration:
447     else if (prop_key_check("tls", k, len) == 0 && tmp) {
448         if (strcasecmp(tmp, "true") == 0 || strcasecmp(tmp, "on") == 0) {
449             if ((out->flags & FLB_IO_TLS) == 0) {
450                 flb_error("[config] %s don't support TLS", out->name);
451                 flb_sds_destroy(tmp);
452                 return -1;
453             }
454 
455             out->use_tls = FLB_TRUE;
456         }

Hence the test to decide whether TLS context needs to be created or not needs to use "use_tls".
