### PR TITLE
out_stdout: add description for properties in config map

### DIFF
--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -159,17 +159,17 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "format", NULL,
      0, FLB_FALSE, 0,
-     NULL
+     "Specifies the data format to be printed. Supported formats are msgpack json, json_lines and json_stream."
     },
     {
      FLB_CONFIG_MAP_STR, "json_date_format", NULL,
      0, FLB_FALSE, 0,
-     NULL
+    "Specifies the name of the date field in output."
     },
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",
      0, FLB_TRUE, offsetof(struct flb_stdout, json_date_key),
-     NULL
+    "Specifies the format of the date. Supported formats are double, iso8601 and epoch."
     },
 
     /* EOF */


### PR DESCRIPTION
Signed-off-by: Atibhi Agrawal <atibhi.a@gmail.com>
Addresses https://github.com/fluent/fluent-bit/pull/2060#discussion_r401884323

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change - [in_dummy.conf](https://github.com/fluent/fluent-bit/blob/master/conf/in_dummy.conf)
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```sh

==18355== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==18355== Command: bin/fluent-bit -c ../conf/in_dummy.conf
==18355== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/04/02 09:35:37] [ info] [storage] version=1.0.3, initializing...
[2020/04/02 09:35:37] [ info] [storage] in-memory
[2020/04/02 09:35:37] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/02 09:35:37] [ info] [engine] started (pid=18355)
[2020/04/02 09:35:37] [ info] [sp] stream processor started
[0] dummy.data: [1585800338.034275215, {"this is"=>"dummy data"}]
[1] dummy.data: [1585800339.000332652, {"this is"=>"dummy data"}]
[2] dummy.data: [1585800340.000315449, {"this is"=>"dummy data"}]
[3] dummy.data: [1585800341.000378468, {"this is"=>"dummy data"}]
[4] dummy.data: [1585800342.000305025, {"this is"=>"dummy data"}]
^C[engine] caught signal (SIGINT)
==18355== 
==18355== HEAP SUMMARY:
==18355==     in use at exit: 0 bytes in 0 blocks
==18355==   total heap usage: 299 allocs, 299 frees, 923,462 bytes allocated
==18355== 
==18355== All heap blocks were freed -- no leaks are possible
==18355== 
==18355== For counts of detected and suppressed errors, rerun with: -v
==18355== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
