### PR TITLE
build: register signv4 if FLB_SIGNV4 and FLB_TLS enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,7 @@ if(FLB_METRICS)
     )
 endif()
 
-if(FLB_METRICS)
+if(FLB_SIGNV4 AND FLB_TLS)
   set(src
     ${src}
     "flb_signv4.c"


### PR DESCRIPTION
The build is currently failing due to option `FLB_SIGNV4` being set to `Yes`, but the `flb_signv4.c` file is gated behind the `FLB_METRICS` option.