### PR TITLE
AWS Credentials Providers PR 3: EC2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(FLB_BACKTRACE          "Enable stacktrace support"    Yes)
 option(FLB_LUAJIT             "Enable Lua Scripting support" Yes)
 option(FLB_RECORD_ACCESSOR    "Enable record accessor"       Yes)
 option(FLB_SIGNV4             "Enable AWS Signv4 support"    Yes)
+option(FLB_AWS                "Enable AWS support"           Yes)
 option(FLB_SYSTEM_STRPTIME    "Use strptime in system libc"  Yes)
 option(FLB_STATIC_CONF        "Build binary using static configuration")
 option(FLB_STREAM_PROCESSOR   "Enable Stream Processor"      Yes)
@@ -362,6 +363,11 @@ endif()
 # Metrics
 if(FLB_METRICS)
   FLB_DEFINITION(FLB_HAVE_METRICS)
+endif()
+
+# AWS
+if (FLB_AWS)
+  FLB_DEFINITION(FLB_HAVE_AWS)
 endif()
 
 # Signv4

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -160,6 +160,31 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
  */
 struct flb_aws_provider *flb_aws_env_provider_create();
 
+/*
+ * New http provider - retrieve credentials from a local http server.
+ * Equivalent to:
+ * https://github.com/aws/aws-sdk-go/tree/master/aws/credentials/endpointcreds
+ *
+ * Calling flb_aws_provider_destroy on this provider frees the memory
+ * used by host and path.
+ */
+struct flb_aws_provider *flb_http_provider_create(struct flb_config *config,
+                                                  flb_sds_t host,
+                                                  flb_sds_t path,
+                                                  struct
+                                                  flb_aws_client_generator
+                                                  *generator);
+
+/*
+ * ECS Provider
+ * The ECS Provider is just a wrapper around the HTTP Provider
+ * with the ECS credentials endpoint.
+ */
+struct flb_aws_provider *flb_ecs_provider_create(struct flb_config *config,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator);
+
 
 /*
  * Helper functions

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -1,0 +1,198 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef FLB_HAVE_AWS
+
+#ifndef FLB_AWS_CREDENTIALS_H
+#define FLB_AWS_CREDENTIALS_H
+
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_io.h>
+#include <monkey/mk_core.h>
+
+/* Refresh creds if they will expire in 5 min or less */
+#define FLB_AWS_REFRESH_WINDOW         300
+
+/*
+ * A structure that wraps the sensitive data needed to sign an AWS request
+ */
+struct flb_aws_credentials {
+    flb_sds_t access_key_id;
+    flb_sds_t secret_access_key;
+    flb_sds_t session_token;
+};
+
+/* defined below but declared here for the function declarations */
+struct flb_aws_provider;
+
+/*
+ * Get credentials using the provider.
+ * Client is in charge of freeing the returned credentials struct.
+ * Returns NULL if credentials could not be obtained.
+ */
+typedef struct flb_aws_credentials*(flb_aws_provider_get_credentials_fn)
+                                   (struct flb_aws_provider *provider);
+
+/*
+ * Force a refesh of cached credentials. If client code receives a response
+ * from AWS indicating that the credentials are expired or invalid,
+ * it can call this method and retry.
+ * Returns 0 if the refresh was successful.
+ */
+typedef int(flb_aws_provider_refresh_fn)(struct flb_aws_provider *provider);
+
+/*
+ * Clean up the underlying provider implementation.
+ * Called by flb_aws_provider_destroy.
+ */
+typedef void(flb_aws_provider_destroy_fn)(struct flb_aws_provider *provider);
+
+/*
+ * Set provider to 'sync' mode; all network IO operations will be performed
+ * synchronously. This must be set if the provider is called when co-routines
+ * are not available (ex: during plugin initialization).
+ */
+typedef void(flb_aws_provider_sync_fn)(struct flb_aws_provider *provider);
+
+/*
+ * Set provider to 'async' mode; all network IO operations will be performed
+ * asynchronously.
+ *
+ * All providers are created in 'async' mode by default.
+ */
+typedef void(flb_aws_provider_async_fn)(struct flb_aws_provider *provider);
+
+/*
+ * This structure is a virtual table for the functions implemented by each
+ * provider
+ */
+struct flb_aws_provider_vtable {
+    flb_aws_provider_get_credentials_fn *get_credentials;
+    flb_aws_provider_refresh_fn *refresh;
+    flb_aws_provider_destroy_fn *destroy;
+    flb_aws_provider_sync_fn *sync;
+    flb_aws_provider_async_fn *async;
+};
+
+/*
+ * A generic structure to represent all providers.
+ */
+struct flb_aws_provider {
+    /*
+     * Fluent Bit is single-threaded but asynchonous. Co-routines are paused
+     * and resumed during blocking IO calls.
+     *
+     * When a refresh is needed, only one co-routine should refresh.
+     */
+    int locked;
+
+    struct flb_aws_provider_vtable *provider_vtable;
+
+    void *implementation;
+
+    /* Standard credentials chain is a list of providers */
+    struct mk_list _head;
+};
+
+/*
+ * Function to free memory used by an aws_credentials structure
+ */
+void flb_aws_credentials_destroy(struct flb_aws_credentials *creds);
+
+/*
+ * Function to free memory used by an flb_aws_provider structure
+ */
+void flb_aws_provider_destroy(struct flb_aws_provider *provider);
+
+
+/*
+ * A provider that uses OIDC tokens provided by kubernetes to obtain
+ * AWS credentials.
+ *
+ * The AWS SDKs have defined a spec for an OIDC provider that obtains tokens
+ * from environment variables or the shared config file.
+ * This provider only contains the functionality needed for EKS- obtaining the
+ * location of the OIDC token from an environment variable.
+ */
+struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
+                                                 struct flb_tls *tls,
+                                                 char *region, char *proxy,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator);
+
+
+/*
+ * STS Assume Role Provider.
+ */
+struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
+                                                 struct flb_tls *tls,
+                                                 struct flb_aws_provider
+                                                 *base_provider,
+                                                 char *external_id,
+                                                 char *role_arn,
+                                                 char *session_name,
+                                                 char *region,
+                                                 char *proxy,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator);
+
+/*
+ * Standard environment variables
+ */
+struct flb_aws_provider *flb_aws_env_provider_create();
+
+
+/*
+ * Helper functions
+ */
+
+time_t flb_aws_cred_expiration(const char* timestamp);
+
+int flb_read_file(const char *path, char **out_buf, size_t *out_size);
+
+struct flb_aws_credentials *flb_parse_sts_resp(char *response,
+                                               time_t *expiration);
+char *flb_sts_uri(char *action, char *role_arn, char *session_name,
+                  char *external_id, char *identity_token);
+char *flb_sts_session_name();
+
+struct flb_aws_credentials *flb_parse_http_credentials(char *response,
+                                                       size_t response_len,
+                                                       time_t *expiration);
+
+/*
+ * Fluent Bit is single-threaded but asynchonous. Only one co-routine will
+ * be running at a time, and they only pause/resume for IO.
+ *
+ * Thus, while synchronization is needed (to prevent multiple co-routines
+ * from duplicating effort and performing the same work), it can be obtained
+ * using a simple integer flag on the provider.
+ */
+
+/* Like a traditional try lock- it does not block if the lock is not obtained */
+int try_lock_provider(struct flb_aws_provider *provider);
+
+void unlock_provider(struct flb_aws_provider *provider);
+
+
+#endif
+#endif /* FLB_HAVE_AWS */

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -185,6 +185,15 @@ struct flb_aws_provider *flb_ecs_provider_create(struct flb_config *config,
                                                  flb_aws_client_generator
                                                  *generator);
 
+/*
+ * EC2 IMDS Provider
+ */
+struct flb_aws_provider *flb_ec2_provider_create(struct flb_config *config,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator);
+
+
 
 /*
  * Helper functions

--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -1,0 +1,143 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2020      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef FLB_HAVE_AWS
+
+#ifndef FLB_AWS_UTIL_H
+#define FLB_AWS_UTIL_H
+
+#define AWS_SERVICE_ENDPOINT_FORMAT            "%s.%s.amazonaws.com"
+#define AWS_SERVICE_ENDPOINT_BASE_LEN          15
+
+#define FLB_AWS_CREDENTIAL_REFRESH_LIMIT       300
+
+/*
+ * The AWS HTTP Client is a wrapper around the Fluent Bit's http library.
+ * It handles tasks which are common to all AWS API requests (retries,
+ * error processing, etc).
+ * It is also easily mockable in unit tests.
+ */
+
+ struct flb_aws_client;
+
+ struct flb_aws_header {
+     char *key;
+     size_t key_len;
+     char *val;
+     size_t val_len;
+ };
+
+typedef struct flb_http_client *(flb_aws_client_request_fn)
+                                (struct flb_aws_client *aws_client,
+                                int method, const char *uri,
+                                const char *body, size_t body_len,
+                                struct flb_aws_header *dynamic_headers,
+                                size_t dynamic_headers_len);
+
+/* TODO: Eventually will need to add a way to call flb_http_buffer_size */
+
+/*
+ * Virtual table for aws http client behavior.
+ * This makes the client's functionality mockable in unit tests.
+ */
+struct flb_aws_client_vtable {
+    flb_aws_client_request_fn *request;
+};
+
+struct flb_aws_client {
+    struct flb_aws_client_vtable *client_vtable;
+
+    /* Name to identify this client: used in log messages and tests */
+    char *name;
+
+    /* Sigv4 */
+    int has_auth;
+    struct flb_aws_provider *provider;
+    char *region;
+    char *service;
+
+    struct flb_upstream *upstream;
+
+    char *host;
+    int port;
+    char *proxy;
+    int flags;
+
+    /*
+     * Additional headers which will be added to all requests.
+     * The AWS client will add auth headers, content length,
+     * and user agent.
+     */
+     struct flb_aws_header *static_headers;
+     size_t static_headers_len;
+
+    /*
+     * If an API responds with 400, we refresh creds and retry.
+     * For safety, credential refresh can only happen once per
+     * FLB_AWS_CREDENTIAL_REFRESH_LIMIT.
+     */
+    time_t refresh_limit;
+};
+
+/*
+ * Frees the aws_client, the internal flb_http_client, error_code,
+ * and flb_upstream.
+ * Caller code must free any other memory.
+ * (Why? - Because all other memory may be static.)
+ */
+void flb_aws_client_destroy(struct flb_aws_client *aws_client);
+
+typedef struct flb_aws_client*(flb_aws_client_create_fn)();
+
+/*
+ * HTTP Client Generator creates a new client structure and sets the vtable.
+ * Unit tests can implement a custom flb_aws_client_generator which returns a mock client.
+ * This structure is a virtual table.
+ * Client code should not free it.
+ */
+struct flb_aws_client_generator {
+    flb_aws_client_create_fn *create;
+};
+
+/* Get the flb_aws_client_generator */
+struct flb_aws_client_generator *flb_aws_client_generator();
+
+/*
+ * Format an AWS regional API endpoint
+ */
+char *flb_aws_endpoint(char* service, char* region);
+
+/*
+ * Parses an AWS API error type returned by a request.
+ */
+flb_sds_t flb_aws_error(char *response, size_t response_len);
+
+/*
+ * Parses the JSON and gets the value for 'key'
+ */
+flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key);
+
+/*
+ * Request data from an IMDS path.
+ */
+int flb_imds_request(struct flb_aws_client *client, char *metadata_path,
+                     flb_sds_t *metadata, size_t *metadata_len);
+
+#endif
+#endif /* FLB_HAVE_AWS */

--- a/include/fluent-bit/flb_signv4.h
+++ b/include/fluent-bit/flb_signv4.h
@@ -20,6 +20,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
 
 #ifdef FLB_HAVE_SIGNV4
 
@@ -32,9 +33,8 @@ flb_sds_t flb_signv4_uri_normalize_path(char *uri, size_t len);
 flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
                         int amz_date,
                         time_t t_now,
-                        char *access_key,
                         char *region, char *service,
-                        char *secret_key, char *security_token);
+                        struct flb_aws_provider *provider);
 
 #endif
 #endif /* FLB_HAVE_SIGNV4 */

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_signv4.h>
+#include <fluent-bit/flb_aws_credentials.h>
 #include <msgpack.h>
 
 #include <time.h>
@@ -37,13 +38,10 @@
 struct flb_output_plugin out_es_plugin;
 
 #ifdef FLB_HAVE_SIGNV4
-static flb_sds_t add_aws_auth(struct flb_elasticsearch *ctx,
-                              struct flb_http_client *c, char *region)
+static flb_sds_t add_aws_auth(struct flb_http_client *c,
+                              struct flb_elasticsearch *ctx)
 {
     flb_sds_t signature = NULL;
-    char *access_key = NULL;
-    char *secret_key = NULL;
-    char *session_token = NULL;
     int ret;
 
     flb_plg_debug(ctx->ins, "Signing request with AWS Sigv4");
@@ -55,24 +53,11 @@ static flb_sds_t add_aws_auth(struct flb_elasticsearch *ctx,
         return NULL;
     }
 
-    /* AWS credentials */
-    access_key = getenv("AWS_ACCESS_KEY_ID");
-    if (!access_key || strlen(access_key) < 1) {
-        flb_plg_error(ctx->ins, "'AWS_ACCESS_KEY_ID' not set");
-        return NULL;
-    }
-
-    secret_key = getenv("AWS_SECRET_ACCESS_KEY");
-    if (!access_key || strlen(access_key) < 1) {
-        flb_plg_error(ctx->ins, "'AWS_SECRET_ACCESS_KEY' not set");
-        return NULL;
-    }
-
-    session_token = getenv("AWS_SESSION_TOKEN");
+    /* User agent for AWS tools must start with "aws-" */
+    flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
-                              access_key, region, "es",
-                              secret_key, session_token);
+                              ctx->aws_region, "es", ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
         return NULL;
@@ -631,9 +616,7 @@ static void cb_es_flush(const void *data, size_t bytes,
 
 #ifdef FLB_HAVE_SIGNV4
     if (ctx->has_aws_auth == FLB_TRUE) {
-        /* User agent for AWS tools must start with "aws-" */
-        flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
-        signature = add_aws_auth(ctx, c, ctx->aws_region);
+        signature = add_aws_auth(c, ctx);
         if (!signature) {
             goto retry;
         }

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -45,6 +45,7 @@ struct flb_elasticsearch {
 #ifdef FLB_HAVE_SIGNV4
     int has_aws_auth;
     char *aws_region;
+    struct flb_aws_provider *aws_provider;
 #endif
 
     /* HTTP Client Setup */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,9 +106,10 @@ endif()
 if(FLB_AWS)
   set(src
     ${src}
+    "aws/flb_aws_util.c"
     "aws/flb_aws_credentials.c"
     "aws/flb_aws_credentials_sts.c"
-    "aws/flb_aws_util.c"
+    "aws/flb_aws_credentials_http.c"
     )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,15 @@ if(FLB_SIGNV4 AND FLB_TLS)
     )
 endif()
 
+if(FLB_AWS)
+  set(src
+    ${src}
+    "aws/flb_aws_credentials.c"
+    "aws/flb_aws_credentials_sts.c"
+    "aws/flb_aws_util.c"
+    )
+endif()
+
 if(FLB_LUAJIT)
   set(src
     ${src}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ if(FLB_AWS)
     "aws/flb_aws_util.c"
     "aws/flb_aws_credentials.c"
     "aws/flb_aws_credentials_sts.c"
+    "aws/flb_aws_credentials_ec2.c"
     "aws/flb_aws_credentials_http.c"
     )
 endif()

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -1,0 +1,322 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_aws_util.h>
+
+#include <jsmn/jsmn.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#define TEN_MINUTES    600
+#define TWELVE_HOURS   43200
+
+/* Credentials Environment Variables */
+#define AWS_ACCESS_KEY_ID              "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_ACCESS_KEY          "AWS_SECRET_ACCESS_KEY"
+#define AWS_SESSION_TOKEN              "AWS_SESSION_TOKEN"
+
+
+/* Environment Provider */
+struct flb_aws_credentials *get_credentials_fn_environment(struct
+                                                           flb_aws_provider
+                                                           *provider)
+{
+    char *access_key = NULL;
+    char *secret_key = NULL;
+    char *session_token = NULL;
+    struct flb_aws_credentials *creds = NULL;
+
+    flb_debug("[aws_credentials] Requesting credentials from the "
+              "env provider..");
+
+    access_key = getenv(AWS_ACCESS_KEY_ID);
+    if (!access_key || strlen(access_key) <= 0) {
+        return NULL;
+    }
+
+    secret_key = getenv(AWS_SECRET_ACCESS_KEY);
+    if (!secret_key || strlen(secret_key) <= 0) {
+        return NULL;
+    }
+
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        flb_errno();
+        return NULL;
+    }
+
+    creds->access_key_id = flb_sds_create(access_key);
+    if (!creds->access_key_id) {
+        flb_aws_credentials_destroy(creds);
+        flb_errno();
+        return NULL;
+    }
+
+    creds->secret_access_key = flb_sds_create(secret_key);
+    if (!creds->secret_access_key) {
+        flb_aws_credentials_destroy(creds);
+        flb_errno();
+        return NULL;
+    }
+
+    session_token = getenv(AWS_SESSION_TOKEN);
+    if (session_token && strlen(session_token) > 0) {
+        creds->session_token = flb_sds_create(session_token);
+        if (!creds->session_token) {
+            flb_aws_credentials_destroy(creds);
+            flb_errno();
+            return NULL;
+        }
+    } else {
+        creds->session_token = NULL;
+    }
+
+    return creds;
+
+}
+
+int refresh_env(struct flb_aws_provider *provider)
+{
+    char *access_key = NULL;
+    char *secret_key = NULL;
+
+    access_key = getenv(AWS_ACCESS_KEY_ID);
+    if (!access_key || strlen(access_key) <= 0) {
+        return -1;
+    }
+
+    secret_key = getenv(AWS_SECRET_ACCESS_KEY);
+    if (!secret_key || strlen(secret_key) <= 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * For the env provider, refresh simply checks if the environment
+ * variables are available.
+ */
+int refresh_fn_environment(struct flb_aws_provider *provider)
+{
+    flb_debug("[aws_credentials] Refresh called on the env provider");
+
+    return refresh_env(provider);
+}
+
+/*
+ * sync and async are no-ops for the env provider because it does not make
+ * network IO calls
+ */
+void sync_fn_environment(struct flb_aws_provider *provider)
+{
+    return;
+}
+
+void async_fn_environment(struct flb_aws_provider *provider)
+{
+    return;
+}
+
+/* Destroy is a no-op for the env provider */
+void destroy_fn_environment(struct flb_aws_provider *provider) {
+    return;
+}
+
+static struct flb_aws_provider_vtable environment_provider_vtable = {
+    .get_credentials = get_credentials_fn_environment,
+    .refresh = refresh_fn_environment,
+    .destroy = destroy_fn_environment,
+    .sync = sync_fn_environment,
+    .async = async_fn_environment,
+};
+
+struct flb_aws_provider *flb_aws_env_provider_create() {
+    struct flb_aws_provider *provider = flb_calloc(1, sizeof(
+                                                   struct flb_aws_provider));
+
+    if (!provider) {
+        flb_errno();
+        return NULL;
+    }
+
+    provider->provider_vtable = &environment_provider_vtable;
+    provider->implementation = NULL;
+
+    return provider;
+}
+
+
+void flb_aws_credentials_destroy(struct flb_aws_credentials *creds)
+{
+    if (creds) {
+        if (creds->access_key_id) {
+            flb_sds_destroy(creds->access_key_id);
+        }
+        if (creds->secret_access_key) {
+            flb_sds_destroy(creds->secret_access_key);
+        }
+        if (creds->secret_access_key) {
+            flb_sds_destroy(creds->session_token);
+        }
+
+        flb_free(creds);
+    }
+}
+
+void flb_aws_provider_destroy(struct flb_aws_provider *provider)
+{
+    if (provider) {
+        if (provider->implementation) {
+            provider->provider_vtable->destroy(provider);
+        }
+
+        flb_free(provider);
+    }
+}
+
+time_t timestamp_to_epoch(const char *timestamp)
+{
+    struct tm tm = {0};
+    time_t seconds;
+    int r;
+
+    r = sscanf(timestamp, "%d-%d-%dT%d:%d:%dZ", &tm.tm_year, &tm.tm_mon,
+               &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+    if (r != 6) {
+        return -1;
+    }
+
+    tm.tm_year -= 1900;
+    tm.tm_mon -= 1;
+    tm.tm_isdst = -1;
+    seconds = timegm(&tm);
+    if (seconds < 0) {
+        return -1;
+    }
+
+    return seconds;
+}
+
+time_t flb_aws_cred_expiration(const char *timestamp)
+{
+    time_t now;
+    time_t expiration = timestamp_to_epoch(timestamp);
+    if (expiration < 0) {
+        flb_warn("[aws_credentials] Could not parse expiration: %s", timestamp);
+        return -1;
+    }
+    /*
+     * Sanity check - expiration should be ~10 minutes to 12 hours in the future
+     * < 10 minutes is problematic because the provider auto-refreshes if creds
+     * expire in 5 minutes. Disabling auto-refresh reduces requests for creds.
+     * (The flb_aws_client will still force a refresh of creds and then retry
+     * if it receives an auth error).
+     * (> 12 hours is impossible with the current APIs and would likely indicate
+     *  a bug in how this code processes timestamps.)
+     */
+     now = time(NULL);
+     if (expiration < (now + TEN_MINUTES)) {
+         flb_warn("[aws_credentials] Credential expiration '%s' is less than"
+                  "10 minutes in the future. Disabling auto-refresh.",
+                  timestamp);
+         return -1;
+     }
+     if (expiration > (now + TWELVE_HOURS)) {
+         flb_warn("[aws_credentials] Credential expiration '%s' is greater than"
+                  "12 hours in the future. This should not be possible.",
+                  timestamp);
+     }
+     return expiration;
+}
+
+int flb_read_file(const char *path, char **out_buf, size_t *out_size)
+{
+    int ret;
+    long bytes;
+    char *buf = NULL;
+    FILE *fp = NULL;
+    struct stat st;
+
+    ret = stat(path, &st);
+    if (ret == -1) {
+        return -1;
+    }
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    buf = flb_malloc(st.st_size + sizeof(char));
+    if (!buf) {
+        flb_errno();
+        fclose(fp);
+        return -1;
+    }
+
+    bytes = fread(buf, st.st_size, 1, fp);
+    if (bytes != 1) {
+        flb_errno();
+        flb_free(buf);
+        fclose(fp);
+        return -1;
+    }
+
+    /* fread does not add null byte */
+    buf[st.st_size] = '\0';
+
+    fclose(fp);
+    *out_buf = buf;
+    *out_size = st.st_size;
+
+    return 0;
+}
+
+/*
+ * Fluent Bit is single-threaded but asynchonous. Only one co-routine will
+ * be running at a time, and they only pause/resume for IO.
+ *
+ * Thus, while synchronization is needed (to prevent multiple co-routines
+ * from duplicating effort and performing the same work), it can be obtained
+ * using a simple integer flag on the provider.
+ */
+
+/* Like a traditional try lock- it does not block if the lock is not obtained */
+int try_lock_provider(struct flb_aws_provider *provider)
+{
+    if (provider->locked == FLB_TRUE) {
+        return FLB_FALSE;
+    }
+    provider->locked = FLB_TRUE;
+    return FLB_TRUE;
+}
+
+void unlock_provider(struct flb_aws_provider *provider)
+{
+    if (provider->locked == FLB_TRUE) {
+        provider->locked = FLB_FALSE;
+    }
+}

--- a/src/aws/flb_aws_credentials_ec2.c
+++ b/src/aws/flb_aws_credentials_ec2.c
@@ -1,0 +1,321 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_aws_util.h>
+
+#include <jsmn/jsmn.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#define AWS_IMDS_ROLE_PATH      "/latest/meta-data/iam/security-credentials/"
+#define AWS_IMDS_ROLE_PATH_LEN  43
+
+#define AWS_IMDS_HOST           "169.254.169.254"
+
+struct flb_aws_provider_ec2;
+static int get_creds_ec2(struct flb_aws_provider_ec2 *implementation);
+static int ec2_credentials_request(struct flb_aws_provider_ec2
+                                   *implementation, char *cred_path);
+
+/* EC2 IMDS Provider */
+
+/*
+ * A provider that obtains credentials from EC2 IMDS.
+ */
+struct flb_aws_provider_ec2 {
+    struct flb_aws_credentials *creds;
+    time_t next_refresh;
+
+    /* upstream connection to IMDS */
+     struct flb_aws_client *client;
+};
+
+struct flb_aws_credentials *get_credentials_fn_ec2(struct flb_aws_provider
+                                                   *provider)
+{
+    struct flb_aws_credentials *creds;
+    int refresh = FLB_FALSE;
+    struct flb_aws_provider_ec2 *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Requesting credentials from the "
+              "EC2 provider..");
+
+    /* a negative next_refresh means that auto-refresh is disabled */
+    if (implementation->next_refresh > 0
+        && time(NULL) > implementation->next_refresh) {
+        refresh = FLB_TRUE;
+    }
+    if (!implementation->creds || refresh == FLB_TRUE) {
+        if (try_lock_provider(provider)) {
+            get_creds_ec2(implementation);
+            unlock_provider(provider);
+        }
+    }
+
+    if (!implementation->creds) {
+        /*
+         * We failed to lock the provider and creds are unset. This means that
+         * another co-routine is performing the refresh.
+         */
+        flb_warn("[aws_credentials] No cached credentials are available and "
+                 "a credential refresh is already in progress. The current "
+                 "co-routine will retry.");
+
+        return NULL;
+    }
+
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        flb_errno();
+        return NULL;
+    }
+
+    creds->access_key_id = flb_sds_create(implementation->creds->access_key_id);
+    if (!creds->access_key_id) {
+        flb_errno();
+        flb_aws_credentials_destroy(creds);
+        return NULL;
+    }
+
+    creds->secret_access_key = flb_sds_create(implementation->creds->
+                                              secret_access_key);
+    if (!creds->secret_access_key) {
+        flb_errno();
+        flb_aws_credentials_destroy(creds);
+        return NULL;
+    }
+
+    if (implementation->creds->session_token) {
+        creds->session_token = flb_sds_create(implementation->creds->
+                                              session_token);
+        if (!creds->session_token) {
+            flb_errno();
+            flb_aws_credentials_destroy(creds);
+            return NULL;
+        }
+
+    } else {
+        creds->session_token = NULL;
+    }
+
+    return creds;
+}
+
+int refresh_fn_ec2(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_ec2 *implementation = provider->implementation;
+    int ret = -1;
+
+    flb_debug("[aws_credentials] Refresh called on the EC2 IMDS provider");
+    if (try_lock_provider(provider)) {
+        ret = get_creds_ec2(implementation);
+        unlock_provider(provider);
+    }
+    return ret;
+}
+
+void sync_fn_ec2(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_ec2 *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Sync called on the EC2 provider");
+    /* remove async flag */
+    implementation->client->upstream->flags &= ~(FLB_IO_ASYNC);
+}
+
+void async_fn_ec2(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_ec2 *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Async called on the EC2 provider");
+    /* add async flag */
+    implementation->client->upstream->flags |= FLB_IO_ASYNC;
+}
+
+void destroy_fn_ec2(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_ec2 *implementation = provider->implementation;
+
+    if (implementation) {
+        if (implementation->creds) {
+            flb_aws_credentials_destroy(implementation->creds);
+        }
+
+        if (implementation->client) {
+            flb_aws_client_destroy(implementation->client);
+        }
+
+        flb_free(implementation);
+        provider->implementation = NULL;
+    }
+
+    return;
+}
+
+static struct flb_aws_provider_vtable ec2_provider_vtable = {
+    .get_credentials = get_credentials_fn_ec2,
+    .refresh = refresh_fn_ec2,
+    .destroy = destroy_fn_ec2,
+    .sync = sync_fn_ec2,
+    .async = async_fn_ec2,
+};
+
+struct flb_aws_provider *flb_ec2_provider_create(struct flb_config *config,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator)
+{
+    struct flb_aws_provider_ec2 *implementation;
+    struct flb_aws_provider *provider;
+    struct flb_upstream *upstream;
+
+    provider = flb_calloc(1, sizeof(struct flb_aws_provider));
+
+    if (!provider) {
+        flb_errno();
+        return NULL;
+    }
+
+    implementation = flb_calloc(1, sizeof(struct flb_aws_provider_ec2));
+
+    if (!implementation) {
+        flb_free(provider);
+        flb_errno();
+        return NULL;
+    }
+
+    provider->provider_vtable = &ec2_provider_vtable;
+    provider->implementation = implementation;
+
+    upstream = flb_upstream_create(config, AWS_IMDS_HOST, 80,
+                                   FLB_IO_TCP, NULL);
+    if (!upstream) {
+        flb_aws_provider_destroy(provider);
+        flb_error("[aws_credentials] EC2 IMDS: connection initialization "
+                  "error");
+        return NULL;
+    }
+
+    implementation->client = generator->create();
+    if (!implementation->client) {
+        flb_aws_provider_destroy(provider);
+        flb_upstream_destroy(upstream);
+        flb_error("[aws_credentials] EC2 IMDS: client creation error");
+        return NULL;
+    }
+    implementation->client->name = "ec2_imds_provider_client";
+    implementation->client->has_auth = FLB_FALSE;
+    implementation->client->provider = NULL;
+    implementation->client->region = NULL;
+    implementation->client->service = NULL;
+    implementation->client->port = 80;
+    implementation->client->flags = 0;
+    implementation->client->proxy = NULL;
+    implementation->client->upstream = upstream;
+
+    return provider;
+}
+
+/* Requests creds from IMDSv1 and sets them on the provider */
+static int get_creds_ec2(struct flb_aws_provider_ec2 *implementation)
+{
+    int ret;
+    flb_sds_t instance_role;
+    size_t instance_role_len;
+    char *cred_path;
+    size_t cred_path_size;
+
+    flb_debug("[aws_credentials] requesting credentials from EC2 IMDS");
+
+    /* Get the name of the instance role */
+    ret = flb_imds_request(implementation->client, AWS_IMDS_ROLE_PATH,
+                           &instance_role, &instance_role_len);
+
+    if (ret < 0) {
+        return -1;
+    }
+
+    flb_debug("[aws_credentials] Requesting credentials for instance role %s",
+              instance_role);
+
+    /* Construct path where we will find the credentials */
+    cred_path_size = sizeof(char) * (AWS_IMDS_ROLE_PATH_LEN +
+                                     instance_role_len) + 1;
+    cred_path = flb_malloc(cred_path_size);
+    if (!cred_path) {
+        flb_sds_destroy(instance_role);
+        flb_errno();
+        return -1;
+    }
+
+    ret = snprintf(cred_path, cred_path_size, "%s%s", AWS_IMDS_ROLE_PATH,
+                   instance_role);
+    if (ret < 0) {
+        flb_sds_destroy(instance_role);
+        flb_free(cred_path);
+        flb_errno();
+        return -1;
+    }
+
+    /* request creds */
+    ret = ec2_credentials_request(implementation, cred_path);
+
+    flb_sds_destroy(instance_role);
+    flb_free(cred_path);
+    return ret;
+
+}
+
+static int ec2_credentials_request(struct flb_aws_provider_ec2
+                                   *implementation, char *cred_path)
+{
+    int ret;
+    flb_sds_t credentials_response;
+    size_t credentials_response_len;
+    struct flb_aws_credentials *creds;
+    time_t expiration;
+
+    ret = flb_imds_request(implementation->client, cred_path,
+                           &credentials_response, &credentials_response_len);
+
+    if (ret < 0) {
+        return -1;
+    }
+
+    creds = flb_parse_http_credentials(credentials_response,
+                                       credentials_response_len,
+                                       &expiration);
+
+    if (creds == NULL) {
+        flb_sds_destroy(credentials_response);
+        return -1;
+    }
+
+    /* destroy existing credentials first */
+    flb_aws_credentials_destroy(implementation->creds);
+    implementation->creds = NULL;
+    /* set new creds */
+    implementation->creds = creds;
+    implementation->next_refresh = expiration - FLB_AWS_REFRESH_WINDOW;
+
+    flb_sds_destroy(credentials_response);
+    return 0;
+}

--- a/src/aws/flb_aws_credentials_http.c
+++ b/src/aws/flb_aws_credentials_http.c
@@ -1,0 +1,519 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_aws_util.h>
+
+#include <jsmn/jsmn.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* HTTP Credentials Endpoints have a standard set of JSON Keys */
+#define AWS_HTTP_RESPONSE_ACCESS_KEY   "AccessKeyId"
+#define AWS_HTTP_RESPONSE_SECRET_KEY   "SecretAccessKey"
+#define AWS_HTTP_RESPONSE_TOKEN        "Token"
+#define AWS_HTTP_RESPONSE_EXPIRATION   "Expiration"
+
+#define ECS_CREDENTIALS_HOST           "169.254.170.2"
+#define ECS_CREDENTIALS_HOST_LEN       13
+#define ECS_CREDENTIALS_PATH_ENV_VAR   "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+
+
+/* Declarations */
+struct flb_aws_provider_http;
+static int http_credentials_request(struct flb_aws_provider_http
+                                    *implementation);
+
+
+/*
+ * HTTP Credentials Provider - retrieve credentials from a local http server
+ * Used to implement the ECS Credentials provider.
+ * Equivalent to:
+ * https://github.com/aws/aws-sdk-go/tree/master/aws/credentials/endpointcreds
+ */
+
+struct flb_aws_provider_http {
+    struct flb_aws_credentials *creds;
+    time_t next_refresh;
+
+    struct flb_aws_client *client;
+
+    /* Host and Path to request credentials */
+    flb_sds_t host;
+    flb_sds_t path;
+};
+
+
+struct flb_aws_credentials *get_credentials_fn_http(struct flb_aws_provider
+                                                    *provider)
+{
+    struct flb_aws_credentials *creds = NULL;
+    int refresh = FLB_FALSE;
+    struct flb_aws_provider_http *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Retrieving credentials from the "
+              "HTTP provider..");
+
+    /* a negative next_refresh means that auto-refresh is disabled */
+    if (implementation->next_refresh > 0
+        && time(NULL) > implementation->next_refresh) {
+        refresh = FLB_TRUE;
+    }
+    if (!implementation->creds || refresh == FLB_TRUE) {
+        if (try_lock_provider(provider)) {
+            http_credentials_request(implementation);
+            unlock_provider(provider);
+        }
+    }
+
+    if (!implementation->creds) {
+        /*
+         * We failed to lock the provider and creds are unset. This means that
+         * another co-routine is performing the refresh.
+         */
+        flb_warn("[aws_credentials] No cached credentials are available and "
+                 "a credential refresh is already in progress. The current "
+                 "co-routine will retry.");
+
+        return NULL;
+    }
+
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        flb_errno();
+        goto error;
+    }
+
+    creds->access_key_id = flb_sds_create(implementation->creds->access_key_id);
+    if (!creds->access_key_id) {
+        flb_errno();
+        goto error;
+    }
+
+    creds->secret_access_key = flb_sds_create(implementation->creds->
+                                              secret_access_key);
+    if (!creds->secret_access_key) {
+        flb_errno();
+        goto error;
+    }
+
+    if (implementation->creds->session_token) {
+        creds->session_token = flb_sds_create(implementation->creds->
+                                              session_token);
+        if (!creds->session_token) {
+            flb_errno();
+            goto error;
+        }
+
+    } else {
+        creds->session_token = NULL;
+    }
+
+    return creds;
+
+error:
+    flb_aws_credentials_destroy(creds);
+    return NULL;
+}
+
+int refresh_fn_http(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_http *implementation = provider->implementation;
+    int ret = -1;
+    flb_debug("[aws_credentials] Refresh called on the http provider");
+
+    if (try_lock_provider(provider)) {
+        ret = http_credentials_request(implementation);
+        unlock_provider(provider);
+    }
+    return ret;
+}
+
+void sync_fn_http(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_http *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Sync called on the http provider");
+    /* remove async flag */
+    implementation->client->upstream->flags &= ~(FLB_IO_ASYNC);
+}
+
+void async_fn_http(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_http *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Async called on the http provider");
+    /* add async flag */
+    implementation->client->upstream->flags |= FLB_IO_ASYNC;
+}
+
+void destroy_fn_http(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_http *implementation = provider->implementation;
+
+    if (implementation) {
+        if (implementation->creds) {
+            flb_aws_credentials_destroy(implementation->creds);
+        }
+
+        if (implementation->client) {
+            flb_aws_client_destroy(implementation->client);
+        }
+
+        if (implementation->host) {
+            flb_sds_destroy(implementation->host);
+        }
+
+        if (implementation->path) {
+            flb_sds_destroy(implementation->path);
+        }
+
+        flb_free(implementation);
+        provider->implementation = NULL;
+    }
+
+    return;
+}
+
+static struct flb_aws_provider_vtable http_provider_vtable = {
+    .get_credentials = get_credentials_fn_http,
+    .refresh = refresh_fn_http,
+    .destroy = destroy_fn_http,
+    .sync = sync_fn_http,
+    .async = async_fn_http,
+};
+
+struct flb_aws_provider *flb_http_provider_create(struct flb_config *config,
+                                                  flb_sds_t host,
+                                                  flb_sds_t path,
+                                                  struct
+                                                  flb_aws_client_generator
+                                                  *generator)
+{
+    struct flb_aws_provider_http *implementation = NULL;
+    struct flb_aws_provider *provider = NULL;
+    struct flb_upstream *upstream = NULL;
+
+    flb_debug("[aws_credentials] Configuring HTTP provider with %s:80%s",
+              host, path);
+
+    provider = flb_calloc(1, sizeof(struct flb_aws_provider));
+
+    if (!provider) {
+        flb_errno();
+        return NULL;
+    }
+
+    implementation = flb_calloc(1, sizeof(struct flb_aws_provider_http));
+
+    if (!implementation) {
+        flb_free(provider);
+        flb_errno();
+        return NULL;
+    }
+
+    provider->provider_vtable = &http_provider_vtable;
+    provider->implementation = implementation;
+
+    implementation->host = host;
+    implementation->path = path;
+
+    upstream = flb_upstream_create(config, host, 80, FLB_IO_TCP, NULL);
+
+    if (!upstream) {
+        flb_aws_provider_destroy(provider);
+        flb_error("[aws_credentials] HTTP Provider: connection initialization "
+                  "error");
+        return NULL;
+    }
+
+    implementation->client = generator->create();
+    if (!implementation->client) {
+        flb_aws_provider_destroy(provider);
+        flb_upstream_destroy(upstream);
+        flb_error("[aws_credentials] HTTP Provider: client creation error");
+        return NULL;
+    }
+    implementation->client->name = "http_provider_client";
+    implementation->client->has_auth = FLB_FALSE;
+    implementation->client->provider = NULL;
+    implementation->client->region = NULL;
+    implementation->client->service = NULL;
+    implementation->client->port = 80;
+    implementation->client->flags = 0;
+    implementation->client->proxy = NULL;
+    implementation->client->upstream = upstream;
+
+    return provider;
+}
+
+/*
+ * ECS Provider
+ * The ECS Provider is just a wrapper around the HTTP Provider
+ * with the ECS credentials endpoint.
+ */
+
+ struct flb_aws_provider *flb_ecs_provider_create(struct flb_config *config,
+                                                  struct
+                                                  flb_aws_client_generator
+                                                  *generator)
+{
+    flb_sds_t host = NULL;
+    flb_sds_t path = NULL;
+    char *path_var = NULL;
+
+    host = flb_sds_create_len(ECS_CREDENTIALS_HOST, ECS_CREDENTIALS_HOST_LEN);
+    if (!host) {
+        flb_errno();
+        return NULL;
+    }
+
+    path_var = getenv(ECS_CREDENTIALS_PATH_ENV_VAR);
+    if (path_var && strlen(path_var) > 0) {
+        path = flb_sds_create(path_var);
+        if (!path) {
+            flb_errno();
+            flb_free(host);
+            return NULL;
+        }
+
+        return flb_http_provider_create(config, host, path, generator);
+    } else {
+        flb_debug("[aws_credentials] Not initializing ECS Provider because"
+                  " %s is not set", ECS_CREDENTIALS_PATH_ENV_VAR);
+        flb_sds_destroy(host);
+        return NULL;
+    }
+
+}
+
+static int http_credentials_request(struct flb_aws_provider_http
+                                    *implementation)
+{
+    char *response = NULL;
+    size_t response_len;
+    time_t expiration;
+    struct flb_aws_credentials *creds = NULL;
+    struct flb_aws_client *client = implementation->client;
+    struct flb_http_client *c = NULL;
+
+    c = client->client_vtable->request(client, FLB_HTTP_GET,
+                                       implementation->path, NULL, 0,
+                                       NULL, 0);
+
+    if (!c || c->resp.status != 200) {
+        flb_debug("[aws_credentials] http credentials request failed");
+        if (c) {
+            flb_http_client_destroy(c);
+        }
+        return -1;
+    }
+
+    response = c->resp.payload;
+    response_len = c->resp.payload_size;
+
+    creds = flb_parse_http_credentials(response, response_len, &expiration);
+    if (!creds) {
+        flb_http_client_destroy(c);
+        return -1;
+    }
+
+    /* destroy existing credentials */
+    flb_aws_credentials_destroy(implementation->creds);
+    implementation->creds = NULL;
+
+    implementation->creds = creds;
+    implementation->next_refresh = expiration - FLB_AWS_REFRESH_WINDOW;
+    flb_http_client_destroy(c);
+    return 0;
+}
+
+/*
+ * All HTTP credentials endpoints (IMDS, ECS, custom) follow the same spec:
+ * {
+ *   "AccessKeyId": "ACCESS_KEY_ID",
+ *   "Expiration": "2019-12-18T21:27:58Z",
+ *   "SecretAccessKey": "SECRET_ACCESS_KEY",
+ *   "Token": "SECURITY_TOKEN_STRING"
+ * }
+ * (some implementations (IMDS) have additional fields)
+ * Returns NULL if any part of parsing was unsuccessful.
+ */
+struct flb_aws_credentials *flb_parse_http_credentials(char *response,
+                                                       size_t response_len,
+                                                       time_t *expiration)
+{
+    jsmntok_t *tokens = NULL;
+    const jsmntok_t *t = NULL;
+    char *current_token = NULL;
+    jsmn_parser parser;
+    int tokens_size = 50;
+    size_t size;
+    int ret;
+    struct flb_aws_credentials *creds = NULL;
+    int i = 0;
+    int len;
+    flb_sds_t tmp;
+
+    /*
+     * Remove/reset existing value of expiration.
+     * Expiration should be in the response, but it is not
+     * strictly speaking needed. Fluent Bit logs a warning if it is missing.
+     */
+    *expiration = -1;
+
+    jsmn_init(&parser);
+
+    size = sizeof(jsmntok_t) * tokens_size;
+    tokens = flb_calloc(1, size);
+    if (!tokens) {
+        goto error;
+    }
+
+    ret = jsmn_parse(&parser, response, response_len,
+                     tokens, tokens_size);
+
+    if (ret == JSMN_ERROR_INVAL || ret == JSMN_ERROR_PART) {
+        flb_error("[aws_credentials] Could not parse http credentials response"
+                  " - invalid JSON.");
+        goto error;
+    }
+
+    /* Shouldn't happen, but just in case, check for too many tokens error */
+    if (ret == JSMN_ERROR_NOMEM) {
+        flb_error("[aws_credentials] Could not parse http credentials response"
+                  " - response contained more tokens than expected.");
+        goto error;
+    }
+
+    /* return value is number of tokens parsed */
+    tokens_size = ret;
+
+    creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        flb_errno();
+        goto error;
+    }
+
+    /*
+     * jsmn will create an array of tokens like:
+     * key, value, key, value
+     */
+    while (i < (tokens_size - 1)) {
+        t = &tokens[i];
+
+        if (t->start == -1 || t->end == -1 || (t->start == 0 && t->end == 0)) {
+            break;
+        }
+
+        if (t->type == JSMN_STRING) {
+            current_token = &response[t->start];
+            len = t->end - t->start;
+
+            if (strncmp(current_token, AWS_HTTP_RESPONSE_ACCESS_KEY, len) == 0)
+            {
+                i++;
+                t = &tokens[i];
+                current_token = &response[t->start];
+                len = t->end - t->start;
+                creds->access_key_id = flb_sds_create_len(current_token, len);
+                if (!creds->access_key_id) {
+                    flb_errno();
+                    goto error;
+                }
+                continue;
+            }
+            if (strncmp(current_token, AWS_HTTP_RESPONSE_SECRET_KEY, len) == 0)
+            {
+                i++;
+                t = &tokens[i];
+                current_token = &response[t->start];
+                len = t->end - t->start;
+                creds->secret_access_key = flb_sds_create_len(current_token,
+                                                              len);
+                if (!creds->secret_access_key) {
+                    flb_errno();
+                    goto error;
+                }
+                continue;
+            }
+            if (strncmp(current_token, AWS_HTTP_RESPONSE_TOKEN, len) == 0) {
+                i++;
+                t = &tokens[i];
+                current_token = &response[t->start];
+                len = t->end - t->start;
+                creds->session_token = flb_sds_create_len(current_token, len);
+                if (!creds->session_token) {
+                    flb_errno();
+                    goto error;
+                }
+                continue;
+            }
+            if (strncmp(current_token, AWS_HTTP_RESPONSE_EXPIRATION, len) == 0)
+            {
+                i++;
+                t = &tokens[i];
+                current_token = &response[t->start];
+                len = t->end - t->start;
+                tmp = flb_sds_create_len(current_token, len);
+                if (!tmp) {
+                    flb_errno();
+                    goto error;
+                }
+                *expiration = flb_aws_cred_expiration(tmp);
+                flb_sds_destroy(tmp);
+                if (*expiration < 0) {
+                    flb_warn("[aws_credentials] '%s' was invalid or "
+                             "could not be parsed. Disabling auto-refresh of "
+                             "credentials.", AWS_HTTP_RESPONSE_EXPIRATION);
+                }
+            }
+        }
+
+        i++;
+    }
+
+    flb_free(tokens);
+
+    if (creds->access_key_id == NULL) {
+        flb_error("[aws_credentials] Missing %s field in http"
+                  "credentials response", AWS_HTTP_RESPONSE_ACCESS_KEY);
+        goto error;
+    }
+
+    if (creds->secret_access_key == NULL) {
+        flb_error("[aws_credentials] Missing %s field in http"
+                  "credentials response", AWS_HTTP_RESPONSE_SECRET_KEY);
+        goto error;
+    }
+
+    if (creds->session_token == NULL) {
+        flb_error("[aws_credentials] Missing %s field in http"
+                  "credentials response", AWS_HTTP_RESPONSE_TOKEN);
+        goto error;
+    }
+
+    return creds;
+
+error:
+    flb_aws_credentials_destroy(creds);
+    flb_free(tokens);
+    return NULL;
+}

--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -1,0 +1,856 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_aws_util.h>
+
+#include <mbedtls/ctr_drbg.h>
+#include "mbedtls/entropy.h"
+#include <jsmn/jsmn.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+
+#define STS_ASSUME_ROLE_URI_FORMAT    "/?Version=2011-06-15&Action=%s\
+&RoleSessionName=%s&RoleArn=%s"
+#define STS_ASSUME_ROLE_URI_BASE_LEN  54
+
+#define CREDENTIALS_NODE              "<Credentials>"
+#define CREDENTIALS_NODE_LEN          13
+#define ACCESS_KEY_NODE               "<AccessKeyId>"
+#define ACCESS_KEY_NODE_LEN           13
+#define SECRET_KEY_NODE               "<SecretAccessKey>"
+#define SECRET_KEY_NODE_LEN           17
+#define SESSION_TOKEN_NODE            "<SessionToken>"
+#define SESSION_TOKEN_NODE_LEN        14
+#define EXPIRATION_NODE               "<Expiration>"
+#define EXPIRATION_NODE_LEN           12
+
+#define TOKEN_FILE_ENV_VAR            "AWS_WEB_IDENTITY_TOKEN_FILE"
+#define ROLE_ARN_ENV_VAR              "AWS_ROLE_ARN"
+#define SESSION_NAME_ENV_VAR          "AWS_ROLE_SESSION_NAME"
+
+#define SESSION_NAME_RANDOM_BYTE_LEN  32
+
+struct flb_aws_provider_eks;
+void bytes_to_string(unsigned char *data, char *buf, size_t len);
+static int assume_with_web_identity(struct flb_aws_provider_eks
+                                    *implementation);
+static int sts_assume_role_request(struct flb_aws_client *sts_client,
+                                   struct flb_aws_credentials **creds,
+                                   char *uri,
+                                   time_t *next_refresh);
+static flb_sds_t get_node(char *cred_node, char* node_name, int node_len);
+
+
+/*
+ * A provider that uses credentials from the base provider to call STS
+ * and assume an IAM Role.
+ */
+struct flb_aws_provider_sts {
+    struct flb_aws_provider *base_provider;
+
+    struct flb_aws_credentials *creds;
+    time_t next_refresh;
+
+    struct flb_aws_client *sts_client;
+
+    /* Fluent Bit uses regional STS endpoints; this is a best practice. */
+    char *endpoint;
+
+    char *uri;
+};
+
+struct flb_aws_credentials *get_credentials_fn_sts(struct flb_aws_provider
+                                                   *provider)
+{
+    struct flb_aws_credentials *creds;
+    int refresh = FLB_FALSE;
+    struct flb_aws_provider_sts *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Requesting credentials from the "
+              "STS provider..");
+
+    /* a negative next_refresh means that auto-refresh is disabled */
+    if (implementation->next_refresh > 0
+        && time(NULL) > implementation->next_refresh) {
+        refresh = FLB_TRUE;
+    }
+    if (!implementation->creds || refresh == FLB_TRUE) {
+        /* credentials need to be refreshed/obtained */
+        if (try_lock_provider(provider)) {
+            flb_debug("[aws_credentials] STS Provider: Refreshing credential "
+                      "cache.");
+            sts_assume_role_request(implementation->sts_client,
+                                    &implementation->creds,
+                                    implementation->uri,
+                                    &implementation->next_refresh);
+            unlock_provider(provider);
+        }
+    }
+
+    if (!implementation->creds) {
+        /*
+         * We failed to lock the provider and creds are unset. This means that
+         * another co-routine is performing the refresh.
+         */
+        flb_warn("[aws_credentials] No cached credentials are available and "
+                 "a credential refresh is already in progress. The current"
+                 "co-routine will retry.");
+
+        return NULL;
+    }
+
+    /* return a copy of the existing cached credentials */
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        goto error;
+    }
+
+    creds->access_key_id = flb_sds_create(implementation->creds->access_key_id);
+    if (!creds->access_key_id) {
+        goto error;
+    }
+
+    creds->secret_access_key = flb_sds_create(implementation->creds->
+                                              secret_access_key);
+    if (!creds->secret_access_key) {
+        goto error;
+    }
+
+    if (implementation->creds->session_token) {
+        creds->session_token = flb_sds_create(implementation->creds->
+                                              session_token);
+        if (!creds->session_token) {
+            goto error;
+        }
+
+    } else {
+        creds->session_token = NULL;
+    }
+
+    return creds;
+
+error:
+    flb_errno();
+    flb_aws_credentials_destroy(creds);
+    return NULL;
+}
+
+int refresh_fn_sts(struct flb_aws_provider *provider) {
+    int ret = -1;
+    struct flb_aws_provider_sts *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Refresh called on the STS provider");
+
+    if (try_lock_provider(provider)) {
+        ret = sts_assume_role_request(implementation->sts_client,
+                                      &implementation->creds, implementation->uri,
+                                      &implementation->next_refresh);
+        unlock_provider(provider);
+    }
+    return ret;
+}
+
+void sync_fn_sts(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_sts *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Sync called on the STS provider");
+    /* Remove async flag */
+    implementation->sts_client->upstream->flags &= ~(FLB_IO_ASYNC);
+}
+
+void async_fn_sts(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_sts *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Async called on the STS provider");
+    /* Add async flag */
+    implementation->sts_client->upstream->flags |= FLB_IO_ASYNC;
+}
+
+void destroy_fn_sts(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_sts *implementation = provider->
+                                                          implementation;
+    if (implementation) {
+        if (implementation->creds) {
+            flb_aws_credentials_destroy(implementation->creds);
+        }
+
+        if (implementation->sts_client) {
+            flb_aws_client_destroy(implementation->sts_client);
+        }
+
+        if (implementation->uri) {
+            flb_free(implementation->uri);
+        }
+
+        if (implementation->endpoint) {
+            flb_free(implementation->endpoint);
+        }
+
+        flb_free(implementation);
+        provider->implementation = NULL;
+    }
+
+    return;
+}
+
+static struct flb_aws_provider_vtable sts_provider_vtable = {
+    .get_credentials = get_credentials_fn_sts,
+    .refresh = refresh_fn_sts,
+    .destroy = destroy_fn_sts,
+    .sync = sync_fn_sts,
+    .async = async_fn_sts,
+};
+
+struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
+                                                 struct flb_tls *tls,
+                                                 struct flb_aws_provider
+                                                 *base_provider,
+                                                 char *external_id,
+                                                 char *role_arn,
+                                                 char *session_name,
+                                                 char *region,
+                                                 char *proxy,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator)
+{
+    struct flb_aws_provider_sts *implementation = NULL;
+    struct flb_aws_provider *provider = NULL;
+    struct flb_upstream *upstream = NULL;
+
+    provider = flb_calloc(1, sizeof(struct flb_aws_provider));
+
+    if (!provider) {
+        flb_errno();
+        return NULL;
+    }
+
+    implementation = flb_calloc(1, sizeof(struct flb_aws_provider_sts));
+
+    if (!implementation) {
+        goto error;
+    }
+
+    provider->provider_vtable = &sts_provider_vtable;
+    provider->implementation = implementation;
+
+    implementation->uri = flb_sts_uri("AssumeRole", role_arn, session_name,
+                                  external_id, NULL);
+    if (!implementation->uri) {
+        goto error;
+    }
+
+    implementation->endpoint = flb_aws_endpoint("sts", region);
+    if (!implementation->endpoint) {
+        goto error;
+    }
+
+    implementation->base_provider = base_provider;
+    implementation->sts_client = generator->create();
+    if (!implementation->sts_client) {
+        goto error;
+    }
+    implementation->sts_client->name = "sts_client_assume_role_provider";
+    implementation->sts_client->has_auth = FLB_TRUE;
+    implementation->sts_client->provider = base_provider;
+    implementation->sts_client->region = region;
+    implementation->sts_client->service = "sts";
+    implementation->sts_client->port = 443;
+    implementation->sts_client->flags = 0;
+    implementation->sts_client->proxy = proxy;
+
+    upstream = flb_upstream_create(config, implementation->endpoint, 443,
+                                   FLB_IO_TLS, tls);
+    if (!upstream) {
+        flb_error("[aws_credentials] Connection initialization error");
+        goto error;
+    }
+
+    implementation->sts_client->upstream = upstream;
+    implementation->sts_client->host = implementation->endpoint;
+
+    return provider;
+
+error:
+    flb_errno();
+    flb_aws_provider_destroy(provider);
+    return NULL;
+}
+
+/*
+ * A provider that uses OIDC tokens provided by kubernetes to obtain
+ * AWS credentials.
+ *
+ * The AWS SDKs have defined a spec for an OIDC provider that obtains tokens
+ * from environment variables or the shared config file.
+ * This provider only contains the functionality needed for EKS- obtaining the
+ * location of the OIDC token from an environment variable.
+ */
+struct flb_aws_provider_eks {
+    struct flb_aws_credentials *creds;
+    /*
+     * Time to auto-refresh creds before they expire. A negative value disables
+     * auto-refresh. Client code can always force a refresh.
+     */
+    time_t next_refresh;
+
+    struct flb_aws_client *sts_client;
+
+    /* Fluent Bit uses regional STS endpoints; this is a best practice. */
+    char *endpoint;
+
+    char *session_name;
+    /* session name can come from env or be generated by the provider */
+    int free_session_name;
+    char *role_arn;
+
+    char *token_file;
+};
+
+
+struct flb_aws_credentials *get_credentials_fn_eks(struct flb_aws_provider
+                                                   *provider)
+{
+    struct flb_aws_credentials *creds = NULL;
+    int refresh = FLB_FALSE;
+    struct flb_aws_provider_eks *implementation = provider->implementation;
+
+    flb_debug("[aws_credentials] Requesting credentials from the "
+              "EKS provider..");
+
+    /* a negative next_refresh means that auto-refresh is disabled */
+    if (implementation->next_refresh > 0
+        && time(NULL) > implementation->next_refresh) {
+        refresh = FLB_TRUE;
+    }
+    if (!implementation->creds || refresh == FLB_TRUE) {
+        if (try_lock_provider(provider)) {
+            flb_debug("[aws_credentials] EKS Provider: Refreshing credential "
+                      "cache.");
+            assume_with_web_identity(implementation);
+            unlock_provider(provider);
+        }
+    }
+
+    if (!implementation->creds) {
+        /*
+         * We failed to lock the provider and creds are unset. This means that
+         * another co-routine is performing the refresh.
+         */
+        flb_warn("[aws_credentials] No cached credentials are available and "
+                 "a credential refresh is already in progress. The current "
+                 "co-routine will retry.");
+
+        return NULL;
+    }
+
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        goto error;
+    }
+
+    creds->access_key_id = flb_sds_create(implementation->creds->access_key_id);
+    if (!creds->access_key_id) {
+        goto error;
+    }
+
+    creds->secret_access_key = flb_sds_create(implementation->creds->
+                                              secret_access_key);
+    if (!creds->secret_access_key) {
+        goto error;
+    }
+
+    if (implementation->creds->session_token) {
+        creds->session_token = flb_sds_create(implementation->creds->
+                                              session_token);
+        if (!creds->session_token) {
+            goto error;
+        }
+
+    } else {
+        creds->session_token = NULL;
+    }
+
+    return creds;
+
+error:
+    flb_errno();
+    flb_aws_credentials_destroy(creds);
+    return NULL;
+}
+
+int refresh_fn_eks(struct flb_aws_provider *provider) {
+    int ret = -1;
+    struct flb_aws_provider_eks *implementation = provider->
+                                                          implementation;
+    flb_debug("[aws_credentials] Refresh called on the EKS provider");
+    if (try_lock_provider(provider)) {
+        ret = assume_with_web_identity(implementation);
+        unlock_provider(provider);
+    }
+    return ret;
+}
+
+void sync_fn_eks(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_eks *implementation = provider->implementation;
+    flb_debug("[aws_credentials] Sync called on the EKS provider");
+    /* remove async flag */
+    implementation->sts_client->upstream->flags &= ~(FLB_IO_ASYNC);
+}
+
+void async_fn_eks(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_eks *implementation = provider->implementation;
+    flb_debug("[aws_credentials] Async called on the EKS provider");
+    /* add async flag */
+    implementation->sts_client->upstream->flags |= FLB_IO_ASYNC;
+}
+
+void destroy_fn_eks(struct flb_aws_provider *provider) {
+    struct flb_aws_provider_eks *implementation = provider->
+                                                          implementation;
+    if (implementation) {
+        if (implementation->creds) {
+            flb_aws_credentials_destroy(implementation->creds);
+        }
+
+        if (implementation->sts_client) {
+            flb_aws_client_destroy(implementation->sts_client);
+        }
+
+        if (implementation->endpoint) {
+            flb_free(implementation->endpoint);
+        }
+        if (implementation->free_session_name == FLB_TRUE) {
+            flb_free(implementation->session_name);
+        }
+
+        flb_free(implementation);
+        provider->implementation = NULL;
+    }
+
+    return;
+}
+
+static struct flb_aws_provider_vtable eks_provider_vtable = {
+    .get_credentials = get_credentials_fn_eks,
+    .refresh = refresh_fn_eks,
+    .destroy = destroy_fn_eks,
+    .sync = sync_fn_eks,
+    .async = async_fn_sts,
+};
+
+struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
+                                                 struct flb_tls *tls,
+                                                 char *region, char *proxy,
+                                                 struct
+                                                 flb_aws_client_generator
+                                                 *generator)
+{
+    struct flb_aws_provider_eks *implementation = NULL;
+    struct flb_aws_provider *provider = NULL;
+    struct flb_upstream *upstream = NULL;
+
+    provider = flb_calloc(1, sizeof(struct flb_aws_provider));
+
+    if (!provider) {
+        flb_errno();
+        return NULL;
+    }
+
+    implementation = flb_calloc(1, sizeof(struct flb_aws_provider_eks));
+
+    if (!implementation) {
+        goto error;
+    }
+
+    provider->provider_vtable = &eks_provider_vtable;
+    provider->implementation = implementation;
+
+    /* session name either comes from the env var or is a random uuid */
+    implementation->session_name = getenv(SESSION_NAME_ENV_VAR);
+    implementation->free_session_name = FLB_FALSE;
+    if (!implementation->session_name ||
+        strlen(implementation->session_name) == 0) {
+        implementation->session_name = flb_sts_session_name();
+        if (!implementation->session_name) {
+            goto error;
+        }
+        implementation->free_session_name = FLB_TRUE;
+    }
+
+    implementation->role_arn = getenv(ROLE_ARN_ENV_VAR);
+    if (!implementation->role_arn || strlen(implementation->role_arn) == 0) {
+        flb_debug("[aws_credentials] Not initializing EKS provider because"
+                  " %s was not set", ROLE_ARN_ENV_VAR);
+        flb_aws_provider_destroy(provider);
+        return NULL;
+    }
+
+    implementation->token_file = getenv(TOKEN_FILE_ENV_VAR);
+    if (!implementation->token_file || strlen(implementation->token_file) == 0)
+    {
+        flb_debug("[aws_credentials] Not initializing EKS provider because"
+                  " %s was not set", TOKEN_FILE_ENV_VAR);
+        flb_aws_provider_destroy(provider);
+        return NULL;
+    }
+
+    implementation->endpoint = flb_aws_endpoint("sts", region);
+    if (!implementation->endpoint) {
+        goto error;
+    }
+
+    implementation->sts_client = generator->create();
+    if (!implementation->sts_client) {
+        goto error;
+    }
+    implementation->sts_client->name = "sts_client_eks_provider";
+    /* AssumeRoleWithWebIdentity does not require sigv4 */
+    implementation->sts_client->has_auth = FLB_FALSE;
+    implementation->sts_client->provider = NULL;
+    implementation->sts_client->region = region;
+    implementation->sts_client->service = "sts";
+    implementation->sts_client->port = 443;
+    implementation->sts_client->flags = 0;
+    implementation->sts_client->proxy = proxy;
+
+    upstream = flb_upstream_create(config, implementation->endpoint, 443,
+                                   FLB_IO_TLS, tls);
+
+    implementation->sts_client->upstream = upstream;
+    implementation->sts_client->host = implementation->endpoint;
+
+    return provider;
+
+error:
+    flb_errno();
+    flb_aws_provider_destroy(provider);
+    return NULL;
+}
+
+/* Generates string which can serve as a unique session name */
+char *flb_sts_session_name() {
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+    char *personalization = NULL;
+    time_t now;
+    unsigned char *random_data = NULL;
+    char *session_name = NULL;
+    int ret;
+
+    personalization = flb_malloc(sizeof(char) * 27);
+    if (!personalization) {
+        goto error;
+    }
+
+    now = time(NULL);
+    ctime_r(&now, personalization);
+
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+
+    ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                (const unsigned char *) personalization,
+                                strlen(personalization));
+    if (ret != 0) {
+        goto error;
+    }
+
+    random_data = flb_malloc(sizeof(unsigned char) *
+                             SESSION_NAME_RANDOM_BYTE_LEN);
+    if (!random_data) {
+        goto error;
+    }
+
+    ret = mbedtls_ctr_drbg_random(&ctr_drbg, random_data,
+                                  SESSION_NAME_RANDOM_BYTE_LEN);
+    if (ret != 0) {
+        goto error;
+    }
+
+    session_name = flb_malloc(sizeof(char) *
+                              (SESSION_NAME_RANDOM_BYTE_LEN + 1));
+    if (!session_name) {
+        goto error;
+    }
+
+    bytes_to_string(random_data, session_name, SESSION_NAME_RANDOM_BYTE_LEN);
+    session_name[SESSION_NAME_RANDOM_BYTE_LEN] = '\0';
+
+    flb_free(random_data);
+    flb_free(personalization);
+
+    return session_name;
+
+error:
+    flb_errno();
+    if (personalization) {
+        flb_free(personalization);
+    }
+    if (random_data) {
+        flb_free(random_data);
+    }
+    if (session_name) {
+        flb_free(session_name);
+    }
+    return NULL;
+}
+
+/* converts random bytes to a string we can safely put in a URL */
+void bytes_to_string(unsigned char *data, char *buf, size_t len) {
+    int index;
+    char charset[] = "0123456789"
+                     "abcdefghijklmnopqrstuvwxyz"
+                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    while (len-- > 0) {
+        index = (int) data[len];
+        index = index % (sizeof(charset) - 1);
+        buf[len] = charset[index];
+    }
+}
+
+static int assume_with_web_identity(struct flb_aws_provider_eks
+                                    *implementation)
+{
+    int ret;
+    char *web_token = NULL;
+    size_t web_token_size;
+    char *uri = NULL;
+
+    ret = flb_read_file(implementation->token_file, &web_token,
+                        &web_token_size);
+    if (ret < 0) {
+        flb_error("[aws_credentials] Could not read web identify token file");
+        return -1;
+    }
+
+    uri = flb_sts_uri("AssumeRoleWithWebIdentity", implementation->role_arn,
+                  implementation->session_name, NULL, web_token);
+    if (!uri) {
+        flb_free(web_token);
+        return -1;
+    }
+
+    ret = sts_assume_role_request(implementation->sts_client,
+                                  &implementation->creds, uri,
+                                  &implementation->next_refresh);
+    flb_free(web_token);
+    flb_free(uri);
+    return ret;
+}
+
+static int sts_assume_role_request(struct flb_aws_client *sts_client,
+                                   struct flb_aws_credentials **creds,
+                                   char *uri,
+                                   time_t *next_refresh)
+{
+    time_t expiration;
+    struct flb_aws_credentials *credentials = NULL;
+    struct flb_http_client *c = NULL;
+    flb_sds_t error_type;
+
+    flb_debug("[aws_credentials] Calling STS..");
+
+    c = sts_client->client_vtable->request(sts_client, FLB_HTTP_GET,
+                                           uri, NULL, 0, NULL, 0);
+
+    if (c && c->resp.status == 200) {
+        credentials = flb_parse_sts_resp(c->resp.payload, &expiration);
+        if (!credentials) {
+            flb_error("[aws_credentials] Failed to parse response from STS");
+            flb_http_client_destroy(c);
+            return -1;
+        }
+
+        /* unset and free existing credentials first */
+        flb_aws_credentials_destroy(*creds);
+        *creds = NULL;
+
+        *next_refresh = expiration - FLB_AWS_REFRESH_WINDOW;
+        *creds = credentials;
+        flb_http_client_destroy(c);
+        return 0;
+    }
+
+    if (c && c->resp.payload_size > 0) {
+        error_type = flb_aws_error(c->resp.payload, c->resp.payload_size);
+        if (error_type) {
+            flb_error("[aws_credentials] STS API responded with %s", error_type);
+        } else {
+            flb_debug("[aws_credentials] STS raw response: \n%s",
+                      c->resp.payload);
+        }
+    }
+
+    if (c) {
+        flb_http_client_destroy(c);
+    }
+    flb_error("[aws_credentials] STS assume role request failed");
+    return -1;
+
+}
+
+/*
+ * The STS APIs return an XML document with credentials.
+ * The part of the document we care about looks like this:
+ * <Credentials>
+ *    <AccessKeyId>akid</AccessKeyId>
+ *    <SecretAccessKey>skid</SecretAccessKey>
+ *    <SessionToken>token</SessionToken>
+ *    <Expiration>2019-11-09T13:34:41Z</Expiration>
+ * </Credentials>
+ */
+struct flb_aws_credentials *flb_parse_sts_resp(char *response,
+                                                    time_t *expiration)
+{
+    struct flb_aws_credentials *creds = NULL;
+    char *cred_node;
+    flb_sds_t tmp = NULL;
+
+    cred_node = strstr(response, CREDENTIALS_NODE);
+    if (!cred_node) {
+        flb_error("[aws_credentials] Could not find '%s' node in sts response",
+                  CREDENTIALS_NODE);
+        return NULL;
+    }
+    cred_node += CREDENTIALS_NODE_LEN;
+
+    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    if (!creds) {
+        flb_errno();
+        return NULL;
+    }
+
+    creds->access_key_id = get_node(cred_node, ACCESS_KEY_NODE,
+                                    ACCESS_KEY_NODE_LEN);
+    if (!creds->access_key_id) {
+        goto error;
+    }
+
+    creds->secret_access_key = get_node(cred_node, SECRET_KEY_NODE,
+                                        SECRET_KEY_NODE_LEN);
+    if (!creds->secret_access_key) {
+        goto error;
+    }
+
+    creds->session_token = get_node(cred_node, SESSION_TOKEN_NODE,
+                                    SESSION_TOKEN_NODE_LEN);
+    if (!creds->session_token) {
+        goto error;
+    }
+
+    tmp = get_node(cred_node, EXPIRATION_NODE, EXPIRATION_NODE_LEN);
+    if (!tmp) {
+        goto error;
+    }
+    *expiration = flb_aws_cred_expiration(tmp);
+
+    flb_sds_destroy(tmp);
+    return creds;
+
+error:
+    flb_aws_credentials_destroy(creds);
+    if (tmp) {
+        flb_sds_destroy(tmp);
+    }
+    return NULL;
+}
+
+/*
+ * Constructs the STS request uri.
+ * external_id can be NULL.
+ */
+char *flb_sts_uri(char *action, char *role_arn, char *session_name,
+              char *external_id, char *identity_token)
+{
+    char *uri = NULL;
+    size_t len = STS_ASSUME_ROLE_URI_BASE_LEN;
+
+    if (external_id) {
+        len += 12; /* will add "&ExternalId=" */
+        len += strlen(external_id);
+    }
+
+    if (identity_token) {
+        len += 18; /* will add "&WebIdentityToken=" */
+        len += strlen(identity_token);
+    }
+
+
+    len += strlen(session_name);
+    len += strlen(role_arn);
+    len += strlen(action);
+    len++; /* null char */
+    uri = flb_malloc(sizeof(char) * (len));
+    if (!uri) {
+        flb_errno();
+        return NULL;
+    }
+
+    snprintf(uri, len, STS_ASSUME_ROLE_URI_FORMAT, action, session_name,
+             role_arn);
+
+    if (external_id) {
+        strncat(uri, "&ExternalId=", 12);
+        strncat(uri, external_id, strlen(external_id));
+    }
+
+    if (identity_token) {
+        strncat(uri, "&WebIdentityToken=", 18);
+        strncat(uri, identity_token, strlen(identity_token));
+    }
+
+    return uri;
+}
+
+static flb_sds_t get_node(char *cred_node, char* node_name, int node_len)
+{
+    char *node = NULL;
+    char *end = NULL;
+    flb_sds_t val = NULL;
+    int len;
+
+    node = strstr(cred_node, node_name);
+    if (!node) {
+        flb_error("[aws_credentials] Could not find '%s' node in sts response",
+                  node_name);
+        return NULL;
+    }
+    node += node_len;
+    end = strchr(node, '<');
+    if (!end) {
+        flb_error("[aws_credentials] Could not find end of '%s' node in "
+                  "sts response", node_name);
+        return NULL;
+    }
+    len = end - node;
+    val = flb_sds_create_len(node, len);
+    if (!val) {
+        flb_errno();
+        return NULL;
+    }
+
+    return val;
+}

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -1,0 +1,365 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_signv4.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_aws_credentials.h>
+
+#include <jsmn/jsmn.h>
+#include <stdlib.h>
+
+struct flb_http_client *request_do(struct flb_aws_client *aws_client,
+                                   int method, const char *uri,
+                                   const char *body, size_t body_len,
+                                   struct flb_aws_header *dynamic_headers,
+                                   size_t dynamic_headers_len);
+
+/*
+ * https://service.region.amazonaws.com(.cn)
+ */
+char *flb_aws_endpoint(char* service, char* region)
+{
+    char *endpoint = NULL;
+    size_t len = AWS_SERVICE_ENDPOINT_BASE_LEN;
+    int is_cn = FLB_FALSE;
+
+
+    /* In the China regions, ".cn" is appended to the URL */
+    if (strcmp("cn-north-1", region) == 0) {
+        len += 3;
+        is_cn = FLB_TRUE;
+    }
+    if (strcmp("cn-northwest-1", region) == 0) {
+        len += 3;
+        is_cn = FLB_TRUE;
+    }
+
+    len += strlen(service);
+    len += strlen(region);
+    len ++; /* null byte */
+
+    endpoint = flb_malloc(sizeof(char) * len);
+    if (!endpoint) {
+        flb_errno();
+        return NULL;
+    }
+
+    snprintf(endpoint, len, AWS_SERVICE_ENDPOINT_FORMAT, service, region);
+
+    if (is_cn) {
+        strncat(endpoint, ".cn", 3);
+    }
+
+    return endpoint;
+
+}
+
+struct flb_http_client *flb_aws_client_request(struct flb_aws_client *aws_client,
+                                               int method, const char *uri,
+                                               const char *body, size_t body_len,
+                                               struct flb_aws_header
+                                               *dynamic_headers,
+                                               size_t dynamic_headers_len)
+{
+    struct flb_http_client *c = NULL;
+
+    //TODO: Need to think more about the retry strategy.
+
+    c = request_do(aws_client, method, uri, body, body_len,
+                   dynamic_headers, dynamic_headers_len);
+
+    /*
+     * 400 or 403 could indicate an issue with credentials- so we force a
+     * refresh on the provider. For safety a refresh can be performed only once
+     * per FLB_AWS_CREDENTIAL_REFRESH_LIMIT.
+     *
+     * Refresh requires async to be enabled
+     */
+    if (aws_client->upstream->flags & FLB_IO_ASYNC) {
+        if (c && (c->resp.status == 400 || c->resp.status == 403)) {
+            if (aws_client->has_auth && time(NULL) > aws_client->refresh_limit) {
+                aws_client->refresh_limit = time(NULL)
+                                            + FLB_AWS_CREDENTIAL_REFRESH_LIMIT;
+                aws_client->provider->provider_vtable->refresh(aws_client->provider);
+            }
+        }
+    }
+
+    return c;
+}
+
+static struct flb_aws_client_vtable client_vtable = {
+    .request = flb_aws_client_request,
+};
+
+struct flb_aws_client *flb_aws_client_create()
+{
+    struct flb_aws_client *client = flb_calloc(1,
+                                                sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &client_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the default vtable */
+
+static struct flb_aws_client_generator default_generator = {
+    .create = flb_aws_client_create,
+};
+
+struct flb_aws_client_generator *flb_aws_client_generator()
+{
+    return &default_generator;
+}
+
+void flb_aws_client_destroy(struct flb_aws_client *aws_client)
+{
+    if (aws_client) {
+        if (aws_client->upstream) {
+            flb_upstream_destroy(aws_client->upstream);
+        }
+        flb_free(aws_client);
+    }
+}
+
+struct flb_http_client *request_do(struct flb_aws_client *aws_client,
+                                   int method, const char *uri,
+                                   const char *body, size_t body_len,
+                                   struct flb_aws_header *dynamic_headers,
+                                   size_t dynamic_headers_len)
+{
+    size_t b_sent;
+    int ret;
+    struct flb_upstream_conn *u_conn = NULL;
+    flb_sds_t signature = NULL;
+    int i;
+    struct flb_aws_header header;
+    struct flb_http_client *c = NULL;
+
+    u_conn = flb_upstream_conn_get(aws_client->upstream);
+    if (!u_conn) {
+        flb_error("[aws_client] connection initialization error");
+        return NULL;
+    }
+
+    /* Compose HTTP request */
+    c = flb_http_client(u_conn, method, uri,
+                        body, body_len,
+                        aws_client->host, aws_client->port,
+                        aws_client->proxy, aws_client->flags);
+
+    if (!c) {
+        flb_error("[aws_client] could not initialize request");
+        goto error;
+    }
+
+    /* Add AWS Fluent Bit user agent */
+    ret = flb_http_add_header(c, "User-Agent", 10,
+                              "aws-fluent-bit-plugin", 21);
+    if (ret < 0) {
+        flb_error("[aws_client] failed to add header to request");
+        goto error;
+    }
+
+    /* add headers */
+    for (i = 0; i < aws_client->static_headers_len; i++) {
+        header = aws_client->static_headers[i];
+        ret =  flb_http_add_header(c,
+                                   header.key, header.key_len,
+                                   header.val, header.val_len);
+        if (ret < 0) {
+            flb_error("[aws_client] failed to add header to request");
+            goto error;
+        }
+    }
+
+    for (i = 0; i < dynamic_headers_len; i++) {
+        header = dynamic_headers[i];
+        ret =  flb_http_add_header(c,
+                                   header.key, header.key_len,
+                                   header.val, header.val_len);
+        if (ret < 0) {
+            flb_error("[aws_client] failed to add header to request");
+            goto error;
+        }
+    }
+
+    if (aws_client->has_auth) {
+        signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
+                                  aws_client->region, aws_client->service,
+                                  aws_client->provider);
+        if (!signature) {
+            flb_error("[aws_client] could not sign request");
+            goto error;
+        }
+    }
+
+    /* Perform request */
+    ret = flb_http_do(c, &b_sent);
+
+    if (ret != 0 || c->resp.status != 200) {
+        flb_error("[aws_client] %s: http_do=%i, HTTP Status: %i",
+                  aws_client->host, ret, c->resp.status);
+    }
+
+    flb_upstream_conn_release(u_conn);
+    flb_sds_destroy(signature);
+    return c;
+
+error:
+    if (u_conn) {
+        flb_upstream_conn_release(u_conn);
+    }
+    if (signature) {
+        flb_sds_destroy(signature);
+    }
+    if (c) {
+        flb_http_client_destroy(c);
+    }
+    return NULL;
+}
+
+/* parses AWS API error responses and returns the value of the __type field */
+flb_sds_t flb_aws_error(char *response, size_t response_len)
+{
+    return flb_json_get_val(response, response_len, "__type");
+}
+
+/* gets the value of a key in a json string */
+flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key)
+{
+    jsmntok_t *tokens = NULL;
+    const jsmntok_t *t = NULL;
+    char *current_token = NULL;
+    jsmn_parser parser;
+    int tokens_size = 10;
+    size_t size;
+    int ret;
+    int i = 0;
+    int len;
+    flb_sds_t error_type = NULL;
+
+    jsmn_init(&parser);
+
+    size = sizeof(jsmntok_t) * tokens_size;
+    tokens = flb_calloc(1, size);
+    if (!tokens) {
+        flb_errno();
+        return NULL;
+    }
+
+    ret = jsmn_parse(&parser, response, response_len,
+                     tokens, tokens_size);
+
+    if (ret == JSMN_ERROR_INVAL || ret == JSMN_ERROR_PART) {
+        flb_free(tokens);
+        flb_debug("[aws_client] Unable to parse API response- response is not"
+                  "not valid JSON.");
+        return NULL;
+    }
+
+    /* return value is number of tokens parsed */
+    tokens_size = ret;
+
+    /*
+     * jsmn will create an array of tokens like:
+     * key, value, key, value
+     */
+    while (i < (tokens_size - 1)) {
+        t = &tokens[i];
+
+        if (t->start == -1 || t->end == -1 || (t->start == 0 && t->end == 0)) {
+            break;
+        }
+
+        if (t->type == JSMN_STRING) {
+            current_token = &response[t->start];
+
+            if (strncmp(current_token, key, strlen(key)) == 0) {
+                i++;
+                t = &tokens[i];
+                current_token = &response[t->start];
+                len = t->end - t->start;
+                error_type = flb_sds_create_len(current_token, len);
+                if (!error_type) {
+                    flb_errno();
+                    flb_free(tokens);
+                    return NULL;
+                }
+                break;
+            }
+        }
+
+        i++;
+    }
+    flb_free(tokens);
+    return error_type;
+}
+
+int flb_imds_request(struct flb_aws_client *client, char *metadata_path,
+                     flb_sds_t *metadata, size_t *metadata_len)
+{
+    struct flb_http_client *c = NULL;
+    flb_sds_t ec2_metadata;
+
+    flb_debug("[imds] Using instance metadata V1");
+    c = client->client_vtable->request(client, FLB_HTTP_GET,
+                                       metadata_path, NULL, 0,
+                                       NULL, 0);
+
+    if (!c) {
+        return -1;
+    }
+
+    if (c->resp.status != 200) {
+        if (c->resp.payload_size > 0) {
+            flb_debug("[ecs_imds] IMDS metadata response\n%s",
+                      c->resp.payload);
+        }
+
+        flb_http_client_destroy(c);
+        return -1;
+    }
+
+    if (c->resp.payload_size > 0) {
+        ec2_metadata = flb_sds_create_len(c->resp.payload,
+                                          c->resp.payload_size);
+
+        if (!ec2_metadata) {
+            flb_errno();
+            return -1;
+        }
+        *metadata = ec2_metadata;
+        *metadata_len = c->resp.payload_size;
+
+        flb_http_client_destroy(c);
+        return 0;
+    }
+    else {
+        flb_debug("[ecs_imds] IMDS metadata response was empty");
+        flb_http_client_destroy(c);
+        return -1;
+    }
+}

--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_credentials.h>
 #include <mbedtls/sha256.h>
 
 #include <stdlib.h>
@@ -984,9 +985,8 @@ static flb_sds_t flb_signv4_add_authorization(struct flb_http_client *c,
 flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
                         int amz_date_header,
                         time_t t_now,
-                        char *access_key,
                         char *region, char *service,
-                        char *secret_key, char *security_token)
+                        struct flb_aws_provider *provider)
 {
     char amzdate[32];
     char datestamp[32];
@@ -996,16 +996,26 @@ flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
     flb_sds_t signature;
     flb_sds_t signed_headers;
     flb_sds_t auth_header;
+    struct flb_aws_credentials *creds;
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_error("[signv4] Provider returned no credentials, service=%s",
+                  service);
+        return NULL;
+    }
 
     gmt = flb_malloc(sizeof(struct tm));
     if (!gmt) {
         flb_errno();
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
 
     if (!gmtime_r(&t_now, gmt)) {
         flb_error("[signv4] error converting given unix timestamp");
         flb_free(gmt);
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
 
@@ -1017,15 +1027,17 @@ flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
     signed_headers = flb_sds_create_size(256);
     if (!signed_headers) {
         flb_error("[signedv4] cannot allocate buffer for auth signed headers");
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
 
     cr = flb_signv4_canonical_request(c, normalize_uri,
                                       amz_date_header, amzdate,
-                                      security_token, &signed_headers);
+                                      creds->session_token, &signed_headers);
     if (!cr) {
         flb_error("[signv4] failed canonical request");
         flb_sds_destroy(signed_headers);
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
 
@@ -1036,28 +1048,32 @@ flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
         flb_error("[signv4] failed string to sign");
         flb_sds_destroy(cr);
         flb_sds_destroy(signed_headers);
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
     flb_sds_destroy(cr);
 
     /* Task 3: calculate the signature */
-    signature = flb_signv4_calculate_signature(string_to_sign, datestamp, service,
-                                               region, secret_key);
+    signature = flb_signv4_calculate_signature(string_to_sign, datestamp,
+                                               service, region,
+                                               creds->secret_access_key);
     if (!signature) {
         flb_error("[signv4] failed calculate_string");
         flb_sds_destroy(signed_headers);
         flb_sds_destroy(string_to_sign);
+        flb_aws_credentials_destroy(creds);
         return NULL;
     }
     flb_sds_destroy(string_to_sign);
 
     /* Task 4: add signature to HTTP request */
     auth_header = flb_signv4_add_authorization(c,
-                                               access_key,
+                                               creds->access_key_id,
                                                datestamp, region, service,
                                                signed_headers, signature);
     flb_sds_destroy(signed_headers);
     flb_sds_destroy(signature);
+    flb_aws_credentials_destroy(creds);
 
     if (!auth_header) {
         flb_error("[signv4] error creating authorization header");

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -53,11 +53,11 @@ if(FLB_AWS)
     ${UNIT_TESTS_FILES}
     aws_util.c
     aws_credentials.c
+    aws_credentials_ec2.c
     aws_credentials_sts.c
     aws_credentials_http.c
     )
 endif()
-
 
 set(UNIT_TESTS_DATA
   data/pack/json_single_map_001.json

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -54,6 +54,7 @@ if(FLB_AWS)
     aws_util.c
     aws_credentials.c
     aws_credentials_sts.c
+    aws_credentials_http.c
     )
 endif()
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -48,6 +48,16 @@ if(FLB_SIGNV4)
     )
 endif()
 
+if(FLB_AWS)
+  set(UNIT_TESTS_FILES
+    ${UNIT_TESTS_FILES}
+    aws_util.c
+    aws_credentials.c
+    aws_credentials_sts.c
+    )
+endif()
+
+
 set(UNIT_TESTS_DATA
   data/pack/json_single_map_001.json
   data/pack/json_single_map_002.json

--- a/tests/internal/aws_credentials.c
+++ b/tests/internal/aws_credentials.c
@@ -1,0 +1,255 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_info.h>
+
+#include "flb_tests_internal.h"
+
+#define ACCESS_KEY "akid"
+#define SECRET_KEY "skid"
+#define TOKEN      "token"
+
+/* Credentials Environment Variables */
+#define AWS_ACCESS_KEY_ID              "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_ACCESS_KEY          "AWS_SECRET_ACCESS_KEY"
+#define AWS_SESSION_TOKEN              "AWS_SESSION_TOKEN"
+
+
+static void unsetenv_credentials()
+{
+    int ret;
+
+    ret = unsetenv(AWS_ACCESS_KEY_ID);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = unsetenv(AWS_SECRET_ACCESS_KEY);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = unsetenv(AWS_SESSION_TOKEN);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+}
+
+/* test for the env provider */
+static void test_environment_provider()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, ACCESS_KEY, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SECRET_ACCESS_KEY, SECRET_KEY, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SESSION_TOKEN, TOKEN, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_aws_env_provider_create();
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    unsetenv_credentials();
+
+    flb_aws_provider_destroy(provider);
+}
+
+/* token is not required */
+static void test_environment_provider_no_token()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, ACCESS_KEY, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SECRET_ACCESS_KEY, SECRET_KEY, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_aws_env_provider_create();
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(creds->session_token == NULL);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(creds->session_token == NULL);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    unsetenv_credentials();
+
+    flb_aws_provider_destroy(provider);
+}
+
+/* access and secret key are required */
+static void test_environment_provider_only_access()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, ACCESS_KEY, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_aws_env_provider_create();
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    unsetenv_credentials();
+
+    flb_aws_provider_destroy(provider);
+}
+
+/* test the env provider when no cred env vars are set */
+static void test_environment_provider_unset()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    unsetenv_credentials();
+
+
+    provider = flb_aws_env_provider_create();
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    flb_aws_provider_destroy(provider);
+}
+
+static void test_credential_expiration()
+{
+    struct tm tm = {0};
+    /* one hour in the future */
+    time_t exp_expected = time(NULL) + 3600;
+    char time_stamp[50];
+    time_t exp_actual;
+    TEST_CHECK(gmtime_r(&exp_expected, &tm) != NULL);
+
+    TEST_CHECK(strftime(time_stamp, 50, "%Y-%m-%dT%H:%M:%SZ", &tm) > 0);
+
+    exp_actual = flb_aws_cred_expiration(time_stamp);
+
+    TEST_CHECK(exp_actual == exp_expected);
+}
+
+TEST_LIST = {
+    { "test_credential_expiration" , test_credential_expiration},
+    { "environment_credential_provider" , test_environment_provider},
+    { "environment_provider_no_token" , test_environment_provider_no_token},
+    { "environment_provider_only_access_key" ,
+    test_environment_provider_only_access},
+    { "environment_credential_provider_unset" ,
+      test_environment_provider_unset},
+    { 0 }
+};

--- a/tests/internal/aws_credentials_ec2.c
+++ b/tests/internal/aws_credentials_ec2.c
@@ -1,0 +1,393 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_client.h>
+
+#include <monkey/mk_core.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "flb_tests_internal.h"
+
+#define ACCESS_KEY_EC2 "ec2_akid"
+#define SECRET_KEY_EC2 "ec2_skid"
+#define TOKEN_EC2      "ec2_token"
+
+#define EC2_CREDENTIALS_RESPONSE "{\n\
+    \"AccessKeyId\": \"ec2_akid\",\n\
+    \"Expiration\": \"2014-10-24T23:00:23Z\",\n\
+    \"RoleArn\": \"EC2_ROLE_ARN\",\n\
+    \"SecretAccessKey\": \"ec2_skid\",\n\
+    \"Token\": \"ec2_token\"\n\
+}"
+
+/*
+ * Unexpected/invalid response. The goal of this is not to test anything
+ * that might happen in production, but rather to test the error handling
+ * code for the providers. This helps ensure all code paths are tested and
+ * the error handling code does not introduce memory leaks.
+ */
+#define MALFORMED_RESPONSE "some complete garbage that is not expected"
+
+#define EC2_TOKEN_RESPONSE     "AQAEAGB5i7Jq-RWC7OFZcjSs3Y5uxo06c5VB1vtYIOyVA=="
+#define EC2_ROLE_NAME_RESPONSE "my-role-Ec2InstanceRole-1CBV45ZZHA1E5"
+
+/*
+ * Global variable to track number of http requests made.
+ * This ensures credentials are being cached properly.
+ */
+int g_request_count;
+
+struct flb_http_client * ec2_role_name_response(struct flb_aws_client *aws_client,
+                                                int method, const char *uri,
+                                                size_t dynamic_headers_len)
+{
+    struct flb_http_client *c = NULL;
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    TEST_CHECK(dynamic_headers_len == 0);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = EC2_ROLE_NAME_RESPONSE;
+    c->resp.payload_size = strlen(EC2_ROLE_NAME_RESPONSE);
+
+    return c;
+}
+
+struct flb_http_client *ec2_credentials_response(struct flb_aws_client *aws_client,
+                                                 int method, const char *uri,
+                                                 size_t dynamic_headers_len)
+{
+    struct flb_http_client *c = NULL;
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    TEST_CHECK(dynamic_headers_len == 0);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = EC2_CREDENTIALS_RESPONSE;
+    c->resp.payload_size = strlen(EC2_CREDENTIALS_RESPONSE);
+
+    return c;
+}
+
+/* test/mock version of the aws_http_client request function */
+struct flb_http_client *test_http_client_request(struct flb_aws_client *aws_client,
+                                                 int method, const char *uri,
+                                                 const char *body, size_t body_len,
+                                                 struct flb_aws_header *dynamic_headers,
+                                                 size_t dynamic_headers_len)
+{
+    g_request_count++;
+    /*
+     * route to the correct response fn using the uri
+     */
+     if (strstr(uri, "latest/meta-data/iam/security-credentials/"
+                            "my-role-Ec2InstanceRole-1CBV45ZZHA1E5") != NULL) {
+         return ec2_credentials_response(aws_client, method, uri,
+                                         dynamic_headers_len);
+     }
+     else if (strstr(uri, "latest/meta-data/iam/security-credentials") != NULL)
+     {
+         return ec2_role_name_response(aws_client, method, uri,
+                                       dynamic_headers_len);
+     }
+
+    /* uri should match one of the above conditions */
+    flb_errno();
+    return NULL;
+
+}
+
+/* Test/mock aws_http_client */
+static struct flb_aws_client_vtable test_vtable = {
+    .request = test_http_client_request,
+};
+
+struct flb_aws_client *test_http_client_create()
+{
+    struct flb_aws_client *client = flb_calloc(1,
+                                                sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &test_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator test_generator = {
+    .create = test_http_client_create,
+};
+
+struct flb_aws_client_generator *generator_in_test()
+{
+    return &test_generator;
+}
+
+/* test/mock version of the aws_http_client request function */
+struct flb_http_client *malformed_http_client_request(struct flb_aws_client
+                                                      *aws_client,
+                                                      int method, const char *uri,
+                                                      const char *body,
+                                                      size_t body_len,
+                                                      struct flb_aws_header
+                                                      *dynamic_headers,
+                                                      size_t dynamic_headers_len)
+{
+    struct flb_http_client *c = NULL;
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = MALFORMED_RESPONSE;
+    c->resp.payload_size = strlen(MALFORMED_RESPONSE);
+
+    return c;
+
+}
+
+/* Test/mock aws_http_client */
+static struct flb_aws_client_vtable malformed_vtable = {
+    .request = malformed_http_client_request,
+};
+
+struct flb_aws_client *malformed_http_client_create()
+{
+    struct flb_aws_client *client = flb_calloc(1, sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &malformed_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator malformed_generator = {
+    .create = malformed_http_client_create,
+};
+
+struct flb_aws_client_generator *generator_malformed()
+{
+    return &malformed_generator;
+}
+
+/* Error case mock - uses a different client and generator than happy case */
+struct flb_http_client *test_http_client_error_case(struct flb_aws_client
+                                                    *aws_client,
+                                                    int method, const char *uri,
+                                                    const char *body,
+                                                    size_t body_len,
+                                                    struct flb_aws_header
+                                                    *dynamic_headers,
+                                                    size_t dynamic_headers_len)
+{
+    /* create an http client so that we can set the response */
+    struct flb_http_client *c = NULL;
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 500;
+    c->resp.payload = "error";
+    c->resp.payload_size = 5;
+
+    return c;
+
+}
+
+/* Test/mock aws_http_client */
+static struct flb_aws_client_vtable error_case_vtable = {
+    .request = test_http_client_error_case,
+};
+
+struct flb_aws_client *test_http_client_create_error_case()
+{
+    struct flb_aws_client *client = flb_calloc(1,
+                                                sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &error_case_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator error_case_generator = {
+    .create = test_http_client_create_error_case,
+};
+
+struct flb_aws_client_generator *generator_in_test_error_case()
+{
+    return &error_case_generator;
+}
+
+static void test_ec2_provider_v1()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+
+    g_request_count = 0;
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_ec2_provider_create(config, generator_in_test());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY_EC2, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY_EC2, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN_EC2, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY_EC2, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY_EC2, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN_EC2, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * 2 requests are made with v1 for the first call to get_credentials.
+     * The second call hits cache. The call to refresh leads to 2 more calls.
+     *
+     */
+    TEST_CHECK(g_request_count == 4);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+static void test_ec2_provider_error_case()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_ec2_provider_create(config, generator_in_test_error_case());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* get_credentials will fail */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+/* unexpected output test- see description for MALFORMED_RESPONSE */
+static void test_ec2_provider_malformed_case()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_ec2_provider_create(config, generator_malformed());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* get_credentials will fail */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+TEST_LIST = {
+    { "test_ec2_provider_v1" , test_ec2_provider_v1},
+    { "test_ec2_provider_error_case" , test_ec2_provider_error_case},
+    { "test_ec2_provider_malformed_response" ,
+    test_ec2_provider_malformed_case},
+    { 0 }
+};

--- a/tests/internal/aws_credentials_http.c
+++ b/tests/internal/aws_credentials_http.c
@@ -1,0 +1,369 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_client.h>
+
+#include <monkey/mk_core.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "flb_tests_internal.h"
+
+#define ACCESS_KEY_HTTP "http_akid"
+#define SECRET_KEY_HTTP "http_skid"
+#define TOKEN_HTTP      "http_token"
+
+#define HTTP_CREDENTIALS_RESPONSE "{\n\
+    \"AccessKeyId\": \"http_akid\",\n\
+    \"Expiration\": \"2014-10-24T23:00:23Z\",\n\
+    \"RoleArn\": \"TASK_ROLE_ARN\",\n\
+    \"SecretAccessKey\": \"http_skid\",\n\
+    \"Token\": \"http_token\"\n\
+}"
+
+/*
+ * Unexpected/invalid HTTP response. The goal of this is not to test anything
+ * that might happen in production, but rather to test the error handling
+ * code for the providers. This helps ensure all code paths are tested and
+ * the error handling code does not introduce memory leaks.
+ */
+#define HTTP_RESPONSE_MALFORMED  "{\n\
+    \"AccessKeyId\": \"http_akid\",\n\
+    \"partially-correct\": \"json\",\n\
+    \"RoleArn\": \"TASK_ROLE_ARN\",\n\
+    \"but incomplete\": \"and not terminated with a closing brace\",\n\
+    \"Token\": \"http_token\""
+
+
+/*
+ * Global Variable that allows us to check the number of calls
+ * made in each test
+ */
+int g_request_count;
+
+struct flb_http_client *request_happy_case(struct flb_aws_client *aws_client,
+                                           int method, const char *uri)
+{
+    struct flb_http_client *c = NULL;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    TEST_CHECK(strstr(uri, "happy-case") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = HTTP_CREDENTIALS_RESPONSE;
+    c->resp.payload_size = strlen(HTTP_CREDENTIALS_RESPONSE);
+
+    return c;
+}
+
+/* unexpected output test- see description for HTTP_RESPONSE_MALFORMED */
+struct flb_http_client *request_malformed(struct flb_aws_client *aws_client,
+                                          int method, const char *uri)
+{
+    struct flb_http_client *c = NULL;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    TEST_CHECK(strstr(uri, "malformed") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = HTTP_RESPONSE_MALFORMED;
+    c->resp.payload_size = strlen(HTTP_RESPONSE_MALFORMED);
+
+    return c;
+}
+
+struct flb_http_client *request_error_case(struct flb_aws_client *aws_client,
+                                           int method, const char *uri)
+{
+    struct flb_http_client *c = NULL;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    TEST_CHECK(strstr(uri, "error-case") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 400;
+    c->resp.payload = NULL;
+    c->resp.payload_size = 0;
+
+    return c;
+}
+
+/* test/mock version of the flb_aws_client request function */
+struct flb_http_client *test_http_client_request(struct flb_aws_client *aws_client,
+                                                 int method, const char *uri,
+                                                 const char *body, size_t body_len,
+                                                 struct flb_aws_header *dynamic_headers,
+                                                 size_t dynamic_headers_len)
+{
+    g_request_count++;
+    /*
+     * route to the correct test case fn using the uri
+     */
+    if (strstr(uri, "happy-case") != NULL) {
+        return request_happy_case(aws_client, method, uri);
+    } else if (strstr(uri, "error-case") != NULL) {
+        return request_error_case(aws_client, method, uri);
+    } else if (strstr(uri, "malformed") != NULL) {
+        return request_malformed(aws_client, method, uri);
+    }
+
+    /* uri should match one of the above conditions */
+    flb_errno();
+    return NULL;
+
+}
+
+/* Test/mock flb_aws_client */
+static struct flb_aws_client_vtable test_vtable = {
+    .request = test_http_client_request,
+};
+
+struct flb_aws_client *test_http_client_create()
+{
+    struct flb_aws_client *client = flb_calloc(1,
+                                                sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &test_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator test_generator = {
+    .create = test_http_client_create,
+};
+
+struct flb_aws_client_generator *generator_in_test()
+{
+    return &test_generator;
+}
+
+/* http and ecs providers */
+static void test_http_provider()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+    flb_sds_t host;
+    flb_sds_t path;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    host = flb_sds_create("127.0.0.1");
+    if (!host) {
+        flb_errno();
+        return;
+    }
+    path = flb_sds_create("/happy-case");
+    if (!path) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_http_provider_create(config, host, path,
+                                 generator_in_test());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Request count should be 2:
+     * - One for the first call to get_credentials (2nd should hit cred cache)
+     * - One for the call to refresh
+     */
+    TEST_CHECK(g_request_count == 2);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+static void test_http_provider_error_case()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+    flb_sds_t host;
+    flb_sds_t path;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    host = flb_sds_create("127.0.0.1");
+    if (!host) {
+        flb_errno();
+        return;
+    }
+    path = flb_sds_create("/error-case");
+    if (!path) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_http_provider_create(config, host, path,
+                                        generator_in_test());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* get_credentials will fail */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+    TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+static void test_http_provider_malformed_response()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+    struct flb_config *config;
+    flb_sds_t host;
+    flb_sds_t path;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    host = flb_sds_create("127.0.0.1");
+    if (!host) {
+        flb_errno();
+        return;
+    }
+    path = flb_sds_create("/malformed");
+    if (!path) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_http_provider_create(config, host, path,
+                                 generator_in_test());
+
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* get_credentials will fail */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+    TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+TEST_LIST = {
+    { "test_http_provider" , test_http_provider},
+    { "test_http_provider_error_case" , test_http_provider_error_case},
+    { "test_http_provider_malformed_response" ,
+    test_http_provider_malformed_response},
+    { 0 }
+};

--- a/tests/internal/aws_credentials_sts.c
+++ b/tests/internal/aws_credentials_sts.c
@@ -1,0 +1,894 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_client.h>
+
+#include <monkey/mk_core.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "flb_tests_internal.h"
+
+#define EKS_ACCESS_KEY "eks_akid"
+#define EKS_SECRET_KEY "eks_skid"
+#define EKS_TOKEN      "eks_token"
+
+#define STS_ACCESS_KEY "sts_akid"
+#define STS_SECRET_KEY "sts_skid"
+#define STS_TOKEN      "sts_token"
+
+/* standard environment variables */
+#define AWS_ACCESS_KEY_ID              "AWS_ACCESS_KEY_ID"
+#define AWS_SECRET_ACCESS_KEY          "AWS_SECRET_ACCESS_KEY"
+#define AWS_SESSION_TOKEN              "AWS_SESSION_TOKEN"
+
+#define TOKEN_FILE_ENV_VAR            "AWS_WEB_IDENTITY_TOKEN_FILE"
+#define ROLE_ARN_ENV_VAR              "AWS_ROLE_ARN"
+#define SESSION_NAME_ENV_VAR          "AWS_ROLE_SESSION_NAME"
+
+#define WEB_TOKEN_FILE FLB_TESTS_DATA_PATH "/data/aws_credentials/\
+web_identity_token_file.txt"
+
+#define STS_RESPONSE_EKS  "<AssumeRoleWithWebIdentityResponse \
+xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">\n\
+  <AssumeRoleWithWebIdentityResult>\n\
+    <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A\n\
+</SubjectFromWebIdentityToken>\n\
+    <Audience>client.5498841531868486423.1548@apps.example.com</Audience>\n\
+    <AssumedRoleUser>\n\
+      <Arn>arn:aws:sts::123456789012:assumed-role/WebIdentityRole/app1</Arn>\n\
+      <AssumedRoleId>AROACLKWSDQRAOEXAMPLE:app1</AssumedRoleId>\n\
+    </AssumedRoleUser>\n\
+    <Credentials>\n\
+      <SessionToken>eks_token</SessionToken>\n\
+      <SecretAccessKey>eks_skid</SecretAccessKey>\n\
+      <Expiration>2014-10-24T23:00:23Z</Expiration>\n\
+      <AccessKeyId>eks_akid</AccessKeyId>\n\
+    </Credentials>\n\
+    <Provider>www.amazon.com</Provider>\n\
+  </AssumeRoleWithWebIdentityResult>\n\
+  <ResponseMetadata>\n\
+    <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>\n\
+  </ResponseMetadata>\n\
+</AssumeRoleWithWebIdentityResponse>"
+
+#define STS_RESPONSE_ASSUME_ROLE "<AssumeRoleResponse \
+xmlns=\"https://sts.amazonaws.com/doc/\n\
+2011-06-15/\">\n\
+  <AssumeRoleResult>\n\
+    <AssumedRoleUser>\n\
+      <Arn>arn:aws:sts::123456789012:assumed-role/demo/TestAR</Arn>\n\
+      <AssumedRoleId>ARO123EXAMPLE123:TestAR</AssumedRoleId>\n\
+    </AssumedRoleUser>\n\
+    <Credentials>\n\
+      <AccessKeyId>sts_akid</AccessKeyId>\n\
+      <SecretAccessKey>sts_skid</SecretAccessKey>\n\
+      <SessionToken>sts_token</SessionToken>\n\
+      <Expiration>2019-11-09T13:34:41Z</Expiration>\n\
+    </Credentials>\n\
+    <PackedPolicySize>6</PackedPolicySize>\n\
+  </AssumeRoleResult>\n\
+  <ResponseMetadata>\n\
+    <RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>\n\
+  </ResponseMetadata>\n\
+</AssumeRoleResponse>"
+
+/*
+ * Unexpected/invalid STS response. The goal of this is not to test anything
+ * that might happen in production, but rather to test the error handling
+ * code for the providers. This helps ensure all code paths are tested and
+ * the error handling code does not introduce memory leaks.
+ */
+
+#define STS_RESPONSE_MALFORMED "{\n\
+    \"__type\": \"some unexpected response\",\n\
+    \"this tests\": the error handling code\",\n\
+\"This looks like JSON but is not valid.\"\n\
+<Credentials><AccessKeyId>It also contains xml tags that a correct\n\
+response would have</SecretAccessKey>"
+
+/*
+ * Global Variable that allows us to check the number of calls
+ * made in each test
+ */
+int g_request_count;
+
+/* Each test case has its own request function */
+
+/* unexpected output test- see description for STS_RESPONSE_MALFORMED */
+struct flb_http_client *request_unexpected_response(struct flb_aws_client
+                                                    *aws_client, int method,
+                                                    const char *uri)
+{
+    struct flb_http_client *c;
+    TEST_CHECK(method == FLB_HTTP_GET);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = STS_RESPONSE_MALFORMED;
+    c->resp.payload_size = strlen(STS_RESPONSE_MALFORMED);
+
+    return c;
+}
+struct flb_http_client *request_eks_test1(struct flb_aws_client *aws_client,
+                                          int method, const char *uri)
+{
+    struct flb_http_client *c;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+    TEST_CHECK(strstr(uri, "Action=AssumeRoleWithWebIdentity") != NULL);
+    TEST_CHECK(strstr(uri, "RoleArn=arn:aws:iam::123456789012:role/test")
+               != NULL);
+    TEST_CHECK(strstr(uri, "WebIdentityToken=this-is-a-fake-jwt") != NULL);
+    TEST_CHECK(strstr(uri, "RoleSessionName=session_name") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = STS_RESPONSE_EKS;
+    c->resp.payload_size = strlen(STS_RESPONSE_EKS);
+
+    return c;
+}
+
+struct flb_http_client *request_eks_flb_sts_session_name(struct flb_aws_client
+                                                         *aws_client,
+                                                         int method,
+                                                         const char *uri)
+{
+    struct flb_http_client *c;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+    TEST_CHECK(strstr(uri, "Action=AssumeRoleWithWebIdentity") != NULL);
+    TEST_CHECK(strstr(uri, "RoleArn=arn:aws:iam::123456789012:role/"
+                           "randomsession") != NULL);
+    TEST_CHECK(strstr(uri, "WebIdentityToken=this-is-a-fake-jwt") != NULL);
+    /* this test case has a random session name */
+    TEST_CHECK(strstr(uri, "RoleSessionName=") != NULL);
+    /* session name should not be the same as test 1 */
+    TEST_CHECK(strstr(uri, "RoleSessionName=session_name") == NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = STS_RESPONSE_EKS;
+    c->resp.payload_size = strlen(STS_RESPONSE_EKS);
+
+    return c;
+}
+
+struct flb_http_client *request_eks_api_error(struct flb_aws_client *aws_client,
+                                              int method, const char *uri)
+{
+    struct flb_http_client *c;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+    TEST_CHECK(strstr(uri, "Action=AssumeRoleWithWebIdentity") != NULL);
+    TEST_CHECK(strstr(uri, "RoleArn=arn:aws:iam::123456789012:role/apierror")
+               != NULL);
+    TEST_CHECK(strstr(uri, "WebIdentityToken=this-is-a-fake-jwt") != NULL);
+    /* this test case has a random session name */
+    TEST_CHECK(strstr(uri, "RoleSessionName=") != NULL);
+    /* session name should not be the same as test 1 */
+    TEST_CHECK(strstr(uri, "RoleSessionName=session_name") == NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 500;
+    c->resp.payload = NULL;
+    c->resp.payload_size = 0;
+
+    return c;
+}
+
+struct flb_http_client *request_sts_test1(struct flb_aws_client *aws_client,
+                                          int method, const char *uri)
+{
+    struct flb_http_client *c;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+    TEST_CHECK(strstr(uri, "Action=AssumeRole") != NULL);
+    TEST_CHECK(strstr(uri, "RoleArn=arn:aws:iam::123456789012:role/test")
+               != NULL);
+    TEST_CHECK(strstr(uri, "ExternalId=external_id") != NULL);
+    TEST_CHECK(strstr(uri, "RoleSessionName=session_name") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 200;
+    c->resp.payload = STS_RESPONSE_ASSUME_ROLE;
+    c->resp.payload_size = strlen(STS_RESPONSE_ASSUME_ROLE);
+
+    return c;
+}
+
+struct flb_http_client *request_sts_api_error(struct flb_aws_client *aws_client,
+                                              int method, const char *uri)
+{
+    struct flb_http_client *c;
+
+    TEST_CHECK(method == FLB_HTTP_GET);
+    TEST_CHECK(strstr(uri, "Action=AssumeRole") != NULL);
+    TEST_CHECK(strstr(uri, "RoleArn=arn:aws:iam::123456789012:role/apierror")
+               != NULL);
+    TEST_CHECK(strstr(uri, "ExternalId=external_id") != NULL);
+    TEST_CHECK(strstr(uri, "RoleSessionName=session_name") != NULL);
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    c->resp.status = 400;
+    c->resp.payload = NULL;
+    c->resp.payload_size = 0;
+
+    return c;
+}
+
+/* test/mock version of the flb_aws_client request function */
+struct flb_http_client *test_http_client_request(struct flb_aws_client *aws_client,
+                                                 int method, const char *uri,
+                                                 const char *body, size_t body_len,
+                                                 struct flb_aws_header
+                                                 *dynamic_headers,
+                                                 size_t dynamic_headers_len)
+{
+    g_request_count++;
+    if (strcmp(aws_client->name, "sts_client_eks_provider") == 0) {
+        /*
+         * route to the correct test case fn using the uri - the role
+         * name is different in each test case.
+         */
+        if (strstr(uri, "test1") != NULL) {
+            return request_eks_test1(aws_client, method, uri);
+        } else if (strstr(uri, "randomsession") != NULL) {
+            return request_eks_flb_sts_session_name(aws_client, method, uri);
+        } else if (strstr(uri, "apierror") != NULL) {
+            return request_eks_api_error(aws_client, method, uri);
+        } else if (strstr(uri, "unexpected_api_response") != NULL) {
+            return request_unexpected_response(aws_client, method, uri);
+        }
+
+        /* uri should match one of the above conditions */
+        flb_errno();
+        return NULL;
+    } else if (strcmp(aws_client->name, "sts_client_assume_role_provider") == 0)
+    {
+        if (strstr(uri, "test1") != NULL) {
+            return request_sts_test1(aws_client, method, uri);
+        } else if (strstr(uri, "apierror") != NULL) {
+            return request_sts_api_error(aws_client, method, uri);
+        } else if (strstr(uri, "unexpected_api_response") != NULL) {
+            return request_unexpected_response(aws_client, method, uri);
+        }
+        /* uri should match one of the above conditions */
+        flb_errno();
+        return NULL;
+    }
+
+    /* client name should match one of the above conditions */
+    flb_errno();
+    return NULL;
+
+}
+
+/* Test/mock flb_aws_client */
+static struct flb_aws_client_vtable test_vtable = {
+    .request = test_http_client_request,
+};
+
+struct flb_aws_client *test_http_client_create()
+{
+    struct flb_aws_client *client = flb_calloc(1,
+                                                sizeof(struct flb_aws_client));
+    if (!client) {
+        flb_errno();
+        return NULL;
+    }
+    client->client_vtable = &test_vtable;
+    return client;
+}
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator test_generator = {
+    .create = test_http_client_create,
+};
+
+struct flb_aws_client_generator *generator_in_test()
+{
+    return &test_generator;
+}
+
+static void unsetenv_eks()
+{
+    int ret;
+
+    ret = unsetenv(TOKEN_FILE_ENV_VAR);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = unsetenv(ROLE_ARN_ENV_VAR);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = unsetenv(SESSION_NAME_ENV_VAR);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+}
+
+static void test_flb_sts_session_name()
+{
+    char *session_name = flb_sts_session_name();
+
+    TEST_CHECK(strlen(session_name) == 32);
+
+    flb_free(session_name);
+}
+
+static void test_sts_uri()
+{
+    char *uri;
+
+    uri = flb_sts_uri("AssumeRole", "myrole", "mysession",
+                  "myexternalid", NULL);
+    TEST_CHECK(strcmp(uri, "/?Version=2011-06-15&Action=AssumeRole"
+                      "&RoleSessionName=mysession&RoleArn=myrole"
+                      "&ExternalId=myexternalid") == 0);
+    flb_free(uri);
+}
+
+static void test_process_sts_response()
+{
+    struct flb_aws_credentials *creds;
+    time_t expiration;
+
+    creds = flb_parse_sts_resp(STS_RESPONSE_EKS, &expiration);
+
+    TEST_CHECK(strcmp(EKS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(EKS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(EKS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+}
+
+static void test_eks_provider() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    /* set env vars */
+    ret = setenv(ROLE_ARN_ENV_VAR, "arn:aws:iam::123456789012:role/test1", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(SESSION_NAME_ENV_VAR, "session_name", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(TOKEN_FILE_ENV_VAR, WEB_TOKEN_FILE, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
+                                generator_in_test());
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(EKS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(EKS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(EKS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(EKS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(EKS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(EKS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Request count should be 2:
+     * - One for the first call to get_credentials (2nd should hit cred cache)
+     * - One for the call to refresh
+     */
+     TEST_CHECK(g_request_count == 2);
+
+    flb_aws_provider_destroy(provider);
+    unsetenv_eks();
+    flb_free(config);
+}
+
+static void test_eks_provider_random_session_name() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    /* set env vars - session name is not set */
+    unsetenv_eks();
+    ret = setenv(ROLE_ARN_ENV_VAR,
+                 "arn:aws:iam::123456789012:role/randomsession", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(TOKEN_FILE_ENV_VAR, WEB_TOKEN_FILE, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
+                                generator_in_test());
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(EKS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(EKS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(EKS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(EKS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(EKS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(EKS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Request count should be 2:
+     * - One for the first call to get_credentials (2nd should hit cred cache)
+     * - One for the call to refresh
+     */
+     TEST_CHECK(g_request_count == 2);
+
+    flb_aws_provider_destroy(provider);
+    unsetenv_eks();
+    flb_free(config);
+}
+
+/* unexpected output test- see description for STS_RESPONSE_MALFORMED */
+static void test_eks_provider_unexpected_api_response() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    unsetenv_eks();
+    ret = setenv(ROLE_ARN_ENV_VAR, "arn:aws:iam::123456789012:role/"
+                 "unexpected_api_response", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(TOKEN_FILE_ENV_VAR, WEB_TOKEN_FILE, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
+                                generator_in_test());
+
+    /* API will return an error - creds will be NULL */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+     TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(provider);
+    unsetenv_eks();
+    flb_free(config);
+}
+
+static void test_eks_provider_api_error() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    unsetenv_eks();
+    ret = setenv(ROLE_ARN_ENV_VAR, "arn:aws:iam::123456789012:role/apierror",
+                 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(TOKEN_FILE_ENV_VAR, WEB_TOKEN_FILE, 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
+                                generator_in_test());
+
+    /* API will return an error - creds will be NULL */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+     TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(provider);
+    unsetenv_eks();
+    flb_free(config);
+}
+
+static void test_sts_provider() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_provider *base_provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    /* use the env provider as the base provider */
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, "base_akid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SECRET_ACCESS_KEY, "base_skid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SESSION_TOKEN, "base_token", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    base_provider = flb_aws_env_provider_create();
+    if (!base_provider) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
+                                       "arn:aws:iam::123456789012:role/test1",
+                                       "session_name", "cn-north-1", NULL,
+                                       generator_in_test());
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(STS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(STS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(STS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    if (!creds) {
+        flb_errno();
+        return;
+    }
+    TEST_CHECK(strcmp(STS_ACCESS_KEY, creds->access_key_id) == 0);
+    TEST_CHECK(strcmp(STS_SECRET_KEY, creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp(STS_TOKEN, creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Request count should be 2:
+     * - One for the first call to get_credentials (2nd should hit cred cache)
+     * - One for the call to refresh
+     */
+     TEST_CHECK(g_request_count == 2);
+
+    flb_aws_provider_destroy(base_provider);
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+static void test_sts_provider_api_error() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_provider *base_provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    /* use the env provider as the base provider */
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, "base_akid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SECRET_ACCESS_KEY, "base_skid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SESSION_TOKEN, "base_token", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    base_provider = flb_aws_env_provider_create();
+    if (!base_provider) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
+                                "arn:aws:iam::123456789012:role/apierror",
+                                "session_name", "cn-north-1", NULL,
+                                generator_in_test());
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+     TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(base_provider);
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+/* unexpected output test- see description for STS_RESPONSE_MALFORMED */
+static void test_sts_provider_unexpected_api_response() {
+    struct flb_config *config;
+    struct flb_aws_provider *provider;
+    struct flb_aws_provider *base_provider;
+    struct flb_aws_credentials *creds;
+    int ret;
+
+    g_request_count = 0;
+
+    config = flb_malloc(sizeof(struct flb_config));
+    if (!config) {
+        flb_errno();
+        return;
+    }
+
+    /* use the env provider as the base provider */
+    /* set environment */
+    ret = setenv(AWS_ACCESS_KEY_ID, "base_akid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SECRET_ACCESS_KEY, "base_skid", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+    ret = setenv(AWS_SESSION_TOKEN, "base_token", 1);
+    if (ret < 0) {
+        flb_errno();
+        return;
+    }
+
+    base_provider = flb_aws_env_provider_create();
+    if (!base_provider) {
+        flb_errno();
+        return;
+    }
+
+    provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
+                                       "arn:aws:iam::123456789012:role/"
+                                       "unexpected_api_response",
+                                       "session_name", "cn-north-1", NULL,
+                                       generator_in_test());
+    if (!provider) {
+        flb_errno();
+        return;
+    }
+
+    /* repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* refresh should return -1 (failure) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret < 0);
+
+    /*
+     * Request count should be 3:
+     * - Each call to get_credentials and refresh invokes the client's
+     * request method and returns a request failure.
+     */
+     TEST_CHECK(g_request_count == 3);
+
+    flb_aws_provider_destroy(base_provider);
+    flb_aws_provider_destroy(provider);
+    flb_free(config);
+}
+
+
+TEST_LIST = {
+    { "test_flb_sts_session_name" , test_flb_sts_session_name},
+    { "test_sts_uri" , test_sts_uri},
+    { "process_sts_response" , test_process_sts_response},
+    { "eks_credential_provider" , test_eks_provider},
+    { "eks_credential_provider_random_session_name" ,
+      test_eks_provider_random_session_name},
+    { "test_eks_provider_unexpected_api_response" ,
+      test_eks_provider_unexpected_api_response},
+    { "eks_credential_provider_api_error" , test_eks_provider_api_error},
+    { "sts_credential_provider" , test_sts_provider},
+    { "sts_credential_provider_api_error" , test_sts_provider_api_error},
+    { "sts_credential_provider_unexpected_api_response" ,
+    test_sts_provider_unexpected_api_response},
+    { 0 }
+};

--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -1,0 +1,54 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_mem.h>
+
+#include "flb_tests_internal.h"
+
+static void test_flb_aws_error()
+{
+    flb_sds_t error_type;
+    char *api_response =  "{\"__type\":\"IncompleteSignatureException\","
+                          "\"message\": \"Credential must have exactly 5 "
+                          "slash-delimited elements, e.g. keyid/date/region/"
+                          "service/term, got '<Credential>'\"}";
+    char *garbage = "garbage"; /* something that can't be parsed */
+
+    error_type = flb_aws_error(api_response, strlen(api_response));
+
+    TEST_CHECK(strcmp("IncompleteSignatureException", error_type) == 0);
+
+    flb_sds_destroy(error_type);
+
+    error_type = flb_aws_error(garbage, strlen(garbage));
+
+    TEST_CHECK(error_type == NULL);
+
+    flb_sds_destroy(error_type);
+}
+
+static void test_flb_aws_endpoint()
+{
+    char *endpoint;
+
+    endpoint = flb_aws_endpoint("cloudwatch", "ap-south-1");
+
+    TEST_CHECK(strcmp("cloudwatch.ap-south-1.amazonaws.com",
+                      endpoint) == 0);
+    flb_free(endpoint);
+
+    /* China regions have a different TLD */
+    endpoint = flb_aws_endpoint("cloudwatch", "cn-north-1");
+
+    TEST_CHECK(strcmp("cloudwatch.cn-north-1.amazonaws.com.cn",
+                      endpoint) == 0);
+    flb_free(endpoint);
+
+}
+
+TEST_LIST = {
+    { "parse_api_error" , test_flb_aws_error},
+    { "flb_aws_endpoint" , test_flb_aws_endpoint},
+    { 0 }
+};

--- a/tests/internal/data/aws_credentials/web_identity_token_file.txt
+++ b/tests/internal/data/aws_credentials/web_identity_token_file.txt
@@ -1,0 +1,1 @@
+this-is-a-fake-jwt


### PR DESCRIPTION
This is the *third* in a series of pull requests to add comprehensive support for AWS credentials in Fluent Bit. 

This PR should be reviewed after #1852 

This pull request adds support for 1 provider:
- EC2: pull credentials from EC2 IMDS


AWS Credential Provider Check List:
- [x] Environment Variables
- [ ] Shared Credentials File (AWS Profile)
- [x] EKS/Kubernetes OIDC tokens
- [x] EC2 Instance Metadata Service
- [x] ECS Credentials Endpoint
- [ ] Standard Chained Provider
- [x] STS Assume Role