### PR TITLE
README: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Fluent Bit runs on x86_64, x86, arm32v7 and arm64v8 architectures.
 
 - High Performance
 - Data Parsing
-  - Convert your unstructured messages using our parsers: [JSON](https://docs.fluentbit.io/manual/parser/json), [Regex](https://docs.fluentbit.io/manual/parser/regular_expression), [LTSV](https://docs.fluentbit.io/manual/parser/ltsv) and [Logfmt](https://docs.fluentbit.io/manual/parser/logfmt)
+  - Convert your unstructured messages using our parsers: [JSON](https://docs.fluentbit.io/manual/pipeline/parsers/json), [Regex](https://docs.fluentbit.io/manual/pipeline/parsers/regular-expression), [LTSV](https://docs.fluentbit.io/manual/pipeline/parsers/ltsv) and [Logfmt](https://docs.fluentbit.io/manual/pipeline/parsers/logfmt)
 - Reliability and Data Integrity
-  - [Backpressure](https://docs.fluentbit.io/manual/configuration/backpressure) Handling
-  - [Data Buffering](https://docs.fluentbit.io/manual/configuration/buffering) in memory and file system
+  - [Backpressure](https://docs.fluentbit.io/manual/administration/backpressure) Handling
+  - [Data Buffering](https://docs.fluentbit.io/manual/administration/buffering-and-storage) in memory and file system
 - Networking
   - Security: built-in TLS/SSL support
   - Asynchronous I/O
@@ -26,8 +26,8 @@ Fluent Bit runs on x86_64, x86, arm32v7 and arm64v8 architectures.
   - More than 50 built-in plugins available
   - Extensibility
     - Write any input, filter or output plugin in C language
-    - Bonus: write [Filters in Lua](https://docs.fluentbit.io/manual/filter/lua) or [Output plugins in Golang](https://docs.fluentbit.io/manual/development/golang_plugins)
-- [Monitoring](https://docs.fluentbit.io/manual/configuration/monitoring): expose internal metrics over HTTP in JSON and [Prometheus](https://prometheus.io/) format
+    - Bonus: write [Filters in Lua](https://docs.fluentbit.io/manual/filter/lua) or [Output plugins in Golang](https://docs.fluentbit.io/manual/development/golang-output-plugins)
+- [Monitoring](https://docs.fluentbit.io/manual/administration/monitoring): expose internal metrics over HTTP in JSON and [Prometheus](https://prometheus.io/) format
 - [Stream Processing](https://docs.fluentbit.io/stream-processing/): Perform data selection and transformation using simple SQL queries
   - Create new streams of data using query results
   - Aggregation Windows
@@ -44,7 +44,7 @@ Fluent Bit runs on x86_64, x86, arm32v7 and arm64v8 architectures.
 
 ## [Documentation](https://docs.fluentbit.io)
 
-Our official project documentation for [installation](https://docs.fluentbit.io/manual/installation), [configuration](https://docs.fluentbit.io/manual/configuration), deployment and development topics is located here:
+Our official project documentation for [installation](https://docs.fluentbit.io/manual/installation), [configuration](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit), deployment and development topics is located here:
 
 - [https://docs.fluentbit.io](https://fluentbit.io)
 
@@ -61,16 +61,16 @@ $ make
 $ bin/fluent-bit -i cpu -o stdout -f 1
 ```
 
-If you are interested into more details, please refer to the [Build & Install](https://docs.fluentbit.io/manual/installation/build_install) section.
+If you are interested into more details, please refer to the [Build & Install](https://docs.fluentbit.io/manual/installation/sources/build-and-install) section.
 
 #### Linux Packages
 
 We provide packages for most common Linux distributions:
 
-- [Debian](https://docs.fluentbit.io/manual/installation/debian)
-- [Raspbian](https://docs.fluentbit.io/manual/installation/raspberry_pi)
-- [Ubuntu](https://docs.fluentbit.io/manual/installation/ubuntu)
-- [CentOS](https://docs.fluentbit.io/manual/installation/redhat_centos)
+- [Debian](https://docs.fluentbit.io/manual/installation/linux/debian)
+- [Raspbian](https://docs.fluentbit.io/manual/installation/linux/raspbian-raspberry-pi)
+- [Ubuntu](https://docs.fluentbit.io/manual/installation/linux/ubuntu)
+- [CentOS](https://docs.fluentbit.io/manual/installation/linux/redhat-centos)
 
 #### Linux / Docker Container Images
 
@@ -92,65 +92,65 @@ Fluent Bit is fully supported on Windows environments, get started with the foll
 
 | name | title | description |
 | :--- | :--- | :--- |
-| [collectd](https://docs.fluentbit.io/manual/input/collectd) | Collectd | Listen for UDP packets from Collectd. |
-| [cpu](https://docs.fluentbit.io/manual/input/cpu) | CPU Usage | measure total CPU usage of the system. |
-| [disk](https://docs.fluentbit.io/manual/input/disk) | Disk Usage | measure Disk I/Os. |
-| [dummy](https://docs.fluentbit.io/manual/input/dummy) | Dummy | generate dummy event. |
-| [exec](https://docs.fluentbit.io/manual/input/exec) | Exec | executes external program and collects event logs. |
-| [forward](https://docs.fluentbit.io/manual/input/forward) | Forward | Fluentd forward protocol. |
-| [head](https://docs.fluentbit.io/manual/input/head) | Head | read first part of files. |
-| [health](https://docs.fluentbit.io/manual/input/health) | Health | Check health of TCP services. |
-| [kmsg](https://docs.fluentbit.io/manual/input/kmsg) | Kernel Log Buffer | read the Linux Kernel log buffer messages. |
-| [mem](https://docs.fluentbit.io/manual/input/mem) | Memory Usage | measure the total amount of memory used on the system. |
-| [mqtt](https://docs.fluentbit.io/manual/input/mqtt) | MQTT | start a MQTT server and receive publish messages. |
-| [netif](https://docs.fluentbit.io/manual/input/netif) | Network Traffic | measure network traffic. |
-| [proc](https://docs.fluentbit.io/manual/input/proc) | Process | Check health of Process. |
-| [random](https://docs.fluentbit.io/manual/input/random) | Random | Generate Random samples. |
-| [serial](https://docs.fluentbit.io/manual/input/serial) | Serial Interface | read data information from the serial interface. |
-| [stdin](https://docs.fluentbit.io/manual/input/stdin) | Standard Input | read data from the standard input. |
-| [syslog](https://docs.fluentbit.io/manual/input/syslog) | Syslog | read syslog messages from a Unix socket. |
-| [systemd](https://docs.fluentbit.io/manual/input/systemd) | Systemd | read logs from Systemd/Journald. |
-| [tail](https://docs.fluentbit.io/manual/input/tail) | Tail | Tail log files. |
-| [tcp](https://docs.fluentbit.io/manual/input/tcp) | TCP | Listen for JSON messages over TCP. |
-| [thermal](https://docs.fluentbit.io/manual/input/thermal) | Thermal | measure system temperature(s). |
+| [collectd](https://docs.fluentbit.io/manual/pipeline/inputs/collectd) | Collectd | Listen for UDP packets from Collectd. |
+| [cpu](https://docs.fluentbit.io/manual/pipeline/inputs/cpu-metrics) | CPU Usage | measure total CPU usage of the system. |
+| [disk](https://docs.fluentbit.io/manual/pipeline/inputs/disk-io-metrics) | Disk Usage | measure Disk I/Os. |
+| [dummy](https://docs.fluentbit.io/manual/pipeline/inputs/dummy) | Dummy | generate dummy event. |
+| [exec](https://docs.fluentbit.io/manual/pipeline/inputs/exec) | Exec | executes external program and collects event logs. |
+| [forward](https://docs.fluentbit.io/manual/pipeline/inputs/forward) | Forward | Fluentd forward protocol. |
+| [head](https://docs.fluentbit.io/manual/pipeline/inputs/head) | Head | read first part of files. |
+| [health](https://docs.fluentbit.io/manual/pipeline/inputs/health) | Health | Check health of TCP services. |
+| [kmsg](https://docs.fluentbit.io/manual/pipeline/inputs/kernel-logs) | Kernel Log Buffer | read the Linux Kernel log buffer messages. |
+| [mem](https://docs.fluentbit.io/manual/pipeline/inputs/memory-metrics) | Memory Usage | measure the total amount of memory used on the system. |
+| [mqtt](https://docs.fluentbit.io/manual/pipeline/inputs/mqtt) | MQTT | start a MQTT server and receive publish messages. |
+| [netif](https://docs.fluentbit.io/manual/pipeline/inputs/network-io-metrics) | Network Traffic | measure network traffic. |
+| [proc](https://docs.fluentbit.io/manual/pipeline/inputs/process) | Process | Check health of Process. |
+| [random](https://docs.fluentbit.io/manual/pipeline/inputs/random) | Random | Generate Random samples. |
+| [serial](https://docs.fluentbit.io/manual/pipeline/inputs/serial-interface) | Serial Interface | read data information from the serial interface. |
+| [stdin](https://docs.fluentbit.io/manual/pipeline/inputs/standard-input) | Standard Input | read data from the standard input. |
+| [syslog](https://docs.fluentbit.io/manual/pipeline/inputs/syslog) | Syslog | read syslog messages from a Unix socket. |
+| [systemd](https://docs.fluentbit.io/manual/pipeline/inputs/systemd) | Systemd | read logs from Systemd/Journald. |
+| [tail](https://docs.fluentbit.io/manual/pipeline/inputs/tail) | Tail | Tail log files. |
+| [tcp](https://docs.fluentbit.io/manual/pipeline/inputs/tcp) | TCP | Listen for JSON messages over TCP. |
+| [thermal](https://docs.fluentbit.io/manual/pipeline/inputs/thermal) | Thermal | measure system temperature(s). |
 
 #### Filter Plugins
 
 | name | title | description |
 | :--- | :--- | :--- |
-| [grep](https://docs.fluentbit.io/manual/filter/grep) | Grep | Match or exclude specific records by patterns. |
-| [kubernetes](https://docs.fluentbit.io/manual/filter/kubernetes) | Kubernetes | Enrich logs with Kubernetes Metadata. |
-| [lua](https://docs.fluentbit.io/manual/filter/lua) | Lua | Filter records using Lua Scripts. |
-| [parser](https://docs.fluentbit.io/manual/filter/parser) | Parser | Parse record. |
-| [record\_modifier](https://docs.fluentbit.io/manual/filter/record_modifier) | Record Modifier | Modify record. |
-| [stdout](https://docs.fluentbit.io/manual/filter/stdout) | Stdout | Print records to the standard output interface. |
-| [throttle](https://docs.fluentbit.io/manual/filter/throttle) | Throttle | Apply rate limit to event flow. |
-| [nest](https://docs.fluentbit.io/manual/filter/nest) | Nest | Nest records under a specified key |
-| [modify](https://docs.fluentbit.io/manual/filter/modify) | Modify | Modifications to record. |
+| [grep](https://docs.fluentbit.io/manual/pipeline/filters/grep) | Grep | Match or exclude specific records by patterns. |
+| [kubernetes](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes) | Kubernetes | Enrich logs with Kubernetes Metadata. |
+| [lua](https://docs.fluentbit.io/manual/pipeline/filters/lua) | Lua | Filter records using Lua Scripts. |
+| [parser](https://docs.fluentbit.io/manual/pipeline/filters/parser) | Parser | Parse record. |
+| [record\_modifier](https://docs.fluentbit.io/manual/pipeline/filters/record-modifier) | Record Modifier | Modify record. |
+| [stdout](https://docs.fluentbit.io/manual/pipeline/filters/standard-output) | Stdout | Print records to the standard output interface. |
+| [throttle](https://docs.fluentbit.io/manual/pipeline/filters/throttle) | Throttle | Apply rate limit to event flow. |
+| [nest](https://docs.fluentbit.io/manual/pipeline/filters/nest) | Nest | Nest records under a specified key |
+| [modify](https://docs.fluentbit.io/manual/pipeline/filters/modify) | Modify | Modifications to record. |
 
 #### Output Plugins
 
 | name | title | description |
 | :--- | :--- | :--- |
-| [azure](https://docs.fluentbit.io/manual/output/azure) | Azure Log Analytics | Ingest records into Azure Log Analytics |
-| [bigquery](https://docs.fluentbit.io/manual/output/bigquery) | BigQuery | Ingest records into Google BigQuery |
-| [counter](https://docs.fluentbit.io/manual/output/counter) | Count Records | Simple records counter. |
-| [datadog](https://docs.fluentbit.io/manual/output/datadog) | Datadog | Ingest logs into Datadog. |
-| [es](https://docs.fluentbit.io/manual/output/elasticsearch) | Elasticsearch | flush records to a Elasticsearch server. |
-| [file](https://docs.fluentbit.io/manual/output/file) | File | Flush records to a file. |
-| [flowcounter](https://docs.fluentbit.io/manual/output/flowcounter) | FlowCounter | Count records. |
-| [forward](https://docs.fluentbit.io/manual/output/forward) | Forward | Fluentd forward protocol. |
-| [http](https://docs.fluentbit.io/manual/output/http) | HTTP | Flush records to an HTTP end point. |
-| [influxdb](https://docs.fluentbit.io/manual/output/influxdb) | InfluxDB | Flush records to InfluxDB time series database. |
-| [kafka](https://docs.fluentbit.io/manual/output/kafka) | Apache Kafka | Flush records to Apache Kafka |
-| [kafka-rest](https://docs.fluentbit.io/manual/output/kafka-rest-proxy) | Kafka REST Proxy | Flush records to a Kafka REST Proxy server. |
-| [stackdriver](https://docs.fluentbit.io/manual/output/stackdriver) | Google Stackdriver Logging | Flush records to Google Stackdriver Logging service. |
-| [stdout](https://docs.fluentbit.io/manual/output/stdout) | Standard Output | Flush records to the standard output. |
-| [splunk](https://docs.fluentbit.io/manual/output/splunk) | Splunk | Flush records to a Splunk Enterprise service |
-| [tcp](https://docs.fluentbit.io/manual/output/tcp) | TCP & TLS | flush records to a TCP server. |
-| [td](https://docs.fluentbit.io/manual/output/td) | [Treasure Data](http://www.treasuredata.com) | Flush records to the [Treasure Data](http://www.treasuredata.com) cloud service for analytics. |
-| [nats](https://docs.fluentbit.io/manual/output/nats) | NATS | flush records to a NATS server. |
-| [null](https://docs.fluentbit.io/manual/output/null) | NULL | throw away events. |
+| [azure](https://docs.fluentbit.io/manual/pipeline/outputs/azure) | Azure Log Analytics | Ingest records into Azure Log Analytics |
+| [bigquery](https://docs.fluentbit.io/manual/pipeline/outputs/bigquery) | BigQuery | Ingest records into Google BigQuery |
+| [counter](https://docs.fluentbit.io/manual/pipeline/outputs/counter) | Count Records | Simple records counter. |
+| [datadog](https://docs.fluentbit.io/manual/pipeline/outputs/datadog) | Datadog | Ingest logs into Datadog. |
+| [es](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | Elasticsearch | flush records to a Elasticsearch server. |
+| [file](https://docs.fluentbit.io/manual/pipeline/outputs/file) | File | Flush records to a file. |
+| [flowcounter](https://docs.fluentbit.io/manual/pipeline/outputs/flowcounter) | FlowCounter | Count records. |
+| [forward](https://docs.fluentbit.io/manual/pipeline/outputs/forward) | Forward | Fluentd forward protocol. |
+| [http](https://docs.fluentbit.io/manual/pipeline/outputs/http) | HTTP | Flush records to an HTTP end point. |
+| [influxdb](https://docs.fluentbit.io/manual/pipeline/outputs/influxdb) | InfluxDB | Flush records to InfluxDB time series database. |
+| [kafka](https://docs.fluentbit.io/manual/pipeline/outputs/kafka) | Apache Kafka | Flush records to Apache Kafka |
+| [kafka-rest](https://docs.fluentbit.io/manual/pipeline/outputs/kafka-rest-proxy) | Kafka REST Proxy | Flush records to a Kafka REST Proxy server. |
+| [nats](https://docs.fluentbit.io/manual/pipeline/outputs/nats) | NATS | flush records to a NATS server. |
+| [null](https://docs.fluentbit.io/manual/pipeline/outputs/null) | NULL | throw away events. |
+| [stackdriver](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver) | Google Stackdriver Logging | Flush records to Google Stackdriver Logging service. |
+| [stdout](https://docs.fluentbit.io/manual/pipeline/outputs/standard-output) | Standard Output | Flush records to the standard output. |
+| [splunk](https://docs.fluentbit.io/manual/pipeline/outputs/splunk) | Splunk | Flush records to a Splunk Enterprise service |
+| [tcp](https://docs.fluentbit.io/manual/pipeline/outputs/tcp-and-tls) | TCP & TLS | flush records to a TCP server. |
+| [td](https://docs.fluentbit.io/manual/pipeline/outputs/treasure-data) | [Treasure Data](http://www.treasuredata.com) | Flush records to the [Treasure Data](http://www.treasuredata.com) cloud service for analytics. |
 
 ## Contributing
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

I fixed many broken links of README.md and modified output plugin list in alphabetical order.
(I moved nats and null output plugins)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
