### PR TITLE
out_datadog: add http proxy support

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -320,7 +320,7 @@ static void cb_datadog_flush(const void *data, size_t bytes,
     client = flb_http_client(upstream_conn, FLB_HTTP_POST, ctx->uri,
                              final_payload_buf, final_payload_size,
                              ctx->host, ctx->port,
-                             NULL, 0);
+                             ctx->proxy, 0);
     if (!client) {
         flb_upstream_conn_release(upstream_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -42,6 +42,11 @@
 
 struct flb_out_datadog {
 
+    /* Proxy */
+    const char *proxy;
+    char *proxy_host;
+    int proxy_port;
+
     /* Configuration */
     flb_sds_t scheme;
     flb_sds_t host;

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -531,7 +531,7 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
     char *fmt_plain =                           \
         "%s %s HTTP/1.%i\r\n";
     char *fmt_proxy =                           \
-        "%s http://%s:%i/%s HTTP/1.%i\r\n"
+        "%s http://%s:%i%s HTTP/1.%i\r\n"
         "Proxy-Connection: KeepAlive\r\n";
 
     struct flb_http_client *c;
@@ -570,11 +570,10 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
         ret = snprintf(buf, FLB_HTTP_BUF_SIZE,
                        fmt_proxy,
                        str_method,
-                       flags & FLB_HTTP_10 ? 0 : 1,
                        host,
                        port,
-                       "",
-                       body_len);
+                       uri,
+                       flags & FLB_HTTP_10 ? 0 : 1);
     }
 
     if (ret == -1) {
@@ -1058,5 +1057,6 @@ void flb_http_client_destroy(struct flb_http_client *c)
     http_headers_destroy(c);
     flb_free(c->resp.data);
     flb_free(c->header_buf);
+    flb_free((void *)c->proxy.host);
     flb_free(c);
 }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -730,6 +730,18 @@ int flb_utils_write_str_buf(const char *str, size_t str_len, char **out, size_t 
     return 0;
 }
 
+static char *flb_copy_host(const char *string, int pos_init, int pos_end)
+{
+    if (string[pos_init] == '[') {            /* IPv6 */
+        if (string[pos_end-1] != ']')
+            return NULL;
+
+        return mk_string_copy_substr(string, pos_init + 1, pos_end - 1);
+    }
+    else
+        return mk_string_copy_substr(string, pos_init, pos_end);
+}
+
 int flb_utils_url_split(const char *in_url, char **out_protocol,
                         char **out_host, char **out_port, char **out_uri)
 {
@@ -771,7 +783,7 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
     }
 
     if (tmp) {
-        host = mk_string_copy_substr(p, 0, tmp - p);
+        host = flb_copy_host(p, 0, tmp - p);
         if (!host) {
             flb_errno();
             goto error;
@@ -792,11 +804,11 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
     else {
         tmp = strchr(p, '/');
         if (tmp) {
-            host = mk_string_copy_substr(p, 0, tmp - p);
+            host = flb_copy_host(p, 0, tmp - p);
             uri = flb_strdup(tmp);
         }
         else {
-            host = flb_strdup(p);
+            host = flb_copy_host(p, 0, strlen(p));
             uri = flb_strdup("/");
         }
     }


### PR DESCRIPTION
Add a new plugin parameter, `proxy` that can be used to to specify an http proxy
to use to send datadog queries.

Signed-off-by: Lénaïc Huard <lenaic.huard@datadoghq.com>