### PR TITLE
add check_configuration option

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -192,7 +192,7 @@ struct flb_config {
 
     struct flb_task_map tasks_map[2048];
 
-    int check_configuration;
+    int dry_run;
 };
 
 #define FLB_CONFIG_LOG_LEVEL(c) (c->log->level)

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -191,6 +191,8 @@ struct flb_config {
     void *sched;
 
     struct flb_task_map tasks_map[2048];
+
+    int check_configuration;
 };
 
 #define FLB_CONFIG_LOG_LEVEL(c) (c->log->level)

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -102,7 +102,7 @@ static void flb_help(int rc, struct flb_config *config)
     printf("%sAvailable Options%s\n", ANSI_BOLD, ANSI_RESET);
     printf("  -b  --storage_path=PATH\tspecify a storage buffering path\n");
     printf("  -c  --config=FILE\tspecify an optional configuration file\n");
-    printf("  -C, --check_configuration\tcheck configration\n");
+    printf("  -D, --dry-run\tdry run\n");
 #ifdef FLB_HAVE_FORK
     printf("  -d, --daemon\t\trun Fluent Bit in background mode\n");
 #endif
@@ -775,6 +775,7 @@ int flb_main(int argc, char **argv)
 #ifdef FLB_HAVE_FORK
         { "daemon",          no_argument      , NULL, 'd' },
 #endif
+        { "dry-run",         no_argument      , NULL, 'D' },
         { "flush",           required_argument, NULL, 'f' },
         { "http",            no_argument      , NULL, 'H' },
         { "log_file",        required_argument, NULL, 'l' },
@@ -823,7 +824,7 @@ int flb_main(int argc, char **argv)
 
     /* Parse the command line options */
     while ((opt = getopt_long(argc, argv,
-                              "b:c:Cdf:i:m:o:R:F:p:e:"
+                              "b:c:dDf:i:m:o:R:F:p:e:"
                               "t:T:l:vqVhL:HP:s:S",
                               long_opts, NULL)) != -1) {
 
@@ -834,14 +835,14 @@ int flb_main(int argc, char **argv)
         case 'c':
             cfg_file = flb_strdup(optarg);
             break;
-        case 'C':
-            config->check_configuration = FLB_TRUE;
-            break;
 #ifdef FLB_HAVE_FORK
         case 'd':
             config->daemon = FLB_TRUE;
             break;
 #endif
+        case 'D':
+            config->dry_run = FLB_TRUE;
+            break;
         case 'e':
             ret = flb_plugin_load_router(optarg, config);
             if (ret == -1) {
@@ -1030,7 +1031,7 @@ int flb_main(int argc, char **argv)
     win32_started();
 #endif
 
-    if (config->check_configuration == FLB_TRUE) {
+    if (config->dry_run == FLB_TRUE) {
         fprintf(stderr, "configuration test is successful\n");
         exit(EXIT_SUCCESS);
     }

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -102,6 +102,7 @@ static void flb_help(int rc, struct flb_config *config)
     printf("%sAvailable Options%s\n", ANSI_BOLD, ANSI_RESET);
     printf("  -b  --storage_path=PATH\tspecify a storage buffering path\n");
     printf("  -c  --config=FILE\tspecify an optional configuration file\n");
+    printf("  -C, --check_configuration\tcheck configration\n");
 #ifdef FLB_HAVE_FORK
     printf("  -d, --daemon\t\trun Fluent Bit in background mode\n");
 #endif
@@ -822,7 +823,7 @@ int flb_main(int argc, char **argv)
 
     /* Parse the command line options */
     while ((opt = getopt_long(argc, argv,
-                              "b:c:df:i:m:o:R:F:p:e:"
+                              "b:c:Cdf:i:m:o:R:F:p:e:"
                               "t:T:l:vqVhL:HP:s:S",
                               long_opts, NULL)) != -1) {
 
@@ -832,6 +833,9 @@ int flb_main(int argc, char **argv)
             break;
         case 'c':
             cfg_file = flb_strdup(optarg);
+            break;
+        case 'C':
+            config->check_configuration = FLB_TRUE;
             break;
 #ifdef FLB_HAVE_FORK
         case 'd':
@@ -1025,6 +1029,11 @@ int flb_main(int argc, char **argv)
 #ifdef FLB_SYSTEM_WINDOWS
     win32_started();
 #endif
+
+    if (config->check_configuration == FLB_TRUE) {
+        fprintf(stderr, "configuration test is successful\n");
+        exit(EXIT_SUCCESS);
+    }
 
     ret = flb_start(ctx);
     if (ret != 0) {


### PR DESCRIPTION
Added check_configuration option to validate configuration.

Fixes #2178.

I prepared `conf/fluent-bit_invalid.conf` and test it.
5c5

```diff
$ diff conf/fluent-bit.conf conf/fluent-bit_invalid.conf
5c5
<     Flush        5
---
>     Flush
```

```shell
# validate config file with valid configuration file.
$ docker run fluent-bit:latest /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf -C

Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

configuration test is successful
$ echo $?
0

# validate config file with valid configuration file.
$ docker run fluent-bit:latest /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf --check_configuration

Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

configuration test is successful
$ echo $?
0

# validate config file with invalid configuration file.
$ docker run fluent-bit:latest /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit_invalid.conf -C
Fluent Bit v1.5.0
[2020/05/17 06:00:08] [  Error] File /fluent-bit/etc/fluent-bit_invalid.conf
[2020/05/17 06:00:08] [  Error] Error in line 5: Each key must have a value
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

$ echo $?
1

# validate config file with invalid configuration file.
$ docker run fluent-bit:latest /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit_invalid.conf --check_configuration
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/05/17 06:00:23] [  Error] File /fluent-bit/etc/fluent-bit_invalid.conf
[2020/05/17 06:00:23] [  Error] Error in line 5: Each key must have a value
$ echo $?
1
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
