### PR TITLE
filter_lua: support new return value to keep timestamp

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -7,7 +7,7 @@
    - cb_replace => Replace record content with a new table
 
    The key inside each function is to do a proper handling of the
-   return values. Each function must return 3 values:
+   return values. Each function must return 4 values:
 
       return code, timestamp, record
 
@@ -15,7 +15,8 @@
 
    - code     : -1 record must be deleted
                  0 record not modified, keep the original
-                 1 record was modified, replace content
+                 1 record was modified, replace timestamp and record.
+                 2 record was modified, replace record and keep timestamp.
    - timestamp: Unix timestamp with precision (double)
    - record   : Table with multiple key/val
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

To fix #2015 
This patch is to support new return value to preserve original timestamp.

| return value | description |
|---------------|-------------|
|-1 | drop the record |
|0 | keep the original |
|1| replace timestamp and record |
|2(new)|keep the original timestamp and replace record|

## configuration example

https://github.com/fluent/fluent-bit/issues/2015#issuecomment-612721855

example.lua
```lua
function test(tag, timestamp, record)
         record["filter"] = "lua"
         return 2, timestamp, record
end
```

output:
```
taka@ubuntu:~/git/fluent-bit/build/2015$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/04/13 13:42:58] [ info] [storage] version=1.0.3, initializing...
[2020/04/13 13:42:58] [ info] [storage] in-memory
[2020/04/13 13:42:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/13 13:42:58] [ info] [engine] started (pid=33800)
[2020/04/13 13:42:58] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2020/04/13 13:42:58] [ info] [sp] stream processor started
[0] hoge�: [1582135200.001000000, {"hoge"=>"hoge"}]
[0] hoge: [1582135200.001000000, {"filter"=>"lua", "hoge"=>"hoge"}]
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
taka@ubuntu:~/git/fluent-bit/build/2015$ valgrind ../bin/fluent-bit -c a.conf 
==33808== Memcheck, a memory error detector
==33808== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33808== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==33808== Command: ../bin/fluent-bit -c a.conf
==33808== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/04/13 13:43:39] [ info] [storage] version=1.0.3, initializing...
[2020/04/13 13:43:39] [ info] [storage] in-memory
[2020/04/13 13:43:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/13 13:43:39] [ info] [engine] started (pid=33808)
[2020/04/13 13:43:39] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2020/04/13 13:43:40] [ info] [sp] stream processor started
[0] hoge�: [1582135200.001000000, {"hoge"=>"hoge"}]
[0] hoge: [1582135200.001000000, {"filter"=>"lua", "hoge"=>"hoge"}]
^C[engine] caught signal (SIGINT)
==33808== 
==33808== HEAP SUMMARY:
==33808==     in use at exit: 0 bytes in 0 blocks
==33808==   total heap usage: 254 allocs, 254 frees, 470,224 bytes allocated
==33808== 
==33808== All heap blocks were freed -- no leaks are possible
==33808== 
==33808== For counts of detected and suppressed errors, rerun with: -v
==33808== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@ubuntu:~/git/fluent-bit/build/2015$ 
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

If the patch is approved, I will write a document about this.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
