### PR TITLE
CloudWatch EMF Metric: Add support for cpu and mem input metrics

### DIFF
--- a/include/fluent-bit/flb_intermediate_metric.h
+++ b/include/fluent-bit/flb_intermediate_metric.h
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2020      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/* Fluent Bit intermediate metric representation */
+
+#ifndef FLB_INTERMEDIATE_METRIC_H
+#define FLB_INTERMEDIATE_METRIC_H
+
+#include <fluent-bit/flb_time.h>
+#include <monkey/mk_core.h>
+#include <msgpack.h>
+
+/* Metric Type- Gague or Counter */
+#define GAUGE 1
+#define COUNTER 2
+
+/* Metric Unit */
+#define PERCENT "Percent"
+#define BYTES "Bytes"
+
+struct flb_intermediate_metric
+{
+    msgpack_object key;
+    msgpack_object value;
+    int metric_type;
+    const char *metric_unit;
+    struct flb_time timestamp;
+
+    struct mk_list _head;
+};
+
+#endif

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -36,6 +36,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_intermediate_metric.h>
 
 #include <monkey/mk_core.h>
 #include <msgpack.h>
@@ -49,6 +50,7 @@
 
 #define ONE_DAY_IN_MILLISECONDS          86400000
 #define FOUR_HOURS_IN_SECONDS            14400
+
 
 static struct flb_aws_header create_group_header = {
     .key = "X-Amz-Target",
@@ -613,12 +615,160 @@ send:
     return 0;
 }
 
+int should_add_to_emf(struct flb_intermediate_metric *an_item)
+{
+    /* Valid for cpu plugin */
+    if (strncmp(an_item->key.via.str.ptr, "cpu_p", 4) == 0 
+    || strncmp(an_item->key.via.str.ptr, "user_p", 6) == 0 
+    || strncmp(an_item->key.via.str.ptr, "system_p", 8) == 0) {
+        return 1;
+    }
+
+    /* Valid for mem plugin */
+    if (strncmp(an_item->key.via.str.ptr, "Mem.total", 9) == 0 
+    || strncmp(an_item->key.via.str.ptr, "Mem.used", 8) == 0 
+    || strncmp(an_item->key.via.str.ptr, "Mem.free", 8) == 0 
+    || strncmp(an_item->key.via.str.ptr, "Swap.total", 10) == 0 
+    || strncmp(an_item->key.via.str.ptr, "Swap.used", 9) == 0 
+    || strncmp(an_item->key.via.str.ptr, "Swap.free", 9) == 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+struct msgpack_object pack_emf_payload(struct flb_cloudwatch *ctx, 
+                                       struct mk_list *flb_intermediate_metrics, 
+                                       const char *input_plugin, 
+                                       struct flb_time tms)
+{
+    struct mk_list *metric_temp;
+    struct mk_list *metric_head;
+
+    /* msgpack::sbuffer is a simple buffer implementation. */
+    msgpack_sbuffer sbuf_emf;
+    msgpack_sbuffer_init(&sbuf_emf);
+
+    /* Serialize values into the buffer using msgpack_sbuffer_write */
+    msgpack_packer packer_emf;
+    msgpack_packer_init(&packer_emf, &sbuf_emf, msgpack_sbuffer_write);
+    int total_items = mk_list_size(flb_intermediate_metrics) + 1;
+    msgpack_pack_map(&packer_emf, total_items);
+
+    /* Pack the _aws map */
+    msgpack_pack_str(&packer_emf, 4);
+    msgpack_pack_str_body(&packer_emf, "_aws", 4);
+
+    msgpack_pack_map(&packer_emf, 2);
+
+    msgpack_pack_str(&packer_emf, 9);
+    msgpack_pack_str_body(&packer_emf, "Timestamp", 9);
+    msgpack_pack_long_long(&packer_emf, tms.tm.tv_sec * 1000L);
+
+    msgpack_pack_str(&packer_emf, 17);
+    msgpack_pack_str_body(&packer_emf, "CloudWatchMetrics", 17);
+    msgpack_pack_array(&packer_emf, 1);
+
+    msgpack_pack_map(&packer_emf, 3);
+
+    msgpack_pack_str(&packer_emf, 9);
+    msgpack_pack_str_body(&packer_emf, "Namespace", 9);
+
+    if (ctx->metric_namespace) {
+        msgpack_pack_str(&packer_emf, flb_sds_len(ctx->metric_namespace));
+        msgpack_pack_str_body(&packer_emf, ctx->metric_namespace, 
+                              flb_sds_len(ctx->metric_namespace));
+    }
+    else {
+        msgpack_pack_str(&packer_emf, 18);
+        msgpack_pack_str_body(&packer_emf, "fluent-bit-metrics", 18);
+    }
+
+    msgpack_pack_str(&packer_emf, 10);
+    msgpack_pack_str_body(&packer_emf, "Dimensions", 10);
+
+    struct mk_list *head, *inner_head;
+    struct flb_split_entry *dimension_list, *entry;
+    struct mk_list *csv_values;
+    if (ctx->metric_dimensions) {
+        msgpack_pack_array(&packer_emf, mk_list_size(ctx->metric_dimensions));
+
+        mk_list_foreach(head, ctx->metric_dimensions) {
+            dimension_list = mk_list_entry(head, struct flb_split_entry, _head);
+            csv_values = flb_utils_split(dimension_list->value, ',', 256);
+            msgpack_pack_array(&packer_emf, mk_list_size(csv_values));
+
+            mk_list_foreach(inner_head, csv_values) {
+                entry = mk_list_entry(inner_head, struct flb_split_entry, _head);
+                msgpack_pack_str(&packer_emf, entry->len);
+                msgpack_pack_str_body(&packer_emf, entry->value, entry->len);
+            }
+            flb_utils_split_free(csv_values);
+        }
+    }
+    else {
+        msgpack_pack_array(&packer_emf, 0);
+    }
+
+    msgpack_pack_str(&packer_emf, 7);
+    msgpack_pack_str_body(&packer_emf, "Metrics", 7);
+
+    if (strcmp(input_plugin, "cpu") == 0) {
+        msgpack_pack_array(&packer_emf, 3);
+    }
+    else if (strcmp(input_plugin, "mem") == 0) {
+        msgpack_pack_array(&packer_emf, 6);
+    }
+    else {
+        msgpack_pack_array(&packer_emf, 0);
+    }
+
+    mk_list_foreach_safe(metric_head, metric_temp, flb_intermediate_metrics) {
+        struct flb_intermediate_metric *an_item = mk_list_entry(metric_head, 
+                                                      struct flb_intermediate_metric, 
+                                                      _head);
+        if (should_add_to_emf(an_item) == 1) {
+            msgpack_pack_map(&packer_emf, 2);
+            msgpack_pack_str(&packer_emf, 4);
+            msgpack_pack_str_body(&packer_emf, "Name", 4);
+            msgpack_pack_object(&packer_emf, an_item->key);
+            msgpack_pack_str(&packer_emf, 4);
+            msgpack_pack_str_body(&packer_emf, "Unit", 4);
+            msgpack_pack_str(&packer_emf, strlen(an_item->metric_unit));
+            msgpack_pack_str_body(&packer_emf, an_item->metric_unit, 
+                                  strlen(an_item->metric_unit));
+        }
+    }
+
+    /* Pack the metric vlaues for each record */
+    mk_list_foreach_safe(metric_head, metric_temp, flb_intermediate_metrics) {
+        struct flb_intermediate_metric *an_item = mk_list_entry(metric_head, 
+                                                      struct flb_intermediate_metric, 
+                                                      _head);
+        msgpack_pack_object(&packer_emf, an_item->key);
+        msgpack_pack_object(&packer_emf, an_item->value);
+    }
+
+    /* 
+     * Deserialize the buffer into msgpack_object instance.
+     * Deserialized object is valid during the msgpack_zone instance alive. 
+     */
+    msgpack_zone mempool;
+    msgpack_zone_init(&mempool, 2048);
+
+    msgpack_object deserialized_emf_object;
+    msgpack_unpack(sbuf_emf.data, sbuf_emf.size, NULL, &mempool, 
+                   &deserialized_emf_object);
+
+    return deserialized_emf_object;
+}
+
 /*
  * Main routine- processes msgpack and sends in batches
  * return value is the number of events processed
  */
-int process_and_send(struct flb_cloudwatch *ctx, struct cw_flush *buf,
-                     struct log_stream *stream,
+int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, 
+                     struct cw_flush *buf, struct log_stream *stream, 
                      const char *data, size_t bytes)
 {
     size_t off = 0;
@@ -638,6 +788,19 @@ int process_and_send(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     int check = FLB_FALSE;
     int found = FLB_FALSE;
     struct flb_time tms;
+
+    /* Added for EMF support */
+    struct flb_intermediate_metric *metric;
+
+    int intermediate_metric_type;
+    char *intermediate_metric_unit;
+    if (strncmp(input_plugin, "cpu", 3) == 0) {
+        intermediate_metric_type = GAUGE;
+        intermediate_metric_unit = PERCENT;
+    } else if (strncmp(input_plugin, "mem", 3) == 0) {
+        intermediate_metric_type = GAUGE;
+        intermediate_metric_unit = BYTES;
+    }
 
     /* unpack msgpack */
     msgpack_unpacked_init(&result);
@@ -701,7 +864,39 @@ int process_and_send(struct flb_cloudwatch *ctx, struct cw_flush *buf,
             continue;
         }
 
-        ret = add_event(ctx, buf, stream, &map, &tms);
+        if (strncmp(input_plugin, "cpu", 3) == 0 
+        || strncmp(input_plugin, "mem", 3) == 0) {
+            /* Added for EMF support: Construct a list */
+            struct mk_list flb_intermediate_metrics;
+            mk_list_init(&flb_intermediate_metrics);
+
+            kv = map.via.map.ptr;
+
+            /* 
+             * Iterate through the record map, extract intermediate metric data, 
+             * and add to the list.
+             */
+            for (i = 0; i < map_size; i++) {
+                metric = flb_malloc(sizeof(struct flb_intermediate_metric));
+                metric->key = (kv + i)->key;
+                metric->value = (kv + i)->val;
+                metric->metric_type = intermediate_metric_type;
+                metric->metric_unit = intermediate_metric_unit;
+                metric->timestamp = tms;
+
+                mk_list_add(&metric->_head, &flb_intermediate_metrics);
+            }  
+
+            struct msgpack_object emf_payload = pack_emf_payload(ctx, 
+                                                                &flb_intermediate_metrics, 
+                                                                input_plugin, 
+                                                                tms);
+            flb_free(metric);
+            ret = add_event(ctx, buf, stream, &emf_payload, &tms);
+        } else {
+            ret = add_event(ctx, buf, stream, &map, &tms);
+        }
+
         if (ret < 0 ) {
             goto error;
         }

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -43,7 +43,7 @@
 
 void cw_flush_destroy(struct cw_flush *buf);
 
-int process_and_send(struct flb_cloudwatch *ctx, struct cw_flush *buf,
+int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, struct cw_flush *buf,
                      struct log_stream *stream,
                      const char *data, size_t bytes);
 int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -549,7 +549,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "metric_dimensions", NULL,
      0, FLB_FALSE, 0,
-     "Metric dimensions is a list of lsits. If you have only one list of "
+     "Metric dimensions is a list of lists. If you have only one list of "
      "dimensions, put the values as a comma seperated string. If you want to put "
      "list of lists, use the list as semicolon seperated strings. If your value "
      "is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]]."

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -549,7 +549,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "metric_dimensions", NULL,
      0, FLB_FALSE, 0,
-     "Metric dimensions is a list of lsit. If you have only one list of "
+     "Metric dimensions is a list of lsits. If you have only one list of "
      "dimensions, put the values as a comma seperated string. If you want to put "
      "list of lists, use the list as semicolon seperated strings. If your value "
      "is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]]."

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -136,6 +136,20 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         goto error;
     }
 
+    tmp = flb_output_get_property("metric_namespace", ins);
+    if (tmp)
+    {
+        flb_plg_info(ctx->ins, "Metric Namespace=%s", tmp);
+        ctx->metric_namespace = flb_sds_create(tmp);
+    }
+
+    tmp = flb_output_get_property("metric_dimensions", ins);
+    if (tmp)
+    {
+        flb_plg_info(ctx->ins, "Metric Dimensions=%s", tmp);
+        ctx->metric_dimensions = flb_utils_split(tmp, ';', 256);
+    }
+
     ctx->create_group = FLB_FALSE;
     tmp = flb_output_get_property("auto_create_group", ins);
     /* native plugins use On/Off as bool, the old Go plugin used true/false */
@@ -365,7 +379,38 @@ static void cb_cloudwatch_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    event_count = process_and_send(ctx, ctx->buf, stream, data, bytes);
+    buf = flb_calloc(1, sizeof(struct cw_flush));
+    if (!buf) {
+        flb_errno();
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /* TODO: could be more efficient in some cases with these memory allocs */
+    buf->out_buf = flb_malloc(sizeof(char) * PUT_LOG_EVENTS_PAYLOAD_SIZE);
+    if (!buf->out_buf) {
+        flb_errno();
+        cw_flush_destroy(buf);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+    buf->out_buf_size = PUT_LOG_EVENTS_PAYLOAD_SIZE;
+
+    buf->tmp_buf = flb_malloc(sizeof(char) * PUT_LOG_EVENTS_PAYLOAD_SIZE);
+    if (!buf->tmp_buf) {
+        flb_errno();
+        cw_flush_destroy(buf);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+    buf->tmp_buf_size = PUT_LOG_EVENTS_PAYLOAD_SIZE;
+
+    buf->events = flb_malloc(sizeof(struct event) * 1000);
+    if (!buf->events) {
+        flb_errno();
+        cw_flush_destroy(buf);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+    buf->events_capacity = 1000;
+
+    event_count = process_and_send(ctx, i_ins->p->name, buf, stream, data, bytes);
     if (event_count < 0) {
         flb_plg_error(ctx->ins, "Failed to send events");
         FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -124,6 +124,14 @@ struct flb_cloudwatch {
 
     /* buffers for data processing and request payload */
     struct cw_flush *buf;
+    /* The namespace to use for the metric */
+    flb_sds_t metric_namespace;
+
+    /* Metric dimensions is a list of lsit. If you have only one list of 
+    dimensions, put the values as a comma seperated string. If you want to put
+    list of lists, use the list as semicolon seperated strings. If your value
+    is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]]*/
+    struct mk_list *metric_dimensions;
 
     /* Plugin output instance reference */
     struct flb_output_instance *ins;

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -52,6 +52,17 @@ struct cw_flush {
     /* buffer used to temporarily hold an event during processing */
     char *event_buf;
     size_t event_buf_size;
+
+    /*
+     * According to the docs:
+     * PutLogEvents: 5 requests per second per log stream.
+     * Additional requests are throttled. This quota can't be changed.
+     * This plugin fast. A single flush might make more than 5 calls,
+     * Then fail, then retry, then be too fast again, on and on.
+     * I have seen this happen.
+     * So we throttle ourselves if more than 5 calls are made per flush
+     */
+    int put_events_calls;
 };
 
 struct cw_event {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -138,7 +138,7 @@ struct flb_cloudwatch {
     /* The namespace to use for the metric */
     flb_sds_t metric_namespace;
 
-    /* Metric dimensions is a list of lsit. If you have only one list of 
+    /* Metric dimensions is a list of lsits. If you have only one list of 
     dimensions, put the values as a comma seperated string. If you want to put
     list of lists, use the list as semicolon seperated strings. If your value
     is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]]*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,15 +128,6 @@ if(FLB_AWS)
     )
 endif()
 
-if(FLB_AWS)
-  set(src
-    ${src}
-    "aws/flb_aws_credentials.c"
-    "aws/flb_aws_credentials_sts.c"
-    "aws/flb_aws_util.c"
-    )
-endif()
-
 if(FLB_LUAJIT)
   set(src
     ${src}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,15 @@ if(FLB_AWS)
     )
 endif()
 
+if(FLB_AWS)
+  set(src
+    ${src}
+    "aws/flb_aws_credentials.c"
+    "aws/flb_aws_credentials_sts.c"
+    "aws/flb_aws_util.c"
+    )
+endif()
+
 if(FLB_LUAJIT)
   set(src
     ${src}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This changes will enable customers to send cpu and mem metrics to CloudWatch in EMF format.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
