### PR TITLE
in_tail: remove unused get_property

### DIFF
--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -53,7 +53,6 @@ int flb_tail_mult_create(struct flb_tail_config *ctx,
     struct flb_parser *parser;
     struct flb_kv *kv;
 
-    tmp = flb_input_get_property("multiline_flush", ins);
     if (ctx->multiline_flush <= 0) {
         ctx->multiline_flush = 1;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
`tmp` is discarded in next `flb_input_get_property`.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
