### PR TITLE
Enable PDB generation on Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,21 @@ endif()
 
 # Update CFLAGS
 if (MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
-  add_compile_options(/MT)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
+  # Use custom CFLAGS for MSVC
+  #
+  #   /W3 ...... Show up to 'production quality' msgs.
+  #   /Zi ...... Generate pdb files.
+  #   /MT ...... Static link C runtimes.
+  #
+  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /W3 /O2 /Zi")
+  set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
+  set(CMAKE_BUILD_TYPE None)
+
+  # Use add_compile_options() to set /MT since Visual Studio
+  # Generator does not notice /MT in CMAKE_C_FLAGS.
+  add_compile_options(/MT)
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,23 +6,24 @@ platform:
   - Win32
   - x64
 
+environment:
+  vspath: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'
+
 configuration:
   - Release
 
 install:
-  - if %PLATFORM%==x86 (set MSYS2_MSYSTEM=MINGW32) else set MSYS2_MSYSTEM=MINGW64
-  - if %PLATFORM%==x86 (set MSYS2_PREFIX=C:\msys64\mingw32) else set MSYS2_PREFIX=C:\msys64\mingw64
   - cmd: set PATH=%MSYS2_PREFIX%\bin;C:\msys64\usr\bin;%PATH%
   - cmd: C:\msys64\usr\bin\pacman -Su --noconfirm bison flex
 
 before_build:
-  - cmd: if "%platform%"=="Win32" set msvc=Visual Studio 15 2017
-  - cmd: if "%platform%"=="x64"   set msvc=Visual Studio 15 2017 Win64
+  - if %PLATFORM%==Win32 call "%vspath%\VC\Auxiliary\Build\vcvars32.bat"
+  - if %PLATFORM%==x64   call "%vspatH%\VC\Auxiliary\Build\vcvars64.bat"
 
 build_script:
   - powershell ".\ci\do-ut.ps1;exit $LASTEXITCODE"
   - cd build
-  - cpack -C "%configuration%"
+  - cpack
 
 artifacts:
   - path: build/td-agent-bit-*.exe

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -1,9 +1,8 @@
 cd build
 
 # CACHE GENERATION
-cmake -G "$ENV:msvc" -DCMAKE_BUILD_TYPE="$ENV:configuration" `
-                     -DCIO_BACKEND_FILESYSTEM=Off `
-                     -DFLB_TESTS_INTERNAL=On `
+cmake -G "NMake Makefiles" `
+                     -D FLB_TESTS_INTERNAL=On `
                      -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
                      -D FLB_WITHOUT_flb-rt-out_td=On `
                      -D FLB_WITHOUT_flb-rt-out_forward=On `
@@ -17,7 +16,7 @@ cmake -G "$ENV:msvc" -DCMAKE_BUILD_TYPE="$ENV:configuration" `
                      ../
 
 # COMPILE
-cmake --build . --config "$ENV:configuration"
+cmake --build .
 
 # RUNNING TESTS
-ctest -C "$ENV:configuration" --build-run-dir $PWD --output-on-failure
+ctest --build-run-dir $PWD --output-on-failure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,6 +297,13 @@ if(FLB_SHARED_LIB)
     target_link_libraries(fluent-bit-shared ${FLB_DEPS} -lpthread)
   endif()
 
+  if (MSVC)
+    set_target_properties(fluent-bit-shared
+      PROPERTIES PDB_NAME fluent-bit.dll)
+    target_link_options(fluent-bit-shared
+      PUBLIC /pdb:$<TARGET_PDB_FILE:fluent-bit-shared>)
+  endif()
+
   # Library install routines
   install(TARGETS fluent-bit-shared
     LIBRARY DESTINATION ${FLB_INSTALL_LIBDIR}
@@ -350,6 +357,14 @@ if(FLB_BINARY)
     OUTPUT_NAME ${FLB_OUT_NAME}
     ENABLE_EXPORTS ON)
   install(TARGETS fluent-bit-bin RUNTIME DESTINATION ${FLB_INSTALL_BINDIR})
+
+  # Include PDB file (if available)
+  if (MSVC)
+    target_link_options(fluent-bit-bin
+      PUBLIC /pdb:$<TARGET_PDB_FILE:fluent-bit-bin>)
+    install(FILES $<TARGET_PDB_FILE:fluent-bit-bin>
+      DESTINATION "${FLB_INSTALL_BINDIR}")
+  endif()
 
   # Detect init system, install upstart, systemd or init.d script
   if(IS_DIRECTORY /lib/systemd/system)


### PR DESCRIPTION
Sean Fausett pointed out that the current Windows release does
not include a debug symbol file. This makes it hard for our
users to analyze a crash dump.

This commit enables the PDB generation, and teaches CMake to
include the symbol file into the release distribution.
