### PR TITLE
tests: runtime: out_stackdriver: update test for multi entries log

### DIFF
--- a/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
+++ b/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
@@ -1,3 +1,4 @@
 {"message":"test severity1", "severity":"INFO"}
 {"message":"test severity2"}
-{"message":"test severity3", "severity":"INFO"}
+{"message":"test severity3", "severity":"DEBUG"}
+{"message":"test severity4"}

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -807,11 +807,14 @@ static void cb_check_multi_entries_severity(void *ctx, int ffd,
     ret = mp_kv_cmp(res_data, res_size, "$entries[0]['severity']", "INFO");
     TEST_CHECK(ret == FLB_TRUE);
 
-    ret = mp_kv_cmp(res_data, res_size, "$entries[1]['severity']", "INFO");
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]['severity']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[2]['severity']", "DEBUG");
     TEST_CHECK(ret == FLB_TRUE);
 
-    ret = mp_kv_cmp(res_data, res_size, "$entries[2]['severity']", "INFO");
-    TEST_CHECK(ret == FLB_TRUE);
+    ret = mp_kv_exists(res_data, res_size, "$entries[3]['severity']");
+    TEST_CHECK(ret == FLB_FALSE);
 
     flb_sds_destroy(res_data);
 }


### PR DESCRIPTION
Update the [unit test for multi-entries logs](https://github.com/fluent/fluent-bit/pull/2384).

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
