### PR TITLE
aws: fix flb_aws_credentials_destroy (CID 304556)

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -461,7 +461,7 @@ void flb_aws_credentials_destroy(struct flb_aws_credentials *creds)
         if (creds->secret_access_key) {
             flb_sds_destroy(creds->secret_access_key);
         }
-        if (creds->secret_access_key) {
+        if (creds->session_token) {
             flb_sds_destroy(creds->session_token);
         }
 


### PR DESCRIPTION
Coverity Scan Issue

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
