### PR TITLE
Added three fuzzers for parser.

### DIFF
--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -1,7 +1,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
 
@@ -15,6 +14,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     /* json parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "json", NULL, NULL, 
+                                    NULL, NULL, MK_FALSE, NULL,
                                     NULL, NULL, MK_FALSE, NULL, 
                                     0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size, 
@@ -29,4 +29,3 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
     return 0;
 }
-

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_parser.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    struct flb_config *fuzz_config;
+    struct flb_parser *fuzz_parser;
+
+    /* json parser */
+    fuzz_config = flb_config_init();
+    fuzz_parser = flb_parser_create("fuzzer", "json", NULL, NULL, 
+                                    NULL, NULL, MK_FALSE, NULL, 
+                                    0, NULL, fuzz_config);
+    flb_parser_do(fuzz_parser, (char*)data, size, 
+                  &out_buf, &out_size, &out_time);
+
+    if (out_buf != NULL) {
+        free(out_buf);
+    }
+
+    flb_parser_destroy(fuzz_parser);
+    flb_config_exit(fuzz_config);
+
+    return 0;
+}
+

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -13,9 +13,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
     /* json parser */
     fuzz_config = flb_config_init();
-    fuzz_parser = flb_parser_create("fuzzer", "json", NULL, NULL, 
+    fuzz_parser = flb_parser_create("fuzzer", "json", NULL, NULL,
                                     NULL, NULL, MK_FALSE, NULL,
-                                    NULL, NULL, MK_FALSE, NULL, 
                                     0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size, 
                   &out_buf, &out_size, &out_time);

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -13,7 +13,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
     /* logfmt parser */
     fuzz_config = flb_config_init();
-    fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, 
+    fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL,
                                     NULL, NULL, NULL, MK_FALSE,
                                     NULL, 0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_parser.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    struct flb_config *fuzz_config;
+    struct flb_parser *fuzz_parser;
+
+    /* logfmt parser */
+    fuzz_config = flb_config_init();
+    fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, 
+                                    NULL, NULL, NULL, MK_FALSE, 
+                                    NULL, 0, NULL, fuzz_config);
+    flb_parser_do(fuzz_parser, (char*)data, size, 
+                  &out_buf, &out_size, &out_time);
+
+    if (out_buf != NULL) {
+        free(out_buf);
+    }
+
+    flb_parser_destroy(fuzz_parser);
+    flb_config_exit(fuzz_config);
+
+    return 0;
+}
+

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -1,7 +1,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
 
@@ -15,9 +14,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     /* logfmt parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, 
-                                    NULL, NULL, NULL, MK_FALSE, 
+                                    NULL, NULL, NULL, MK_FALSE,
                                     NULL, 0, NULL, fuzz_config);
-    flb_parser_do(fuzz_parser, (char*)data, size, 
+    flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 
     if (out_buf != NULL) {
@@ -29,4 +28,3 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
     return 0;
 }
-

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -1,7 +1,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
 
@@ -17,7 +16,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, 
                                     NULL, NULL, NULL, MK_FALSE, 
                                     NULL, 0, NULL, fuzz_config);
-    flb_parser_do(fuzz_parser, (char*)data, size, 
+    flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 
     if (out_buf != NULL) {

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_parser.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    struct flb_config *fuzz_config;
+    struct flb_parser *fuzz_parser;
+
+    /* ltsvc parser */
+    fuzz_config = flb_config_init();
+    fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, 
+                                    NULL, NULL, NULL, MK_FALSE, 
+                                    NULL, 0, NULL, fuzz_config);
+    flb_parser_do(fuzz_parser, (char*)data, size, 
+                  &out_buf, &out_size, &out_time);
+
+    if (out_buf != NULL) {
+        free(out_buf);
+    }
+
+    flb_parser_destroy(fuzz_parser);
+    flb_config_exit(fuzz_config);
+
+    return 0;
+}

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -13,7 +13,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
     /* ltsvc parser */
     fuzz_config = flb_config_init();
-    fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, 
+    fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL,
                                     NULL, NULL, NULL, MK_FALSE, 
                                     NULL, 0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added three new fuzzers for parsers.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
