### PR TITLE
engine: fix can not print stack trace when fluent bit run in container

### DIFF
--- a/include/fluent-bit/flb_stacktrace.h
+++ b/include/fluent-bit/flb_stacktrace.h
@@ -48,7 +48,7 @@ static int flb_stacktrace_print_callback(void *data, uintptr_t pc,
 {
     struct flb_stacktrace *p = data;
 
-    fprintf(stdout, "#%-2i 0x%-17lx in  %s() at %s:%d\n",
+    fprintf(stderr, "#%-2i 0x%-17lx in  %s() at %s:%d\n",
             p->line,
             (unsigned long) pc,
             function == NULL ? "???" : function,


### PR DESCRIPTION
When fluent-bit runs in the container, if it captures a SIGSEGV signal, it can not print the stack trace to stdout.
It seemly likes the stdout had to be closed after the fluent bit receives a SIGSEGV signal. This pr fix this bug
by making the stack trace to output to stderr.

Signed-off-by: wanjunlei <wanjunlei@yunify.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
