### PR TITLE
out_pgsql: Added target_include_directories() to CMakeLists.txt to

### DIFF
--- a/plugins/out_pgsql/CMakeLists.txt
+++ b/plugins/out_pgsql/CMakeLists.txt
@@ -3,4 +3,5 @@ set(src
   )
 
 FLB_PLUGIN(out_pgsql "${src}" "")
+target_include_directories(flb-plugin-out_pgsql PRIVATE ${PostgreSQL_INCLUDE_DIRS})
 target_link_libraries(flb-plugin-out_pgsql -lpq)

--- a/plugins/out_pgsql/pgsql.h
+++ b/plugins/out_pgsql/pgsql.h
@@ -23,7 +23,7 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_time.h>
 
-#include <postgresql/libpq-fe.h>
+#include <libpq-fe.h>
 
 #define FLB_PGSQL_HOST "127.0.0.1"
 #define FLB_PGSQL_PORT 5432


### PR DESCRIPTION
The plugin was compiling without issues on Debian based distributions but not on RedHat based distributions, this PR fix that issue using CMake capabilities 