### PR TITLE
scripts: fix description about return value

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -7,7 +7,7 @@
    - cb_replace => Replace record content with a new table
 
    The key inside each function is to do a proper handling of the
-   return values. Each function must return 4 values:
+   return values. Each function must return 3 values:
 
       return code, timestamp, record
 


### PR DESCRIPTION
via review comment https://github.com/fluent/fluent-bit/pull/2100#discussion_r411054204.

I fixed the number of return value.
The patch fixes only comment in lua script.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
