### PR TITLE
gzip: fix wrong usage of address when calculating available size

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -92,7 +92,7 @@ int flb_gzip_compress(void *in_data, size_t in_len,
     flush = Z_NO_FLUSH;
     while (1) {
         strm.next_out  = pb + strm.total_out;
-        strm.avail_out = out_size - (pb - (uint8_t *) out_data);
+        strm.avail_out = out_size - (pb - (uint8_t *) out_buf);
 
         if (strm.avail_in == 0) {
             flush = Z_FINISH;


### PR DESCRIPTION
`flb_gzip_compress()` calculate `strm.avail_out` while compressing the buffer. However, it wrongly uses `out_data` which is argument to this function and likely to be an address of local variable in stack (large value). This should be `out_buf` which is the start address and `pb` belongs to.

Here's the difference in `tests/internal/gzip.c`:
#### AS-IS
```plain
$ gdb ./flb-it-gzip
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-115.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home1/irteamsu/fluent-bit/build/bin/flb-it-gzip...done.
(gdb) b flb_gzip.c:95
Breakpoint 1 at 0x4053e4: file /home1/irteamsu/fluent-bit/src/flb_gzip.c, line 95.
(gdb) r
Starting program: /home1/irteamsu/fluent-bit/build/bin/./flb-it-gzip
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Test compress...
Breakpoint 1, flb_gzip_compress (in_data=0x414ca8, in_len=261, out_data=0x7fffffffe038, out_len=0x7fffffffe030) at /home1/irteamsu/fluent-bit/src/flb_gzip.c:95
95              strm.avail_out = out_size - (pb - (uint8_t *) out_data);
Missing separate debuginfos, use: debuginfo-install bzip2-libs-1.0.6-13.el7.x86_64 elfutils-libelf-0.176-2.el7.x86_64 elfutils-libs-0.176-2.el7.x86_64 glibc-2.17-292.el7.x86_64 libattr-2.4.46-13.el7.x86_64 libcap-2.22-10.el7.x86_64 libgcc-4.8.5-39.el7.x86_64 libgcrypt-1.5.3-14.el7.x86_64 libgpg-error-1.12-3.el7.x86_64 libselinux-2.5-14.1.el7.x86_64 lz4-1.7.5-3.el7.x86_64 pcre-8.32-17.el7.x86_64 systemd-libs-219-67.el7_7.3.x86_64 xz-libs-5.2.2-1.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) p out_size - (pb - (uint8_t *) out_data)
$1 = 140737481949395
```

#### TO-BE
```plain
$ gdb ./flb-it-gzip
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-115.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home1/irteamsu/fluent-bit/build/bin/flb-it-gzip...done.
(gdb) b flb_gzip.c:95
Breakpoint 1 at 0x4053e4: file /home1/irteamsu/fluent-bit/src/flb_gzip.c, line 95.
(gdb) r
Starting program: /home1/irteamsu/fluent-bit/build/bin/./flb-it-gzip
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Test compress...
Breakpoint 1, flb_gzip_compress (in_data=0x414ca8, in_len=261, out_data=0x7fffffffe038, out_len=0x7fffffffe030) at /home1/irteamsu/fluent-bit/src/flb_gzip.c:95
95              strm.avail_out = out_size - (pb - (uint8_t *) out_buf);
Missing separate debuginfos, use: debuginfo-install bzip2-libs-1.0.6-13.el7.x86_64 elfutils-libelf-0.176-2.el7.x86_64 elfutils-libs-0.176-2.el7.x86_64 glibc-2.17-292.el7.x86_64 libattr-2.4.46-13.el7.x86_64 libcap-2.22-10.el7.x86_64 libgcc-4.8.5-39.el7.x86_64 libgcrypt-1.5.3-14.el7.x86_64 libgpg-error-1.12-3.el7.x86_64 libselinux-2.5-14.1.el7.x86_64 lz4-1.7.5-3.el7.x86_64 pcre-8.32-17.el7.x86_64 systemd-libs-219-67.el7_7.3.x86_64 xz-libs-5.2.2-1.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) p out_size - (pb - (uint8_t *) out_buf)
$1 = 283
```

![스크린샷 2020-02-28 18 34 59](https://user-images.githubusercontent.com/14037793/75536721-13437a80-5a59-11ea-9f11-516f0198029d.png)

Signed-off-by: Lee Byeoksan <lee.byeoksan+github@gmail.com>


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
