### PR TITLE
aws_credentials_sts: fix typo in vtable (bug fix)

### DIFF
--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -509,7 +509,7 @@ static struct flb_aws_provider_vtable eks_provider_vtable = {
     .refresh = refresh_fn_eks,
     .destroy = destroy_fn_eks,
     .sync = sync_fn_eks,
-    .async = async_fn_sts,
+    .async = async_fn_eks,
 };
 
 struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,


### PR DESCRIPTION


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
