### PR TITLE
out_stackdriver: add 'operation' field to the entries

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -2,6 +2,7 @@ set(src
   gce_metadata.c
   stackdriver_conf.c
   stackdriver.c
+  stackdriver_operation.c
   )
 
 FLB_PLUGIN(out_stackdriver "${src}" "")

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -46,6 +46,8 @@
 /* Default Resource type */
 #define FLB_SDS_RESOURCE_TYPE "global"
 
+#define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -1,0 +1,144 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_operation.h"
+
+typedef enum {
+    NO_OPERATION = 1,
+    OPERATION_EXISTED = 2
+} operation_status;
+
+
+void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
+                         int *operation_first, int *operation_last, 
+                         msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 9);
+    msgpack_pack_str_body(mp_pck, "operation", 9);
+    msgpack_pack_map(mp_pck, 4);
+    msgpack_pack_str(mp_pck, 2);
+    msgpack_pack_str_body(mp_pck, "id", 2);
+    msgpack_pack_str(mp_pck, flb_sds_len(*operation_id));
+    msgpack_pack_str_body(mp_pck, *operation_id, flb_sds_len(*operation_id));
+    msgpack_pack_str(mp_pck, 8);
+    msgpack_pack_str_body(mp_pck, "producer", 8);
+    msgpack_pack_str(mp_pck, flb_sds_len(*operation_producer));
+    msgpack_pack_str_body(mp_pck, *operation_producer, flb_sds_len(*operation_producer));
+    msgpack_pack_str(mp_pck, 5);
+    msgpack_pack_str_body(mp_pck, "first", 5);
+    if (*operation_first == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+    
+    msgpack_pack_str(mp_pck, 4);
+    msgpack_pack_str_body(mp_pck, "last", 4);
+    if (*operation_last == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+}
+
+/* Return true if operation extracted */
+int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
+                      int *operation_first, int *operation_last, 
+                      msgpack_object *obj, int *extra_subfields)
+{
+    operation_status op_status = NO_OPERATION;
+
+    if (obj->via.map.size != 0) {    	
+        msgpack_object_kv *p = obj->via.map.ptr;
+        msgpack_object_kv *const pend = obj->via.map.ptr + obj->via.map.size;
+
+        for (; p < pend && op_status == NO_OPERATION; ++p) {
+            if (p->val.type == MSGPACK_OBJECT_MAP && p->key.type == MSGPACK_OBJECT_STR
+                && strncmp(OPERATION_FIELD_IN_JSON, p->key.via.str.ptr, p->key.via.str.size) == 0) {
+                
+                op_status = OPERATION_EXISTED;
+                msgpack_object sub_field = p->val;
+                
+                msgpack_object_kv *tmp_p = sub_field.via.map.ptr;
+                msgpack_object_kv *const tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+                /* Validate the subfields of operation */
+                for (; tmp_p < tmp_pend; ++tmp_p) {
+                    if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                        continue;
+                    }
+                    if (strncmp("id", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
+                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+                            continue;
+                        }
+                        *operation_id = flb_sds_copy(*operation_id, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
+                    }
+                    else if (strncmp("producer", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
+                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+                            continue;
+                        }
+                        *operation_producer = flb_sds_copy(*operation_producer, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
+                    }
+                    else if (strncmp("first", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
+                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
+                            continue;
+                        }
+                        if (tmp_p->val.via.boolean) {
+                            *operation_first = FLB_TRUE;
+                        }
+                    }
+                    else if (strncmp("last", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
+                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
+                            continue;
+                        }
+                        if (tmp_p->val.via.boolean) {
+                            *operation_last = FLB_TRUE;
+                        }
+                    }
+                    else {
+                        /* extra sub-fields */ 
+                        *extra_subfields += 1;
+                    }
+
+                }
+            }
+        }
+    }
+    
+    return op_status == OPERATION_EXISTED;
+}
+
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields) {
+    msgpack_object_kv *p = operation->via.map.ptr;
+    msgpack_object_kv *const pend = operation->via.map.ptr + operation->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (strncmp("id", p->key.via.str.ptr, p->key.via.str.size) != 0 
+            && strncmp("producer", p->key.via.str.ptr, p->key.via.str.size) != 0
+            && strncmp("first", p->key.via.str.ptr, p->key.via.str.size) != 0
+            && strncmp("last", p->key.via.str.ptr, p->key.via.str.size) != 0) {
+            msgpack_pack_object(mp_pck, p->key);
+            msgpack_pack_object(mp_pck, p->val);
+        }
+    }
+
+}

--- a/plugins/out_stackdriver/stackdriver_operation.h
+++ b/plugins/out_stackdriver/stackdriver_operation.h
@@ -1,0 +1,36 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_OPERATION_H
+#define FLB_STD_OPERATION_H
+
+#include "stackdriver.h"
+
+void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
+                         int *operation_first, int *operation_last, 
+                         msgpack_packer *mp_pck);
+
+int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
+                      int *operation_first, int *operation_last, 
+                      msgpack_object *obj, int *extra_subfields);
+
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields);
+
+
+#endif

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -57,6 +57,7 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_STDOUT       "out_stdout.c")
   FLB_RT_TEST(FLB_OUT_STACKDRIVER  "out_stackdriver.c")
   FLB_RT_TEST(FLB_OUT_TD           "out_td.c")
+
 endif()
 
 

--- a/tests/runtime/data/stackdriver/stackdriver_test_operation.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_operation.h
@@ -1,0 +1,62 @@
+#define OPERATION_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"test_id\","          \
+            "\"producer\": \"test_producer\","      \
+            "\"first\": true,"      \
+            "\"last\": true"       \
+        "}"     \
+	"}]"
+
+#define EMPTY_OPERATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define OPERATION_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/operation\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_SUBFIELDS	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"first\": false,"      \
+            "\"last\": false"       \
+        "}"     \
+	"}]"
+
+#define SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": 123,"          \
+            "\"producer\": true,"      \
+            "\"first\": \"some string\","      \
+            "\"last\": 123"       \
+        "}"     \
+	"}]"
+
+#define EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"test_id\","          \
+            "\"producer\": \"test_producer\","      \
+            "\"first\": true,"      \
+            "\"last\": true,"       \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -30,6 +30,7 @@
 
 /* JSON payload example */
 #include "data/stackdriver/json.h"
+#include "data/stackdriver/stackdriver_test_operation.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -76,8 +77,7 @@ static int mp_kv_cmp(char *json_data, size_t json_len, char *key_accessor, char 
         flb_error("invalid record accessor key, aborting test");
         goto out;
     }
-
-    /* Process map using the record_accessor */
+    
     rval = flb_ra_get_value_object(ra, map);
     TEST_CHECK(rval != NULL);
     msgpack_unpacked_destroy(&result);
@@ -89,6 +89,183 @@ static int mp_kv_cmp(char *json_data, size_t json_len, char *key_accessor, char 
     TEST_CHECK(rval->type == FLB_RA_STRING);
     if (strcmp(rval->val.string, val) == 0) {
         ret = FLB_TRUE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_cmp_integer(char *json_data, size_t json_len, char *key_accessor, int64_t val)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    TEST_CHECK(rval != NULL);
+    msgpack_unpacked_destroy(&result);
+    if (!rval) {
+        goto out;
+    }
+
+    TEST_CHECK(rval->type == FLB_RA_INT);
+    if (rval->val.i64 == val) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_cmp_boolean(char *json_data, size_t json_len, char *key_accessor, bool val)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    TEST_CHECK(rval != NULL);
+    msgpack_unpacked_destroy(&result);
+    if (!rval) {
+        goto out;
+    }
+
+    TEST_CHECK(rval->type == FLB_RA_BOOL);
+    if (rval->val.boolean == val) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_exists(char *json_data, size_t json_len, char *key_accessor)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    msgpack_unpacked_destroy(&result);
+    if (rval) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
     }
 
  out:
@@ -138,6 +315,174 @@ static void cb_check_gce_instance(void *ctx, int ffd,
     /* instance_id */
     ret = mp_kv_cmp(res_data, res_size,
                     "$resource['labels']['instance_id']", "333222111");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_common_case(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "test_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "test_producer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_operation(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_in_string(void *ctx, int ffd,
+                                         int res_ret, void *res_data, size_t res_size,
+                                         void *data)
+{
+    int ret;
+
+    /* 'operation' is not a map, won't be extracted from jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+
+static void cb_check_operation_partial_subfields(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_incorrect_type_subfields(void *ctx, int ffd,
+                                                        int res_ret, void *res_data, size_t res_size,
+                                                        void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_extra_subfields(void *ctx, int ffd,
+                                               int res_ret, void *res_data, size_t res_size,
+                                               void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "test_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "test_producer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key3']", true);
     TEST_CHECK(ret == FLB_TRUE);
 
     flb_sds_destroy(res_data);
@@ -224,9 +569,255 @@ void flb_test_resource_gce_instance()
     flb_destroy(ctx);
 }
 
+void flb_test_operation_common()
+{
+    int ret;
+    int size = sizeof(OPERATION_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_common_case,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) OPERATION_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_operation()
+{
+    int ret;
+    int size = sizeof(EMPTY_OPERATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_operation,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_OPERATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_in_string()
+{
+    int ret;
+    int size = sizeof(OPERATION_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_in_string,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) OPERATION_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_SUBFIELDS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_partial_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_SUBFIELDS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_incorrect_type_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_extra_subfields()
+{
+    int ret;
+    int size = sizeof(EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_extra_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
-    {"resource_global"      , flb_test_resource_global },
+    {"resource_global", flb_test_resource_global },
     {"resource_gce_instance", flb_test_resource_gce_instance },
+    {"operation_common_case", flb_test_operation_common},
+    {"empty_operation", flb_test_empty_operation},
+    {"operation_not_a_map", flb_test_operation_in_string},
+    {"operation_partial_subfields", flb_test_operation_partial_subfields},
+    {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
+    {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as operation and sourceLocation.

This patch enables the stackdriver to extract 'operation' field from the jsonPayload and add it to the entries sent to the Google Logging Agent APIs.

Besides, the unit tests for `operation` are added.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [check] Example configuration file for the change
- [check] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [check] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
-  Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
