### PR TITLE
out_stackdriver: test: multi entries log

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1138,9 +1138,10 @@ static int stackdriver_format(struct flb_config *config,
          *  "timestamp": "..."
          * }
          */
-
+        entry_size = 3;
         /* Extract severity */
-         if (ctx->severity_key
+        severity_extracted = FLB_FALSE;
+        if (ctx->severity_key
             && get_severity_level(&severity, obj, ctx->severity_key) == 0) {
             severity_extracted = FLB_TRUE;
             entry_size += 1;

--- a/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
+++ b/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
@@ -1,0 +1,3 @@
+{"message":"test severity1", "severity":"INFO"}
+{"message":"test severity2"}
+{"message":"test severity3", "severity":"INFO"}


### PR DESCRIPTION
This is the unit test for multi-entries log.
It is the following part of PR#[2380](https://github.com/fluent/fluent-bit/pull/2380#issue-454905278).

This PR will be pending due to the [issue](https://github.com/fluent/fluent-bit/pull/2380#issuecomment-662548318) of `in_tail`.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
