### PR TITLE
upstream: fix a segfault bug in flb_upstream_conn_release()

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -402,6 +402,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
          * notified if the 'available keepalive connection' gets disconnected by
          * the remote endpoint we need to add it again.
          */
+        MK_EVENT_NEW(&conn->event);
         conn->event.handler = cb_upstream_conn_ka_dropped;
         conn->event.data    = &conn;
 


### PR DESCRIPTION
Make sure to clear dirty state from the previous connection
before reusing an event object.

It was confusing mk_core to double-delete an already deleted event,
resulting in random crash on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>