### PR TITLE
Fixing memleak in do_glob.

### DIFF
--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -120,6 +120,7 @@ static inline int do_glob(const char *pattern, int flags,
     int ret;
     int new_flags;
     char *tmp = NULL;
+    int tmp_needs_free = FLB_FALSE;
     (void) not_used;
 
     /* Save current values */
@@ -142,6 +143,7 @@ static inline int do_glob(const char *pattern, int flags,
         if (tmp != pattern) {
             /* the path was expanded */
             pattern = tmp;
+            tmp_needs_free = FLB_TRUE;
         }
 
         /* remove unused flag */
@@ -155,7 +157,7 @@ static inline int do_glob(const char *pattern, int flags,
     /* remove temporary buffer, if allocated by expand_tilde above.
      * Note that this buffer is only used for libc implementations
      * that do not support the GLOB_TILDE flag, like musl. */
-    if (tmp != NULL && tmp != pattern) {
+    if ((tmp != NULL) && (tmp_needs_free == FLB_TRUE)) {
         flb_free(tmp);
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Comparing tmp and pattern pointers before freeing memory potentially allocated by extend_tilde function is not correct: in case extend_tilde allocates memory and returns a pointer different than pattern, we make pattern equal to tmp, therefore the check for whether these pointers are not equal is never  satisfied. To avoid memory leak on platforms without GLOBE_TILDE I added additional "boolean" variable tmp_needs_free.

Fixes #2096 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change (this piece of code doesn't have debug logging)
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found (it's not possible to run valgrind on the platform I'm working on due to free memory restrictions)

**Documentation**
Documentation update is not required

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
