### PR TITLE
filter_lua: support protected mode (#2148)

### DIFF
--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -418,7 +418,18 @@ static int cb_lua_filter(const void *data, size_t bytes,
         lua_pushstring(ctx->lua->state, tag);
         lua_pushnumber(ctx->lua->state, ts);
         lua_pushmsgpack(ctx->lua->state, p);
-        lua_call(ctx->lua->state, 3, 3);
+        if (ctx->protected_mode) {
+            ret = lua_pcall(ctx->lua->state, 3, 3, 0);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "error code %d: %s",
+                              ret, lua_tostring(ctx->lua->state, -1));
+                lua_pop(ctx->lua->state, 1);
+                return FLB_FILTER_NOTOUCH;
+            }
+        }
+        else {
+            lua_call(ctx->lua->state, 3, 3);
+        }
 
         /* Initialize Return values */
         l_code = 0;

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -424,6 +424,9 @@ static int cb_lua_filter(const void *data, size_t bytes,
                 flb_plg_error(ctx->ins, "error code %d: %s",
                               ret, lua_tostring(ctx->lua->state, -1));
                 lua_pop(ctx->lua->state, 1);
+                msgpack_sbuffer_destroy(&tmp_sbuf);
+                msgpack_sbuffer_destroy(&data_sbuf);
+                msgpack_unpacked_destroy(&result);
                 return FLB_FILTER_NOTOUCH;
             }
         }

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -140,6 +140,11 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         flb_utils_split_free(split);
     }
 
+    lf->protected_mode = FLB_FALSE;
+    tmp = flb_filter_get_property("protected_mode", ins);
+    if (tmp) {
+        lf->protected_mode = flb_utils_bool(tmp);
+    }
 
     return lf;
 }

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -140,7 +140,7 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         flb_utils_split_free(split);
     }
 
-    lf->protected_mode = FLB_FALSE;
+    lf->protected_mode = FLB_TRUE;
     tmp = flb_filter_get_property("protected_mode", ins);
     if (tmp) {
         lf->protected_mode = flb_utils_bool(tmp);

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -39,6 +39,7 @@ struct lua_filter {
     flb_sds_t call;                   /* function name   */
     flb_sds_t buffer;                 /* json dec buffer */
     int    l2c_types_num;             /* number of l2c_types */
+    int    protected_mode;            /* exec lua function in protected mode */
     struct mk_list l2c_types;         /* data types (lua -> C) */
     struct flb_luajit *lua;           /* state context   */
     struct flb_filter_instance *ins;  /* filter instance */


### PR DESCRIPTION
Fixes #2148. 

I added `protected_mode` property to prevent crash when fluent-bit executes invalid lua script.
refs https://www.lua.org/pil/24.3.1.html
If the property is enabled, fluent-bit reports error and continues filtering. 

protected mode is less performance,
so I added property to be able to select unprotected mode and not to change default behavior.
(Default is False)

a.conf:
```
[INPUT]
    Name dummy
    dummy {"test":"data"}

[FILTER]
    Name lua
    Match *
    script break.lua
    call breaking
    protected_mode true

[OUTPUT]
    Name stdout
    Match *
```

break.lua:
```lua
function breaking(tag, timestamp, record)
    print(errordata["panic"])
    return 0, timestamp, record
end
```

valgrind output:
```
buntu:~/git/fluent-bit/build/2148$ valgrind ../bin/fluent-bit -c a.conf 
==27166== Memcheck, a memory error detector
==27166== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27166== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==27166== Command: ../bin/fluent-bit -c a.conf
==27166== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/05/04 08:36:51] [ info] [storage] version=1.0.3, initializing...
[2020/05/04 08:36:51] [ info] [storage] in-memory
[2020/05/04 08:36:51] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/05/04 08:36:51] [ info] [engine] started (pid=27166)
[2020/05/04 08:36:51] [ info] [sp] stream processor started
[2020/05/04 08:36:52] [error] [filter:lua:lua.0] error code 2: break.lua:2: attempt to index global 'errordata' (a nil value)
[2020/05/04 08:36:53] [error] [filter:lua:lua.0] error code 2: break.lua:2: attempt to index global 'errordata' (a nil value)
[2020/05/04 08:36:54] [error] [filter:lua:lua.0] error code 2: break.lua:2: attempt to index global 'errordata' (a nil value)
[2020/05/04 08:36:55] [error] [filter:lua:lua.0] error code 2: break.lua:2: attempt to index global 'errordata' (a nil value)
[0] dummy.0: [1588549012.816531447, {"test"=>"data"}]
[1] dummy.0: [1588549013.794092379, {"test"=>"data"}]
[2] dummy.0: [1588549014.793519420, {"test"=>"data"}]
[3] dummy.0: [1588549015.794093299, {"test"=>"data"}]
[2020/05/04 08:36:56] [error] [filter:lua:lua.0] error code 2: break.lua:2: attempt to index global 'errordata' (a nil value)
^C[engine] caught signal (SIGINT)
==27166== 
==27166== HEAP SUMMARY:
==27166==     in use at exit: 41,280 bytes in 10 blocks
==27166==   total heap usage: 326 allocs, 316 frees, 970,992 bytes allocated
==27166== 
==27166== LEAK SUMMARY:
==27166==    definitely lost: 280 bytes in 5 blocks
==27166==    indirectly lost: 41,000 bytes in 5 blocks
==27166==      possibly lost: 0 bytes in 0 blocks
==27166==    still reachable: 0 bytes in 0 blocks
==27166==         suppressed: 0 bytes in 0 blocks
==27166== Rerun with --leak-check=full to see details of leaked memory
==27166== 
==27166== For counts of detected and suppressed errors, rerun with: -v
==27166== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

|Key|Description|
|----|-------------|
|protected_mode| If enabled, Lua script will be executed in protected mode. It is prevent to crash when executes invalid Lua script. Default is false.|
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
