### PR TITLE
out_forward: Add a new option 'Empty_Shared_Key'

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -628,8 +628,19 @@ static int forward_config_ha(const char *upstream_file,
         }
 
         /* Shared key */
+        tmp = flb_upstream_node_get_property("empty_shared_key", node);
+        if (tmp && flb_utils_bool(tmp)) {
+            fc->empty_shared_key = FLB_TRUE;
+        }
+        else {
+            fc->empty_shared_key = FLB_FALSE;
+        }
+
         tmp = flb_upstream_node_get_property("shared_key", node);
-        if (tmp) {
+        if (fc->empty_shared_key == FLB_TRUE) {
+            fc->shared_key = flb_sds_create("");
+        }
+        else if (tmp) {
             fc->shared_key = flb_sds_create(tmp);
         }
         else {
@@ -755,9 +766,23 @@ static int forward_config_simple(struct flb_forward *ctx,
     flb_output_upstream_set(ctx->u, ins);
 
     /* Shared Key */
+    tmp = flb_output_get_property("empty_shared_key", ins);
+    if (tmp && flb_utils_bool(tmp)) {
+        fc->empty_shared_key = FLB_TRUE;
+    }
+    else {
+        fc->empty_shared_key = FLB_FALSE;
+    }
+
     tmp = flb_output_get_property("shared_key", ins);
-    if (tmp) {
+    if (fc->empty_shared_key) {
+        fc->shared_key = flb_sds_create("");
+    }
+    else if (tmp) {
         fc->shared_key = flb_sds_create(tmp);
+    }
+    else {
+        fc->shared_key = NULL;
     }
 
     tmp = flb_output_get_property("username", ins);

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -46,6 +46,7 @@ struct flb_forward_config {
     /* config */
     flb_sds_t shared_key;     /* shared key                   */
     flb_sds_t self_hostname;  /* hotname used in certificate  */
+    int empty_shared_key;     /* use an empty string as shared key */
     int require_ack_response; /* Require acknowledge for "chunk" */
     int send_options;         /* send options in messages */
 


### PR DESCRIPTION
Fluentd allows to use an empty string "" as a shared key. This means
that the following configuration is perfectly valid in Fluentd.

    <source>
      @type forward
      <security>
        shared_key ""
        self_hostname foo
      </security>
    </source>

The trouble is that Fluent Bit was being unable to connect to such
a Fluentd node, because Fluent Bit's configuration syntax did not
allow to specify an empty string.

This adds a new boolean option 'Empty_Shared_Key' that enables us to
circumvent the limitation, and should make Fluent Bit on par with
Fluentd.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>