### PR TITLE
Adds three new fuzzers.

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -3,6 +3,9 @@ set(UNIT_TESTS_FILES
   parse_json_fuzzer.c
   parse_logfmt_fuzzer.c
   parse_ltsv_fuzzer.c
+  msgpack_parse_fuzzer.c
+  msgpack_to_gelf_fuzzer.c
+  pack_json_state_fuzzer.c
   )
 
 # Prepare list of unit tests

--- a/tests/internal/fuzzers/msgpack_parse_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_parse_fuzzer.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <msgpack.h>
+#include <fluent-bit/flb_pack.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    if (size != 512)
+        return 0;
+   
+    /* target the conversion of raw msgpack to json */
+    flb_sds_t record;
+    record = flb_msgpack_raw_to_json_sds(data, size);
+    flb_sds_destroy(record);
+
+    return 0;
+}

--- a/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <string.h>
+#include <msgpack.h>
+#include <fluent-bit/flb_pack.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    if (size != 512)
+        return 0;
+
+    /* Target the conversion of raw msgpack to gelf */
+    flb_sds_t record;
+    struct flb_time tm;
+    struct flb_gelf_fields fields = {0};
+    fields.short_message_key = flb_sds_create("AAAAAAAAAA");
+    record = flb_msgpack_raw_to_gelf(data, size, &tm, &fields);
+
+    /* cleanup */
+    flb_sds_destroy(record);
+    flb_sds_destroy(fields.short_message_key);
+
+    return 0;
+}

--- a/tests/internal/fuzzers/pack_json_state_fuzzer.c
+++ b/tests/internal/fuzzers/pack_json_state_fuzzer.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <fluent-bit/flb_pack.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    int out_size= 0;
+    char *out_buf = NULL;
+    struct flb_pack_state state;
+
+    /* Target json packer */
+    flb_pack_state_init(&state);
+    flb_pack_json_state(data, size, &out_buf, &out_size, &state);
+    flb_pack_state_reset(&state);
+    if (out_buf != NULL)
+        flb_free(out_buf);
+
+    return 0;
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds three new fuzzers. These target msgpack conversions as well as json packing.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
