### PR TITLE
filter_kubernetes: Support config of endpoint path in Kube_URL.

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -50,10 +50,11 @@
  */
 #define FLB_MERGE_BUF_SIZE  2048  /* 2KB */
 
-/* Kubernetes API server info */
-#define FLB_API_HOST  "kubernetes.default.svc"
-#define FLB_API_PORT  443
-#define FLB_API_TLS   FLB_TRUE
+/* Kubernetes API default endpoint info */
+#define FLB_KUBE_API_HOST  "kubernetes.default.svc"
+#define FLB_KUBE_API_PORT  443
+#define FLB_KUBE_API_TLS   FLB_TRUE
+#define FLB_KUBE_API_PATH  "/api/v1"
 
 /*
  * Default expected Kubernetes tag prefix, this is used mostly when source
@@ -73,6 +74,7 @@ struct flb_kube {
     char *api_host;
     int api_port;
     int api_https;
+    char *api_path;
     int use_journal;
     int labels;
     int annotations;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -218,7 +218,7 @@ static int get_api_server_info(struct flb_kube *ctx,
 
         ret = snprintf(uri, sizeof(uri) - 1,
                        FLB_KUBE_API_FMT,
-                       namespace, podname);
+                       ctx->api_path, namespace, podname);
         if (ret == -1) {
             flb_upstream_conn_release(u_conn);
             return -1;

--- a/plugins/filter_kubernetes/kube_meta.h
+++ b/plugins/filter_kubernetes/kube_meta.h
@@ -51,9 +51,7 @@ struct flb_kube_meta {
 #define FLB_KUBE_NAMESPACE "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 #define FLB_KUBE_TOKEN "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #define FLB_KUBE_CA "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-#define FLB_KUBE_API_HOST "kubernetes.default.svc"
-#define FLB_KUBE_API_PORT 443
-#define FLB_KUBE_API_FMT "/api/v1/namespaces/%s/pods/%s"
+#define FLB_KUBE_API_FMT "%s/namespaces/%s/pods/%s"
 
 int flb_kube_meta_init(struct flb_kube *ctx, struct flb_config *config);
 int flb_kube_meta_fetch(struct flb_kube *ctx);

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -675,11 +675,11 @@ static struct flb_config_map config_map[] = {
      "keep original log content if it was successfully parsed and merged"
     },
 
-    /* Full Kubernetes API server URL */
+    /* Kubernetes API endpoint URL */
     {
      FLB_CONFIG_MAP_STR, "kube_url", "https://kubernetes.default.svc",
      0, FLB_FALSE, 0,
-     "Kubernetes API server URL"
+     "Kubernetes API endpoint URL (path defaulting to /api/v1)"
     },
 
     /*

--- a/tests/runtime/filter_kubernetes.md
+++ b/tests/runtime/filter_kubernetes.md
@@ -1,8 +1,10 @@
 # Filter Kubernetes Tests
 
-The tests implemented on [filter_kubernets.c]() file aims to take different Kubernetes Pod log files (formats) and play with different setups. These files resides in the [data/kubernetes]() directory and each .log file have it corresponding .meta  which contains the metadata associated with the Pod.
+The tests implemented in [filter_kubernetes.c]() aim to take different Kubernetes Pod log files (formats) and play with different setups. These files reside in the [data/kubernetes]() directory and each .log file has a corresponding .meta file which contains the metadata associated with the Pod.
 
-The unit test implements a fake Kubernetes API server to expose .meta files when the filter query for such data. This make things easier to test without to spawn a real cluster.
+The unit test implements a fake Kubernetes API server to expose .meta files when the filter queries for such data. This makes things easier to test without spawning a real cluster.
+
+It also means the tests do not cover code used when connecting to a real cluster but they verify related config is processed without error and additional details can be verified manually by changing the LOG_LEVEL preprocessor constant temporarily.
 
 If you find that a specific test is missing, don't hesitate to open an issue on our Github repository.
 


### PR DESCRIPTION
The motivation is to make it possible to test config against a rancher cluster
before deployment.

Also fix a bug that the default port is only correct for the default protocol
i.e. HTTPS but also used incorrectly when Kube_URL is configured with http: and
no port. RFC-1738 dictates that the port is 80 in that case.

On the other hand, for backward compatibility the same default path is applied
if none is specified. If you really want none then specify the root /. In other
cases a trailing / is ignored and always inserted when the URL is used later.

The default path is extracted to FLB_KUBE_API_PATH. Similar constants are now
only defined in kube_conf.h, Unused duplicates in kube_meta.h have been removed
but the names were better so now used kube_conf.h.

Signed-off-by: Jim Wright <jim@wright.cz>

<!-- Provide summary of changes -->

- plugin code changes described above
- extension of unit test - not much can be automatically checked but test cases that exercise the code are there and that helps during development

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

None AFAIK but it is possible someone reported the port issue as a bug.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
