### PR TITLE
out_stackdriver: Add bool_map[]

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -130,4 +130,10 @@ struct local_resource_id_list {
     struct mk_list _head;
 };
 
+typedef enum {
+    TO_BE_REMOVED = 0,
+    TO_BE_REMAINED = 1,
+    TAIL_OF_ARRAY = 2
+} bool_map_t;
+
 #endif

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -131,8 +131,8 @@ struct local_resource_id_list {
 };
 
 typedef enum {
-    TO_BE_REMOVED = 0,
-    TO_BE_REMAINED = 1,
+    TO_BE_REMAINED = 0,
+    TO_BE_REMOVED = 1,
     TAIL_OF_ARRAY = 2
 } bool_map_t;
 


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
To clean up and split out part of the logic from the pack_json_payload(5) function to make it looks cleaner. The idea is inspired by our current implementation of filter record_modifier plugin. See [here](https://github.com/fluent/fluent-bit/blob/016560de45e6db0b44bfc05cacdafbf29b7e205f/plugins/filter_record_modifier/filter_modifier.c#L183) for details.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
