### PR TITLE
http_client: Content-Type header buffer should have enough space for integer

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -510,7 +510,7 @@ static int add_host_and_content_length(struct flb_http_client *c)
             flb_errno();
             return -1;
         }
-        len = snprintf(tmp, sizeof(tmp) - 1, "%i", c->body_len);
+        len = snprintf(tmp, 32, "%i", c->body_len);
         flb_http_add_header(c, "Content-Length", 14, tmp, len);
         flb_free(tmp);
     }


### PR DESCRIPTION
Hi, this pr should fix the problem that HTTP request sent by flb_http_client contains an illegal `Content-Type` header with `\0` character.

I found this when trying to send my logs to ES by fluent-bit. Error logs like this:

```
[2020/03/09 07:39:10] [error] [output:es:es.0] HTTP status=400 URI=/_bulk, response:
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 166062\u0000"}],"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 166062\u0000"},"status":4
00}

[2020/03/09 07:39:14] [error] [output:es:es.0] HTTP status=400 URI=/_bulk, response:
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 166420\u0000"}],"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 166420\u0000"},"status":4
00}

[2020/03/09 07:39:17] [error] [output:es:es.0] HTTP status=400 URI=/_bulk, response:
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 159048\u0000"}],"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 159048\u0000"},"status":4
00}

[2020/03/09 07:39:17] [error] [output:es:es.0] HTTP status=400 URI=/_bulk, response:
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 253126\u0000"}],"type":"illegal_argument_exception","reason":"a header value contains a prohibited character '\u0000': 253126\u0000"},"status":4
00}
```

And by doing strace on fluent-bit I found that it makes an unexpected header, with `\0` chars in `Content-Type`:

```
114501 sendto(56, "POST /_bulk HTTP/1.1\r\nHost: es_server:9200\r\nContent-Length: 166062\0\r\nContent-Type: application/x-ndjson\r\nUser-Agent: Fluent-Bit\r\n\r\n", 131, 0, NULL, 0) = 131 <0.000031>
114501 sendto(56, ""..., 524288, 0, NULL, 0) = 86880 <0.000075>
```

I believe that the `snprintf` function used by `flb_http_client` should have enough length for a single integer instead of a `sizeof(char *)`