### PR TITLE
in_tail: tweak the return code of tail_scan_pattern()

### DIFF
--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -87,6 +87,9 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx)
  * supports patterns with "nested" wildcards like below.
  *
  *     tail_scan_pattern("C:\fluent-bit\*\*.txt", ctx);
+ *
+ * On success, the number of files found is returned (zero indicates
+ * "no file found"). On error, -1 is returned.
  */
 static int tail_scan_pattern(const char *path, struct flb_tail_config *ctx)
 {
@@ -131,7 +134,7 @@ static int tail_scan_pattern(const char *path, struct flb_tail_config *ctx)
 
     h = FindFirstFileA(pattern, &data);
     if (h == INVALID_HANDLE_VALUE) {
-        return -1;
+        return 0;  /* none matched */
     }
 
     do {


### PR DESCRIPTION
Currently tail_scan_pattern() returns -1 if no file is found to
match the given pattern. For this reason, the caller was unable
to distinguish "no file found" and "an unexpected error occured".

Make it sure to return 0 if no file is found. This should allow
flb_tail_scan() to emit this message:

    [debug] 0 new files found on path 'C:\*\test.log'

instead of:

    [warn] error scanning path: C:\*\test.log

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
