### PR TITLE
out_cloudwatch_logs: Disable net.keepalive in test

### DIFF
--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -33,6 +33,7 @@ void flb_test_cloudwatch_success(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -69,6 +70,7 @@ void flb_test_cloudwatch_already_exists_create_group(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -105,6 +107,7 @@ void flb_test_cloudwatch_already_exists_create_stream(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -141,6 +144,7 @@ void flb_test_cloudwatch_error_create_group(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -177,6 +181,7 @@ void flb_test_cloudwatch_error_create_stream(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -213,6 +218,7 @@ void flb_test_cloudwatch_error_put_log_events(void)
     flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
