### PR TITLE
fix a segmentation fault issue in logging worker 

### DIFF
--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -94,6 +94,11 @@ static inline int log_read(flb_pipefd_t fd, struct flb_log *log)
         perror("bytes");
         return -1;
     }
+    if (msg.size > sizeof(msg.msg)) {
+        fprintf(stderr, "[log] message too long: %zi > %zi",
+                msg.size, sizeof(msg.msg));
+        return -1;
+    }
     log_push(&msg, log);
 
     return bytes;

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -89,7 +89,7 @@ static inline int log_read(flb_pipefd_t fd, struct flb_log *log)
      * under the PIPE_BUF limit (4KB on Linux) and our messages are always 1KB,
      * we can trust we will always get a full message on each read(2).
      */
-    bytes = flb_pipe_r(fd, &msg, sizeof(struct log_message));
+    bytes = flb_pipe_read_all(fd, &msg, sizeof(struct log_message));
     if (bytes <= 0) {
         perror("bytes");
         return -1;
@@ -415,7 +415,7 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
 
     w = flb_worker_get();
     if (w) {
-        int n = flb_pipe_w(w->log[1], &msg, sizeof(msg));
+        int n = flb_pipe_write_all(w->log[1], &msg, sizeof(msg));
         if (n == -1) {
             perror("write");
         }

--- a/src/flb_pipe.c
+++ b/src/flb_pipe.c
@@ -129,6 +129,7 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count)
                 flb_time_msleep(50);
                 continue;
             }
+            return -1;
         }
         else if (bytes == 0) {
             /* Broken pipe ? */
@@ -160,6 +161,7 @@ ssize_t flb_pipe_write_all(int fd, const void *buf, size_t count)
                 flb_time_msleep(50);
                 continue;
             }
+            return -1;
         }
         else if (bytes == 0) {
             /* Broken pipe ? */


### PR DESCRIPTION
The current logic assumes that read(2) never does a partial read
on a certain condition. This is really not guaranteed by POSIX,
and indeed not the case on Windows.

Use flb_pipe_write_all() and flb_pipe_write_all() to avoid partial
I/O in a portable manner.

Note: This patch is a joint efffort with @gitfool. It is verified to fix
random memory crash issue #2251 on WIndows.