### PR TITLE
in_udp:  Input plugin for UDP messages.  WIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ option(FLB_IN_COLLECTD        "Enable Collectd input plugin"        Yes)
 option(FLB_IN_STATSD          "Enable StatsD input plugin"          Yes)
 option(FLB_IN_STORAGE_BACKLOG "Enable storage backlog input plugin" Yes)
 option(FLB_IN_EMITTER         "Enable emitter input plugin"         Yes)
+option(FLB_IN_UDP             "Enable UDP input plugin"             Yes)
 option(FLB_OUT_AZURE          "Enable Azure output plugin"          Yes)
 option(FLB_OUT_BIGQUERY       "Enable BigQuery output plugin"       Yes)
 option(FLB_OUT_COUNTER        "Enable Counter output plugin"        Yes)
@@ -188,6 +189,7 @@ option(FLB_FILTER_NEST        "Enable nest filter"                  Yes)
 option(FLB_FILTER_LUA         "Enable Lua scripting filter"         Yes)
 option(FLB_FILTER_RECORD_MODIFIER "Enable record_modifier filter"   Yes)
 
+
 # Debug callbacks
 option(FLB_HTTP_CLIENT_DEBUG  "Enable HTTP Client debug callbacks"   No)
 
@@ -210,6 +212,7 @@ if(FLB_ALL)
   set(FLB_IN_DUMMY     1)
   set(FLB_IN_NETIF     1)
   set(FLB_IN_EXEC      1)
+  set(FLB_IN_UDP       1)
 
   # Output plugins
   set(FLB_OUT_ES       1)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -159,6 +159,7 @@ endif()
 if(FLB_PARSER)
   REGISTER_IN_PLUGIN("in_syslog")
   REGISTER_IN_PLUGIN("in_exec")
+  REGISTER_IN_PLUGIN("in_udp")
 endif()
 
 REGISTER_IN_PLUGIN("in_tcp")

--- a/plugins/in_udp/CMakeLists.txt
+++ b/plugins/in_udp/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(src
+  udp_conf.c
+  udp_server.c
+  udp_conn.c
+  udp_prot.c
+  udp.c)
+
+FLB_PLUGIN(in_udp "${src}" "")

--- a/plugins/in_udp/udp.c
+++ b/plugins/in_udp/udp.c
@@ -1,0 +1,150 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <msgpack.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_utils.h>
+
+#include "udp.h"
+#include "udp_conf.h"
+#include "udp_server.h"
+#include "udp_conn.h"
+#include "udp_prot.h"
+
+/* cb_collect callback */
+/*
+ * Collect a datagrams
+ */
+static int in_udp_collect_udp(struct flb_input_instance *i_ins,
+                                 struct flb_config *config,
+                                 void *in_context)
+{
+    int bytes;
+    char *nl;
+    char *line;
+    char *endp;
+    struct flb_udp *ctx = in_context;
+    (void) i_ins;
+
+    bytes = recvfrom(ctx->server_fd,
+                     ctx->buffer_data, ctx->buffer_size - 1, 0,
+                     NULL, NULL);
+    if (bytes > 0) {
+        ctx->buffer_data[bytes] = '\0';
+        ctx->buffer_len = bytes;
+        if (ctx->multi_line) {
+            line = ctx->buffer_data;
+            endp = ctx->buffer_data + bytes;
+            while ((nl = strchr(line,'\n')) != NULL) {
+                *nl = 0;
+                if ((nl - line) > 0) {
+                    udp_prot_process_udp(line, nl - line, ctx);
+                }
+                line = nl + 1;
+            }
+            if (line < endp) {
+                udp_prot_process_udp(line, endp - line, ctx);
+            }
+        } else {
+            udp_prot_process_udp(ctx->buffer_data, ctx->buffer_len, ctx);
+        }
+    }
+    else {
+        flb_errno();
+    }
+    ctx->buffer_len = 0;
+
+    return 0;
+}
+
+/* Initialize plugin */
+static int in_udp_init(struct flb_input_instance *in,
+                          struct flb_config *config, void *data)
+{
+    int ret;
+    struct flb_udp *ctx;
+
+    /* Allocate space for the configuration */
+    ctx = udp_conf_create(in, config);
+    if (!ctx) {
+        flb_plg_error(in, "could not initialize plugin");
+        return -1;
+    }
+
+    if ((ctx->mode == FLB_UDP_UNIX) && !ctx->unix_path) {
+        flb_plg_error(ctx->ins, "Unix path not defined");
+        udp_conf_destroy(ctx);
+        return -1;
+    }
+
+    /* Create Unix Socket */
+    ret = udp_server_create(ctx);
+    if (ret == -1) {
+        udp_conf_destroy(ctx);
+        return -1;
+    }
+
+    /* Set context */
+    flb_input_set_context(in, ctx);
+
+    /* Collect events for every opened connection to our socket */
+    ret = flb_input_set_collector_socket(in,
+                                         in_udp_collect_udp,
+                                         ctx->server_fd,
+                                         config);
+
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "Could not set collector");
+        udp_conf_destroy(ctx);
+    }
+
+    return 0;
+}
+
+static int in_udp_exit(void *data, struct flb_config *config)
+{
+    struct flb_udp *ctx = data;
+    (void) config;
+
+    udp_conn_exit(ctx);
+    udp_conf_destroy(ctx);
+
+    return 0;
+}
+
+
+struct flb_input_plugin in_udp_plugin = {
+    .name         = "udp",
+    .description  = "Udp",
+    .cb_init      = in_udp_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = NULL,
+    .cb_flush_buf = NULL,
+    .cb_exit      = in_udp_exit,
+    .flags        = FLB_INPUT_NET
+};

--- a/plugins/in_udp/udp.h
+++ b/plugins/in_udp/udp.h
@@ -1,0 +1,68 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_UDP_H
+#define FLB_IN_UDP_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
+
+/* Udp modes */
+#define FLB_UDP_UNIX  1
+#define FLB_UDP_INET  2
+
+/* 32KB chunk size */
+#define FLB_UDP_CHUNK   32768
+
+/* Context / Config*/
+struct flb_udp {
+    /* Listening mode: unix udp, unix tcp or normal tcp */
+    int mode;
+
+    /* Network mode */
+    char *listen;
+    char *port;
+
+    /* Unix socket (UDP/TCP)*/
+    int server_fd;
+    char *unix_path;
+    unsigned int unix_perm;
+
+    /* UDP buffer, data length and buffer size */
+    char *buffer_data;
+    size_t buffer_len;
+    size_t buffer_size;
+    int    multi_line;
+    int    rtrim;
+
+    /* Buffers setup */
+    size_t buffer_max_size;
+    size_t buffer_chunk_size;
+
+    /* Configuration */
+    struct flb_parser *parser;
+
+    /* List for connections and event loop */
+    struct mk_list connections;
+    struct mk_event_loop *evl;
+    struct flb_input_instance *ins;
+};
+
+#endif

--- a/plugins/in_udp/udp_conf.c
+++ b/plugins/in_udp/udp_conf.c
@@ -1,0 +1,173 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_utils.h>
+
+#include "udp.h"
+#include "udp_server.h"
+#include "udp_conf.h"
+
+struct flb_udp *udp_conf_create(struct flb_input_instance *ins,
+                                      struct flb_config *config)
+{
+    const char *tmp;
+    int port_num;
+    const char *bind_addr;
+    char port[64];
+    struct flb_udp *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct flb_udp));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->evl = config->evl;
+    ctx->ins = ins;
+    ctx->buffer_data = NULL;
+    ctx->server_fd = -1;
+    ctx->rtrim = 1;
+
+    mk_list_init(&ctx->connections);
+
+    /* Udp mode: unix / inet */
+    tmp = flb_input_get_property("mode", ins);
+    if (tmp) {
+        if (strcasecmp(tmp, "unix") == 0) {
+            ctx->mode = FLB_UDP_UNIX;
+        }
+        else if (strcasecmp(tmp, "inet") == 0) {
+            ctx->mode = FLB_UDP_INET;
+        }
+        else {
+            flb_error("[in_udp] Unknown udp mode %s", tmp);
+            udp_conf_destroy(ctx);
+            return NULL;
+        }
+    }
+    else {
+        ctx->mode = FLB_UDP_UNIX;
+    }
+
+    /* Check if TCP mode was requested */
+
+    if (ctx->mode == FLB_UDP_INET) {
+
+        tmp = flb_input_get_property("port", ins);
+        if (tmp) {
+            port_num = strtol(tmp, NULL, 10);
+        } else {
+            port_num = 5588;
+        }
+        /*
+            flb_error("[in_udp] no udp port");
+            udp_conf_destroy(ctx);
+            return NULL;
+        */
+
+        tmp = flb_input_get_property("bind", ins);
+        if (tmp) {
+            bind_addr = tmp;
+        } else {
+            bind_addr = "0.0.0.0";
+        }
+        /* Listen interface (if not set, defaults to 0.0.0.0:5140) */
+        flb_input_net_default_listener(bind_addr, port_num, ins);
+        ctx->listen = ins->host.listen;
+        snprintf(port, sizeof(port) - 1, "%d", ins->host.port);
+        ctx->port = flb_strdup(port);
+    }
+
+    /* Unix socket path and permission */
+    if (ctx->mode == FLB_UDP_UNIX) {
+
+        tmp = flb_input_get_property("path", ins);
+        if (!tmp) {
+            flb_error("[in_udp] no udp/unix no path given");
+            udp_conf_destroy(ctx);
+            return NULL;
+        }
+        ctx->unix_path = flb_strdup(tmp);
+
+        tmp = flb_input_get_property("unix_perm", ins);
+        if (tmp) {
+            ctx->unix_perm = strtol(tmp, NULL, 8) & 07777;
+        } else {
+            ctx->unix_perm = 0644;
+        }
+    }
+
+    /* Buffer Chunk Size */
+    tmp = flb_input_get_property("buffer_chunk_size", ins);
+    if (!tmp) {
+        ctx->buffer_chunk_size = FLB_UDP_CHUNK; /* 32KB */
+    }
+    else {
+        ctx->buffer_chunk_size = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* Buffer Max Size */
+    tmp = flb_input_get_property("buffer_max_size", ins);
+    if (!tmp) {
+        ctx->buffer_max_size = ctx->buffer_chunk_size;
+    }
+    else {
+        ctx->buffer_max_size  = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* multiline */
+    tmp = flb_input_get_property("multi_line", ins);
+    if (tmp) {
+        ctx->multi_line = flb_utils_bool(tmp);
+    }
+
+    /* rtrim  (right trim input) */
+    tmp = flb_input_get_property("rtrim", ins);
+    if (tmp) {
+        ctx->rtrim = flb_utils_bool(tmp);
+    }
+
+    /* Parser */
+    tmp = flb_input_get_property("parser", ins);
+    if (tmp) {
+        ctx->parser = flb_parser_get(tmp, config);
+    }
+
+    return ctx;
+}
+
+int udp_conf_destroy(struct flb_udp *ctx)
+{
+    if (ctx->buffer_data) {
+        flb_free(ctx->buffer_data);
+        ctx->buffer_data = NULL;
+    }
+
+    udp_server_destroy(ctx);
+
+    flb_free(ctx);
+
+    return 0;
+}

--- a/plugins/in_udp/udp_conf.h
+++ b/plugins/in_udp/udp_conf.h
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_UDP_CONF_H
+#define FLB_IN_UDP_CONF_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
+
+#include "udp.h"
+
+struct flb_udp *udp_conf_create(struct flb_input_instance *i_ins,
+                                      struct flb_config *config);
+int udp_conf_destroy(struct flb_udp *ctx);
+
+#endif

--- a/plugins/in_udp/udp_conn.c
+++ b/plugins/in_udp/udp_conn.c
@@ -1,0 +1,58 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_network.h>
+
+#include "udp.h"
+#include "udp_conf.h"
+#include "udp_conn.h"
+#include "udp_prot.h"
+
+
+int udp_conn_del(struct udp_conn *conn)
+{
+    /* Unregister the file descriptior from the event-loop */
+    mk_event_del(conn->ctx->evl, &conn->event);
+
+    /* Release resources */
+    mk_list_del(&conn->_head);
+    close(conn->fd);
+    flb_free(conn->buf_data);
+    flb_free(conn);
+
+    return 0;
+}
+
+int udp_conn_exit(struct flb_udp *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct udp_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct udp_conn, _head);
+        udp_conn_del(conn);
+    }
+
+    return 0;
+}

--- a/plugins/in_udp/udp_conn.h
+++ b/plugins/in_udp/udp_conn.h
@@ -1,0 +1,51 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_UDP_CONN_H
+#define FLB_IN_UDP_CONN_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+
+#include "udp.h"
+
+/* Respresents a connection */
+struct udp_conn {
+    struct mk_event event;           /* Built-in event data for mk_events */
+    int fd;                          /* Socket file descriptor            */
+    int status;                      /* Connection status                 */
+
+    /* Buffer */
+    char *buf_data;                  /* Buffer data                       */
+    size_t buf_size;                 /* Buffer size                       */
+    size_t buf_len;                  /* Buffer length                     */
+    size_t buf_parsed;               /* Parsed buffer (offset)            */
+    struct flb_input_instance *ins;  /* Parent plugin instance            */
+    struct flb_udp *ctx;          /* Plugin configuration context      */
+
+    struct mk_list _head;
+};
+
+int udp_conn_event(void *data);
+struct udp_conn *udp_conn_add(int fd, struct flb_udp *ctx);
+int udp_conn_del(struct udp_conn *conn);
+int udp_conn_exit(struct flb_udp *ctx);
+
+#endif

--- a/plugins/in_udp/udp_prot.c
+++ b/plugins/in_udp/udp_prot.c
@@ -1,0 +1,134 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "udp.h"
+#include "udp_conn.h"
+
+#include <string.h>
+
+
+static size_t rtrimlen(char *buf,  size_t size)
+{
+    uint8_t *b = (uint8_t*) buf;
+    uint8_t *p;
+    if (size <= 0) {
+        return size;
+    }
+    for (p = (uint8_t*) b + (size - 1); p >= b; p--) {
+        if (*p > 32) {
+            return p - b + 1;
+        }
+    }
+    return 0;
+}
+
+static inline int pack_line(struct flb_udp *ctx,
+                            struct flb_time *time, char *data, size_t data_size)
+{
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* Initialize local msgpack buffer */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    flb_time_append_to_msgpack(time, &mp_pck, 0);
+    msgpack_sbuffer_write(&mp_sbuf, data, data_size);
+
+    flb_input_chunk_append_raw(ctx->ins, NULL, 0, mp_sbuf.data, mp_sbuf.size);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    return 0;
+}
+
+
+int udp_prot_process_parsed(char *buf, size_t size, struct flb_udp *ctx)
+{
+    int ret;
+    void *out_buf;
+    size_t out_size;
+    struct flb_time out_time = {0};
+
+    ret = flb_parser_do(ctx->parser, buf, size,
+                        &out_buf, &out_size, &out_time);
+    if (ret >= 0) {
+        if (flb_time_to_double(&out_time) == 0) {
+            flb_time_get(&out_time);
+        }
+        pack_line(ctx, &out_time, out_buf, out_size);
+        flb_free(out_buf);
+    }
+    else {
+        flb_plg_warn(ctx->ins, "error parsing log message with parser '%s'",
+                     ctx->parser->name);
+        flb_plg_debug(ctx->ins, "unparsed log message: %.*s",
+                      (int) size, buf);
+        return -1;
+    }
+    return 0;
+}
+
+int udp_prot_process_unparsed(char *buf, size_t size, struct flb_udp *ctx)
+{
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* Initialize local msgpack buffer */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+
+    flb_pack_time_now(&mp_pck);
+
+    msgpack_pack_map(&mp_pck, 1);
+    /* key: message == 7 */
+    msgpack_pack_str(&mp_pck, 7);
+    msgpack_pack_str_body(&mp_pck, "message",7);
+
+    /* value: input  */
+    msgpack_pack_str(&mp_pck, size);
+    msgpack_pack_str_body(&mp_pck, buf,size);
+
+    flb_input_chunk_append_raw(ctx->ins, NULL, 0, mp_sbuf.data, mp_sbuf.size);
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    return 0;
+}
+
+int udp_prot_process_udp(char *buf, size_t size, struct flb_udp *ctx)
+{
+    if (ctx->rtrim) {
+        size = rtrimlen(buf, size);
+    }
+
+    if (ctx->parser) {
+        udp_prot_process_parsed(buf, size, ctx);
+    } else {
+        udp_prot_process_unparsed(buf, size, ctx);
+    }
+    return 0;
+}

--- a/plugins/in_udp/udp_prot.h
+++ b/plugins/in_udp/udp_prot.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_UDP_PROT_H
+#define FLB_IN_UDP_PROT_H
+
+#include <fluent-bit/flb_info.h>
+
+#include "udp.h"
+
+int udp_prot_process(struct udp_conn *conn);
+int udp_prot_process_udp(char *buf, size_t size, struct flb_udp *ctx);
+
+#endif

--- a/plugins/in_udp/udp_server.c
+++ b/plugins/in_udp/udp_server.c
@@ -1,0 +1,149 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_macros.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_network.h>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "udp.h"
+
+static int udp_server_unix_create(struct flb_udp *ctx)
+{
+    flb_sockfd_t fd = -1;
+    unsigned long len;
+    size_t address_length;
+    struct sockaddr_un address;
+
+    fd = flb_net_socket_create_udp(AF_UNIX, FLB_TRUE);
+
+    if (fd == -1) {
+        return -1;
+    }
+
+    ctx->server_fd = fd;
+
+    /* Prepare the unix socket path */
+    unlink(ctx->unix_path);
+    len = strlen(ctx->unix_path);
+
+    address.sun_family = AF_UNIX;
+    sprintf(address.sun_path, "%s", ctx->unix_path);
+    address_length = sizeof(address.sun_family) + len + 1;
+    if (bind(fd, (struct sockaddr *) &address, address_length) != 0) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+
+    if (chmod(address.sun_path, ctx->unix_perm)) {
+        flb_errno();
+        flb_error("[in_udp] cannot set permission on '%s' to %04o",
+                  address.sun_path, ctx->unix_perm);
+        close(fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int udp_server_net_create(struct flb_udp *ctx)
+{
+    ctx->server_fd = flb_net_server_udp(ctx->port, ctx->listen);
+
+    if (ctx->server_fd > 0) {
+        flb_info("[in_udp] UDP server binding %s:%s",
+                 ctx->listen, ctx->port);
+    }
+    else {
+        flb_error("[in_udp] could not bind address %s:%s. Aborting",
+                  ctx->listen, ctx->port);
+        return -1;
+    }
+
+    flb_net_socket_nonblocking(ctx->server_fd);
+
+    return 0;
+}
+
+int udp_server_create(struct flb_udp *ctx)
+{
+    int ret;
+
+    /* Create UDP buffer */
+    ctx->buffer_data = flb_calloc(1, ctx->buffer_chunk_size);
+    if (!ctx->buffer_data) {
+            flb_errno();
+            return -1;
+    }
+    ctx->buffer_size = ctx->buffer_chunk_size;
+    flb_info("[in_udp] UDP buffer size set to %lu bytes",
+             ctx->buffer_size);
+
+
+    if (ctx->mode == FLB_UDP_INET) {
+        ret = udp_server_net_create(ctx);
+    }
+    else {
+        /* Create unix socket end-point */
+        ret = udp_server_unix_create(ctx);
+    }
+
+    if (ret != 0) {
+        flb_free(ctx->buffer_data);
+        ctx->buffer_data = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+int udp_server_destroy(struct flb_udp *ctx)
+{
+    if (ctx->mode == FLB_UDP_UNIX) {
+        if (ctx->unix_path) {
+            unlink(ctx->unix_path);
+            flb_free(ctx->unix_path);
+        }
+    }
+
+    if (ctx->port) {
+        flb_free(ctx->port);
+        ctx->port = NULL;
+    }
+
+    if (ctx->server_fd >= 0) {
+        close(ctx->server_fd);
+        ctx->server_fd = -1;
+    }
+
+    if (ctx->buffer_data) {
+        flb_free(ctx->buffer_data);
+        ctx->buffer_data = NULL;
+    }
+    return 0;
+}

--- a/plugins/in_udp/udp_server.h
+++ b/plugins/in_udp/udp_server.h
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_UDP_SERVER_H
+#define FLB_IN_UDP_SERVER_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+
+#include "udp.h"
+
+int udp_server_create(struct flb_udp *ctx);
+int udp_server_destroy(struct flb_udp *ctx);
+
+#endif


### PR DESCRIPTION

Signed-off-by: Jukka Pihl <jukka.pihl@iki.fi>

<!-- Provide summary of changes -->

Implements general UDP input plugin. 
Can split UDP input messages to lines which can handled individually.

Copied and changed from in_syslog.

Config Parameters:

```
  mode              unix|inet    socket type
  port              NUM          inet udp port number  (mode:inet)
  bind              IPADDRESS    inet bind address  (mode:inet)  (optional)
  path              socket-path  unix socket address
  buffer_chunk_size size         size of UDP packet buffer (default: 32k)
  multi_line        boolean      split UDP message to lines (default: false)
  rtrim             boolean      trim ending whitespaces from lines (default: true)
  parser            parsername   parser to use.
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Implements #1244 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
