### PR TITLE
in_syslog: remove typo of Time_Format in syslog-rfc3164 parser config

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -83,7 +83,6 @@
     Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
     Time_Key    time
     Time_Format %b %d %H:%M:%S
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
     Time_Keep   On
 
 [PARSER]


### PR DESCRIPTION
Signed-off-by: Spike Wu <xwu@splunk.com>

<!-- Provide summary of changes -->
The Time_Format should not appear twice in syslog-rfc3164 parser config(cause issue in my local run), and based on the RFC 3164 standard [here](https://tools.ietf.org/html/rfc3164#section-4.1.2), the first one should be correct (The second one should be the timestamp format of RFC-5424)
```
The TIMESTAMP field is the local time and is in the format of "Mmm dd
   hh:mm:ss" (without the quote marks) where:

         Mmm is the English language abbreviation for the month of the
         year with the first character in uppercase and the other two
         characters in lowercase.  The following are the only acceptable
         values:

         Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec

         dd is the day of the month.  If the day of the month is less
         than 10, then it MUST be represented as a space and then the
         number.  For example, the 7th day of August would be
         represented as "Aug  7", with two spaces between the "g" and
         the "7".
```


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
