### PR TITLE
out_stackdriver: support special field - insertId

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -778,10 +778,7 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
         if (p->key.type != MSGPACK_OBJECT_STR) {
             continue;
         }
-        if (p->key.via.str.size == INSERT_ID_SIZE 
-            && strncmp(DEFAULT_INSERT_ID_KEY, 
-                       p->key.via.str.ptr, 
-                       p->key.via.str.size) == 0) {
+        if (validate_key(p->key, DEFAULT_INSERT_ID_KEY, INSERT_ID_SIZE)) {
             if (p->val.type == MSGPACK_OBJECT_STR && p->val.via.str.size > 0) {
                 *insert_id_value = p->val;
                 ret = INSERTID_VALID;
@@ -1210,7 +1207,7 @@ static int stackdriver_format(struct flb_config *config,
          * }
          */
         entry_size = 3;
-        
+
         /* Extract severity */
         severity_extracted = FLB_FALSE;
         if (ctx->severity_key

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,7 +49,8 @@
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
-
+#define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
+#define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
 
@@ -132,5 +133,10 @@ struct local_resource_id_list {
     struct mk_list _head;
 };
 
+typedef enum {
+    INSERTID_VALID = 0,
+    INSERTID_INVALID = 1,
+    INSERTID_NOT_PRESENT = 2
+} insert_id_status;
 
 #endif

--- a/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
@@ -1,0 +1,27 @@
+
+#define INSERTID_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"test_insertId\" "		\
+	"}]"
+
+#define EMPTY_INSERTID	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"\" "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_INT	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": 123 "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_MAP	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": "		\
+        "{"           \       
+        "}"     \
+	"}]"	
+	


### PR DESCRIPTION
According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

Since the PR #2302 is too large, we separate it into several parts.
In this part, we support the `insertId` field.

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
