### PR TITLE
http: add content-length header after body is set

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -567,8 +567,6 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
     c->flags       = flags;
     mk_list_init(&c->headers);
 
-    add_host_and_content_length(c);
-
     /* Check if we have a query string */
     p = strchr(uri, '?');
     if (p) {
@@ -592,6 +590,8 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
         c->body_buf = body;
         c->body_len = body_len;
     }
+
+    add_host_and_content_length(c);
 
     /* Check proxy data */
     if (proxy) {


### PR DESCRIPTION
Fixes a bug I committed in fcf15a9

(content length header was added before body was set, so it was always 0).

Fixes #1896 