### PR TITLE
lib: tutf8e: change CMAKE_C_FLAGS to append options to fix Yocto reci…

### DIFF
--- a/lib/tutf8e/CMakeLists.txt
+++ b/lib/tutf8e/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tutf8e)
 # Not supported: -std=c90 (lacks support for inline)
 # Supported:     -std=gnu90, -std=c99 or -std=gnu99
 
-set(CMAKE_C_FLAGS "-Os -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -Wall")
 
 include_directories(include)
 add_library(tutf8e STATIC src/tutf8e.c)


### PR DESCRIPTION
…pe build

Signed-off-by: Jonathan Crockett <jonathan@sleepiqlabs.com>

<!-- Provide summary of changes -->

Building fluent-bit with bitbake in a Yocto cross compiling setup fails building tut8fe.

The CMakeLists.txt for tut8fe replaced the contents of CMAKE_C_FLAGS which for builds using the bitbake recipe(s) in the root directory (fluent-bit_*.bb) would fail to build because bitbake uses this variable to pass in values needed for cross compilation. This patch changes this to append the contents to existing CMAKE_C_FLAGS instead of replacing them so the bitbake fluent-bit recipe will work.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
