### PR TITLE
log: Log File size limit and Log rotation for fluent-bit logs

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -130,6 +130,8 @@ struct flb_config {
 
     /* Logging */
     char *log_file;
+    int log_file_sz_mb;
+    int log_file_history;
     struct flb_log *log;
 
     /* Parser Conf */
@@ -280,14 +282,16 @@ enum conf_type {
     FLB_CONF_TYPE_OTHER,
 };
 
-#define FLB_CONF_STR_FLUSH        "Flush"
-#define FLB_CONF_STR_GRACE        "Grace"
-#define FLB_CONF_STR_DAEMON       "Daemon"
-#define FLB_CONF_STR_LOGFILE      "Log_File"
-#define FLB_CONF_STR_LOGLEVEL     "Log_Level"
-#define FLB_CONF_STR_PARSERS_FILE "Parsers_File"
-#define FLB_CONF_STR_PLUGINS_FILE "Plugins_File"
-#define FLB_CONF_STR_STREAMS_FILE "Streams_File"
+#define FLB_CONF_STR_FLUSH              "Flush"
+#define FLB_CONF_STR_GRACE              "Grace"
+#define FLB_CONF_STR_DAEMON             "Daemon"
+#define FLB_CONF_STR_LOGFILE            "Log_File"
+#define FLB_CONF_STR_LOGLEVEL           "Log_Level"
+#define FLB_CONF_STR_LOGFILE_SIZE       "Log_File_Size"
+#define FLB_CONF_STR_LOGFILE_HISTORY    "Log_File_History"
+#define FLB_CONF_STR_PARSERS_FILE       "Parsers_File"
+#define FLB_CONF_STR_PLUGINS_FILE       "Plugins_File"
+#define FLB_CONF_STR_STREAMS_FILE       "Streams_File"
 
 /* FLB_HAVE_HTTP_SERVER */
 #ifdef FLB_HAVE_HTTP_SERVER

--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -52,12 +52,19 @@ extern FLB_TLS_DEFINE(struct flb_log, flb_log_ctx)
 #define FLB_LOG_EVENT    MK_EVENT_NOTIFICATION
 #define FLB_LOG_MNG      1024
 
+/* Logging Limits */
+#define FLB_LOGFILE_MAX_HISTORY     20
+#define FLB_LOGFILE_MAX_SIZE        2000      
+#define FLB_LOGFILE_DEFAULT_SIZE    20
+
 /* Logging main context */
 struct flb_log {
     struct mk_event event;     /* worker event for manager */
     flb_pipefd_t ch_mng[2];    /* worker channel manager   */
     uint16_t type;             /* log type                 */
     uint16_t level;            /* level                    */
+    uint16_t max_sz_mb;        /* max size of a single log file in MB */
+    uint8_t max_history;       /* max log files to be retained */
     char *out;                 /* FLB_LOG_FILE or FLB_LOG_SOCKET */
     pthread_t tid;             /* thread ID   */
     struct flb_worker *worker; /* non-real worker reference */
@@ -96,11 +103,14 @@ static inline int flb_log_check(int l) {
 }
 
 struct flb_log *flb_log_create(struct flb_config *config, int type,
-                               int level, char *out);
+                             int level, uint16_t max_sz_mb, 
+                             uint8_t max_history, char *out);
 int flb_log_set_level(struct flb_config *config, int level);
 int flb_log_get_level_str(char *str);
 
 int flb_log_set_file(struct flb_config *config, char *out);
+int flb_log_set_history(struct flb_config *config, uint8_t max_history);
+int flb_log_set_size(struct flb_config *config, uint16_t max_sz_mb);
 
 int flb_log_destroy(struct flb_log *log, struct flb_config *config);
 void flb_log_print(int type, const char *file, int line, const char *fmt, ...);

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -77,6 +77,14 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, log)},
 
+    {FLB_CONF_STR_LOGFILE_SIZE,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, log_file_sz_mb)},
+
+    {FLB_CONF_STR_LOGFILE_HISTORY,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, log_file_history)},
+
 #ifdef FLB_HAVE_HTTP_SERVER
     {FLB_CONF_STR_HTTP_SERVER,
      FLB_CONF_TYPE_BOOL,

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -517,7 +517,19 @@ static int flb_engine_log_start(struct flb_config *config)
         type = FLB_LOG_STDERR;
     }
 
-    if (flb_log_create(config, type, level, config->log_file) == NULL) {
+    if (config->log_file_sz_mb == 0) {
+        config->log_file_sz_mb = FLB_LOGFILE_DEFAULT_SIZE;
+    }
+    
+    if (config->log_file_sz_mb > FLB_LOGFILE_MAX_SIZE) {
+        config->log_file_sz_mb = FLB_LOGFILE_MAX_SIZE;
+    }
+
+    if (config->log_file_history > FLB_LOGFILE_MAX_HISTORY) {
+        config->log_file_history = FLB_LOGFILE_MAX_HISTORY;
+    }
+
+    if (flb_log_create(config, type, level, config->log_file_sz_mb, config->log_file_history, config->log_file) == NULL) {
         return -1;
     }
 

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -415,7 +415,7 @@ void flb_test_input_chunk_fs_chunks_size_real()
     TEST_CHECK(evl != NULL);
     cfg->evl = evl;
 
-    flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, NULL);
+    flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, 20, 0, NULL);
 
     i_ins = flb_input_new(cfg, "dummy", NULL, FLB_TRUE);
     i_ins->storage_type = CIO_STORE_FS;


### PR DESCRIPTION
Currently fluent-bit logs can be redirected to a file using Log_File.
But there is no configuration option to limit the size of the file. Additionally, there is no log rotation that can be enabled for fluent-bit logs.
These might be useful when we want to collect fluent-bit process logs itself and also to debug.

Added new configuration parameters:
Log_File_Size - Size limit in MB for the file specified by Log_File.
Log_File_History - Max number of backups to be kept.
These backups are kept as <Log_File>.1, <Log_File>.2 etc.

Sample configuration.
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    debug
    Log_File     ./fb_log.log
    Log_File_Size     1   
    Log_File_History  2

This PR has the corresponding changes.
