### PR TITLE
out_stackdriver: add new configurable option `tag_prefix`

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -100,6 +100,7 @@ struct flb_stackdriver {
 
     flb_sds_t labels_key;
     flb_sds_t local_resource_id;
+    flb_sds_t tag_prefix;
 
     /* other */
     flb_sds_t resource;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -331,6 +331,16 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->labels_key = flb_sds_create(DEFAULT_LABELS_KEY);
     }
 
+    tmp = flb_output_get_property("tag_prefix", ins);
+    if (tmp) {
+        ctx->tag_prefix = flb_sds_create(tmp);
+    }
+    else {
+        if (ctx->k8s_resource_type == FLB_TRUE) {
+            ctx->tag_prefix = flb_sds_create(ctx->resource);
+        }
+    }
+
     return ctx;
 }
 
@@ -362,6 +372,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->resource);
     flb_sds_destroy(ctx->severity_key);
     flb_sds_destroy(ctx->labels_key);
+    flb_sds_destroy(ctx->tag_prefix);
 
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1543,7 +1543,6 @@ static void cb_check_timestamp_format_duo_fields_incorrect_type(void *ctx, int f
     flb_sds_destroy(res_data);
 }
 
-
 void flb_test_resource_global()
 {
     int ret;
@@ -1566,6 +1565,49 @@ void flb_test_resource_global()
                    "match", "test",
                    "google_service_credentials", SERVICE_CREDENTIALS,
                    "resource", "global",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_global_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_global_custom_prefix()
+{
+    /* configuring tag_prefix for non-k8s resource type should have no effect at all */
+    int ret;
+    int size = sizeof(JSON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "global",
+                   "tag_prefix", "custom_tag",
                    NULL);
 
     /* Enable test mode */
@@ -2080,6 +2122,50 @@ void flb_test_resource_k8s_container_multi_tag_value()
     /* Ingest data sample */
     flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_COMMON_DIFF_TAGS, size_two);
 
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_container_custom_tag_prefix()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "kube_custom_tag.testnamespace.testpod.testctr", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "kube_custom_tag.*",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "tag_prefix", "kube_custom_tag",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_NO_LOCAL_RESOURCE_ID, size);
 
     sleep(2);
     flb_stop(ctx);
@@ -3480,6 +3566,7 @@ void flb_test_timestamp_format_duo_fields_incorrect_type()
 TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
     {"resource_global", flb_test_resource_global },
+    {"resource_global_custom_prefix", flb_test_resource_global_custom_prefix },
     {"resource_gce_instance", flb_test_resource_gce_instance },
 
     /* test insertId */
@@ -3508,6 +3595,7 @@ TEST_LIST = {
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_container_no_local_resource_id", flb_test_resource_k8s_container_no_local_resource_id },
     {"resource_k8s_container_multi_tag_value", flb_test_resource_k8s_container_multi_tag_value } ,
+    {"resource_k8s_container_custom_tag_prefix", flb_test_resource_k8s_container_custom_tag_prefix },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
     {"resource_k8s_node_no_local_resource_id", flb_test_resource_k8s_node_no_local_resource_id },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch will enable users to make change on the tag_prefix required for the k8s resource type. Users needed to use tag prefix `k8s_container.*` for k8s_resource type before because the tag prefix is used to validate the tag value of the log record. This patch will provide an interface to customize the tag_prefix when using k8s resource types in stackdriver plugin.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
