### PR TITLE
in_dummy: support new property dummy_sec/dummy_nsec

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -75,6 +75,8 @@ static inline int flb_time_equal(struct flb_time *t0, struct flb_time *t1) {
 int flb_time_get(struct flb_time *tm);
 int flb_time_msleep(uint32_t ms);
 double flb_time_to_double(struct flb_time *tm);
+int flb_time_add(struct flb_time *base, struct flb_time *duration,
+                 struct flb_time *result);
 int flb_time_diff(struct flb_time *time1,
                   struct flb_time *time0, struct flb_time *result);
 int flb_time_append_to_msgpack(struct flb_time *tm, msgpack_packer *pk, int fmt);

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -33,6 +33,27 @@
 #include "in_dummy.h"
 
 
+static int set_dummy_timestamp(msgpack_packer *mp_pck, struct flb_dummy *ctx)
+{
+    struct flb_time t;
+    struct flb_time diff;
+    struct flb_time dummy_time;
+    int ret;
+
+    if (ctx->base_timestamp == NULL) {
+        ctx->base_timestamp = flb_malloc(sizeof(struct flb_time));
+        flb_time_get(ctx->base_timestamp);
+        ret = flb_time_append_to_msgpack(ctx->dummy_timestamp, mp_pck, 0);
+    } else {
+        flb_time_get(&t);
+        flb_time_diff(&t, ctx->base_timestamp, &diff);
+        flb_time_add(ctx->dummy_timestamp, &diff, &dummy_time);
+        ret = flb_time_append_to_msgpack(&dummy_time, mp_pck, 0);
+    }
+
+    return ret;
+}
+
 /* cb_collect callback */
 static int in_dummy_collect(struct flb_input_instance *ins,
                             struct flb_config *config, void *in_context)
@@ -62,7 +83,11 @@ static int in_dummy_collect(struct flb_input_instance *ins,
         if (result.data.type == MSGPACK_OBJECT_MAP) {
             /* { map => val, map => val, map => val } */
             msgpack_pack_array(&mp_pck, 2);
-            flb_pack_time_now(&mp_pck);
+            if (ctx->dummy_timestamp != NULL){
+                set_dummy_timestamp(&mp_pck, ctx);
+            } else {
+                flb_pack_time_now(&mp_pck);
+            }
             msgpack_pack_str_body(&mp_pck, pack + start, off - start);
         }
         start = off;
@@ -80,6 +105,8 @@ static int in_dummy_collect(struct flb_input_instance *ins,
 
 static int config_destroy(struct flb_dummy *ctx)
 {
+    flb_free(ctx->dummy_timestamp);
+    flb_free(ctx->base_timestamp);
     flb_free(ctx->dummy_message);
     flb_free(ctx->ref_msgpack);
     flb_free(ctx);
@@ -92,6 +119,8 @@ static int configure(struct flb_dummy *ctx,
                      struct timespec *tm)
 {
     const char *str = NULL;
+    struct flb_time dummy_time;
+    int dummy_time_enabled = FLB_FALSE;
     int root_type;
     int  ret = -1;
     long val  = 0;
@@ -122,6 +151,27 @@ static int configure(struct flb_dummy *ctx,
     if (str != NULL && (val = atoi(str)) > 1) {
         tm->tv_sec = 0;
         tm->tv_nsec = 1000000000 / val;
+    }
+
+    /* dummy timestamp */
+    ctx->dummy_timestamp = NULL;
+    ctx->base_timestamp = NULL;
+    flb_time_zero(&dummy_time);
+
+    str = flb_input_get_property("dummy_sec", in);
+    if (str != NULL && (val = atoi(str)) >= 0) {
+        dummy_time_enabled = FLB_TRUE;
+        dummy_time.tm.tv_sec = val;
+    }
+    str = flb_input_get_property("dummy_nsec", in);
+    if (str != NULL && (val = atoi(str)) >= 0) {
+        dummy_time_enabled = FLB_TRUE;
+        dummy_time.tm.tv_nsec = val;
+    }
+
+    if (dummy_time_enabled) {
+        ctx->dummy_timestamp = flb_malloc(sizeof(struct flb_time));
+        flb_time_copy(ctx->dummy_timestamp, &dummy_time);
     }
 
     ret = flb_pack_json(ctx->dummy_message,

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -158,12 +158,12 @@ static int configure(struct flb_dummy *ctx,
     ctx->base_timestamp = NULL;
     flb_time_zero(&dummy_time);
 
-    str = flb_input_get_property("dummy_sec", in);
+    str = flb_input_get_property("start_time_sec", in);
     if (str != NULL && (val = atoi(str)) >= 0) {
         dummy_time_enabled = FLB_TRUE;
         dummy_time.tm.tv_sec = val;
     }
-    str = flb_input_get_property("dummy_nsec", in);
+    str = flb_input_get_property("start_time_nsec", in);
     if (str != NULL && (val = atoi(str)) >= 0) {
         dummy_time_enabled = FLB_TRUE;
         dummy_time.tm.tv_nsec = val;

--- a/plugins/in_dummy/in_dummy.h
+++ b/plugins/in_dummy/in_dummy.h
@@ -34,6 +34,9 @@ struct flb_dummy {
 
     char *ref_msgpack;
     size_t ref_msgpack_size;
+
+    struct flb_time *dummy_timestamp;
+    struct flb_time *base_timestamp;
     struct flb_input_instance *ins;
 };
 

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -89,6 +89,25 @@ double flb_time_to_double(struct flb_time *tm)
     return (double)(tm->tm.tv_sec) + ((double)tm->tm.tv_nsec/(double)ONESEC_IN_NSEC);
 }
 
+int flb_time_add(struct flb_time *base, struct flb_time *duration, struct flb_time *result)
+{
+    if (base == NULL || duration == NULL|| result == NULL) {
+        return -1;
+    }
+    result->tm.tv_sec  = base->tm.tv_sec  + duration->tm.tv_sec;
+    result->tm.tv_nsec = base->tm.tv_nsec + duration->tm.tv_nsec;
+
+    if (result->tm.tv_nsec > ONESEC_IN_NSEC) {
+        result->tm.tv_nsec -= ONESEC_IN_NSEC;
+        result->tm.tv_sec++;
+    } else if (result->tm.tv_nsec < 0) {
+        result->tm.tv_nsec += ONESEC_IN_NSEC;
+        result->tm.tv_sec--;
+    }
+
+    return 0;
+}
+
 int flb_time_diff(struct flb_time *time1,
                   struct flb_time *time0,struct flb_time *result)
 {


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

timestamp issue (especially filter plugin issue like #2015) is hard to reproduce.
(e.g. write dummy logfile and use in_tail to parse it or use in_forward and send dummy message pack event ...)

I added new property `dummy_sec` and `dummy_nsec` for debugging.
It makes timestamp of event configurable.

If `dummy_sec` and `dummy_nsec` are not set, in_dummy works as usual.
in_dummy uses current time as timestamp.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

a.conf:
```python
[INPUT]
    Name dummy
    dummy_sec  1582135200
    dummy_nsec 1000000

[OUTPUT]
    Name stdout
    Match *.*
```

output is like this.
Timestamp is overwritten.
```
taka@ubuntu:~/git/fluent-bit/build/dummy_timestamp$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/04/16 17:19:52] [ info] [storage] version=1.0.3, initializing...
[2020/04/16 17:19:52] [ info] [storage] in-memory
[2020/04/16 17:19:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/16 17:19:52] [ info] [engine] started (pid=85027)
[2020/04/16 17:19:52] [ info] [sp] stream processor started
[0] dummy.0: [1582135200.001000000, {"message"=>"dummy"}]
[1] dummy.0: [1582135201.001701210, {"message"=>"dummy"}]
[2] dummy.0: [1582135202.002102959, {"message"=>"dummy"}]
[3] dummy.0: [1582135203.001472454, {"message"=>"dummy"}]
^C[engine] caught signal (SIGINT)
taka@ubuntu:~/git/fluent-bit/build/dummy_timestamp$ 
```

valgrind :
```
taka@ubuntu:~/git/fluent-bit/build/dummy_timestamp$ valgrind ../bin/fluent-bit -c a.conf 
==84554== Memcheck, a memory error detector
==84554== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==84554== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==84554== Command: ../bin/fluent-bit -c a.conf
==84554== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/04/16 16:51:41] [ info] [storage] version=1.0.3, initializing...
[2020/04/16 16:51:41] [ info] [storage] in-memory
[2020/04/16 16:51:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/16 16:51:41] [ info] [engine] started (pid=84554)
[2020/04/16 16:51:42] [ info] [sp] stream processor started
[0] dummy.0: [1582135200.001000000, {"message"=>"dummy"}]
[1] dummy.0: [1582135200.986187041, {"message"=>"dummy"}]
[2] dummy.0: [1582135201.986513491, {"message"=>"dummy"}]
[3] dummy.0: [1582135202.985781083, {"message"=>"dummy"}]
^C[engine] caught signal (SIGINT)
==84554== 
==84554== HEAP SUMMARY:
==84554==     in use at exit: 0 bytes in 0 blocks
==84554==   total heap usage: 230 allocs, 230 frees, 750,696 bytes allocated
==84554== 
==84554== All heap blocks were freed -- no leaks are possible
==84554== 
==84554== For counts of detected and suppressed errors, rerun with: -v
==84554== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@ubuntu:~/git/fluent-bit/build/dummy_timestamp$ 
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

| Key | Description |
| :--- | :--- |
|Dummy_sec|Dummy base timestamp in seconds.|
|Dummy_nsec|Dummy base timestamp in nanoseconds.|

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
