### PR TITLE
in_tail: add more path delimiters to the sanitization list

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -516,7 +516,7 @@ static int tag_compose(char *tag, char *fname, char *out_buf, size_t *out_size,
 
         /* Sanitize buffer */
         for (i = 0; i < buf_s; i++) {
-            if (out_buf[i] == '/') {
+            if (out_buf[i] == '/' || out_buf[i] == '\\' || out_buf[i] == ':') {
                 if (i > 0) {
                     out_buf[i] = '.';
                 }


### PR DESCRIPTION
Unix and Windows use different characters as delimiters. Unix
uses `/`, and Windows uses `\`. Windows also uses `:` for drive
names.

This patch teaches Fluent Bit about both flavors of delimiters,
so that it can produce a pretty tag like:

    prefix.c.users.public.test.log

... not something like:

    prefix.c:\users\public\test\log

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>