### PR TITLE
patch k8s-nginx-ingress parser configuration to match latest ingress-…

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -25,10 +25,10 @@
     Time_Format %d/%b/%Y:%H:%M:%S %z
 
 [PARSER]
-    # https://rubular.com/r/P8zgLD5K73fp2n
+    # https://rubular.com/r/IhIbCAIs7ImOkc
     Name        k8s-nginx-ingress
     Format      regex
-    Regex       ^(?<host>[^ ]*) - - \[(?<time>[^\]]*)\] \\*"(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?\\*" (?<code>[^ ]*) (?<size>[^ ]*) \\*"(?<referer>[^\"]*)\\*" \\*"(?<agent>[^\"]*)\\*" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
+    Regex       ^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
     Time_Key    time
     Time_Format %d/%b/%Y:%H:%M:%S %z
 


### PR DESCRIPTION
This adds the user field back to the k8s-nginx-ingress parser configuration that was removed in the latest update: #1869
It is based on the latest (v 0.30.0) k8s ingress-nginx log format, found here: [/kubernetes/ingress-nginx/blob/nginx-0.30.0/docs/user-guide/nginx-configuration/log-format.md](/kubernetes/ingress-nginx/blob/nginx-0.30.0/docs/user-guide/nginx-configuration/log-format.md)
Test: https://rubular.com/r/IhIbCAIs7ImOkc
@arjun921 I removed the `\\*` strings you added in #1869. I can't see any reason for them, looks like a mistake - matching zero or more consecutive backslashes?