### PR TITLE
in_syslog: make syslog_prot_process() more verbose on parse errors

### DIFF
--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -104,7 +104,9 @@ int syslog_prot_process(struct syslog_conn *conn)
             flb_free(out_buf);
         }
         else {
-            flb_warn("[in_syslog] error parsing log message");
+            flb_warn("[in_syslog] error parsing log message from '%s'",
+                     flb_input_name(conn->in));
+            flb_debug("[in_syslog] the message was '%.*s'", len, p);
         }
 
         conn->buf_parsed += len + 1;


### PR DESCRIPTION
Right now, in_syslog throws the following error when it fails to parse
an incoming message:

    [2020/01/31 18:03:27] [ warn] [in_syslog] error parsing log message

... which is somewhat too terse to be useful for debugging. Paritcularly
it is not quite possible to find out which message the plugin failed to
parse.

So I modified the debug logging call so that it outputs the error info
in a more verbose manner. Now the output looks like:

    [2020/01/31 17:56:20] [ warn] [in_syslog] error parsing log message from 'system-syslog'
    [2020/01/31 17:56:20] [debug] [in_syslog] the message was '-- Logs begin at 20:30'

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>