### PR TITLE
sp: fix group-by matching rule for string values

### DIFF
--- a/src/stream_processor/flb_sp_groupby.c
+++ b/src/stream_processor/flb_sp_groupby.c
@@ -24,6 +24,7 @@
 int flb_sp_groupby_compare(const void *lhs, const void *rhs)
 {
     int i;
+    int strcmp_result;
     struct aggr_node *left = (struct aggr_node *) lhs;
     struct aggr_node *right = (struct aggr_node *) rhs;
     struct aggr_num *lval;
@@ -68,7 +69,10 @@ int flb_sp_groupby_compare(const void *lhs, const void *rhs)
             }
         }
         else if (lval->type == FLB_SP_STRING && rval->type == FLB_SP_STRING) {
-            return strcmp((const char *) lval->string, (const char *) rval->string);
+            strcmp_result = strcmp((const char *) lval->string, (const char *) rval->string);
+            if (strcmp_result != 0) {
+              return strcmp_result;
+            }
         }
         else { /* Sides have different types */
             return -1;


### PR DESCRIPTION
Signed-off-by: Masoud Koleini <masoud.koleini@arm.com>

Fixes the bug in GROUP BY string comparison.

fixes https://github.com/fluent/fluent-bit/issues/1794

output for the sample provided in the issue:
```
[0] bind_sp_1: [1591243567.965556140, {"query_domain_name"=>"google.com", "query_type"=>"A", "hits"=>2}]
[1] bind_sp_1: [1591243567.965565394, {"query_domain_name"=>"facebook.com", "query_type"=>"A", "hits"=>2}]
[2] bind_sp_1: [1591243567.965567060, {"query_domain_name"=>"google.com", "query_type"=>"AAAA", "hits"=>2}]
[3] bind_sp_1: [1591243567.965568394, {"query_domain_name"=>"facebook.com", "query_type"=>"CNAME", "hits"=>2}]
```

Valgrind output:
```
==23092== Memcheck, a memory error detector
==23092== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23092== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==23092== Command: ./build/bin/fluent-bit -c conf/bug.conf
==23092== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/06/04 06:04:48] [ info] [storage] version=1.0.4, initializing...
[2020/06/04 06:04:48] [ info] [storage] in-memory
[2020/06/04 06:04:48] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/06/04 06:04:48] [ info] [engine] started (pid=23092)
[2020/06/04 06:04:48] [ info] [sp] stream processor started
[2020/06/04 06:04:48] [ info] [sp] registered task: bind_sp_1
[2020/06/04 06:04:48] [ info] inotify_fs_add(): inode=1843611 watch_fd=1 name=/home/m/fluent-bit/dns_bind.log
==23092== Warning: client switching stacks?  SP change: 0x1ffeffff48 --> 0x5d31bf0
==23092==          to suppress, use: --max-stackframe=137324454744 or greater
==23092== Warning: client switching stacks?  SP change: 0x5d31b68 --> 0x1ffeffff48
==23092==          to suppress, use: --max-stackframe=137324454880 or greater
==23092== Warning: client switching stacks?  SP change: 0x1ffeffff48 --> 0x5d31b68
==23092==          to suppress, use: --max-stackframe=137324454880 or greater
==23092==          further instances of this message will not be shown.
[0] bind_sp_1: [1591250689.967288190, {"query_domain_name"=>"google.com", "query_type"=>"A", "hits"=>2}]
[1] bind_sp_1: [1591250689.970829049, {"query_domain_name"=>"facebook.com", "query_type"=>"A", "hits"=>2}]
[2] bind_sp_1: [1591250689.970854882, {"query_domain_name"=>"google.com", "query_type"=>"AAAA", "hits"=>2}]
[3] bind_sp_1: [1591250689.970873570, {"query_domain_name"=>"facebook.com", "query_type"=>"CNAME", "hits"=>2}]
^C[engine] caught signal (SIGINT)
[2020/06/04 06:04:53] [ info] [input] pausing bind_raw_log
[2020/06/04 06:04:53] [ info] [input] pausing bind_sp_1
[2020/06/04 06:04:53] [ info] inotify_fs_remove(): inode=1843611 watch_fd=1
==23092== 
==23092== HEAP SUMMARY:
==23092==     in use at exit: 0 bytes in 0 blocks
==23092==   total heap usage: 2,851 allocs, 2,851 frees, 1,160,469 bytes allocated
==23092== 
==23092== All heap blocks were freed -- no leaks are possible
==23092== 
==23092== For counts of detected and suppressed errors, rerun with: -v
==23092== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
