### PR TITLE
build: enable out_azure on Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -44,7 +44,7 @@ set(FLB_IN_EMITTER            Yes)
 
 # OUTPUT plugins
 # ==============
-set(FLB_OUT_AZURE              No)
+set(FLB_OUT_AZURE             Yes)
 set(FLB_OUT_BIGQUERY           No)
 set(FLB_OUT_COUNTER           Yes)
 set(FLB_OUT_DATADOG           Yes)


### PR DESCRIPTION
out_azure is already ported to Windows and usable (I confirmed
it on Windows Server 2019, connecting to Azure log Analytics).

This patch includes the plugin into the release builds.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>