### PR TITLE
out_splunk: Fix crashes when passed non-array input data

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -74,7 +74,14 @@ static int splunk_format(const void *in_buf, size_t in_bytes,
     msgpack_unpacked_init(&result);
 
     while (msgpack_unpack_next(&result, in_buf, in_bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+
         root = result.data;
+        if (root.via.array.size != 2) {
+            continue;
+        }
 
         /* Get timestamp */
         flb_time_pop_from_msgpack(&tm, &result, &obj);


### PR DESCRIPTION
Similar to #2456, in our production k8s environment Fluent Bit will crash with the following:

```
[engine] caught signal (SIGSEGV)
#0  0x561a400562eb      in  splunk_format() at plugins/out_splunk/splunk.c:114
#1  0x561a4005657a      in  cb_splunk_flush() at plugins/out_splunk/splunk.c:175
#2  0x561a3ffe24df      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:449
#3  0x561a4040a8a6      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
```

Once again, I tracked this down to `splunk_format()` being passed non-array data. This will then cause a segfault when trying to read key-value pairs out of an assumed-to-be-there map.

Specifically, it seems to get passed an object with type `MSGPACK_OBJECT_POSITIVE_INTEGER`. Occasionally it'll get passed an array *containing* a positive integer with value 0, too -- but since that gets interpreted as the map size, this won't cause a crash with this patch.

I noticed that other output plugins already make a check for the object type, including `es`, `gelf`, `influxdb`, `kube_meta`, `td`, and `syslog` -- but `splunk` currently does not. This patch simply adds one.

Obviously this is just a fix for the symptom, not the cause, and is almost certainly related to the same underlying issue as #2456. But since it really just makes `splunk` more consistent with other plugins, I thought it would be acceptable in its own right.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
