### PR TITLE
stop caching metadata for pods which failed apiserver query

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -887,6 +887,11 @@ static int get_and_merge_meta(struct flb_kube *ctx, struct flb_kube_meta *meta,
                         meta->namespace, meta->podname,
                         &api_buf, &api_size);
 
+    /* retry on apiserver query failure */
+    if (api_buf == NULL) {
+        return -1;
+    }
+
     ret = merge_meta(meta, ctx,
                      api_buf, api_size,
                      out_buf, out_size);

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -887,7 +887,7 @@ static int get_and_merge_meta(struct flb_kube *ctx, struct flb_kube_meta *meta,
                         meta->namespace, meta->podname,
                         &api_buf, &api_size);
 
-    /* retry on apiserver query failure */
+    /* ealy return if api server response is empty which prevents the result from being cached */
     if (api_buf == NULL) {
         return -1;
     }


### PR DESCRIPTION
this will make it retry metadata query after it failed to get a valid response from apiserver. it's meant to fix https://github.com/fluent/fluent-bit/issues/1839