### PR TITLE
gitignore: add chunkio/cio_version.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ include/fluent-bit/flb_plugins.h
 include/fluent-bit/flb_version.h
 include/fluent-bit/conf/*.h
 init/fluent-bit.service
+lib/chunkio/include/chunkio/cio_version.h
 lib/monkey/monkey.service
 lib/monkey/include/monkey/mk_core/mk_core_info.h


### PR DESCRIPTION
Signed-off-by: Nick Fischer <nicfisch@amazon.com>

<!-- Provide summary of changes -->
Add `.gitignore` entry for `lib/chunkio/include/chunkio/cio_version.h`. It seems this file is generated from `lib/chunkio/include/chunkio/cio_version.h.in` and it looks like we ignore other files generated in this same fashion.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
