### PR TITLE
metrics.c: fix missing prometheus HELP string #1849

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -299,12 +299,18 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     qsort(metrics_arr, num_metrics, sizeof(char *), string_cmp);
 
     /* When a new metric starts add TYPE annotation. */
+    sds = flb_sds_cat(sds, "# HELP ", 7);
+    sds = flb_sds_cat(sds, metrics_arr[0], extract_metric_name_end_position(metrics_arr[0]));
+    sds = flb_sds_cat(sds, " fluentbit_metrics\n", 20);
     sds = flb_sds_cat(sds, "# TYPE ", 7);
     sds = flb_sds_cat(sds, metrics_arr[0], extract_metric_name_end_position(metrics_arr[0]));
     sds = flb_sds_cat(sds, " counter\n", 9);
     for (i = 0; i < num_metrics; i++) {
         sds = flb_sds_cat(sds, metrics_arr[i], strlen(metrics_arr[i]));
         if ((i != num_metrics - 1) && (is_same_metric(metrics_arr[i], metrics_arr[i+1]) == 0)) {
+            sds = flb_sds_cat(sds, "# HELP ", 7);
+            sds = flb_sds_cat(sds, metrics_arr[i+1], extract_metric_name_end_position(metrics_arr[i+1]));
+            sds = flb_sds_cat(sds, " fluentbit_metrics\n", 20);
             sds = flb_sds_cat(sds, "# TYPE ", 7);
             sds = flb_sds_cat(sds, metrics_arr[i+1], extract_metric_name_end_position(metrics_arr[i+1]));
             sds = flb_sds_cat(sds, " counter\n", 9);
@@ -312,6 +318,7 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     }
 
     /* Attach process_start_time_seconds metric. */
+    sds = flb_sds_cat(sds, "# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.\n", 89);
     sds = flb_sds_cat(sds, "# TYPE process_start_time_seconds gauge\n", 40);
     sds = flb_sds_cat(sds, "process_start_time_seconds ", 27);
     sds = flb_sds_cat(sds, start_time_str, start_time_len);


### PR DESCRIPTION
adds missing "HELP... " strings to prometheus metrics for compatibilty
with prometheus pushgateway.

 output of /api/v1/metrics/prometheus:
```
# HELP fluentbit_input_bytes_total fluentbit_metrics
# TYPE fluentbit_input_bytes_total counter
fluentbit_input_bytes_total{name="cpu.0"} 7608 1580245280923
# HELP fluentbit_input_records_total fluentbit_metrics
# TYPE fluentbit_input_records_total counter
fluentbit_input_records_total{name="cpu.0"} 24 1580245280923
# HELP fluentbit_output_errors_total fluentbit_metrics
# TYPE fluentbit_output_errors_total counter
fluentbit_output_errors_total{name="stdout.0"} 0 1580245280923
# HELP fluentbit_output_proc_bytes_total fluentbit_metrics
# TYPE fluentbit_output_proc_bytes_total counter
fluentbit_output_proc_bytes_total{name="stdout.0"} 6023 1580245280923
# HELP fluentbit_output_proc_records_total fluentbit_metrics
# TYPE fluentbit_output_proc_records_total counter
fluentbit_output_proc_records_total{name="stdout.0"} 19 1580245280923
# HELP fluentbit_output_retries_failed_total fluentbit_metrics
# TYPE fluentbit_output_retries_failed_total counter
fluentbit_output_retries_failed_total{name="stdout.0"} 0 1580245280923
# HELP fluentbit_output_retries_total fluentbit_metrics
# TYPE fluentbit_output_retries_total counter
fluentbit_output_retries_total{name="stdout.0"} 0 1580245280923
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1580245256
```

Signed-off-by: Michael Voelker <novecento@gmx.de>