### PR TITLE
out_cloudwatch_logs: Rename 'event' to 'cw_event'

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -67,6 +67,7 @@ set(FLB_OUT_NULL              Yes)
 set(FLB_OUT_FLOWCOUNTER       Yes)
 set(FLB_OUT_KAFKA              No)
 set(FLB_OUT_KAFKA_REST         No)
+set(FLB_OUT_CLOUDWATCH_LOGS   Yes)
 
 # FILTER plugins
 # ==============

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_utils.h>
@@ -38,7 +39,6 @@
 #include <monkey/mk_core.h>
 #include <msgpack.h>
 #include <string.h>
-#include <unistd.h>
 #include <stdio.h>
 
 #include "cloudwatch_logs.h"
@@ -310,7 +310,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     }
     buf->tmp_buf_size = PUT_LOG_EVENTS_PAYLOAD_SIZE;
 
-    buf->events = flb_malloc(sizeof(struct event) * 1000);
+    buf->events = flb_malloc(sizeof(struct cw_event) * 1000);
     if (!buf->events) {
         flb_errno();
         cw_flush_destroy(buf);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -40,7 +40,7 @@ struct cw_flush {
     size_t data_size;
 
     /* log events- each of these has a pointer to their message in tmp_buf */
-    struct event *events;
+    struct cw_event *events;
     int events_capacity;
     /* current event */
     int event_index;
@@ -54,7 +54,7 @@ struct cw_flush {
     size_t event_buf_size;
 };
 
-struct event {
+struct cw_event {
     char *json;
     size_t len;
     // TODO: re-usable in kinesis streams plugin if we make it timespec instead


### PR DESCRIPTION
libevent exports a struct with the same name (`struct event` in
event2/event_struct.h). For this reason, this plugin fails to
compile if libevent backend is enabled.

Also unistd.h is not POSIX standard and not all platforms (in
particular Windows) do not provide it. Include flb_compat.h to
abstract away the header inclusion.

With this patch, I can confirm out_cloudwatch_logs can be compiled
and run on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
