### PR TITLE
in_tail: When option exit_on_eof=true wait for all the files to be read

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -153,7 +153,9 @@ static int in_tail_collect_static(struct flb_input_instance *ins,
             if (file->config->exit_on_eof) {
                 flb_plg_info(ctx->ins, "inode=%"PRIu64" file=%s ended, stop",
                              file->inode, file->name);
-                flb_engine_exit(config);
+                if (mk_list_size(&ctx->files_static) == 1) {
+                    flb_engine_exit(config);
+                }
             }
             /* Promote file to 'events' type handler */
             flb_plg_debug(ctx->ins, "inode=%"PRIu64" file=%s promote to TAIL_EVENT",


### PR DESCRIPTION
Currently using the option `exit_on_eof` in `true` with the `tail` plugin works well with one file, but when reading a bunch of files it fails since the plugin will exit as soon as it reach the first EOF in one of the files, this will prevent that until it reach the last file 

