### PR TITLE
Added if around db usage

### DIFF
--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -171,10 +171,12 @@ static int tail_fs_check(struct flb_input_instance *ins,
             file->buf_len = 0;
             memcpy(&fst->st, &st, sizeof(struct stat));
 
+#ifdef FLB_HAVE_SQLDB
             /* Update offset in database file */
             if (ctx->db) {
                 flb_tail_db_file_offset(file, ctx);
             }
+#endif
         }
 
         if (file->offset < st.st_size) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added an if clause around a db usage in an input plugin.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A ] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
