### PR TITLE
filter_parser: refactor cb_parser_filter

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -53,6 +53,20 @@ static int msgpackobj2char(msgpack_object *obj,
     return ret;
 }
 
+static inline int is_key_to_parse(struct filter_parser_ctx *ctx,
+                                  msgpack_object *key)
+{
+    const char *key_str;
+    int key_len;
+
+    if ( msgpackobj2char(key, &key_str, &key_len) < 0 ) {
+                /* key is not string */
+        return FLB_FALSE;
+    }
+    return (key_len == ctx->key_name_len &&
+            !strncmp(key_str, ctx->key_name, key_len));
+}
+
 static int add_parser(const char *parser, struct filter_parser_ctx *ctx,
                        struct flb_config *config)
 {
@@ -178,6 +192,92 @@ static int cb_parser_init(struct flb_filter_instance *f_ins,
     return 0;
 }
 
+static int kv_array_init(struct kv_array *arr, size_t size)
+{
+    int i;
+
+    arr->len = size;
+    arr->index = 0;
+    arr->kv = flb_malloc(sizeof(msgpack_object_kv*) * size);
+    if (!arr->kv) {
+        return -1;
+    }
+    for (i = 0; i < size; i++){
+        arr->kv[i] = NULL;
+    }
+
+    return 0;
+}
+static void kv_array_destroy(struct kv_array *arr)
+{
+    flb_free(arr->kv);
+    arr->kv = NULL;
+}
+
+static void kv_array_push(struct kv_array *arr, msgpack_object_kv *kv)
+{
+    arr->kv[arr->index] = kv;
+    arr->index++;
+}
+
+static msgpack_object_kv* kv_array_pop(struct kv_array *arr)
+{
+    msgpack_object_kv *ret;
+    arr->index--;
+    arr->len--;
+
+    ret = arr->kv[arr->index];
+    arr->kv[arr->index] = NULL;
+
+    return ret;
+}
+
+static int parse_msgpack_value(struct filter_parser_ctx *ctx, msgpack_object* val,
+                   char **out_buf, size_t  *out_size, struct flb_time *tm)
+{
+
+    int ret = -1;
+
+    struct mk_list *head;
+    struct filter_parser *fp;
+    const char *val_str;
+    int val_len;
+
+    struct flb_time parsed_time;
+
+    if ( msgpackobj2char(val, &val_str, &val_len) < 0 ) {
+        /* val is not string */
+        return -1;
+    }
+
+    /* Lookup parser */
+    mk_list_foreach(head, &ctx->parsers) {
+        fp = mk_list_entry(head, struct filter_parser, _head);
+
+        /* Reset time */
+        flb_time_zero(&parsed_time);
+
+        ret = flb_parser_do(fp->parser, val_str, val_len,
+                                  (void **) out_buf, out_size,
+                                  &parsed_time);
+        if (ret >= 0) {
+            /*
+             * If the parser succeeded we need to check the
+             * status of the parsed time. If the time was
+             * parsed successfully 'parsed_time' will be
+             * different than zero, if so, override the time
+             * holder with the new value, otherwise keep the
+             * original.
+             */
+            if (flb_time_to_double(&parsed_time) != 0.0) {
+                flb_time_copy(tm, &parsed_time);
+            }
+            break;
+        }
+    }
+    return ret;
+}
+
 static int cb_parser_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **ret_buf, size_t *ret_bytes,
@@ -185,7 +285,6 @@ static int cb_parser_filter(const void *data, size_t bytes,
                             void *context,
                             struct flb_config *config)
 {
-    int continue_parsing;
     struct filter_parser_ctx *ctx = context;
     msgpack_unpacked result;
     size_t off = 0;
@@ -197,23 +296,16 @@ static int cb_parser_filter(const void *data, size_t bytes,
     msgpack_object_kv *kv;
     int i;
     int ret = FLB_FILTER_NOTOUCH;
-    int parse_ret = -1;
+
     int map_num;
-    const char *key_str;
-    int key_len;
-    const char *val_str;
-    int val_len;
+
     char *out_buf;
     size_t out_size;
-    struct flb_time parsed_time;
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
 
-    msgpack_object_kv **append_arr = NULL;
-    size_t            append_arr_len;
-    int                append_arr_i;
-    struct mk_list *head;
-    struct filter_parser *fp;
+    struct kv_array preserved;
+    preserved.kv = NULL;
 
     /* Create temporal msgpack buffer */
     msgpack_sbuffer_init(&tmp_sbuf);
@@ -222,122 +314,99 @@ static int cb_parser_filter(const void *data, size_t bytes,
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         out_buf = NULL;
-        append_arr_i = 0;
-
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }
+
+        /* preserve original timestamp */
         flb_time_pop_from_msgpack(&tm, &result, &obj);
-        if (obj->type == MSGPACK_OBJECT_MAP) {
-            map_num = obj->via.map.size;
-            if (ctx->reserve_data) {
-                append_arr_len = obj->via.map.size;
-                append_arr = flb_malloc(sizeof(msgpack_object_kv*) * append_arr_len);
-                if (!append_arr) {
-                    flb_errno();
-                    msgpack_unpacked_destroy(&result);
-                    msgpack_sbuffer_destroy(&tmp_sbuf);
-                    return FLB_FILTER_NOTOUCH;
-                }
 
-                for (i = 0; i < append_arr_len; i++){
-                    append_arr[i] = NULL;
-                }
-            }
-
-            continue_parsing = FLB_TRUE;
-            for (i = 0; i < map_num && continue_parsing; i++) {
-                kv = &obj->via.map.ptr[i];
-                if (ctx->reserve_data) {
-                    append_arr[append_arr_i] = kv;
-                    append_arr_i++;
-                }
-                if ( msgpackobj2char(&kv->key, &key_str, &key_len) < 0 ) {
-                    /* key is not string */
-                    continue;
-                }
-                if (key_len == ctx->key_name_len &&
-                    !strncmp(key_str, ctx->key_name, key_len)) {
-                    if ( msgpackobj2char(&kv->val, &val_str, &val_len) < 0 ) {
-                        /* val is not string */
-                        continue;
-                    }
-
-                    /* Lookup parser */
-                    mk_list_foreach(head, &ctx->parsers) {
-                        fp = mk_list_entry(head, struct filter_parser, _head);
-
-                        /* Reset time */
-                        flb_time_zero(&parsed_time);
-
-                        parse_ret = flb_parser_do(fp->parser, val_str, val_len,
-                                            (void **) &out_buf, &out_size,
-                                            &parsed_time);
-                        if (parse_ret >= 0) {
-                            /*
-                             * If the parser succeeded we need to check the
-                             * status of the parsed time. If the time was
-                             * parsed successfully 'parsed_time' will be
-                             * different than zero, if so, override the time
-                             * holder with the new value, otherwise keep the
-                             * original.
-                             */
-                            if (flb_time_to_double(&parsed_time) != 0.0) {
-                                flb_time_copy(&tm, &parsed_time);
-                            }
-
-                            if (ctx->reserve_data) {
-                                if (!ctx->preserve_key) {
-                                    append_arr_i--;
-                                    append_arr_len--;
-                                    append_arr[append_arr_i] = NULL;
-                                }
-                            }
-                            else {
-                                continue_parsing = FLB_FALSE;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (out_buf != NULL) {
-                msgpack_pack_array(&tmp_pck, 2);
-                flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
-                if (ctx->reserve_data) {
-                    char *new_buf = NULL;
-                    int  new_size;
-                    int ret;
-                    ret = flb_msgpack_expand_map(out_buf, out_size,
-                                                 append_arr, append_arr_len,
-                                                 &new_buf, &new_size);
-                    if (ret == -1) {
-                        flb_plg_error(ctx->ins, "cannot expand map");
-                        flb_free(append_arr);
-                        msgpack_unpacked_destroy(&result);
-                        return FLB_FILTER_NOTOUCH;
-                    }
-
-                    flb_free(out_buf);
-                    out_buf = new_buf;
-                    out_size = new_size;
-                }
-                msgpack_sbuffer_write(&tmp_sbuf, out_buf, out_size);
-                flb_free(out_buf);
-                ret = FLB_FILTER_MODIFIED;
-            }
-            else {
-                /* re-use original data*/
-                msgpack_pack_object(&tmp_pck, result.data);
-            }
-            flb_free(append_arr);
-            append_arr = NULL;
-        }
-        else {
+        if (obj->type != MSGPACK_OBJECT_MAP) {
             continue;
         }
+
+        map_num = obj->via.map.size;
+        if (ctx->reserve_data) {
+            if ( kv_array_init(&preserved, map_num) < 0 ) {
+                flb_errno();
+                ret = FLB_FILTER_NOTOUCH;
+                goto end_cb_parser_filter;
+            }
+        }
+
+        /*
+          1. lookup each key value pairs and parse.
+             preserve pairs when reserve_data/preserve_key enabled.
+        */
+
+        for (i = 0; i < map_num; i++) {
+            kv = &obj->via.map.ptr[i];
+
+            if (ctx->reserve_data) {
+                /* save kv */
+                kv_array_push(&preserved, kv);
+            }
+
+            if (is_key_to_parse(ctx, &kv->key)) {
+                if ( parse_msgpack_value(ctx, &kv->val,
+                                         &out_buf, &out_size, &tm) >= 0 ) {
+                    /* parser succeeded */
+                    if (ctx->reserve_data) {
+                        if (!ctx->preserve_key) {
+                            /* remove the original key-value */
+                            kv_array_pop(&preserved);
+                        }
+                    }
+                    else {
+                        /* other pairs will be thrown away. */
+                        break;
+                    }
+                }
+            }
+        }
+
+        /* 2. modify records if parser succeeded. */
+
+        if (out_buf == NULL) {
+            /* no records are parsed */
+            /* re-use original data */
+            msgpack_pack_object(&tmp_pck, result.data);
+        }
+        else {
+            /* append parsed data */
+            msgpack_pack_array(&tmp_pck, 2);
+            flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
+            if (ctx->reserve_data) {
+                /* append preserved key value pairs */
+
+                char *new_buf = NULL;
+                int  new_size;
+                int ret_api;
+                ret_api = flb_msgpack_expand_map(out_buf, out_size,
+                                             preserved.kv, preserved.len,
+                                             &new_buf, &new_size);
+                if (ret_api < 0) {
+                    flb_plg_error(ctx->ins, "cannot expand map");
+                    flb_free(out_buf);
+                    kv_array_destroy(&preserved);
+                    ret = FLB_FILTER_NOTOUCH;
+                    goto end_cb_parser_filter;
+                }
+
+                flb_free(out_buf);
+                out_buf = new_buf;
+                out_size = new_size;
+            }
+            msgpack_sbuffer_write(&tmp_sbuf, out_buf, out_size);
+            flb_free(out_buf);
+            ret = FLB_FILTER_MODIFIED;
+        }
+        kv_array_destroy(&preserved);
     }
+
+    /* 3. clean up */
+
+ end_cb_parser_filter:
     msgpack_unpacked_destroy(&result);
 
     if (ret == FLB_FILTER_NOTOUCH) {

--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -30,6 +30,12 @@ struct filter_parser {
     struct mk_list _head;
 };
 
+struct kv_array {
+    msgpack_object_kv** kv;
+    size_t              len;
+    int                 index;
+};
+
 struct filter_parser_ctx {
     char     *key_name;
     int    key_name_len;


### PR DESCRIPTION
Before fixing filter_parser issue, I want to clean up filter_parser code.

All unit tests of filter_parser (flb-rt-filter_parser) work correctly and valgrind reports no error.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

## Unit test output
```
taka@ubuntu:~/git/fluent-bit/build$ bin/flb-rt-filter_parser 
Test filter_parser_extract_fields...            [2020/04/18 22:58:32] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 22:58:32] [ info] [storage] in-memory
[2020/04/18 22:58:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 22:58:32] [ info] [engine] started (pid=30541)
[2020/04/18 22:58:32] [ info] [sp] stream processor started
[2020/04/18 22:58:33] [ warn] [engine] service will stop in 5 seconds
[2020/04/18 22:58:37] [ info] [engine] service stopped
[   OK   ]
Test filter_parser_reserve_data_off...          [2020/04/18 22:58:37] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 22:58:37] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 22:58:37] [ info] [storage] in-memory
[2020/04/18 22:58:37] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 22:58:37] [ info] [engine] started (pid=30546)
[2020/04/18 22:58:37] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 22:58:37] [debug] [router] match rule lib.0:lib.0
[2020/04/18 22:58:37] [ info] [sp] stream processor started
[2020/04/18 22:58:37] [debug] [task] created task=0x7f4ffc01be90 id=0 OK
[2020/04/18 22:58:37] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example"}]
[2020/04/18 22:58:37] [debug] [task] destroy task=0x7f4ffc01be90 (task_id=0)
[2020/04/18 22:58:38] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 22:58:38] [ info] [engine] service stopped
[   OK   ]
Test filter_parser_handle_time_key...           [2020/04/18 22:58:39] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 22:58:39] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 22:58:39] [ info] [storage] in-memory
[2020/04/18 22:58:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 22:58:39] [ info] [engine] started (pid=30550)
[2020/04/18 22:58:39] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 22:58:39] [debug] [router] match rule lib.0:lib.0
[2020/04/18 22:58:39] [ info] [sp] stream processor started
[2020/04/18 22:58:39] [debug] [task] created task=0x7f4ffc01be90 id=0 OK
[2020/04/18 22:58:39] [debug] [test_filter_parser] received message: [1509575121.648000,{"message":"This is an example"}]
[2020/04/18 22:58:39] [debug] [task] destroy task=0x7f4ffc01be90 (task_id=0)
[2020/04/18 22:58:40] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 22:58:40] [ info] [engine] service stopped
[   OK   ]
Test filter_parser_ignore_malformed_time...     [2020/04/18 22:58:40] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 22:58:40] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 22:58:40] [ info] [storage] in-memory
[2020/04/18 22:58:40] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 22:58:40] [ info] [engine] started (pid=30554)
[2020/04/18 22:58:40] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 22:58:40] [debug] [router] match rule lib.0:lib.0
[2020/04/18 22:58:40] [ info] [sp] stream processor started
[2020/04/18 22:58:40] [ warn] [parser:timestamp] Invalid time format %Y-%m-%dT%H:%M:%S for '2017_$!^-11-01T22:25:21.648'.
[2020/04/18 22:58:40] [debug] [task] created task=0x7f4ffc01be90 id=0 OK
[2020/04/18 22:58:40] [debug] [test_filter_parser] received message: [1448403340.000000,{"@timestamp":"2017_$!^-11-01T22:25:21.648","log":"An example"}]
[2020/04/18 22:58:40] [debug] [task] destroy task=0x7f4ffc01be90 (task_id=0)
[2020/04/18 22:58:41] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 22:58:41] [ info] [engine] service stopped
[   OK   ]
Test filter_parser_preserve_original_field...   [2020/04/18 22:58:42] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 22:58:42] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 22:58:42] [ info] [storage] in-memory
[2020/04/18 22:58:42] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 22:58:42] [ info] [engine] started (pid=30558)
[2020/04/18 22:58:42] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 22:58:42] [debug] [router] match rule lib.0:lib.0
[2020/04/18 22:58:42] [ info] [sp] stream processor started
[2020/04/18 22:58:42] [debug] [task] created task=0x7f4ffc01be90 id=0 OK
[2020/04/18 22:58:42] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example","data":"100 0.5 true This is an example","log":"An example"}]
[2020/04/18 22:58:42] [debug] [task] destroy task=0x7f4ffc01be90 (task_id=0)
[2020/04/18 22:58:43] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 22:58:43] [ info] [engine] service stopped
[   OK   ]
SUCCESS: All unit tests have passed.
```

## Valgrind report
```
taka@ubuntu:~/git/fluent-bit/build$ valgrind bin/flb-rt-filter_parser 
==30761== Memcheck, a memory error detector
==30761== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==30761== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==30761== Command: bin/flb-rt-filter_parser
==30761== 
Test filter_parser_extract_fields...            [2020/04/18 23:06:39] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 23:06:39] [ info] [storage] in-memory
[2020/04/18 23:06:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 23:06:39] [ info] [engine] started (pid=30763)
[2020/04/18 23:06:39] [ info] [sp] stream processor started
[2020/04/18 23:06:40] [ warn] [engine] service will stop in 5 seconds
[2020/04/18 23:06:44] [ info] [engine] service stopped
[   OK   ]
==30763== 
==30763== HEAP SUMMARY:
==30763==     in use at exit: 1,637 bytes in 9 blocks
==30763==   total heap usage: 274 allocs, 265 frees, 671,064 bytes allocated
==30763== 
==30763== LEAK SUMMARY:
==30763==    definitely lost: 0 bytes in 0 blocks
==30763==    indirectly lost: 0 bytes in 0 blocks
==30763==      possibly lost: 288 bytes in 1 blocks
==30763==    still reachable: 1,349 bytes in 8 blocks
==30763==         suppressed: 0 bytes in 0 blocks
==30763== Rerun with --leak-check=full to see details of leaked memory
==30763== 
==30763== For counts of detected and suppressed errors, rerun with: -v
==30763== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test filter_parser_reserve_data_off...          [2020/04/18 23:06:46] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 23:06:46] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 23:06:46] [ info] [storage] in-memory
[2020/04/18 23:06:46] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 23:06:46] [ info] [engine] started (pid=30767)
[2020/04/18 23:06:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 23:06:46] [debug] [router] match rule lib.0:lib.0
[2020/04/18 23:06:46] [ info] [sp] stream processor started
[2020/04/18 23:06:47] [debug] [task] created task=0x5c79690 id=0 OK
[2020/04/18 23:06:47] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example"}]
[2020/04/18 23:06:47] [debug] [task] destroy task=0x5c79690 (task_id=0)
[2020/04/18 23:06:47] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 23:06:47] [ info] [engine] service stopped
[   OK   ]
==30767== 
==30767== HEAP SUMMARY:
==30767==     in use at exit: 1,637 bytes in 9 blocks
==30767==   total heap usage: 256 allocs, 247 frees, 556,134 bytes allocated
==30767== 
==30767== LEAK SUMMARY:
==30767==    definitely lost: 0 bytes in 0 blocks
==30767==    indirectly lost: 0 bytes in 0 blocks
==30767==      possibly lost: 288 bytes in 1 blocks
==30767==    still reachable: 1,349 bytes in 8 blocks
==30767==         suppressed: 0 bytes in 0 blocks
==30767== Rerun with --leak-check=full to see details of leaked memory
==30767== 
==30767== For counts of detected and suppressed errors, rerun with: -v
==30767== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test filter_parser_handle_time_key...           [2020/04/18 23:06:48] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 23:06:49] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 23:06:49] [ info] [storage] in-memory
[2020/04/18 23:06:49] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 23:06:49] [ info] [engine] started (pid=30771)
[2020/04/18 23:06:49] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 23:06:49] [debug] [router] match rule lib.0:lib.0
[2020/04/18 23:06:49] [ info] [sp] stream processor started
[2020/04/18 23:06:50] [debug] [task] created task=0x5c7c720 id=0 OK
[2020/04/18 23:06:50] [debug] [test_filter_parser] received message: [1509575121.648000,{"message":"This is an example"}]
[2020/04/18 23:06:50] [debug] [task] destroy task=0x5c7c720 (task_id=0)
[2020/04/18 23:06:50] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 23:06:50] [ info] [engine] service stopped
[   OK   ]
==30771== 
==30771== HEAP SUMMARY:
==30771==     in use at exit: 1,637 bytes in 9 blocks
==30771==   total heap usage: 230 allocs, 221 frees, 570,372 bytes allocated
==30771== 
==30771== LEAK SUMMARY:
==30771==    definitely lost: 0 bytes in 0 blocks
==30771==    indirectly lost: 0 bytes in 0 blocks
==30771==      possibly lost: 288 bytes in 1 blocks
==30771==    still reachable: 1,349 bytes in 8 blocks
==30771==         suppressed: 0 bytes in 0 blocks
==30771== Rerun with --leak-check=full to see details of leaked memory
==30771== 
==30771== For counts of detected and suppressed errors, rerun with: -v
==30771== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test filter_parser_ignore_malformed_time...     [2020/04/18 23:06:52] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 23:06:52] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 23:06:52] [ info] [storage] in-memory
[2020/04/18 23:06:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 23:06:52] [ info] [engine] started (pid=30775)
[2020/04/18 23:06:52] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 23:06:52] [debug] [router] match rule lib.0:lib.0
[2020/04/18 23:06:52] [ info] [sp] stream processor started
[2020/04/18 23:06:52] [ warn] [parser:timestamp] Invalid time format %Y-%m-%dT%H:%M:%S for '2017_$!^-11-01T22:25:21.648'.
[2020/04/18 23:06:53] [debug] [task] created task=0x5c7c860 id=0 OK
[2020/04/18 23:06:53] [debug] [test_filter_parser] received message: [1448403340.000000,{"@timestamp":"2017_$!^-11-01T22:25:21.648","log":"An example"}]
[2020/04/18 23:06:53] [debug] [task] destroy task=0x5c7c860 (task_id=0)
[2020/04/18 23:06:53] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 23:06:53] [ info] [engine] service stopped
[   OK   ]
==30775== 
==30775== HEAP SUMMARY:
==30775==     in use at exit: 1,637 bytes in 9 blocks
==30775==   total heap usage: 233 allocs, 224 frees, 570,537 bytes allocated
==30775== 
==30775== LEAK SUMMARY:
==30775==    definitely lost: 0 bytes in 0 blocks
==30775==    indirectly lost: 0 bytes in 0 blocks
==30775==      possibly lost: 288 bytes in 1 blocks
==30775==    still reachable: 1,349 bytes in 8 blocks
==30775==         suppressed: 0 bytes in 0 blocks
==30775== Rerun with --leak-check=full to see details of leaked memory
==30775== 
==30775== For counts of detected and suppressed errors, rerun with: -v
==30775== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test filter_parser_preserve_original_field...   [2020/04/18 23:06:55] [debug] [storage] [cio stream] new stream registered: lib.0
[2020/04/18 23:06:55] [ info] [storage] version=1.0.3, initializing...
[2020/04/18 23:06:55] [ info] [storage] in-memory
[2020/04/18 23:06:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/04/18 23:06:55] [ info] [engine] started (pid=30779)
[2020/04/18 23:06:55] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/04/18 23:06:55] [debug] [router] match rule lib.0:lib.0
[2020/04/18 23:06:55] [ info] [sp] stream processor started
[2020/04/18 23:06:56] [debug] [task] created task=0x5c7d9c0 id=0 OK
[2020/04/18 23:06:56] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example","data":"100 0.5 true This is an example","log":"An example"}]
[2020/04/18 23:06:56] [debug] [task] destroy task=0x5c7d9c0 (task_id=0)
[2020/04/18 23:06:56] [ warn] [engine] service will stop in 1 seconds
[2020/04/18 23:06:57] [ info] [engine] service stopped
[   OK   ]
==30779== 
==30779== HEAP SUMMARY:
==30779==     in use at exit: 1,637 bytes in 9 blocks
==30779==   total heap usage: 264 allocs, 255 frees, 572,896 bytes allocated
==30779== 
==30779== LEAK SUMMARY:
==30779==    definitely lost: 0 bytes in 0 blocks
==30779==    indirectly lost: 0 bytes in 0 blocks
==30779==      possibly lost: 288 bytes in 1 blocks
==30779==    still reachable: 1,349 bytes in 8 blocks
==30779==         suppressed: 0 bytes in 0 blocks
==30779== Rerun with --leak-check=full to see details of leaked memory
==30779== 
==30779== For counts of detected and suppressed errors, rerun with: -v
==30779== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==30761== 
==30761== HEAP SUMMARY:
==30761==     in use at exit: 0 bytes in 0 blocks
==30761==   total heap usage: 3 allocs, 3 frees, 1,069 bytes allocated
==30761== 
==30761== All heap blocks were freed -- no leaks are possible
==30761== 
==30761== For counts of detected and suppressed errors, rerun with: -v
==30761== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
