### PR TITLE
lib: monkey: declare mk_plugin_$(name) struct as extern

### DIFF
--- a/lib/monkey/plugins/CMakeLists.txt
+++ b/lib/monkey/plugins/CMakeLists.txt
@@ -57,7 +57,7 @@ macro(MK_BUILD_PLUGIN name)
       # struct reference on mk_static_plugins.h
       set(static_plugins "${static_plugins}monkey-${name}-static;")
       set(STATIC_PLUGINS_INIT "${STATIC_PLUGINS_INIT}\n    p = &mk_plugin_${name};\n    mk_list_add(&p->_head, plugins);\n")
-      set(STATIC_PLUGINS_DECL "${STATIC_PLUGINS_DECL}struct mk_plugin mk_plugin_${name};\n")
+      set(STATIC_PLUGINS_DECL "${STATIC_PLUGINS_DECL}extern struct mk_plugin mk_plugin_${name};\n")
 
       # append message to stdout
       set(mode "[== static ==]")


### PR DESCRIPTION
Declare `mk_plugin_$(name)` struct as `extern`.

Without specifying `extern`, the symbol(`mk_plugin_liana` in our case) will be multiply defined, as a new instance of the variable will be defined in every file that header is included in and it won't be initialized.  This causes the plugin not being registered properly and crashes the metrics server when the metrics endpoint is hit.
```
[2020/05/26 22:08:31] [Warning] Plugin 'null' is not registering all fields properly
```
This problem manifests in our home grown build system, but not outside, so it's not easy to reproduce, but I think this fix makes sense in general. 

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/a] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
