### PR TITLE
input: make flb_input_new() zero-initialize input instances

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -117,7 +117,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         }
 
         /* Create plugin instance */
-        instance = flb_malloc(sizeof(struct flb_input_instance));
+        instance = flb_calloc(1, sizeof(struct flb_input_instance));
         if (!instance) {
             flb_errno();
             return NULL;


### PR DESCRIPTION
I noticed that Fluent Bit sometimes fails to start up with SIGSEGV,
seemingly at random.

The reason turned out that some fields in flb_input_instance were
not initialized to NULL properly, so conditionals such as

    if (in->host.listen) {
        listen = in->host.listen;
    }

... were not really reliable, and could pass a random memory
location to variables. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>