### PR TITLE
scheduler: fix infinite loop bug on Windows

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -323,8 +323,10 @@ int flb_sched_request_destroy(struct flb_config *config,
      */
     flb_sched_timer_invalidate(timer);
 
+#ifndef FLB_SYSTEM_WINDOWS
     /* Close pipe after invalidating timer */
     flb_pipe_close(req->fd);
+#endif
 
     /* Remove request */
     flb_free(req);


### PR DESCRIPTION
The request object and its event object hold a reference to the
same file descriptor. As such, if we call close(2) on one reference,
it implicitly invalidates another reference.

This design is potentially dangerous. Since Windows can reuse the
descriptor number immediately after the first close call.

For example, consider the following case:

      close(req->fd)           // close fd:601
      fd = open("other_file")  // return fd:601 (reused)
      close(event->fd)         // ???

The second close(2) can close an unrelated file, which may well be
an important fd for the core engine.

I believe this is the root cause of "Windows enters busy loop under
heavy load" issue reported by Thomas Heggelund.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
