### PR TITLE
task: use return value of flb_sched_request_create

### DIFF
--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -93,7 +93,6 @@ int flb_task_retry_reschedule(struct flb_task_retry *retry, struct flb_config *c
 
     task = retry->parent;
     seconds = flb_sched_request_create(config, retry, retry->attemps);
-    seconds = -1;
     if (seconds == -1) {
         /*
          * This is the worse case scenario: 'cannot re-schedule a retry'. If the Chunk


### PR DESCRIPTION
<!-- Provide summary of changes -->
Reassigning `seconds` would make it always go into the worst case.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
