### PR TITLE
parser: initialize decoders with NULL to avoid SIGSEGV

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -412,7 +412,7 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
     struct mk_list *head;
     struct stat st;
     struct flb_parser_types *types = NULL;
-    struct mk_list *decoders;
+    struct mk_list *decoders = NULL;
 
 #ifndef FLB_HAVE_STATIC_CONF
     ret = stat(file, &st);


### PR DESCRIPTION
When Fluent Bit encounters with a partial parser definition, it
crashes badly with a segmentation fault.

    $ ./bin/fluent-bit -R parser.conf -c tail.conf
    ...
    [2020/01/15 16:11:21] [error] [parser] no parser 'format' found for 'simple' in file 'conf/timestamp.parser'
    [engine] caught signal (SIGSEGV)
    #0  0x558bc4a0a226      in  flb_parser_decoder_list_destroy() at src/flb_parser_decoder.c:700
    #1  0x558bc4a05d75      in  flb_parser_conf_file() at src/flb_parser.c:566
    #2  0x558bc49f4bdd      in  flb_config_set_property() at src/flb_config.c:406
    #3  0x558bc49e24ae      in  flb_service_conf() at src/fluent-bit.c:446
    #4  0x558bc49e2f90      in  main() at src/fluent-bit.c:807
    #5  0x7fa1cb7f109a      in  ???() at ???:0
    #6  0x558bc49e13a9      in  ???() at ???:0
    #7  0xffffffffffffffff  in  ???() at ???:0
    Aborted

This is just because `decoders` is not being initialized properly,
and that confuses Fluent Bit to deallocate a random memmory block
on the cleanup path. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>