### PR TITLE
Fix typo in in_tail to fix build with FLB_HAVE_REGEX=Off

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -415,7 +415,6 @@ static int tag_compose(char *tag, struct flb_regex *tag_regex, char *fname,
 #else
 static int tag_compose(char *tag, char *fname, char *out_buf, size_t *out_size,
                        struct flb_tail_config *ctx)
-)
 #endif
 {
     int i;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Build of in_tail plugin is broken when FLB_HAVE_REGEX isn't set because of redundant parenthesis, which came from this commit: https://github.com/fluent/fluent-bit/commit/5e70c21dc6bb4d2548a8f66d2e05f8d7be234cd8#diff-77b5412db7cc81c07e52ff8f074fd00aR419

Without it build completes successfully

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
