### PR TITLE
build: Generate PDB on Microsoft Visual C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ endif()
 if (MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
+  # Generate a PDB file.
+  set(CMAKE_C_FLAGS "$(CMAKE_C_FLAGS) /Zi")
+  set(CMAKE_EXE_LINKER_FLAGS "$(CMAKE_EXE_LINKER_FLAGS) /Debug /Zf")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -334,6 +334,13 @@ if(FLB_BINARY)
     ENABLE_EXPORTS ON)
   install(TARGETS fluent-bit-bin RUNTIME DESTINATION ${FLB_INSTALL_BINDIR})
 
+  # Include PDB file (if available)
+  if (MSVC)
+    install(FILES $<TARGET_PDB_FILE:fluent-bit-bin>
+      DESTINATION "${FLB_INSTALL_BINDIR}"
+      OPTIONAL)
+  endif()
+
   # Detect init system, install upstart, systemd or init.d script
   if(IS_DIRECTORY /lib/systemd/system)
     set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")


### PR DESCRIPTION
Sean Fausett pointed out that the current Windows release does
not include a debug symbol file. This makes it hard for our
users to analyze a crash dump.

This commit enables the PDB generation, and teaches CMake to
include the symbol file into the release distribution.

    td-agent-bit-1.5.0-win32/bin/
    ├── fluent-bit.dll
    ├── fluent-bit.exe
    └── fluent-bit.pdb

The original issue is #2251.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
