### PR TITLE
out_stackdriver: add ability to use kubernetes metadata for logName

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -69,6 +69,7 @@ struct flb_stackdriver {
     /* other */
     flb_sds_t resource;
     flb_sds_t severity_key;
+    flb_sds_t logname_from_k8s_meta;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -286,6 +286,11 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->severity_key = flb_sds_create(tmp);
     }
 
+    tmp = flb_output_get_property("logname_from_k8s_meta", ins);
+    if (tmp) {
+        ctx->logname_from_k8s_meta = flb_sds_create(tmp);
+    }
+
     return ctx;
 }
 
@@ -306,6 +311,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->token_uri);
     flb_sds_destroy(ctx->resource);
     flb_sds_destroy(ctx->severity_key);
+    flb_sds_destroy(ctx->logname_from_k8s_meta);
 
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);


### PR DESCRIPTION
This commit implements using kubernetes metadata from payload
(container_name and namespace_name) to set logName entry for
stackdriver. Also new config key is used to enable this functioniality.

Example:
[OUTPUT]
    Name            stackdriver
    Match           *
    logname_from_k8s_meta On

Instead of using "Tag" for logName, this will be using
<namespace_name>_<conatiner_name> for logName.

Signed-off-by: kantica <kantica@gmail.com>
