### PR TITLE
in_tail: dockermode: fix mem leak (CID 304957)

### DIFF
--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -286,6 +286,7 @@ int flb_tail_dmode_process_content(time_t now,
             flb_errno();
             return -1;
         }
+        file->dmode_buf = tmp;
 
         tmp_copy = flb_sds_copy(file->dmode_lastline, line, line_len);
         if (!tmp_copy) {
@@ -293,7 +294,6 @@ int flb_tail_dmode_process_content(time_t now,
             return -1;
         }
 
-        file->dmode_buf = tmp;
         file->dmode_lastline = tmp_copy;
         file->dmode_flush_timeout = now + (ctx->docker_mode_flush - 1);
 


### PR DESCRIPTION
Coverity Scan issue

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
