### PR TITLE
tests: internal: sds: add test for flb_sds_cat_utf8()

### DIFF
--- a/tests/internal/sds.c
+++ b/tests/internal/sds.c
@@ -37,8 +37,21 @@ static void test_sds_printf()
     flb_sds_destroy(s);
 }
 
+static void test_sds_cat_utf8()
+{
+    flb_sds_t s;
+    char *utf8_str = "\xe8\x9f\xb9\xf0\x9f\xa6\x80";
+
+    s = flb_sds_create("");
+    flb_sds_cat_utf8(&s, utf8_str, strlen(utf8_str));
+
+    TEST_CHECK(strcmp(s, "\\u87f9\\u1f980") == 0);
+    flb_sds_destroy(s);
+}
+
 TEST_LIST = {
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
+    { "sds_cat_utf8", test_sds_cat_utf8},
     { 0 }
 };


### PR DESCRIPTION
This adds unit tests for `flb_sds_cat_utf8()` so that we can prevent future
similar bugs similar to #1995 from happening.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----