### PR TITLE
upstream: fix segmentation fault on net.keepalive=yes

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -388,7 +388,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
     u = conn->u;
 
     /* If this is a valid KA connection just recycle */
-    if (conn->u->net.keepalive == FLB_TRUE && conn->recycle == FLB_TRUE) {
+    if (conn->u->net.keepalive == FLB_TRUE && conn->recycle == FLB_TRUE && conn->fd > -1) {
         /*
          * This connection is still useful, move it to the 'available' queue and
          * initialize variables.


### PR DESCRIPTION
Under heavy load, Fluent Bit sometimes crashes with the following
message.

    [upstream] KA connection #-1 to 127.0.0.1:24224 has been assigned (recycled)

This is obviously broken. This log suggests that file descriptor is
already closed (-1), so the keepalive mode should never recycle it.

This patch fixes the bug by adding check for closed connections.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
