### PR TITLE
engine: avoid segmentation faults while formatting stack size

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -411,8 +411,8 @@ int flb_engine_start(struct flb_config *config)
 
     /* Debug coroutine stack size */
     flb_utils_bytes_to_human_readable_size(config->coro_stack_size,
-                                           (char *) &tmp, sizeof(tmp));
-    flb_debug("[engine] coroutine stack size: %lu bytes (%s)",
+                                           tmp, sizeof(tmp));
+    flb_debug("[engine] coroutine stack size: %u bytes (%s)",
               config->coro_stack_size, tmp);
 
     /* Create the event loop and set it in the global configuration */


### PR DESCRIPTION
This actually fixes two bugs:

 - The argument to "flb_utils_bytes_to_human_readable_size()" is
   wrong. It's `*char[]`, where it should be `char[]`.

 - The format string for coro_stack_size should be "%u" (not "%lu"),
   since it is declared as unsigned integer.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>