### PR TITLE
build: fix "vcruntime140.dll is missing" error on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # Update CFLAGS
 if (MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
+  add_compile_options(/MT)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")


### PR DESCRIPTION
Farcop reported that Fluent Bit fails to run on a freshly installed
Windows. In particular, it hangs with the following message:

> The program can't start because VCRuntime140.dll is missing from
> your computer. Try reinstalling the program to fix this problem.

This patch fixes it by tweaking the compiler flags.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>