### PR TITLE
Url_Path config to reach kafka rest proxy via a Load Balancer

### DIFF
--- a/plugins/out_kafka_rest/kafka.h
+++ b/plugins/out_kafka_rest/kafka.h
@@ -51,6 +51,7 @@ struct flb_kafka_rest {
 
     /* HTTP URI */
     char uri[256];
+    char *url_path;
 
     /* Upstream connection to the backend server */
     struct flb_upstream *u;

--- a/plugins/out_kafka_rest/kafka_conf.c
+++ b/plugins/out_kafka_rest/kafka_conf.c
@@ -163,7 +163,16 @@ struct flb_kafka_rest *flb_kr_conf_create(struct flb_output_instance *ins,
     }
 
     /* Set partition based on topic */
-    snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/topics/%s", ctx->topic);
+    tmp = flb_output_get_property("url_path", ins);
+    if (tmp) {
+        ctx->url_path = flb_strdup(tmp);
+        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/topics/%s", ctx->url_path, ctx->topic);
+    }
+    else {
+        ctx->url_path = NULL;
+        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/topics/%s", ctx->topic);
+    }
+
 
     /* Kafka: message key */
     tmp = flb_output_get_property("message_key", ins);
@@ -187,6 +196,10 @@ int flb_kr_conf_destroy(struct flb_kafka_rest *ctx)
 
     flb_free(ctx->time_key);
     flb_free(ctx->time_key_format);
+
+    if (ctx->url_path) {
+        flb_free(ctx->url_path);
+    }
 
     if (ctx->include_tag_key) {
         flb_free(ctx->tag_key);


### PR DESCRIPTION
Signed-off-by: Pradeep Hiremande <16595434+phiremande@users.noreply.github.com>

<!-- Provide summary of changes -->
Introduces new configuration parameter to the kafka-rest output plugin.
Url_Path

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #2528 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
[OUTPUT]
    Name kafka-rest
    Match *
    Port 80
    Url_Path /myapi

- [ ] Debug log output from testing the change
[fblog_urlpath.log](https://github.com/fluent/fluent-bit/files/5176304/fblog_urlpath.log)

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[vglog_urlpath.log](https://github.com/fluent/fluent-bit/files/5176307/vglog_urlpath.log)
None related to the changes.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature
Yes.

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
