### PR TITLE
parser: fix segmentation fault on "Types" option

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -526,7 +526,7 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
         time_offset = get_parser_key("Time_Offset", config, section);
 
         /* Types */
-        types_str = mk_rconf_section_get_key(section, "Types", MK_RCONF_STR);
+        types_str = get_parser_key("Types", config, section);
         if (types_str) {
             types_len = proc_types_str(types_str, &types);
         }


### PR DESCRIPTION
Thomas Heggelund reported a segmentation fault issue on the "Types"
option. His configuration was:

    [PARSER]
        Name    dips-log4net-multiline
        Format  regex
        Regex   ^(?<test>.*)$
        Types test:integer

It turned out that c197f1c1 introduced a new method get_parser_key()
but forgot to apply that change to some option.

Due to this inconsistency, it ended up calling flb_sds_destroy() on a
plain char*. Resolve that issue by fixing the inconsistent key
retrieval.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
