### PR TITLE
out_cloudwatch_logs: fix mem leak (CID 304900)

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -120,6 +120,7 @@ struct flb_http_client *mock_http_call(char *error_env_var, char *api)
     c = flb_calloc(1, sizeof(struct flb_http_client));
     if (!c) {
         flb_errno();
+        flb_free(error);
         return NULL;
     }
     mk_list_init(&c->headers);


### PR DESCRIPTION
Coverity Issue

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
