### PR TITLE
aws: Adding sts endpoint for CW and ES plugins

### DIFF
--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -175,6 +175,7 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
                                                  char *role_arn,
                                                  char *session_name,
                                                  char *region,
+                                                 char *sts_endpoint,
                                                  char *proxy,
                                                  struct
                                                  flb_aws_client_generator

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -142,6 +142,7 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
                                                             *config,
                                                             struct flb_tls *tls,
                                                             char *region,
+                                                            char *sts_endpoint,
                                                             char *proxy,
                                                             struct
                                                             flb_aws_client_generator
@@ -158,7 +159,9 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
  */
 struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
                                                  struct flb_tls *tls,
-                                                 char *region, char *proxy,
+                                                 char *region, 
+                                                 char *sts_endpoint,
+                                                 char *proxy,
                                                  struct
                                                  flb_aws_client_generator
                                                  *generator);

--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -119,6 +119,9 @@ struct flb_aws_client_generator {
     flb_aws_client_create_fn *create;
 };
 
+/* Remove protocol from endpoint */
+char *removeProtocol (char *endpoint, char *protocol);
+
 /* Get the flb_aws_client_generator */
 struct flb_aws_client_generator *flb_aws_client_generator();
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -117,10 +117,15 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     tmp = flb_output_get_property("endpoint", ins);
     if (tmp) {
         ctx->custom_endpoint = FLB_TRUE;
-        ctx->endpoint = (char *) tmp;
+        ctx->endpoint = removeProtocol((char *) tmp, "https://");
     }
     else {
         ctx->custom_endpoint = FLB_FALSE;
+    }
+
+    tmp = flb_output_get_property("sts_endpoint", ins);
+    if (tmp) {
+        ctx->sts_endpoint = (char *) tmp;
     }
 
     tmp = flb_output_get_property("log_key", ins);
@@ -231,6 +236,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                                     (char *) ctx->role_arn,
                                                     session_name,
                                                     (char *) ctx->region,
+                                                    (char *) ctx->sts_endpoint,
                                                     NULL,
                                                     flb_aws_client_generator());
         if (!ctx->aws_provider) {
@@ -510,6 +516,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "endpoint", NULL,
      0, FLB_FALSE, 0,
      "Specify a custom endpoint for the CloudWatch Logs API"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
+     0, FLB_FALSE, 0,
+     "Specify a custom sts endpoint for the CloudWatch Logs API"
     },
 
     /* EOF */

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -123,11 +123,6 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->custom_endpoint = FLB_FALSE;
     }
 
-    tmp = flb_output_get_property("sts_endpoint", ins);
-    if (tmp) {
-        ctx->sts_endpoint = (char *) tmp;
-    }
-
     tmp = flb_output_get_property("log_key", ins);
     if (tmp) {
         ctx->log_key = tmp;
@@ -153,6 +148,10 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->role_arn = tmp;
     }
 
+    tmp = flb_output_get_property("sts_endpoint", ins);
+    if (tmp) {
+        ctx->sts_endpoint = (char *) tmp;
+    }
 
     ctx->group_created = FLB_FALSE;
 
@@ -196,7 +195,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
 
     ctx->aws_provider = flb_standard_chain_provider_create(config,
                                                            &ctx->cred_tls,
-                                                           "us-west-2",
+                                                           (char *) ctx->region,
+                                                           (char *) ctx->sts_endpoint,
                                                            NULL,
                                                            flb_aws_client_generator());
     if (!ctx->aws_provider) {
@@ -521,7 +521,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
      0, FLB_FALSE, 0,
-     "Specify a custom sts endpoint for the CloudWatch Logs API"
+     "Specify a custom endpoint for the STS API, can be used with the role_arn parameter"
     },
 
     /* EOF */

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -102,6 +102,7 @@ struct flb_cloudwatch {
     const char *log_stream_prefix;
     const char *log_group;
     const char *region;
+    const char *sts_endpoint;
     const char *log_format;
     const char *role_arn;
     const char *log_key;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -803,7 +803,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "aws_sts_endpoint", "",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_sts_endpoint),
-     "STS endpoint"
+     "Custom endpoint for the AWS STS API, used with the AWS_Role_ARN option"
     },
     {
      FLB_CONFIG_MAP_STR, "aws_role_arn", "",

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -801,6 +801,11 @@ static struct flb_config_map config_map[] = {
      "AWS Region of your Amazon ElasticSearch Service cluster"
     },
     {
+     FLB_CONFIG_MAP_STR, "aws_sts_endpoint", "",
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_sts_endpoint),
+     "STS endpoint"
+    },
+    {
      FLB_CONFIG_MAP_STR, "aws_role_arn", "",
      0, FLB_FALSE, 0,
      "AWS IAM Role to assume to put records to your Amazon ES cluster"

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -45,6 +45,7 @@ struct flb_elasticsearch {
 #ifdef FLB_HAVE_AWS
     int has_aws_auth;
     char *aws_region;
+    char *aws_sts_endpoint;
     struct flb_aws_provider *aws_provider;
     struct flb_aws_provider *base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -173,6 +173,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             ctx->aws_provider = flb_standard_chain_provider_create(config,
                                                                    &ctx->aws_tls,
                                                                    ctx->aws_region,
+                                                                   ctx->aws_sts_endpoint,
                                                                    NULL,
                                                                    flb_aws_client_generator());
             if (!ctx->aws_provider) {

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -162,6 +162,14 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             }
             ctx->aws_region = (char *) tmp;
 
+            tmp = flb_output_get_property("aws_sts_endpoint", ins);
+            if (!tmp) {
+                flb_error("[out_es] aws_sts_endpoint not set");
+                flb_es_conf_destroy(ctx);
+                return NULL;
+            }
+            ctx->aws_sts_endpoint = (char *) tmp;
+
             ctx->aws_provider = flb_standard_chain_provider_create(config,
                                                                    &ctx->aws_tls,
                                                                    ctx->aws_region,
@@ -215,6 +223,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                                             aws_role_arn,
                                                             aws_session_name,
                                                             ctx->aws_region,
+                                                            ctx->aws_sts_endpoint,
                                                             NULL,
                                                             flb_aws_client_generator());
                 /* Session name can be freed once provider is created */

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -98,11 +98,17 @@ static int cb_firehose_init(struct flb_output_instance *ins,
     tmp = flb_output_get_property("endpoint", ins);
     if (tmp) {
         ctx->custom_endpoint = FLB_TRUE;
-        ctx->endpoint = (char *) tmp;
+        ctx->endpoint = removeProtocol((char *) tmp, "https://");
     }
     else {
         ctx->custom_endpoint = FLB_FALSE;
     }
+
+    tmp = flb_output_get_property("sts_endpoint", ins);
+    if (tmp) {
+        ctx->sts_endpoint = (char *) tmp;
+    }
+
 
     tmp = flb_output_get_property("log_key", ins);
     if (tmp) {
@@ -153,6 +159,7 @@ static int cb_firehose_init(struct flb_output_instance *ins,
     ctx->aws_provider = flb_standard_chain_provider_create(config,
                                                            &ctx->cred_tls,
                                                            (char *) ctx->region,
+                                                           ctx->sts_endpoint,
                                                            NULL,
                                                            flb_aws_client_generator());
     if (!ctx->aws_provider) {
@@ -192,6 +199,7 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                                     (char *) ctx->role_arn,
                                                     session_name,
                                                     (char *) ctx->region,
+                                                    ctx->sts_endpoint,
                                                     NULL,
                                                     flb_aws_client_generator());
         if (!ctx->aws_provider) {
@@ -397,6 +405,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "endpoint", NULL,
      0, FLB_FALSE, 0,
      "Specify a custom endpoint for the Firehose API"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
+     0, FLB_FALSE, 0,
+    "Custom endpoint for the STS API."
     },
 
     /* EOF */

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -86,6 +86,7 @@ struct flb_firehose {
     const char *region;
     const char *role_arn;
     const char *log_key;
+    char *sts_endpoint;
     int custom_endpoint;
 
     /* must be freed on shutdown if custom_endpoint is not set */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -94,6 +94,7 @@ struct flb_s3 {
     char *s3_key_format;
     char *tag_delimiters;
     char *endpoint;
+    char *sts_endpoint;
     int free_endpoint;
     int use_put_object;
 

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -236,6 +236,7 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
                                                             *config,
                                                             struct flb_tls *tls,
                                                             char *region,
+                                                            char *sts_endpoint,
                                                             char *proxy,
                                                             struct
                                                             flb_aws_client_generator
@@ -284,7 +285,7 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
                   "standard chain");
     }
 
-    sub_provider = flb_eks_provider_create(config, tls, region, proxy, generator);
+    sub_provider = flb_eks_provider_create(config, tls, region, sts_endpoint, proxy, generator);
     if (sub_provider) {
         /* EKS provider can fail if we are not running in k8s */;
         mk_list_add(&sub_provider->_head, &implementation->sub_providers);

--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -67,6 +67,7 @@ static flb_sds_t get_node(char *cred_node, char* node_name, int node_len);
  * and assume an IAM Role.
  */
 struct flb_aws_provider_sts {
+    int custom_endpoint;
     struct flb_aws_provider *base_provider;
 
     struct flb_aws_credentials *creds;
@@ -236,7 +237,7 @@ void destroy_fn_sts(struct flb_aws_provider *provider) {
             flb_sds_destroy(implementation->uri);
         }
 
-        if (implementation->endpoint) {
+        if (implementation->custom_endpoint == FLB_FALSE) {
             flb_free(implementation->endpoint);
         }
 
@@ -294,8 +295,17 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
         goto error;
     }
 
-    implementation->endpoint = removeProtocol(sts_endpoint, "https://");
-    if (!implementation->endpoint) {
+    if (sts_endpoint) {
+        implementation->endpoint = removeProtocol(sts_endpoint, "https://");
+    }
+    else {
+        implementation->endpoint = flb_aws_endpoint("sts", region);
+    }
+
+    implementation->custom_endpoint = FLB_TRUE;
+    
+    if(!implementation->endpoint) {
+        implementation->custom_endpoint = FLB_FALSE;
         goto error;
     }
 
@@ -343,6 +353,7 @@ error:
  * location of the OIDC token from an environment variable.
  */
 struct flb_aws_provider_eks {
+    int custom_endpoint;
     struct flb_aws_credentials *creds;
     /*
      * Time to auto-refresh creds before they expire. A negative value disables
@@ -490,7 +501,7 @@ void destroy_fn_eks(struct flb_aws_provider *provider) {
             flb_aws_client_destroy(implementation->sts_client);
         }
 
-        if (implementation->endpoint) {
+        if (implementation->custom_endpoint == FLB_FALSE) {
             flb_free(implementation->endpoint);
         }
         if (implementation->free_session_name == FLB_TRUE) {
@@ -515,7 +526,9 @@ static struct flb_aws_provider_vtable eks_provider_vtable = {
 
 struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
                                                  struct flb_tls *tls,
-                                                 char *region, char *proxy,
+                                                 char *region, 
+                                                 char *sts_endpoint,
+                                                 char *proxy,
                                                  struct
                                                  flb_aws_client_generator
                                                  *generator)
@@ -569,8 +582,17 @@ struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
         return NULL;
     }
 
-    implementation->endpoint = flb_aws_endpoint("sts", region);
-    if (!implementation->endpoint) {
+    if (sts_endpoint) {
+        implementation->endpoint = removeProtocol(sts_endpoint, "https://");
+    }
+    else {
+        implementation->endpoint = flb_aws_endpoint("sts", region);
+    }
+
+    implementation->custom_endpoint = FLB_TRUE;
+
+    if(!implementation->endpoint) {
+        implementation->custom_endpoint = FLB_FALSE;
         goto error;
     }
 

--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -297,15 +297,14 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
 
     if (sts_endpoint) {
         implementation->endpoint = removeProtocol(sts_endpoint, "https://");
+        implementation->custom_endpoint = FLB_TRUE;
     }
     else {
         implementation->endpoint = flb_aws_endpoint("sts", region);
+        implementation->custom_endpoint = FLB_FALSE;
     }
 
-    implementation->custom_endpoint = FLB_TRUE;
-    
     if(!implementation->endpoint) {
-        implementation->custom_endpoint = FLB_FALSE;
         goto error;
     }
 
@@ -526,7 +525,7 @@ static struct flb_aws_provider_vtable eks_provider_vtable = {
 
 struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
                                                  struct flb_tls *tls,
-                                                 char *region, 
+                                                 char *region,
                                                  char *sts_endpoint,
                                                  char *proxy,
                                                  struct
@@ -584,15 +583,14 @@ struct flb_aws_provider *flb_eks_provider_create(struct flb_config *config,
 
     if (sts_endpoint) {
         implementation->endpoint = removeProtocol(sts_endpoint, "https://");
+        implementation->custom_endpoint = FLB_TRUE;
     }
     else {
         implementation->endpoint = flb_aws_endpoint("sts", region);
+        implementation->custom_endpoint = FLB_FALSE;
     }
 
-    implementation->custom_endpoint = FLB_TRUE;
-
     if(!implementation->endpoint) {
-        implementation->custom_endpoint = FLB_FALSE;
         goto error;
     }
 

--- a/src/aws/flb_aws_credentials_sts.c
+++ b/src/aws/flb_aws_credentials_sts.c
@@ -264,6 +264,7 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
                                                  char *role_arn,
                                                  char *session_name,
                                                  char *region,
+                                                 char *sts_endpoint,
                                                  char *proxy,
                                                  struct
                                                  flb_aws_client_generator
@@ -293,7 +294,7 @@ struct flb_aws_provider *flb_sts_provider_create(struct flb_config *config,
         goto error;
     }
 
-    implementation->endpoint = flb_aws_endpoint("sts", region);
+    implementation->endpoint = removeProtocol(sts_endpoint, "https://");
     if (!implementation->endpoint) {
         goto error;
     }

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -209,7 +209,7 @@ char *flb_s3_endpoint(char* bucket, char* region)
 }
 
 char *removeProtocol (char *endpoint, char *protocol) {
-    if (strstr(endpoint, protocol)){
+    if (strncmp(protocol, endpoint, strlen(protocol)) == 0){
         endpoint = endpoint + strlen(protocol);
     }
     return endpoint;

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -208,6 +208,14 @@ char *flb_s3_endpoint(char* bucket, char* region)
 
 }
 
+char *removeProtocol (char *endpoint, char *protocol) {
+    if (strstr(endpoint, protocol)){
+        endpoint = endpoint + strlen(protocol);
+    }
+    return endpoint;
+}
+
+
 struct flb_http_client *flb_aws_client_request(struct flb_aws_client *aws_client,
                                                int method, const char *uri,
                                                const char *body, size_t body_len,

--- a/tests/internal/aws_credentials.c
+++ b/tests/internal/aws_credentials.c
@@ -276,6 +276,7 @@ static void test_standard_chain_provider()
     mk_list_init(&config->upstreams);
 
     provider = flb_standard_chain_provider_create(config, NULL, "us-west-2",
+                                                  "https://sts.us-west-2.amazonaws.com",
                                                   NULL,
                                                   flb_aws_client_generator());
     if (!provider) {

--- a/tests/internal/aws_credentials_sts.c
+++ b/tests/internal/aws_credentials_sts.c
@@ -695,8 +695,9 @@ static void test_sts_provider() {
 
     provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
                                        "arn:aws:iam::123456789012:role/test1",
-                                       "session_name", "cn-north-1", NULL,
-                                       generator_in_test());
+                                       "session_name", "cn-north-1",
+                                        "https://sts.us-west-2.amazonaws.com",
+                                        NULL, generator_in_test());
     if (!provider) {
         flb_errno();
         return;
@@ -784,7 +785,9 @@ static void test_sts_provider_api_error() {
 
     provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
                                 "arn:aws:iam::123456789012:role/apierror",
-                                "session_name", "cn-north-1", NULL,
+                                "session_name", "cn-north-1",
+                                 "https://sts.us-west-2.amazonaws.com",
+                                 NULL,
                                 generator_in_test());
     if (!provider) {
         flb_errno();
@@ -859,7 +862,9 @@ static void test_sts_provider_unexpected_api_response() {
     provider = flb_sts_provider_create(config, NULL, base_provider, "external_id",
                                        "arn:aws:iam::123456789012:role/"
                                        "unexpected_api_response",
-                                       "session_name", "cn-north-1", NULL,
+                                       "session_name", "cn-north-1", 
+                                       "https://sts.us-west-2.amazonaws.com",
+                                       NULL,
                                        generator_in_test());
     if (!provider) {
         flb_errno();

--- a/tests/internal/aws_credentials_sts.c
+++ b/tests/internal/aws_credentials_sts.c
@@ -427,8 +427,9 @@ static void test_eks_provider() {
         return;
     }
 
-    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
-                                generator_in_test());
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", 
+                                "https://sts.us-west-2.amazonaws.com",
+                                NULL, generator_in_test());
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -499,8 +500,9 @@ static void test_eks_provider_random_session_name() {
         return;
     }
 
-    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
-                                generator_in_test());
+    provider = flb_eks_provider_create(config, NULL, "us-west-2",
+                                "https://sts.us-west-2.amazonaws.com",
+                                NULL, generator_in_test());
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -571,8 +573,9 @@ static void test_eks_provider_unexpected_api_response() {
         return;
     }
 
-    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
-                                generator_in_test());
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", 
+                                "https://sts.us-west-2.amazonaws.com",
+                                NULL, generator_in_test());
 
     /* API will return an error - creds will be NULL */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -626,8 +629,9 @@ static void test_eks_provider_api_error() {
         return;
     }
 
-    provider = flb_eks_provider_create(config, NULL, "us-west-2", NULL,
-                                generator_in_test());
+    provider = flb_eks_provider_create(config, NULL, "us-west-2", 
+                                "https://sts.us-west-2.amazonaws.com",
+                                NULL, generator_in_test());
 
     /* API will return an error - creds will be NULL */
     creds = provider->provider_vtable->get_credentials(provider);


### PR DESCRIPTION
- Added STS endpoint support for CW and ES plugin.

- Add sts_endpoint option in eks_provider and aws_sts_provider

- Added support to specify endpoint and sts_endpoint with or without the protocol. 

_E.g. endpoint logs.us-west-2.amazonaws.com and endpoint https://logs.us-west-2.amazonaws.com will work._ 

```
[OUTPUT]
    Name cloudwatch_logs
    Match *
    log_stream_prefix fluent-bit-
    log_group_name fluent
    region us-west-2
    auto_create_group On
    role_arn arn:aws:iam::xxxxxxxxxxxx:role/test
    sts_endpoint https://sts.us-west-2.amazonaws.com
    endpoint logs.us-west-2.amazonaws.com
```
```
[OUTPUT]
    Name  es
    Match *
    Host vpc-test-domain-ke7thhzoo7jawrhmz6mb7ite7y.us-west-2.es.amazonaws.com
    Port  443
    Index my_index
    Type  my_type
    Aws_Auth On
    Aws_Region us-west-2
    aws_role_arn arn:aws:iam::xxxxxxxxxxxx:role/test
    aws_sts_endpoint https://sts.us-west-2.amazonaws.com
    tls On
    tls.verify On
    tls.debug 1

```
Debug Logs

![image](https://user-images.githubusercontent.com/21286441/91225512-937d2c80-e6d8-11ea-865d-d977e24295d7.png)

![image](https://user-images.githubusercontent.com/21286441/91226030-4ea5c580-e6d9-11ea-966d-848dfd25c5bc.png)

Valgrind Logs
[valgrind_aws_credentials.log](https://github.com/fluent/fluent-bit/files/5131456/valgrind_aws_credentials.log)
[valgrind_aws_credentials_sts.log](https://github.com/fluent/fluent-bit/files/5131458/valgrind_aws_credentials_sts.log)


Signed-off-by: Meghna Prabhu <meghnapr@amazon.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
