### PR TITLE
flb_encoding: charset encoding for input plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ if(FLB_ALL)
   # Global
   set(FLB_DEBUG        1)
   set(FLB_TLS          1)
+  set(FLB_UTF8_ENCODER 1)
 
   # Input plugins
   set(FLB_IN_CPU       1)
@@ -402,7 +403,8 @@ endif()
 
 # tutf8e
 if(FLB_UTF8_ENCODER)
-  add_subdirectory(${FLB_PATH_LIB_TUTF8E} EXCLUDE_FROM_ALL)
+  add_subdirectory(${FLB_PATH_LIB_TUTF8E})
+  FLB_DEFINITION(FLB_HAVE_UTF8_ENCODER)
 endif()
 
 # xxHash

--- a/include/fluent-bit/flb_encoding.h
+++ b/include/fluent-bit/flb_encoding.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_ENCODING_H
+#define FLB_ENCODING_H
+
+#include <tutf8e.h>
+
+
+#define FLB_ENCODING_SUCCESS      0
+#define FLB_ENCODING_FAILURE     -1
+
+struct flb_encoding {
+    TUTF8encoder encoder;
+    const char *invalid;
+};
+
+
+struct flb_encoding *flb_encoding_open(const char *encoding, const char *replacement);
+
+int flb_encoding_decode(struct flb_encoding *ec,
+                        char *str, size_t slen,
+                        char **result, size_t *result_len);
+
+void flb_encoding_close(struct flb_encoding *ic);
+
+#endif

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -24,6 +24,10 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 
+#ifdef FLB_HAVE_UTF8_ENCODER
+#include <fluent-bit/flb_encoding.h>
+#endif
+
 /* Syslog modes */
 #define FLB_SYSLOG_UNIX_TCP  1
 #define FLB_SYSLOG_UNIX_UDP  2
@@ -63,6 +67,11 @@ struct flb_syslog {
     struct mk_list connections;
     struct mk_event_loop *evl;
     struct flb_input_instance *ins;
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    struct flb_encoding *encoding;
+#endif
+
 };
 
 #endif

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -34,6 +34,9 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
                                       struct flb_config *config)
 {
     const char *tmp;
+#ifdef FLB_HAVE_UTF8_ENCODER
+    const char *tmp2;
+#endif
     char port[16];
     struct flb_syslog *ctx;
 
@@ -133,6 +136,20 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
         syslog_conf_destroy(ctx);
         return NULL;
     }
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    /* utf8 encoder */
+    tmp = flb_input_get_property("encoding", ins);
+    if (tmp) {
+        tmp2 = flb_input_get_property("encoding_replacement", ins);
+        ctx->encoding = flb_encoding_open(tmp,tmp2);
+        if (!ctx->encoding) {
+            flb_error("[in_syslog] illegal encoding: %s", tmp);
+            syslog_conf_destroy(ctx);
+            return NULL;
+        }
+    }
+#endif
 
     return ctx;
 }

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -160,6 +160,13 @@ int syslog_conf_destroy(struct flb_syslog *ctx)
         flb_free(ctx->buffer_data);
         ctx->buffer_data = NULL;
     }
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    if(ctx->encoding) {
+        flb_encoding_close(ctx->encoding);
+    }
+#endif
+
     syslog_server_destroy(ctx);
     flb_free(ctx);
 

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -628,6 +628,19 @@ static struct flb_config_map config_map[] = {
     },
 #endif
 
+#ifdef FLB_HAVE_UTF8_ENCODER
+    {
+     FLB_CONFIG_MAP_STR, "encoding", NULL,
+     0, FLB_FALSE, 0,
+     "specify the input encoding for converting to UTF-8",
+    },
+    {
+     FLB_CONFIG_MAP_STR, "encoding_replacement", NULL,
+     0, FLB_FALSE, 0,
+     "Replacement in case of decoding error (default: unicode replacement char)",
+    },
+#endif
+    
     /* Multiline Options */
 #ifdef FLB_HAVE_PARSER
     {

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -640,7 +640,7 @@ static struct flb_config_map config_map[] = {
      "Replacement in case of decoding error (default: unicode replacement char)",
     },
 #endif
-    
+
     /* Multiline Options */
 #ifdef FLB_HAVE_PARSER
     {

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -82,8 +82,10 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     int i;
     long nsec;
     const char *tmp;
+#ifdef FLB_HAVE_UTF8_ENCODER    
+    const char *tmp2;
+#endif
     struct flb_tail_config *ctx;
-
     ctx = flb_calloc(1, sizeof(struct flb_tail_config));
     if (!ctx) {
         flb_errno();
@@ -184,6 +186,19 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     if (ctx->multiline == FLB_TRUE) {
         ret = flb_tail_mult_create(ctx, ins, config);
         if (ret == -1) {
+            flb_tail_config_destroy(ctx);
+            return NULL;
+        }
+    }
+#endif
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    tmp = flb_input_get_property("encoding", ins);
+    if (tmp) {
+        tmp2 = flb_input_get_property("encoding_relacement", ins);
+        ctx->encoding = flb_encoding_open(tmp,tmp2);
+        if (!ctx->encoding) {
+            flb_plg_error(ctx->ins,"illegal encoding: %s", tmp);
             flb_tail_config_destroy(ctx);
             return NULL;
         }

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -98,6 +98,9 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
 #ifdef FLB_HAVE_SQLDB
     ctx->db_sync = 1;  /* sqlite sync 'normal' */
 #endif
+#ifdef FLB_HAVE_UTF8_ENCODER
+    ctx->encoding = NULL;
+#endif
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);
@@ -457,6 +460,12 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
         sqlite3_finalize(config->stmt_rotate_file);
         sqlite3_finalize(config->stmt_offset);
         flb_tail_db_close(config->db);
+    }
+#endif
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    if(config->encoding) {
+        flb_encoding_close(config->encoding);
     }
 #endif
 

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -33,6 +33,9 @@
 #ifdef FLB_HAVE_PARSER
 #include <fluent-bit/multiline/flb_ml.h>
 #endif
+#ifdef FLB_HAVE_UTF8_ENCODER
+#include <fluent-bit/flb_encoding.h>
+#endif
 
 
 /* Metrics */
@@ -102,6 +105,10 @@ struct flb_tail_config {
     sqlite3_stmt *stmt_delete_file;
     sqlite3_stmt *stmt_rotate_file;
     sqlite3_stmt *stmt_offset;
+#endif
+
+#ifdef FLB_HAVE_UTF8_ENCODER
+    struct flb_encoding *encoding;
 #endif
 
     /* Parser / Format */

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -307,6 +307,10 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
     msgpack_sbuffer *out_sbuf;
     msgpack_packer *out_pck;
     struct flb_tail_config *ctx = file->config;
+#ifdef FLB_HAVE_UTF8_ENCODER
+    char *decoded;
+    size_t decoded_len;
+#endif
 
     /* Create a temporary msgpack buffer */
     msgpack_sbuffer_init(&mp_sbuf);
@@ -371,6 +375,18 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         line_len = len - crlf;
         repl_line = NULL;
 
+#ifdef FLB_HAVE_UTF8_ENCODER
+        decoded = NULL;
+        if(ctx->encoding) {
+            ret = flb_encoding_decode(ctx->encoding, line, line_len, &decoded, &decoded_len);
+            if (ret != FLB_ENCODING_SUCCESS) {
+                flb_plg_error(ctx->ins, "encoding failed '%.*s'", line_len, line);
+                goto go_next;
+            }
+            line = decoded;
+            line_len  = decoded_len;
+        }
+#endif
         if (ctx->ml_ctx) {
             ret = flb_ml_append(ctx->ml_ctx, file->ml_stream_id,
                                 FLB_ML_TYPE_TEXT,
@@ -421,7 +437,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
                 /* Parser failed, pack raw text */
                 flb_time_get(&out_time);
                 flb_tail_file_pack_line(out_sbuf, out_pck, &out_time,
-                                        data, len, file, processed_bytes);
+                                        line, len, file, processed_bytes);
             }
         }
         else if (ctx->multiline == FLB_TRUE) {
@@ -465,6 +481,12 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         processed_bytes += len + 1;
         file->parsed = 0;
         lines++;
+#ifdef FLB_HAVE_UTF8_ENCODER
+        if(decoded) {
+            flb_free(decoded);
+            decoded = NULL;
+        }
+#endif
     }
     file->parsed = file->buf_len;
 
@@ -519,6 +541,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
     }
 
     msgpack_sbuffer_destroy(out_sbuf);
+
     return lines;
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -335,6 +335,10 @@ set(FLB_DEPS
   ${FLB_DEPS}
   tutf8e
   )
+set(src
+  ${src}
+  "flb_encoding.c"
+  )
 endif()
 
 # Record Accessor

--- a/src/flb_encoding.c
+++ b/src/flb_encoding.c
@@ -1,0 +1,161 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019      The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+
+#include <string.h>
+#include <time.h>
+#include <ctype.h>
+
+#include <fluent-bit/flb_macros.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_encoding.h>
+
+
+#include <tutf8e.h>
+
+/*
+ *
+ *  flb_encoding_open(encoding,replacement):
+ *
+ *  encoding:
+ *    iso-8859-1,...
+ *    windows-1251 windows-1252, ..
+ *
+ *  replacement:
+ *      \R        use replacement character 0xFFD  (default)
+ *      \I        ignore/skip bad chars
+ *      \E        fail if bad chars
+ *      ...       use that as replacement char
+ *
+ */
+
+
+static unsigned char replacement_utf8[4] = { 0xEF, 0xBF, 0xBD , 0 };
+
+
+static const char *parse_replacement(const char *replacement) {
+
+    if (!replacement) {
+        return (const char*)replacement_utf8;
+    }
+    if (!strcmp(replacement,"\\R")) {
+        return (const char*)replacement_utf8;
+    }
+    if (!strcmp(replacement,"\\I")) {
+        return "";
+    }
+    if (!strcmp(replacement,"\\?")) {
+        return "?";
+    }
+    if (!strcmp(replacement,"\\E")) {
+        return NULL;
+    }
+
+    return replacement;
+}
+
+struct flb_encoding *flb_encoding_open(const char *encoding, const char *replacement) {
+    struct flb_encoding *ec;
+    TUTF8encoder encoder;
+    const char *invalid;
+
+    if ((encoder = tutf8e_encoder(encoding)) == NULL) {
+        flb_error("[flb_encoding] unknown encoding: %s", encoding);
+        return NULL;
+    }
+
+    invalid = parse_replacement(replacement);
+
+    ec = flb_calloc(sizeof(struct flb_encoding),1);
+
+    if (!ec) {
+        flb_errno();
+        return NULL;
+    }
+
+    if (invalid) {
+        invalid = flb_strdup(invalid);
+        if (!invalid) {
+            flb_errno();
+            flb_free(ec);
+            return NULL;
+        }
+    }
+
+    ec->encoder = encoder;
+    ec->invalid = invalid;
+    return ec;
+}
+
+
+int flb_encoding_decode(struct flb_encoding *ec,
+                        char *str, size_t slen,
+                        char **result, size_t *result_len)
+{
+    size_t outlen = 0;
+    char *outbuf;
+    int ret;
+
+    *result = NULL;
+    *result_len = 0;
+
+    if (slen == 0) {
+        *result = flb_strdup("");
+        *result_len = 0;
+        return FLB_ENCODING_SUCCESS;
+    }
+
+    ret = tutf8e_encoder_buffer_length(ec->encoder, str, ec->invalid,  slen, &outlen);
+
+    if (ret != TUTF8E_OK) {
+        return FLB_ENCODING_FAILURE;
+    }
+
+    outbuf = flb_malloc(outlen + 1);
+    if(outbuf == NULL) {
+        flb_error("[flb_encoding] out of memory (%zu)", (int) outlen  + 1);
+        return FLB_ENCODING_FAILURE;
+    }
+
+    ret = tutf8e_encoder_buffer_encode(ec->encoder, str, slen, ec->invalid, outbuf, &outlen);
+
+    if (ret != TUTF8E_OK) {
+        flb_free(outbuf);
+        return FLB_ENCODING_FAILURE;
+    }
+
+    outbuf[outlen] = 0;
+    *result = outbuf;
+    *result_len = outlen;
+
+    return FLB_ENCODING_SUCCESS;
+}
+
+void flb_encoding_close(struct flb_encoding *ec) {
+    if (ec) {
+        if (ec->invalid) {
+            flb_free((char*)ec->invalid);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->

Adds library flb_encoding for doing charset encoding   CHARSET => UTF8. 

* Uses lib/tutf8e-library. 
* Only 8-bit charsets are supported.
* At first *in_tail* plugin is supported, later in_syslog and others. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
