### PR TITLE
Use SQL that is supported by Postgres and CockroachDB.

### DIFF
--- a/plugins/out_pgsql/pgsql.c
+++ b/plugins/out_pgsql/pgsql.c
@@ -317,7 +317,7 @@ static void cb_pgsql_flush(const void *data, size_t bytes,
     snprintf(query, str_len,
              "INSERT INTO %s "
              "SELECT %s, "
-             "to_timestamp(CAST(value->>'%s' as FLOAT)), * "
+             "CAST(value->>'%s' AS INTERVAL) + DATE'1970-01-01', * "
              "FROM json_array_elements(%s);",
              ctx->db_table, tag_escaped, ctx->timestamp_key, json);
     flb_plg_trace(ctx->ins, "query: %s", query);


### PR DESCRIPTION
This changes the SQL in pgsql.c:320 to support Postgres and [CockroachDB](https://www.cockroachlabs.com/product/).  CRDB [supports the Postgres wire protocol](https://www.cockroachlabs.com/blog/why-postgres/), but does not have `to_timestamp`.  I tested the SQL in fiddle for Postgres 9.3 and 9.6.

This may not be the best way to do this, so maybe someone else can build on this.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change -- no changes
- [ ] Debug log output from testing the change
Here are some logs from a pod in kubernetes:
```
Fluent Bit v1.5.2
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/07/27 15:54:41] [ info] [engine] started (pid=1)
[2020/07/27 15:54:41] [ info] [storage] version=1.0.4, initializing...
[2020/07/27 15:54:41] [ info] [storage] in-memory
[2020/07/27 15:54:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/07/27 15:54:41] [ info] [filter:kubernetes:kubernetes.0] https=1 host=kubernetes.default.svc port=443
[2020/07/27 15:54:41] [ info] [filter:kubernetes:kubernetes.0] local POD info OK
[2020/07/27 15:54:41] [ info] [filter:kubernetes:kubernetes.0] testing connectivity with API server...
[2020/07/27 15:54:41] [ info] [filter:kubernetes:kubernetes.0] API server connectivity OK
[2020/07/27 15:54:41] [ info] [output:pgsql:pgsql.0] Opening connection: #0
[2020/07/27 15:54:41] [ info] [output:pgsql:pgsql.0] switching postgresql connection to non-blocking mode
[2020/07/27 15:54:41] [ info] [output:pgsql:pgsql.0] host=cockroachdb-public port=26257 dbname=fluentbit OK
[2020/07/27 15:54:41] [ info] [output:pgsql:pgsql.0] we check that the table "fluentbit" exists, if not we create it
[2020/07/27 15:54:41] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2020/07/27 15:54:41] [ info] [sp] stream processor started
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

I don't seem to have the tools (or C know-how) to build locally, but did build it in a Docker container.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
