### PR TITLE
Port Azure BLOB plugin to Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -42,6 +42,7 @@ set(FLB_IN_EMITTER            Yes)
 # OUTPUT plugins
 # ==============
 set(FLB_OUT_AZURE             Yes)
+set(FLB_OUT_AZURE_BLOB        Yes)
 set(FLB_OUT_BIGQUERY           No)
 set(FLB_OUT_COUNTER           Yes)
 set(FLB_OUT_DATADOG           Yes)

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -49,6 +49,7 @@ void flb_utils_split_free_entry(struct flb_split_entry *entry);
 void flb_utils_split_free(struct mk_list *list);
 int flb_utils_timer_consume(flb_pipefd_t fd);
 int64_t flb_utils_size_to_bytes(const char *size);
+int flb_utils_hex2int(char *hex, int len);
 int flb_utils_time_to_seconds(const char *time);
 int flb_utils_pipe_byte_consume(flb_pipefd_t fd);
 int flb_utils_bool(const char *val);

--- a/plugins/out_azure_blob/azure_blob_uri.c
+++ b/plugins/out_azure_blob/azure_blob_uri.c
@@ -91,7 +91,7 @@ flb_sds_t azb_uri_decode(const char *uri, size_t len)
             hex[1] = uri[i + 2];
             hex[2] = '\0';
 
-            hex_result = mk_utils_hex2int(hex, 2);
+            hex_result = flb_utils_hex2int(hex, 2);
             out[c++] = hex_result;
             i += 2;
         }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -434,6 +434,37 @@ int64_t flb_utils_size_to_bytes(const char *size)
     return val;
 }
 
+int flb_utils_hex2int(char *hex, int len)
+{
+    int i = 0;
+    int res = 0;
+    char c;
+
+    while ((c = *hex++) && i < len) {
+        res *= 0x10;
+
+        if (c >= 'a' && c <= 'f') {
+            res += (c - 0x57);
+        }
+        else if (c >= 'A' && c <= 'F') {
+            res += (c - 0x37);
+        }
+        else if (c >= '0' && c <= '9') {
+            res += (c - 0x30);
+        }
+        else {
+            return -1;
+        }
+        i++;
+    }
+
+    if (res < 0) {
+        return -1;
+    }
+
+    return res;
+}
+
 int flb_utils_time_to_seconds(const char *time)
 {
     int len;

--- a/tests/internal/mp.c
+++ b/tests/internal/mp.c
@@ -1,5 +1,6 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_mp.h>
@@ -10,7 +11,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #define APACHE_10K    FLB_TESTS_DATA_PATH "/data/mp/apache_10k.mp"
 


### PR DESCRIPTION
With this PR merged, `out_azure_blob` can be compiled and linked
on Windows.

I confirmed it works on Windows Server 2019 by sending test data
to  Azure Storage Account.

This patch also should fix CI builds on AppVeyor.
