### PR TITLE
out_stackdriver: initialize entry size at the beginning of the loop in stack_format

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1138,9 +1138,10 @@ static int stackdriver_format(struct flb_config *config,
          *  "timestamp": "..."
          * }
          */
-
+        entry_size = 3;
         /* Extract severity */
-         if (ctx->severity_key
+        severity_extracted = FLB_FALSE;
+        if (ctx->severity_key
             && get_severity_level(&severity, obj, ctx->severity_key) == 0) {
             severity_extracted = FLB_TRUE;
             entry_size += 1;


### PR DESCRIPTION
Fix the bug discussed on Slack: https://fluent-all.slack.com/archives/C0CTQGHKJ/p1595353491285900

In this PR, I initialized the `log entry size` at the beginning of the loop in stack_driver.

Use cases:
Set the config file `fluent-bit.conf` as:
```
[SERVICE]
   Flush     1
   Daemon    off
   Log_Level debug
   Parsers_File parser.conf
[INPUT]
   Name    tail
   Path    flb_text.log
   Parser JSON_fmt
   tag    multi-line-bit
[OUTPUT]
   Name   stackdriver
   Match  *
   resource    gce_instance
   severity_key  severity
[FILTER]
   Name modify
   Match *
   Add severity INFO
```
and `parser.conf:` as
```
[PARSER]
   Name  JSON_fmt
   Format  json
```

Then set `flb_text.log` as:
```
{"message":"test severity1"}
{"message":"test severity2"}
{"message":"test severity3"}
```

Before this PR, there will be an error like this:
```
[2020/07/21 17:02:44] [ warn] [output:stackdriver:stackdriver.0] error
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \"\": Root element must be a message.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "description": "Invalid JSON payload received. Unknown name \"\": Root element must be a message."
          }
        ]
      }
    ]
  }
}
```
After the PR, we can successfully get the logEntry:
```
{
  "insertId": "gnnl4hg59qusse",
  "jsonPayload": {
    "message": "testing severity1",
    "severity": "INFO"
  },
  "resource": {
    "type": "gce_instance",
    "labels": {
      "project_id": "319338990662",
      "zone": "us-central1-a",
      "instance_id": "8910924506933411818"
    }
  },
  "timestamp": "2020-07-22T06:14:50.041413587Z",
  "severity": "INFO",
  "logName": "projects/ops-instrumentation-intern/logs/multi-line-bit",
  "receiveTimestamp": "2020-07-22T06:14:50.223573765Z"
}
```

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
