### PR TITLE
parser: add Envoy access log parser

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -95,6 +95,15 @@
     Time_Key time
 
 [PARSER]
+    # https://rubular.com/r/3fVxCrE5iFiZim
+    Name    envoy
+    Format  regex
+    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"  
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
+    Time_Key start_time
+
+[PARSER]
     # http://rubular.com/r/tjUt3Awgg4
     Name cri
     Format regex


### PR DESCRIPTION
This pull request refers to issue #1973 

This addition adds the ability to parse the access logs generated by Envoy.
Envoy Version: `1.14.0-dev-3d1620`

Signed-off-by: Carmen Puccio <CarmenAPuccio@gmail.com>