### PR TITLE
out_cloudwatch_logs: alloc event buffer to max size in init

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -521,27 +521,12 @@ int add_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
 {
     int ret;
     struct cw_event *event;
-    int new_len;
-    size_t size;
     int retry_add = FLB_FALSE;
     int event_bytes = 0;
 
     if (buf->event_index == 0) {
         /* init */
         reset_flush_buf(ctx, buf, stream);
-    }
-
-    /* re-alloc event buffer if needed */
-    if ((buf->event_index + 1) >= buf->events_capacity) {
-        new_len = MAX_EVENTS_PER_PUT;
-        size = sizeof(struct cw_event) * new_len;
-        flb_plg_debug(ctx->ins, "Increasing event buffer to %d", new_len);
-        buf->events = flb_realloc(buf->events, size);
-        if (!buf->events) {
-            flb_errno();
-            return -1;
-        }
-        buf->events_capacity = new_len;
     }
 
 retry_add_event:

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -310,13 +310,13 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     }
     buf->tmp_buf_size = PUT_LOG_EVENTS_PAYLOAD_SIZE;
 
-    buf->events = flb_malloc(sizeof(struct cw_event) * 1000);
+    buf->events = flb_malloc(sizeof(struct cw_event) * MAX_EVENTS_PER_PUT);
     if (!buf->events) {
         flb_errno();
         cw_flush_destroy(buf);
         goto error;
     }
-    buf->events_capacity = 1000;
+    buf->events_capacity = MAX_EVENTS_PER_PUT;
 
     ctx->buf = buf;
 


### PR DESCRIPTION

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
