### PR TITLE
out_gelf: accept possible level values

### DIFF
--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -548,9 +548,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                 key_len = 5;
                 if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                     if ( v->via.u64 > 7 ) {
-                        flb_error("[flb_msgpack_to_gelf] level is %" PRIu64 ", "
+                        flb_warn("[flb_msgpack_to_gelf] level is %" PRIu64 ", "
                                   "but should be in 0..7 or a syslog keyword", v->via.u64);
-                        return NULL;
                     }
                 }
                 else if (v->type == MSGPACK_OBJECT_STR) {
@@ -578,9 +577,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                             }
                         }
                         if (allowed_levels[n] == NULL) {
-                            flb_error("[flb_msgpack_to_gelf] level is '%.*s', "
+                            flb_warn("[flb_msgpack_to_gelf] level is '%.*s', "
                                       "but should be in 0..7 or a syslog keyword", val_len, val);
-                            return NULL;
                         }
                     }
                 }

--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -582,6 +582,10 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                         }
                     }
                 }
+                else {
+                    flb_error("[flb_msgpack_to_gelf] level must be a non-negative integer or a string");
+                    return NULL;
+                }
             }
             else if ((key_len == full_message_key_len) &&
                      !strncmp(key, full_message_key, full_message_key_len)) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
As discussed with myself in https://github.com/fluent/fluent-bit/issues/2256, the restrictions on log level in GELF is a **should**, and also it is an optional field; so it doesn't seem to have a hard restriction on level value, as Graylog accepts the non-standard levels.
So I changed the attempt to be some kind of best-effort to match with standards, but if it's not, send it anyway and just throw a warning.

This PR also adds invocation of an error when level is not a string or a non-negative integer (As I haven't seen any negative log level and I think other data types mustn't be valid, yes?)

----

**Testing**
- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
