### PR TITLE
filter_rewrite_tag: Add mem_buf_limit to rewrite tag filter emitter.

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -458,7 +458,7 @@ static struct flb_config_map config_map[] = {
      NULL
     },
     {
-     FLB_CONFIG_MAP_SIZE, "emitter_mem_buf_limit", 0,
+     FLB_CONFIG_MAP_SIZE, "emitter_mem_buf_limit", FLB_RTAG_MEM_BUF_LIMIT_DEFAULT,
      FLB_FALSE, FLB_TRUE, offsetof(struct flb_rewrite_tag, emitter_mem_buf_limit),
      "set a memory buffer limit to restrict memory usage of emitter"
     },

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -58,6 +58,11 @@ static int emitter_create(struct flb_rewrite_tag *ctx)
                      ins->name);
     }
 
+    /* Set the emitter_mem_buf_limit */
+    if(ctx->emitter_mem_buf_limit > 0) {
+        ins->mem_buf_limit = ctx->emitter_mem_buf_limit;
+    }
+
     /* Set the storage type */
     ret = flb_input_set_property(ins, "storage.type",
                                  ctx->emitter_storage_type);
@@ -452,7 +457,11 @@ static struct flb_config_map config_map[] = {
      FLB_FALSE, FLB_TRUE, offsetof(struct flb_rewrite_tag, emitter_storage_type),
      NULL
     },
-
+    {
+     FLB_CONFIG_MAP_SIZE, "emitter_mem_buf_limit", 0,
+     FLB_FALSE, FLB_TRUE, offsetof(struct flb_rewrite_tag, emitter_mem_buf_limit),
+     "set a memory buffer limit to restrict memory usage of emitter"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/filter_rewrite_tag/rewrite_tag.h
+++ b/plugins/filter_rewrite_tag/rewrite_tag.h
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_input.h>
 
 #define FLB_RTAG_METRIC_EMITTED    200
+#define FLB_RTAG_MEM_BUF_LIMIT_DEFAULT  "10M"
 
 /* Rewrite rule  */
 struct rewrite_rule {

--- a/plugins/filter_rewrite_tag/rewrite_tag.h
+++ b/plugins/filter_rewrite_tag/rewrite_tag.h
@@ -41,6 +41,7 @@ struct rewrite_rule {
 struct flb_rewrite_tag {
     flb_sds_t emitter_name;                 /* emitter input plugin name */
     flb_sds_t emitter_storage_type;         /* emitter storage type */
+    size_t emitter_mem_buf_limit;           /* Emitter buffer limit */
     struct mk_list rules;                   /* processed rules */
     struct mk_list *cm_rules;               /* config_map rules (only strings) */
     struct flb_input_instance *ins_emitter; /* emitter input plugin instance */


### PR DESCRIPTION
This fixes an issue found during load testing the rewrite_tag filter

At very heavy loads (3K/sec records) the emitter buffer was seen to grow unbounded
until an OOM event.  During this test a complex lua filter was utilized and the
output was kinesis.  This is of note because more processing load seems to make
the issue occur at lower rates.

This patch has been load tested by in a kubernetes environment:

pod -> docker-json-driver -> fluenbit-daemonset -> kinesis

The config was something similar to this:

tail -> modify_filter -> kubernetes -> lua_filter -> rewrite_tag -> kinesis

Signed-off-by: Zack Wine <zwine@synamedia.com>

Add `emitter_mem_buf_limit` option to rewrite tag filter emitter to prevent unbounded memory growth.  A new setting on the rewrite_tag filter `emitter_mem_buf_limit` will limit the amount of memory the emitter will buffer if backpressure is received from the output.

Addresses:  #2073

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**


- [ ] Documentation required for this feature



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
