### PR TITLE
out_es: fix/improve trace_error output

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -676,8 +676,10 @@ static void cb_es_flush(const void *data, size_t bytes,
                      * If trace_error is set, trace the actual
                      * input/output to Elasticsearch that caused the problem.
                      */
-                    flb_plg_error(ctx->ins, "error: Input\n%s\nOutput\n%s",
-                                  pack, c->resp.payload);
+                    flb_plg_debug(ctx->ins, "error caused by: Input\n%s\n",
+                                   pack);
+                    flb_plg_error(ctx->ins, "error: Output\n%s",
+                                  c->resp.payload);
                 }
                 goto retry;
             }


### PR DESCRIPTION
Previously, when trace_error was enabled, a single error log would
be produced with the raw elasticsearch output and the raw input
that caused the error. This was imperfect because the fluent bit
logging functions truncate output. Long inputs could prevent the
output from being printed.

With this change, the input and output is printed in separate
calls. The input is printed as debug, so that users can control
whether or not it is printed. The actual error output is still
printed at the error level.

Signed-off-by: Wesley Pettit <wppttt@amazon.com>


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
