### PR TITLE
filter_parser: cancel parsing if one parser is matched when Reserve_Data is enabled

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -295,8 +295,8 @@ static int cb_parser_filter(const void *data, size_t bytes,
                             }
                             else {
                                 continue_parsing = FLB_FALSE;
-                                break;
                             }
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
To fix #2250 

filter_parser supports multiple parsers.
However the behavior is different depending on `Reserve_Data` property when some parsers matched.
If `Reserve_Data` is enabled, filter_parser tries to parse "all" parser configuration even if one of them is matched.

Configuration and the expected behavior is here.
https://github.com/fluent/fluent-bit/issues/2250#issuecomment-643550026


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [*] Example configuration file for the change
- [*] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [*] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Debug log and Valgrind output
```
$ valgrind bin/fluent-bit -c 2250/tmp/a.conf 
==72428== Memcheck, a memory error detector
==72428== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==72428== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==72428== Command: bin/fluent-bit -c 2250/tmp/a.conf
==72428== 
Fluent Bit v1.5.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/06/13 12:30:19] [ info] [storage] version=1.0.4, initializing...
[2020/06/13 12:30:19] [ info] [storage] in-memory
[2020/06/13 12:30:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/06/13 12:30:19] [ info] [engine] started (pid=72428)
[2020/06/13 12:30:19] [ info] [sp] stream processor started
[0] dummy.0: [1592019020.350044381, {"one"=>"hoge", "original"=>"hoge"}]
[1] dummy.0: [1592019021.317029670, {"one"=>"hoge", "original"=>"hoge"}]
[2] dummy.0: [1592019022.316339743, {"one"=>"hoge", "original"=>"hoge"}]
[3] dummy.0: [1592019023.317252126, {"one"=>"hoge", "original"=>"hoge"}]
^C[engine] caught signal (SIGINT)
==72428== 
==72428== HEAP SUMMARY:
==72428==     in use at exit: 0 bytes in 0 blocks
==72428==   total heap usage: 492 allocs, 492 frees, 1,136,554 bytes allocated
==72428== 
==72428== All heap blocks were freed -- no leaks are possible
==72428== 
==72428== For counts of detected and suppressed errors, rerun with: -v
==72428== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
