### PR TITLE
in_tail: Support multiline functionality (not filter) in dockermode

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -405,6 +405,13 @@ static struct flb_config_map config_map[] = {
      "wait period time in seconds to flush queued unfinished split lines."
 
     },
+#ifdef FLB_HAVE_REGEX
+    {
+     FLB_CONFIG_MAP_STR, "docker_mode_parser", NULL,
+     0, FLB_FALSE, 0,
+     "specify the parser name to fetch log first line for muliline log"
+    },
+#endif
     {
      FLB_CONFIG_MAP_STR, "path_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_tail_config, path_key),

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -98,6 +98,7 @@ struct flb_tail_config {
     /* Docker mode */
     int docker_mode;           /* Docker mode enabled ?  */
     int docker_mode_flush;     /* Docker mode flush/wait */
+    struct flb_parser *docker_mode_parser; /* Parser for separate multiline logs */
 
     /* Lists head for files consumed statically (read) and by events (inotify) */
     struct mk_list files_static;

--- a/plugins/in_tail/tail_dockermode.h
+++ b/plugins/in_tail/tail_dockermode.h
@@ -30,7 +30,8 @@ int flb_tail_dmode_process_content(time_t now,
                                    char* line, size_t line_len,
                                    char **repl_line, size_t *repl_line_len,
                                    struct flb_tail_file *file,
-                                   struct flb_tail_config *ctx);
+                                   struct flb_tail_config *ctx,
+                                   msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck);
 void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                           struct flb_tail_file *file, struct flb_tail_config *ctx);
 int flb_tail_dmode_pending_flush(struct flb_input_instance *ins,

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -281,7 +281,7 @@ static int process_content(struct flb_tail_file *file, off_t *bytes)
         if (ctx->docker_mode) {
             ret = flb_tail_dmode_process_content(now, line, line_len,
                                                  &repl_line, &repl_line_len,
-                                                 file, ctx);
+                                                 file, ctx, out_sbuf, out_pck);
             if (ret >= 0) {
                 if (repl_line == line) {
                     repl_line = NULL;
@@ -290,9 +290,8 @@ static int process_content(struct flb_tail_file *file, off_t *bytes)
                     line = repl_line;
                     line_len = repl_line_len;
                 }
-                if (ret == 0) {
-                    goto go_next;
-                }
+                /* Skip normal parsers flow */
+                goto go_next;
             }
             else {
                 flb_tail_dmode_flush(out_sbuf, out_pck, file, ctx);
@@ -682,6 +681,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->mult_skipping = FLB_FALSE;
     msgpack_sbuffer_init(&file->mult_sbuf);
     file->dmode_flush_timeout = 0;
+    file->dmode_complete = true;
     file->dmode_buf = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 65536 : 0);
     file->dmode_lastline = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 20000 : 0);
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -69,6 +69,7 @@ struct flb_tail_file {
     time_t dmode_flush_timeout; /* time when docker mode started         */
     flb_sds_t dmode_buf;        /* buffer for docker mode                */
     flb_sds_t dmode_lastline;   /* last incomplete line                  */
+    bool dmode_complete;        /* buffer contains completed log         */
 
     /* buffering */
     off_t parsed;

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -28,6 +28,7 @@ if(FLB_OUT_LIB)
   FLB_RT_TEST(FLB_IN_HEAD          "in_head.c")
   FLB_RT_TEST(FLB_IN_DUMMY         "in_dummy.c")
   FLB_RT_TEST(FLB_IN_RANDOM        "in_random.c")
+  FLB_RT_TEST(FLB_IN_TAIL          "in_tail.c")
 endif()
 
 # Filter Plugins

--- a/tests/runtime/data/tail/log/dockermode.log
+++ b/tests/runtime/data/tail/log/dockermode.log
@@ -1,0 +1,3 @@
+{"log":"Single log\n"}
+{"log":"Second log\n"}
+{"log":"Third log\n"}

--- a/tests/runtime/data/tail/log/dockermode_multiple_lines.log
+++ b/tests/runtime/data/tail/log/dockermode_multiple_lines.log
@@ -1,0 +1,6 @@
+{"log":"2020-03-24 Multiple lines: \n"}
+{"log":"first bullet point\n"}
+{"log":"second bullet point\n"}
+{"log":"third bullet point\n"}
+{"log":"fourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/data/tail/log/dockermode_splitted_line.log
+++ b/tests/runtime/data/tail/log/dockermode_splitted_line.log
@@ -1,0 +1,6 @@
+{"log":"2020-03-24 Single "}
+{"log":"li"}
+{"log":"ne\n"}
+{"log":"2020-03-24 Another "}
+{"log":"single "}
+{"log":"line\n"}

--- a/tests/runtime/data/tail/log/dockermode_splitted_multiple_lines.log
+++ b/tests/runtime/data/tail/log/dockermode_splitted_multiple_lines.log
@@ -1,0 +1,8 @@
+{"log":"2020-03-24 Multiple lines: \n"}
+{"log":"first bullet point\n"}
+{"log":"second bullet point\n"}
+{"log":"third "}
+{"log":"bullet "}
+{"log":"point\n"}
+{"log":"fourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/data/tail/out/dockermode.out
+++ b/tests/runtime/data/tail/out/dockermode.out
@@ -1,0 +1,3 @@
+{"log":"Single log\n"}
+{"log":"Second log\n"}
+{"log":"Third log\n"}

--- a/tests/runtime/data/tail/out/dockermode_multiple_lines.out
+++ b/tests/runtime/data/tail/out/dockermode_multiple_lines.out
@@ -1,0 +1,2 @@
+{"log":"2020-03-24 Multiple lines: \nfirst bullet point\nsecond bullet point\nthird bullet point\nfourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/data/tail/out/dockermode_splitted_line.out
+++ b/tests/runtime/data/tail/out/dockermode_splitted_line.out
@@ -1,0 +1,2 @@
+{"log":"2020-03-24 Single line\n"}
+{"log":"2020-03-24 Another single line\n"}

--- a/tests/runtime/data/tail/out/dockermode_splitted_multiple_lines.out
+++ b/tests/runtime/data/tail/out/dockermode_splitted_multiple_lines.out
@@ -1,0 +1,2 @@
+{"log":"2020-03-24 Multiple lines: \nfirst bullet point\nsecond bullet point\nthird bullet point\nfourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/data/tail/parsers.conf
+++ b/tests/runtime/data/tail/parsers.conf
@@ -1,0 +1,10 @@
+[PARSER]
+    Name                     docker
+    Format                   json
+    Time_Key                 time
+    Time_Format              %Y-%m-%dT%H:%M:%S.%L%z
+
+[PARSER]
+    Name                     docker_multiline
+    Format                   regex
+    Regex                    (?<log>^{"log":"\d{4}-\d{2}-\d{2}.*)

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -1,0 +1,294 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2016 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+Approach for this tests is basing on filter_kubernetes tests
+*/
+
+#include <fluent-bit.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include "flb_tests_runtime.h"
+
+
+
+#define DPATH            FLB_TESTS_DATA_PATH "/data/tail"
+#define MAX_LINES        32
+
+int64_t result_time;
+struct tail_test_result {
+    const char *target;
+    int   nMatched;
+};
+
+struct tail_file_lines {
+  char *lines[MAX_LINES];
+  int lines_c; 
+};
+
+
+static inline int64_t set_result(int64_t v)
+{
+    int64_t old = __sync_lock_test_and_set(&result_time, v);
+    return old;
+}
+
+
+static int file_to_buf(const char *path, char **out_buf, size_t *out_size)
+{
+    int ret;
+    long bytes;
+    char *buf;
+    FILE *fp;
+    struct stat st;
+
+    ret = stat(path, &st);
+    if (ret == -1) {
+        return -1;
+    }
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    buf = flb_malloc(st.st_size);
+    if (!buf) {
+        flb_errno();
+        fclose(fp);
+        return -1;
+    }
+
+    bytes = fread(buf, st.st_size, 1, fp);
+    if (bytes != 1) {
+        flb_errno();
+        flb_free(buf);
+        fclose(fp);
+        return -1;
+    }
+
+    fclose(fp);
+    *out_buf = buf;
+    *out_size = st.st_size;
+
+    return 0;
+}
+
+/* Given a target, lookup the .out file and return it content in a tail_file_lines structure */
+static struct tail_file_lines *get_out_file_content(const char *target)
+{
+    int ret;
+    char file[PATH_MAX];
+    char *p;
+    char *out_buf;
+    size_t out_size;
+    struct tail_file_lines *file_lines = flb_malloc(sizeof (struct tail_file_lines));
+    file_lines->lines_c = 0;
+
+    snprintf(file, sizeof(file) - 1, DPATH "/out/%s.out", target);
+
+    ret = file_to_buf(file, &out_buf, &out_size);
+    TEST_CHECK_(ret == 0, "getting output file content: %s", file);
+    if (ret != 0) {
+        file_lines->lines_c = 0;
+        return file_lines;
+    }
+
+    file_lines->lines[file_lines->lines_c++] = out_buf;
+    
+    for (int i=0; i<out_size; i++) {
+      // Nullify \n and \r characters
+      p = (char *)(out_buf + i);
+      if (*p == '\n' || *p == '\r') {
+        *p = '\0';
+
+        if (i == out_size - 1) {
+          break;
+        }
+
+        if (*++p != '\0' && *p != '\n' && *p != '\r' && file_lines->lines_c < MAX_LINES) {
+          file_lines->lines[file_lines->lines_c++] = p;
+        }
+      }
+    }
+
+    // printf("Just before return: %s\n", file_lines.lines[0]);
+    return file_lines;
+}
+
+static int cb_check_result(void *record, size_t size, void *data)
+{
+    struct tail_test_result *result;
+    struct tail_file_lines *out;
+
+    result = (struct tail_test_result *) data;
+
+    char *check;
+
+    out = get_out_file_content(result->target);
+    // printf("What we got from function: %s\n", out.lines[0]);
+    if (!out->lines_c) {
+        goto exit;
+    }
+    /*
+      * Our validation is: check that the one of the output lines
+      * in the output record.
+      */
+    for (int i=0; i<out->lines_c; i++) {
+      check = strstr(record, out->lines[i]);
+      if (check != NULL) {
+          result->nMatched++;
+          goto exit;
+      }
+    }
+
+exit:
+    if (size > 0) {
+        flb_free(record);
+    }
+    if (out->lines_c) {
+        flb_free(out->lines[0]);
+        flb_free(out);
+    }
+    return 0;
+}
+
+void do_test(char *system, const char *target, int tExpected, int nExpected, ...)
+{
+    int64_t ret;
+    flb_ctx_t    *ctx    = NULL;
+    int in_ffd;
+    int out_ffd;
+    va_list va;
+    char *key;
+    char *value;
+    char path[PATH_MAX];
+    struct tail_test_result result = {0};
+
+    result.nMatched = 0;
+    result.target = target;
+
+    struct flb_lib_out_cb cb;
+    cb.cb   = cb_check_result;
+    cb.data = &result;
+
+    /* initialize */
+    set_result(0);
+
+    ctx = flb_create();
+
+    ret = flb_service_set(ctx,
+                          "Log_Level", "error",
+                          "Parsers_File", DPATH "/parsers.conf",
+                          NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    in_ffd = flb_input(ctx, (char *) system, NULL);
+    TEST_CHECK(in_ffd >= 0);
+    TEST_CHECK(flb_input_set(ctx, in_ffd, "tag", "test", NULL) == 0);
+
+    /* Compose path based on target */
+    snprintf(path, sizeof(path) - 1, DPATH "/log/%s.log", target);
+    TEST_CHECK_(access(path, R_OK) == 0, "accessing log file: %s", path);
+
+    TEST_CHECK(flb_input_set(ctx, in_ffd,
+                            "Path", path,
+                            "Docker_Mode", "On",
+                            "Parser", "docker",
+                            NULL) == 0);
+
+    va_start(va, nExpected);
+    while ((key = va_arg(va, char *))) {
+        value = va_arg(va, char *);
+        TEST_CHECK(value != NULL);
+        TEST_CHECK(flb_input_set(ctx, in_ffd, key, value, NULL) == 0);
+    }
+    va_end(va);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd,
+                              "match", "test",
+                              "format", "json",
+                              NULL) == 0);
+
+    TEST_CHECK(flb_service_set(ctx, "Flush", "0.5",
+                                    "Grace", "1",
+                                    NULL) == 0);
+
+    /* Start test */
+    /* Start the engine */
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "starting engine");
+
+    /* Poll for up to 2 seconds or until we got a match */
+    for (ret = 0; ret < tExpected && result.nMatched < nExpected; ret++) {
+        usleep(1000);
+    }
+
+    TEST_CHECK(result.nMatched == nExpected);
+    TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, nExpected);
+
+    ret = flb_stop(ctx);
+    TEST_CHECK_(ret == 0, "stopping engine");
+    
+    if (ctx) {
+        flb_destroy(ctx);
+    }
+}
+
+void flb_test_in_tail_dockermode()
+{
+    do_test("tail", "dockermode", 20000, 3,
+            NULL);
+}
+
+void flb_test_in_tail_dockermode_splitted_line()
+{
+    do_test("tail", "dockermode_splitted_line", 20000, 2,
+            NULL);
+}
+
+void flb_test_in_tail_dockermode_multiple_lines()
+{
+    do_test("tail", "dockermode_multiple_lines", 20000, 2,
+            "Docker_Mode_Parser", "docker_multiline",
+            NULL);
+}
+
+void flb_test_in_tail_dockermode_splitted_multiple_lines()
+{
+    do_test("tail", "dockermode_splitted_multiple_lines", 20000, 2,
+            "Docker_Mode_Parser", "docker_multiline",
+            NULL);
+}
+
+
+/* Test list */
+TEST_LIST = {
+#ifdef in_tail
+    {"in_tail_dockermode",    flb_test_in_tail_dockermode},
+    {"in_tail_dockermode_splitted_line",    flb_test_in_tail_dockermode_splitted_line},
+    {"in_tail_dockermode_multiple_lines",    flb_test_in_tail_dockermode_multiple_lines},
+    {"in_tail_dockermode_splitted_multiple_lines",    flb_test_in_tail_dockermode_splitted_multiple_lines},
+#endif
+    {NULL, NULL}
+};


### PR DESCRIPTION
Use Parser to verify if line is valid first line while using dockermode.

For example input:
```
{"log":"2020-03-24 Test line of first log\n"}
{"log":"           Another line of first log\n"}
{"log":"2020-03-24 Test line of second log\n"}

```

And regex: `Regex (?<log>^{"log":"\d{4}-\d{2}-\d{2}.*)`

Will output:
```
[0] containers.var.log.containers.test.log: [1585071971.732015500,
    {"log"=>"{"log":"2020-03-24 Test line of first log
    \n           Another line of first log\n"}"}]
[1] containers.var.log.containers.test.log: [1585071975.000917200,
    {"log"=>"{"log":"2020-03-24 Test line of second log\n"}"}]
```

Fixes #1115 

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
Documentation should be updated with information how parser is use to catch multiline docker log

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
