### PR TITLE
bin: do not use SIGCONT on Windows

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -363,19 +363,19 @@ static void flb_signal_handler(int signal)
     write(STDERR_FILENO, s, sizeof(s) - 1);
     switch (signal) {
         flb_print_signal(SIGINT);
-#ifndef _WIN32
+#ifndef FLB_SYSTEM_WINDOWS
         flb_print_signal(SIGQUIT);
         flb_print_signal(SIGHUP);
+        flb_print_signal(SIGCONT);
 #endif
         flb_print_signal(SIGTERM);
         flb_print_signal(SIGSEGV);
-        flb_print_signal(SIGCONT);
     };
 
     /* Signal handlers */
     switch (signal) {
     case SIGINT:
-#ifndef _WIN32
+#ifndef FLB_SYSTEM_WINDOWS
     case SIGQUIT:
     case SIGHUP:
 #endif
@@ -393,9 +393,11 @@ static void flb_signal_handler(int signal)
         flb_stacktrace_print();
 #endif
         abort();
+#ifndef FLB_SYSTEM_WINDOWS
     case SIGCONT:
         flb_dump(config);
         break;
+#endif
     default:
         break;
     }
@@ -404,13 +406,13 @@ static void flb_signal_handler(int signal)
 static void flb_signal_init()
 {
     signal(SIGINT,  &flb_signal_handler);
-#ifndef _WIN32
+#ifndef FLB_SYSTEM_WINDOWS
     signal(SIGQUIT, &flb_signal_handler);
     signal(SIGHUP,  &flb_signal_handler);
+    signal(SIGCONT, &flb_signal_handler);
 #endif
     signal(SIGTERM, &flb_signal_handler);
     signal(SIGSEGV, &flb_signal_handler);
-    signal(SIGCONT, &flb_signal_handler);
 }
 
 static int input_set_property(struct flb_input_instance *in, char *kv)


### PR DESCRIPTION
Windows has only a limited support for POSIX signals, and SIGCONT
is not one of them (not defined in signal.h).

Add ifdefs to code blocks that use SIGCONT to avoid compile errors.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>

----
**Testing**

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

