### PR TITLE
aws: always close file before returning (CID 304895)

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -553,6 +553,7 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size)
     ret = fstat(fd, &st);
     if (ret == -1) {
         flb_errno();
+        fclose(fp);
         return -1;
     }
 


### PR DESCRIPTION
Coverity Issue.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
