### PR TITLE
http_client: fix format string mismatch

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -619,8 +619,7 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
                        fmt_plain,
                        str_method,
                        uri,
-                       flags & FLB_HTTP_10 ? 0 : 1,
-                       body_len);
+                       flags & FLB_HTTP_10 ? 0 : 1);
     }
     else {
         ret = snprintf(buf, FLB_HTTP_BUF_SIZE,


### PR DESCRIPTION
`fmt_plain` expects 3 arguments, but `body_len` is the 4th.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
