### PR TITLE
out_nrlogs: wrap output in an array to match the API

### DIFF
--- a/plugins/out_nrlogs/newrelic.c
+++ b/plugins/out_nrlogs/newrelic.c
@@ -158,16 +158,17 @@ static flb_sds_t newrelic_compose_payload(struct flb_newrelic *ctx,
      * Following the New Relic Fluentd implementation, this is the
      * suggested structure for our payload:
      *
-     *     payload = {
-     *     'common' => {
-     *       'attributes' => {
-     *         'plugin' => {
-     *           'type' => 'fluentd',
-     *           'version' => NewrelicFluentdOutput::VERSION,
+     *     payload = {[
+     *       'common' => {
+     *         'attributes' => {
+     *           'plugin' => {
+     *             'type' => 'fluentd',
+     *             'version' => NewrelicFluentdOutput::VERSION,
+     *           }
      *         }
-     *       }
-     *     },
-     *     'logs' => []
+     *       },
+     *       'logs' => []
+     *     ]}
      */
 
     /* Count number of records */
@@ -177,6 +178,9 @@ static flb_sds_t newrelic_compose_payload(struct flb_newrelic *ctx,
     msgpack_unpacked_init(&result);
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* The New Relic MELT API format is wrapped in an array */
+    msgpack_pack_array(&mp_pck, 1);
 
     /* Map for 'common' and 'logs' */
     msgpack_pack_map(&mp_pck, 2);


### PR DESCRIPTION
This patch fixes the format of the New Relic output payload - the payload needs to be an array.

While the current format will send the data successfully, New Relic interprets the whole payload as a stringified array. By sending as an array, we meet the New Relic MELT API spec, and are able to distinguish individual key/values from the payload.

Sample spec can be seen here: https://docs.newrelic.com/docs/logs/new-relic-logs/log-api/introduction-log-api#log-attribute-examples


Signed-off-by: Julian Giuca <julian@newrelic.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
