### PR TITLE
sp: remove redundant memory free for groupby items

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -2357,7 +2357,6 @@ static int sp_process_hopping_slot(const char *tag, int tag_len,
         }
         else {
             flb_free(nums);
-            flb_free(aggr_node_hs->groupby_nums);
             flb_free(aggr_node_hs);
         }
     }


### PR DESCRIPTION
Signed-off-by: Masoud Koleini <masoud.koleini@arm.com>

remove redundant memory free for groupby items

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
