### PR TITLE
filter_kubernetes: Poll DNS status on Windows pods

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -140,6 +140,9 @@ struct flb_kube {
     char *auth;
     size_t auth_len;
 
+    int dns_retries;
+    int dns_wait_time;
+
     struct flb_tls tls;
     struct flb_config *config;
     struct flb_hash *hash_table;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -786,6 +786,22 @@ static struct flb_config_map config_map[] = {
      "use 'dummy' metadata, do not talk to API server"
     },
 
+    /*
+     * Poll DNS status to mitigate unreliable network issues.
+     * See fluent/fluent-bit/2144.
+     */
+    {
+     FLB_CONFIG_MAP_INT, "dns_retries", "6",
+     0, FLB_TRUE, offsetof(struct flb_kube, dns_retries),
+     "dns lookup retries N times until the network start working"
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "dns_wait_time", "30",
+     0, FLB_TRUE, offsetof(struct flb_kube, dns_wait_time),
+     "dns interval between network status checks"
+    },
+
     /* EOF */
     {0}
 };


### PR DESCRIPTION
Windows pods are known to have unstable network immediately after
boot. This has been causing deployment failures for many users.

Work around that by adding small code to poll the network status.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>