### PR TITLE
utils: fix flb_utils_print_setup

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -169,33 +169,55 @@ void flb_utils_print_setup(struct flb_config *config)
     struct flb_input_plugin *plugin;
     struct flb_input_collector *collector;
     struct flb_input_instance *in;
+    struct flb_filter_instance *f;
+    struct flb_output_instance *out;
 
-    flb_info("Configuration");
+    flb_info("Configuration:");
 
     /* general */
-    flb_info(" flush time     : %i seconds", config->flush);
+    flb_info(" flush time     | %f seconds", config->flush);
+    flb_info(" grace          | %i seconds", config->grace);
+    flb_info(" daemon         | %i", config->daemon);
 
     /* Inputs */
-    flb_info(" input plugins  : ");
+    flb_info("___________");
+    flb_info(" inputs:");
     mk_list_foreach(head, &config->inputs) {
         in = mk_list_entry(head, struct flb_input_instance, _head);
-        flb_info("%s ", in->p->name);
+        flb_info("     %s", in->p->name);
+    }
+
+    /* Filters */
+    flb_info("___________");
+    flb_info(" filters:");
+    mk_list_foreach(head, &config->filters) {
+        f = mk_list_entry(head, struct flb_filter_instance, _head);
+        flb_info("     %s", f->name);
+    }
+
+    /* Outputs */
+    flb_info("___________");
+    flb_info(" outputs:");
+    mk_list_foreach(head, &config->outputs) {
+        out = mk_list_entry(head, struct flb_output_instance, _head);
+        flb_info("     %s", out->name);
     }
 
     /* Collectors */
-    flb_info(" collectors     : ");
+    flb_info("___________");
+    flb_info(" collectors:");
     mk_list_foreach(head, &config->collectors) {
         collector = mk_list_entry(head, struct flb_input_collector, _head);
         plugin = collector->instance->p;
 
         if (collector->seconds > 0) {
             flb_info("[%s %lus,%luns] ",
-                     plugin->name,
-                     collector->seconds,
-                     collector->nanoseconds);
+                      plugin->name,
+                      collector->seconds,
+                      collector->nanoseconds);
         }
         else {
-            printf("[%s] ", plugin->name);
+            flb_info("     [%s] ", plugin->name);
         }
 
     }

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -842,7 +842,8 @@ int main(int argc, char **argv)
         flb_utils_error(FLB_ERR_OUTPUT_UNDEF);
     }
 
-    if (config->verbose == FLB_TRUE) {
+    /* debug or trace */
+    if (config->verbose >= FLB_LOG_DEBUG) {
         flb_utils_print_setup(config);
     }
 


### PR DESCRIPTION
Previously, if log level was set to error you'd get some weird print statements:

```
[2020/01/29 08:28:04] [ info] Configuration
[2020/01/29 08:28:04] [ info]  flush time     : 9190080 seconds
[2020/01/29 08:28:04] [ info]  input plugins  :
[2020/01/29 08:28:04] [ info] dummy
[2020/01/29 08:28:04] [ info] cpu
[2020/01/29 08:28:04] [ info]  collectors     :
```

It seems the goal of these statements was to print the current config. I've changed it to print more useful information, and also made it so it only prints these messages if log level is debug or trace:

```
[2020/01/29 08:24:32] [ info] Configuration:
[2020/01/29 08:24:32] [ info]  flush time     | 5.000000 seconds
[2020/01/29 08:24:32] [ info]  grace          | 5 seconds
[2020/01/29 08:24:32] [ info]  daemon         | 0
[2020/01/29 08:24:32] [ info] ___________
[2020/01/29 08:24:32] [ info]  inputs:
[2020/01/29 08:24:32] [ info]      dummy
[2020/01/29 08:24:32] [ info]      cpu
[2020/01/29 08:24:32] [ info] ___________
[2020/01/29 08:24:32] [ info]  filters:
[2020/01/29 08:24:32] [ info] ___________
[2020/01/29 08:24:32] [ info]  outputs:
[2020/01/29 08:24:32] [ info]      stdout.0
[2020/01/29 08:24:32] [ info] ___________
[2020/01/29 08:24:32] [ info]  collectors:
```