### PR TITLE
in_tail: Implement a full wildcard support for Windows

### DIFF
--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -55,6 +55,147 @@ static int tail_is_excluded(char *path, struct flb_tail_config *ctx)
     return FLB_FALSE;
 }
 
+/*
+ * This function is a thin wrapper over flb_tail_file_append(),
+ * adding normalization and sanity checks on top of it.
+ */
+static int tail_register_file(const char *target, struct flb_tail_config *ctx)
+{
+    struct stat st;
+    char path[MAX_PATH];
+
+    if (_fullpath(path, target, MAX_PATH) == NULL) {
+        flb_error("[in_tail] cannot get absolute path of %s", target);
+        return -1;
+    }
+
+    if (stat(path, &st) != 0 || !S_ISREG(st.st_mode)) {
+        return -1;
+    }
+
+    if (tail_is_excluded(path, ctx) == FLB_TRUE) {
+        flb_trace("[in_tail] skip '%s' (excluded)", path);
+        return -1;
+    }
+
+    if (flb_tail_file_exists(path, ctx) == FLB_TRUE) {
+        return -1;
+    }
+
+    return flb_tail_file_append(path, &st, FLB_TAIL_STATIC, ctx);
+}
+
+/*
+ * Perform patern match on the given path string. This function
+ * supports patterns with "nested" wildcards like below.
+ *
+ *     tail_scan_pattern("C:\fluent-bit\*\*.txt", ctx);
+ */
+static int tail_scan_pattern(const char *path, struct flb_tail_config *ctx)
+{
+    char *star, *p0, *p1;
+    char pattern[MAX_PATH];
+    char buf[MAX_PATH];
+    int ret;
+    int n_added = 0;
+    HANDLE h;
+    WIN32_FIND_DATA data;
+
+    if (strlen(path) > MAX_PATH - 1) {
+        flb_error("[in_tail] path too long '%s'");
+        return -1;
+    }
+
+    star = strchr(path, '*');
+    if (star == NULL) {
+        return -1;
+    }
+
+    /*
+     * C:\data\tmp\input_*.conf
+     *            0<-----|
+     */
+    p0 = star;
+    while (path <= p0 && *p0 != '\\') {
+        p0--;
+    }
+
+    /*
+     * C:\data\tmp\input_*.conf
+     *                   |---->1
+     */
+    p1 = star;
+    while (*p1 && *p1 != '\\') {
+        p1++;
+    }
+
+    memcpy(pattern, path, (p1 - path));
+    pattern[p1 - path] = '\0';
+
+    h = FindFirstFileA(pattern, &data);
+    if (h == INVALID_HANDLE_VALUE) {
+        return -1;
+    }
+
+    do {
+        /* Ignore the current and parent dirs */
+        if (!strcmp(".", data.cFileName) || !strcmp("..", data.cFileName)) {
+            continue;
+        }
+
+        /* Avoid an infinite loop */
+        if (strchr(data.cFileName, '*')) {
+            continue;
+        }
+
+        /* Create a path (prefix + filename + suffix) */
+        memcpy(buf, path, p0 - path + 1);
+        buf[p0 - path + 1] = '\0';
+
+        if (strlen(buf) + strlen(data.cFileName) + strlen(p1) > MAX_PATH - 1) {
+            flb_warn("[in_tail] '%s%s%s' is too long", buf, data.cFileName, p1);
+            continue;
+        }
+        strcat(buf, data.cFileName);
+        strcat(buf, p1);
+
+        if (strchr(p1, '*')) {
+            ret = tail_scan_pattern(buf, ctx); /* recursive */
+            if (ret >= 0) {
+                n_added += ret;
+            }
+            continue;
+        }
+
+        /* Try to register the target file */
+        ret = tail_register_file(buf, ctx);
+        if (ret == 0) {
+            n_added++;
+        }
+    } while (FindNextFileA(h, &data) != 0);
+
+    FindClose(h);
+    return n_added;
+}
+
+static int tail_do_scan(const char *path, struct flb_tail_config *ctx)
+{
+    int ret;
+    int n_added = 0;
+
+    if (strchr(path, '*')) {
+        return tail_scan_pattern(path, ctx);
+    }
+
+    /* No wildcard involved. Let's just handle the file... */
+    ret = tail_register_file(path, ctx);
+    if (ret == 0) {
+        n_added++;
+    }
+
+    return n_added;
+}
+
 static int tail_exclude_generate(struct flb_tail_config *ctx)
 {
     struct mk_list *list;


### PR DESCRIPTION
This patch adds a full wildcard support to in_tail on Windows, which has
been in our "TODO" list for a while (since 55e27e0).

With this patch applied, I can confirm that nested wildcard pathspecs
(like below) just work fine.

```ini
[INPUT]
  Nat lme tail
  Tag  app.log
  Path C:\myapp\*\*.log
```