### PR TITLE
compat: A quick fix for build failure on Windows due to SHUT_RDWR

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -47,6 +47,9 @@
 #define PATH_MAX MAX_PATH
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #define S_ISLNK(m) (0)  /* Windows doesn't support S_IFLNK */
+#define SHUT_RD   SD_RECEIVE
+#define SHUT_WR   SD_SEND
+#define SHUT_RDWR SD_BOTH
 
 /* monkey exposes a broken vsnprintf macro. Undo it  */
 #undef vsnprintf


### PR DESCRIPTION
A recently introduced code uses SHUT_RDWR to shutdown both send
and receive ends of a socket. This implementation does not work
as expected on Windows where SHUT_* constants do not exist.

Work around this issue by aliasing SD_BOTH to SHUT_RDWR.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>