### PR TITLE
http_server: metrics: prometheus: add fluentbit_build_info metric (#2…

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_version.h>
 #include "metrics.h"
 
 #include <fluent-bit/flb_http_server.h>
@@ -392,6 +393,25 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     null_check(tmp_sds);
     tmp_sds = flb_sds_cat(sds, "\n", 1);
     null_check(tmp_sds);
+
+    /* Attach fluentbit_build_info metric. */
+    tmp_sds = flb_sds_cat(sds, "# HELP fluentbit_build_info Build version information.\n", 55);
+    null_check(tmp_sds);
+    tmp_sds = flb_sds_cat(sds, "# TYPE fluentbit_build_info gauge\n", 34);
+    null_check(tmp_sds);
+    tmp_sds = flb_sds_cat(sds, "fluentbit_build_info{version=\"", 30);
+    null_check(tmp_sds);
+    tmp_sds = flb_sds_cat(sds, FLB_VERSION_STR, sizeof(FLB_VERSION_STR) - 1);
+    null_check(tmp_sds);
+    tmp_sds = flb_sds_cat(sds, "\",edition=\"", 11);
+    null_check(tmp_sds);
+#ifdef FLB_ENTERPRISE
+    tmp_sds = flb_sds_cat(sds, "Enterprise\"} 1\n", 15);
+    null_check(tmp_sds);
+#else
+    tmp_sds = flb_sds_cat(sds, "Community\"} 1\n", 14);
+    null_check(tmp_sds);
+#endif
 
     msgpack_unpacked_destroy(&result);
     buf->users--;


### PR DESCRIPTION
…262)

this PR adds metric fluentbit_build_info to prometheus metrics

added metric output:

\# HELP fluentbit_build_info Build version information.
\# TYPE fluentbit_build_info gauge
fluentbit_build_info{version="1.5.0",edition="Community"} 1

Signed-off-by: Michael Voelker <novecento@gmx.de>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
