### PR TITLE
in_tail: fix compilation error due to recent updates

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -43,7 +43,6 @@
 
 #ifdef _MSC_VER
 static int get_inode(int fd, uint64_t *inode, struct flb_tail_config *ctx)
-)
 {
     HANDLE h;
     BY_HANDLE_FILE_INFORMATION info;

--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -197,28 +197,6 @@ static int tail_do_scan(const char *path, struct flb_tail_config *ctx)
     return n_added;
 }
 
-static int tail_exclude_generate(struct flb_tail_config *ctx)
-{
-    struct mk_list *list;
-
-    /*
-     * The exclusion path might content multiple exclusion patterns, first
-     * let's split the content into a list.
-     */
-    list = flb_utils_split(ctx->exclude_path, ',', -1);
-    if (!list) {
-        return -1;
-    }
-
-    if (mk_list_is_empty(list) == 0) {
-        return 0;
-    }
-
-    /* We use the same list head returned by flb_utils_split() */
-    ctx->exclude_list = list;
-    return 0;
-}
-
 static int tail_filepath(char *buf, int len, const char *basedir, const char *filename)
 {
     char drive[_MAX_DRIVE];
@@ -255,10 +233,6 @@ int flb_tail_scan(const char *pattern, struct flb_tail_config *ctx)
     int n_added;
 
     flb_plg_debug(ctx->ins, "scanning path %s", pattern);
-
-    if (ctx->exclude_path) {
-        tail_exclude_generate(ctx);
-    }
 
     n_added = tail_do_scan(pattern, ctx);
     if (n_added >= 0) {


### PR DESCRIPTION
This is a supplemental patch for a8976f2e90, applying interface
changes introduced by the commit to Windows code paths.

With this, in_tail can be compiled and linked again.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>