### PR TITLE
strptime: Add a fallback macro for `timezone`

### DIFF
--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -115,6 +115,21 @@ static	char *_flb_strptime(const char *, const char *, struct tm *, int);
 static	const u_char *_find_string(const u_char *, int *, const char * const *,
 	    const char * const *, int);
 
+/*
+ * FreeBSD does not support `timezone` in time.h.
+ * https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=24590
+ */
+#ifdef __FreeBSD__
+int flb_timezone(void)
+{
+    struct tm tm;
+    time_t t = 0;
+    tzset();
+    localtime_r(&t, &tm);
+    return -(tm.tm_gmtoff);
+}
+#define timezone (flb_timezone())
+#endif
 
 char *
 flb_strptime(const char *buf, const char *fmt, struct tm *tm)


### PR DESCRIPTION
According to the UNIX standard:

    The external variable timezone shall be set to the difference,
    in seconds, between Coordinated Universal Time (UTC) and local
    standard time

FreeBSD is incompatible with this standard. In particular, since it
exposes a function symbol `char* timezone(int, int)`, expressions
like `-(timezone)` causes a compile error.

Fix #2491 by adding a compat macro for FreeBSD.
