### PR TITLE
in_exec: fix logging crash

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -136,6 +136,8 @@ static int in_exec_config_read(struct flb_exec *ctx,
     const char *cmd = NULL;
     const char *pval = NULL;
 
+    ctx->ins = in;
+
     /* filepath setting */
     cmd = flb_input_get_property("command", in);
     if (cmd == NULL) {


### PR DESCRIPTION
Fixes crash caused by missing reference to logging context.

Signed-off-by: yang-padawan <25978390+yang-padawan@users.noreply.github.com>

<!-- Provide summary of changes -->

Adding missing reference to logging context.
Logging was updated by 2c7c16db to use newly added `ins` attribute of `flb_exec` struct. That attribute was never populated, causing crashes whenever a log should have been produced by the plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #2523

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
See #2523 for configuration.

- [x] Debug log output from testing the change
```
$ ./bin/fluent-bit -c fluent_bit.conf
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/03 13:50:53] [ info] [engine] started (pid=30348)
[2020/09/03 13:50:53] [ info] [storage] version=1.0.5, initializing...
[2020/09/03 13:50:53] [ info] [storage] in-memory
[2020/09/03 13:50:53] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/03 13:50:53] [ info] [sp] stream processor started
[2020/09/03 13:50:53] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:50:54] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:50:55] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:50:56] [error] [input:exec:exec.0] parser returned an error
[0] exec_cat: [1599133853.676003147, {"which"=>"first"}]
[1] exec_cat: [1599133853.676090673, {"which"=>"second"}]
[2] exec_cat: [1599133854.674486320, {"which"=>"first"}]
[3] exec_cat: [1599133854.674519301, {"which"=>"second"}]
[4] exec_cat: [1599133855.675480665, {"which"=>"first"}]
[5] exec_cat: [1599133855.675512145, {"which"=>"second"}]
[6] exec_cat: [1599133856.675368474, {"which"=>"first"}]
[7] exec_cat: [1599133856.675399705, {"which"=>"second"}]
[2020/09/03 13:50:57] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:50:58] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:50:59] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:51:00] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 13:51:01] [error] [input:exec:exec.0] parser returned an error
^C[engine] caught signal (SIGINT)
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
 $ valgrind ~/ws/fluent-bit/build/bin/fluent-bit -c reduced.conf
==1503== Memcheck, a memory error detector
==1503== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1503== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==1503== Command: /home/mstaron/ws/fluent-bit/build/bin/fluent-bit -c reduced.conf
==1503==
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/03 14:12:02] [ info] [engine] started (pid=1503)
[2020/09/03 14:12:02] [ info] [storage] version=1.0.5, initializing...
[2020/09/03 14:12:02] [ info] [storage] in-memory
[2020/09/03 14:12:02] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/03 14:12:02] [ info] [sp] stream processor started
[2020/09/03 14:12:02] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 14:12:03] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 14:12:04] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 14:12:05] [error] [input:exec:exec.0] parser returned an error
==1503== Warning: client switching stacks?  SP change: 0x1ffefff8b8 --> 0x5ded280
==1503==          to suppress, use: --max-stackframe=137323685432 or greater
==1503== Warning: client switching stacks?  SP change: 0x5ded1e8 --> 0x1ffefff8b8
==1503==          to suppress, use: --max-stackframe=137323685584 or greater
==1503== Warning: client switching stacks?  SP change: 0x1ffefff8b8 --> 0x5ded1e8
==1503==          to suppress, use: --max-stackframe=137323685584 or greater
==1503==          further instances of this message will not be shown.
[0] exec_cat: [1599135122.715805980, {"which"=>"first"}]
[2020/09/03 14:12:06] [error] [input:exec:exec.0] parser returned an error

...

[8] exec_cat: [1599135585.687343263, {"which"=>"first"}]
[9] exec_cat: [1599135585.687683476, {"which"=>"second"}]
[2020/09/03 14:19:46] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 14:19:47] [error] [input:exec:exec.0] parser returned an error
[2020/09/03 14:19:48] [error] [input:exec:exec.0] parser returned an error
^C[engine] caught signal (SIGINT)
==1503==
==1503== HEAP SUMMARY:
==1503==     in use at exit: 0 bytes in 0 blocks
==1503==   total heap usage: 11,981 allocs, 11,981 frees, 60,907,168 bytes allocated
==1503==
==1503== All heap blocks were freed -- no leaks are possible
==1503==
==1503== For counts of detected and suppressed errors, rerun with: -v
==1503== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
