### PR TITLE
out_stackdriver: support special field - timestamp

### DIFF
--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -5,6 +5,7 @@ set(src
   stackdriver_operation.c
   stackdriver_source_location.c
   stackdriver_http_request.c
+  stackdriver_timestamp.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/stackdriver_timestamp.c
+++ b/plugins/out_stackdriver/stackdriver_timestamp.c
@@ -1,0 +1,158 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_timestamp.h"
+#include <fluent-bit/flb_regex.h>
+
+static int is_integer(char *str, int size) {
+    int i;
+    for (i = 0; i < size; ++ i) {
+        if (!isdigit(str[i])) {
+            return FLB_FALSE;
+        }
+    }
+    return FLB_TRUE;
+}
+
+static void try_assign_time(long long seconds, long long nanos, 
+                            struct flb_time *tms)
+{
+    if (seconds != 0) {
+        tms->tm.tv_sec = seconds;
+        tms->tm.tv_nsec = nanos;    
+    }
+}
+
+static long long get_integer(msgpack_object obj)
+{
+    if (obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        return obj.via.i64;
+    }
+    else if (obj.type == MSGPACK_OBJECT_STR 
+             && is_integer(obj.via.str.ptr, 
+                           obj.via.str.size)) {
+        return atoll(obj.via.str.ptr);
+    }
+    return 0;
+}
+
+static int extract_format_timestamp_object(msgpack_object *obj,
+                                           struct flb_time *tms)
+{
+    int seconds_found = FLB_FALSE;
+    int nanos_found = FLB_FALSE;
+    long long seconds = 0;
+    long long nanos = 0;
+
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend; ++p) {
+        if (!validate_key(p->key, "timestamp", 9) 
+            || p->val.type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
+
+        tmp_p = p->val.via.map.ptr;
+        tmp_pend = p->val.via.map.ptr + p->val.via.map.size;
+
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (validate_key(tmp_p->key, "seconds", 7)) {
+                seconds_found = FLB_TRUE;
+                seconds = get_integer(tmp_p->val);
+                
+                if (nanos_found == FLB_TRUE) {
+                    try_assign_time(seconds, nanos, tms);
+                    return FLB_TRUE;
+                }
+            }
+            else if (validate_key(tmp_p->key, "nanos", 5)) {
+                nanos_found = FLB_TRUE;
+                nanos = get_integer(tmp_p->val);
+
+                if (seconds_found == FLB_TRUE) {
+                    try_assign_time(seconds, nanos, tms);
+                    return FLB_TRUE;
+                }
+            }
+        }
+    }
+    return FLB_FALSE;
+}
+
+static int extract_format_timestamp_duo_fields(msgpack_object *obj,
+                                               struct flb_time *tms)
+{
+    int seconds_found = FLB_FALSE;
+    int nanos_found = FLB_FALSE;
+    long long seconds = 0;
+    long long nanos = 0;
+
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, "timestampSeconds", 16)) {
+            seconds_found = FLB_TRUE;
+            seconds = get_integer(p->val);
+
+            if (nanos_found == FLB_TRUE) {
+                try_assign_time(seconds, nanos, tms);
+                return FLB_TRUE;
+            }
+        }
+        else if (validate_key(p->key, "timestampNanos", 14)) {
+            nanos_found = FLB_TRUE;
+            nanos = get_integer(p->val);
+
+            if (seconds_found == FLB_TRUE) {
+                try_assign_time(seconds, nanos, tms);
+                return FLB_TRUE;
+            }
+        } 
+    }
+
+    return FLB_FALSE;
+}
+
+timestamp_status extract_timestamp(msgpack_object *obj,
+                                   struct flb_time *tms)
+{
+    if (extract_format_timestamp_object(obj, tms)) {
+        return FORMAT_TIMESTAMP_OBJECT;
+    }
+    if (extract_format_timestamp_duo_fields(obj, tms)) {
+        return FORMAT_TIMESTAMP_DUO_FIELDS;
+    }
+    return TIMESTAMP_NOT_PRESENT;
+}

--- a/plugins/out_stackdriver/stackdriver_timestamp.h
+++ b/plugins/out_stackdriver/stackdriver_timestamp.h
@@ -1,0 +1,48 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_TIMESTAMP_H
+#define FLB_STD_TIEMSTAMP_H
+
+#include "stackdriver.h"
+#include <fluent-bit/flb_time.h>
+
+typedef enum {
+    TIMESTAMP_NOT_PRESENT = 0,
+    FORMAT_TIMESTAMP_OBJECT = 1,
+    FORMAT_TIMESTAMP_DUO_FIELDS = 2
+} timestamp_status;
+
+/* 
+ * Currently support two formats of time-related fields
+ *      - "timestamp":{"seconds", "nanos"}
+ *      - "timestampSeconds"/"timestampNanos"
+ * 
+ * If timestamp field is not existed, return TIMESTAMP_NOT_PRESENT 
+ * If timestamp format is "timestamp":{"seconds", "nanos"}, 
+ * set the time and return FORMAT_TIMESTAMP
+ * 
+ * If timestamp format is "timestampSeconds"/"timestampNanos", 
+ * set the time and return FORMAT_TIMESTAMPSECONDS
+ */
+timestamp_status extract_timestamp(msgpack_object *obj,
+                                   struct flb_time *tms);
+
+
+#endif

--- a/tests/runtime/data/stackdriver/stackdriver_test_timestamp.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_timestamp.h
@@ -1,0 +1,62 @@
+/* timestamp after parsing: 2020-07-21T16:40:42.000012345Z */
+#define TIMESTAMP_FORMAT_OBJECT_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"seconds\": \"1595349642\","          \
+            "\"nanos\": \"12345\""      \
+        "}"     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_NOT_A_MAP	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": \"string\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_MISSING_SUBFIELD	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"nanos\": \"12345\""      \
+        "}"     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_INCORRECT_TYPE_SUBFIELDS	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"seconds\": \"string\","          \
+            "\"nanos\": true"      \
+        "}"     \
+	"}]"
+
+
+/* timestamp after parsing: 2020-07-21T16:40:42.000012345Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_COMMON_CASE	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"1595349642\","	     \
+        "\"timestampNanos\": \"12345\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_MISSING_NANOS	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"1595349642\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_INCORRECT_TYPE	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"string\","	     \
+        "\"timestampNanos\": true"	     \
+	"}]"


### PR DESCRIPTION
According to https://cloud.google.com/logging/docs/agent/configuration#special-fields, there are some special fields in structured payloads, such as insertId and sourceLocation.

In this PR, we support two formats of `timestamp`:
	1. "timestamp":{"seconds": "", "nanos":""}
	2. "timestampSeconds":"" & "timestampNanos":""

Signed-off-by: scgao <scgao@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
