### PR TITLE
http_client: fixing SSL error when specifying 443 port in the host header

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -530,7 +530,13 @@ static int add_host_and_content_length(struct flb_http_client *c)
         out_port = c->port;
     }
 
-    tmp = flb_sds_printf(&host, "%s:%i", out_host, out_port);
+    if (c->flags & FLB_IO_TLS && out_port == 443) {
+        tmp = flb_sds_copy(host, out_host, strlen(out_host));
+    }
+    else {
+        tmp = flb_sds_printf(&host, "%s:%i", out_host, out_port);
+    }
+
     if (!tmp) {
         flb_sds_destroy(host);
         flb_error("[http_client] cannot compose temporary host header");


### PR DESCRIPTION
Host header for HTTPS should not contain 443 port as certificates might not be valid when the port is used in the hostname.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
  - I can't run Valgrind on Ubuntu 20.04. I installed libc6-dbg and libc6-dbg:i386, but did not work. I tried installing from sources - did not work either.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
