### PR TITLE
Fix build on macOS 10.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if (MSVC)
   # Use add_compile_options() to set /MT since Visual Studio
   # Generator does not notice /MT in CMAKE_C_FLAGS.
   add_compile_options(/MT)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fno-common")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -11,6 +11,10 @@ add_library(libluajit STATIC IMPORTED GLOBAL)
 set(LUAJIT_SRC ${CMAKE_CURRENT_SOURCE_DIR}/lib/LuaJIT-2.1.0-beta3)
 set(LUAJIT_DEST ${CMAKE_CURRENT_BINARY_DIR})
 
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
+endif()
+
 # luajit (UNIX)
 # =============
 ExternalProject_Add(luajit
@@ -18,7 +22,7 @@ ExternalProject_Add(luajit
   EXCLUDE_FROM_ALL TRUE
   SOURCE_DIR ${LUAJIT_SRC}
   CONFIGURE_COMMAND ./configure
-  BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} BUILD_MODE=static XCFLAGS="-fPIC"
+  BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} CFLAGS=${CFLAGS} BUILD_MODE=static "XCFLAGS=-fPIC"
   INSTALL_COMMAND cp src/libluajit.a "${LUAJIT_DEST}/lib/libluajit.a")
 
 # luajit (Windows)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix build error on macOS 10.15

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #2220

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
