### PR TITLE
out_stackdriver: provide interface for ingesting customize labels

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -46,6 +46,8 @@
 /* Default Resource type */
 #define FLB_SDS_RESOURCE_TYPE "global"
 
+#define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;
@@ -65,6 +67,8 @@ struct flb_stackdriver {
     flb_sds_t zone;
     flb_sds_t instance_id;
     flb_sds_t instance_name;
+
+    flb_sds_t labels_key;
 
     /* other */
     flb_sds_t resource;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -286,6 +286,13 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->severity_key = flb_sds_create(tmp);
     }
 
+    tmp = flb_output_get_property("labels_key", ins);
+    if (tmp) {
+        ctx->labels_key = flb_sds_create(tmp);
+    } else {
+        ctx->labels_key = flb_sds_create(DEFAULT_LABELS_KEY);
+    }
+
     return ctx;
 }
 
@@ -306,6 +313,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->token_uri);
     flb_sds_destroy(ctx->resource);
     flb_sds_destroy(ctx->severity_key);
+    flb_sds_destroy(ctx->labels_key);
 
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
In the FluentD output plugin, it supports the extractions to convert the custom labels to the logEntry (see here). Currently there is no parsing function in out_stackdriver plugin to convert the cunstom labels to the logEntry (root-level) labels. Therefore this feature request will request the feature to perform this mapping. For example, we can provide a naming convention in out_stackdriver that all labels under prefix ‘logging.googleapis.com/labels’ in one log message are extracted and set as labels under the log entry.

This patch will support fluent bit out_stackdriver to perform ingesting customize labels.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#2282 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
