### PR TITLE
build: Enable in_statsd on Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -38,7 +38,7 @@ set(FLB_IN_DUMMY              Yes)
 set(FLB_IN_NETIF               No)
 set(FLB_IN_WINLOG             Yes)
 set(FLB_IN_COLLECTD            No)
-set(FLB_IN_STATSD              No)
+set(FLB_IN_STATSD             Yes)
 set(FLB_IN_STORAGE_BACKLOG     No)
 
 # OUTPUT plugins


### PR DESCRIPTION
I can confirm that in_statsd is already working fine on Windows.
Let's just make it available to Windows users.

**Screenshot**

![instatsd](https://user-images.githubusercontent.com/8974561/72509866-c4b49500-388b-11ea-86c1-be54246eb938.png)


Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>