### PR TITLE
out_cloudwatch_logs: fix mem leak in init (CID 304902)

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -55,7 +55,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                               struct flb_config *config, void *data)
 {
     const char *tmp;
-    char *session_name;
+    char *session_name = NULL;
     struct flb_cloudwatch *ctx = NULL;
     struct cw_flush *buf = NULL;
     int ret;
@@ -327,6 +327,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     return 0;
 
 error:
+    flb_free(session_name);
     flb_plg_error(ctx->ins, "Initialization failed");
     flb_cloudwatch_ctx_destroy(ctx);
     return -1;


### PR DESCRIPTION
Coverity Issue

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
