### PR TITLE
sds: fix double lookup of int2hex

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -259,11 +259,11 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
             s[head->len++] = '\\';
             s[head->len++] = 'u';
             if (cp > 0xFFFF) {
-                c = int2hex[ (unsigned char) ((cp & 0xf00000) >> 20)];
+                c = (unsigned char) ((cp & 0xf00000) >> 20);
                 if (c > 0) {
                     s[head->len++] = int2hex[c];
                 }
-                c = int2hex[ (unsigned char) ((cp & 0x0f0000) >> 16)];
+                c = (unsigned char) ((cp & 0x0f0000) >> 16);
                 if (c > 0) {
                     s[head->len++] = int2hex[c];
                 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
After int2hex lookup, c is greater than or equal to '0' = 48, so in the
second lookup, it overruns the int2hex array.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
