### PR TITLE
aws: sts: fix compiler warnings and missing initialization in structures

### DIFF
--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_aws_util.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_io.h>
+#include <fluent-bit/flb_sds.h>
 #include <monkey/mk_core.h>
 
 /* Refresh creds if they will expire in 5 min or less */
@@ -232,8 +233,8 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size);
 
 struct flb_aws_credentials *flb_parse_sts_resp(char *response,
                                                time_t *expiration);
-char *flb_sts_uri(char *action, char *role_arn, char *session_name,
-                  char *external_id, char *identity_token);
+flb_sds_t flb_sts_uri(char *action, char *role_arn, char *session_name,
+                      char *external_id, char *identity_token);
 char *flb_sts_session_name();
 
 struct flb_aws_credentials *flb_parse_http_credentials(char *response,

--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -77,7 +77,7 @@ struct flb_aws_provider_sts {
     /* Fluent Bit uses regional STS endpoints; this is a best practice. */
     char *endpoint;
 
-    char *uri;
+    flb_sds_t uri;
 };
 
 struct flb_aws_credentials *get_credentials_fn_sts(struct flb_aws_provider
@@ -219,8 +219,10 @@ void async_fn_sts(struct flb_aws_provider *provider) {
 }
 
 void destroy_fn_sts(struct flb_aws_provider *provider) {
-    struct flb_aws_provider_sts *implementation = provider->
-                                                          implementation;
+    struct flb_aws_provider_sts *implementation;
+
+    implementation = provider->implementation;
+
     if (implementation) {
         if (implementation->creds) {
             flb_aws_credentials_destroy(implementation->creds);
@@ -231,7 +233,7 @@ void destroy_fn_sts(struct flb_aws_provider *provider) {
         }
 
         if (implementation->uri) {
-            flb_free(implementation->uri);
+            flb_sds_destroy(implementation->uri);
         }
 
         if (implementation->endpoint) {
@@ -272,14 +274,12 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
     struct flb_upstream *upstream = NULL;
 
     provider = flb_calloc(1, sizeof(struct flb_aws_provider));
-
     if (!provider) {
         flb_errno();
         return NULL;
     }
 
     implementation = flb_calloc(1, sizeof(struct flb_aws_provider_sts));
-
     if (!implementation) {
         goto error;
     }
@@ -288,7 +288,7 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
     provider->implementation = implementation;
 
     implementation->uri = flb_sts_uri("AssumeRole", role_arn, session_name,
-                                  external_id, NULL);
+                                      external_id, NULL);
     if (!implementation->uri) {
         goto error;
     }
@@ -399,7 +399,7 @@ struct flb_aws_credentials *get_credentials_fn_eks(struct flb_aws_provider
         return NULL;
     }
 
-    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
     if (!creds) {
         goto error;
     }
@@ -422,7 +422,8 @@ struct flb_aws_credentials *get_credentials_fn_eks(struct flb_aws_provider
             goto error;
         }
 
-    } else {
+    }
+    else {
         creds->session_token = NULL;
     }
 
@@ -691,7 +692,7 @@ static int assume_with_web_identity(struct flb_aws_provider_eks
     int ret;
     char *web_token = NULL;
     size_t web_token_size;
-    char *uri = NULL;
+    flb_sds_t uri = NULL;
     int init_mode = implementation->sts_client->debug_only;
 
     ret = flb_read_file(implementation->token_file, &web_token,
@@ -706,7 +707,7 @@ static int assume_with_web_identity(struct flb_aws_provider_eks
     }
 
     uri = flb_sts_uri("AssumeRoleWithWebIdentity", implementation->role_arn,
-                  implementation->session_name, NULL, web_token);
+                      implementation->session_name, NULL, web_token);
     if (!uri) {
         flb_free(web_token);
         return -1;
@@ -716,7 +717,7 @@ static int assume_with_web_identity(struct flb_aws_provider_eks
                                   &implementation->creds, uri,
                                   &implementation->next_refresh);
     flb_free(web_token);
-    flb_free(uri);
+    flb_sds_destroy(uri);
     return ret;
 }
 
@@ -812,7 +813,7 @@ struct flb_aws_credentials *flb_parse_sts_resp(char *response,
     }
     cred_node += CREDENTIALS_NODE_LEN;
 
-    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
     if (!creds) {
         flb_errno();
         return NULL;
@@ -857,10 +858,11 @@ error:
  * Constructs the STS request uri.
  * external_id can be NULL.
  */
-char *flb_sts_uri(char *action, char *role_arn, char *session_name,
-              char *external_id, char *identity_token)
+flb_sds_t flb_sts_uri(char *action, char *role_arn, char *session_name,
+                      char *external_id, char *identity_token)
 {
-    char *uri = NULL;
+    flb_sds_t tmp;
+    flb_sds_t uri = NULL;
     size_t len = STS_ASSUME_ROLE_URI_BASE_LEN;
 
     if (external_id) {
@@ -878,23 +880,25 @@ char *flb_sts_uri(char *action, char *role_arn, char *session_name,
     len += strlen(role_arn);
     len += strlen(action);
     len++; /* null char */
-    uri = flb_malloc(sizeof(char) * (len));
+
+    uri = flb_sds_create_size(len);
     if (!uri) {
-        flb_errno();
         return NULL;
     }
 
-    snprintf(uri, len, STS_ASSUME_ROLE_URI_FORMAT, action, session_name,
-             role_arn);
+    tmp = flb_sds_printf(&uri, STS_ASSUME_ROLE_URI_FORMAT, action, session_name,
+                         role_arn);
+    if (!tmp) {
+        flb_sds_destroy(uri);
+        return NULL;
+    }
 
     if (external_id) {
-        strncat(uri, "&ExternalId=", 12);
-        strncat(uri, external_id, strlen(external_id));
+        flb_sds_printf(&uri, "&ExternalId=%s", external_id);
     }
 
     if (identity_token) {
-        strncat(uri, "&WebIdentityToken=", 18);
-        strncat(uri, identity_token, strlen(identity_token));
+        flb_sds_printf(&uri, "&WebIdentityToken=%s", identity_token);
     }
 
     return uri;

--- a/tests/internal/aws_credentials_sts.c
+++ b/tests/internal/aws_credentials_sts.c
@@ -369,14 +369,14 @@ static void test_flb_sts_session_name()
 
 static void test_sts_uri()
 {
-    char *uri;
+    flb_sds_t uri;
 
     uri = flb_sts_uri("AssumeRole", "myrole", "mysession",
-                  "myexternalid", NULL);
+                      "myexternalid", NULL);
     TEST_CHECK(strcmp(uri, "/?Version=2011-06-15&Action=AssumeRole"
                       "&RoleSessionName=mysession&RoleArn=myrole"
                       "&ExternalId=myexternalid") == 0);
-    flb_free(uri);
+    flb_sds_destroy(uri);
 }
 
 static void test_process_sts_response()
@@ -882,7 +882,7 @@ static void test_sts_provider_unexpected_api_response() {
      * - Each call to get_credentials and refresh invokes the client's
      * request method and returns a request failure.
      */
-     TEST_CHECK(g_request_count == 3);
+    TEST_CHECK(g_request_count == 3);
 
     flb_aws_provider_destroy(base_provider);
     flb_aws_provider_destroy(provider);


### PR DESCRIPTION
- Fix compiler warnings on strncat() usage, replace it with flb_sds
- Valgrind test raised warnings about unitialized variables when handling certain test exceptions

__Valgrind Output__

```
$ valgrind --leak-check=full bin/flb-it-aws_credentials_sts 
==297656== Memcheck, a memory error detector
==297656== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==297656== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==297656== Command: bin/flb-it-aws_credentials_sts
==297656== 
Test test_flb_sts_session_name...               [   OK   ]
==297657== 
==297657== HEAP SUMMARY:
==297657==     in use at exit: 90 bytes in 2 blocks
==297657==   total heap usage: 15 allocs, 13 frees, 6,051 bytes allocated
==297657== 
==297657== LEAK SUMMARY:
==297657==    definitely lost: 0 bytes in 0 blocks
==297657==    indirectly lost: 0 bytes in 0 blocks
==297657==      possibly lost: 0 bytes in 0 blocks
==297657==    still reachable: 90 bytes in 2 blocks
==297657==         suppressed: 0 bytes in 0 blocks
==297657== Reachable blocks (those to which a pointer was found) are not shown.
==297657== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297657== 
==297657== For lists of detected and suppressed errors, rerun with: -s
==297657== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test test_sts_uri...                            [   OK   ]
==297658== 
==297658== HEAP SUMMARY:
==297658==     in use at exit: 90 bytes in 2 blocks
==297658==   total heap usage: 6 allocs, 4 frees, 1,513 bytes allocated
==297658== 
==297658== LEAK SUMMARY:
==297658==    definitely lost: 0 bytes in 0 blocks
==297658==    indirectly lost: 0 bytes in 0 blocks
==297658==      possibly lost: 0 bytes in 0 blocks
==297658==    still reachable: 90 bytes in 2 blocks
==297658==         suppressed: 0 bytes in 0 blocks
==297658== Reachable blocks (those to which a pointer was found) are not shown.
==297658== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297658== 
==297658== For lists of detected and suppressed errors, rerun with: -s
==297658== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test process_sts_response...                    [2020/06/30 15:21:08] [ warn] [aws_credentials] Credential expiration '2014-10-24T23:00:23Z' is less than10 minutes in the future. Disabling auto-refresh.
[   OK   ]
==297659== 
==297659== HEAP SUMMARY:
==297659==     in use at exit: 90 bytes in 2 blocks
==297659==   total heap usage: 17 allocs, 15 frees, 6,096 bytes allocated
==297659== 
==297659== LEAK SUMMARY:
==297659==    definitely lost: 0 bytes in 0 blocks
==297659==    indirectly lost: 0 bytes in 0 blocks
==297659==      possibly lost: 0 bytes in 0 blocks
==297659==    still reachable: 90 bytes in 2 blocks
==297659==         suppressed: 0 bytes in 0 blocks
==297659== Reachable blocks (those to which a pointer was found) are not shown.
==297659== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297659== 
==297659== For lists of detected and suppressed errors, rerun with: -s
==297659== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test eks_credential_provider...                 [2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2014-10-24T23:00:23Z' is less than10 minutes in the future. Disabling auto-refresh.
[2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2014-10-24T23:00:23Z' is less than10 minutes in the future. Disabling auto-refresh.
[   OK   ]
==297660== 
==297660== HEAP SUMMARY:
==297660==     in use at exit: 90 bytes in 2 blocks
==297660==   total heap usage: 58 allocs, 56 frees, 37,173 bytes allocated
==297660== 
==297660== LEAK SUMMARY:
==297660==    definitely lost: 0 bytes in 0 blocks
==297660==    indirectly lost: 0 bytes in 0 blocks
==297660==      possibly lost: 0 bytes in 0 blocks
==297660==    still reachable: 90 bytes in 2 blocks
==297660==         suppressed: 0 bytes in 0 blocks
==297660== Reachable blocks (those to which a pointer was found) are not shown.
==297660== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297660== 
==297660== For lists of detected and suppressed errors, rerun with: -s
==297660== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test eks_credential_provider_random_session_name... [2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2014-10-24T23:00:23Z' is less than10 minutes in the future. Disabling auto-refresh.
[2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2014-10-24T23:00:23Z' is less than10 minutes in the future. Disabling auto-refresh.
[   OK   ]
==297661== 
==297661== HEAP SUMMARY:
==297661==     in use at exit: 90 bytes in 2 blocks
==297661==   total heap usage: 58 allocs, 56 frees, 36,814 bytes allocated
==297661== 
==297661== LEAK SUMMARY:
==297661==    definitely lost: 0 bytes in 0 blocks
==297661==    indirectly lost: 0 bytes in 0 blocks
==297661==      possibly lost: 0 bytes in 0 blocks
==297661==    still reachable: 90 bytes in 2 blocks
==297661==         suppressed: 0 bytes in 0 blocks
==297661== Reachable blocks (those to which a pointer was found) are not shown.
==297661== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297661== 
==297661== For lists of detected and suppressed errors, rerun with: -s
==297661== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test test_eks_provider_unexpected_api_response... [2020/06/30 15:21:09] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:09] [error] [aws_credentials] Failed to parse response from STS
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:09] [error] [aws_credentials] Failed to parse response from STS
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:09] [error] [aws_credentials] Failed to parse response from STS
[   OK   ]
==297662== 
==297662== HEAP SUMMARY:
==297662==     in use at exit: 90 bytes in 2 blocks
==297662==   total heap usage: 52 allocs, 50 frees, 41,990 bytes allocated
==297662== 
==297662== LEAK SUMMARY:
==297662==    definitely lost: 0 bytes in 0 blocks
==297662==    indirectly lost: 0 bytes in 0 blocks
==297662==      possibly lost: 0 bytes in 0 blocks
==297662==    still reachable: 90 bytes in 2 blocks
==297662==         suppressed: 0 bytes in 0 blocks
==297662== Reachable blocks (those to which a pointer was found) are not shown.
==297662== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297662== 
==297662== For lists of detected and suppressed errors, rerun with: -s
==297662== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test eks_credential_provider_api_error...       [2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[   OK   ]
==297664== 
==297664== HEAP SUMMARY:
==297664==     in use at exit: 90 bytes in 2 blocks
==297664==   total heap usage: 46 allocs, 44 frees, 41,582 bytes allocated
==297664== 
==297664== LEAK SUMMARY:
==297664==    definitely lost: 0 bytes in 0 blocks
==297664==    indirectly lost: 0 bytes in 0 blocks
==297664==      possibly lost: 0 bytes in 0 blocks
==297664==    still reachable: 90 bytes in 2 blocks
==297664==         suppressed: 0 bytes in 0 blocks
==297664== Reachable blocks (those to which a pointer was found) are not shown.
==297664== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297664== 
==297664== For lists of detected and suppressed errors, rerun with: -s
==297664== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test sts_credential_provider...                 [2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2019-11-09T13:34:41Z' is less than10 minutes in the future. Disabling auto-refresh.
[2020/06/30 15:21:09] [ warn] [aws_credentials] Credential expiration '2019-11-09T13:34:41Z' is less than10 minutes in the future. Disabling auto-refresh.
[   OK   ]
==297672== 
==297672== HEAP SUMMARY:
==297672==     in use at exit: 90 bytes in 2 blocks
==297672==   total heap usage: 51 allocs, 49 frees, 27,428 bytes allocated
==297672== 
==297672== LEAK SUMMARY:
==297672==    definitely lost: 0 bytes in 0 blocks
==297672==    indirectly lost: 0 bytes in 0 blocks
==297672==      possibly lost: 0 bytes in 0 blocks
==297672==    still reachable: 90 bytes in 2 blocks
==297672==         suppressed: 0 bytes in 0 blocks
==297672== Reachable blocks (those to which a pointer was found) are not shown.
==297672== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297672== 
==297672== For lists of detected and suppressed errors, rerun with: -s
==297672== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test sts_credential_provider_api_error...       [2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The currentco-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[2020/06/30 15:21:09] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The currentco-routine will retry.
[2020/06/30 15:21:09] [error] [aws_credentials] STS assume role request failed
[   OK   ]
==297673== 
==297673== HEAP SUMMARY:
==297673==     in use at exit: 90 bytes in 2 blocks
==297673==   total heap usage: 34 allocs, 32 frees, 27,168 bytes allocated
==297673== 
==297673== LEAK SUMMARY:
==297673==    definitely lost: 0 bytes in 0 blocks
==297673==    indirectly lost: 0 bytes in 0 blocks
==297673==      possibly lost: 0 bytes in 0 blocks
==297673==    still reachable: 90 bytes in 2 blocks
==297673==         suppressed: 0 bytes in 0 blocks
==297673== Reachable blocks (those to which a pointer was found) are not shown.
==297673== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297673== 
==297673== For lists of detected and suppressed errors, rerun with: -s
==297673== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test sts_credential_provider_unexpected_api_response... [2020/06/30 15:21:10] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:10] [error] [aws_credentials] Failed to parse response from STS
[2020/06/30 15:21:10] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The currentco-routine will retry.
[2020/06/30 15:21:10] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:10] [error] [aws_credentials] Failed to parse response from STS
[2020/06/30 15:21:10] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The currentco-routine will retry.
[2020/06/30 15:21:10] [error] [aws_credentials] Could not find '<SecretAccessKey>' node in sts response
[2020/06/30 15:21:10] [error] [aws_credentials] Failed to parse response from STS
[   OK   ]
==297674== 
==297674== HEAP SUMMARY:
==297674==     in use at exit: 90 bytes in 2 blocks
==297674==   total heap usage: 40 allocs, 38 frees, 27,501 bytes allocated
==297674== 
==297674== LEAK SUMMARY:
==297674==    definitely lost: 0 bytes in 0 blocks
==297674==    indirectly lost: 0 bytes in 0 blocks
==297674==      possibly lost: 0 bytes in 0 blocks
==297674==    still reachable: 90 bytes in 2 blocks
==297674==         suppressed: 0 bytes in 0 blocks
==297674== Reachable blocks (those to which a pointer was found) are not shown.
==297674== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==297674== 
==297674== For lists of detected and suppressed errors, rerun with: -s
==297674== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==297656== 
==297656== HEAP SUMMARY:
==297656==     in use at exit: 0 bytes in 0 blocks
==297656==   total heap usage: 4 allocs, 4 frees, 1,151 bytes allocated
==297656== 
==297656== All heap blocks were freed -- no leaks are possible
==297656== 
==297656== For lists of detected and suppressed errors, rerun with: -s
==297656== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
