### PR TITLE
out_stackdriver: add 'k8s_container' , 'k8s_node' and 'k8s_pod' to supported resource types

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -47,6 +47,12 @@
 #define FLB_SDS_RESOURCE_TYPE "global"
 
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
+#define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
+#define LEN_LOCAL_RESOURCE_ID_KEY 40
+
+#define K8S_CONTAINER "k8s_container"
+#define K8S_NODE      "k8s_node"
+#define K8S_POD       "k8s_pod"
 
 struct flb_stackdriver {
     /* credentials */
@@ -67,6 +73,15 @@ struct flb_stackdriver {
     flb_sds_t zone;
     flb_sds_t instance_id;
     flb_sds_t instance_name;
+
+    /* kubernetes specific */
+    flb_sds_t cluster_name;
+    flb_sds_t cluster_location;
+    flb_sds_t namespace_name;
+    flb_sds_t pod_name;
+    flb_sds_t container_name;
+    flb_sds_t node_name;
+    bool k8s_resource_type;
 
     /* other */
     flb_sds_t resource;
@@ -99,5 +114,10 @@ typedef enum {
     FLB_STD_DEBUG     = 100,
     FLB_STD_DEFAULT   = 0
 } severity_t;
+
+struct local_resource_id_list {
+    flb_sds_t val;
+    struct mk_list _head;
+};
 
 #endif

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -57,7 +57,6 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_STDOUT       "out_stdout.c")
   FLB_RT_TEST(FLB_OUT_STACKDRIVER  "out_stackdriver.c")
   FLB_RT_TEST(FLB_OUT_TD           "out_td.c")
-
 endif()
 
 

--- a/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/* k8s_container */
+#define K8S_CONTAINER_COMMON	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_CONTAINER_COMMON\","		\
+    "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\""		\
+	"}]"
+
+/* k8s_node */
+#define K8S_NODE_COMMON	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_NODE_COMMON\","		\
+    "\"logging.googleapis.com/local_resource_id\": \"k8s_node.testnode\","		\
+	"\"PRIORITY\": 6,"		\
+	"\"SYSLOG_FACILITY\": 3,"		\
+	"\"_CAP_EFFECTIVE\": \"3fffffffff\","		\
+	"\"_PID\": 1387,"		\
+	"\"_SYSTEMD_UNIT\": \"docker.service\","		\
+	"\"END_KEY\": \"JSON_END\""		\
+	"}]"
+
+/* k8s_pod */
+#define K8S_POD_COMMON	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_POD_COMMON\","		\
+    "\"logging.googleapis.com/local_resource_id\": \"k8s_pod.testnamespace.testpod\","		\
+	"\"key_0\": false,"		\
+	"\"key_1\": true,"		\
+	"\"key_2\": \"some string\","		\
+	"\"key_3\": 0.12345678,"		\
+	"\"key_4\": 5000,"		\
+	"\"END_KEY\": \"JSON_END\""		\
+	"}]"
+    


### PR DESCRIPTION
<!-- Provide summary of changes -->
For now stackdriver output plugin only supports 'global' and 'gce_instance' resource types. More resource types need to be supported like 'k8s_container", "k8s_node" and "k8s_pod"

This patch will enable fluent-bit stackdriver to support `k8s_container`, `k8s_node` and `k8s_pod` resource types.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Issue number #1003 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
