### PR TITLE
in_tcp: add 'Clear_Null_Bytes' option

### DIFF
--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -31,6 +31,7 @@
 struct flb_in_tcp_config {
     int server_fd;                  /* TCP server file descriptor  */
     int format;                     /* Data format */
+    int clear_nullbytes;            /* clear embedded null bytes   */
     size_t buffer_size;             /* Buffer size for each reader */
     size_t chunk_size;              /* Chunk allocation size       */
     char *listen;                   /* Listen interface            */

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -31,7 +31,7 @@
 struct flb_in_tcp_config {
     int server_fd;                  /* TCP server file descriptor  */
     int format;                     /* Data format */
-    int clear_nullbytes;            /* clear embedded null bytes   */
+    int clear_null_bytes;           /* clear embedded null bytes   */
     size_t buffer_size;             /* Buffer size for each reader */
     size_t chunk_size;              /* Chunk allocation size       */
     char *listen;                   /* Listen interface            */

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -94,6 +94,13 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *ins)
         ctx->separator = flb_sds_create_len("\n", 1);
     }
 
+    tmp = flb_input_get_property("clear_nullbytes", ins);
+    if (tmp) {
+        ctx->clear_nullbytes = flb_utils_bool(tmp);
+    } else {
+        ctx->clear_nullbytes = FLB_FALSE;
+    }
+
     /* Listen interface (if not set, defaults to 0.0.0.0:5170) */
     flb_input_net_default_listener("0.0.0.0", 5170, ins);
     ctx->listen = ins->host.listen;

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -94,11 +94,11 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *ins)
         ctx->separator = flb_sds_create_len("\n", 1);
     }
 
-    tmp = flb_input_get_property("clear_nullbytes", ins);
+    tmp = flb_input_get_property("clear_null_bytes", ins);
     if (tmp) {
-        ctx->clear_nullbytes = flb_utils_bool(tmp);
+        ctx->clear_null_bytes = flb_utils_bool(tmp);
     } else {
-        ctx->clear_nullbytes = FLB_FALSE;
+        ctx->clear_null_bytes = FLB_FALSE;
     }
 
     /* Listen interface (if not set, defaults to 0.0.0.0:5170) */

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -85,6 +85,15 @@ static ssize_t parse_payload_json(struct tcp_conn *conn)
     int ret;
     int out_size;
     char *pack;
+    char *p;
+
+    /* clear embedded null bytes (for example GELF record separators */
+    if (conn->ctx->clear_nullbytes) {
+        while ((p = memchr(conn->buf_data, '\0', conn->buf_len))) {
+            flb_plg_trace(conn->ctx->ins, "clear null byte at position %d", p-conn->buf_data );
+            *p = ' ';
+        }
+    }
 
     ret = flb_pack_json_state(conn->buf_data, conn->buf_len,
                               &pack, &out_size, &conn->pack_state);

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -88,7 +88,7 @@ static ssize_t parse_payload_json(struct tcp_conn *conn)
     char *p;
 
     /* clear embedded null bytes (for example GELF record separators */
-    if (conn->ctx->clear_nullbytes) {
+    if (conn->ctx->clear_null_bytes) {
         while ((p = memchr(conn->buf_data, '\0', conn->buf_len))) {
             flb_plg_trace(conn->ctx->ins, "clear null byte at position %d", p-conn->buf_data );
             *p = ' ';


### PR DESCRIPTION
When set to true all embedded null bytes in json formatted data are
cleared before processing. This is useful to ingest GELF data via TCP,
which is using null byte delimiters for subsequent messages in one TCP
connection. Without this functionality subsequent messages are ignored.

Example config:

    [INPUT]
        Name      tcp
        Log_Level trace
        Format    json
        Clear_Nullbytes true

    [OUTPUT]
        Name    stdout
        Match   *

Local test with embedded null bytes:

    echo -en '{"key1": "value1"}\0{"key2": "value2"}\0' |  nc 127.0.0.1 5170

Output:

    [2020/04/01 14:38:29] [ info] [input:tcp:tcp.0] listening on 0.0.0.0:5170
    [2020/04/01 14:38:29] [ info] [sp] stream processor started
    [2020/04/01 14:38:32] [trace] [input:tcp:tcp.0 at plugins/in_tcp/tcp.c:48] new TCP connection arrived FD=19
    [2020/04/01 14:38:32] [trace] [input:tcp:tcp.0 at plugins/in_tcp/tcp_conn.c:219] read()=38 pre_len=0 now_len=38
    [2020/04/01 14:38:32] [trace] [input:tcp:tcp.0 at plugins/in_tcp/tcp_conn.c:93] clear null byte at position 18
    [2020/04/01 14:38:32] [trace] [input:tcp:tcp.0 at plugins/in_tcp/tcp_conn.c:93] clear null byte at position 37
    [0] tcp.0: [1585744712.328304126, {"key1"=>"value1"}]
    [1] tcp.0: [1585744712.328324721, {"key2"=>"value2"}]

Signed-off-by: Philipp Hoefflin <philipp.hoefflin@haufe-lexware.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
