### PR TITLE
ra: Fix crashes when ra_key_val_id() is passed a non-map

### DIFF
--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -78,6 +78,10 @@ static int ra_key_val_id(flb_sds_t ckey, msgpack_object map)
     int map_size;
     msgpack_object key;
 
+    if (map.type != MSGPACK_OBJECT_MAP) {
+        return -1;
+    }
+
     map_size = map.via.map.size;
     for (i = 0; i < map_size; i++) {
         key = map.via.map.ptr[i].key;


### PR DESCRIPTION
In our production k8s environment Fluent Bit will constantly crash with the following:

```
[engine] caught signal (SIGSEGV)
#0  0x559f5469c459      in  ra_key_val_id() at src/flb_ra_key.c:83
#1  0x559f5469ca2c      in  flb_ra_key_regex_match() at src/flb_ra_key.c:294
#2  0x559f5469c11c      in  flb_ra_regex_match() at src/flb_record_accessor.c:577
#3  0x559f546834cd      in  process_record() at plugins/filter_rewrite_tag/rewrite_tag.c:305
#4  0x559f546836d5      in  cb_rewrite_tag_filter() at plugins/filter_rewrite_tag/rewrite_tag.c:377
#5  0x559f545d4b79      in  flb_filter_do() at src/flb_filter.c:118
#6  0x559f545fb537      in  flb_input_chunk_append_raw() at src/flb_input_chunk.c:473
#7  0x559f54610b76      in  cb_queue_chunks() at plugins/in_emitter/emitter.c:142
#8  0x559f545d462f      in  flb_input_collector_fd() at src/flb_input.c:979
#9  0x559f545e1213      in  flb_engine_handle_event() at src/flb_engine.c:306
#10 0x559f545e1213      in  flb_engine_start() at src/flb_engine.c:558
#11 0x559f54555370      in  flb_main() at src/fluent-bit.c:1035
#12 0x559f545553be      in  main() at src/fluent-bit.c:1048
#13 0x7fa789ff809a      in  ???() at ???:0
#14 0x559f54553049      in  ???() at ???:0
#15 0xffffffffffffffff  in  ???() at ???:0

```

I haven't been able to come up with a reproducible test case for this, but instrumenting the function in question revealed that `ra_key_val_id()` is sometimes passed a non-map msgpack object. This patch simply validates the input and returns the existing error code.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
