### PR TITLE
aws: Make "aws" module compilable on Windows

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -78,6 +78,15 @@ static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
     return result;
 }
 
+static inline char *ctime_r(const time_t *timep, char *result)
+{
+    char *tmp = ctime(timep);
+    if (tmp == NULL) {
+        return NULL;
+    }
+    return strcpy(result, tmp);
+}
+
 /*
  * We can't just define localtime_r here, since mk_core/mk_utils.c is
  * exposing a symbol with the same name inadvertently.

--- a/src/aws/flb_aws_credentials_profile.c
+++ b/src/aws/flb_aws_credentials_profile.c
@@ -29,7 +29,6 @@
 
  #include <sys/types.h>
  #include <sys/stat.h>
- #include <unistd.h>
  #include <ctype.h>
 
 #define ACCESS_KEY_PROPERTY_NAME            "aws_access_key_id"


### PR DESCRIPTION
@PettitWesley The changes required are actually small.

 - Add a compat implementation for ctime_r(3)
 - Don't include <unistd.h>

I tested on Visual Studio 2019 that aws/flb_*.c compiles fine with
this patch.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>