### PR TITLE
out_stackdriver: Modify logName based on stream value

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -699,27 +699,25 @@ static int get_severity_level(severity_t * s, const msgpack_object * o,
 static int get_stream(msgpack_object_map map)
 {
     int i;
-    int len_stream;
+    int len_stdout;
     int val_size;
     msgpack_object k;
     msgpack_object v;
 
-    len_stream = sizeof(STDOUT) - 1;
+    /* len(stdout) == len(stderr) */
+    len_stdout = sizeof(STDOUT) - 1;
     for (i = 0; i < map.size; i++) {
         k = map.ptr[i].key;
         v = map.ptr[i].val;
         if (k.type == MSGPACK_OBJECT_STR &&
             strncmp(k.via.str.ptr, "stream", k.via.str.size) == 0) {
             val_size = v.via.str.size;
-            if (val_size == len_stream) {
+            if (val_size == len_stdout) {
                 if (strncmp(v.via.str.ptr, STDOUT, val_size) == 0) {
                     return STREAM_STDOUT;
                 }
                 else if (strncmp(v.via.str.ptr, STDERR, val_size) == 0) {
                     return STREAM_STDERR;
-                }
-                else {
-                    return STREAM_UNKNOWN;
                 }
             }
         }

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -699,23 +699,28 @@ static int get_severity_level(severity_t * s, const msgpack_object * o,
 static int get_stream(msgpack_object_map map)
 {
     int i;
+    int len_stream;
+    int val_size;
     msgpack_object k;
     msgpack_object v;
 
+    len_stream = sizeof(STDOUT) - 1;
     for (i = 0; i < map.size; i++) {
         k = map.ptr[i].key;
         v = map.ptr[i].val;
-
         if (k.type == MSGPACK_OBJECT_STR &&
             strncmp(k.via.str.ptr, "stream", k.via.str.size) == 0) {
-            if (strncmp(v.via.str.ptr, "stdout", strlen("stdout")) == 0) {
-                return STREAM_STDOUT;
-            }
-            else if (strncmp(v.via.str.ptr, "stderr", strlen("stderr")) == 0) {
-                return STREAM_STDERR;
-            }
-            else {
-               return STREAM_UNKNOWN;
+            val_size = v.via.str.size;
+            if (val_size == len_stream) {
+                if (strncmp(v.via.str.ptr, STDOUT, val_size) == 0) {
+                    return STREAM_STDOUT;
+                }
+                else if (strncmp(v.via.str.ptr, STDERR, val_size) == 0) {
+                    return STREAM_STDERR;
+                }
+                else {
+                    return STREAM_UNKNOWN;
+                }
             }
         }
     }
@@ -842,7 +847,7 @@ static int stackdriver_format(struct flb_config *config,
     size_t off = 0;
     char path[PATH_MAX];
     char time_formatted[255];
-    char *newtag;
+    const char *newtag;
     struct tm tm;
     struct flb_time tms;
     msgpack_object *obj;

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -696,6 +696,33 @@ static int get_severity_level(severity_t * s, const msgpack_object * o,
     return -1;
 }
 
+static int get_stream(msgpack_object_map map)
+{
+    int i;
+    msgpack_object k;
+    msgpack_object v;
+
+    for (i = 0; i < map.size; i++) {
+        k = map.ptr[i].key;
+        v = map.ptr[i].val;
+
+        if (k.type == MSGPACK_OBJECT_STR &&
+            strncmp(k.via.str.ptr, "stream", k.via.str.size) == 0) {
+            if (strncmp(v.via.str.ptr, "stdout", strlen("stdout")) == 0) {
+                return STREAM_STDOUT;
+            }
+            else if (strncmp(v.via.str.ptr, "stderr", strlen("stderr")) == 0) {
+                return STREAM_STDERR;
+            }
+            else {
+               return STREAM_UNKNOWN;
+            }
+        }
+    }
+
+    return STREAM_UNKNOWN;
+}
+
 static int pack_json_payload(int operation_extracted, int operation_extra_size, 
                              msgpack_packer* mp_pck, msgpack_object *obj)
 {
@@ -809,11 +836,13 @@ static int stackdriver_format(struct flb_config *config,
     int ret;
     int array_size = 0;
     /* The default value is 3: timestamp, jsonPayload, logName. */
-    int entry_size = 3; 
+    int entry_size = 3;
+    int stream;
     size_t s;
     size_t off = 0;
     char path[PATH_MAX];
     char time_formatted[255];
+    char *newtag;
     struct tm tm;
     struct flb_time tms;
     msgpack_object *obj;
@@ -1106,9 +1135,20 @@ static int stackdriver_format(struct flb_config *config,
         msgpack_pack_str_body(&mp_pck, "jsonPayload", 11);
         pack_json_payload(operation_extracted, operation_extra_size, &mp_pck, obj);
 
+        /* avoid modifying the original tag */
+        newtag = tag;
+        if (ctx->k8s_resource_type) {
+            stream = get_stream(result.data.via.array.ptr[1].via.map);
+            if (stream == STREAM_STDOUT) {
+                newtag = "stdout";
+            }
+            else if (stream == STREAM_STDERR) {
+                newtag = "stderr";
+            }
+        }
         /* logName */
         len = snprintf(path, sizeof(path) - 1,
-                       "projects/%s/logs/%s", ctx->project_id, tag);
+                       "projects/%s/logs/%s", ctx->project_id, newtag);
 
         msgpack_pack_str(&mp_pck, 7);
         msgpack_pack_str_body(&mp_pck, "logName", 7);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -54,6 +54,10 @@
 #define K8S_NODE      "k8s_node"
 #define K8S_POD       "k8s_pod"
 
+#define STREAM_STDOUT 1
+#define STREAM_STDERR 2
+#define STREAM_UNKNOWN 3
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -58,6 +58,9 @@
 #define STREAM_STDERR 2
 #define STREAM_UNKNOWN 3
 
+#define STDOUT "stdout"
+#define STDERR "stderr"
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
One feature of stackdriver output plugin in fluentd is that we will provide more information on log name based on the value of stream field. This feature is missing in fluent bit and this patch will add this feature back.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
