### PR TITLE
in_winlog: add missing header "flb_sqldb.h"

### DIFF
--- a/plugins/in_winlog/in_winlog.c
+++ b/plugins/in_winlog/in_winlog.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_kernel.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_sqldb.h>
 #include <sddl.h>
 #include "winlog.h"
 


### PR DESCRIPTION
Visual C++ assumes that a function returns "int" if there is no
preceeding prototype declaration. Due to this behaviour, the
pointer to the SQLite context was being silently truncated.

The fix is just to include fluent-bit/flb_sqldb.h.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>