### PR TITLE
in_tail: fix follow symlink target change. if a target linked by syml…

### DIFF
--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -39,9 +39,8 @@
 static inline int flb_tail_file_name_cmp(char *name,
                                         struct flb_tail_file *file)
 {
-#if defined(__linux__)
-    return strcmp(name, file->name);
-#elif defined(FLB_SYSTEM_WINDOWS)
+
+#if defined(FLB_SYSTEM_WINDOWS)
     return _stricmp(name, file->real_name);
 #else
     return strcmp(name, file->real_name);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -44,9 +44,7 @@ struct flb_tail_file {
     ino_t inode;
 #endif
     char *name;                 /* target file name given by scan routine */
-#if !defined(__linux)
     char *real_name;            /* real file name in the file system */
-#endif
     size_t name_len;
     time_t rotated;
     off_t pending_bytes;


### PR DESCRIPTION
in_tail: fix follow symlink target change. if a target linked by symlink changes, fluent-bit tails both new file and old file.(#1118)