### PR TITLE
engine: fix segfault on invalid output configuration

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -453,7 +453,7 @@ int flb_engine_start(struct flb_config *config)
 
     /* Initialize output plugins */
     ret = flb_output_init_all(config);
-    if (ret == -1 && config->support_mode == FLB_FALSE) {
+    if (ret == -1) {
         return -1;
     }
 


### PR DESCRIPTION
The following configuration causes memory crash:

    [Output]
      Name File
      Patt /var/log/test.log

The reason is that Fluent Bit ignores the error return from
`flb_output_init_all()`, and boldly proceeds into the main loop
without output plugins being initialized.

Fix the return code check so that it can exit on error properly.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
