### PR TITLE
in_cpu: Normalize per-process CPU stats by number of cores.

### DIFF
--- a/plugins/in_cpu/cpu.c
+++ b/plugins/in_cpu/cpu.c
@@ -333,16 +333,17 @@ struct cpu_snapshot *snapshot_pid_percent(struct cpu_stats *cstats,
     sum_pre = (snap_pre->v_user + snap_pre->v_system);
     sum_now = (snap_now->v_user + snap_now->v_system);
 
-    snap_now->p_cpu = CPU_METRIC_USAGE(sum_pre, sum_now, ctx);
+    snap_now->p_cpu = CPU_METRIC_SYS_AVERAGE(sum_pre, sum_now, ctx);
 
     /* User space CPU% */
-    snap_now->p_user = CPU_METRIC_USAGE(snap_pre->v_user, snap_now->v_user,
-                                        ctx);
+    snap_now->p_user = CPU_METRIC_SYS_AVERAGE(snap_pre->v_user,
+                                              snap_now->v_user,
+                                              ctx);
 
     /* Kernel space CPU% */
-    snap_now->p_system = CPU_METRIC_USAGE(snap_pre->v_system,
-                                          snap_now->v_system,
-                                          ctx);
+    snap_now->p_system = CPU_METRIC_SYS_AVERAGE(snap_pre->v_system,
+                                                snap_now->v_system,
+                                                ctx);
 
 #ifdef FLB_TRACE
     flb_trace("cpu[pid=%i] all=%s%f%s user=%s%f%s system=%s%f%s",

--- a/plugins/in_cpu/cpu.h
+++ b/plugins/in_cpu/cpu.h
@@ -131,21 +131,4 @@ static inline double CPU_METRIC_USAGE(unsigned long pre, unsigned long now,
     return total;
 }
 
-/* Returns the CPU % utilization of a given CPU core */
-static inline double CPU_METRIC_PID_USAGE(unsigned long pre, unsigned long now,
-                                          struct flb_cpu *ctx)
-{
-    double diff;
-    double total = 0;
-
-    if (pre == now) {
-        return 0.0;
-    }
-
-    diff = ULL_ABS(now, pre);
-    total = 100.0 * ((diff / ctx->cpu_ticks) / (ctx->interval_sec + 1e-9*ctx->interval_nsec));
-
-    return total;
-}
-
 #endif


### PR DESCRIPTION
Handle per-process CPU stats the same way as system CPU stats by normalizing the value by the number of CPU cores.

Signed-off-by: yang-padawan <25978390+yang-padawan@users.noreply.github.com>

<!-- Provide summary of changes -->

Changes the function called to compute per-process CPU stats (`/proc/[pid]/stat`) from per-core stats function to system-wide stats function. Removes the unused `CPU_METRIC_PID_USAGE` function.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #2542 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change

```
$ bin/fluent-bit -i cpu -p 'pid=18721' -t proc_cpu -i cpu -t sys_cpu -o stdout -m '*' -vv
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/11 14:59:46] [ info] Configuration:
[2020/09/11 14:59:46] [ info]  flush time     | 5.000000 seconds
[2020/09/11 14:59:46] [ info]  grace          | 5 seconds
[2020/09/11 14:59:46] [ info]  daemon         | 0
[2020/09/11 14:59:46] [ info] ___________
[2020/09/11 14:59:46] [ info]  inputs:
[2020/09/11 14:59:46] [ info]      cpu
[2020/09/11 14:59:46] [ info]      cpu
[2020/09/11 14:59:46] [ info] ___________
[2020/09/11 14:59:46] [ info]  filters:
[2020/09/11 14:59:46] [ info] ___________
[2020/09/11 14:59:46] [ info]  outputs:
[2020/09/11 14:59:46] [ info]      stdout.0
[2020/09/11 14:59:46] [ info] ___________
[2020/09/11 14:59:46] [ info]  collectors:
[2020/09/11 14:59:46] [ info] [engine] started (pid=13314)
[2020/09/11 14:59:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/11 14:59:46] [debug] [storage] [cio stream] new stream registered: cpu.0
[2020/09/11 14:59:46] [debug] [storage] [cio stream] new stream registered: cpu.1
[2020/09/11 14:59:46] [ info] [storage] version=1.0.5, initializing...
[2020/09/11 14:59:46] [ info] [storage] in-memory
[2020/09/11 14:59:46] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/11 14:59:46] [trace] [router] input=cpu.0 tag=proc_cpu
[2020/09/11 14:59:46] [debug] [router] match rule cpu.0:stdout.0
[2020/09/11 14:59:46] [trace] [router] input=cpu.1 tag=sys_cpu
[2020/09/11 14:59:46] [debug] [router] match rule cpu.1:stdout.0
[2020/09/11 14:59:46] [ info] [sp] stream processor started
[2020/09/11 14:59:46] [trace] [input:cpu:cpu.0 at .../fluent-bit/plugins/in_cpu/cpu.c:468] PID 18721 CPU 0.00%
[2020/09/11 14:59:46] [trace] [input:cpu:cpu.1 at .../fluent-bit/plugins/in_cpu/cpu.c:414] CPU 0.12%
[2020/09/11 14:59:47] [trace] [input:cpu:cpu.0 at .../fluent-bit/plugins/in_cpu/cpu.c:468] PID 18721 CPU 0.12%
[2020/09/11 14:59:47] [trace] [input:cpu:cpu.1 at .../fluent-bit/plugins/in_cpu/cpu.c:414] CPU 19.38%
[2020/09/11 14:59:48] [trace] [input:cpu:cpu.0 at .../fluent-bit/plugins/in_cpu/cpu.c:468] PID 18721 CPU 1.12%
[2020/09/11 14:59:48] [trace] [input:cpu:cpu.1 at .../fluent-bit/plugins/in_cpu/cpu.c:414] CPU 11.50%
[2020/09/11 14:59:49] [trace] [input:cpu:cpu.0 at .../fluent-bit/plugins/in_cpu/cpu.c:468] PID 18721 CPU 0.12%
[2020/09/11 14:59:49] [trace] [input:cpu:cpu.1 at .../fluent-bit/plugins/in_cpu/cpu.c:414] CPU 0.88%
[2020/09/11 14:59:50] [trace] [task 0x1e5cb20] created (id=0)
[2020/09/11 14:59:50] [debug] [task] created task=0x1e5cb20 id=0 OK
[2020/09/11 14:59:50] [trace] [thread 0x1e5cc10] created (custom data at 0x1e5cc30, size=64
[0] proc_cpu: [1599829186.670084976, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000}]
[1] proc_cpu: [1599829187.670001352, {"cpu_p"=>0.125000, "user_p"=>0.125000, "system_p"=>0.000000}]
[2] proc_cpu: [1599829188.670125101, {"cpu_p"=>1.125000, "user_p"=>1.125000, "system_p"=>0.000000}]
[3] proc_cpu: [1599829189.670197592, {"cpu_p"=>0.125000, "user_p"=>0.125000, "system_p"=>0.000000}]
[2020/09/11 14:59:50] [trace] [task 0x1e5cd30] created (id=1)
[2020/09/11 14:59:50] [debug] [task] created task=0x1e5cd30 id=1 OK
[2020/09/11 14:59:50] [trace] [thread 0x1e5ce00] created (custom data at 0x1e5ce20, size=64
[0] sys_cpu: [1599829186.670288763, {"cpu_p"=>0.125000, "user_p"=>0.125000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>1.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>0.000000, "cpu2.p_user"=>0.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>0.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>0.000000, "cpu4.p_cpu"=>0.000000, "cpu4.p_user"=>0.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>0.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>0.000000, "cpu6.p_cpu"=>0.000000, "cpu6.p_user"=>0.000000, "cpu6.p_system"=>0.000000, "cpu7.p_cpu"=>0.000000, "cpu7.p_user"=>0.000000, "cpu7.p_system"=>0.000000}]
[1] sys_cpu: [1599829187.670119513, {"cpu_p"=>19.375000, "user_p"=>10.875000, "system_p"=>8.500000, "cpu0.p_cpu"=>11.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>7.000000, "cpu1.p_cpu"=>14.000000, "cpu1.p_user"=>5.000000, "cpu1.p_system"=>9.000000, "cpu2.p_cpu"=>11.000000, "cpu2.p_user"=>3.000000, "cpu2.p_system"=>8.000000, "cpu3.p_cpu"=>11.000000, "cpu3.p_user"=>3.000000, "cpu3.p_system"=>8.000000, "cpu4.p_cpu"=>12.000000, "cpu4.p_user"=>3.000000, "cpu4.p_system"=>9.000000, "cpu5.p_cpu"=>71.000000, "cpu5.p_user"=>65.000000, "cpu5.p_system"=>6.000000, "cpu6.p_cpu"=>10.000000, "cpu6.p_user"=>2.000000, "cpu6.p_system"=>8.000000, "cpu7.p_cpu"=>16.000000, "cpu7.p_user"=>4.000000, "cpu7.p_system"=>12.000000}]
[2] sys_cpu: [1599829188.670276673, {"cpu_p"=>11.500000, "user_p"=>9.125000, "system_p"=>2.375000, "cpu0.p_cpu"=>4.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>18.000000, "cpu1.p_user"=>11.000000, "cpu1.p_system"=>7.000000, "cpu2.p_cpu"=>2.000000, "cpu2.p_user"=>1.000000, "cpu2.p_system"=>1.000000, "cpu3.p_cpu"=>7.000000, "cpu3.p_user"=>5.000000, "cpu3.p_system"=>2.000000, "cpu4.p_cpu"=>3.000000, "cpu4.p_user"=>1.000000, "cpu4.p_system"=>2.000000, "cpu5.p_cpu"=>49.000000, "cpu5.p_user"=>47.000000, "cpu5.p_system"=>2.000000, "cpu6.p_cpu"=>2.000000, "cpu6.p_user"=>1.000000, "cpu6.p_system"=>1.000000, "cpu7.p_cpu"=>6.000000, "cpu7.p_user"=>2.000000, "cpu7.p_system"=>4.000000}]
[3] sys_cpu: [1599829189.670377769, {"cpu_p"=>0.875000, "user_p"=>0.375000, "system_p"=>0.500000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>1.000000, "cpu1.p_user"=>1.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>2.000000, "cpu2.p_user"=>1.000000, "cpu2.p_system"=>1.000000, "cpu3.p_cpu"=>0.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>0.000000, "cpu4.p_cpu"=>1.000000, "cpu4.p_user"=>1.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>0.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>0.000000, "cpu6.p_cpu"=>2.000000, "cpu6.p_user"=>1.000000, "cpu6.p_system"=>1.000000, "cpu7.p_cpu"=>2.000000, "cpu7.p_user"=>1.000000, "cpu7.p_system"=>1.000000}]


...
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
$ valgrind bin/fluent-bit -i cpu -p 'pid=18721' -o stdout
==10990== Memcheck, a memory error detector
==10990== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10990== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==10990== Command: bin/fluent-bit -i cpu -p pid=18721 -o stdout
==10990==
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/11 14:44:10] [ info] [engine] started (pid=10990)
[2020/09/11 14:44:10] [ info] [storage] version=1.0.5, initializing...
[2020/09/11 14:44:10] [ info] [storage] in-memory
[2020/09/11 14:44:10] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/11 14:44:10] [ info] [sp] stream processor started
==10990== Warning: client switching stacks?  SP change: 0x1ffefff948 --> 0x5dbc980
==10990==          to suppress, use: --max-stackframe=137323884488 or greater
==10990== Warning: client switching stacks?  SP change: 0x5dbc8e8 --> 0x1ffefff948
==10990==          to suppress, use: --max-stackframe=137323884640 or greater
==10990== Warning: client switching stacks?  SP change: 0x1ffefff948 --> 0x5dbc8e8
==10990==          to suppress, use: --max-stackframe=137323884640 or greater
==10990==          further instances of this message will not be shown.
[0] cpu.0: [1599828251.677230955, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000}]

...

[5] cpu.0: [1599828365.670296954, {"cpu_p"=>13.250000, "user_p"=>12.875000, "system_p"=>0.375000}]
^C[engine] caught signal (SIGINT)
[2020/09/11 14:46:10] [ info] [input] pausing cpu.0
==10990==
==10990== HEAP SUMMARY:
==10990==     in use at exit: 0 bytes in 0 blocks
==10990==   total heap usage: 1,385 allocs, 1,385 frees, 11,854,313 bytes allocated
==10990==
==10990== All heap blocks were freed -- no leaks are possible
==10990==
==10990== For counts of detected and suppressed errors, rerun with: -v
==10990== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
