### PR TITLE
in_winlog: Bring back the 'EventId' field

### DIFF
--- a/plugins/in_winlog/pack.c
+++ b/plugins/in_winlog/pack.c
@@ -325,7 +325,7 @@ void winlog_pack_event(msgpack_packer *mp_pck, PEVENTLOGRECORD evt,
     msgpack_pack_array(mp_pck, 2);
     flb_pack_time_now(mp_pck);
 
-    msgpack_pack_map(mp_pck, 11);
+    msgpack_pack_map(mp_pck, 12);
 
     /* RecordNumber */
     msgpack_pack_str(mp_pck, 12);
@@ -347,6 +347,11 @@ void winlog_pack_event(msgpack_packer *mp_pck, PEVENTLOGRECORD evt,
         flb_plg_error(ctx->ins, "invalid TimeWritten %i", evt->TimeWritten);
         pack_nullstr(mp_pck);
     }
+
+    /* EventId */
+    msgpack_pack_str(mp_pck, 7);
+    msgpack_pack_str_body(mp_pck, "EventID", 7);
+    msgpack_pack_uint32(mp_pck, evt->EventID);
 
     /* EventType */
     msgpack_pack_str(mp_pck, 9);


### PR DESCRIPTION
The "EventId" field was removed in cd54540a in part of an effort
to canonicalize the output format.

The assumption behind the removal was that "EventId" was too low
level to be meaningful for uesrs, and just having the human readable
"Message" field is just enough.

Our assumption was wrong. This reverts the removal to resolve
#2426 ("WinLog input plugin stopped reporting the EventId").

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>