### PR TITLE
Fix copy paste

### DIFF
--- a/plugins/in_forward/fw_config.h
+++ b/plugins/in_forward/fw_config.h
@@ -18,8 +18,8 @@
  *  limitations under the License.
  */
 
-#ifndef FLB_MQTT_CONFIG_H
-#define FLB_MQTT_CONFIG_H
+#ifndef FLB_IN_FW_CONFIG_H
+#define FLB_IN_FW_CONFIG_H
 
 #include "fw.h"
 


### PR DESCRIPTION
Use FLB_IN_FW_CONFIG_H instead the MQTT one

Looks like there is a file copy leftover.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
