### PR TITLE
filter_kubernetes: Fetch meta from K8s when docker_id is changed

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -74,6 +74,7 @@ struct flb_kube {
     int api_port;
     int api_https;
     int use_journal;
+    int use_docker_id;
     int labels;
     int annotations;
     int dummy_meta;

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -74,7 +74,7 @@ struct flb_kube {
     int api_port;
     int api_https;
     int use_journal;
-    int use_docker_id;
+    int cache_use_docker_id;
     int labels;
     int annotations;
     int dummy_meta;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -842,6 +842,9 @@ static inline int extract_meta(struct flb_kube *ctx,
         if (meta->container_name) {
             n += meta->container_name_len + 1;
         }
+        if (ctx->cache_use_docker_id && meta->docker_id) {
+            n += meta->docker_id_len + 1;
+        }
         meta->cache_key = flb_malloc(n);
         if (!meta->cache_key) {
             flb_errno();

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -866,6 +866,13 @@ static inline int extract_meta(struct flb_kube *ctx,
             off += meta->container_name_len;
         }
 
+        if (ctx->use_docker_id && meta->docker_id) {
+            /* Separator */
+            meta->cache_key[off++] = ':';
+            memcpy(meta->cache_key + off, meta->docker_id, meta->docker_id_len);
+            off += meta->docker_id_len;
+        }
+
         meta->cache_key[off] = '\0';
         meta->cache_key_len = off;
     }

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -866,7 +866,7 @@ static inline int extract_meta(struct flb_kube *ctx,
             off += meta->container_name_len;
         }
 
-        if (ctx->use_docker_id && meta->docker_id) {
+        if (ctx->cache_use_docker_id && meta->docker_id) {
             /* Separator */
             meta->cache_key[off++] = ':';
             memcpy(meta->cache_key + off, meta->docker_id, meta->docker_id_len);

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -802,6 +802,13 @@ static struct flb_config_map config_map[] = {
      "dns interval between network status checks"
     },
 
+    /* Fetch K8s meta when docker_id has changed */
+    {
+     FLB_CONFIG_MAP_BOOL, "use_docker_id", "false",
+     0, FLB_TRUE, offsetof(struct flb_kube, use_docker_id),
+     "fetch K8s meta when docker_id is changed"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -804,8 +804,8 @@ static struct flb_config_map config_map[] = {
 
     /* Fetch K8s meta when docker_id has changed */
     {
-     FLB_CONFIG_MAP_BOOL, "use_docker_id", "false",
-     0, FLB_TRUE, offsetof(struct flb_kube, use_docker_id),
+     FLB_CONFIG_MAP_BOOL, "cache_use_docker_id", "false",
+     0, FLB_TRUE, offsetof(struct flb_kube, cache_use_docker_id),
      "fetch K8s meta when docker_id is changed"
     },
 


### PR DESCRIPTION
In certain scenario, namespace, pod_name and container_name
will remain the same even when a new docker image is deployed.
K8s filter therefore won't try to fetch meta from K8s.
This further results in outdated metadata (e.g. container_image).

This patch introduce a new configuration 'use_docker_id'.
When enabled, docker_id will be taken into account when constructing cache_key.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [x] Documentation required for this feature
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
