### PR TITLE
conf: parsers: fix syslog-rfc5424 timestamp format

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -65,7 +65,7 @@
     Format      regex
     Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|-)) (?<message>.+)$
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep   On
 
 [PARSER]


### PR DESCRIPTION
The timestamp in RFC 5424 conforms to RFC 3339 and it should accept
timezone, such as "2019-10-18T11:50:47.788+03:00". Without it all
timestamps from syslog input are treated as UTC.

Signed-off-by: Ji-Ping Shen <ji-ping.shen@relexsolutions.com>