### PR TITLE
pack: Use PRIu64/PRId64 to format 64 bit integers.

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -463,7 +463,7 @@ static int msgpack2json(char *buf, int *off, size_t left,
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
         {
             char temp[32] = {0};
-            i = snprintf(temp, sizeof(temp)-1, "%lu", (unsigned long)o->via.u64);
+            i = snprintf(temp, sizeof(temp)-1, "%"PRIu64, o->via.u64);
             ret = try_to_write(buf, off, left, temp, i);
         }
         break;
@@ -471,7 +471,7 @@ static int msgpack2json(char *buf, int *off, size_t left,
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
         {
             char temp[32] = {0};
-            i = snprintf(temp, sizeof(temp)-1, "%ld", (signed long)o->via.i64);
+            i = snprintf(temp, sizeof(temp)-1, "%"PRId64, o->via.i64);
             ret = try_to_write(buf, off, left, temp, i);
         }
         break;


### PR DESCRIPTION
Do not use `%lu` to format 64-bit int; A long can be 32-bit depending
on the system, so this line can implicitly truncate the target value.

This should fix the "timestamps are truncated inproperly" bug on
out_datadog reported by #2527. 

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
