### PR TITLE
filter_kubernetes: Tweak FLB_KUBE_TAG_PREFIX for Windows

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -59,7 +59,11 @@
  * Default expected Kubernetes tag prefix, this is used mostly when source
  * data comes from in_tail with custom tags like: kube.service.*
  */
+#ifdef FLB_SYSTEM_WINDOWS
+#define FLB_KUBE_TAG_PREFIX "kube.c.var.log.containers."
+#else
 #define FLB_KUBE_TAG_PREFIX "kube.var.log.containers."
+#endif
 
 struct kube_meta;
 


### PR DESCRIPTION
A typical setup on Windows pods includes something like this:

```
[INPUT]
    Name Tail
    Path c:\var\log\containers\*
    Tag  kube.*
```

In this case, in_tail emits events with a tag prefixed with
"kube.c.var.log.containers". Let's make it the default value
on Windows build.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>