### PR TITLE
out_stackdriver: Add generic resources, config labels, metadata server override

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -17,10 +17,10 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_oauth2.h>
-#include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_utils.h>

--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -163,7 +163,7 @@ int gce_metadata_read_zone(struct flb_stackdriver *ctx)
         i++;
         j++;
     }
-    flb_kv_item_create(&ctx->labels, "zone", zone);
+    flb_kv_item_create(&ctx->resource_labels, "zone", zone);
     flb_sds_destroy(zone);
     flb_sds_destroy(payload);
 
@@ -182,7 +182,7 @@ int gce_metadata_read_project_id(struct flb_stackdriver *ctx)
         flb_sds_destroy(payload);
         return -1;
     }
-    flb_kv_item_create(&ctx->labels, "project_id", payload);
+    flb_kv_item_create(&ctx->resource_labels, "project_id", payload);
     flb_sds_destroy(payload);
     return 0;
 }
@@ -199,7 +199,7 @@ int gce_metadata_read_instance_id(struct flb_stackdriver *ctx)
         flb_sds_destroy(payload);
         return -1;
     }
-    flb_kv_item_create(&ctx->labels, "project_id", payload);
+    flb_kv_item_create(&ctx->resource_labels, "project_id", payload);
     flb_sds_destroy(payload);
     return 0;
 }

--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -17,12 +17,14 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_http_client.h>
-#include <fluent-bit/flb_pack.h>
-#include <fluent-bit/flb_utils.h>
-#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_oauth2.h>
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_utils.h>
+
 
 #include <msgpack.h>
 
@@ -161,7 +163,7 @@ int gce_metadata_read_zone(struct flb_stackdriver *ctx)
         i++;
         j++;
     }
-    ctx->zone = flb_sds_create(zone);
+    flb_kv_item_create(&ctx->labels, "zone", zone);
     flb_sds_destroy(zone);
     flb_sds_destroy(payload);
 
@@ -180,7 +182,7 @@ int gce_metadata_read_project_id(struct flb_stackdriver *ctx)
         flb_sds_destroy(payload);
         return -1;
     }
-    ctx->project_id = flb_sds_create(payload);
+    flb_kv_item_create(&ctx->labels, "project_id", payload);
     flb_sds_destroy(payload);
     return 0;
 }
@@ -197,7 +199,7 @@ int gce_metadata_read_instance_id(struct flb_stackdriver *ctx)
         flb_sds_destroy(payload);
         return -1;
     }
-    ctx->instance_id = flb_sds_create(payload);
+    flb_kv_item_create(&ctx->labels, "project_id", payload);
     flb_sds_destroy(payload);
     return 0;
 }

--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -163,7 +163,7 @@ int gce_metadata_read_zone(struct flb_stackdriver *ctx)
         i++;
         j++;
     }
-    flb_kv_item_create(&ctx->resource_labels, "zone", zone);
+    set_resource_label("zone", zone, ctx);
     flb_sds_destroy(zone);
     flb_sds_destroy(payload);
 
@@ -182,7 +182,8 @@ int gce_metadata_read_project_id(struct flb_stackdriver *ctx)
         flb_sds_destroy(payload);
         return -1;
     }
-    flb_kv_item_create(&ctx->resource_labels, "project_id", payload);
+    ctx->project_id = flb_sds_create(payload);
+    set_resource_label("project_id", payload, ctx);
     flb_sds_destroy(payload);
     return 0;
 }
@@ -198,8 +199,8 @@ int gce_metadata_read_instance_id(struct flb_stackdriver *ctx)
         flb_plg_error(ctx->ins, "can't fetch instance id from the metadata server");
         flb_sds_destroy(payload);
         return -1;
-    }
-    flb_kv_item_create(&ctx->resource_labels, "project_id", payload);
+    };
+    set_resource_label("instance_id", payload, ctx);
     flb_sds_destroy(payload);
     return 0;
 }

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -328,7 +328,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
         flb_plg_warn(ctx->ins, "token retrieval failed");
     }
 
-    label = flb_kv_get_key_value("project_id", &ctx->labels);
+    label = flb_kv_get_key_value("project_id", &ctx->resource_labels);
     if (label == NULL) {
         ret = gce_metadata_read_project_id(ctx);
         if (ret == -1) {
@@ -340,7 +340,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     flb_plg_info(ctx->ins, "%s resource found", ctx->resource);
 
     if (strncasecmp(ctx->resource, "gce_instance", 12) == 0) {
-        label = flb_kv_get_key_value("zone", &ctx->labels);
+        label = flb_kv_get_key_value("zone", &ctx->resource_labels);
         if (label == NULL) {
             ret = gce_metadata_read_zone(ctx);
             if (ret == -1) {
@@ -349,7 +349,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
             }
         }
 
-        label = flb_kv_get_key_value("instance_id", &ctx->labels);
+        label = flb_kv_get_key_value("instance_id", &ctx->resource_labels);
         if (label == NULL) {
             ret = gce_metadata_read_instance_id(ctx);
             if (ret == -1) {
@@ -358,32 +358,32 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
             }
         }
     } else if (strncasecmp(ctx->resource, "generic_", 8) == 0) {
-        label = flb_kv_get_key_value("location", &ctx->labels);
+        label = flb_kv_get_key_value("location", &ctx->resource_labels);
         if (label == NULL) {
             flb_plg_error(ctx->ins, "get location for generic_node/task failed");
             return -1;
         }
 
-        label = flb_kv_get_key_value("namespace", &ctx->labels);
+        label = flb_kv_get_key_value("namespace", &ctx->resource_labels);
         if (label == NULL) {
             flb_plg_error(ctx->ins, "get namespace for generic_node/task failed");
             return -1;
         }
 
         if (strncasecmp(ctx->resource, "generic_node", 12) == 0) {;
-            label = flb_kv_get_key_value("node_id", &ctx->labels);
+            label = flb_kv_get_key_value("node_id", &ctx->resource_labels);
             if (label == NULL) {
                 flb_plg_error(ctx->ins, "get node_id for generic_node failed");
                 return -1;
             }
         } else {
-            label = flb_kv_get_key_value("job", &ctx->labels);
+            label = flb_kv_get_key_value("job", &ctx->resource_labels);
             if (label == NULL) {
                 flb_plg_error(ctx->ins, "get job for generic_task failed");
                 return -1;
             }
 
-            label = flb_kv_get_key_value("task_id", &ctx->labels);
+            label = flb_kv_get_key_value("task_id", &ctx->resource_labels);
             if (label == NULL) {
                 flb_plg_error(ctx->ins, "get task_id for generic_task failed");
                 return -1;
@@ -554,8 +554,8 @@ static int stackdriver_format(const void *data, size_t bytes,
      * generic_node - project_id, location, namespace, node_id
      * generic_task - project_id, location, namespace, job, task_id
      */
-    msgpack_pack_map(&mp_pck, mk_list_size(&ctx->labels));
-    mk_list_foreach(label, &ctx->labels) {
+    msgpack_pack_map(&mp_pck, mk_list_size(&ctx->resource_labels));
+    mk_list_foreach(label, &ctx->resource_labels) {
         kv = mk_list_entry(label, struct flb_kv, _head);
         msgpack_pack_str(&mp_pck, flb_sds_len(kv->key));
         msgpack_pack_str_body(&mp_pck, kv->key, flb_sds_len(kv->key));

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -74,7 +74,6 @@ struct flb_stackdriver {
      * project_id is reused from the parsed credentials file and present in all
      * monitored resources.
      */
-
     struct mk_list resource_labels;
 
     /* other */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,6 +49,19 @@
 /* Default Resource type */
 #define FLB_SDS_RESOURCE_TYPE "global"
 
+/* Holds a resource label and its value */
+struct flb_std_label {
+    const char *label;
+    flb_sds_t value;
+};
+
+/* Holds all information about a resource */
+struct flb_std_resource {
+    const char *type;
+    struct flb_std_label labels[10];
+    bool metadata_enabled;
+};
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;
@@ -67,18 +80,12 @@ struct flb_stackdriver {
     /* metadata server url */
     flb_sds_t metadata_server;
 
-    /*
-     * Stackdriver monitored resource labels
-     * see: https://cloud.google.com/logging/docs/api/v2/resource-list
-     *
-     * project_id is reused from the parsed credentials file and present in all
-     * monitored resources.
-     */
-    struct mk_list resource_labels;
-
-    /* other */
-    flb_sds_t resource;
     flb_sds_t severity_key;
+
+    /*
+     * A Stackdriver monitored resource and its labels
+     */
+    struct flb_std_resource *resource;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -64,6 +64,9 @@ struct flb_stackdriver {
     flb_sds_t token_uri;
     bool metadata_server_auth;
 
+    /* metadata server url */
+    flb_sds_t metadata_server;
+
     /*
      * Stackdriver monitored resource labels
      * see: https://cloud.google.com/logging/docs/api/v2/resource-list
@@ -72,14 +75,11 @@ struct flb_stackdriver {
      * monitored resources.
      */
 
-    struct mk_list labels;
+    struct mk_list resource_labels;
 
     /* other */
     flb_sds_t resource;
     flb_sds_t severity_key;
-
-    /* metadata server url */
-    flb_sds_t metadata_server;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -29,6 +29,9 @@
 /* refresh token every 50 minutes */
 #define FLB_STD_TOKEN_REFRESH 3000
 
+/* GCE Metadata Server URL */
+#define FLB_STD_META_URL  "http://metadata.google.internal"
+
 /* Stackdriver Logging write scope */
 #define FLB_STD_SCOPE     "https://www.googleapis.com/auth/logging.write"
 
@@ -61,14 +64,22 @@ struct flb_stackdriver {
     flb_sds_t token_uri;
     bool metadata_server_auth;
 
-    /* metadata server (GCP specific, WIP) */
-    flb_sds_t zone;
-    flb_sds_t instance_id;
-    flb_sds_t instance_name;
+    /*
+     * Stackdriver monitored resource labels
+     * see: https://cloud.google.com/logging/docs/api/v2/resource-list
+     *
+     * project_id is reused from the parsed credentials file and present in all
+     * monitored resources.
+     */
+
+    struct mk_list labels;
 
     /* other */
     flb_sds_t resource;
     flb_sds_t severity_key;
+
+    /* metadata server url */
+    flb_sds_t metadata_server;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -59,6 +59,7 @@ struct flb_std_label {
 struct flb_std_resource {
     const char *type;
     struct flb_std_label labels[10];
+    size_t label_cnt;
     bool metadata_enabled;
 };
 

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -49,7 +49,7 @@ static int validate_resource(const char *res)
         * Resource types
         * 'global', 'gce_instance', `generic_node', 'generic_task' are supported
     */
-    char *valid_resources[] = {
+    static const char *valid_resources[] = {
         "global",
         "gce_instance",
         "generic_node",
@@ -57,8 +57,8 @@ static int validate_resource(const char *res)
         NULL
     };
 
-    for(char **r = valid_resources; *r; ++r) {
-        if(strcasecmp(res, *r) == 0) {
+    for (const char **r = valid_resources; *r; ++r) {
+        if (strcasecmp(res, *r) == 0) {
             return 0;
         }
     }
@@ -197,9 +197,12 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
 {
     int ret;
     const char *tmp;
+    static const char rlabel_prefix[] = "resource_label.";
+    static const size_t rlabel_prefix_len = sizeof(rlabel_prefix) - 1;
     struct flb_stackdriver *ctx;
     struct flb_kv *kv;
     struct mk_list *labels;
+
 
     /* Allocate config context */
     ctx = flb_calloc(1, sizeof(struct flb_stackdriver));
@@ -317,10 +320,10 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     */
     mk_list_foreach(labels, &ins->properties) {
         kv = mk_list_entry(labels, struct flb_kv, _head);
-        if (strncasecmp(kv->key, "label.", 6) == 0 &&
-            flb_sds_len(kv->key) > 6) {
+        if (strncasecmp(kv->key, rlabel_prefix, rlabel_prefix_len) == 0 &&
+            flb_sds_len(kv->key) > rlabel_prefix_len) {
                 /* Copy actual label back to kv key */
-                kv->key = flb_sds_create(kv->key + 6);
+                kv->key = flb_sds_create(kv->key + rlabel_prefix_len);
                 /* Create a new label value pair in list */
                 flb_kv_item_create(&ctx->resource_labels, kv->key, kv->val);
             }

--- a/plugins/out_stackdriver/stackdriver_conf.h
+++ b/plugins/out_stackdriver/stackdriver_conf.h
@@ -23,6 +23,7 @@
 
 #include "stackdriver.h"
 
+int set_resource_label(const char *key, const char *val, struct flb_stackdriver *ctx);
 struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *ins,
                                         struct flb_config *config);
 int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx);


### PR DESCRIPTION
Add ability to specify Stackdriver monitored resource types generic_node
and generic_task which need manual labels set.

resource generic_task
resource generic_node

Add ability to specify manual labeling for Stackdriver output plugin

label.<label name> <label value>
ie. label.node_id ${HOSTNAME}

Add ability to override the metadata server target.
Defaults to http://metadata.google.internal

metadata_server <server url>
ie. metadata_server http://metadata.google.internal

Signed-off-by: Joey DeStefanis <jdestefanis@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
