### PR TITLE
http_server: metrics: prometheus: add help string #1849

### DIFF
--- a/src/http_server/api/v1/metrics.h
+++ b/src/http_server/api/v1/metrics.h
@@ -23,7 +23,10 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_http_server.h>
+#include <fluent-bit/flb_sds.h>
 
 int api_v1_metrics(struct flb_hs *hs);
+
+flb_sds_t metrics_help_txt(char *metric_name, flb_sds_t *metric_helptxt);
 
 #endif


### PR DESCRIPTION
adds missing "HELP... " strings to prometheus metrics for compatibilty
with prometheus pushgateway.

output of /api/v1/metrics/prometheus:
```
# HELP fluentbit_input_bytes_total fluentbit_metrics
# TYPE fluentbit_input_bytes_total counter
fluentbit_input_bytes_total{name="cpu.0"} 7608 1580245280923
# HELP fluentbit_input_records_total fluentbit_metrics
# TYPE fluentbit_input_records_total counter
fluentbit_input_records_total{name="cpu.0"} 24 1580245280923
# HELP fluentbit_output_errors_total fluentbit_metrics
# TYPE fluentbit_output_errors_total counter
fluentbit_output_errors_total{name="stdout.0"} 0 1580245280923
# HELP fluentbit_output_proc_bytes_total fluentbit_metrics
# TYPE fluentbit_output_proc_bytes_total counter
fluentbit_output_proc_bytes_total{name="stdout.0"} 6023 1580245280923
# HELP fluentbit_output_proc_records_total fluentbit_metrics
# TYPE fluentbit_output_proc_records_total counter
fluentbit_output_proc_records_total{name="stdout.0"} 19 1580245280923
# HELP fluentbit_output_retries_failed_total fluentbit_metrics
# TYPE fluentbit_output_retries_failed_total counter
fluentbit_output_retries_failed_total{name="stdout.0"} 0 1580245280923
# HELP fluentbit_output_retries_total fluentbit_metrics
# TYPE fluentbit_output_retries_total counter
fluentbit_output_retries_total{name="stdout.0"} 0 1580245280923
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1580245256
```

Signed-off-by: Michael Voelker <novecento@gmx.de>