### PR TITLE
Add source_address and source_host for syslog/udp input

### DIFF
--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -72,14 +72,17 @@ static int in_syslog_collect_udp(struct flb_input_instance *i_ins,
     int bytes;
     struct flb_syslog *ctx = in_context;
     (void) i_ins;
+    struct flb_syslog_client_info client_info;
 
     bytes = recvfrom(ctx->server_fd,
                      ctx->buffer_data, ctx->buffer_size - 1, 0,
-                     NULL, NULL);
+                     (struct sockaddr*) &client_info.client, &client_info.client_len);
+
     if (bytes > 0) {
         ctx->buffer_data[bytes] = '\0';
         ctx->buffer_len = bytes;
-        syslog_prot_process_udp(ctx->buffer_data, ctx->buffer_len, ctx);
+
+        syslog_prot_process_udp(ctx->buffer_data, ctx->buffer_len, ctx, &client_info);
     }
     else {
         flb_errno();

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -42,6 +42,9 @@ struct flb_syslog {
     char *listen;
     char *port;
 
+    char *host_key;
+    char *addr_key;
+
     /* Unix socket (UDP/TCP)*/
     int server_fd;
     char *unix_path;
@@ -63,6 +66,11 @@ struct flb_syslog {
     struct mk_list connections;
     struct mk_event_loop *evl;
     struct flb_input_instance *ins;
+};
+
+struct flb_syslog_client_info {
+   struct sockaddr_in client;
+   int client_len;
 };
 
 #endif

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -114,6 +114,12 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
         ctx->buffer_max_size  = flb_utils_size_to_bytes(tmp);
     }
 
+    tmp = flb_input_get_property("source_hostname_key", ins);
+    ctx->host_key = tmp ? flb_strdup(tmp) : NULL;
+
+    tmp = flb_input_get_property("source_address_key", ins);
+    ctx->addr_key = tmp ? flb_strdup(tmp) : NULL;
+
     /* Parser */
     tmp = flb_input_get_property("parser", ins);
     if (tmp) {

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -26,6 +26,6 @@
 #include "syslog.h"
 
 int syslog_prot_process(struct syslog_conn *conn);
-int syslog_prot_process_udp(char *buf, size_t size, struct flb_syslog *ctx);
+int syslog_prot_process_udp(char *buf, size_t size, struct flb_syslog *ctx, struct flb_syslog_client_info *client_info);
 
 #endif

--- a/plugins/in_syslog/syslog_server.c
+++ b/plugins/in_syslog/syslog_server.c
@@ -152,6 +152,14 @@ int syslog_server_destroy(struct flb_syslog *ctx)
         flb_free(ctx->port);
     }
 
+    if (ctx->addr_key) {
+        flb_free(ctx->addr_key);
+    }
+
+    if (ctx->host_key) {
+        flb_free(ctx->host_key);
+    }
+
     close(ctx->server_fd);
 
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->
This provides the feature of adding the src host and src address when using the syslog input source. It behaves similarly to fluentd proper, and uses the same keys in its configuration. E.g. `Source_Hostname_Key`  and `Source_Address_Key`. Essentially, when these configurations are specified in the configuration, when a UDP connection is established it adds these attributes to the resulting log data. 

As I'm not that familiar with msgpack, I'm sure there is a more efficient way to accomplish what I did here. I imagine that there will have to be a few revisions, which is why I'm not going to fill out the entirel pull request form, as I imagine this info may change as time goes on.  

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
N/A
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
```
[INPUT]
    Name syslog
    Tag cool
    Parser generic
    Port 514
    Mode udp
    Source_Hostname_Key src_host
    Source_Address_Key src_addr

[OUTPUT]
    Name stdout
    Match *
```
- [X] Debug log output from testing the change
```
[root@2187e7fc5060 bin]# echo 'This is kind of crazy' | ncat -u 127.0.0.1 514
[root@2187e7fc5060 bin]# [0] cool: [1596554014.039203200, {"text"=>"This is kind of crazy", "src_addr"=>"127.0.0.1", "src_host"=>"anantes-650-1-50-46.w2-0.abo.wanadoo.fr"}]
[2020/08/04 15:13:34] [debug] [task] created task=0x15ff340 id=0 OK
[0] cool: [1596554014.039203200, {"text"=>"This is kind of crazy", "src_addr"=>"127.0.0.1", "src_host"=>"anantes-650-1-50-46.w2-0.abo.wanadoo.fr"}]
[2020/08/04 15:13:34] [debug] [task] destroy task=0x15ff340 (task_id=0)
```
I am on a private network (and using loopback) so the hostname resolution is weird, but normally it would resolve to the address of the source. 

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
Will perform this if this is a change you are interested in. 

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
The docs will need to be updated and I'm willing to do that if you think this is change you want to include in the main baseline. 

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
