### PR TITLE
upstream: fix access of FLB_HAVE_TLS only struct member

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -260,8 +260,10 @@ struct flb_upstream_conn *flb_upstream_conn_get(struct flb_upstream *u)
         mk_list_add(&conn->_head, &u->busy_queue);
 
         /* I/O Timeouts */
+#ifdef FLB_HAVE_TLS
         conn->tls_handshake_start = -1;
         conn->tls_handshake_timeout = -1;
+#endif
 
         flb_debug("[upstream] KA connection #%i to %s:%i has been assigned (recycled)",
                   conn->fd, u->tcp_host, u->tcp_port);


### PR DESCRIPTION
<!-- Provide summary of changes -->
placed conditional macro around access to a conditional struct member.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
No issue created or found.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
