### PR TITLE
out_forward: add null check for crx->u before deallocation

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1188,7 +1188,9 @@ static int cb_forward_exit(void *data, struct flb_config *config)
         }
     }
     else {
-        flb_upstream_destroy(ctx->u);
+        if (ctx->u) {
+            flb_upstream_destroy(ctx->u);
+        }
     }
     flb_free(ctx);
 


### PR DESCRIPTION
Without this patch, the following command-line invocation
causes memory corruption.

    $ fluent-bit -i dummy -o forward -p Time_as_Integer=invalid

This is because `ctx->u` can be null, depending on when
`cb_forward_init()` aborted the initialization process.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
