### PR TITLE
input_chunk: change mem buf overlimit message to warning

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -307,7 +307,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
 static inline int flb_input_chunk_protect(struct flb_input_instance *i)
 {
     if (flb_input_chunk_is_overlimit(i) == FLB_TRUE) {
-        flb_debug("[input] %s paused (mem buf overlimit)",
+        flb_warn("[input] %s paused (mem buf overlimit)",
                  i->name);
         if (!flb_input_buf_paused(i)) {
             if (i->p->cb_pause) {


### PR DESCRIPTION
See #1903, I think this message should probably be a warning instead of debug.