### PR TITLE
sp: fix memory leak related to groupby string values

### DIFF
--- a/include/fluent-bit/stream_processor/flb_sp.h
+++ b/include/fluent-bit/stream_processor/flb_sp.h
@@ -167,6 +167,7 @@ struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
                                        const char *query);
 int flb_sp_fd_event(int fd, struct flb_sp *sp);
 void flb_sp_task_destroy(struct flb_sp_task *task);
+void groupby_nums_destroy(struct aggr_num *groupby_nums, int size);
 void flb_sp_aggr_node_destroy(struct flb_sp_cmd *cmd,
                               struct aggr_node *aggr_node);
 

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -668,6 +668,19 @@ struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
     return task;
 }
 
+void groupby_nums_destroy(struct aggr_num *groupby_nums, int size)
+{
+    int i;
+
+    for (i = 0; i < size; i++) {
+        if (groupby_nums[i].type == FLB_SP_STRING) {
+            flb_sds_destroy(groupby_nums[i].string);
+          }
+    }
+
+    flb_free(groupby_nums);
+}
+
 /*
  * Destroy aggregation node context: before to use this function make sure
  * to unlink from the linked list.
@@ -690,12 +703,7 @@ void flb_sp_aggr_node_destroy(struct flb_sp_cmd *cmd,
         }
     }
 
-    for (i = 0; i < aggr_node->groupby_keys; i++) {
-        num = &aggr_node->groupby_nums[i];
-        if (num->type == FLB_SP_STRING) {
-            flb_sds_destroy(num->string);
-        }
-    }
+    groupby_nums_destroy(aggr_node->groupby_nums, aggr_node->groupby_keys);
 
     key_id = 0;
     mk_list_foreach(head, &cmd->keys) {
@@ -723,7 +731,6 @@ void flb_sp_aggr_node_destroy(struct flb_sp_cmd *cmd,
     }
 
     flb_free(aggr_node->nums);
-    flb_free(aggr_node->groupby_nums);
     flb_free(aggr_node->ts);
     flb_free(aggr_node);
 }
@@ -1666,14 +1673,14 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
 
         /* if some GROUP BY keys are not found in the record */
         if (values_found < gb_entries) {
-            flb_free(gb_nums);
+            groupby_nums_destroy(gb_nums, gb_entries);
             return NULL;
         }
 
         aggr_node = (struct aggr_node *) flb_calloc(1, sizeof(struct aggr_node));
         if (!aggr_node) {
             flb_errno();
-            flb_free(gb_nums);
+            groupby_nums_destroy(gb_nums, gb_entries);
             return NULL;
         }
 


### PR DESCRIPTION
Signed-off-by: Masoud Koleini <masoud.koleini@arm.com>

Fixed memory leak related to string storage of group by keys 

Valgrind output:
```
==22625== Memcheck, a memory error detector
==22625== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22625== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==22625== Command: build/bin/flb-it-stream_processor
==22625== 
Test invalid_queries...                         [2020/06/25 23:53:14] [ info] [sp] stream processor started
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT id, MIN(id) FROM STREAM:FLB;
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT *, COUNT(id) FROM STREAM:FLB;
[2020/06/25 23:53:14] [error] [sp] syntax error, unexpected IDENTIFIER, expecting STRING at 'SELECT * FROM TAG:FLB WHERE bool = NULL ;'
[2020/06/25 23:53:14] [error] [sp] invalid query on task 'invalid_query': 'SELECT * FROM TAG:FLB WHERE bool = NULL ;'
[2020/06/25 23:53:14] [error] [sp] syntax error, unexpected IDENTIFIER, expecting STRING at 'SELECT * FROM TAG:FLB WHERE @record.some_random_func() ;'
[2020/06/25 23:53:14] [error] [sp] invalid query on task 'invalid_query': 'SELECT * FROM TAG:FLB WHERE @record.some_random_func() ;'
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT id, MIN(id) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND) GROUP BY bool;
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT *, COUNT(id) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND) GROUP BY bool;
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT *, COUNT(bool) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND) GROUP BY bool;
[2020/06/25 23:53:14] [error] [sp] aggregated query cannot mix not aggregated keys: SELECT *, bool, COUNT(bool) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND) GROUP BY bool;
[   OK   ]
==22626== 
==22626== HEAP SUMMARY:
==22626==     in use at exit: 45 bytes in 2 blocks
==22626==   total heap usage: 143 allocs, 141 frees, 35,010 bytes allocated
==22626== 
==22626== LEAK SUMMARY:
==22626==    definitely lost: 0 bytes in 0 blocks
==22626==    indirectly lost: 0 bytes in 0 blocks
==22626==      possibly lost: 0 bytes in 0 blocks
==22626==    still reachable: 45 bytes in 2 blocks
==22626==         suppressed: 0 bytes in 0 blocks
==22626== Reachable blocks (those to which a pointer was found) are not shown.
==22626== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22626== 
==22626== For counts of detected and suppressed errors, rerun with: -v
==22626== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test select_keys...                             [2020/06/25 23:53:14] [ info] [sp] stream processor started
[2020/06/25 23:53:14] [ info] [sp test] id=0, SQL => 'SELECT * FROM STREAM:FLB;'
[2020/06/25 23:53:14] [ info] [sp test] id=1, SQL => 'SELECT id, word2 FROM STREAM:FLB;'
[2020/06/25 23:53:14] [ info] [sp test] id=2, SQL => 'SELECT * FROM STREAM:FLB WHERE bytes > 10.290;'
[2020/06/25 23:53:14] [ info] [sp test] id=3, SQL => 'SELECT * FROM STREAM:FLB WHERE word2 = 'rlz' or word3 = 'rlz';'
[2020/06/25 23:53:14] [ info] [sp test] id=4, SQL => 'SELECT * FROM STREAM:FLB WHERE word2 = 'rlz' and word3 IS NOT NULL;'
[2020/06/25 23:53:14] [ info] [sp test] id=5, SQL => 'SELECT * FROM STREAM:FLB WHERE word3 IS NULL;'
[2020/06/25 23:53:14] [ info] [sp test] id=6, SQL => 'SELECT * FROM STREAM:FLB WHERE bool != true;'
[2020/06/25 23:53:14] [ info] [sp test] id=7, SQL => 'SELECT * FROM STREAM:FLB WHERE bytes <> 10;'
[2020/06/25 23:53:14] [ info] [sp test] id=8, SQL => 'SELECT MIN(id), MAX(id), COUNT(*), SUM(bytes), AVG(bytes) FROM STREAM:FLB;'
[2020/06/25 23:53:14] [ info] [sp test] id=9, SQL => 'SELECT COUNT(*) FROM STREAM:FLB;'
[2020/06/25 23:53:14] [ info] [sp test] id=10, SQL => 'SELECT MIN(id), MAX(id), COUNT(*), SUM(bytes), AVG(bytes) FROM STREAM:FLB;'
[2020/06/25 23:53:14] [ info] [sp test] id=11, SQL => 'SELECT bool, MIN(id), MAX(id), COUNT(*), SUM(bytes), AVG(bytes) FROM STREAM:FLB WHERE word3 IS NOT NULL GROUP BY bool;'
[2020/06/25 23:53:14] [ info] [sp test] id=12, SQL => 'SELECT NOW(), NOW() as tnow FROM STREAM:FLB WHERE bytes > 10;'
[2020/06/25 23:53:14] [ info] [sp test] id=13, SQL => 'SELECT UNIX_TIMESTAMP(), UNIX_TIMESTAMP() as ts FROM STREAM:FLB WHERE bytes > 10;'
[2020/06/25 23:53:14] [ info] [sp test] id=14, SQL => 'SELECT id FROM TAG:'no-matches' WHERE bytes > 10;'
[2020/06/25 23:53:14] [ info] [sp test] id=15, SQL => 'SELECT id FROM TAG:'samples' WHERE bytes > 10;'
[2020/06/25 23:53:14] [ info] [sp test] id=16, SQL => 'SELECT id FROM TAG:'samples' WHERE bytes = 10 AND @record.contains(word2);'
[2020/06/25 23:53:14] [ info] [sp test] id=17, SQL => 'SELECT id FROM TAG:'samples' WHERE @record.contains(x);'
[0] [1592504045.677874, {"id"=>0, "word1"=>"fluent", "word2"=>"logging", "bytes"=>10, "bool"=>true, "usage"=>10}]
[0] [1592504045.677887, {"id"=>1, "word1"=>"fluentd", "word2"=>"rlz", "bytes"=>10.000000, "bool"=>true, "usage"=>20}]
[0] [1592504045.677892, {"id"=>2, "word1"=>"fluent-bit", "word3"=>"rlz", "bytes"=>10, "bool"=>true, "usage"=>30}]
[0] [1592504045.677896, {"id"=>3, "word1"=>"fluent-logger", "word3"=>"", "bytes"=>10, "bool"=>true, "usage"=>40}]
[0] [1592504045.677900, {"id"=>4, "word1"=>"forward", "word3"=>"plain", "bytes"=>10, "bool"=>true, "usage"=>50}]
[0] [1592504045.677905, {"id"=>5, "word5"=>"forward-protocol", "word6"=>"secure", "bytes"=>10, "bool"=>true, "usage"=>60}]
[0] [1592504045.677910, {"id"=>6, "word1"=>"stream", "word3"=>"processing", "bytes"=>10.200000, "bool"=>false, "usage"=>70}]
[0] [1592504045.677914, {"id"=>7, "word1"=>"edge-rocks", "word6"=>"", "bytes"=>10, "bool"=>true, "usage"=>80}]
[0] [1592504045.677918, {"id"=>8, "word1"=>"treasure-data", "word3"=>"cncf", "bytes"=>10, "bool"=>true, "usage"=>90}]
[0] [1592504045.677923, {"id"=>9, "word1"=>"arm", "word3"=>"linux foundation", "bytes"=>"10.30", "bool"=>false, "usage"=>100}]
[0] [1592504045.677927, {"id"=>10, "word1"=>"fluent-bit", "word3"=>nil, "bytes"=>10, "bool"=>true, "usage"=>110}]
[0] [1592504045.677874, {"id"=>0, "word2"=>"logging"}]
[0] [1592504045.677887, {"id"=>1, "word2"=>"rlz"}]
[0] [1592504045.677892, {"id"=>2}]
[0] [1592504045.677896, {"id"=>3}]
[0] [1592504045.677900, {"id"=>4}]
[0] [1592504045.677905, {"id"=>5}]
[0] [1592504045.677910, {"id"=>6}]
[0] [1592504045.677914, {"id"=>7}]
[0] [1592504045.677918, {"id"=>8}]
[0] [1592504045.677923, {"id"=>9}]
[0] [1592504045.677927, {"id"=>10}]
[0] [1592504045.677923, {"id"=>9, "word1"=>"arm", "word3"=>"linux foundation", "bytes"=>"10.30", "bool"=>false, "usage"=>100}]
[0] [1592504045.677887, {"id"=>1, "word1"=>"fluentd", "word2"=>"rlz", "bytes"=>10.000000, "bool"=>true, "usage"=>20}]
[0] [1592504045.677892, {"id"=>2, "word1"=>"fluent-bit", "word3"=>"rlz", "bytes"=>10, "bool"=>true, "usage"=>30}]
[0] [1592504045.677887, {"id"=>1, "word1"=>"fluentd", "word2"=>"rlz", "bytes"=>10.000000, "bool"=>true, "usage"=>20}]
[0] [1592504045.677927, {"id"=>10, "word1"=>"fluent-bit", "word3"=>nil, "bytes"=>10, "bool"=>true, "usage"=>110}]
[0] [1592504045.677910, {"id"=>6, "word1"=>"stream", "word3"=>"processing", "bytes"=>10.200000, "bool"=>false, "usage"=>70}]
[0] [1592504045.677923, {"id"=>9, "word1"=>"arm", "word3"=>"linux foundation", "bytes"=>"10.30", "bool"=>false, "usage"=>100}]
[0] [1592504045.677910, {"id"=>6, "word1"=>"stream", "word3"=>"processing", "bytes"=>10.200000, "bool"=>false, "usage"=>70}]
[0] [1592504045.677923, {"id"=>9, "word1"=>"arm", "word3"=>"linux foundation", "bytes"=>"10.30", "bool"=>false, "usage"=>100}]
[0] [1593129194.691653, {"MIN(id)"=>0, "MAX(id)"=>10, "COUNT(*)"=>11, "SUM(bytes)"=>110.500000, "AVG(bytes)"=>10.045455}]
[0] [1593129194.701238, {"COUNT(*)"=>11}]
[0] [1593129194.702539, {"MIN(id)"=>0, "MAX(id)"=>10, "COUNT(*)"=>11, "SUM(bytes)"=>110.500000, "AVG(bytes)"=>10.045455}]
[0] [1593129194.713600, {"bool"=>1, "MIN(id)"=>0, "MAX(id)"=>8, "COUNT(*)"=>8, "SUM(bytes)"=>80.000000, "AVG(bytes)"=>10.000000}]
[0] [1593129194.714171, {"bool"=>0, "MIN(id)"=>6, "MAX(id)"=>9, "COUNT(*)"=>2, "SUM(bytes)"=>20.500000, "AVG(bytes)"=>10.250000}]
[0] [1592504045.677910, {"NOW()"=>"2020-06-25 23:53:14", "tnow"=>"2020-06-25 23:53:14"}]
[0] [1592504045.677923, {"NOW()"=>"2020-06-25 23:53:14", "tnow"=>"2020-06-25 23:53:14"}]
[0] [1592504045.677910, {"UNIX_TIMESTAMP()"=>1593129194, "ts"=>1593129194}]
[0] [1592504045.677923, {"UNIX_TIMESTAMP()"=>1593129194, "ts"=>1593129194}]
[0] [1592504045.677910, {"id"=>6}]
[0] [1592504045.677923, {"id"=>9}]
[0] [1592504045.677874, {"id"=>0}]
[0] [1592504045.677887, {"id"=>1}]
[   OK   ]
==22627== 
==22627== HEAP SUMMARY:
==22627==     in use at exit: 45 bytes in 2 blocks
==22627==   total heap usage: 2,043 allocs, 2,041 frees, 2,861,185 bytes allocated
==22627== 
==22627== LEAK SUMMARY:
==22627==    definitely lost: 0 bytes in 0 blocks
==22627==    indirectly lost: 0 bytes in 0 blocks
==22627==      possibly lost: 0 bytes in 0 blocks
==22627==    still reachable: 45 bytes in 2 blocks
==22627==         suppressed: 0 bytes in 0 blocks
==22627== Reachable blocks (those to which a pointer was found) are not shown.
==22627== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22627== 
==22627== For counts of detected and suppressed errors, rerun with: -v
==22627== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test select_subkeys...                          [2020/06/25 23:53:14] [ info] [sp] stream processor started
[2020/06/25 23:53:14] [ info] [sp test] id=0, SQL => 'SELECT * FROM STREAM:FLB WHERE map['sub1']['sub2']['color'] = 'blue';'
[2020/06/25 23:53:14] [ info] [sp test] id=1, SQL => 'SELECT * FROM STREAM:FLB WHERE map['sub1']['sub2'] = 123;'
[2020/06/25 23:53:14] [ info] [sp test] id=2, SQL => 'SELECT * FROM STREAM:FLB WHERE map['sub1']['sub2']['color'] = 'blue' OR map['sub1']['sub2']['color'] = 'red'  OR map['color'] = 'blue'; '
[2020/06/25 23:53:14] [ info] [sp test] id=3, SQL => 'SELECT * FROM STREAM:FLB WHERE @record.contains(map['sub1']['sub3']) OR @record.contains(map['color']); '
[2020/06/25 23:53:14] [ info] [sp test] id=4, SQL => 'SELECT map['sub1']['sub2']['color'] FROM STREAM:FLB WHERE map['sub1']['sub2']['color'] = 'blue';'
[2020/06/25 23:53:14] [ info] [sp test] id=5, SQL => 'SELECT SUM(map['sub1']['sub2']) FROM STREAM:FLB WHERE map['sub1']['sub2'] = 123;'
[2020/06/25 23:53:14] [ info] [sp test] id=6, SQL => 'SELECT AVG(map['sub1']['sub2']) FROM STREAM:FLB WHERE map['sub1']['sub2'] = 123;'
[2020/06/25 23:53:14] [ info] [sp test] id=7, SQL => 'SELECT COUNT(map['sub1']['sub2']) FROM STREAM:FLB WHERE map['sub1']['sub2'] = 123;'
[2020/06/25 23:53:14] [ info] [sp test] id=8, SQL => 'SELECT MIN(map['sub1']['sub2']) FROM STREAM:FLB WHERE map['sub1']['sub2'] > 0;'
[2020/06/25 23:53:14] [ info] [sp test] id=9, SQL => 'SELECT MAX(map['sub1']['sub3']) FROM STREAM:FLB WHERE map['sub1']['sub3'] > 0;'
[2020/06/25 23:53:14] [ info] [sp test] id=10, SQL => 'SELECT SUM(map['sub1']['sub3']) FROM STREAM:FLB GROUP BY map['mtype'];'
[2020/06/25 23:53:14] [ info] [sp test] id=11, SQL => 'SELECT map['sub1']['stype'], map['mtype'], SUM(map['sub1']['sub3']) FROM STREAM:FLB GROUP BY map['mtype'], map['sub1']['stype'];'
[2020/06/25 23:53:14] [ info] [sp test] id=12, SQL => 'SELECT map['sub1']['stype'], map['sub1']['sub4'], SUM(map['sub1']['sub3']) FROM STREAM:FLB GROUP BY map['sub1']['stype'], map['sub1']['sub4'];'
[0] [1592504045.677959, {"id"=>0, "map"=>{"sub1"=>{"sub2"=>{"color"=>"blue"}}}}]
[0] [1592504045.677966, {"id"=>2, "map"=>{"sub1"=>{"sub2"=>123}}}]
[0] [1592504045.677969, {"id"=>3, "map"=>{"sub1"=>{"sub2"=>"123", "stype"=>"a"}, "mtype"=>0}}]
[0] [1592504045.677959, {"id"=>0, "map"=>{"sub1"=>{"sub2"=>{"color"=>"blue"}}}}]
[0] [1592504045.677963, {"id"=>1, "map"=>{"sub1"=>{"sub2"=>{"color"=>"red"}, "sub4"=>"circle"}}}]
[0] [1592504045.677971, {"id"=>4, "map"=>{"color"=>"blue"}}]
[0] [1592504045.677971, {"id"=>4, "map"=>{"color"=>"blue"}}]
[0] [1592504045.677975, {"id"=>5, "map"=>{"sub1"=>{"sub3"=>"100", "stype"=>"a", "sub4"=>"circle"}, "mtype"=>0}}]
[0] [1592504045.677979, {"id"=>6, "map"=>{"sub1"=>{"sub3"=>"0.50", "stype"=>"b", "sub4"=>"rectangle"}, "mtype"=>1}}]
[0] [1592504045.677984, {"id"=>7, "map"=>{"sub1"=>{"sub3"=>"5.50", "stype"=>"a", "sub4"=>"triangle"}, "mtype"=>0}}]
[0] [1592504045.677987, {"id"=>8, "map"=>{"sub1"=>{"sub3"=>"10.50", "stype"=>"b", "sub4"=>"rectangle"}, "mtype"=>2}}]
[0] [1592504045.677959, {"map['sub1']['sub2']['color']"=>"blue"}]
[0] [1593129194.923936, {"SUM(map['sub1']['sub2'])"=>246}]
[0] [1593129194.929939, {"AVG(map['sub1']['sub2'])"=>123.000000}]
[0] [1593129194.937823, {"COUNT(map['sub1']['sub2'])"=>2}]
[0] [1593129194.942020, {"MIN(map['sub1']['sub2'])"=>123}]
[0] [1593129194.953055, {"MAX(map['sub1']['sub3'])"=>100.000000}]
[0] [1593129194.964012, {"SUM(map['sub1']['sub3'])"=>105.500000}]
[0] [1593129194.964036, {"SUM(map['sub1']['sub3'])"=>0.500000}]
[0] [1593129194.964047, {"SUM(map['sub1']['sub3'])"=>10.500000}]
[0] [1593129194.971869, {"map['sub1']['stype']"=>"a", "map['mtype']"=>0, "SUM(map['sub1']['sub3'])"=>105.500000}]
[0] [1593129194.973130, {"map['sub1']['stype']"=>"b", "map['mtype']"=>1, "SUM(map['sub1']['sub3'])"=>0.500000}]
[0] [1593129194.973156, {"map['sub1']['stype']"=>"b", "map['mtype']"=>2, "SUM(map['sub1']['sub3'])"=>10.500000}]
[0] [1593129194.976574, {"map['sub1']['stype']"=>"a", "map['sub1']['sub4']"=>"circle", "SUM(map['sub1']['sub3'])"=>100}]
[0] [1593129194.976613, {"map['sub1']['stype']"=>"b", "map['sub1']['sub4']"=>"rectangle", "SUM(map['sub1']['sub3'])"=>11.000000}]
[0] [1593129194.976635, {"map['sub1']['stype']"=>"a", "map['sub1']['sub4']"=>"triangle", "SUM(map['sub1']['sub3'])"=>5.500000}]
[   OK   ]
==22628== 
==22628== HEAP SUMMARY:
==22628==     in use at exit: 45 bytes in 2 blocks
==22628==   total heap usage: 1,731 allocs, 1,729 frees, 1,714,789 bytes allocated
==22628== 
==22628== LEAK SUMMARY:
==22628==    definitely lost: 0 bytes in 0 blocks
==22628==    indirectly lost: 0 bytes in 0 blocks
==22628==      possibly lost: 0 bytes in 0 blocks
==22628==    still reachable: 45 bytes in 2 blocks
==22628==         suppressed: 0 bytes in 0 blocks
==22628== Reachable blocks (those to which a pointer was found) are not shown.
==22628== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22628== 
==22628== For counts of detected and suppressed errors, rerun with: -v
==22628== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test window...                                  [2020/06/25 23:53:15] [ info] [sp] stream processor started
[2020/06/25 23:53:19] [ info] [sp test] id=0, SQL => 'SELECT SUM(id), AVG(id) FROM STREAM:FLB WINDOW TUMBLING (5 SECOND) WHERE word3 IS NOT NULL;'
[2020/06/25 23:53:19] [ info] [sp test] id=1, SQL => 'SELECT MIN(id), MAX(id), COUNT(*), SUM(bytes), AVG(bytes) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND);'
[2020/06/25 23:53:20] [ info] [sp test] id=2, SQL => 'SELECT bool, MIN(id), MAX(id), COUNT(*), SUM(bytes), AVG(bytes) FROM STREAM:FLB WINDOW TUMBLING (1 SECOND) WHERE word3 IS NOT NULL GROUP BY bool;'
[2020/06/25 23:53:26] [ info] [sp test] id=3, SQL => 'SELECT SUM(id), AVG(id) FROM STREAM:FLB WINDOW HOPPING (5 SECOND, ADVANCE BY 2 SECOND) WHERE word3 IS NOT NULL;'
[2020/06/25 23:53:27] [ info] [sp test] id=4, SQL => 'SELECT AVG(usage), TIMESERIES_FORECAST(id, usage, 20) FROM STREAM:FLB WINDOW TUMBLING (5 SECOND);'
[2020/06/25 23:53:32] [ info] [sp test] id=5, SQL => 'SELECT AVG(usage), TIMESERIES_FORECAST(id, usage, 20) FROM STREAM:FLB WINDOW HOPPING (5 SECOND, ADVANCE BY 2 SECOND);'
[2020/06/25 23:53:33] [ info] [sp test] id=6, SQL => 'SELECT AVG(usage), TIMESERIES_FORECAST_R(id, usage, 500, 10000) FROM STREAM:FLB WINDOW TUMBLING (5 SECOND);'
[2020/06/25 23:53:39] [ info] [sp test] id=7, SQL => 'SELECT AVG(usage), TIMESERIES_FORECAST_R(id, usage, 500, 10000) FROM STREAM:FLB WINDOW HOPPING (5 SECOND, ADVANCE BY 2 SECOND);'
[0] [1593129199.128013, {"SUM(id)"=>225, "AVG(id)"=>4.500000}]
[0] [1593129199.128013, {"SUM(id)"=>225, "AVG(id)"=>4.500000}]
[0] [1593129199.970752, {"MIN(id)"=>0, "MAX(id)"=>10, "COUNT(*)"=>11, "SUM(bytes)"=>110.500000, "AVG(bytes)"=>10.045455}]
[0] [1593129199.970752, {"MIN(id)"=>0, "MAX(id)"=>10, "COUNT(*)"=>11, "SUM(bytes)"=>110.500000, "AVG(bytes)"=>10.045455}]
[0] [1593129200.789788, {"bool"=>1, "MIN(id)"=>0, "MAX(id)"=>8, "COUNT(*)"=>8, "SUM(bytes)"=>80.000000, "AVG(bytes)"=>10.000000}]
[0] [1593129200.791539, {"bool"=>0, "MIN(id)"=>6, "MAX(id)"=>9, "COUNT(*)"=>2, "SUM(bytes)"=>20.500000, "AVG(bytes)"=>10.250000}]
[0] [1593129200.789788, {"bool"=>1, "MIN(id)"=>0, "MAX(id)"=>8, "COUNT(*)"=>8, "SUM(bytes)"=>80.000000, "AVG(bytes)"=>10.000000}]
[0] [1593129200.791539, {"bool"=>0, "MIN(id)"=>6, "MAX(id)"=>9, "COUNT(*)"=>2, "SUM(bytes)"=>20.500000, "AVG(bytes)"=>10.250000}]
[0] [1593129204.817859, {"SUM(id)"=>161, "AVG(id)"=>8.944445}]
[0] [1593129206.424260, {"SUM(id)"=>266, "AVG(id)"=>16.625000}]
[0] [1593129206.424260, {"SUM(id)"=>266, "AVG(id)"=>16.625000}]
[0] [1593129207.237425, {"AVG(usage)"=>60.000000, "FORECAST"=>310.000000}]
[0] [1593129207.237425, {"AVG(usage)"=>60.000000, "FORECAST"=>310.000000}]
[0] [1593129211.247875, {"AVG(usage)"=>100.000000, "FORECAST"=>390.000000}]
[0] [1593129212.851771, {"AVG(usage)"=>175.000000, "FORECAST"=>460.000000}]
[0] [1593129212.851771, {"AVG(usage)"=>175.000000, "FORECAST"=>460.000000}]
[0] [1593129213.656442, {"AVG(usage)"=>60.000000, "FORECAST_R"=>39.000000}]
[0] [1593129213.656442, {"AVG(usage)"=>60.000000, "FORECAST_R"=>39.000000}]
[0] [1593129217.668856, {"AVG(usage)"=>100.000000, "FORECAST_R"=>31.000000}]
[0] [1593129219.273163, {"AVG(usage)"=>175.000000, "FORECAST_R"=>24.000000}]
[0] [1593129219.273163, {"AVG(usage)"=>175.000000, "FORECAST_R"=>24.000000}]
[   OK   ]
==22629== 
==22629== HEAP SUMMARY:
==22629==     in use at exit: 45 bytes in 2 blocks
==22629==   total heap usage: 1,852 allocs, 1,850 frees, 2,290,104 bytes allocated
==22629== 
==22629== LEAK SUMMARY:
==22629==    definitely lost: 0 bytes in 0 blocks
==22629==    indirectly lost: 0 bytes in 0 blocks
==22629==      possibly lost: 0 bytes in 0 blocks
==22629==    still reachable: 45 bytes in 2 blocks
==22629==         suppressed: 0 bytes in 0 blocks
==22629== Reachable blocks (those to which a pointer was found) are not shown.
==22629== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22629== 
==22629== For counts of detected and suppressed errors, rerun with: -v
==22629== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test snapshot...                                [2020/06/25 23:53:39] [ info] [sp] stream processor started
[2020/06/25 23:53:39] [ info] [sp test] id=0, SQL => 'SELECT * FROM STREAM:FLB LIMIT 5;'
[2020/06/25 23:53:39] [ info] [sp test] id=1, SQL => 'SELECT * FROM STREAM:FLB;'
[2020/06/25 23:53:39] [ info] [sp test] id=2, SQL => 'SELECT * FROM STREAM:FLB;'
[2020/06/25 23:53:39] [ info] [sp test] id=3, SQL => 'SELECT * FROM STREAM:FLB;'
[0] [1592504053.694412, {"id"=>14, "word1"=>"fluent-logger", "word3"=>"", "bytes"=>10, "bool"=>true, "usage"=>150}]
[0] [1592504055.695671, {"id"=>15, "word1"=>"forward", "word3"=>"plain", "bytes"=>10, "bool"=>true, "usage"=>160}]
[0] [1592504055.695680, {"id"=>16, "word5"=>"forward-protocol", "word6"=>"secure", "bytes"=>10, "bool"=>true, "usage"=>170}]
[0] [1592504055.695687, {"id"=>17, "word1"=>"stream", "word3"=>"processing", "bytes"=>10.200000, "bool"=>false, "usage"=>180}]
[0] [1592504055.695692, {"id"=>18, "word1"=>"edge-rocks", "word6"=>"", "bytes"=>10, "bool"=>true, "usage"=>190}]
[0] [1592504051.691383, {"id"=>8, "word1"=>"treasure-data", "word3"=>"cncf", "bytes"=>10, "bool"=>true, "usage"=>90}]
[0] [1592504051.691392, {"id"=>9, "word1"=>"arm", "word3"=>"linux foundation", "bytes"=>"10.30", "bool"=>false, "usage"=>100}]
[0] [1592504051.691397, {"id"=>10, "word1"=>"fluent-bit", "word3"=>nil, "bytes"=>10, "bool"=>true, "usage"=>110}]
[0] [1592504053.694391, {"id"=>11, "word1"=>"fluent", "word2"=>"logging", "bytes"=>10, "bool"=>true, "usage"=>120}]
[0] [1592504053.694403, {"id"=>12, "word1"=>"fluentd", "word2"=>"rlz", "bytes"=>10.000000, "bool"=>true, "usage"=>130}]
[0] [1592504053.694407, {"id"=>13, "word1"=>"fluent-bit", "word3"=>"rlz", "bytes"=>10, "bool"=>true, "usage"=>140}]
[0] [1592504053.694412, {"id"=>14, "word1"=>"fluent-logger", "word3"=>"", "bytes"=>10, "bool"=>true, "usage"=>150}]
[0] [1592504055.695671, {"id"=>15, "word1"=>"forward", "word3"=>"plain", "bytes"=>10, "bool"=>true, "usage"=>160}]
[0] [1592504055.695680, {"id"=>16, "word5"=>"forward-protocol", "word6"=>"secure", "bytes"=>10, "bool"=>true, "usage"=>170}]
[0] [1592504055.695687, {"id"=>17, "word1"=>"stream", "word3"=>"processing", "bytes"=>10.200000, "bool"=>false, "usage"=>180}]
[0] [1592504055.695692, {"id"=>18, "word1"=>"edge-rocks", "word6"=>"", "bytes"=>10, "bool"=>true, "usage"=>190}]
[   OK   ]
==22631== 
==22631== HEAP SUMMARY:
==22631==     in use at exit: 45 bytes in 2 blocks
==22631==   total heap usage: 822 allocs, 820 frees, 3,012,092 bytes allocated
==22631== 
==22631== LEAK SUMMARY:
==22631==    definitely lost: 0 bytes in 0 blocks
==22631==    indirectly lost: 0 bytes in 0 blocks
==22631==      possibly lost: 0 bytes in 0 blocks
==22631==    still reachable: 45 bytes in 2 blocks
==22631==         suppressed: 0 bytes in 0 blocks
==22631== Reachable blocks (those to which a pointer was found) are not shown.
==22631== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22631== 
==22631== For counts of detected and suppressed errors, rerun with: -v
==22631== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==22625== 
==22625== HEAP SUMMARY:
==22625==     in use at exit: 0 bytes in 0 blocks
==22625==   total heap usage: 3 allocs, 3 frees, 4,141 bytes allocated
==22625== 
==22625== All heap blocks were freed -- no leaks are possible
==22625== 
==22625== For counts of detected and suppressed errors, rerun with: -v
==22625== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ X] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
