### PR TITLE
out_stackdriver: support special field - httpRequest

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -4,6 +4,7 @@ set(src
   stackdriver.c
   stackdriver_operation.c
   stackdriver_source_location.c
+  stackdriver_http_request.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -32,6 +32,7 @@
 #include "stackdriver_conf.h"
 #include "stackdriver_operation.h"
 #include "stackdriver_source_location.h"
+#include "stackdriver_http_request.h"
 #include "stackdriver_helper.h"
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
@@ -793,10 +794,12 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
     return ret;
 }
                                                                                         
-static int pack_json_payload(int insert_id_extracted,
+static int pack_json_payload(int insert_id_extracted, 
                              int operation_extracted, int operation_extra_size,
                              int source_location_extracted, 
                              int source_location_extra_size,
+                             int http_request_extracted, 
+                             int http_request_extra_size,
                              msgpack_packer *mp_pck, msgpack_object *obj,
                              struct flb_stackdriver *ctx)
 {
@@ -826,13 +829,16 @@ static int pack_json_payload(int insert_id_extracted,
         /* more special fields are required to be added */
     };
 
-    if(insert_id_extracted == FLB_TRUE) {
+    if (insert_id_extracted == FLB_TRUE) {
         to_remove += 1;
     }
     if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
         to_remove += 1;
     }
-    if(source_location_extracted == FLB_TRUE && source_location_extra_size == 0) {
+    if (source_location_extracted == FLB_TRUE && source_location_extra_size == 0) {
+        to_remove += 1;
+    }
+    if (http_request_extracted == FLB_TRUE && http_request_extra_size == 0) {
         to_remove += 1;
     }
 
@@ -893,6 +899,18 @@ static int pack_json_payload(int insert_id_extracted,
                 msgpack_pack_object(mp_pck, kv->key);
                 pack_extra_source_location_subfields(mp_pck, &kv->val, 
                                                      source_location_extra_size);
+            }
+            continue;
+        }
+        
+        if (validate_key(kv->key, HTTPREQUEST_FIELD_IN_JSON, 
+                         HTTP_REQUEST_KEY_SIZE) 
+            && kv->val.type == MSGPACK_OBJECT_MAP) {
+
+            if(http_request_extra_size > 0) {
+                msgpack_pack_object(mp_pck, kv->key);
+                pack_extra_http_request_subfields(mp_pck, &kv->val, 
+                                                  http_request_extra_size);
             }
             continue;
         }
@@ -976,6 +994,11 @@ static int stackdriver_format(struct flb_config *config,
     flb_sds_t source_location_function;
     int source_location_extracted = FLB_FALSE;
     int source_location_extra_size = 0;
+    
+    /* Parameters for httpRequest */
+    struct http_request_field http_request;
+    int http_request_extracted = FLB_FALSE;
+    int http_request_extra_size = 0;
 
     /* Count number of records */
     array_size = flb_mp_count(data, bytes);
@@ -1282,6 +1305,15 @@ static int stackdriver_format(struct flb_config *config,
         if (source_location_extracted == FLB_TRUE) {
             entry_size += 1;
         }
+        
+        /* Extract httpRequest */
+        init_http_request(&http_request);
+        http_request_extra_size = 0;
+        http_request_extracted = extract_http_request(&http_request, obj, 
+                                                      &http_request_extra_size);
+        if (http_request_extracted == FLB_TRUE) {
+            entry_size += 1;
+        }
 
         /* Extract labels */
         labels_ptr = parse_labels(ctx, obj);
@@ -1324,6 +1356,11 @@ static int stackdriver_format(struct flb_config *config,
             add_source_location_field(&source_location_file, source_location_line, 
                                       &source_location_function, &mp_pck);
         }
+        
+        /* Add httpRequest field into the log entry */
+        if (http_request_extracted == FLB_TRUE) {
+            add_http_request_field(&http_request, &mp_pck);
+        }
 
         /* labels */
         if (labels_ptr != NULL) {
@@ -1337,6 +1374,7 @@ static int stackdriver_format(struct flb_config *config,
         flb_sds_destroy(operation_producer);
         flb_sds_destroy(source_location_file);
         flb_sds_destroy(source_location_function);
+        destroy_http_request(&http_request);
 
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);
@@ -1345,6 +1383,8 @@ static int stackdriver_format(struct flb_config *config,
                           operation_extracted, operation_extra_size,
                           source_location_extracted,
                           source_location_extra_size, 
+                          http_request_extracted, 
+                          http_request_extra_size,
                           &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -51,10 +51,12 @@
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
+#define HTTPREQUEST_FIELD_IN_JSON "logging.googleapis.com/http_request"
 #define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
 #define SOURCE_LOCATION_SIZE 37
+#define HTTP_REQUEST_KEY_SIZE 35
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"

--- a/plugins/out_stackdriver/stackdriver_http_request.c
+++ b/plugins/out_stackdriver/stackdriver_http_request.c
@@ -1,0 +1,373 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <fluent-bit/flb_regex.h>
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_http_request.h"
+
+typedef enum {
+    NO_HTTPREQUEST = 1,
+    HTTPREQUEST_EXISTS = 2
+} http_request_status;
+
+void init_http_request(struct http_request_field *http_request)
+{
+    http_request->latency = flb_sds_create("");
+    http_request->protocol = flb_sds_create("");
+    http_request->referer = flb_sds_create("");
+    http_request->remoteIp = flb_sds_create("");
+    http_request->requestMethod = flb_sds_create("");
+    http_request->requestUrl = flb_sds_create("");
+    http_request->serverIp = flb_sds_create("");
+    http_request->userAgent = flb_sds_create("");
+
+    http_request->cacheFillBytes = 0;
+    http_request->requestSize = 0;
+    http_request->responseSize = 0;
+    http_request->status = 0;
+
+    http_request->cacheHit = FLB_FALSE;
+    http_request->cacheLookup = FLB_FALSE;
+    http_request->cacheValidatedWithOriginServer = FLB_FALSE;
+}
+
+void destroy_http_request(struct http_request_field *http_request)
+{
+    flb_sds_destroy(http_request->latency);
+    flb_sds_destroy(http_request->protocol);
+    flb_sds_destroy(http_request->referer);
+    flb_sds_destroy(http_request->remoteIp);
+    flb_sds_destroy(http_request->requestMethod);
+    flb_sds_destroy(http_request->requestUrl);
+    flb_sds_destroy(http_request->serverIp);
+    flb_sds_destroy(http_request->userAgent);
+}
+
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 11);
+    msgpack_pack_str_body(mp_pck, "httpRequest", 11);
+
+    if (flb_sds_is_empty(http_request->latency) == FLB_TRUE) {
+        msgpack_pack_map(mp_pck, 14);
+    }
+    else {
+        msgpack_pack_map(mp_pck, 15);
+
+        msgpack_pack_str(mp_pck, HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str_body(mp_pck, HTTP_REQUEST_LATENCY, 
+                              HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str(mp_pck, flb_sds_len(http_request->latency));
+        msgpack_pack_str_body(mp_pck, http_request->latency, 
+                              flb_sds_len(http_request->latency));
+    }
+
+    /* String sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_METHOD, 
+                          HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestMethod));
+    msgpack_pack_str_body(mp_pck, http_request->requestMethod, 
+                          flb_sds_len(http_request->requestMethod));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_URL, 
+                          HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestUrl));
+    msgpack_pack_str_body(mp_pck, http_request->requestUrl, 
+                          flb_sds_len(http_request->requestUrl));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_USER_AGENT, 
+                          HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->userAgent));
+    msgpack_pack_str_body(mp_pck, http_request->userAgent, 
+                          flb_sds_len(http_request->userAgent));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REMOTE_IP, 
+                          HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->remoteIp));
+    msgpack_pack_str_body(mp_pck, http_request->remoteIp, 
+                          flb_sds_len(http_request->remoteIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_SERVER_IP, 
+                          HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->serverIp));
+    msgpack_pack_str_body(mp_pck, http_request->serverIp, 
+                          flb_sds_len(http_request->serverIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REFERER, 
+                          HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->referer));
+    msgpack_pack_str_body(mp_pck, http_request->referer, 
+                          flb_sds_len(http_request->referer));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_PROTOCOL, 
+                          HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->protocol));
+    msgpack_pack_str_body(mp_pck, http_request->protocol, 
+                          flb_sds_len(http_request->protocol));
+
+    /* Integer sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUESTSIZE, 
+                          HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->requestSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_RESPONSESIZE, 
+                          HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->responseSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_STATUS, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->status);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                          HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->cacheFillBytes);
+
+    /* Boolean sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_LOOKUP, 
+                          HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_HIT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_HIT, 
+                          HTTP_REQUEST_CACHE_HIT_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                          HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    if (http_request->cacheValidatedWithOriginServer == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+}
+
+/* latency should be in the format: 
+ *      whitespace (opt.) + integer + point & decimal (opt.)
+ *      + whitespace (opt.) + "s" + whitespace (opt.) 
+ */
+static void validate_latency(msgpack_object_str latency_in_payload, 
+                             struct http_request_field *http_request) {
+    flb_sds_t pattern = flb_sds_create("^\\s*\\d+(.\\d+)?\\s*s\\s*$");
+    char extract_latency[latency_in_payload.size];
+    struct flb_regex *regex;
+
+    int status = 0;
+    int i = 0, j = 0;
+
+    regex = flb_regex_create(pattern);
+    status = flb_regex_match(regex, latency_in_payload.ptr, latency_in_payload.size);
+    flb_regex_destroy(regex);
+    flb_sds_destroy(pattern);
+
+    if (status == 1) {
+        for (; i < latency_in_payload.size; ++ i) {
+            if (latency_in_payload.ptr[i] == '.' || latency_in_payload.ptr[i] == 's' 
+                || isdigit(latency_in_payload.ptr[i])) {
+                extract_latency[j] = latency_in_payload.ptr[i];
+                ++ j;
+            }
+        }
+        http_request->latency = flb_sds_copy(http_request->latency, extract_latency, j);
+    }
+}
+
+/* Return true if httpRequest extracted */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields)
+{
+    http_request_status op_status = NO_HTTPREQUEST;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {
+        return FLB_FALSE;
+    }
+
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend && op_status == NO_HTTPREQUEST; ++p) {
+
+        if (p->val.type != MSGPACK_OBJECT_MAP
+            || !validate_key(p->key, HTTPREQUEST_FIELD_IN_JSON, 
+                             HTTP_REQUEST_KEY_SIZE)) {
+
+            continue;
+        }
+
+        op_status = HTTPREQUEST_EXISTS;
+        msgpack_object sub_field = p->val;
+
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of httpRequest */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, HTTP_REQUEST_LATENCY, 
+                             HTTP_REQUEST_LATENCY_SIZE)) {                
+                if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+                    continue;
+                }
+                validate_latency(tmp_p->val.via.str, http_request);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_PROTOCOL, 
+                                  HTTP_REQUEST_PROTOCOL_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->protocol);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REFERER, 
+                                  HTTP_REQUEST_REFERER_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->referer);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REMOTE_IP, 
+                                  HTTP_REQUEST_REMOTE_IP_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->remoteIp);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUEST_METHOD, 
+                                  HTTP_REQUEST_REQUEST_METHOD_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->requestMethod);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUEST_URL, 
+                                  HTTP_REQUEST_REQUEST_URL_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->requestUrl);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_SERVER_IP, 
+                                  HTTP_REQUEST_SERVER_IP_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->serverIp);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_USER_AGENT, 
+                                  HTTP_REQUEST_USER_AGENT_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->userAgent);
+            }
+
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                                  HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->cacheFillBytes);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUESTSIZE, 
+                                  HTTP_REQUEST_REQUESTSIZE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->requestSize);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_RESPONSESIZE, 
+                                  HTTP_REQUEST_RESPONSESIZE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->responseSize);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_STATUS, 
+                                  HTTP_REQUEST_STATUS_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->status);
+            }
+
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_HIT, 
+                                  HTTP_REQUEST_CACHE_HIT_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, &http_request->cacheHit);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+                                  HTTP_REQUEST_CACHE_LOOKUP_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, &http_request->cacheLookup);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                                  HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, 
+                                         &http_request->cacheValidatedWithOriginServer);
+            }
+
+            else {
+                *extra_subfields += 1;
+            }
+        }
+    }
+
+    return op_status == HTTPREQUEST_EXISTS;
+}
+
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields) {
+    msgpack_object_kv *p = http_request->via.map.ptr;
+    msgpack_object_kv *const pend = http_request->via.map.ptr + http_request->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, HTTP_REQUEST_LATENCY, 
+                         HTTP_REQUEST_LATENCY_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_PROTOCOL, 
+                            HTTP_REQUEST_PROTOCOL_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REFERER, 
+                            HTTP_REQUEST_REFERER_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REMOTE_IP, 
+                            HTTP_REQUEST_REMOTE_IP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUEST_METHOD, 
+                            HTTP_REQUEST_REQUEST_METHOD_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUEST_URL, 
+                            HTTP_REQUEST_REQUEST_URL_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_SERVER_IP, 
+                            HTTP_REQUEST_SERVER_IP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_USER_AGENT, 
+                            HTTP_REQUEST_USER_AGENT_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                            HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUESTSIZE, 
+                            HTTP_REQUEST_REQUESTSIZE_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_RESPONSESIZE, 
+                            HTTP_REQUEST_RESPONSESIZE_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_STATUS, 
+                            HTTP_REQUEST_STATUS_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_HIT, 
+                            HTTP_REQUEST_CACHE_HIT_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+                            HTTP_REQUEST_CACHE_LOOKUP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                            HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
+
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_http_request.h
+++ b/plugins/out_stackdriver/stackdriver_http_request.h
@@ -1,0 +1,119 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HTTPREQUEST_H
+#define FLB_STD_HTTPREQUEST_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define HTTP_REQUEST_LATENCY "latency"
+#define HTTP_REQUEST_PROTOCOL "protocol"
+#define HTTP_REQUEST_REFERER "referer"
+#define HTTP_REQUEST_REMOTE_IP "remoteIp"
+#define HTTP_REQUEST_REQUEST_METHOD "requestMethod"
+#define HTTP_REQUEST_REQUEST_URL "requestUrl"
+#define HTTP_REQUEST_SERVER_IP "serverIp"
+#define HTTP_REQUEST_USER_AGENT "userAgent"
+#define HTTP_REQUEST_CACHE_FILL_BYTES "cacheFillBytes"
+#define HTTP_REQUEST_REQUESTSIZE "requestSize"
+#define HTTP_REQUEST_RESPONSESIZE "responseSize"
+#define HTTP_REQUEST_STATUS "status"
+#define HTTP_REQUEST_CACHE_HIT "cacheHit"
+#define HTTP_REQUEST_CACHE_LOOKUP "cacheLookup"
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER "cacheValidatedWithOriginServer"
+
+#define HTTP_REQUEST_LATENCY_SIZE 7
+#define HTTP_REQUEST_PROTOCOL_SIZE  8
+#define HTTP_REQUEST_REFERER_SIZE 7
+#define HTTP_REQUEST_REMOTE_IP_SIZE 8 
+#define HTTP_REQUEST_REQUEST_METHOD_SIZE 13
+#define HTTP_REQUEST_REQUEST_URL_SIZE 10
+#define HTTP_REQUEST_SERVER_IP_SIZE 8
+#define HTTP_REQUEST_USER_AGENT_SIZE 9
+#define HTTP_REQUEST_CACHE_FILL_BYTES_SIZE 14
+#define HTTP_REQUEST_REQUESTSIZE_SIZE 11
+#define HTTP_REQUEST_RESPONSESIZE_SIZE 12
+#define HTTP_REQUEST_STATUS_SIZE 6
+#define HTTP_REQUEST_CACHE_HIT_SIZE 8
+#define HTTP_REQUEST_CACHE_LOOKUP_SIZE 11
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE 30
+
+
+struct http_request_field {
+    flb_sds_t latency;
+    flb_sds_t protocol;
+    flb_sds_t referer;
+    flb_sds_t remoteIp;
+    flb_sds_t requestMethod;
+    flb_sds_t requestUrl;
+    flb_sds_t serverIp;
+    flb_sds_t userAgent;
+
+    int64_t cacheFillBytes;
+    int64_t requestSize;
+    int64_t responseSize;
+    int64_t status;
+
+    int cacheHit;
+    int cacheLookup;
+    int cacheValidatedWithOriginServer;
+};
+
+void init_http_request(struct http_request_field *http_request);
+void destroy_http_request(struct http_request_field *http_request);
+
+/* 
+ *  Add httpRequest field to the entries.
+ *  The structure of httpRequest is as shown in struct http_request_field
+ */   
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck);
+
+/*
+ *  Extract the httpRequest field from the jsonPayload.
+ *  If the httpRequest field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "requestMethod": "GET",
+ *          "latency": "1s",
+ *          "cacheLookup": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields);
+
+#endif

--- a/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
@@ -1,0 +1,134 @@
+#define HTTPREQUEST_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define EMPTY_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/http_request\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": 123,"          \
+            "\"requestUrl\": 123,"      \
+            "\"userAgent\": 123,"      \
+            "\"remoteIp\": 123,"          \
+            "\"serverIp\": true,"      \
+            "\"referer\": true,"          \
+            "\"latency\": false,"      \
+            "\"protocol\": false,"      \
+            "\"requestSize\": \"some string\","          \
+            "\"responseSize\": true,"      \
+            "\"status\": false,"      \
+            "\"cacheFillBytes\": false,"          \
+            "\"cacheLookup\": \"some string\","      \
+            "\"cacheHit\": 123,"      \
+            "\"cacheValidatedWithOriginServer\": 123"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true,"      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"
+
+
+/* Tests for 'latency' */
+#define HTTPREQUEST_LATENCY_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_SPACES	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100. 00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  s100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_END	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00    \""      \
+        "}"     \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -36,6 +36,7 @@
 #include "data/stackdriver/stackdriver_test_labels.h"
 #include "data/stackdriver/stackdriver_test_insert_id.h"
 #include "data/stackdriver/stackdriver_test_source_location.h"
+#include "data/stackdriver/stackdriver_test_http_request.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -1030,6 +1031,348 @@ static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_http_request_common_case(void *ctx, int ffd,
+                                             int res_ret, void *res_data, size_t res_size,
+                                             void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "test_requestMethod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "test_requestUrl");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "test_userAgent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "test_remoteIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "test_serverIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "test_referer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "test_protocol");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "0s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 200);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_http_request(void *ctx, int ffd,
+                                        int res_ret, void *res_data, size_t res_size,
+                                        void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_in_string(void *ctx, int ffd,
+                                            int res_ret, void *res_data, size_t res_size,
+                                            void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['httpRequest']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_partial_subfields(void *ctx, int ffd,
+                                                    int res_ret, void *res_data, size_t res_size,
+                                                    void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_incorrect_type_subfields(void *ctx, int ffd,
+                                                           int res_ret, void *res_data, size_t res_size,
+                                                           void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_extra_subfields(void *ctx, int ffd,
+                                                  int res_ret, void *res_data, size_t res_size,
+                                                  void *data)
+{
+     int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "test_requestMethod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "test_requestUrl");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "test_userAgent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "test_remoteIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "test_serverIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "test_referer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "test_protocol");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "0s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 200);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key3']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_lantency_common_case(void *ctx, int ffd,
+                                                       int res_ret, void *res_data, size_t res_size,
+                                                       void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "100.00s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_latency_incorrect_format(void *ctx, int ffd,
+                                                           int res_ret, void *res_data, size_t res_size,
+                                                           void *data)
+{
+    int ret;
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
 
 void flb_test_resource_global()
 {
@@ -2095,6 +2438,406 @@ void flb_test_source_location_extra_subfields()
     flb_destroy(ctx);
 }
 
+void flb_test_http_request_common_case()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_http_request()
+{
+    int ret;
+    int size = sizeof(EMPTY_HTTPREQUEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_http_request,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_HTTPREQUEST, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_in_string()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_HTTPREQUEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_partial_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_HTTPREQUEST, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_incorrect_type_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_extra_subfields()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_extra_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_common_case()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_lantency_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_spaces()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_SPACES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_SPACES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_string()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_end()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_END) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_END, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
@@ -2131,6 +2874,18 @@ TEST_LIST = {
     {"custom_labels", flb_test_custom_labels },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
+
+    /* test httpRequest */
+    {"httpRequest_common_case", flb_test_http_request_common_case},
+    {"empty_httpRequest", flb_test_empty_http_request},
+    {"httpRequest_not_a_map", flb_test_http_request_in_string},
+    {"httpRequest_partial_subfields", flb_test_http_request_partial_subfields},
+    {"httpRequest_subfields_in_incorret_type", flb_test_http_request_incorrect_type_subfields},
+    {"httpRequest_extra_subfields_exist", flb_test_http_request_extra_subfields},
+    {"httpRequest_common_latency", flb_test_http_request_latency_common_case},
+    {"httpRequest_latency_incorrect_spaces", flb_test_http_request_latency_invalid_spaces},
+    {"httpRequest_latency_incorrect_string", flb_test_http_request_latency_invalid_string},
+    {"httpRequest_latency_incorrect_end", flb_test_http_request_latency_invalid_end},
 
     {NULL, NULL}
 };

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1030,6 +1030,7 @@ static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+
 void flb_test_resource_global()
 {
     int ret;
@@ -2121,7 +2122,7 @@ TEST_LIST = {
     {"sourceLocation_partial_subfields", flb_test_source_location_partial_subfields},
     {"sourceLocation_subfields_in_incorrect_type", flb_test_source_location_incorrect_type_subfields},
     {"sourceLocation_extra_subfields_exist", flb_test_source_location_extra_subfields},
-
+    
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },


### PR DESCRIPTION
According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

Since the PR #2302 is too large, we separate it into several parts.
In this part, we update the `httpRequest` field.

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
