### PR TITLE
filter_kubernetes: set 'Host' header to avoid 400 Bad Request errors

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -225,8 +225,10 @@ static int get_api_server_info(struct flb_kube *ctx,
 
         /* Compose HTTP Client request */
         c = flb_http_client(u_conn, FLB_HTTP_GET,
-                            uri,
-                            NULL, 0, NULL, 0, NULL, 0);
+                            uri, NULL, 0,
+                            ctx->api_host,
+                            ctx->api_port,
+                            NULL, 0);
         flb_http_buffer_size(c, ctx->buffer_size);
 
         flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);


### PR DESCRIPTION
Kent Rancourt reports that 3fce26dce breaks the metainfo retrieval
routine. In particular, since this commit, k8s's API server always
responds to our requests with the following error.

    400 Bad Request: missing required Host header

This patch fixes the issue by adding the missing Host header to our
HTTP requests,

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>