### PR TITLE
build: make Fluent Bit compilable as Snap application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ if(FLB_BACKTRACE)
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-5a99ff7f/
     CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-5a99ff7f/configure ${AUTOCONF_HOST_OPT} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
     BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) DESTDIR= install
     )
   add_library(libbacktrace STATIC IMPORTED GLOBAL)
   set_target_properties(libbacktrace PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/backtrace-prefix/lib/libbacktrace.a")

--- a/cmake/onigmo.cmake
+++ b/cmake/onigmo.cmake
@@ -28,7 +28,7 @@ ExternalProject_Add(onigmo
   CONFIGURE_COMMAND ./configure ${AUTOCONF_HOST_OPT} --with-pic --disable-shared --enable-static --prefix=${ONIGMO_DEST}
   CFLAGS=-std=gnu99\ -Wall\ -pipe\ -Os\ -g0\ -s\ -fno-stack-protector\ -fomit-frame-pointer\ -DNDEBUG\ -U_FORTIFY_SOURCE
   BUILD_COMMAND $(MAKE)
-  INSTALL_COMMAND $(MAKE) install)
+  INSTALL_COMMAND $(MAKE) DESTDIR= install)
 else()
 ExternalProject_Add(onigmo
   BUILD_IN_SOURCE TRUE
@@ -38,7 +38,7 @@ ExternalProject_Add(onigmo
   CONFIGURE_COMMAND ./configure ${AUTOCONF_HOST_OPT} --with-pic --disable-shared --enable-static --prefix=${ONIGMO_DEST}
   CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
   BUILD_COMMAND $(MAKE)
-  INSTALL_COMMAND $(MAKE) install)
+  INSTALL_COMMAND $(MAKE) DESTDIR= install)
 endif()
 
 # Onigmo (Windows)


### PR DESCRIPTION
When we perform a snap build, it results in the following error.

    Failed to run 'cmake --build . -- -j2' for 'fluent-bit': Exited with code 2.
    Verify that the part is using the correct parameters and try again.

It turns out that snapcraft's cmake plugin sets DESTDIR automatically,
and it confuses Makefile to install libonigmo.a into a wrong path.

So here is a trivial patch that add `DESTDIR=` to installation commands.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>