### PR TITLE
out_es: update user-agent for Amazon ES to conform with AWS standards

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -42,10 +42,10 @@ struct flb_elasticsearch {
     char *http_passwd;
 
     /* AWS Auth */
-    #ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_SIGNV4
     int has_aws_auth;
     char *aws_region;
-    #endif
+#endif
 
     /* HTTP Client Setup */
     size_t buffer_size;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -123,7 +123,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
         snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/_bulk", path);
     }
 
-    #ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_SIGNV4
     /* AWS Auth */
     ctx->has_aws_auth = FLB_FALSE;
     tmp = flb_output_get_property("aws_auth", ins);
@@ -142,7 +142,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             ctx->aws_region = (char *) tmp;
         }
     }
-    #endif
+#endif
 
     return ctx;
 }


### PR DESCRIPTION
When `AWS_auth` is `On`, the user-agent will match that of the other AWS fluent bit plugins: https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/blob/master/plugins/user_agent.go#L32