### PR TITLE
filter_modify: Add data type condition checker to `Modify` filter.

### DIFF
--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -73,4 +73,6 @@ int flb_hash_get_by_id(struct flb_hash *ht, int id,
                        const char **out_buf, size_t *out_size);
 int flb_hash_del(struct flb_hash *ht, const char *key);
 
+unsigned int gen_hash(const void *key, int len);
+
 #endif

--- a/plugins/filter_modify/modify.h
+++ b/plugins/filter_modify/modify.h
@@ -24,6 +24,24 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_filter.h>
 
+/* 
+ * Speed up Key_Value_Type_Matches condition check,
+ * use `switch` + `hash()` instead of `if ... else` + `strncmp()`.
+ *
+ * Note, it's arch sensitive, little-endian (LE) ONLY due to the implementation
+ * of hash function, see `gen_hash()` in `flb_hash.c`.
+ */
+#define FLB_FILTER_MODIFY_HASH_NIL    976956422U
+#define FLB_FILTER_MODIFY_HASH_BOOL   4022539617U
+#define FLB_FILTER_MODIFY_HASH_NUMBER 4188039317U
+#define FLB_FILTER_MODIFY_HASH_INT    3831089057U
+#define FLB_FILTER_MODIFY_HASH_FLOAT  1075678673U
+#define FLB_FILTER_MODIFY_HASH_STR    3331274845U
+#define FLB_FILTER_MODIFY_HASH_ARRAY  968645473U
+#define FLB_FILTER_MODIFY_HASH_MAP    671111262U
+#define FLB_FILTER_MODIFY_HASH_BIN    3587806299U
+#define FLB_FILTER_MODIFY_HASH_EXT    1459784193U
+
 enum FLB_FILTER_MODIFY_RULETYPE {
   RENAME,
   HARD_RENAME,
@@ -45,8 +63,11 @@ enum FLB_FILTER_MODIFY_CONDITIONTYPE {
   KEY_VALUE_DOES_NOT_EQUAL,
   KEY_VALUE_MATCHES,
   KEY_VALUE_DOES_NOT_MATCH,
+  KEY_VALUE_TYPE_MATCHES,
+  KEY_VALUE_TYPE_DOES_NOT_MATCH,
   MATCHING_KEYS_HAVE_MATCHING_VALUES,
-  MATCHING_KEYS_DO_NOT_HAVE_MATCHING_VALUES
+  MATCHING_KEYS_DO_NOT_HAVE_MATCHING_VALUES,
+  MATCHING_KEY
 };
 
 struct filter_modify_ctx

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -41,7 +41,7 @@
  * 2. It will not produce the same results on little-endian and big-endian
  *    machines.
  */
-static unsigned int gen_hash(const void *key, int len)
+unsigned int gen_hash(const void *key, int len)
 {
     /* 'm' and 'r' are mixing constants generated offline.
        They're not really 'magic', they just happen to work well.  */


### PR DESCRIPTION
<!-- Provide summary of changes -->

## Summary

It would be good if Fluent Bit supports strong data type condition check when applied in *structured* log stream. I implemented a data type condition checker for `Modify` filter.

Check data type using `lua` filter **isn't clear enough for end-user** and **costs more performance overhead**.

## Usage

`Modify` filter supports two new conditions. See `modify_filter_example.conf` below.

| Condition | Parameter 1 | Parameter 2 | Description |
| :-------- | :---------- | :---------- | :---------- |
| Key_Value_Type_Matches | STRING:KEY | STRING:VALUE | Is `true` if `KEY` exists and its value data type is `VALUE`. |
| Key_Value_Type_Does_Not_Match | STRING:KEY | STRING:VALUE | Is `true` if `KEY` exists and its value data type is not `VALUE`. |

Parameter 2 data type string literal could be:
- `nil`
- `bool`
- `number`
- `int`
- `float`
- `str`
- `array`
- `map`

```plain
[INPUT]
    Name dummy
    Tag  test
    dummy {"nilType": null, "boolType": true, "intType": 123, "floatType": 3.14159, "strType": "awesome!", "arrayType": [1, 2, 3], "mapType": {"k": "v"}}

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name  modify
    Match *

    Condition Key_Value_Type_Matches             nilType           nil
    Condition Key_Value_Type_Matches             boolType          bool
    Condition Key_Value_Type_Matches             intType           int
    Condition Key_Value_Type_Matches             floatType         float
    Condition Key_Value_Type_Matches             strType           str
    Condition Key_Value_Type_Matches             arrayType         array
    Condition Key_Value_Type_Matches             mapType           map

    Condition Key_Value_Type_Does_Not_Match      mapType           array

    Rename nilType nilTypeMatches
    Rename mapType mapTypeDoesNotMatch

```
> `modify_filter_example.conf`

## Unit Tests
Here comes unit testing results.

```plain
13/31 Test #13: flb-rt-filter_kubernetes .........   Passed  193.00 sec
      Start 14: flb-rt-filter_parser
14/31 Test #14: flb-rt-filter_parser .............   Passed   20.00 sec
      Start 15: flb-rt-filter_modify
15/31 Test #15: flb-rt-filter_modify .............   Passed   55.00 sec
      Start 16: flb-rt-core_engine
16/31 Test #16: flb-rt-core_engine ...............   Passed   20.00 sec
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

## Addresses

#2530

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
