### PR TITLE
upstream: remove an unnecessary `event.data` assignment

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -403,7 +403,6 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
          * the remote endpoint we need to add it again.
          */
         conn->event.handler = cb_upstream_conn_ka_dropped;
-        conn->event.data    = &conn;
 
         ret = mk_event_add(u->evl, conn->fd,
                            FLB_ENGINE_EV_CUSTOM,


### PR DESCRIPTION
When keepalive mode is enabled, flb_upstream_release() attempts to
overwrite event.data with a custom data. This assignment is unsafe,
since that field is used to hold internal metadata within mk_core.

Nor this assignment is required. In fact, anyone including
`cb_upstream_conn_ka_dropped()` does not rely on that bit of data.

This patch removes it, and fixes the memory crash issue on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
