### PR TITLE
in_exec: add Multiline option to exec input plugin

### DIFF
--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -36,6 +36,7 @@
 struct flb_exec {
     const char  *cmd;
     struct flb_parser  *parser;
+    int  multiline;
     char *buf;
     size_t buf_size;
     struct flb_input_instance *ins;


### PR DESCRIPTION
This change adds `Multiline` boolean option to `exec` input plugin configuration. This option is handled the same way as existing boolean options - allows `yes`, `on`, `true`, `no`, `off`, `false`. If disabled (default), the behavior remains identical to previous versions. If enabled, output of executed command is not split by newlines, but is sent in its entirety in a single record. For both cases, if the output data size exceeds specified `buf_size`, the data will be split. This change also fixes an issue where last character was removed from record payload if buffer size limit was reached, even if the character was not a LF.

Fixes #2500
Fixes #2504

**Testing**

Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Example configuration:
```
[INPUT]
    Name          exec
    Tag           exec_ls
    Command       ls /var/log
    Interval_Sec  1
    Interval_NSec 0
    Buf_Size      1k
    Multiline     true

[OUTPUT]
    Name   stdout
    Match  *
```
Original behavior:
```
$ bin/fluent-bit  -i exec -p 'command=ls /tmp/fluent_bit_example/' -p "multiline=off" -o stdout
```
```
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/08/26 14:55:42] [ info] [engine] started (pid=8730)
[2020/08/26 14:55:42] [ info] [storage] version=1.0.5, initializing...
[2020/08/26 14:55:42] [ info] [storage] in-memory
[2020/08/26 14:55:42] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/08/26 14:55:42] [ info] [sp] stream processor started
[0] exec.0: [1598446542.675938630, {"exec"=>"config1.cfg"}]
[1] exec.0: [1598446542.676011977, {"exec"=>"file_1.txt"}]
[2] exec.0: [1598446542.676026535, {"exec"=>"logfile.log"}]
```
Multiline option enabled:
```
$ bin/fluent-bit  -i exec -p 'command=ls /tmp/fluent_bit_example/' -p "multiline=on" -o stdout
```
```
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/08/26 14:57:26] [ info] [engine] started (pid=8768)
[2020/08/26 14:57:26] [ info] [storage] version=1.0.5, initializing...
[2020/08/26 14:57:26] [ info] [storage] in-memory
[2020/08/26 14:57:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/08/26 14:57:26] [ info] [sp] stream processor started
[0] exec.0: [1598446646.675991579, {"exec"=>"config1.cfg
file_1.txt
logfile.log
"}]
```
Multiline disabled with limited buffer (fixed #2504 - no characters are lost when buffer size is reached):
```
$ bin/fluent-bit  -i exec -p 'command=ls /tmp/fluent_bit_example/' -p "multiline=off" -p "buf_size=8" -o stdout
```
```
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/08/26 14:59:26] [ info] [engine] started (pid=8794)
[2020/08/26 14:59:26] [ info] [storage] version=1.0.5, initializing...
[2020/08/26 14:59:26] [ info] [storage] in-memory
[2020/08/26 14:59:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/08/26 14:59:26] [ info] [sp] stream processor started
[0] exec.0: [1598446766.676937171, {"exec"=>"config1"}]
[1] exec.0: [1598446766.677012103, {"exec"=>".cfg"}]
[2] exec.0: [1598446766.677026260, {"exec"=>"file_1."}]
[3] exec.0: [1598446766.677029179, {"exec"=>"txt"}]
[4] exec.0: [1598446766.677031879, {"exec"=>"logfile"}]
[5] exec.0: [1598446766.677034766, {"exec"=>".log"}]
```
Multiline enabled with limited buffer:
```
$ bin/fluent-bit  -i exec -p 'command=ls /tmp/fluent_bit_example/' -p "multiline=on" -p "buf_size=8" -o stdout
```
```
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/08/26 15:01:05] [ info] [engine] started (pid=8853)
[2020/08/26 15:01:05] [ info] [storage] version=1.0.5, initializing...
[2020/08/26 15:01:05] [ info] [storage] in-memory
[2020/08/26 15:01:05] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/08/26 15:01:05] [ info] [sp] stream processor started
[0] exec.0: [1598446865.675997128, {"exec"=>"config1"}]
[1] exec.0: [1598446865.676069180, {"exec"=>".cfg
fi"}]
[2] exec.0: [1598446865.676083013, {"exec"=>"le_1.tx"}]
[3] exec.0: [1598446865.676085910, {"exec"=>"t
logfi"}]
[4] exec.0: [1598446865.676088340, {"exec"=>"le.log
"}]
```

Valgrind:
```
$valgrind --leak-check=yes bin/fluent-bit  -i exec -p 'command=ls /tmp/fluent_bit_example/' -p "multiline=on" -p "buf_size=8" -o stdout
```
```
==9175== Memcheck, a memory error detector
==9175== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9175== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==9175== Command: bin/fluent-bit -i exec -p command=ls\ /tmp/fluent_bit_example/ -p multiline=on -p buf_size=8 -o stdout
==9175==
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/08/26 15:10:22] [ info] [engine] started (pid=9175)
[2020/08/26 15:10:22] [ info] [storage] version=1.0.5, initializing...
[2020/08/26 15:10:22] [ info] [storage] in-memory
[2020/08/26 15:10:22] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/08/26 15:10:22] [ info] [sp] stream processor started
==9175== Warning: client switching stacks?  SP change: 0x1ffefff8f8 --> 0x5dec880
==9175==          to suppress, use: --max-stackframe=137323688056 or greater
==9175== Warning: client switching stacks?  SP change: 0x5dec7e8 --> 0x1ffefff8f8
==9175==          to suppress, use: --max-stackframe=137323688208 or greater
==9175== Warning: client switching stacks?  SP change: 0x1ffefff8f8 --> 0x5dec7e8
==9175==          to suppress, use: --max-stackframe=137323688208 or greater
==9175==          further instances of this message will not be shown.

...

^C[engine] caught signal (SIGINT)
==9175==
==9175== HEAP SUMMARY:
==9175==     in use at exit: 0 bytes in 0 blocks
==9175==   total heap usage: 3,918 allocs, 3,918 frees, 24,075,440 bytes allocated
==9175==
==9175== All heap blocks were freed -- no leaks are possible
==9175==
==9175== For counts of detected and suppressed errors, rerun with: -v
==9175== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
