### PR TITLE
in_tail: fix symlink log rotation for fs_stat on linux

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -819,7 +819,7 @@ void flb_tail_file_remove(struct flb_tail_file *file)
 
     flb_free(file->buf_data);
     flb_free(file->name);
-#if !defined(__linux__)
+#if !defined(__linux__) || !defined(FLB_HAVE_INOTIFY)
     flb_free(file->real_name);
 #endif
 
@@ -1121,7 +1121,7 @@ int flb_tail_file_name_dup(char *path, struct flb_tail_file *file)
     }
     file->name_len = strlen(file->name);
 
-#if !defined(__linux__)
+#if !defined(__linux__) || !defined(FLB_HAVE_INOTIFY)
     if (file->real_name) {
         flb_free(file->real_name);
     }

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -51,7 +51,7 @@ static inline int flb_tail_file_name_cmp(char *name,
 static inline int flb_tail_target_file_name_cmp(char *name,
                                                 struct flb_tail_file *file)
 {
-#if defined(__linux__)
+#if defined(__linux__) && defined(FLB_HAVE_INOTIFY)
     return strcmp(name, file->name);
 #elif defined(FLB_SYSTEM_WINDOWS)
     return _stricmp(name, file->real_name);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -44,7 +44,7 @@ struct flb_tail_file {
     ino_t inode;
 #endif
     char *name;                 /* target file name given by scan routine */
-#if !defined(__linux)
+#if !defined(__linux) || !defined(FLB_HAVE_INOTIFY)
     char *real_name;            /* real file name in the file system */
 #endif
     size_t name_len;


### PR DESCRIPTION
When compiled with FLB_HAVE_INOTIFY=no for linux, records were continuously
resent if the files in PATH are symlinks.  This patch ensures the fs_stat file
monitoring correctly handles symlinks when checking for file rotations.

The issue was found when running fluentbit as a daemonset in kubernetes where all
files in /var/log/containers/* are symlinks.

This patch was tested by forwarding 1M records of 1K size when compiled with
both FLB_HAVE_INOTIFY=no/yes and verifying the output metrics reported exactly
1M records.  The test was executed by running a container logging to stdout
in a kubernetes cluster where symlinks are the target input.  Further docker
was configured to rotate logs at 10M to ensure multiple file rotations
occurred.

Signed-off-by: Zack Wine <zwine@synamedia.com>


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
