### PR TITLE
aws: bug fix: flb_aws_is_auth_error payload can be NULL

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -158,6 +158,10 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size)
 {
     flb_sds_t error = NULL;
 
+    if (payload_size == 0) {
+        return FLB_FALSE;
+    }
+
     /* Fluent Bit calls the STS API which returns XML */
     if (strcasestr(payload, "InvalidClientTokenId") != NULL) {
         return FLB_TRUE;


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
