### PR TITLE
out_stackdriver: Construct local_resource_id from tag when field is missing

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -99,6 +99,7 @@ struct flb_stackdriver {
     bool k8s_resource_type;
 
     flb_sds_t labels_key;
+    flb_sds_t local_resource_id;
 
     /* other */
     flb_sds_t resource;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -347,6 +347,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         flb_sds_destroy(ctx->node_name);
         flb_sds_destroy(ctx->cluster_name);
         flb_sds_destroy(ctx->cluster_location);
+        flb_sds_destroy(ctx->local_resource_id);
     }
 
     flb_sds_destroy(ctx->credentials_file);

--- a/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
@@ -8,12 +8,30 @@
     "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\""		\
 	"}]"
 
+#define K8S_CONTAINER_NO_LOCAL_RESOURCE_ID	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_CONTAINER_COMMON_NO_LOCAL_RESOURCE_ID\""		\
+	"}]"
+
 /* k8s_node */
 #define K8S_NODE_COMMON	"["		\
 	"1591649196,"			\
 	"{"				\
     "\"message\": \"K8S_NODE_COMMON\","		\
     "\"logging.googleapis.com/local_resource_id\": \"k8s_node.testnode\","		\
+	"\"PRIORITY\": 6,"		\
+	"\"SYSLOG_FACILITY\": 3,"		\
+	"\"_CAP_EFFECTIVE\": \"3fffffffff\","		\
+	"\"_PID\": 1387,"		\
+	"\"_SYSTEMD_UNIT\": \"docker.service\","		\
+	"\"END_KEY\": \"JSON_END\""		\
+	"}]"
+
+#define K8S_NODE_NO_LOCAL_RESOURCE_ID	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_NODE_NO_LOCAL_RESOURCE_ID\","		\
 	"\"PRIORITY\": 6,"		\
 	"\"SYSLOG_FACILITY\": 3,"		\
 	"\"_CAP_EFFECTIVE\": \"3fffffffff\","		\
@@ -36,3 +54,16 @@
 	"\"END_KEY\": \"JSON_END\""		\
 	"}]"
     
+#define K8S_POD_NO_LOCAL_RESOURCE_ID	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_POD_NO_LOCAL_RESOURCE_ID\","		\
+	"\"key_0\": false,"		\
+	"\"key_1\": true,"		\
+	"\"key_2\": \"some string\","		\
+	"\"key_3\": 0.12345678,"		\
+	"\"key_4\": 5000,"		\
+	"\"END_KEY\": \"JSON_END\""		\
+	"}]"
+
+	

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -2236,6 +2236,136 @@ void flb_test_custom_labels_k8s_resource_type()
     flb_destroy(ctx);
 }
 
+void flb_test_resource_k8s_container_no_local_resource_id()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", 
+                  "k8s_container.testnamespace.testpod.testctr", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "k8s_container.*",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_node_no_local_resource_id()
+{
+    int ret;
+    int size = sizeof(K8S_NODE_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "k8s_node.testnode", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "k8s_node.*",
+                   "resource", "k8s_node",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_node_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_NODE_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_pod_no_local_resource_id()
+{
+    int ret;
+    int size = sizeof(K8S_POD_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "k8s_pod.testnamespace.testpod", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "k8s_pod.*",
+                   "resource", "k8s_pod",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_pod_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_POD_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_multi_entries_severity()
 {
     int ret;
@@ -3270,8 +3400,11 @@ TEST_LIST = {
     
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
+    {"resource_k8s_container_no_local_resource_id", flb_test_resource_k8s_container_no_local_resource_id },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
+    {"resource_k8s_node_no_local_resource_id", flb_test_resource_k8s_node_no_local_resource_id },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },
+    {"resource_k8s_pod_no_local_resource_id", flb_test_resource_k8s_pod_no_local_resource_id },
     {"default_labels", flb_test_default_labels },
     {"custom_labels", flb_test_custom_labels },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },


### PR DESCRIPTION
<!-- Provide summary of changes -->
out_stackdriver relies on the **local_resource_id** to extract kubernetes meta information and then put them into the resource labels. However there is case that local_resource_id is missing from the payLoad. Therefore we need to construct the local_resource_id from the current tag value of the log event. As the tag value is assigned in the begging of the logging pipeline by tail plugin. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
