### PR TITLE
Added missing fflush(stdout) to flb_dump 

### DIFF
--- a/src/flb_dump.c
+++ b/src/flb_dump.c
@@ -252,4 +252,9 @@ void flb_dump(struct flb_config *ctx)
 
     /* Storage Layer */
     dump_storage(ctx);
+
+    /* Make sure to flush the stdout buffer in case output
+     * has been redirected to a file
+     */
+    fflush(stdout);
 }


### PR DESCRIPTION
Addresses issue raised in #2175 where it is not possible to view the Internal dump if stdout is redirected to `tee` or a file.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
