### PR TITLE
input: avoid destroying the same collector timer twice

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -787,6 +787,10 @@ int flb_input_collector_pause(int coll_id, struct flb_input_instance *in)
         return -1;
     }
 
+    if (coll->running == FLB_FALSE) {
+        return 0;
+    }
+
     config = in->config;
     if (coll->type == FLB_COLLECT_TIME) {
         /*


### PR DESCRIPTION
Pausing the same timer twice can result in a nasty memory error,
since mk_event_timeout_destroy() is not guaranteed to be idempotent
(notably it's unsafe on the "select" backend).

I can confirm that this issues was causing occasional segmentation
faults on Windows platform. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>