### PR TITLE
out_es: support nanosecond timestamp precision

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -329,13 +329,6 @@ static int elasticsearch_format(struct flb_config *config,
             flb_time_pop_from_msgpack(&tms, &result, &obj);
         }
 
-        /*
-         * Timestamp: Elasticsearch only support fractional seconds in
-         * milliseconds unit, not nanoseconds, so we take our nsec value and
-         * change it representation.
-         */
-        tms.tm.tv_nsec = (tms.tm.tv_nsec / 1000000);
-
         map   = root.via.array.ptr[1];
         map_size = map.via.map.size;
 
@@ -387,8 +380,14 @@ static int elasticsearch_format(struct flb_config *config,
         gmtime_r(&tms.tm.tv_sec, &tm);
         s = strftime(time_formatted, sizeof(time_formatted) - 1,
                      ctx->time_key_format, &tm);
-        len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
-                       ".%03" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec);
+        if (ctx->time_key_nanos) {
+            len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
+                           ".%09" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec);
+        } else {
+            len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
+                           ".%03" PRIu64 "Z",
+                           (uint64_t) tms.tm.tv_nsec / 1000000);
+        }
 
         s += len;
         msgpack_pack_str(&tmp_pck, s);
@@ -843,6 +842,11 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "time_key_format", FLB_ES_DEFAULT_TIME_KEYF,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, time_key_format),
+     NULL
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "time_key_nanos", "false",
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch, time_key_nanos),
      NULL
     },
     {

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -91,6 +91,9 @@ struct flb_elasticsearch {
     /* time key format */
     flb_sds_t time_key_format;
 
+    /* time key nanoseconds */
+    int time_key_nanos;
+
     /* include_tag_key */
     int include_tag_key;
     flb_sds_t tag_key;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Starting in Elasticsearch 7, a "date_nanos" data type was added, increasing timestamp precision from milliseconds to nanoseconds.

This patch adds a "Time_Key_Nanos" option which tells the ElasticSearch output plugin to send 9 decimal places instead of 3 to ElasticSearch.

Tests are included, and a patch to document the new option will be submitted shortly.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #2014.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
