### PR TITLE
ra: fix undefined behavior on error

### DIFF
--- a/src/record_accessor/flb_ra_parser.c
+++ b/src/record_accessor/flb_ra_parser.c
@@ -224,12 +224,12 @@ struct flb_ra_parser *flb_ra_parser_string_create(char *str, int len)
         flb_ra_parser_destroy(rp);
         return NULL;
     }
+    rp->key->subkeys = NULL;
     rp->key->name = flb_sds_create_len(str, len);
     if (!rp->key->name) {
         flb_ra_parser_destroy(rp);
         return NULL;
     }
-    rp->key->subkeys = NULL;
 
     return rp;
 }


### PR DESCRIPTION
flb_ra_parser_destroy(rp) may attempt to free uninitialized key->subkeys
when key->name failed to allocate.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
