### PR TITLE
record_accessor: fix parser to ignore dots in subkeys

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -91,6 +91,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
     int len;
     int pre = 0;
     int end = 0;
+    int quote_cnt;
     struct flb_ra_parser *rp;
     struct flb_ra_parser *rp_str = NULL;
 
@@ -184,8 +185,16 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
             continue;
         }
 
+        quote_cnt = 0;
         for (end = i + 1; end < len; end++) {
-            if (buf[end] == '.' || buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
+            if (buf[end] == '\'') {
+              ++quote_cnt;
+            }
+            else if (buf[end] == '.' && (quote_cnt & 0x01)) {
+              // ignore '.' if it is inside a string/subkey
+              continue;
+            }
+            else if (buf[end] == '.' || buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
                 break;
             }
         }

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -155,8 +155,71 @@ void cb_translate()
     msgpack_unpacked_destroy(&result);
 }
 
+void cb_dots_subkeys()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", \"kubernetes\": {\"annotations\": "
+        "{\"fluentbit.io/tag\": \"thetag\"}}}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = "$kubernetes['annotations']['fluentbit.io/tag']";
+
+    fmt_out = "thetag";
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, out_buf, out_size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+}
+
 TEST_LIST = {
-    { "keys"       , cb_keys},
-    { "translate"  , cb_translate},
+    { "keys"        , cb_keys},
+    { "translate"   , cb_translate},
+    { "dots_subkeys", cb_dots_subkeys},
     { NULL }
 };

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -185,7 +185,7 @@ void cb_dots_subkeys()
     }
 
     /* Formatter */
-    fmt = "$kubernetes['annotations']['fluentbit.io/tag']";
+    fmt = flb_sds_create("$kubernetes['annotations']['fluentbit.io/tag']");
 
     fmt_out = "thetag";
 


### PR DESCRIPTION
This fixes record accessor `ra_parse_buffer` to allow dots inside subkeys.

Fixes https://github.com/fluent/fluent-bit/issues/2151

Test results:
```
./build/bin/flb-it-record_accessor
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a

type       : STRING
string     : ' extra '

type       : KEYMAP
key name   : bbb
 - subkey  : b

type       : STRING
string     : ' final access'

=== test ===
type       : KEYMAP
key name   : b
 - subkey  : x
 - subkey  : y

=== test ===
type       : KEYMAP
key name   : z

=== test ===
type       : STRING
string     : 'abc'
[2020/05/22 02:43:54] [error] [record accessor] syntax error, unexpected $end, expecting ']' at '$abc['a''
[   OK   ]
Test translate...                               == input ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
== output ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
[   OK   ]
Test dots_subkeys...                            == input ==
thetag
== output ==
thetag
[   OK   ]
SUCCESS: All unit tests have passed.
```

Example configuration file:
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    Parsers_File parsers.conf

[INPUT]
    Name          dummy
    Dummy         {"key1": "something", "kubernetes": {"annotations": {"fluentbit.io/tag": "thetag"}}}
    Rate          1
    Tag           dummy

[FILTER]
    Name   rewrite_tag
    Match  dummy
    Rule   $kubernetes['annotations']['fluentbit.io/tag']  ^([a-zA-Z0-9]+)$  kube.tag.$1.$TAG[3].$TAG[4]  false

[OUTPUT]
    Name  stdout
    Match *
```

Valgrind output:
```
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/05/22 02:55:30] [ info] [storage] version=1.0.4, initializing...
[2020/05/22 02:55:30] [ info] [storage] in-memory
[2020/05/22 02:55:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/05/22 02:55:30] [ info] [engine] started (pid=16591)
[2020/05/22 02:55:30] [ info] [sp] stream processor started
==16591== Warning: client switching stacks?  SP change: 0x1ffeffff78 --> 0x5cfdb80
==16591==          to suppress, use: --max-stackframe=137324667896 or greater
==16591== Warning: client switching stacks?  SP change: 0x5cfdaf8 --> 0x1ffeffff78
==16591==          to suppress, use: --max-stackframe=137324668032 or greater
==16591== Warning: client switching stacks?  SP change: 0x1ffeffff78 --> 0x5cfdaf8
==16591==          to suppress, use: --max-stackframe=137324668032 or greater
==16591==          further instances of this message will not be shown.
[0] kube.tag.thetag..: [1590116130.568567272, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116131.594647996, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116132.559524968, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116133.559467571, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116134.559718987, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116135.558869431, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
[0] kube.tag.thetag..: [1590116136.560546254, {"key1"=>"something", "kubernetes"=>{"annotations"=>{"fluentbit.io/tag"=>"thetag"}}}]
^C[engine] caught signal (SIGINT)
[2020/05/22 02:55:38] [ info] [input] pausing emitter_for_rewrite_tag.0
==16591== 
==16591== HEAP SUMMARY:
==16591==     in use at exit: 0 bytes in 0 blocks
==16591==   total heap usage: 2,760 allocs, 2,760 frees, 5,243,736 bytes allocated
==16591== 
==16591== All heap blocks were freed -- no leaks are possible
==16591== 
==16591== For counts of detected and suppressed errors, rerun with: -v
==16591== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
