### PR TITLE
input_chunk: change mem buf resume message to info

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -308,7 +308,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
         in->mem_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
             in->p->cb_resume(in->context, in->config);
-            flb_debug("[input] %s resume (mem buf overlimit)",
+            flb_info("[input] %s resume (mem buf overlimit)",
                       in->name);
         }
     }


### PR DESCRIPTION


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
