### PR TITLE
out_forward: add tag overwrite mode

### DIFF
--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -46,6 +46,7 @@ struct flb_forward_config {
     /* config */
     flb_sds_t shared_key;     /* shared key                   */
     flb_sds_t self_hostname;  /* hostname used in certificate  */
+    flb_sds_t tag;            /* Overwrite tag on forward */
     int empty_shared_key;     /* use an empty string as shared key */
     int require_ack_response; /* Require acknowledge for "chunk" */
     int send_options;         /* send options in messages */


### PR DESCRIPTION
Add a tag overwrite configuration to the forward output.
This allows unconditionally overwriting a specific tag.

It is useful in a scenario such as:

	[OUTPUT]
	    Name            forward
	    Match           kube.*
	    Host            logs.DOMAIN
	    Port            24224
	    Self_hostname   ${HOSTNAME}
	    Tag      cluster.kube.__CLUSTER__
	    tls             on
	    tls.verify      on
	    tls.debug 2
	    tls.crt_file    /etc/certs/ca.crt
	    tls.key_file    /etc/certs/ca.key

where fluent-bit is used to forward logs to a central aggregator,
but we wish to overwrite a specific tag to indicate the source cluster.

Signed-off-by: Don Bowman <don@agilicus.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
