### PR TITLE
out_stackdriver: provide interface for ingesting customize labels

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -360,12 +360,12 @@ static struct mk_list *parse_local_resource_id_to_list(char *str, char *type)
     return list;
 }
 
-/*
-*    process_local_resource_id():
-*  - extract the value from "logging.googleapis.com/local_resource_id" field
-*  - use extracted value to assign the label keys for different resource types
-*    that are specified in the configuration of stackdriver_out plugin
-*/
+/* 
+ *    process_local_resource_id():
+ *  - extract the value from "logging.googleapis.com/local_resource_id" field
+ *  - use extracted value to assign the label keys for different resource types
+ *    that are specified in the configuration of stackdriver_out plugin
+ */
 static int process_local_resource_id(const void *data, size_t bytes,
                                      struct flb_stackdriver *ctx, char *type)
 {
@@ -528,6 +528,36 @@ static int process_local_resource_id(const void *data, size_t bytes,
         flb_sds_destroy(ctx->pod_name);
     }
     return -1;
+}
+
+/*
+ * parse_labels
+ * - Iterate throught the original payload (obj) and find out the entry that matches
+ *   the labels_key 
+ * - Used to convert all labels under labels_key to root-level `labels` field
+ */
+static msgpack_object *parse_labels(struct flb_stackdriver *ctx, msgpack_object *obj)
+{
+    int i;
+    int len;
+    msgpack_object_kv *kv = NULL;
+
+    if (!obj || obj->type != MSGPACK_OBJECT_MAP) {
+        return NULL;
+    }
+
+    len = flb_sds_len(ctx->labels_key);
+    for (i = 0; i < obj->via.map.size; i++) {
+        kv = &obj->via.map.ptr[i];
+        if (flb_sds_casecmp(ctx->labels_key, kv->key.via.str.ptr, len) == 0) {
+            /* only the first matching entry will be returned */
+            return &kv->val;
+        }
+    }
+
+    flb_plg_debug(ctx->ins, "labels_key [%s] not found in the payload", 
+                  ctx->labels_key);
+    return NULL;
 }
 
 static int cb_stackdriver_init(struct flb_output_instance *ins,
@@ -729,8 +759,9 @@ static int get_stream(msgpack_object_map map)
     return STREAM_UNKNOWN;
 }
 
-static int pack_json_payload(int operation_extracted, int operation_extra_size,
-                             msgpack_packer *mp_pck, msgpack_object *obj)
+static int pack_json_payload(int operation_extracted, int operation_extra_size, 
+                             msgpack_packer* mp_pck, msgpack_object *obj,
+                             struct flb_stackdriver *ctx)
 {
     /* Specified fields include local_resource_id, operation, sourceLocation ... */
     int i, j;
@@ -753,8 +784,9 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
      */
     flb_sds_t to_be_removed[] =
     {
-        local_resource_id_key
-        /* more special fields are required to be added: labels .. */
+        local_resource_id_key,
+        ctx->labels_key
+        /* more special fields are required to be added */
     };
 
     if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
@@ -834,6 +866,7 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
     flb_sds_destroy(local_resource_id_key);
     return 0;
 }
+
 static int stackdriver_format(struct flb_config *config,
                               struct flb_input_instance *ins,
                               void *plugin_context,
@@ -856,6 +889,7 @@ static int stackdriver_format(struct flb_config *config,
     struct tm tm;
     struct flb_time tms;
     msgpack_object *obj;
+    msgpack_object *labels_ptr;
     msgpack_unpacked result;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
@@ -1095,6 +1129,8 @@ static int stackdriver_format(struct flb_config *config,
          * Pack entry
          *
          * {
+         *  "severity": "...",
+         *  "labels": "...",
          *  "logName": "...",
          *  "jsonPayload": {...},
          *  "timestamp": "..."
@@ -1121,6 +1157,20 @@ static int stackdriver_format(struct flb_config *config,
             entry_size += 1;
         }
 
+        /* Extract labels */
+        labels_ptr = parse_labels(ctx, obj);
+        if (labels_ptr != NULL) {
+            if (labels_ptr->type != MSGPACK_OBJECT_MAP) {
+                flb_plg_error(ctx->ins, "the type of labels should be map");
+                flb_sds_destroy(operation_id);
+                flb_sds_destroy(operation_producer);
+                msgpack_unpacked_destroy(&result);
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
+            }
+            entry_size += 1;
+        }
+
         msgpack_pack_map(&mp_pck, entry_size);
 
         /* Add severity into the log entry */
@@ -1136,6 +1186,13 @@ static int stackdriver_format(struct flb_config *config,
                                 &operation_first, &operation_last, &mp_pck);
         }
 
+        /* labels */
+        if (labels_ptr != NULL) {
+            msgpack_pack_str(&mp_pck, 6);
+            msgpack_pack_str_body(&mp_pck, "labels", 6);
+            msgpack_pack_object(&mp_pck, *labels_ptr);
+        }
+        
         /* Clean up id and producer if operation extracted */
         flb_sds_destroy(operation_id);
         flb_sds_destroy(operation_producer);
@@ -1143,7 +1200,7 @@ static int stackdriver_format(struct flb_config *config,
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);
         msgpack_pack_str_body(&mp_pck, "jsonPayload", 11);
-        pack_json_payload(operation_extracted, operation_extra_size, &mp_pck, obj);
+        pack_json_payload(operation_extracted, operation_extra_size, &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */
         newtag = tag;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -48,6 +48,7 @@
 
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
+#define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 
 #define K8S_CONTAINER "k8s_container"
@@ -89,6 +90,8 @@ struct flb_stackdriver {
     flb_sds_t container_name;
     flb_sds_t node_name;
     bool k8s_resource_type;
+    
+    flb_sds_t labels_key;
 
     /* other */
     flb_sds_t resource;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -321,7 +321,15 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             flb_stackdriver_conf_destroy(ctx);
             return NULL;
         }
-    } 
+    }
+    
+    tmp = flb_output_get_property("labels_key", ins);
+    if (tmp) {
+        ctx->labels_key = flb_sds_create(tmp);
+    }
+    else {
+        ctx->labels_key = flb_sds_create(DEFAULT_LABELS_KEY);
+    }
 
     return ctx;
 }
@@ -352,6 +360,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->token_uri);
     flb_sds_destroy(ctx->resource);
     flb_sds_destroy(ctx->severity_key);
+    flb_sds_destroy(ctx->labels_key);
 
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);

--- a/tests/runtime/data/stackdriver/stackdriver_test_labels.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_labels.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#define DEFAULT_LABELS	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": "		\
+        "{"            \
+            "\"testA\": \"valA\","          \
+            "\"testB\": \"valB\""      \
+        "}"     \
+	"}]"
+
+#define CUSTOM_LABELS	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/customlabels\": "		\
+        "{"            \
+            "\"testA\": \"valA\","          \
+            "\"testB\": \"valB\""      \
+        "}"     \
+	"}]"
+
+#define DEFAULT_LABELS_K8S_RESOURCE_TYPE	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\","		\
+        "\"logging.googleapis.com/labels\": "		\
+        "{"            \
+            "\"testA\": \"valA\","          \
+            "\"testB\": \"valB\""      \
+        "}"     \
+	"}]"
+
+#define CUSTOM_LABELS_K8S_RESOURCE_TYPE	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\","		\
+        "\"logging.googleapis.com/customlabels\": "		\
+        "{"            \
+            "\"testA\": \"valA\","          \
+            "\"testB\": \"valB\""      \
+        "}"     \
+	"}]"
+

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -32,6 +32,7 @@
 #include "data/stackdriver/json.h"
 #include "data/stackdriver/stackdriver_test_operation.h"
 #include "data/stackdriver/stackdriver_test_k8s_resource.h"
+#include "data/stackdriver/stackdriver_test_labels.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -525,7 +526,6 @@ static void cb_check_operation_in_string(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
-
 static void cb_check_operation_partial_subfields(void *ctx, int ffd,
                                                  int res_ret, void *res_data, size_t res_size,
                                                  void *data)
@@ -615,6 +615,184 @@ static void cb_check_operation_extra_subfields(void *ctx, int ffd,
 
     ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key3']", true);
     TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_default_labels(void *ctx, int ffd,
+                                    int res_ret, void *res_data, size_t res_size,
+                                    void *data)
+{
+    int ret;
+
+    /* check 'labels' field has been added to root-level of log entry */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check fields inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testA']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check field inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testB']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `labels_key` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/labels']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_custom_labels(void *ctx, int ffd,
+                                   int res_ret, void *res_data, size_t res_size,
+                                   void *data)
+{
+    int ret;
+
+    /* check 'labels' field has been added to root-level of log entry */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check fields inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testA']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check field inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testB']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `labels_key` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/customlabels']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_default_labels_k8s_resource_type(void *ctx, int ffd,
+                                                      int res_ret, void *res_data, size_t res_size,
+                                                      void *data)
+{
+    int ret;
+
+    /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "k8s_container");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "test_cluster_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* cluster name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['cluster_name']", "test_cluster_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace_name']", "testnamespace");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* pod name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['pod_name']", "testpod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* container name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['container_name']", "testctr");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `local_resource_id` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/local_resource_id']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* check 'labels' field has been added to root-level of log entry */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check fields inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testA']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check field inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testB']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `labels_key` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/labels']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_custom_labels_k8s_resource_type(void *ctx, int ffd,
+                                                     int res_ret, void *res_data, size_t res_size,
+                                                     void *data)
+{
+    int ret;
+
+    /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "k8s_container");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "test_cluster_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* cluster name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['cluster_name']", "test_cluster_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace_name']", "testnamespace");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* pod name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['pod_name']", "testpod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* container name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['container_name']", "testctr");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `local_resource_id` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/local_resource_id']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* check 'labels' field has been added to root-level of log entry */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check fields inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testA']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check field inside 'labels' field */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']['testB']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `labels_key` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/customlabels']");
+    TEST_CHECK(ret == FLB_FALSE);
 
     flb_sds_destroy(res_data);
 }
@@ -1068,6 +1246,176 @@ void flb_test_resource_k8s_pod_common()
     flb_destroy(ctx);
 }
 
+void flb_test_default_labels()
+{
+    int ret;
+    int size = sizeof(DEFAULT_LABELS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "global",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_default_labels,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) DEFAULT_LABELS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_custom_labels()
+{
+    int ret;
+    int size = sizeof(CUSTOM_LABELS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "global",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "labels_key", "logging.googleapis.com/customlabels",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_custom_labels,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) CUSTOM_LABELS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_default_labels_k8s_resource_type()
+{
+    int ret;
+    int size = sizeof(DEFAULT_LABELS_K8S_RESOURCE_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_default_labels_k8s_resource_type,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) DEFAULT_LABELS_K8S_RESOURCE_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_custom_labels_k8s_resource_type()
+{
+    int ret;
+    int size = sizeof(CUSTOM_LABELS_K8S_RESOURCE_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "labels_key", "logging.googleapis.com/customlabels",
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_custom_labels_k8s_resource_type,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) CUSTOM_LABELS_K8S_RESOURCE_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"resource_global", flb_test_resource_global },
@@ -1081,5 +1429,9 @@ TEST_LIST = {
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },
+    {"default_labels", flb_test_default_labels },
+    {"custom_labels", flb_test_custom_labels },
+    {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
+    {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
     {NULL, NULL}
 };


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
In the FluentD output plugin, it supports the extractions to convert the custom labels to the logEntry (see here). Currently there is no parsing function in out_stackdriver plugin to convert the cunstom labels to the logEntry (root-level) labels. Therefore this feature request will request the feature to perform this mapping. For example, we can provide a naming convention in out_stackdriver that all labels under prefix ‘logging.googleapis.com/labels’ in one log message are extracted and set as labels under the log entry.

This patch will support fluent bit out_stackdriver to perform ingesting customize labels.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
The issue number that it is related to:  #2282 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
