### PR TITLE
build: use cmake variable magic instead of `cmake`

### DIFF
--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -30,7 +30,7 @@ if (MSVC)
     SOURCE_DIR ${LUAJIT_SRC}/src
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ./msvcbuild.bat static
-    INSTALL_COMMAND cmake -E copy lua51.lib "${LUAJIT_DEST}/lib/libluajit.lib")
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy lua51.lib "${LUAJIT_DEST}/lib/libluajit.lib")
 endif()
 
 # Hook the buld definition to 'libluajit' target

--- a/cmake/onigmo.cmake
+++ b/cmake/onigmo.cmake
@@ -48,10 +48,10 @@ if(MSVC)
     BUILD_IN_SOURCE TRUE
     EXCLUDE_FROM_ALL TRUE
     SOURCE_DIR ${ONIGMO_SRC}
-    CONFIGURE_COMMAND cmake -E copy win32/Makefile win32/config.h ${ONIGMO_SRC}
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy win32/Makefile win32/config.h ${ONIGMO_SRC}
     BUILD_COMMAND nmake ARCH=${ONIGMO_ARCH}
-    INSTALL_COMMAND cmake -E copy build_${ONIGMO_ARCH}/onigmo_s.lib ${ONIGMO_DEST}/lib/libonigmo.lib
-            COMMAND cmake -E copy onigmo.h ${ONIGMO_DEST}/include/)
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy build_${ONIGMO_ARCH}/onigmo_s.lib ${ONIGMO_DEST}/lib/libonigmo.lib
+            COMMAND ${CMAKE_COMMAND} -E copy onigmo.h ${ONIGMO_DEST}/include/)
 endif()
 
 # Hook the buld definition to 'libonigmo' target


### PR DESCRIPTION
Some Windows systems do not set PATH to cmake.exe. For this reason,
invoking cmake can sometimes fail with an error "unrecognized
command: cmake".

Work around that by using CMAKE_COMMAND that contains an absolute
path to cmake.exe.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>