### PR TITLE
in_mqtt: register config_map

### DIFF
--- a/plugins/in_mqtt/mqtt.c
+++ b/plugins/in_mqtt/mqtt.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_config_map.h>
 
 #include "mqtt.h"
 #include "mqtt_conn.h"
@@ -115,6 +116,13 @@ static int in_mqtt_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */	
+static struct flb_config_map config_map[] = {	
+        	
+    /* EOF */	
+    {0}	
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_mqtt_plugin = {
     .name         = "mqtt",
@@ -124,5 +132,6 @@ struct flb_input_plugin in_mqtt_plugin = {
     .cb_collect   = in_mqtt_collect,
     .cb_flush_buf = NULL,
     .cb_exit      = in_mqtt_exit,
+    .config_map   = config_map,
     .flags        = FLB_INPUT_NET,
 };


### PR DESCRIPTION
Signed-off-by: Atibhi Agrawal <atibhi.a@gmail.com>
Fixes #1672 
Registers config_map for in_mqtt.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
