### PR TITLE
out_kafka: add dynamic_topic option

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -154,35 +154,53 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
             if (key.via.str.size == ctx->topic_key_len &&
                 strncmp(key.via.str.ptr, ctx->topic_key, ctx->topic_key_len) == 0) {
                 topic = flb_kafka_topic_lookup((char *) val.via.str.ptr,
-                                               val.via.str.size,
-                                               ctx);
-                /* Add topic on the fly to topiclist and use it */
+                                               val.via.str.size, ctx);
+                /* Add extracted topic on the fly to topiclist */
                 if (ctx->dynamic_topic) {
+                    /* Only if default topic is set and this topicname is not set for this message */
                     if (strncmp(topic->name, flb_kafka_topic_default(ctx)->name, val.via.str.size) == 0 &&
-                       (strncmp(topic->name, val.via.str.ptr, val.via.str.size) != 0) ) {
+                        (strncmp(topic->name, val.via.str.ptr, val.via.str.size) != 0) ) {
+                        if (strstr(val.via.str.ptr, ",")) {
+                            /* Don't allow commas in kafkatopic name */
+                            flb_warn("',' not allowed in dynamic_kafka topic names");
+                            continue;
+                        }
+                        if (val.via.str.size > 64) {
+                            /* Don't allow length of dynamic kafka topics > 64 */
+                            flb_warn(" dynamic kafka topic length > 64 not allowed");
+                            continue;
+                        }
                         dynamic_topic = flb_malloc(val.via.str.size + 1);
                         if (!dynamic_topic) {
+                            /* Use default topic */
                             flb_errno();
-                            /* in this case we use the default topic */
-                            break;
+                            continue;
                         }
                         strncpy(dynamic_topic, val.via.str.ptr, val.via.str.size);
                         dynamic_topic[val.via.str.size] = '\0';
-
-                        topics = flb_utils_split(dynamic_topic, ',', 1);
+                        topics = flb_utils_split(dynamic_topic, ',', 0);
+                        if (!topics) {
+                            /* Use the default topic */
+                            flb_errno();
+                            flb_free(dynamic_topic);
+                            continue;
+                        }
                         mk_list_foreach(head, topics) {
+                            /* Add the (one) found topicname to the topic configuration */
                             entry = mk_list_entry(head, struct flb_split_entry, _head);
                             topic = flb_kafka_topic_create(entry->value, ctx);
                             if (!topic) {
+                                /* Use default topic  */
                                 flb_error("[out_kafka] cannot register topic '%s'",
                                           entry->value);
+                                topic = flb_kafka_topic_lookup((char *) val.via.str.ptr,
+                                                               val.via.str.size, ctx);
                             }
                             else {
                                 flb_info("[out_kafka] new topic added: %s", dynamic_topic);
-                                break;
                             }
-                        flb_free(dynamic_topic);
                         }
+                        flb_free(dynamic_topic);
                     }
                 }
             }

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -114,6 +114,15 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
         ctx->topic_key = NULL;
     }
 
+    /* Config: dynamic_topic */
+    tmp = flb_output_get_property("dynamic_topic", ins);
+    if (tmp) {
+        ctx->dynamic_topic = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->dynamic_topic = FLB_FALSE;
+    }
+
     /* Config: Format */
     tmp = flb_output_get_property("format", ins);
     if (tmp) {

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -82,6 +82,8 @@ struct flb_kafka {
      */
     int blocked;
 
+    int dynamic_topic;
+
     /* Internal */
     rd_kafka_t *producer;
     rd_kafka_conf_t *conf;


### PR DESCRIPTION
this PR enhances plugin out_kafka with 'dynamic_topic' option. See
  fluent/fluent-bit-docs#259
If dynamic_topic is set, unknown 'new' topics found in Topic_Key are
added on the fly to Topics.

This feature is helpful in kubernetes/openshift environment, forwarding the
logs of all pods to distinct kafka topics, when e.g. the topics are
extracted from a pod's annotation field. The static listing of all topics in the
configuration is not practicable for dynamic scaling up kubernetes
environments

configuration example:
```
  Topics               logging_ichp_dev
  Topic_Key            topickey
  Dynamic_Topic        on
``

the commit was tested in an openshift-environment and logoutput is:
```
[2020/01/21 12:49:57] [ info] [out_kafka] brokers='kafka-t-0.europe.intranet: 9093' topics='logging_ichp_dev'
[2020/01/21 12:49:57] [ info] [filter_kube] https=1 host=kubernetes.default.s vc.cluster.local port=443
[2020/01/21 12:49:57] [ info] [filter_kube] local POD info OK
[2020/01/21 12:49:57] [ info] [filter_kube] testing connectivity with API server...
[2020/01/21 12:49:57] [ info] [filter_kube] API server connectivity OK
[2020/01/21 12:49:57] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2020/01/21 12:49:57] [ info] [sp] stream processor started
[2020/01/21 12:50:15] [ info] [out_kafka] new topic added: logging_ichp_kpvbxkqr
[2020/01/21 12:50:16] [ info] [out_kafka] new topic added: logging_ichp_abmdfttr
[2020/01/21 12:50:26] [ info] [out_kafka] new topic added: logging_ichp_afpjxcuo
[2020/01/21 12:50:27] [ info] [out_kafka] new topic added: logging_ichp_cvokihyd
[2020/01/21 12:50:37] [ info] [out_kafka] new topic added: logging_ichp_qbjazmgz
[2020/01/21 12:50:37] [ info] [out_kafka] new topic added: logging_ichp_sblqgdyg
[2020/01/21 12:50:46] [ info] [out_kafka] new topic added: logging_ichp_jcofmlqs
[2020/01/21 12:50:46] [ info] [out_kafka] new topic added: logging_ichp_orjaiuph
[2020/01/21 12:50:56] [ info] [out_kafka] new topic added: logging_ichp_pblxhzkb
[2020/01/21 12:51:06] [ info] [out_kafka] new topic added: logging_ichp_mhyvwcha
[2020/01/21 12:51:16] [ info] [out_kafka] new topic added: logging3_ichp_dev
[2020/01/21 12:51:27] [ info] [out_kafka] new topic added: logging2_ichp_dev
```

Signed-off-by: Michael Voelker <novecento@gmx.de>