### PR TITLE
signv4: fixes to sigv4 algorithm

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -430,6 +430,61 @@ static int proxy_parse(const char *proxy, struct flb_http_client *c)
     return 0;
 }
 
+static int add_host_and_content_length(struct flb_http_client *c)
+{
+    int len;
+    flb_sds_t tmp;
+    flb_sds_t host;
+    char *out_host;
+    int out_port;
+    struct flb_upstream *u = c->u_conn->u;
+
+    if (!c->host) {
+        out_host = u->tcp_host;
+    }
+    else {
+        out_host = (char *) c->host;
+    }
+
+    len = strlen(out_host);
+    host = flb_sds_create_size(len + 32);
+    if (!host) {
+        flb_error("[http_client] cannot create temporal buffer");
+        return -1;
+    }
+
+    if (c->port == 0) {
+        out_port = u->tcp_port;
+    }
+    else {
+        out_port = c->port;
+    }
+
+    tmp = flb_sds_printf(&host, "%s:%i", out_host, out_port);
+    if (!tmp) {
+        flb_sds_destroy(host);
+        flb_error("[http_client] cannot compose temporary host header");
+        return -1;
+    }
+
+    flb_http_add_header(c, "Host", 4, host, flb_sds_len(host));
+    flb_sds_destroy(host);
+
+    /* Content-Length */
+    if (c->body_len >= 0) {
+        tmp = flb_malloc(32);
+        if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+        len = snprintf(tmp, sizeof(tmp) - 1, "%i", c->body_len);
+        flb_http_add_header(c, "Content-Length", 14, tmp, len);
+        flb_free(tmp);
+    }
+
+    return 0;
+}
+
 struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
                                         int method, const char *uri,
                                         const char *body, size_t body_len,
@@ -511,6 +566,8 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
     c->header_len  = ret;
     c->flags       = flags;
     mk_list_init(&c->headers);
+
+    add_host_and_content_length(c);
 
     /* Check if we have a query string */
     p = strchr(uri, '?');
@@ -745,90 +802,11 @@ static int http_header_push(struct flb_http_client *c, struct flb_kv *header)
     return 0;
 }
 
-static int header_exists(struct flb_http_client *c, char *header_buf, int len)
-{
-    int found = FLB_FALSE;
-    struct mk_list *head;
-    struct flb_kv *header;
-
-    mk_list_foreach(head, &c->headers) {
-        header = mk_list_entry(head, struct flb_kv, _head);
-        if (flb_sds_len(header->key) != len) {
-            continue;
-        }
-
-        if (strncasecmp(header->key, header_buf, len) == 0) {
-            found = FLB_TRUE;
-            break;
-        }
-    }
-
-    return found;
-}
-
 static int http_headers_compose(struct flb_http_client *c)
 {
     int ret;
-    int len;
-    flb_sds_t tmp;
-    flb_sds_t host;
-    char *out_host;
-    int out_port;
     struct mk_list *head;
     struct flb_kv *header;
-    struct flb_upstream *u = c->u_conn->u;
-
-    /* Check if the 'Host' header exists, if is missing, just add it */
-    ret = header_exists(c, "Host", 4);
-    if (ret == FLB_FALSE) {
-        if (!c->host) {
-            out_host = u->tcp_host;
-        }
-        else {
-            out_host = (char *) c->host;
-        }
-
-        len = strlen(out_host);
-        host = flb_sds_create_size(len + 32);
-        if (!host) {
-            flb_error("[http_client] cannot create temporal buffer");
-            return -1;
-        }
-
-        if (c->port == 0) {
-            out_port = u->tcp_port;
-        }
-        else {
-            out_port = c->port;
-        }
-
-        tmp = flb_sds_printf(&host, "%s:%i", out_host, out_port);
-        if (!tmp) {
-            flb_sds_destroy(host);
-            flb_error("[http_client] cannot compose temporal host header");
-            return -1;
-        }
-
-        flb_http_add_header(c,
-                            "Host", 4,
-                            host, flb_sds_len(host));
-        flb_sds_destroy(host);
-    }
-
-    /* Content-Length */
-    ret = header_exists(c, "Content-Length", 14);
-    if (ret == FLB_FALSE) {
-        if (c->body_len >= 0) {
-            tmp = flb_malloc(32);
-            if (!tmp) {
-                flb_errno();
-                return -1;
-        }
-            len = snprintf(tmp, sizeof(tmp) - 1, "%i", c->body_len);
-            flb_http_add_header(c, "Content-Length", 14, tmp, len);
-            flb_free(tmp);
-        }
-    }
 
     /* Push header list to one buffer */
     mk_list_foreach(head, &c->headers) {

--- a/tests/internal/signv4.c
+++ b/tests/internal/signv4.c
@@ -292,6 +292,26 @@ static struct flb_http_client *convert_request_file(char *request,
                         req->payload, req->payload ? flb_sds_len(req->payload): -1,
                         NULL, -1, NULL, 0);
 
+    /*
+     * flb_http_client automatically adds host and content-length
+     * for the tests we remove these since all headers come from
+     * the the test file
+     */
+     mk_list_foreach(head, &c->headers) {
+         kv = mk_list_entry(head, struct flb_kv, _head);
+         if (strncasecmp(kv->key, "Host", 4) == 0) {
+             flb_kv_item_destroy(kv);
+             break;
+         }
+     }
+     mk_list_foreach(head, &c->headers) {
+         kv = mk_list_entry(head, struct flb_kv, _head);
+         if (strncasecmp(kv->key, "Content-Length", 14) == 0) {
+             flb_kv_item_destroy(kv);
+             break;
+         }
+     }
+
     /* Append registered headers */
     mk_list_foreach(head, &req->headers) {
         kv = mk_list_entry(head, struct flb_kv, _head);


### PR DESCRIPTION
Re-implements the functionality in [9cccabe](https://github.com/fluent/fluent-bit/commit/9cccabe319286d5cb3c3e072de65de60b5c11432).

In order for sigv4 to work properly, host must be added as a header in the mk_list of headers. The problem with 9cccabe is that it adds the host header in `flb_http_do`, which is called after `flb_signv4_do` when making a request to AWS. 

There are also two small additional fixes which are explained in my commit message.

This PR also adds a slightly hacky fix to the signv4 tests so that the only headers in the client are from the test files.

In a separate branch, I have tested making a real API request to AWS using this code- it worked.