### PR TITLE
filter_rewrite_tag: port the plugin to Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -40,6 +40,7 @@ set(FLB_IN_WINLOG             Yes)
 set(FLB_IN_COLLECTD            No)
 set(FLB_IN_STATSD             Yes)
 set(FLB_IN_STORAGE_BACKLOG     No)
+set(FLB_IN_EMITTER            Yes)
 
 # OUTPUT plugins
 # ==============

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -79,6 +79,7 @@ set(FLB_FILTER_THROTTLE       Yes)
 set(FLB_FILTER_NEST           Yes)
 set(FLB_FILTER_LUA            Yes)
 set(FLB_FILTER_RECORD_MODIFIER Yes)
+set(FLB_FILTER_REWRITE_TAG    Yes)
 
 # Search bison and flex executables
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -330,7 +330,7 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
          * If a record was emitted, the variable 'keep' will define if the record must
          * be preserved or not.
          */
-        ret = process_record(tag, tag_len, map, data + pre, off - pre, &keep, ctx);
+        ret = process_record(tag, tag_len, map, (char *) data + pre, off - pre, &keep, ctx);
         if (ret == FLB_TRUE) {
             /* A record with the new tag was emitted */
             emitted++;
@@ -343,7 +343,7 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
          * - record was not emitted
          */
         if ((ret == FLB_TRUE && keep == FLB_TRUE) || ret == FLB_FALSE) {
-            msgpack_sbuffer_write(&mp_sbuf, data + pre, off - pre);
+            msgpack_sbuffer_write(&mp_sbuf, (char *) data + pre, off - pre);
         }
 
         /* Adjust previous offset */

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_plugin.h>
@@ -26,7 +27,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 struct em_chunk {
     flb_sds_t tag;


### PR DESCRIPTION
This contains a series of small fixes that bring `filter_rewrite_tag`
(and `in_emitter`) to Windows platforms.

With this applied, I can confirm that I can rewrite tags with Fluent Bit
running on cmd.exe.

**Test Configuration**

```ini
[INPUT]
    NAME   dummy
    Dummy  {"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}
    Tag    test_tag

[FILTER]
    Name          rewrite_tag
    Match         test_tag
    Rule          $tool ^(fluent)$  from.$TAG.new.$tool.$sub['s1']['s2'].out false

[OUTPUT]
    Name  stdout
    Match from.*
```

**Execution Result**
```
C:> fluent-bit.exe -c rewrite.conf
...
[0] from.test_tag.new.fluent.bit.out: [1581663803.613948700, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[1] from.test_tag.new.fluent.bit.out: [1581663804.613835400, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[2] from.test_tag.new.fluent.bit.out: [1581663805.613760600, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[3] from.test_tag.new.fluent.bit.out: [1581663806.613737000, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
```