### PR TITLE
out_stackdriver: support special fields - insertId/sourceLocation/httpRequest

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -3,6 +3,9 @@ set(src
   stackdriver_conf.c
   stackdriver.c
   stackdriver_operation.c
+  stackdriver_source_location.c
+  stackdriver_http_request.c
+  stackdriver_helper.c
   )
 
 FLB_PLUGIN(out_stackdriver "${src}" "")

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -799,7 +799,8 @@ static int pack_json_payload(int insert_id_extracted,
                              int source_location_extracted, 
                              int source_location_extra_size,
                              int http_request_extracted, int http_request_extra_size, 
-                             msgpack_packer *mp_pck, msgpack_object *obj)
+                             msgpack_packer *mp_pck, msgpack_object *obj,
+                             struct flb_stackdriver *ctx)
 {
     /* Specified fields include local_resource_id, operation, sourceLocation ... */
     int i, j;
@@ -1385,7 +1386,7 @@ static int stackdriver_format(struct flb_config *config,
         pack_json_payload(insert_id_extracted, operation_extracted, 
                           operation_extra_size, source_location_extracted, 
                           source_location_extra_size, http_request_extracted, 
-                          http_request_extra_size, &mp_pck, obj);
+                          http_request_extra_size, &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */
         newtag = tag;

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -33,6 +33,7 @@
 #include "stackdriver_operation.h"
 #include "stackdriver_source_location.h"
 #include "stackdriver_http_request.h"
+#include "stackdriver_helper.h"
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
 
@@ -779,8 +780,7 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
         if (p->key.type != MSGPACK_OBJECT_STR) {
             continue;
         }
-        if (sizeof(INSERTID_IN_JSON) - 1 == p->key.via.str.size 
-            && strncmp(INSERTID_IN_JSON, p->key.via.str.ptr, p->key.via.str.size) == 0) {
+        if (cmp_str_helper(p->key, INSERTID_IN_JSON, sizeof(INSERTID_IN_JSON) - 1)) {
             if (p->val.type == MSGPACK_OBJECT_STR && p->val.via.str.size > 0) {
                 *insert_id_value = p->val;
                 ret = INSERTID_VALID;
@@ -879,14 +879,12 @@ static int pack_json_payload(int insert_id_extracted,
         key_not_found = 1;
         
         if (insert_id_extracted == FLB_TRUE 
-            && kv->val.type == MSGPACK_OBJECT_STR
-            && sizeof(INSERTID_IN_JSON) - 1 == kv->key.via.str.size 
-            && strncmp(INSERTID_IN_JSON, kv->key.via.str.ptr, kv->key.via.str.size) == 0 ) {
+            && cmp_str_helper(kv->key, INSERTID_IN_JSON, sizeof(INSERTID_IN_JSON) - 1) ) {
             continue;
         }
         
-        if (sizeof(OPERATION_FIELD_IN_JSON) - 1 == kv->key.via.str.size
-            && strncmp(OPERATION_FIELD_IN_JSON, kv->key.via.str.ptr, kv->key.via.str.size) == 0 
+        if (cmp_str_helper(kv->key, OPERATION_FIELD_IN_JSON, 
+                           sizeof(OPERATION_FIELD_IN_JSON) - 1)
             && kv->val.type == MSGPACK_OBJECT_MAP) {
 
             if (operation_extra_size > 0) {
@@ -896,8 +894,8 @@ static int pack_json_payload(int insert_id_extracted,
             continue;
         }
 
-        if (sizeof(SOURCELOCATION_FIELD_IN_JSON) - 1 == kv->key.via.str.size
-            && strncmp(SOURCELOCATION_FIELD_IN_JSON, kv->key.via.str.ptr, kv->key.via.str.size) == 0 
+        if (cmp_str_helper(kv->key, SOURCELOCATION_FIELD_IN_JSON, 
+                           sizeof(SOURCELOCATION_FIELD_IN_JSON) - 1) 
             && kv->val.type == MSGPACK_OBJECT_MAP) {
 
             if(source_location_extra_size > 0) {
@@ -908,8 +906,8 @@ static int pack_json_payload(int insert_id_extracted,
             continue;
         }
                                                                                         
-        if (sizeof(HTTPREQUEST_FIELD_IN_JSON) - 1 == kv->key.via.str.size
-            && strncmp(HTTPREQUEST_FIELD_IN_JSON, kv->key.via.str.ptr, kv->key.via.str.size) == 0 
+        if (cmp_str_helper(kv->key, HTTPREQUEST_FIELD_IN_JSON, 
+                           sizeof(HTTPREQUEST_FIELD_IN_JSON) - 1) 
             && kv->val.type == MSGPACK_OBJECT_MAP) {
 
             if(http_request_extra_size > 0) {

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -46,9 +46,13 @@
 /* Default Resource type */
 #define FLB_SDS_RESOURCE_TYPE "global"
 
+#define INSERTID_IN_JSON "logging.googleapis.com/insertId"
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
+#define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
+#define HTTPREQUEST_FIELD_IN_JSON "logging.googleapis.com/http_request"
+
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 
 #define K8S_CONTAINER "k8s_container"
@@ -129,5 +133,11 @@ struct local_resource_id_list {
     flb_sds_t val;
     struct mk_list _head;
 };
+
+typedef enum {
+    INSERTID_VALID = 0,
+    INSERTID_INVALID = 1,
+    INSERTID_NOT_PRESENT = 2
+} insert_id_status;
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -1,0 +1,69 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include "stackdriver.h"
+
+int cmp_helper(msgpack_object key, const char* str, const int size) {
+    if (size != key.via.str.size 
+        || strncmp(str, key.via.str.ptr, key.via.str.size) != 0) {
+        return FLB_FALSE;
+    }
+    return FLB_TRUE;
+}
+
+int assign_subfield_str(msgpack_object_kv *tmp_p, const char* str, 
+                        const int size, flb_sds_t *subfield) {
+    if (cmp_helper(tmp_p->key, str, size)) {
+        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+            return 0;
+        }
+        *subfield = flb_sds_copy(*subfield, tmp_p->val.via.str.ptr, 
+                                 tmp_p->val.via.str.size);
+        return 0;
+    }
+    return -1;
+}
+
+int assign_subfield_bool(msgpack_object_kv *tmp_p, const char* str, 
+                         const int size, int *subfield) {
+    if (cmp_helper(tmp_p->key, str, size)) {
+        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
+            return 0;
+        }
+        if (tmp_p->val.via.boolean) {
+            *subfield = FLB_TRUE;
+        }
+        return 0;
+    }
+    return -1;
+}
+
+int assign_subfield_int(msgpack_object_kv *tmp_p, const char* str, 
+                        const int size, int *subfield) {
+    if (cmp_helper(tmp_p->key, str, size)) {
+        if (tmp_p->val.type == MSGPACK_OBJECT_STR) {
+            *subfield = atoll(tmp_p->val.via.str.ptr);
+        }
+        else if (tmp_p->val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            *subfield = tmp_p->val.via.i64;
+        }
+        return 0;
+    }
+    return -1;
+}

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -1,0 +1,36 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HELPER_H
+#define FLB_STD_HELPER_H
+
+#include "stackdriver.h"
+
+int cmp_helper(msgpack_object key, const char* str, const int size);
+
+int assign_subfield_str(msgpack_object_kv *tmp_p, const char* str, 
+                        const int size, flb_sds_t *subfield);
+
+int assign_subfield_bool(msgpack_object_kv *tmp_p, const char* str, 
+                         const int size, int *subfield);
+
+int assign_subfield_int(msgpack_object_kv *tmp_p, const char* str, 
+                        const int size, int *subfield);
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -22,7 +22,8 @@
 
 #include "stackdriver.h"
 
-int cmp_helper(msgpack_object key, const char* str, const int size);
+/* Compare key->via.str and str. Return FLB_TRUE if matches */
+int cmp_str_helper(msgpack_object key, const char* str, const int size);
 
 int assign_subfield_str(msgpack_object_kv *tmp_p, const char* str, 
                         const int size, flb_sds_t *subfield);

--- a/plugins/out_stackdriver/stackdriver_http_request.c
+++ b/plugins/out_stackdriver/stackdriver_http_request.c
@@ -230,7 +230,7 @@ int extract_http_request(struct http_request_field *http_request,
     for (; p < pend && op_status == NO_HTTPREQUEST; ++p) {
         if (p->val.type != MSGPACK_OBJECT_MAP
             || p->key.type != MSGPACK_OBJECT_STR
-            || !cmp_helper(p->key, HTTPREQUEST_FIELD_IN_JSON, 
+            || !cmp_str_helper(p->key, HTTPREQUEST_FIELD_IN_JSON, 
                            sizeof(HTTPREQUEST_FIELD_IN_JSON) - 1)) {
             
             continue;
@@ -248,7 +248,7 @@ int extract_http_request(struct http_request_field *http_request,
                 continue;
             }
 
-            if (cmp_helper(tmp_p->key, HTTP_REQUEST_LATENCY, 
+            if (cmp_str_helper(tmp_p->key, HTTP_REQUEST_LATENCY, 
                            HTTP_REQUEST_LATENCY_SIZE)) {                
                 if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
                     continue;
@@ -257,74 +257,74 @@ int extract_http_request(struct http_request_field *http_request,
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_PROTOCOL, 
                                          HTTP_REQUEST_PROTOCOL_SIZE, 
-                                         &http_request->protocol) == 0) {
+                                         &http_request->protocol) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REFERER, 
                                          HTTP_REQUEST_REFERER_SIZE, 
-                                         &http_request->referer) == 0) {
+                                         &http_request->referer) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REMOTE_IP, 
                                          HTTP_REQUEST_REMOTE_IP_SIZE, 
-                                         &http_request->remoteIp) == 0) {
+                                         &http_request->remoteIp) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REQUEST_METHOD, 
                                          HTTP_REQUEST_REQUEST_METHOD_SIZE, 
-                                         &http_request->requestMethod) == 0) {
+                                         &http_request->requestMethod) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REQUEST_URL, 
                                          HTTP_REQUEST_REQUEST_URL_SIZE, 
-                                         &http_request->requestUrl) == 0) {
+                                         &http_request->requestUrl) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_SERVER_IP, 
                                          HTTP_REQUEST_SERVER_IP_SIZE, 
-                                         &http_request->serverIp) == 0) {
+                                         &http_request->serverIp) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, HTTP_REQUEST_USER_AGENT, 
                                          HTTP_REQUEST_USER_AGENT_SIZE, 
-                                         &http_request->userAgent) == 0) {
+                                         &http_request->userAgent) == FLB_TRUE) {
                 continue;
             }
 
             else if (assign_subfield_int(tmp_p, HTTP_REQUEST_CACHE_FILL_BYTES, 
                                          HTTP_REQUEST_CACHE_FILL_BYTES_SIZE, 
-                                         &http_request->cacheFillBytes) == 0) {
+                                         &http_request->cacheFillBytes) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_int(tmp_p, HTTP_REQUEST_REQUESTSIZE, 
                                          HTTP_REQUEST_REQUESTSIZE_SIZE, 
-                                         &http_request->requestSize) == 0) {
+                                         &http_request->requestSize) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_int(tmp_p, HTTP_REQUEST_RESPONSESIZE, 
                                          HTTP_REQUEST_RESPONSESIZE_SIZE, 
-                                         &http_request->responseSize) == 0) {
+                                         &http_request->responseSize) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_int(tmp_p, HTTP_REQUEST_STATUS, 
                                          HTTP_REQUEST_STATUS_SIZE, 
-                                         &http_request->status) == 0) {
+                                         &http_request->status) == FLB_TRUE) {
                 continue;
             }
 
             else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_HIT, 
                                           HTTP_REQUEST_CACHE_HIT_SIZE, 
-                                          &http_request->cacheHit) == 0) {
+                                          &http_request->cacheHit) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_LOOKUP, 
                                           HTTP_REQUEST_CACHE_LOOKUP_SIZE, 
-                                          &http_request->cacheLookup) == 0) {
+                                          &http_request->cacheLookup) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
                                           HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE, 
-                                          &http_request->cacheValidatedWithOriginServer) == 0) {
+                                          &http_request->cacheValidatedWithOriginServer) == FLB_TRUE) {
                 continue;
             }
 
@@ -346,35 +346,35 @@ void pack_extra_http_request_subfields(msgpack_packer *mp_pck,
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (cmp_helper(p->key, HTTP_REQUEST_LATENCY, 
+        if (cmp_str_helper(p->key, HTTP_REQUEST_LATENCY, 
                        HTTP_REQUEST_LATENCY_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_PROTOCOL, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_PROTOCOL, 
                           HTTP_REQUEST_PROTOCOL_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_REFERER, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_REFERER, 
                           HTTP_REQUEST_REFERER_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_REMOTE_IP, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_REMOTE_IP, 
                           HTTP_REQUEST_REMOTE_IP_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_REQUEST_METHOD, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_REQUEST_METHOD, 
                           HTTP_REQUEST_REQUEST_METHOD_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_REQUEST_URL, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_REQUEST_URL, 
                           HTTP_REQUEST_REQUEST_URL_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_SERVER_IP, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_SERVER_IP, 
                           HTTP_REQUEST_SERVER_IP_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_USER_AGENT, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_USER_AGENT, 
                           HTTP_REQUEST_USER_AGENT_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
                           HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_REQUESTSIZE, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_REQUESTSIZE, 
                           HTTP_REQUEST_REQUESTSIZE_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_RESPONSESIZE, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_RESPONSESIZE, 
                           HTTP_REQUEST_RESPONSESIZE_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_STATUS, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_STATUS, 
                           HTTP_REQUEST_STATUS_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_CACHE_HIT, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_CACHE_HIT, 
                           HTTP_REQUEST_CACHE_HIT_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_CACHE_LOOKUP, 
                           HTTP_REQUEST_CACHE_LOOKUP_SIZE)
-            || cmp_helper(p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+            || cmp_str_helper(p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
                           HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
             
             continue;

--- a/plugins/out_stackdriver/stackdriver_http_request.c
+++ b/plugins/out_stackdriver/stackdriver_http_request.c
@@ -1,0 +1,386 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <fluent-bit/flb_regex.h>
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_http_request.h"
+
+typedef enum {
+    NO_HTTPREQUEST = 1,
+    HTTPREQUEST_EXISTS = 2
+} http_request_status;
+
+void init_http_request(struct http_request_field *http_request)
+{
+    http_request->latency = flb_sds_create("");
+    http_request->protocol = flb_sds_create("");
+    http_request->referer = flb_sds_create("");
+    http_request->remoteIp = flb_sds_create("");
+    http_request->requestMethod = flb_sds_create("");
+    http_request->requestUrl = flb_sds_create("");
+    http_request->serverIp = flb_sds_create("");
+    http_request->userAgent = flb_sds_create("");
+
+    http_request->cacheFillBytes = 0;
+    http_request->requestSize = 0;
+    http_request->responseSize = 0;
+    http_request->status = 0;
+
+    http_request->cacheHit = FLB_FALSE;
+    http_request->cacheLookup = FLB_FALSE;
+    http_request->cacheValidatedWithOriginServer = FLB_FALSE;
+}
+
+void destroy_http_request(struct http_request_field *http_request)
+{
+    flb_sds_destroy(http_request->latency);
+    flb_sds_destroy(http_request->protocol);
+    flb_sds_destroy(http_request->referer);
+    flb_sds_destroy(http_request->remoteIp);
+    flb_sds_destroy(http_request->requestMethod);
+    flb_sds_destroy(http_request->requestUrl);
+    flb_sds_destroy(http_request->serverIp);
+    flb_sds_destroy(http_request->userAgent);
+}
+
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 11);
+    msgpack_pack_str_body(mp_pck, "httpRequest", 11);
+
+    if (flb_sds_is_empty(http_request->latency) == FLB_TRUE) {
+        msgpack_pack_map(mp_pck, 14);
+    }
+    else {
+        msgpack_pack_map(mp_pck, 15);
+
+        msgpack_pack_str(mp_pck, HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str_body(mp_pck, HTTP_REQUEST_LATENCY, 
+                              HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str(mp_pck, flb_sds_len(http_request->latency));
+        msgpack_pack_str_body(mp_pck, http_request->latency, 
+                              flb_sds_len(http_request->latency));
+    }
+
+    /* String sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_METHOD, 
+                          HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestMethod));
+    msgpack_pack_str_body(mp_pck, http_request->requestMethod, 
+                          flb_sds_len(http_request->requestMethod));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_URL, 
+                          HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestUrl));
+    msgpack_pack_str_body(mp_pck, http_request->requestUrl, 
+                          flb_sds_len(http_request->requestUrl));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_USER_AGENT, 
+                          HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->userAgent));
+    msgpack_pack_str_body(mp_pck, http_request->userAgent, 
+                          flb_sds_len(http_request->userAgent));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REMOTE_IP, 
+                          HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->remoteIp));
+    msgpack_pack_str_body(mp_pck, http_request->remoteIp, 
+                          flb_sds_len(http_request->remoteIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_SERVER_IP, 
+                          HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->serverIp));
+    msgpack_pack_str_body(mp_pck, http_request->serverIp, 
+                          flb_sds_len(http_request->serverIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REFERER, 
+                          HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->referer));
+    msgpack_pack_str_body(mp_pck, http_request->referer, 
+                          flb_sds_len(http_request->referer));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_PROTOCOL, 
+                          HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->protocol));
+    msgpack_pack_str_body(mp_pck, http_request->protocol, 
+                          flb_sds_len(http_request->protocol));
+
+    /* Integer sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUESTSIZE, 
+                          HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->requestSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_RESPONSESIZE, 
+                          HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->responseSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_STATUS, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->status);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                          HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->cacheFillBytes);
+
+    /* Boolean sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_LOOKUP, 
+                          HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+                                                                                    
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_HIT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_HIT, 
+                          HTTP_REQUEST_CACHE_HIT_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                          HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    if (http_request->cacheValidatedWithOriginServer == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+}
+
+/* latency should be in the format: 
+ *      whitespace (opt.) + integer + point & decimal (opt.)
+ *      + whitespace (opt.) + "s" + whitespace (opt.) 
+ */
+static void validate_latency(msgpack_object_str latency_in_payload, 
+                             struct http_request_field *http_request) {
+    flb_sds_t pattern = flb_sds_create("^\\s*\\d+(.\\d+)?\\s*s\\s*$");
+    char extract_latency[latency_in_payload.size];
+    struct flb_regex *regex;
+
+    int status = 0;
+    int i = 0, j = 0;
+
+    regex = flb_regex_create(pattern);
+    status = flb_regex_match(regex, latency_in_payload.ptr, latency_in_payload.size);
+    flb_regex_destroy(regex);
+    flb_sds_destroy(pattern);
+
+    if (status == 1) {
+        for (; i < latency_in_payload.size; ++ i) {
+            if (latency_in_payload.ptr[i] == '.' || latency_in_payload.ptr[i] == 's' 
+                || isdigit(latency_in_payload.ptr[i])) {
+                extract_latency[j] = latency_in_payload.ptr[i];
+                ++ j;
+            }
+        }
+        http_request->latency = flb_sds_copy(http_request->latency, extract_latency, j);
+    }
+}
+                                                                                        
+/* Return true if httpRequest extracted */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields)
+{
+    http_request_status op_status = NO_HTTPREQUEST;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {
+        return FLB_FALSE;
+    }
+                                                                                        
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+                                                                                        
+    for (; p < pend && op_status == NO_HTTPREQUEST; ++p) {
+        if (p->val.type != MSGPACK_OBJECT_MAP
+            || p->key.type != MSGPACK_OBJECT_STR
+            || !cmp_helper(p->key, HTTPREQUEST_FIELD_IN_JSON, 
+                           sizeof(HTTPREQUEST_FIELD_IN_JSON) - 1)) {
+            
+            continue;
+        }
+
+        op_status = HTTPREQUEST_EXISTS;
+        msgpack_object sub_field = p->val;
+        
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+                                                                                        
+        /* Validate the subfields of httpRequest */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (cmp_helper(tmp_p->key, HTTP_REQUEST_LATENCY, 
+                           HTTP_REQUEST_LATENCY_SIZE)) {                
+                if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+                    continue;
+                }
+                validate_latency(tmp_p->val.via.str, http_request);
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_PROTOCOL, 
+                                         HTTP_REQUEST_PROTOCOL_SIZE, 
+                                         &http_request->protocol) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REFERER, 
+                                         HTTP_REQUEST_REFERER_SIZE, 
+                                         &http_request->referer) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REMOTE_IP, 
+                                         HTTP_REQUEST_REMOTE_IP_SIZE, 
+                                         &http_request->remoteIp) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REQUEST_METHOD, 
+                                         HTTP_REQUEST_REQUEST_METHOD_SIZE, 
+                                         &http_request->requestMethod) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_REQUEST_URL, 
+                                         HTTP_REQUEST_REQUEST_URL_SIZE, 
+                                         &http_request->requestUrl) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_SERVER_IP, 
+                                         HTTP_REQUEST_SERVER_IP_SIZE, 
+                                         &http_request->serverIp) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, HTTP_REQUEST_USER_AGENT, 
+                                         HTTP_REQUEST_USER_AGENT_SIZE, 
+                                         &http_request->userAgent) == 0) {
+                continue;
+            }
+
+            else if (assign_subfield_int(tmp_p, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                                         HTTP_REQUEST_CACHE_FILL_BYTES_SIZE, 
+                                         &http_request->cacheFillBytes) == 0) {
+                continue;
+            }
+            else if (assign_subfield_int(tmp_p, HTTP_REQUEST_REQUESTSIZE, 
+                                         HTTP_REQUEST_REQUESTSIZE_SIZE, 
+                                         &http_request->requestSize) == 0) {
+                continue;
+            }
+            else if (assign_subfield_int(tmp_p, HTTP_REQUEST_RESPONSESIZE, 
+                                         HTTP_REQUEST_RESPONSESIZE_SIZE, 
+                                         &http_request->responseSize) == 0) {
+                continue;
+            }
+            else if (assign_subfield_int(tmp_p, HTTP_REQUEST_STATUS, 
+                                         HTTP_REQUEST_STATUS_SIZE, 
+                                         &http_request->status) == 0) {
+                continue;
+            }
+
+            else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_HIT, 
+                                          HTTP_REQUEST_CACHE_HIT_SIZE, 
+                                          &http_request->cacheHit) == 0) {
+                continue;
+            }
+            else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_LOOKUP, 
+                                          HTTP_REQUEST_CACHE_LOOKUP_SIZE, 
+                                          &http_request->cacheLookup) == 0) {
+                continue;
+            }
+            else if (assign_subfield_bool(tmp_p, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                                          HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE, 
+                                          &http_request->cacheValidatedWithOriginServer) == 0) {
+                continue;
+            }
+
+            else {
+                *extra_subfields += 1;
+            }
+        }
+    }
+    
+    return op_status == HTTPREQUEST_EXISTS;
+}
+                                                                                        
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields) {
+    msgpack_object_kv *p = http_request->via.map.ptr;
+    msgpack_object_kv *const pend = http_request->via.map.ptr + http_request->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (cmp_helper(p->key, HTTP_REQUEST_LATENCY, 
+                       HTTP_REQUEST_LATENCY_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_PROTOCOL, 
+                          HTTP_REQUEST_PROTOCOL_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_REFERER, 
+                          HTTP_REQUEST_REFERER_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_REMOTE_IP, 
+                          HTTP_REQUEST_REMOTE_IP_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_REQUEST_METHOD, 
+                          HTTP_REQUEST_REQUEST_METHOD_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_REQUEST_URL, 
+                          HTTP_REQUEST_REQUEST_URL_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_SERVER_IP, 
+                          HTTP_REQUEST_SERVER_IP_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_USER_AGENT, 
+                          HTTP_REQUEST_USER_AGENT_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                          HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_REQUESTSIZE, 
+                          HTTP_REQUEST_REQUESTSIZE_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_RESPONSESIZE, 
+                          HTTP_REQUEST_RESPONSESIZE_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_STATUS, 
+                          HTTP_REQUEST_STATUS_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_CACHE_HIT, 
+                          HTTP_REQUEST_CACHE_HIT_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+                          HTTP_REQUEST_CACHE_LOOKUP_SIZE)
+            || cmp_helper(p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                          HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
+            
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_http_request.h
+++ b/plugins/out_stackdriver/stackdriver_http_request.h
@@ -1,0 +1,119 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HTTPREQUEST_H
+#define FLB_STD_HTTPREQUEST_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define HTTP_REQUEST_LATENCY "latency"
+#define HTTP_REQUEST_PROTOCOL "protocol"
+#define HTTP_REQUEST_REFERER "referer"
+#define HTTP_REQUEST_REMOTE_IP "remoteIp"
+#define HTTP_REQUEST_REQUEST_METHOD "requestMethod"
+#define HTTP_REQUEST_REQUEST_URL "requestUrl"
+#define HTTP_REQUEST_SERVER_IP "serverIp"
+#define HTTP_REQUEST_USER_AGENT "userAgent"
+#define HTTP_REQUEST_CACHE_FILL_BYTES "cacheFillBytes"
+#define HTTP_REQUEST_REQUESTSIZE "requestSize"
+#define HTTP_REQUEST_RESPONSESIZE "responseSize"
+#define HTTP_REQUEST_STATUS "status"
+#define HTTP_REQUEST_CACHE_HIT "cacheHit"
+#define HTTP_REQUEST_CACHE_LOOKUP "cacheLookup"
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER "cacheValidatedWithOriginServer"
+
+#define HTTP_REQUEST_LATENCY_SIZE 7
+#define HTTP_REQUEST_PROTOCOL_SIZE  8
+#define HTTP_REQUEST_REFERER_SIZE 7
+#define HTTP_REQUEST_REMOTE_IP_SIZE 8 
+#define HTTP_REQUEST_REQUEST_METHOD_SIZE 13
+#define HTTP_REQUEST_REQUEST_URL_SIZE 10
+#define HTTP_REQUEST_SERVER_IP_SIZE 8
+#define HTTP_REQUEST_USER_AGENT_SIZE 9
+#define HTTP_REQUEST_CACHE_FILL_BYTES_SIZE 14
+#define HTTP_REQUEST_REQUESTSIZE_SIZE 11
+#define HTTP_REQUEST_RESPONSESIZE_SIZE 12
+#define HTTP_REQUEST_STATUS_SIZE 6
+#define HTTP_REQUEST_CACHE_HIT_SIZE 8
+#define HTTP_REQUEST_CACHE_LOOKUP_SIZE 11
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE 30
+
+
+struct http_request_field {
+    flb_sds_t latency;
+    flb_sds_t protocol;
+    flb_sds_t referer;
+    flb_sds_t remoteIp;
+    flb_sds_t requestMethod;
+    flb_sds_t requestUrl;
+    flb_sds_t serverIp;
+    flb_sds_t userAgent;
+
+    int64_t cacheFillBytes;
+    int64_t requestSize;
+    int64_t responseSize;
+    int64_t status;
+    
+    int cacheHit;
+    int cacheLookup;
+    int cacheValidatedWithOriginServer;
+};
+
+void init_http_request(struct http_request_field *http_request);
+void destroy_http_request(struct http_request_field *http_request);
+
+/* 
+ *  Add httpRequest field to the entries.
+ *  The structure of httpRequest is as shown in struct http_request_field
+ */   
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck);
+
+/*
+ *  Extract the httpRequest field from the jsonPayload.
+ *  If the httpRequest field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "requestMethod": "GET",
+ *          "latency": "1s",
+ *          "cacheLookup": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields);
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -83,8 +83,8 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
     for (; p < pend && op_status == NO_OPERATION; ++p) {
 
         if (p->val.type != MSGPACK_OBJECT_MAP || p->key.type != MSGPACK_OBJECT_STR
-            || !cmp_helper(p->key, OPERATION_FIELD_IN_JSON, 
-                          sizeof(OPERATION_FIELD_IN_JSON) - 1)) {
+            || !cmp_str_helper(p->key, OPERATION_FIELD_IN_JSON, 
+                           sizeof(OPERATION_FIELD_IN_JSON) - 1)) {
             continue;
         }
 
@@ -101,19 +101,22 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
             }
 
             if (assign_subfield_str(tmp_p, OPERATION_ID, 
-                                    OPERATION_ID_SIZE, operation_id) == 0) {
+                                    OPERATION_ID_SIZE, operation_id) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, OPERATION_PRODUCER, 
-                                         OPERATION_PRODUCER_SIZE, operation_producer) == 0) {
+                                         OPERATION_PRODUCER_SIZE, 
+                                         operation_producer) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_bool(tmp_p, OPERATION_FIRST, 
-                                          OPERATION_FIRST_SIZE, operation_first) == 0) {
+                                          OPERATION_FIRST_SIZE, 
+                                          operation_first) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_bool(tmp_p, OPERATION_LAST, 
-                                          OPERATION_LAST_SIZE, operation_last) == 0) {
+                                          OPERATION_LAST_SIZE, 
+                                          operation_last) == FLB_TRUE) {
                 continue;
             }
             else {
@@ -133,10 +136,10 @@ void pack_extra_operation_subfields(msgpack_packer *mp_pck,
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (cmp_helper(p->key, OPERATION_ID, OPERATION_ID_SIZE)
-            || cmp_helper(p->key, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE)
-            || cmp_helper(p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)
-            || cmp_helper(p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+        if (cmp_str_helper(p->key, OPERATION_ID, OPERATION_ID_SIZE)
+            || cmp_str_helper(p->key, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE)
+            || cmp_str_helper(p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)
+            || cmp_str_helper(p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
             continue;
         }
 

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -16,6 +16,7 @@
  *  limitations under the License.
  */
 #include "stackdriver.h"
+#include "stackdriver_helper.h"
 #include "stackdriver_operation.h"
 
 typedef enum {
@@ -23,24 +24,28 @@ typedef enum {
     OPERATION_EXISTED = 2
 } operation_status;
 
-
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck)
 {    
     msgpack_pack_str(mp_pck, 9);
     msgpack_pack_str_body(mp_pck, "operation", 9);
+
     msgpack_pack_map(mp_pck, 4);
-    msgpack_pack_str(mp_pck, 2);
-    msgpack_pack_str_body(mp_pck, "id", 2);
+
+    msgpack_pack_str(mp_pck, OPERATION_ID_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_ID, OPERATION_ID_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_id));
     msgpack_pack_str_body(mp_pck, *operation_id, flb_sds_len(*operation_id));
-    msgpack_pack_str(mp_pck, 8);
-    msgpack_pack_str_body(mp_pck, "producer", 8);
+
+    msgpack_pack_str(mp_pck, OPERATION_PRODUCER_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_producer));
-    msgpack_pack_str_body(mp_pck, *operation_producer, flb_sds_len(*operation_producer));
-    msgpack_pack_str(mp_pck, 5);
-    msgpack_pack_str_body(mp_pck, "first", 5);
+    msgpack_pack_str_body(mp_pck, *operation_producer, 
+                          flb_sds_len(*operation_producer));
+
+    msgpack_pack_str(mp_pck, OPERATION_FIRST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_FIRST, OPERATION_FIRST_SIZE);
     if (*operation_first == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -48,8 +53,8 @@ void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer,
         msgpack_pack_false(mp_pck);
     }
     
-    msgpack_pack_str(mp_pck, 4);
-    msgpack_pack_str_body(mp_pck, "last", 4);
+    msgpack_pack_str(mp_pck, OPERATION_LAST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_LAST, OPERATION_LAST_SIZE);
     if (*operation_last == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -64,60 +69,55 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
                       msgpack_object *obj, int *extra_subfields)
 {
     operation_status op_status = NO_OPERATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
 
-    if (obj->via.map.size != 0) {    	
-        msgpack_object_kv *p = obj->via.map.ptr;
-        msgpack_object_kv *const pend = obj->via.map.ptr + obj->via.map.size;
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
 
-        for (; p < pend && op_status == NO_OPERATION; ++p) {
-            if (p->val.type == MSGPACK_OBJECT_MAP && p->key.type == MSGPACK_OBJECT_STR
-                && strncmp(OPERATION_FIELD_IN_JSON, p->key.via.str.ptr, p->key.via.str.size) == 0) {
-                
-                op_status = OPERATION_EXISTED;
-                msgpack_object sub_field = p->val;
-                
-                msgpack_object_kv *tmp_p = sub_field.via.map.ptr;
-                msgpack_object_kv *const tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+    for (; p < pend && op_status == NO_OPERATION; ++p) {
 
-                /* Validate the subfields of operation */
-                for (; tmp_p < tmp_pend; ++tmp_p) {
-                    if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
-                        continue;
-                    }
-                    if (strncmp("id", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_id = flb_sds_copy(*operation_id, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("producer", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_producer = flb_sds_copy(*operation_producer, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("first", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_first = FLB_TRUE;
-                        }
-                    }
-                    else if (strncmp("last", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_last = FLB_TRUE;
-                        }
-                    }
-                    else {
-                        /* extra sub-fields */ 
-                        *extra_subfields += 1;
-                    }
+        if (p->val.type != MSGPACK_OBJECT_MAP || p->key.type != MSGPACK_OBJECT_STR
+            || !cmp_helper(p->key, OPERATION_FIELD_IN_JSON, 
+                          sizeof(OPERATION_FIELD_IN_JSON) - 1)) {
+            continue;
+        }
 
-                }
+        op_status = OPERATION_EXISTED;
+        msgpack_object sub_field = p->val;
+        
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of operation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (assign_subfield_str(tmp_p, OPERATION_ID, 
+                                    OPERATION_ID_SIZE, operation_id) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, OPERATION_PRODUCER, 
+                                         OPERATION_PRODUCER_SIZE, operation_producer) == 0) {
+                continue;
+            }
+            else if (assign_subfield_bool(tmp_p, OPERATION_FIRST, 
+                                          OPERATION_FIRST_SIZE, operation_first) == 0) {
+                continue;
+            }
+            else if (assign_subfield_bool(tmp_p, OPERATION_LAST, 
+                                          OPERATION_LAST_SIZE, operation_last) == 0) {
+                continue;
+            }
+            else {
+                *extra_subfields += 1;
             }
         }
     }
@@ -125,20 +125,23 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
     return op_status == OPERATION_EXISTED;
 }
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields) {
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, 
+                                    msgpack_object *operation, int extra_subfields) {
     msgpack_object_kv *p = operation->via.map.ptr;
     msgpack_object_kv *const pend = operation->via.map.ptr + operation->via.map.size;
 
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (strncmp("id", p->key.via.str.ptr, p->key.via.str.size) != 0 
-            && strncmp("producer", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("first", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("last", p->key.via.str.ptr, p->key.via.str.size) != 0) {
-            msgpack_pack_object(mp_pck, p->key);
-            msgpack_pack_object(mp_pck, p->val);
+        if (cmp_helper(p->key, OPERATION_ID, OPERATION_ID_SIZE)
+            || cmp_helper(p->key, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE)
+            || cmp_helper(p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)
+            || cmp_helper(p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+            continue;
         }
-    }
 
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
 }
+

--- a/plugins/out_stackdriver/stackdriver_operation.h
+++ b/plugins/out_stackdriver/stackdriver_operation.h
@@ -22,15 +22,62 @@
 
 #include "stackdriver.h"
 
+/* subfield name and size */
+#define OPERATION_ID "id"
+#define OPERATION_PRODUCER "producer"
+#define OPERATION_FIRST "first"
+#define OPERATION_LAST "last"
+
+#define OPERATION_ID_SIZE 2
+#define OPERATION_PRODUCER_SIZE 8
+#define OPERATION_FIRST_SIZE 5
+#define OPERATION_LAST_SIZE 4
+
+/* 
+ *  Add operation field to the entries.
+ *  The structure of operation is:
+ *  {
+ *      "id": string,
+ *      "producer": string,
+ *      "first": boolean,
+ *      "last": boolean
+ *  }
+ * 
+ */                                                                                     
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck);
 
+/*
+ *  Extract the operation field from the jsonPayload.
+ *  If the operation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
 int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                       int *operation_first, int *operation_last, 
                       msgpack_object *obj, int *extra_subfields);
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields);
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "id": "id1",
+ *          "producer": "id2",
+ *          "first": true,
+ *          "last": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, 
+                                    int extra_subfields);
 
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_source_location.c
+++ b/plugins/out_stackdriver/stackdriver_source_location.c
@@ -1,0 +1,140 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_source_location.h"
+
+typedef enum {
+    NO_SOURCELOCATION = 1,
+    SOURCELOCATION_EXISTED = 2
+} source_location_status;
+
+
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line, 
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 14);
+    msgpack_pack_str_body(mp_pck, "sourceLocation", 14);
+    msgpack_pack_map(mp_pck, 3);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_file));
+    msgpack_pack_str_body(mp_pck, *source_location_file, 
+                          flb_sds_len(*source_location_file));
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_int64(mp_pck, source_location_line);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FUNCTION, 
+                          SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_function));
+    msgpack_pack_str_body(mp_pck, *source_location_function, 
+                          flb_sds_len(*source_location_function));
+}
+
+/* Return FLB_TRUE if sourceLocation extracted */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields)
+{
+    source_location_status op_status = NO_SOURCELOCATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {   
+        return FLB_FALSE;
+    } 	
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend && op_status == NO_SOURCELOCATION; ++p) {
+
+        if (p->val.type != MSGPACK_OBJECT_MAP 
+            || p->key.type != MSGPACK_OBJECT_STR
+            || !cmp_helper(p->key, SOURCELOCATION_FIELD_IN_JSON, 
+                           sizeof(SOURCELOCATION_FIELD_IN_JSON) - 1)) {
+
+            continue;
+        }
+
+        op_status = SOURCELOCATION_EXISTED;
+        msgpack_object sub_field = p->val;
+        
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of sourceLocation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (assign_subfield_str(tmp_p, SOURCE_LOCATION_FILE, 
+                                    SOURCE_LOCATION_FILE_SIZE, 
+                                    source_location_file) == 0) {
+                continue;
+            }
+            else if (assign_subfield_str(tmp_p, SOURCE_LOCATION_FUNCTION, 
+                                         SOURCE_LOCATION_FUNCTION_SIZE, 
+                                         source_location_function) == 0) {
+                continue;
+            }
+            else if (assign_subfield_int(tmp_p, SOURCE_LOCATION_LINE, 
+                                         SOURCE_LOCATION_LINE_SIZE, 
+                                         source_location_line) == 0) {
+                continue;
+            }
+            else {
+                *extra_subfields += 1;
+            }
+
+        }
+    }
+    
+    
+    return op_status == SOURCELOCATION_EXISTED;
+}
+
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields) {
+    msgpack_object_kv *p = source_location->via.map.ptr;
+    msgpack_object_kv *const pend = source_location->via.map.ptr + source_location->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (cmp_helper(p->key, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE)
+            || cmp_helper(p->key, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE)
+            || cmp_helper(p->key, SOURCE_LOCATION_FUNCTION, 
+                          SOURCE_LOCATION_FUNCTION_SIZE)) {
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_source_location.c
+++ b/plugins/out_stackdriver/stackdriver_source_location.c
@@ -74,7 +74,7 @@ int extract_source_location(flb_sds_t *source_location_file,
 
         if (p->val.type != MSGPACK_OBJECT_MAP 
             || p->key.type != MSGPACK_OBJECT_STR
-            || !cmp_helper(p->key, SOURCELOCATION_FIELD_IN_JSON, 
+            || !cmp_str_helper(p->key, SOURCELOCATION_FIELD_IN_JSON, 
                            sizeof(SOURCELOCATION_FIELD_IN_JSON) - 1)) {
 
             continue;
@@ -94,17 +94,17 @@ int extract_source_location(flb_sds_t *source_location_file,
 
             if (assign_subfield_str(tmp_p, SOURCE_LOCATION_FILE, 
                                     SOURCE_LOCATION_FILE_SIZE, 
-                                    source_location_file) == 0) {
+                                    source_location_file) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_str(tmp_p, SOURCE_LOCATION_FUNCTION, 
                                          SOURCE_LOCATION_FUNCTION_SIZE, 
-                                         source_location_function) == 0) {
+                                         source_location_function) == FLB_TRUE) {
                 continue;
             }
             else if (assign_subfield_int(tmp_p, SOURCE_LOCATION_LINE, 
                                          SOURCE_LOCATION_LINE_SIZE, 
-                                         source_location_line) == 0) {
+                                         source_location_line) == FLB_TRUE) {
                 continue;
             }
             else {
@@ -127,9 +127,9 @@ void pack_extra_source_location_subfields(msgpack_packer *mp_pck,
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (cmp_helper(p->key, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE)
-            || cmp_helper(p->key, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE)
-            || cmp_helper(p->key, SOURCE_LOCATION_FUNCTION, 
+        if (cmp_str_helper(p->key, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE)
+            || cmp_str_helper(p->key, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE)
+            || cmp_str_helper(p->key, SOURCE_LOCATION_FUNCTION, 
                           SOURCE_LOCATION_FUNCTION_SIZE)) {
             continue;
         }

--- a/plugins/out_stackdriver/stackdriver_source_location.h
+++ b/plugins/out_stackdriver/stackdriver_source_location.h
@@ -1,0 +1,81 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_SOURCELOCATION_H
+#define FLB_STD_SOURCELOCATION_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define SOURCE_LOCATION_FILE "file"
+#define SOURCE_LOCATION_LINE "line"
+#define SOURCE_LOCATION_FUNCTION "function"
+
+#define SOURCE_LOCATION_FILE_SIZE 4
+#define SOURCE_LOCATION_LINE_SIZE 4
+#define SOURCE_LOCATION_FUNCTION_SIZE 8
+
+/* 
+ *  Add sourceLocation field to the entries.
+ *  The structure of sourceLocation is:
+ *  {
+ *      "file": string,
+ *      "line": int,
+ *      "function": string
+ *  }
+ */   
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line,
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck);
+
+/*
+ *  Extract the sourceLocation field from the jsonPayload.
+ *  If the sourceLocation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "file": "file1",
+ *          "line": 1,
+ *          "function": "func1",
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields);
+
+
+#endif

--- a/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
@@ -1,0 +1,135 @@
+#define HTTPREQUEST_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define EMPTY_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/http_request\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": 123,"          \
+            "\"requestUrl\": 123,"      \
+            "\"userAgent\": 123,"      \
+            "\"remoteIp\": 123,"          \
+            "\"serverIp\": true,"      \
+            "\"referer\": true,"          \
+            "\"latency\": false,"      \
+            "\"protocol\": false,"      \
+            "\"requestSize\": \"some string\","          \
+            "\"responseSize\": true,"      \
+            "\"status\": false,"      \
+            "\"cacheFillBytes\": false,"          \
+            "\"cacheLookup\": \"some string\","      \
+            "\"cacheHit\": 123,"      \
+            "\"cacheValidatedWithOriginServer\": 123"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true,"      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"
+
+
+/* Tests for 'latency' */
+#define HTTPREQUEST_LATENCY_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_SPACES	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100. 00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  s100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_END	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00    \""      \
+        "}"     \
+	"}]"
+

--- a/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
@@ -1,0 +1,26 @@
+#define INSERTID_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"test_insertId\" "		\
+	"}]"
+
+#define EMPTY_INSERTID	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"\" "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_INT	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": 123 "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_MAP	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": "		\
+        "{"           \       
+        "}"     \
+	"}]"			
+

--- a/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
@@ -1,0 +1,69 @@
+#define SOURCELOCATION_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_COMMON_CASE_LINE_IN_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": \"123\","      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define EMPTY_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/sourceLocation\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"function\": \"test_function\""   \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": 123,"          \
+            "\"line\": \"some string\","      \
+            "\"function\": true"      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\","      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"


### PR DESCRIPTION
* This PR is too large to review. So I split it into four parts. The first is #2347, second one is #2353 

According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

This patch enables the stackdriver to extract insertId/sourceLocation/httpRequest field from the jsonPayload and add it to the entries sent to the Google Logging Agent APIs.

Besides, the unit tests are added.

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
