### PR TITLE
build: Use flb_strptime() by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,6 @@ option(FLB_LUAJIT              "Enable Lua Scripting support" Yes)
 option(FLB_RECORD_ACCESSOR     "Enable record accessor"       Yes)
 option(FLB_SIGNV4              "Enable AWS Signv4 support"    Yes)
 option(FLB_AWS                "Enable AWS support"            Yes)
-option(FLB_SYSTEM_STRPTIME     "Use strptime in system libc"  Yes)
 option(FLB_STATIC_CONF         "Build binary using static configuration")
 option(FLB_STREAM_PROCESSOR    "Enable Stream Processor"      Yes)
 option(FLB_CORO_STACK_SIZE     "Set coroutine stack size")
@@ -562,11 +561,6 @@ if("${GNU_HOST}" STREQUAL "")
     set(AUTOCONF_HOST_OPT "")
 else()
     set(AUTOCONF_HOST_OPT "--host=${GNU_HOST}")
-endif()
-
-# strptime(2) support
-if (FLB_SYSTEM_STRPTIME)
-  FLB_DEFINITION(FLB_HAVE_SYSTEM_STRPTIME)
 endif()
 
 # Memory Allocator

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -10,9 +10,6 @@ set(FLB_EXAMPLES              Yes)
 set(FLB_PARSER                Yes)
 set(FLB_TLS                   Yes)
 
-# Windows does not support strptime(3)
-set(FLB_SYSTEM_STRPTIME        No)
-
 # INPUT plugins
 # =============
 set(FLB_IN_CPU                 No)


### PR DESCRIPTION
Lionel Cons reports that Fluent Bit sometimes adds odd "drift"
to timestamps e.g. parsing "10000" with "%s" results in 13600.0
rather than 10000.0.

This occurs because "%s" is parsed differently depending on the
implementation of strptime(). Some use localtime() internally,
and others use gmtime(). This causes the parsed result to vary
by the amount of each system's time offset.

This patch attempts to fix that issue by defaulting to our own
version of strptime(), and hence makes the behaviour much more
consistent across platforms.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>