### PR TITLE
out_syslog: Add nested key support.

### DIFF
--- a/plugins/out_syslog/syslog_conf.c
+++ b/plugins/out_syslog/syslog_conf.c
@@ -93,6 +93,15 @@ struct flb_syslog *flb_syslog_config_create(struct flb_output_instance *ins,
                 goto clean;
             }
         }
+        else if (!strcasecmp(prop->key, "syslog_nested_key_separator")) {
+            if (ctx->nested_key_separator == NULL) {
+                ctx->nested_key_separator = flb_sds_create(prop->val);
+            }
+            else {
+                flb_plg_error(ctx->ins, "syslog_nested_key_separator already defined");
+                goto clean;
+            }
+        }
         else if (!strcasecmp(prop->key, "syslog_severity_key")) {
             if (ctx->severity_key == NULL) {
                 ctx->severity_key = flb_sds_create(prop->val);
@@ -178,6 +187,7 @@ clean:
 
 void flb_syslog_config_destroy(struct flb_syslog *ctx)
 {
+    flb_sds_destroy(ctx->nested_key_separator);
     flb_sds_destroy(ctx->severity_key);
     flb_sds_destroy(ctx->facility_key);
     flb_sds_destroy(ctx->hostname_key);

--- a/plugins/out_syslog/syslog_conf.h
+++ b/plugins/out_syslog/syslog_conf.h
@@ -33,6 +33,7 @@ struct flb_syslog {
     int mode;
     int format;
     int maxsize;
+    flb_sds_t nested_key_separator;
     flb_sds_t severity_key;
     flb_sds_t facility_key;
     flb_sds_t timestamp_key;


### PR DESCRIPTION
Signed-off-by: Pascal Rivard <privard@rbbn.com>

<!-- Provide summary of changes -->
Add nested key support in the out_syslog plugin. When a nested key separator is provided in the config, recursively iterate through map values inside the key-values provided by fluent-bit. Build a list of expanded keys with associated values, using the defined separator. Iterate through that list to find the defined syslog keys.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #2168

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [
[valgrind-out.txt](https://github.com/fluent/fluent-bit/files/5153232/valgrind-out.txt)
[fluent-bit.log](https://github.com/fluent/fluent-bit/files/5153233/fluent-bit.log)
[logs.zip](https://github.com/fluent/fluent-bit/files/5153234/logs.zip)



 ] Documentation required for this feature

NOTE: Valgrind shows a leak, but it seems to have to do with this line, which was not modified in this PR. From what I see, this string is never freed.

syslog_conf.c: 167
          ctx->sd_key[ctx->nsd] = flb_sds_create(prop->val);

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
