### PR TITLE
utils: set default http/https port

### DIFF
--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -18,8 +18,10 @@ struct url_check {
 
 struct url_check url_checks[] = {
     {0, "https://fluentbit.io/something",
-     "https", "fluentbit.io", NULL, "/something"},
-    {0, "https://fluentbit.io", "https", "fluentbit.io", NULL, "/"},
+     "https", "fluentbit.io", "443", "/something"},
+    {0, "http://fluentbit.io/something",
+     "http", "fluentbit.io", "80", "/something"},
+    {0, "https://fluentbit.io", "https", "fluentbit.io", "443", "/"},
     {0, "https://fluentbit.io:1234/something",
     "https", "fluentbit.io", "1234", "/something"},
     {0, "https://fluentbit.io:1234", "https", "fluentbit.io", "1234", "/"},


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch is to fix internal test `flb-it-utils ` error.

`flb_utils_url_split` sets "443" or "80" when port number is missing.
https://github.com/fluent/fluent-bit/blob/master/src/flb_utils.c#L816

So, I modified expected port number on such testcases and add "http" testcase.

## Error Example
https://travis-ci.org/github/fluent/fluent-bit/jobs/672310084#L2021
```
33/41 Test #34: flb-it-utils .....................***Failed    0.00 sec
Test url_split...                               [ FAILED ]
  utils.c:85: Check port == NULL... failed
  utils.c:85: Check port == NULL... failed
Test write_str...                               [   OK   ]
FAILED: 1 of 2 unit tests have failed.
```


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
taka@ubuntu:~/git/fluent-bit/build$ valgrind bin/flb-it-utils 
==24907== Memcheck, a memory error detector
==24907== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24907== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==24907== Command: bin/flb-it-utils
==24907== 
Test url_split...                               [   OK   ]
==24908== 
==24908== HEAP SUMMARY:
==24908==     in use at exit: 18 bytes in 2 blocks
==24908==   total heap usage: 31 allocs, 29 frees, 1,247 bytes allocated
==24908== 
==24908== LEAK SUMMARY:
==24908==    definitely lost: 0 bytes in 0 blocks
==24908==    indirectly lost: 0 bytes in 0 blocks
==24908==      possibly lost: 0 bytes in 0 blocks
==24908==    still reachable: 18 bytes in 2 blocks
==24908==         suppressed: 0 bytes in 0 blocks
==24908== Rerun with --leak-check=full to see details of leaked memory
==24908== 
==24908== For counts of detected and suppressed errors, rerun with: -v
==24908== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test write_str...                               [   OK   ]
==24909== 
==24909== HEAP SUMMARY:
==24909==     in use at exit: 18 bytes in 2 blocks
==24909==   total heap usage: 3 allocs, 1 frees, 1,042 bytes allocated
==24909== 
==24909== LEAK SUMMARY:
==24909==    definitely lost: 0 bytes in 0 blocks
==24909==    indirectly lost: 0 bytes in 0 blocks
==24909==      possibly lost: 0 bytes in 0 blocks
==24909==    still reachable: 18 bytes in 2 blocks
==24909==         suppressed: 0 bytes in 0 blocks
==24909== Rerun with --leak-check=full to see details of leaked memory
==24909== 
==24909== For counts of detected and suppressed errors, rerun with: -v
==24909== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==24907== 
==24907== HEAP SUMMARY:
==24907==     in use at exit: 0 bytes in 0 blocks
==24907==   total heap usage: 3 allocs, 3 frees, 1,042 bytes allocated
==24907== 
==24907== All heap blocks were freed -- no leaks are possible
==24907== 
==24907== For counts of detected and suppressed errors, rerun with: -v
==24907== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@ubuntu:~/git/fluent-bit/build$ 

```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
