### PR TITLE
http_client: mark connection as non-reuseable on failure

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1014,6 +1014,7 @@ int flb_http_do(struct flb_http_client *c, size_t *bytes)
                  * We could not allocate more space, let the caller handle
                  * this.
                  */
+                flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
                 return 0;
             }
             available = flb_http_buffer_available(c) - 1;


### PR DESCRIPTION
flb_http_client supports internal buffer size limit. If server
tries to send more data than the maximum size limit, the client
will refuse to receive it.

This behaviour is problematic when combined with keep-alive mode;
Since flb_http_do() can leave some data in the socket, the next
HTTP request can be confused by the leftover.

For example, if the socket has the following data (unread):

    "data":["from", "previous", "conn"]}

The next HTTP request will see the following response:

    "data":["from", "previous", "conn"]}HTTP/1.1 200 OK
    Content-Type: text/html
    Accept-Ranges: bytes
    Last-Modified: Sat, 30 May 2020 23:47:16 GMT
    ...

This bug is originally reported by @gitfool on https://github.com/fluent/fluent-bit/issues/960#issuecomment-651457397.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>