### PR TITLE
aws: fix time of check, time of use in flb_read_file (CID 304550)

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -542,14 +542,17 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size)
     char *buf = NULL;
     FILE *fp = NULL;
     struct stat st;
-
-    ret = stat(path, &st);
-    if (ret == -1) {
-        return -1;
-    }
+    int fd;
 
     fp = fopen(path, "r");
     if (!fp) {
+        return -1;
+    }
+
+    fd = fileno(fp);
+    ret = fstat(fd, &st);
+    if (ret == -1) {
+        flb_errno();
         return -1;
     }
 


### PR DESCRIPTION
Coverity Issue

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
