### PR TITLE
WIP: Add Grafana Loki JSON format

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -47,6 +47,7 @@
 #define FLB_PACK_JSON_FORMAT_JSON        1
 #define FLB_PACK_JSON_FORMAT_STREAM      2
 #define FLB_PACK_JSON_FORMAT_LINES       3
+#define FLB_PACK_JSON_FORMAT_LOKI        4
 
 struct flb_pack_state {
     int multiple;         /* support multiple jsons? */

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -108,6 +108,7 @@ static int http_post(struct flb_out_http *ctx,
     if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_STREAM) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES) ||
+        (ctx->out_format == FLB_PACK_JSON_FORMAT_LOKI) ||
         (ctx->out_format == FLB_HTTP_OUT_GELF)) {
         flb_http_add_header(c,
                             FLB_HTTP_CONTENT_TYPE,
@@ -283,7 +284,8 @@ static void cb_http_flush(const void *data, size_t bytes,
 
     if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_STREAM) ||
-        (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES)) {
+        (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES) ||
+        (ctx->out_format == FLB_PACK_JSON_FORMAT_LOKI)) {
 
         json = flb_pack_msgpack_to_json_format(data, bytes,
                                                ctx->out_format,


### PR DESCRIPTION
This allows to use the existing HTTP output to push logs into Grafana Loki. This uses the JSON format for pushing logs into Loki (using protobuf would require more dependencies). (cf. #994)

My use case is to ship logs into Loki from embedded devices, where Grafana's existing golang plugin (https://github.com/grafana/loki/pull/847) is not ideal. 

I am more than happy to provide more quality (docs, tests, ...). But first I would like to understand if this is something that would be accepted upstream. 

A config would look like this:

```


[OUTPUT]
    Name         http
    Match        *
    Host         loki.example.net
    Port         443
    URI          /loki/api/v1/push
    Format       json_loki
    tls          On
    tls.debug    1
    tls.key_file client.key
    tls.crt_file client.crt
```

To test the JSON format stdout can also be used:

```
[OUTPUT]
    Name   stdout
    Match  *
    Format json_loki
```

I think ideally we would also merge matching labels into a single array element. I certainly would love some feedback as my last C project is some time ago :)