### PR TITLE
out_stackdriver: support special field - sourceLocation

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src
   stackdriver_conf.c
   stackdriver.c
   stackdriver_operation.c
+  stackdriver_source_location.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1270,8 +1270,8 @@ static int stackdriver_format(struct flb_config *config,
 
         /* Extract sourceLocation */
         source_location_file = flb_sds_create("");
-        source_location_function = flb_sds_create("");
         source_location_line = 0;
+        source_location_function = flb_sds_create("");
         source_location_extra_size = 0;
         source_location_extracted = extract_source_location(&source_location_file, 
                                                             &source_location_line,

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -31,6 +31,7 @@
 #include "stackdriver.h"
 #include "stackdriver_conf.h"
 #include "stackdriver_operation.h"
+#include "stackdriver_source_location.h"
 #include "stackdriver_helper.h"
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
@@ -791,10 +792,12 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
     }
     return ret;
 }
-
-static int pack_json_payload(int insert_id_extracted, 
-                             int operation_extracted, int operation_extra_size, 
-                             msgpack_packer* mp_pck, msgpack_object *obj,
+                                                                                        
+static int pack_json_payload(int insert_id_extracted,
+                             int operation_extracted, int operation_extra_size,
+                             int source_location_extracted, 
+                             int source_location_extra_size,
+                             msgpack_packer *mp_pck, msgpack_object *obj,
                              struct flb_stackdriver *ctx)
 {
     /* Specified fields include local_resource_id, operation, sourceLocation ... */
@@ -827,6 +830,9 @@ static int pack_json_payload(int insert_id_extracted,
         to_remove += 1;
     }
     if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
+        to_remove += 1;
+    }
+    if(source_location_extracted == FLB_TRUE && source_location_extra_size == 0) {
         to_remove += 1;
     }
 
@@ -875,6 +881,18 @@ static int pack_json_payload(int insert_id_extracted,
             if (operation_extra_size > 0) {
                 msgpack_pack_object(mp_pck, kv->key);
                 pack_extra_operation_subfields(mp_pck, &kv->val, operation_extra_size);
+            }
+            continue;
+        }
+
+        if (validate_key(kv->key, SOURCELOCATION_FIELD_IN_JSON, 
+                         SOURCE_LOCATION_SIZE)
+            && kv->val.type == MSGPACK_OBJECT_MAP) {
+
+            if (source_location_extra_size > 0) {
+                msgpack_pack_object(mp_pck, kv->key);
+                pack_extra_source_location_subfields(mp_pck, &kv->val, 
+                                                     source_location_extra_size);
             }
             continue;
         }
@@ -951,6 +969,13 @@ static int stackdriver_format(struct flb_config *config,
     int operation_last = FLB_FALSE;
     int operation_extracted = FLB_FALSE;
     int operation_extra_size = 0;
+
+    /* Parameters for sourceLocation */
+    flb_sds_t source_location_file;
+    int64_t source_location_line = 0;
+    flb_sds_t source_location_function;
+    int source_location_extracted = FLB_FALSE;
+    int source_location_extra_size = 0;
 
     /* Count number of records */
     array_size = flb_mp_count(data, bytes);
@@ -1243,6 +1268,21 @@ static int stackdriver_format(struct flb_config *config,
             entry_size += 1;
         }
 
+        /* Extract sourceLocation */
+        source_location_file = flb_sds_create("");
+        source_location_function = flb_sds_create("");
+        source_location_line = 0;
+        source_location_extra_size = 0;
+        source_location_extracted = extract_source_location(&source_location_file, 
+                                                            &source_location_line,
+                                                            &source_location_function, 
+                                                            obj, 
+                                                            &source_location_extra_size);
+
+        if (source_location_extracted == FLB_TRUE) {
+            entry_size += 1;
+        }
+
         /* Extract labels */
         labels_ptr = parse_labels(ctx, obj);
         if (labels_ptr != NULL) {
@@ -1279,6 +1319,12 @@ static int stackdriver_format(struct flb_config *config,
                                 &operation_first, &operation_last, &mp_pck);
         }
 
+        /* Add sourceLocation field into the log entry */
+        if (source_location_extracted == FLB_TRUE) {
+            add_source_location_field(&source_location_file, source_location_line, 
+                                      &source_location_function, &mp_pck);
+        }
+
         /* labels */
         if (labels_ptr != NULL) {
             msgpack_pack_str(&mp_pck, 6);
@@ -1289,12 +1335,16 @@ static int stackdriver_format(struct flb_config *config,
         /* Clean up */
         flb_sds_destroy(operation_id);
         flb_sds_destroy(operation_producer);
+        flb_sds_destroy(source_location_file);
+        flb_sds_destroy(source_location_function);
 
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);
         msgpack_pack_str_body(&mp_pck, "jsonPayload", 11);
-        pack_json_payload(insert_id_extracted, 
-                          operation_extracted, operation_extra_size, 
+        pack_json_payload(insert_id_extracted,
+                          operation_extracted, operation_extra_size,
+                          source_location_extracted,
+                          source_location_extra_size, 
                           &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -50,9 +50,11 @@
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
+#define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
 #define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
+#define SOURCE_LOCATION_SIZE 37
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"

--- a/plugins/out_stackdriver/stackdriver_source_location.c
+++ b/plugins/out_stackdriver/stackdriver_source_location.c
@@ -1,0 +1,138 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_source_location.h"
+
+typedef enum {
+    NO_SOURCELOCATION = 1,
+    SOURCELOCATION_EXISTED = 2
+} source_location_status;
+
+
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line, 
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 14);
+    msgpack_pack_str_body(mp_pck, "sourceLocation", 14);
+    msgpack_pack_map(mp_pck, 3);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_file));
+    msgpack_pack_str_body(mp_pck, *source_location_file, 
+                          flb_sds_len(*source_location_file));
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_int64(mp_pck, source_location_line);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FUNCTION, 
+                          SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_function));
+    msgpack_pack_str_body(mp_pck, *source_location_function, 
+                          flb_sds_len(*source_location_function));
+}
+
+/* Return FLB_TRUE if sourceLocation extracted */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields)
+{
+    source_location_status op_status = NO_SOURCELOCATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {   
+        return FLB_FALSE;
+    } 	
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend && op_status == NO_SOURCELOCATION; ++p) {
+
+        if (p->val.type != MSGPACK_OBJECT_MAP 
+            || p->key.type != MSGPACK_OBJECT_STR
+            || !validate_key(p->key, SOURCELOCATION_FIELD_IN_JSON, 
+                             SOURCE_LOCATION_SIZE)) {
+
+            continue;
+        }
+
+        op_status = SOURCELOCATION_EXISTED;
+        msgpack_object sub_field = p->val;
+
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of sourceLocation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, 
+                             SOURCE_LOCATION_FILE, 
+                             SOURCE_LOCATION_FILE_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, source_location_file);
+            }
+            else if (validate_key(tmp_p->key, 
+                                  SOURCE_LOCATION_FUNCTION, 
+                                  SOURCE_LOCATION_FUNCTION_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, source_location_function);
+            }
+            else if (validate_key(tmp_p->key, 
+                                  SOURCE_LOCATION_LINE, 
+                                  SOURCE_LOCATION_LINE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, source_location_line);
+            }
+            else {
+                *extra_subfields += 1;
+            }
+        }
+    }
+
+    return op_status == SOURCELOCATION_EXISTED;
+}
+
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields) {
+    msgpack_object_kv *p = source_location->via.map.ptr;
+    msgpack_object_kv *const pend = source_location->via.map.ptr + source_location->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE)
+            || validate_key(p->key, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE)
+            || validate_key(p->key, SOURCE_LOCATION_FUNCTION, 
+                            SOURCE_LOCATION_FUNCTION_SIZE)) {
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_source_location.h
+++ b/plugins/out_stackdriver/stackdriver_source_location.h
@@ -1,0 +1,81 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_SOURCELOCATION_H
+#define FLB_STD_SOURCELOCATION_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define SOURCE_LOCATION_FILE "file"
+#define SOURCE_LOCATION_LINE "line"
+#define SOURCE_LOCATION_FUNCTION "function"
+
+#define SOURCE_LOCATION_FILE_SIZE 4
+#define SOURCE_LOCATION_LINE_SIZE 4
+#define SOURCE_LOCATION_FUNCTION_SIZE 8
+
+/* 
+ *  Add sourceLocation field to the entries.
+ *  The structure of sourceLocation is:
+ *  {
+ *      "file": string,
+ *      "line": int,
+ *      "function": string
+ *  }
+ */   
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line,
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck);
+
+/*
+ *  Extract the sourceLocation field from the jsonPayload.
+ *  If the sourceLocation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "file": "file1",
+ *          "line": 1,
+ *          "function": "func1",
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields);
+
+
+#endif

--- a/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
@@ -1,0 +1,70 @@
+#define SOURCELOCATION_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_COMMON_CASE_LINE_IN_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": \"123\","      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define EMPTY_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/sourceLocation\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"function\": \"test_function\""   \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": 123,"          \
+            "\"line\": \"some string\","      \
+            "\"function\": true"      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\","      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"
+    

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -35,6 +35,7 @@
 #include "data/stackdriver/stackdriver_test_k8s_resource.h"
 #include "data/stackdriver/stackdriver_test_labels.h"
 #include "data/stackdriver/stackdriver_test_insert_id.h"
+#include "data/stackdriver/stackdriver_test_source_location.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -855,6 +856,180 @@ static void cb_check_multi_entries_severity(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_source_location_common_case(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_common_case_line_in_string(void *ctx, int ffd,
+                                                                int res_ret, void *res_data, size_t res_size,
+                                                                void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_source_location(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_in_string(void *ctx, int ffd,
+                                               int res_ret, void *res_data, size_t res_size,
+                                               void *data)
+{
+    int ret;
+
+    /* sourceLocation remains in jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_partial_subfields(void *ctx, int ffd,
+                                                       int res_ret, void *res_data, size_t res_size,
+                                                       void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_incorrect_type_subfields(void *ctx, int ffd,
+                                                              int res_ret, void *res_data, size_t res_size,
+                                                              void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
+                                                     int res_ret, void *res_data, size_t res_size,
+                                                     void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key3']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
 void flb_test_resource_global()
 {
     int ret;
@@ -1639,6 +1814,286 @@ void flb_test_multi_entries_severity()
     flb_destroy(ctx);
 }
 
+void flb_test_source_location_common_case()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_line_in_string()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_COMMON_CASE_LINE_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_common_case_line_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_COMMON_CASE_LINE_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_source_location()
+{
+    int ret;
+    int size = sizeof(EMPTY_SOURCELOCATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_source_location,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_SOURCELOCATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_in_string()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_SOURCELOCATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_partial_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_SOURCELOCATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_incorrect_type_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_extra_subfields()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_extra_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
@@ -1657,6 +2112,15 @@ TEST_LIST = {
     {"operation_partial_subfields", flb_test_operation_partial_subfields},
     {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
     {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
+
+    /* test sourceLocation */
+    {"sourceLocation_common_case", flb_test_source_location_common_case},
+    {"sourceLocation_line_in_string", flb_test_source_location_line_in_string},
+    {"empty_sourceLocation", flb_test_empty_source_location},
+    {"sourceLocation_not_a_map", flb_test_source_location_in_string},
+    {"sourceLocation_partial_subfields", flb_test_source_location_partial_subfields},
+    {"sourceLocation_subfields_in_incorrect_type", flb_test_source_location_incorrect_type_subfields},
+    {"sourceLocation_extra_subfields_exist", flb_test_source_location_extra_subfields},
 
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },


### PR DESCRIPTION
According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

Since the PR #2302 is too large, we separate it into several parts.
In this part, we update the `sourceLocation` field.

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
