### PR TITLE
out_cloudwatch_logs: fix double free on session_name (CID 304942)

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -240,6 +240,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         }
         /* session name can freed after provider is created */
         flb_free(session_name);
+        session_name = NULL;
     }
 
     /* initialize credentials and set to sync mode */


### PR DESCRIPTION
One of my fixes to one of the Coverity issues found last week caused a new issue because I am not yet a good C programmer..

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
