### PR TITLE
Update permissions of dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     bison
 
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
+RUN chmod 777 /fluent-bit/log
 COPY . /tmp/src/
 RUN rm -rf /tmp/src/build/*
 


### PR DESCRIPTION
Adjust permissions of storage location so fluent-bit can run as a non-root user.  E.g.
```
docker run -v ${PWD}/configs/fluent/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro -v ${PWD}/logs:/app/logs -p 24223:24224 -u ${UID}:${GID} docker.io/fluent/fluent-bit:1.4
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
