### PR TITLE
out_nats: fix variable typo

### DIFF
--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -54,7 +54,7 @@ static int cb_nats_init(struct flb_output_instance *ins, struct flb_config *conf
     upstream = flb_upstream_create(config,
                                    ins->host.name,
                                    ins->host.port,
-                                   FLB_IO_TCP,
+                                   io_flags,
                                    NULL);
     if (!upstream) {
         flb_free(ctx);


### PR DESCRIPTION
Otherwise `io_flags` is unused.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
