### PR TITLE
in_syslog: save read logs during pausing and resend later

### DIFF
--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -23,6 +23,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_time.h>
 
 /* Syslog modes */
 #define FLB_SYSLOG_UNIX_TCP  1
@@ -63,6 +64,16 @@ struct flb_syslog {
     struct mk_list connections;
     struct mk_event_loop *evl;
     struct flb_input_instance *ins;
+
+    struct mk_list pending_lines;
+};
+
+struct syslog_pending_line {
+    void *out_buf;
+    size_t out_size;
+    struct flb_time out_time;
+
+    struct mk_list _head;
 };
 
 #endif

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -46,6 +46,7 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
     ctx->ins = ins;
     ctx->buffer_data = NULL;
     mk_list_init(&ctx->connections);
+    mk_list_init(&ctx->pending_lines);
 
     /* Syslog mode: unix_udp, unix_tcp, tcp or udp */
     tmp = flb_input_get_property("mode", ins);
@@ -144,6 +145,8 @@ int syslog_conf_destroy(struct flb_syslog *ctx)
         ctx->buffer_data = NULL;
     }
     syslog_server_destroy(ctx);
+    syslog_pack_pending_lines(ctx);
+    syslog_drop_pending_lines(ctx);
     flb_free(ctx);
 
     return 0;

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -25,6 +25,8 @@
 
 #include "syslog.h"
 
+int syslog_drop_pending_lines(struct flb_syslog *ctx);
+int syslog_pack_pending_lines(struct flb_syslog *ctx);
 int syslog_prot_process(struct syslog_conn *conn);
 int syslog_prot_process_udp(char *buf, size_t size, struct flb_syslog *ctx);
 


### PR DESCRIPTION
Save syslog records that have been read after pause and send them when the input is resumed.

The records are only saved in memory and it doesn't guarantee there would be no loss during syslog input pause, but should be able to save most records during the fluent-bit-pause-then-syslog-drop-connection stage.

Signed-off-by: Ji-Ping Shen <ji-ping.shen@relexsolutions.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
