### PR TITLE
out_azure: Add support for resource-context access mode  #2184

### DIFF
--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -206,7 +206,11 @@ static int build_headers(struct flb_http_client *c,
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
     flb_http_add_header(c, "x-ms-date", 9, rfc1123date,
                         flb_sds_len(rfc1123date));
-
+    /* Header resource_id is optional */
+    if (ctx->resource_id) {
+        flb_http_add_header(c, "x-ms-AzureResourceId", 20, ctx->resource_id ,flb_sds_len(ctx->resource_id));
+        flb_plg_debug(ctx->ins, "resource_id=%s", ctx->resource_id);
+    }
     size = 32 + flb_sds_len(ctx->customer_id) + olen;
     auth = flb_malloc(size);
     if (!auth) {

--- a/plugins/out_azure/azure.h
+++ b/plugins/out_azure/azure.h
@@ -36,6 +36,10 @@ struct flb_azure {
     /* account setup */
     flb_sds_t customer_id;
     flb_sds_t log_type;
+    flb_sds_t subscription_id;
+    flb_sds_t resource_group;
+    flb_sds_t resource_id;
+    flb_sds_t additional_providers;
     flb_sds_t shared_key;
     flb_sds_t dec_shared_key;
 


### PR DESCRIPTION
Add support for the resource-context access mode
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/design-logs-deployment#access-mode)

Fixes #2184 

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[SERVICE]
    Flush           5
    Daemon          off
    Log_Level       debug

[INPUT]
    Name mem
    Tag  mem

[OUTPUT]
    Name azure
    Match *
    Customer_ID xxxxxx
    Shared_Key  xxxxxx
    Resource_Group test
    Subscription_ID xxxxxx
    Additional_providers providers/Microsoft.OperationalInsights/workspaces/test
```

- [x] Debug log output from testing the change
```
[2020/09/14 07:57:46] [ info] Configuration:
[2020/09/14 07:57:46] [ info]  flush time     | 5.000000 seconds
[2020/09/14 07:57:46] [ info]  grace          | 5 seconds
[2020/09/14 07:57:46] [ info]  daemon         | 0
[2020/09/14 07:57:46] [ info] ___________
[2020/09/14 07:57:46] [ info]  inputs:
[2020/09/14 07:57:46] [ info]      mem
[2020/09/14 07:57:46] [ info] ___________
[2020/09/14 07:57:46] [ info]  filters:
[2020/09/14 07:57:46] [ info] ___________
[2020/09/14 07:57:46] [ info]  outputs:
[2020/09/14 07:57:46] [ info]      azure.0
[2020/09/14 07:57:46] [ info] ___________
[2020/09/14 07:57:46] [ info]  collectors:
[2020/09/14 07:57:46] [ info] [engine] started (pid=16379)
[2020/09/14 07:57:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/14 07:57:46] [debug] [storage] [cio stream] new stream registered: mem.0
[2020/09/14 07:57:46] [ info] [storage] version=1.0.5, initializing...
[2020/09/14 07:57:46] [ info] [storage] in-memory
[2020/09/14 07:57:46] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/14 07:57:46] [ info] [output:azure:azure.0] customer_id='xxxxxx' host='xxxxxx.ods.opinsights.azure.com:443'
[2020/09/14 07:57:46] [debug] [router] match rule mem.0:azure.0
[2020/09/14 07:57:46] [ info] [sp] stream processor started
[2020/09/14 07:57:50] [debug] [task] created task=0x5bb4cb93e3e0 id=0 OK
[2020/09/14 07:57:51] [debug] [output:azure:azure.0] resource_id=/resource/subscriptions/xxxxxx/resourcegroups/test/providers/Microsoft.OperationalInsights/workspaces/test
[2020/09/14 07:57:51] [ info] [output:azure:azure.0] customer_id=xxxxxx,
[azure_out_valgrind.log](https://github.com/fluent/fluent-bit/files/5216455/azure_out_valgrind.log)
 HTTP status=200
[2020/09/14 07:57:51] [debug] [upstream] KA connection #19 to xxxxxx.ods.opinsights.azure.com:443 is now available
[2020/09/14 07:57:51] [debug] [task] destroy task=0x5bb4cb93e3e0 (task_id=0)
[2020/09/14 07:57:55] [debug] [task] created task=0x5bb4cba7b1e0 id=0 OK
[2020/09/14 07:57:55] [debug] [upstream] KA connection #19 to xxxxxx.ods.opinsights.azure.com:443 has been assigned (recycled)
[2020/09/14 07:57:55] [debug] [output:azure:azure.0] resource_id=/resource/subscriptions/xxxxxx/resourcegroups/test/providers/Microsoft.OperationalInsights/workspaces/test
[2020/09/14 07:57:55] [ info] [output:azure:azure.0] customer_id=xxxxxx, HTTP status=200
[2020/09/14 07:57:55] [debug] [upstream] KA connection #19 to xxxxxx.ods.opinsights.azure.com:443 is now available
[2020/09/14 07:57:55] [debug] [task] destroy task=0x5bb4cba7b1e0 (task_id=0)
[2020/09/14 07:58:00] [debug] [task] created task=0x5bb4cba7d9e0 id=0 OK
[2020/09/14 07:58:00] [debug] [upstream] KA connection #19 to xxxxxx.ods.opinsights.azure.com:443 has been assigned (recycled)
[2020/09/14 07:58:00] [debug] [output:azure:azure.0] resource_id=/resource/subscriptions/xxxxxx/resourcegroups/test/providers/Microsoft.OperationalInsights/workspaces/test
[2020/09/14 07:58:00] [ info] [output:azure:azure.0] customer_id=xxxxxx, HTTP status=200
[2020/09/14 07:58:00] [debug] [upstream] KA connection #19 to xxxxxx.ods.opinsights.azure.com:443 is now available
[2020/09/14 07:58:00] [debug] [task] destroy task=0x5bb4cba7d9e0 (task_id=0)
```

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[azure_out_valgrind.log](https://github.com/fluent/fluent-bit/files/5216457/azure_out_valgrind.log)

**Documentation**
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/379

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
