### PR TITLE
tests: internal: config_map: fix test for mult_slist

### DIFF
--- a/tests/internal/config_map.c
+++ b/tests/internal/config_map.c
@@ -272,7 +272,7 @@ void test_multiple()
     flb_kv_item_create(&prop, "mult_clist", "d, e, f");
     flb_kv_item_create(&prop, "mult_clist", "g, h, i");
 
-    flb_kv_item_create(&prop, "mult_slist", "d e f");
+    flb_kv_item_create(&prop, "mult_slist", "d e f g");
 
     map = flb_config_map_create(config_map_mult);
     TEST_CHECK(map != NULL);


### PR DESCRIPTION
Since `FLB_CONFIG_MAP_SLIST_4` requires 4 strings at least, we
need to pass something like "a b c d", not "a b c".

This should fix the CI failure occurring on 013a2553.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>