### PR TITLE
lib: do not forget to initialize TLS keys for output plugins

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -452,7 +452,7 @@ int flb_start(flb_ctx_t *ctx)
     struct mk_event *event;
     struct flb_config *config;
 
-    pthread_once(&flb_lib_once, flb_thread_prepare);
+    pthread_once(&flb_lib_once, flb_init_env);
 
     config = ctx->config;
     ret = mk_utils_worker_spawn(flb_lib_worker, config, &tid);


### PR DESCRIPTION
I noticed that unit tests for macOS were failing on Travis CI with
the following error message.

    No output has been received in the last 10m0s, this potentially
    indicates a stalled build or something wrong with the build itself.

It turned out that we introduced a new TLS variable in 30d271ea,
but never added a code path to initialized it. This was causing
runtime test programs to deadlock on flb_start().

This should fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>