### PR TITLE
ci: travis: remove deprecated key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 dist: bionic
 language: c
-# The leak sanitizer uses ptrace, which doesn't work under the
-# travis container infrastructure, so we enable 'sudo'
-sudo: true
 
 git:
   depth: 3
@@ -49,7 +46,6 @@ matrix:
     - os: linux
       env: FLB_OPT="-DFLB_COVERAGE=On"
       dist: bionic
-      sudo: true
       language: c
       compiler: gcc
       script: |
@@ -61,7 +57,6 @@ matrix:
       services:
         - docker
       dist: bionic
-      sudo: true
       language: c
       compiler: gcc
       env: DOCKER_BUILD=1


### PR DESCRIPTION
See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
