### PR TITLE
tests: internal: signv4: skip Signv4 unit testing on Windows

### DIFF
--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -13,6 +13,7 @@ cmake -G "$ENV:msvc" -DCMAKE_BUILD_TYPE="$ENV:configuration" `
                      -D FLB_WITHOUT_flb-it-unit_sizes=On `
                      -D FLB_WITHOUT_flb-it-network=On `
                      -D FLB_WITHOUT_flb-it-pack=On `
+                     -D FLB_WITHOUT_flb-it-signv4=On `
                      ../
 
 # COMPILE


### PR DESCRIPTION
This should fix the build failure on AppVeyor.

The test program for Signv4 depends on `dirent.h` for test suite
discovery. However, since Windows provides neither `dirent.h` nor
its equivalent functions, we cannot easily port the testing script
to Windows.

So this disables the signv4 testing for now. We need to revisit
this issue after we prepare a compatiblity layer for dirent.h.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>