### PR TITLE
in_tail: add error handling to flb_tail_db_file_set()

### DIFF
--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -112,6 +112,10 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
     memset(&qs, '\0', sizeof(qs));
     ret = flb_sqldb_query(ctx->db,
                           query, cb_file_check, &qs);
+    if (ret == FLB_ERROR) {
+        flb_plg_error(ctx->ins, "cannot execute SQL: %s", query);
+        return -1;
+    }
 
     if (qs.rows == 0) {
         /* Register the file */
@@ -121,6 +125,7 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
                  file->name, (uint64_t) 0, (uint64_t) file->inode, created);
         ret = flb_sqldb_query(ctx->db, query, NULL, NULL);
         if (ret == FLB_ERROR) {
+            flb_plg_error(ctx->ins, "cannot execute SQL: %s", query);
             return -1;
         }
 


### PR DESCRIPTION
We have a few bug reports regarding to this function. Evidently
the SQL query generation can be broken on certain cases, but
we don't uncover the exact condition yet.

This patch adds additional logging to failure paths, to help
future debugging.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
