### PR TITLE
conf: parsers: fix syslog-rfc5424 extradata

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -64,7 +64,7 @@
 [PARSER]
     Name        syslog-rfc5424
     Format      regex
-    Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|-)) (?<message>.+)$
+    Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$
     Time_Key    time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep   On


### PR DESCRIPTION
Fix the regex for *extradata* because it consumes everything between `[` from extradata and the last `]` in *message*, if the latter is present.

This is not meant to be a perfect solution because structural data may contain complex text with escaping chars, such as `[name="\\\] "]`, which is difficult if not impossible to be parsed properly by regex. However, it'd still be better to have wrongly parsed part ended up in *message* rather than *extradata*, which is more often ignored.

Signed-off-by: Ji-Ping Shen <ji-ping.shen@relexsolutions.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
