### PR TITLE
out_es: fix replace_dots in array values

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -153,8 +153,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          * The value can be any data type, if it's an array we need to
          * pass it to es_pack_array_content.
          */
-        else if (v->type == MSGPACK_OBJECT_ARRAY)
-        {
+        else if (v->type == MSGPACK_OBJECT_ARRAY) {
           msgpack_pack_array(tmp_pck, v->via.array.size);
           es_pack_array_content(tmp_pck, *v, ctx);
         }
@@ -173,27 +172,26 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
                                  struct flb_elasticsearch *ctx)
 {
-  msgpack_object *e;
+    msgpack_object *e;
 
-  for (int i = 0; i < array.via.array.size; i++)
-  {
-    e = &array.via.array.ptr[i];
-    if (e->type == MSGPACK_OBJECT_MAP)
-    {
-      msgpack_pack_map(tmp_pck, e->via.map.size);
-      es_pack_map_content(tmp_pck, *e, ctx);
+    for (int i = 0; i < array.via.array.size; i++) {
+        e = &array.via.array.ptr[i];
+        if (e->type == MSGPACK_OBJECT_MAP)
+        {
+            msgpack_pack_map(tmp_pck, e->via.map.size);
+            es_pack_map_content(tmp_pck, *e, ctx);
+        }
+        else if (e->type == MSGPACK_OBJECT_ARRAY)
+        {
+            msgpack_pack_array(tmp_pck, e->via.array.size);
+            es_pack_array_content(tmp_pck, *e, ctx);
+        }
+        else
+        {
+            msgpack_pack_object(tmp_pck, *e);
+        }
     }
-    else if (e->type == MSGPACK_OBJECT_ARRAY)
-    {
-      msgpack_pack_array(tmp_pck, e->via.array.size);
-      es_pack_array_content(tmp_pck, *e, ctx);
-    }
-    else
-    {
-      msgpack_pack_object(tmp_pck, *e);
-    }
-  }
-  return 0;
+    return 0;
 }
 
 /*

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -37,7 +37,7 @@
 
 struct flb_output_plugin out_es_plugin;
 
-inline int es_pack_array_content(msgpack_packer *tmp_pck,
+static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
                                  struct flb_elasticsearch *ctx);
 
@@ -71,9 +71,9 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 }
 #endif /* FLB_HAVE_AWS */
 
-static inline int es_pack_map_content(msgpack_packer *tmp_pck,
-                                      msgpack_object map,
-                                      struct flb_elasticsearch *ctx)
+static int es_pack_map_content(msgpack_packer *tmp_pck,
+                               msgpack_object map,
+                               struct flb_elasticsearch *ctx)
 {
     int i;
     char *ptr_key = NULL;
@@ -169,7 +169,7 @@ static inline int es_pack_map_content(msgpack_packer *tmp_pck,
   * Iterate through the array and sanitize elements.
   * Mutual recursion with es_pack_map_content.
   */
-inline int es_pack_array_content(msgpack_packer *tmp_pck,
+static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
                                  struct flb_elasticsearch *ctx)
 {


### PR DESCRIPTION
By creating `es_pack_array_content` function and using it to deal with map values that are arrays, replace dots now runs on the elements of arrays.

<!-- Provide summary of changes -->

`es_pack_array_content` function created and used on map values if they are arrays. It is mutually recursive with `es_pack_map_content`, i.e. if an element of the array is a map, run `es_pack_map_content` on it, if an value of a map is an array, run `es_pack_array_content` on it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #2093 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [n/a] Example configuration file for the change

- [x] Debug log output from testing the change

`Dummy {".le.vel":"error", ".fo.o":[{".o.k": [{".b.ar": "baz"}]}]}`

yields:

```
      {
        "_index" : "fluent-bit",
        "_type" : "flb_type",
        "_id" : "HZ0PmXEBZm-eHs2kSTYK",
        "_score" : 1.0,
        "_source" : {
          "@timestamp" : "2020-04-20T19:27:27.002Z",
          "_le_vel" : "error",
          "_fo_o" : [
            {
              "_o_k" : [
                {
                  "_b_ar" : "baz"
                }
              ]
            }
          ]
        }
      }
```

😄 

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

major thanks to @npaun for advice on this one.

cc @edsiper @PettitWesley 

PS @PettitWesley worth noting I used the docker compose method to build, run and test a container upon code changes since my local environment is not setup for C.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

