### PR TITLE
out_stackdriver: fix metadata not assigned correctly (issue-2423)

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -388,7 +388,7 @@ static int extract_local_resource_id(const void *data, size_t bytes,
 
         map = root.via.array.ptr[1].via.map;
         ctx->local_resource_id = get_str_value_from_msgpack_map(map, LOCAL_RESOURCE_ID_KEY,
-                                                           LEN_LOCAL_RESOURCE_ID_KEY);
+                                                                LEN_LOCAL_RESOURCE_ID_KEY);
         if (!ctx->local_resource_id) {
             /* if local_resource_id is not found, use the tag of the log */
             flb_plg_debug(ctx->ins, "local_resource_id not found, "
@@ -415,6 +415,7 @@ static int process_local_resource_id(struct flb_stackdriver *ctx, char *type)
 {
     int ret = -1;
     int first = FLB_TRUE;
+    int counter = 0;
     int len_k8s_container;
     int len_k8s_node;
     int len_k8s_pod;
@@ -451,15 +452,26 @@ static int process_local_resource_id(struct flb_stackdriver *ctx, char *type)
             }
 
             /* Follow the order of fields in local_resource_id */
-            if (!ctx->namespace_name) {
+            if (counter == 0) {
+                if (ctx->namespace_name) {
+                    flb_sds_destroy(ctx->namespace_name);
+                }
                 ctx->namespace_name = flb_sds_create(ptr->val);
             }
-            else if (!ctx->pod_name) {
+            else if (counter == 1) {
+                if (ctx->pod_name) {
+                    flb_sds_destroy(ctx->pod_name);
+                }
                 ctx->pod_name = flb_sds_create(ptr->val);
             }
-            else if (!ctx->container_name) {
+            else if (counter == 2) {
+                if (ctx->container_name) {
+                    flb_sds_destroy(ctx->container_name);
+                }
                 ctx->container_name = flb_sds_create(ptr->val);
             }
+
+            counter++;
         }
 
         if (!ctx->namespace_name || !ctx->pod_name || !ctx->container_name) {
@@ -484,6 +496,9 @@ static int process_local_resource_id(struct flb_stackdriver *ctx, char *type)
             }
 
             if (ptr != NULL) {
+                if (ctx->node_name) {
+                    flb_sds_destroy(ctx->node_name);
+                }
                 ctx->node_name = flb_sds_create(ptr->val);
             }
         }
@@ -510,12 +525,20 @@ static int process_local_resource_id(struct flb_stackdriver *ctx, char *type)
             }
 
             /* Follow the order of fields in local_resource_id */
-            if (!ctx->namespace_name) {
+            if (counter == 0) {
+                if (ctx->namespace_name) {
+                    flb_sds_destroy(ctx->namespace_name);
+                }
                 ctx->namespace_name = flb_sds_create(ptr->val);
             }
-            else if (!ctx->pod_name) {
+            else if (counter == 1) {
+                if (ctx->pod_name) {
+                    flb_sds_destroy(ctx->pod_name);
+                }
                 ctx->pod_name = flb_sds_create(ptr->val);
             }
+
+            counter++;
         }
 
         if (!ctx->namespace_name || !ctx->pod_name) {

--- a/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
@@ -8,6 +8,13 @@
     "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\""		\
 	"}]"
 
+#define K8S_CONTAINER_COMMON_DIFF_TAGS	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_CONTAINER_COMMON\","		\
+    "\"logging.googleapis.com/local_resource_id\": \"k8s_container.diffnamespace.diffpod.diffctr\""		\
+	"}]"
+
 #define K8S_CONTAINER_NO_LOCAL_RESOURCE_ID	"["		\
 	"1591649196,"			\
 	"{"				\


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
The issue #2423 is caused by that the k8s metadata in the stackdriver context are shared for the same stackdriver instance. However different logs might contain different value of metadata. This patch will fix the issue.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#2423 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
