### PR TITLE
filter_rewrite_tag: add and-combination for rules

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.h
+++ b/plugins/filter_rewrite_tag/rewrite_tag.h
@@ -32,6 +32,7 @@
 /* Rewrite rule  */
 struct rewrite_rule {
     int keep_record;                       /* keep original record ? */
+    int and_combination;                   /* rule combination: false: OR, true: AND */
     struct flb_regex *regex;               /* matching regex */
     struct flb_record_accessor *ra_key;    /* key record accessor */
     struct flb_record_accessor *ra_tag;    /* tag record accessor */


### PR DESCRIPTION
rules in rewrite_tag filter were combined with OR combination. In some usecases
an AND-combination is helpful. For instance, when logmessages in kubernetes from
customer namespaces should be dropped, which haven't set a special annotation
field. Without an AND-combination, two filter section are necessary, to get this
done.

Configuration example:
to each rule a fifth field with true|false can be added. 'true' means, that this
rule should be "AND"-combined with the next rule. "false" means default "OR"
behaviour, and is not needed. So its full compatible with old filter configuration.

```
[FILTER]
    Name          rewrite_tag
    Match         tail
    Rule          $log ^(1|3)$    newtag_or    false false
    Rule          $log ^(.*end)$  newtag_and_1 false true
    Rule          $log ^(1.*)$    newtag_and_2 false false
    Rule          $log ^(2.*)$    newtag_or    false
```

Signed-off-by: Michael Voelker <novecento@gmx.de>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
