### PR TITLE
[cherry-pick] out_datadog: add gzip http payload compression (#1772)

### DIFF
--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -62,6 +62,9 @@ struct flb_out_datadog {
     flb_sds_t dd_tags;
     flb_sds_t dd_message_key;
 
+    /* Compression mode (gzip) */
+    int compress_gzip;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *upstream;
 };

--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -152,6 +152,16 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     ctx->nb_additional_entries++;
     flb_debug("[out_datadog] ctx->json_date_key: %s", ctx->json_date_key);
 
+    /* Compress (gzip) */
+    tmp = flb_output_get_property("compress", ins);
+    ctx->compress_gzip = FLB_FALSE;
+    if (tmp) {
+        if (strcasecmp(tmp, "gzip") == 0) {
+            ctx->compress_gzip = FLB_TRUE;
+        }
+    }
+    flb_debug("[out_datadog] ctx->compress_gzip: %i", ctx->compress_gzip);
+   
     /* Prepare an upstream handler */
     upstream = flb_upstream_create(config, ctx->host, ctx->port, io_flags, &ins->tls);
     if (!upstream) {


### PR DESCRIPTION
Introduce a new plugin parameter: `compression`.
If `compression=gzip`, the http payload is send compressed in gzip
format.
By default, the compression is not activated.
