### PR TITLE
win32: add 'Windows Service' support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,7 +305,11 @@ endif()
 # Binary / Executable
 if(FLB_BINARY)
   find_package (Threads)
-  add_executable(fluent-bit-bin fluent-bit.c flb_dump.c)
+  if (FLB_SYSTEM_WINDOWS)
+    add_executable(fluent-bit-bin fluent-bit.c flb_dump.c win32/winsvc.c)
+  else()
+    add_executable(fluent-bit-bin fluent-bit.c flb_dump.c)
+  endif()
   add_sanitizers(fluent-bit-bin)
 
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -53,6 +53,11 @@
 #include <mcheck.h>
 #endif
 
+#ifdef FLB_SYSTEM_WINDOWS
+extern int win32_main(int, char**);
+extern void win32_started(void);
+#endif
+
 struct flb_config *config;
 
 #define PLUGIN_INPUT    0
@@ -725,7 +730,7 @@ flb_service_conf_end:
     return ret;
 }
 
-int main(int argc, char **argv)
+int flb_main(int argc, char **argv)
 {
     int opt;
     int ret;
@@ -1019,10 +1024,23 @@ int main(int argc, char **argv)
     flb_thread_prepare();
     flb_output_prepare();
 
+#ifdef FLB_SYSTEM_WINDOWS
+    win32_started();
+#endif
+
     ret = flb_engine_start(config);
     if (ret == -1 && config) {
         flb_engine_shutdown(config);
     }
 
     return ret;
+}
+
+int main(int argc, char **argv)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    return win32_main(argc, argv);
+#else
+    return flb_main(argc, argv);
+#endif
 }

--- a/src/win32/winsvc.c
+++ b/src/win32/winsvc.c
@@ -1,0 +1,118 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <Windows.h>
+
+struct flb_config;
+extern struct flb_config *config;
+extern int flb_engine_exit(struct flb_config*);
+extern int flb_main(int, char**);
+
+/* Windows Service utils */
+#define svc_name "fluent-bit"
+static SERVICE_STATUS_HANDLE hstatus;
+static int win32_argc;
+static char **win32_argv;
+
+static void svc_notify(DWORD status)
+{
+    SERVICE_STATUS ss;
+
+    ss.dwServiceType = SERVICE_USER_OWN_PROCESS;
+    ss.dwCurrentState = status;
+    ss.dwWin32ExitCode = NO_ERROR;
+    ss.dwServiceSpecificExitCode = NO_ERROR;
+    ss.dwControlsAccepted = SERVICE_ACCEPT_STOP;
+    ss.dwWaitHint = 30000;
+    ss.dwCheckPoint = 0;
+
+    /*
+     * According to MSDN (SetServiceStatus), accepting control on
+     * SERVICE_START_PENDING can crash the service.
+     */
+    if (status == SERVICE_START_PENDING) {
+        ss.dwControlsAccepted = 0;
+    }
+
+    SetServiceStatus(hstatus, &ss);
+}
+
+static void WINAPI svc_handler(DWORD ctrl)
+{
+    switch (ctrl)
+    {
+    case SERVICE_CONTROL_STOP:
+        svc_notify(SERVICE_STOP_PENDING);
+        flb_engine_exit(config);
+        return;
+    default:
+        break;
+    }
+}
+
+static void WINAPI svc_main(DWORD svc_argc, LPTSTR *svc_argv)
+{
+    hstatus = RegisterServiceCtrlHandler(svc_name, svc_handler);
+    if (!hstatus) {
+        return;
+    }
+
+    svc_notify(SERVICE_START_PENDING);
+    flb_main(win32_argc, win32_argv);
+    svc_notify(SERVICE_STOPPED);
+}
+
+/*
+ * Notify SCM that Fluent Bit is running.
+ *
+ * Note: Call this function in the main execution flow (immediately
+ * before the engine is starting).
+ */
+void win32_started(void)
+{
+    if (hstatus) {
+        svc_notify(SERVICE_RUNNING);
+    }
+}
+
+static const SERVICE_TABLE_ENTRY svc_table[] = {
+    {svc_name, svc_main},
+    {NULL, NULL}
+};
+
+int win32_main(int argc, char **argv)
+{
+    win32_argc = argc;
+    win32_argv = argv;
+
+    if (StartServiceCtrlDispatcher(svc_table)) {
+        return 0;
+    }
+
+    if (GetLastError() != ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
+        return -1;
+    }
+
+    /*
+     * If we cannot connect to SCM, we assume that "fluent-bit.exe"
+     * was invoked from the command line.
+     */
+    return flb_main(argc, argv);
+}


### PR DESCRIPTION
Windows services are equivalent to "daemon" in UNIX (i.e. long-running
background processes). This support is long-awaited by users who want
to run Fluent Bit on their servers.

In particular, this patch allows users to do:

    % sc.exe create fluent-bit \
             binpath= "\flb\fluent-bit.exe -c \flb\fluent-bit.conf"

and now "fluent-bit" can be started and managed as a normal Windows
service.

    % sc.exe start fluent-bit
    % sc.exe query fluent-bit
    SERVICE_NAME: fluent-bit
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 4 Running

Fixes #1693. 

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
