### PR TITLE
core:  flb_scheduler fix for macOS

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -44,7 +44,11 @@ static inline int consume_byte(flb_pipefd_t fd)
 
     /* We need to consume the byte */
     ret = flb_pipe_r(fd, &val, sizeof(val));
+#ifdef __APPLE__
+    if (ret < 0) {
+#else
     if (ret <= 0) {
+#endif
         flb_errno();
         return -1;
     }


### PR DESCRIPTION

<!-- Provide summary of changes -->

https://github.com/fluent/fluent-bit/blob/d1bcfa8d1767020ff1a3bf68f004193eb49ceacd/src/flb_scheduler.c#L46-L50

src/flb_scheduler.c: cosumer_bytes() gives errors in macOS (10.13,... ?).
function flb_pipe_r can return value 0 which is consider as error. 
This patch allows return value zero.

Probably we should test if ret == 0 is ok in other operating systems. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #2460 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
