### PR TITLE
out_stackdriver: update special field - operation

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src
   stackdriver_conf.c
   stackdriver.c
   stackdriver_operation.c
+  stackdriver_helper.c
   )
 
 FLB_PLUGIN(out_stackdriver "${src}" "")

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -31,6 +31,7 @@
 #include "stackdriver.h"
 #include "stackdriver_conf.h"
 #include "stackdriver_operation.h"
+#include "stackdriver_helper.h"
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
 
@@ -761,8 +762,9 @@ static int get_stream(msgpack_object_map map)
     return STREAM_UNKNOWN;
 }
 
+                                                                                        
 static int pack_json_payload(int operation_extracted, int operation_extra_size, 
-                             msgpack_packer* mp_pck, msgpack_object *obj,
+                             msgpack_packer *mp_pck, msgpack_object *obj,
                              struct flb_stackdriver *ctx)
 {
     /* Specified fields include local_resource_id, operation, sourceLocation ... */
@@ -791,7 +793,7 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
         /* more special fields are required to be added */
     };
 
-    if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
+    if(operation_extracted == FLB_TRUE && operation_extra_size == 0) {
         to_remove += 1;
     }
 
@@ -814,12 +816,6 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
     }
 
     new_map_size = map_size - to_remove;
-    /* optimize, pack the original obj */
-    if (new_map_size == map_size) {
-        msgpack_pack_object(mp_pck, *obj);
-        flb_sds_destroy(local_resource_id_key);
-        return 0;
-    }
 
     ret = msgpack_pack_map(mp_pck, new_map_size);
     if (ret < 0) {
@@ -831,8 +827,9 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
     kv = obj->via.map.ptr;
     for(; kv != kvend; ++kv	) {
         key_not_found = 1;
-        /* processing logging.googleapis.com/operation */
-        if (strncmp(OPERATION_FIELD_IN_JSON, kv->key.via.str.ptr, kv->key.via.str.size) == 0
+        
+        if (validate_key(kv->key, OPERATION_FIELD_IN_JSON, 
+                         OPERATION_KEY_SIZE)
             && kv->val.type == MSGPACK_OBJECT_MAP) {
 
             if (operation_extra_size > 0) {
@@ -898,11 +895,11 @@ static int stackdriver_format(struct flb_config *config,
     flb_sds_t out_buf;
     struct flb_stackdriver *ctx = plugin_context;
 
-    /* Parameters in severity */
+    /* Parameters for severity */
     int severity_extracted = FLB_FALSE;
     severity_t severity;
 
-    /* Parameters in Operation */
+    /* Parameters for Operation */
     flb_sds_t operation_id;
     flb_sds_t operation_producer;
     int operation_first = FLB_FALSE;
@@ -1139,6 +1136,7 @@ static int stackdriver_format(struct flb_config *config,
          * }
          */
         entry_size = 3;
+
         /* Extract severity */
         severity_extracted = FLB_FALSE;
         if (ctx->severity_key
@@ -1154,7 +1152,8 @@ static int stackdriver_format(struct flb_config *config,
         operation_last = FLB_FALSE;
         operation_extra_size = 0;
         operation_extracted = extract_operation(&operation_id, &operation_producer,
-                                                &operation_first, &operation_last, obj, &operation_extra_size);
+                                                &operation_first, &operation_last, obj, 
+                                                &operation_extra_size);
 
         if (operation_extracted == FLB_TRUE) {
             entry_size += 1;
@@ -1196,14 +1195,15 @@ static int stackdriver_format(struct flb_config *config,
             msgpack_pack_object(&mp_pck, *labels_ptr);
         }
         
-        /* Clean up id and producer if operation extracted */
+        /* Clean up */
         flb_sds_destroy(operation_id);
         flb_sds_destroy(operation_producer);
 
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);
         msgpack_pack_str_body(&mp_pck, "jsonPayload", 11);
-        pack_json_payload(operation_extracted, operation_extra_size, &mp_pck, obj, ctx);
+        pack_json_payload(operation_extracted, operation_extra_size, 
+                          &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */
         newtag = tag;

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -793,7 +793,7 @@ static int pack_json_payload(int operation_extracted, int operation_extra_size,
         /* more special fields are required to be added */
     };
 
-    if(operation_extracted == FLB_TRUE && operation_extra_size == 0) {
+    if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
         to_remove += 1;
     }
 

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,7 +49,9 @@
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
+
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
+#define OPERATION_KEY_SIZE 32
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"
@@ -129,5 +131,6 @@ struct local_resource_id_list {
     flb_sds_t val;
     struct mk_list _head;
 };
+
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -59,7 +59,4 @@ void assign_subfield_int(msgpack_object obj, int *subfield) {
     else if (obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
         *subfield = obj.via.i64;
     }
-    else {
-        *subfield = 0;
-    }
 }

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -52,7 +52,7 @@ void try_assign_subfield_bool(msgpack_object obj, int *subfield) {
     }
 }
 
-void try_assign_subfield_int(msgpack_object obj, int *subfield) {
+void try_assign_subfield_int(msgpack_object obj, int64_t *subfield) {
     if (obj.type == MSGPACK_OBJECT_STR) {
         *subfield = atoll(obj.via.str.ptr);
     }

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -1,0 +1,65 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include "stackdriver.h"
+
+int equal_obj_str(msgpack_object obj, const char *str, const int size) {
+    if (obj.type != MSGPACK_OBJECT_STR) {
+        return FLB_FALSE;
+    }
+    if (size != obj.via.str.size 
+        || strncmp(str, obj.via.str.ptr, obj.via.str.size) != 0) {
+        return FLB_FALSE;
+    }
+    return FLB_TRUE;
+}
+
+int validate_key(msgpack_object obj, const char *str, const int size) {
+    return equal_obj_str(obj, str, size);
+}
+
+void assign_subfield_str(msgpack_object obj, flb_sds_t *subfield) {
+    if (obj.type == MSGPACK_OBJECT_STR) {
+        *subfield = flb_sds_copy(*subfield, obj.via.str.ptr, 
+                                 obj.via.str.size);
+    }
+}
+
+void assign_subfield_bool(msgpack_object obj, int *subfield) {
+    if (obj.type == MSGPACK_OBJECT_BOOLEAN) {
+        if (obj.via.boolean) {
+            *subfield = FLB_TRUE;
+        }
+        else {
+            *subfield = FLB_FALSE;
+        }
+    }
+}
+
+void assign_subfield_int(msgpack_object obj, int *subfield) {
+    if (obj.type == MSGPACK_OBJECT_STR) {
+        *subfield = atoll(obj.via.str.ptr);
+    }
+    else if (obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        *subfield = obj.via.i64;
+    }
+    else {
+        *subfield = 0;
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -34,14 +34,14 @@ int validate_key(msgpack_object obj, const char *str, const int size) {
     return equal_obj_str(obj, str, size);
 }
 
-void assign_subfield_str(msgpack_object obj, flb_sds_t *subfield) {
+void try_assign_subfield_str(msgpack_object obj, flb_sds_t *subfield) {
     if (obj.type == MSGPACK_OBJECT_STR) {
         *subfield = flb_sds_copy(*subfield, obj.via.str.ptr, 
                                  obj.via.str.size);
     }
 }
 
-void assign_subfield_bool(msgpack_object obj, int *subfield) {
+void try_assign_subfield_bool(msgpack_object obj, int *subfield) {
     if (obj.type == MSGPACK_OBJECT_BOOLEAN) {
         if (obj.via.boolean) {
             *subfield = FLB_TRUE;
@@ -52,7 +52,7 @@ void assign_subfield_bool(msgpack_object obj, int *subfield) {
     }
 }
 
-void assign_subfield_int(msgpack_object obj, int *subfield) {
+void try_assign_subfield_int(msgpack_object obj, int *subfield) {
     if (obj.type == MSGPACK_OBJECT_STR) {
         *subfield = atoll(obj.via.str.ptr);
     }

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -35,18 +35,18 @@ int validate_key(msgpack_object obj, const char *str, const int size);
  * if obj->type is string, assign obj->val to subfield 
  * Otherwise leave the subfield untouched
  */
-void assign_subfield_str(msgpack_object obj, flb_sds_t *subfield);
+void try_assign_subfield_str(msgpack_object obj, flb_sds_t *subfield);
 
 /* 
  * if obj->type is boolean, assign obj->val to subfield 
  * Otherwise leave the subfield untouched
  */
-void assign_subfield_bool(msgpack_object obj, int *subfield);
+void try_assign_subfield_bool(msgpack_object obj, int *subfield);
 
 /* 
  * if obj->type is valid, assign obj->val to subfield 
  * Otherwise leave the subfield untouched
  */
-void assign_subfield_int(msgpack_object obj, int *subfield);
+void try_assign_subfield_int(msgpack_object obj, int *subfield);
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -1,0 +1,52 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HELPER_H
+#define FLB_STD_HELPER_H
+
+#include "stackdriver.h"
+
+/* 
+ * Compare obj->via.str and str. 
+ * Return FLB_TRUE if they are equal. 
+ * Return FLB_FALSE if obj->type is not string or they are not equal
+ */
+int equal_obj_str(msgpack_object obj, const char *str, const int size);
+
+int validate_key(msgpack_object obj, const char *str, const int size);
+
+/* 
+ * if obj->type is string, assign obj->val to subfield 
+ * Otherwise leave the subfield untouched
+ */
+void assign_subfield_str(msgpack_object obj, flb_sds_t *subfield);
+
+/* 
+ * if obj->type is boolean, assign obj->val to subfield 
+ * Otherwise leave the subfield untouched
+ */
+void assign_subfield_bool(msgpack_object obj, int *subfield);
+
+/* 
+ * if obj->type is valid, assign obj->val to subfield 
+ * Otherwise leave assign 0
+ */
+void assign_subfield_int(msgpack_object obj, int *subfield);
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -47,6 +47,6 @@ void try_assign_subfield_bool(msgpack_object obj, int *subfield);
  * if obj->type is valid, assign obj->val to subfield 
  * Otherwise leave the subfield untouched
  */
-void try_assign_subfield_int(msgpack_object obj, int *subfield);
+void try_assign_subfield_int(msgpack_object obj, int64_t *subfield);
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -45,7 +45,7 @@ void assign_subfield_bool(msgpack_object obj, int *subfield);
 
 /* 
  * if obj->type is valid, assign obj->val to subfield 
- * Otherwise leave assign 0
+ * Otherwise leave the subfield untouched
  */
 void assign_subfield_int(msgpack_object obj, int *subfield);
 

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -101,17 +101,17 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
             }
 
             if (validate_key(tmp_p->key, OPERATION_ID, OPERATION_ID_SIZE)) {
-                assign_subfield_str(tmp_p->val, operation_id);
+                try_assign_subfield_str(tmp_p->val, operation_id);
             }
             else if (validate_key(tmp_p->key, OPERATION_PRODUCER, 
                                   OPERATION_PRODUCER_SIZE)) {
-                assign_subfield_str(tmp_p->val, operation_producer);
+                try_assign_subfield_str(tmp_p->val, operation_producer);
             }
             else if (validate_key(tmp_p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)) {
-                assign_subfield_bool(tmp_p->val, operation_first);
+                try_assign_subfield_bool(tmp_p->val, operation_first);
             }
             else if (validate_key(tmp_p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
-                assign_subfield_bool(tmp_p->val, operation_last);
+                try_assign_subfield_bool(tmp_p->val, operation_last);
             }
             else {
                 *extra_subfields += 1;

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -16,6 +16,7 @@
  *  limitations under the License.
  */
 #include "stackdriver.h"
+#include "stackdriver_helper.h"
 #include "stackdriver_operation.h"
 
 typedef enum {
@@ -23,24 +24,28 @@ typedef enum {
     OPERATION_EXISTED = 2
 } operation_status;
 
-
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck)
 {    
     msgpack_pack_str(mp_pck, 9);
     msgpack_pack_str_body(mp_pck, "operation", 9);
+
     msgpack_pack_map(mp_pck, 4);
-    msgpack_pack_str(mp_pck, 2);
-    msgpack_pack_str_body(mp_pck, "id", 2);
+
+    msgpack_pack_str(mp_pck, OPERATION_ID_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_ID, OPERATION_ID_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_id));
     msgpack_pack_str_body(mp_pck, *operation_id, flb_sds_len(*operation_id));
-    msgpack_pack_str(mp_pck, 8);
-    msgpack_pack_str_body(mp_pck, "producer", 8);
+
+    msgpack_pack_str(mp_pck, OPERATION_PRODUCER_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_producer));
-    msgpack_pack_str_body(mp_pck, *operation_producer, flb_sds_len(*operation_producer));
-    msgpack_pack_str(mp_pck, 5);
-    msgpack_pack_str_body(mp_pck, "first", 5);
+    msgpack_pack_str_body(mp_pck, *operation_producer, 
+                          flb_sds_len(*operation_producer));
+
+    msgpack_pack_str(mp_pck, OPERATION_FIRST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_FIRST, OPERATION_FIRST_SIZE);
     if (*operation_first == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -48,8 +53,8 @@ void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer,
         msgpack_pack_false(mp_pck);
     }
     
-    msgpack_pack_str(mp_pck, 4);
-    msgpack_pack_str_body(mp_pck, "last", 4);
+    msgpack_pack_str(mp_pck, OPERATION_LAST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_LAST, OPERATION_LAST_SIZE);
     if (*operation_last == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -64,81 +69,75 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
                       msgpack_object *obj, int *extra_subfields)
 {
     operation_status op_status = NO_OPERATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
 
-    if (obj->via.map.size != 0) {    	
-        msgpack_object_kv *p = obj->via.map.ptr;
-        msgpack_object_kv *const pend = obj->via.map.ptr + obj->via.map.size;
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
 
-        for (; p < pend && op_status == NO_OPERATION; ++p) {
-            if (p->val.type == MSGPACK_OBJECT_MAP && p->key.type == MSGPACK_OBJECT_STR
-                && strncmp(OPERATION_FIELD_IN_JSON, p->key.via.str.ptr, p->key.via.str.size) == 0) {
-                
-                op_status = OPERATION_EXISTED;
-                msgpack_object sub_field = p->val;
-                
-                msgpack_object_kv *tmp_p = sub_field.via.map.ptr;
-                msgpack_object_kv *const tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+    for (; p < pend && op_status == NO_OPERATION; ++p) {
 
-                /* Validate the subfields of operation */
-                for (; tmp_p < tmp_pend; ++tmp_p) {
-                    if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
-                        continue;
-                    }
-                    if (strncmp("id", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_id = flb_sds_copy(*operation_id, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("producer", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_producer = flb_sds_copy(*operation_producer, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("first", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_first = FLB_TRUE;
-                        }
-                    }
-                    else if (strncmp("last", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_last = FLB_TRUE;
-                        }
-                    }
-                    else {
-                        /* extra sub-fields */ 
-                        *extra_subfields += 1;
-                    }
+        if (p->val.type != MSGPACK_OBJECT_MAP || p->key.type != MSGPACK_OBJECT_STR
+            || !validate_key(p->key, OPERATION_FIELD_IN_JSON, 
+                             OPERATION_KEY_SIZE)) {
+            continue;
+        }
 
-                }
+        op_status = OPERATION_EXISTED;
+        msgpack_object sub_field = p->val;
+        
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of operation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, OPERATION_ID, OPERATION_ID_SIZE)) {
+                assign_subfield_str(tmp_p->val, operation_id);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_PRODUCER, 
+                                  OPERATION_PRODUCER_SIZE)) {
+                assign_subfield_str(tmp_p->val, operation_producer);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)) {
+                assign_subfield_bool(tmp_p->val, operation_first);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+                assign_subfield_bool(tmp_p->val, operation_last);
+            }
+            else {
+                *extra_subfields += 1;
             }
         }
     }
-    
+
     return op_status == OPERATION_EXISTED;
 }
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields) {
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, 
+                                    msgpack_object *operation, int extra_subfields) {
     msgpack_object_kv *p = operation->via.map.ptr;
     msgpack_object_kv *const pend = operation->via.map.ptr + operation->via.map.size;
 
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (strncmp("id", p->key.via.str.ptr, p->key.via.str.size) != 0 
-            && strncmp("producer", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("first", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("last", p->key.via.str.ptr, p->key.via.str.size) != 0) {
-            msgpack_pack_object(mp_pck, p->key);
-            msgpack_pack_object(mp_pck, p->val);
+        if (validate_key(p->key, OPERATION_ID, OPERATION_ID_SIZE)
+            || validate_key(p->key, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE)
+            || validate_key(p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)
+            || validate_key(p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+            continue;
         }
-    }
 
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
 }

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -82,7 +82,7 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
 
     for (; p < pend && op_status == NO_OPERATION; ++p) {
 
-        if (p->val.type != MSGPACK_OBJECT_MAP || p->key.type != MSGPACK_OBJECT_STR
+        if (p->val.type != MSGPACK_OBJECT_MAP
             || !validate_key(p->key, OPERATION_FIELD_IN_JSON, 
                              OPERATION_KEY_SIZE)) {
             continue;

--- a/plugins/out_stackdriver/stackdriver_operation.h
+++ b/plugins/out_stackdriver/stackdriver_operation.h
@@ -22,15 +22,62 @@
 
 #include "stackdriver.h"
 
+/* subfield name and size */
+#define OPERATION_ID "id"
+#define OPERATION_PRODUCER "producer"
+#define OPERATION_FIRST "first"
+#define OPERATION_LAST "last"
+
+#define OPERATION_ID_SIZE 2
+#define OPERATION_PRODUCER_SIZE 8
+#define OPERATION_FIRST_SIZE 5
+#define OPERATION_LAST_SIZE 4
+
+/* 
+ *  Add operation field to the entries.
+ *  The structure of operation is:
+ *  {
+ *      "id": string,
+ *      "producer": string,
+ *      "first": boolean,
+ *      "last": boolean
+ *  }
+ * 
+ */                                                                                     
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck);
 
+/*
+ *  Extract the operation field from the jsonPayload.
+ *  If the operation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
 int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                       int *operation_first, int *operation_last, 
                       msgpack_object *obj, int *extra_subfields);
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields);
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "id": "id1",
+ *          "producer": "id2",
+ *          "first": true,
+ *          "last": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, 
+                                    int extra_subfields);
 
 
 #endif

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1124,6 +1124,7 @@ void flb_test_operation_extra_subfields()
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
                               cb_check_operation_extra_subfields,
                               NULL, NULL);
+
     /* Start */
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);
@@ -1484,12 +1485,16 @@ TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
     {"resource_global", flb_test_resource_global },
     {"resource_gce_instance", flb_test_resource_gce_instance },
+
+    /* test operation */
     {"operation_common_case", flb_test_operation_common},
     {"empty_operation", flb_test_empty_operation},
     {"operation_not_a_map", flb_test_operation_in_string},
     {"operation_partial_subfields", flb_test_operation_partial_subfields},
     {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
     {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
+
+    /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },
@@ -1497,5 +1502,6 @@ TEST_LIST = {
     {"custom_labels", flb_test_custom_labels },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
+
     {NULL, NULL}
 };


### PR DESCRIPTION
According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

Since the PR #2302 is too large, we separate it into several parts.
In this part, we update the `operation` field.
Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
