### PR TITLE
parser: interpolate the date field with a reasonable value

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -705,6 +705,11 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
         }
 
         gmtime_r(&time_now, &tmy);
+
+        /* Make the timestamp default to today */
+        tm->tm_mon = tmy.tm_mon;
+        tm->tm_mday = tmy.tm_mday;
+
         uint64_t t = tmy.tm_year + 1900;
 
         fmt = tmp;


### PR DESCRIPTION
Mehdi Hamidi reported that Fluent Bit always defaults to "31 December"
if the incoming records do not contain any date information. For example,
suppose that we have set up something like below:

    [PARSER]
      Name nginx
      Format regex
      Time_Format %H:%M:%S

... then Fluent Bit would parse '12:00:00' into '2020/12/31 12:00:00'
regardless of what the day is today.

This is a fix for the issue and make Fluent Bit to use "today" as a
reasonable default value.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>