### PR TITLE
out_flowcounter: add missing semi-colon

### DIFF
--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -148,7 +148,7 @@ static int out_fcount_init(struct flb_output_instance *ins, struct flb_config *c
     ret = configure(ctx, ins, config);
     if (ret < 0) {
         flb_free(ctx);
-        return -1
+        return -1;
     }
 
     flb_output_set_context(ins, ctx);


### PR DESCRIPTION
Sorry, #1649 is a broken patch. It causes compilation error.
This patch is to fix it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
