### PR TITLE
fixes double free issue #2497

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -191,14 +191,14 @@ static int destroy_conn(struct flb_upstream_conn *u_conn)
 #endif
 
     if (u_conn->fd > 0) {
+        u_conn->fd = -1;
         flb_socket_close(u_conn->fd);
+        /* remove connection from the queue */
+        mk_list_del(&u_conn->_head);
+
+        u->n_connections--;
+        flb_free(u_conn);
     }
-
-    /* remove connection from the queue */
-    mk_list_del(&u_conn->_head);
-
-    u->n_connections--;
-    flb_free(u_conn);
 
     return 0;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the destroy connection, the connection object is removed from the list twice and the object is freed twice. The fix, sets the socket fd to "-1" after the first destruction and doesn't take any action if the destroy is called the 2nd time.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#2497 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
As mentioned in the #2497 
- [ ] Debug log output from testing the change
```
187 ^[[1m[^[[0m2020/08/27 12:54:03^[[1m]^[[0m [^[[93mdebug^[[0m] [upstream] KA connection #-1 to 192.168.99.99:    80 has been disconnected by the remote service
188 ^[[1m[^[[0m2020/08/27 12:54:03^[[1m]^[[0m [^[[93mdebug^[[0m] [upstream] destroy connection #-1 to 192.168.9    9.99:80
```
Here the log shows "-1", which indicates that 2nd call to destroy was called.
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[vglog_org.log](https://github.com/fluent/fluent-bit/files/5134832/vglog_org.log)

From the valgrind log we see that the "Invalid write of size 8" log isn't present as mentioned in #2497.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
