### PR TITLE
in_tail: Add large file support for Windows

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -43,7 +43,7 @@
 #include "tail_dockermode.h"
 #include "tail_multiline.h"
 
-static inline int consume_byte(int fd)
+static inline int consume_byte(flb_pipefd_t fd)
 {
     int ret;
     uint64_t val;
@@ -229,7 +229,6 @@ static int in_tail_watcher_callback(struct flb_input_instance *ins,
     struct flb_tail_file *file;
     (void) config;
 
-#ifndef _MSC_VER
     mk_list_foreach_safe(head, tmp, &ctx->files_event) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
         if (file->is_link == FLB_TRUE) {
@@ -242,8 +241,6 @@ static int in_tail_watcher_callback(struct flb_input_instance *ins,
             flb_tail_file_rotated(file);
         }
     }
-
-#endif
     return ret;
 }
 

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -49,7 +49,7 @@ static inline int consume_byte(int fd)
     uint64_t val;
 
     /* We need to consume the byte */
-    ret = flb_pipe_r(fd, &val, sizeof(val));
+    ret = flb_pipe_r(fd, (char *) &val, sizeof(val));
     if (ret <= 0) {
         flb_errno();
         return -1;

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -39,13 +39,8 @@
 
 struct flb_tail_config {
     int fd_notify;             /* inotify fd               */
-#ifdef _WIN32
-    intptr_t ch_manager[2];    /* pipe: channel manager    */
-    intptr_t ch_pending[2];    /* pipe: pending events     */
-#else
-    int ch_manager[2];         /* pipe: channel manager    */
-    int ch_pending[2];         /* pipe: pending events     */
-#endif
+    flb_pipefd_t ch_manager[2];    /* pipe: channel manager    */
+    flb_pipefd_t ch_pending[2];    /* pipe: pending events     */
     int ch_reads;              /* count number if signal reads */
     int ch_writes;             /* count number of signal writes */
 

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -29,7 +29,7 @@
 struct query_status {
     int id;
     int rows;
-    off_t offset;
+    int64_t offset;
 };
 
 /* Open or create database required by tail plugin */

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -173,12 +173,12 @@ int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     return 0;
 }
 
-static int process_content(struct flb_tail_file *file, off_t *bytes)
+static int process_content(struct flb_tail_file *file, size_t *bytes)
 {
-    int len;
+    size_t len;
     int lines = 0;
     int ret;
-    off_t processed_bytes = 0;
+    size_t processed_bytes = 0;
     char *data;
     char *end;
     char *p;
@@ -377,7 +377,7 @@ static int tag_compose(char *tag, char *fname, char *out_buf, size_t *out_size,
 #endif
 {
     int i;
-    int len;
+    size_t len;
     char *p;
     size_t buf_s = 0;
 #ifdef FLB_HAVE_REGEX
@@ -544,8 +544,8 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
 {
     int fd;
     int ret;
-    int len;
-    off_t offset;
+    size_t len;
+    int64_t offset;
     char *tag;
     size_t tag_len;
     struct flb_tail_file *file;
@@ -697,7 +697,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
 
     /* Seek if required */
     if (file->offset > 0) {
-        flb_plg_debug(ctx->ins, "inode=%"PRIu64" appended file following on offset=%lu",
+        flb_plg_debug(ctx->ins, "inode=%"PRIu64" appended file following on offset=%"PRId64,
                       file->inode, file->offset);
         offset = lseek(file->fd, file->offset, SEEK_SET);
         if (offset == -1) {
@@ -800,8 +800,8 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
     int ret;
     char *tmp;
     size_t size;
-    off_t capacity;
-    off_t processed_bytes;
+    size_t capacity;
+    size_t processed_bytes;
     ssize_t bytes;
     struct stat st;
     struct flb_tail_config *ctx;
@@ -1261,7 +1261,7 @@ int flb_tail_file_purge(struct flb_input_instance *ins,
             if (ret == 0) {
                 flb_plg_debug(ctx->ins,
                               "inode=%"PRIu64" purge rotated file %s " \
-                              "(offset=%lu / size = %"PRIu64")",
+                              "(offset=%"PRId64" / size = %"PRIu64")",
                               file->inode, file->name, file->offset, st.st_size);
                 if (file->pending_bytes > 0 && flb_input_buf_paused(ins)) {
                     flb_plg_warn(ctx->ins, "purged rotated file while data "
@@ -1271,7 +1271,7 @@ int flb_tail_file_purge(struct flb_input_instance *ins,
             }
             else {
                 flb_plg_debug(ctx->ins,
-                              "inode=%"PRIu64" purge rotated file %s (offset=%lu)",
+                              "inode=%"PRIu64" purge rotated file %s (offset=%"PRId64")",
                               file->inode, file->name, file->offset);
             }
 

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1057,7 +1057,7 @@ char *flb_tail_file_name(struct flb_tail_file *file)
     char tmp[128];
 #elif defined(__APPLE__)
     char path[PATH_MAX];
-#elif defined(_MSC_VER)
+#elif defined(FLB_SYSTEM_WINDOWS)
     HANDLE h;
 #endif
 
@@ -1097,10 +1097,10 @@ char *flb_tail_file_name(struct flb_tail_file *file)
     memcpy(buf, path, len);
     buf[len] = '\0';
 
-#elif defined(_MSC_VER)
+#elif defined(FLB_SYSTEM_WINDOWS)
     int len;
 
-    h = _get_osfhandle(file->fd);
+    h = (HANDLE) _get_osfhandle(file->fd);
     if (h == INVALID_HANDLE_VALUE) {
         flb_errno();
         flb_free(buf);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -34,9 +34,9 @@ struct flb_tail_file {
     int watch_fd;
     /* file lookup info */
     int fd;
-    off_t size;
-    off_t offset;
-    off_t last_line;
+    int64_t size;
+    int64_t offset;
+    int64_t last_line;
     uint64_t  inode;
     uint64_t  link_inode;
     int   is_link;
@@ -44,7 +44,7 @@ struct flb_tail_file {
     char *real_name;            /* real file name in the file system */
     size_t name_len;
     time_t rotated;
-    off_t pending_bytes;
+    int64_t pending_bytes;
 
     /* dynamic tag for this file */
     int tag_len;
@@ -67,8 +67,8 @@ struct flb_tail_file {
     bool dmode_complete;        /* buffer contains completed log         */
 
     /* buffering */
-    off_t parsed;
-    off_t buf_len;
+    size_t parsed;
+    size_t buf_len;
     size_t buf_size;
     char *buf_data;
 

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -159,7 +159,7 @@ static int tail_fs_event(struct flb_input_instance *ins,
                          struct flb_config *config, void *in_context)
 {
     int ret;
-    off_t offset;
+    int64_t offset;
     struct mk_list *head;
     struct mk_list *tmp;
     struct flb_tail_config *ctx = in_context;

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -86,7 +86,7 @@ static int tail_fs_check(struct flb_input_instance *ins,
                          struct flb_config *config, void *in_context)
 {
     int ret;
-    off_t offset;
+    int64_t offset;
     char *name;
     struct mk_list *tmp;
     struct mk_list *head;

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -273,7 +273,7 @@ static inline int is_last_key_val_string(char *buf, size_t size)
 }
 
 int flb_tail_mult_process_content(time_t now,
-                                  char *buf, int len,
+                                  char *buf, size_t len,
                                   struct flb_tail_file *file,
                                   struct flb_tail_config *ctx)
 {

--- a/plugins/in_tail/tail_multiline.h
+++ b/plugins/in_tail/tail_multiline.h
@@ -44,7 +44,7 @@ int flb_tail_mult_create(struct flb_tail_config *ctx,
 int flb_tail_mult_destroy(struct flb_tail_config *ctx);
 
 int flb_tail_mult_process_content(time_t now,
-                                  char *buf, int len,
+                                  char *buf, size_t len,
                                   struct flb_tail_file *file,
                                   struct flb_tail_config *ctx);
 int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf,

--- a/plugins/in_tail/tail_signal.h
+++ b/plugins/in_tail/tail_signal.h
@@ -44,7 +44,7 @@ static inline int tail_signal_manager(struct flb_tail_config *ctx)
     }
 
     /* Insert a dummy event into the channel manager */
-    n = flb_pipe_w(ctx->ch_manager[1], &val, sizeof(val));
+    n = flb_pipe_w(ctx->ch_manager[1], (const char *) &val, sizeof(val));
     if (n == -1) {
         flb_errno();
         return -1;
@@ -62,7 +62,7 @@ static inline int tail_signal_pending(struct flb_tail_config *ctx)
     uint64_t val = 0xc002;
 
     /* Insert a dummy event into the 'pending' channel */
-    n = flb_pipe_w(ctx->ch_pending[1], &val, sizeof(val));
+    n = flb_pipe_w(ctx->ch_pending[1], (const char *) &val, sizeof(val));
 
     /*
      * If we get EAGAIN, it simply means pending channel is full. As
@@ -86,7 +86,7 @@ static inline int tail_consume_pending(struct flb_tail_config *ctx)
      * blocked (pipe is empty).
      */
     do {
-        ret = flb_pipe_r(ctx->ch_pending[0], &val, sizeof(val));
+        ret = flb_pipe_r(ctx->ch_pending[0], (char *) &val, sizeof(val));
         if (ret <= 0 && !FLB_PIPE_WOULDBLOCK()) {
             flb_errno();
             return -1;

--- a/plugins/in_tail/win32/stat.h
+++ b/plugins/in_tail/win32/stat.h
@@ -39,4 +39,6 @@ int win32_fstat(const char *path, struct win32_stat *wst);
 #define WIN32_S_IFLNK 0xc000
 #define WIN32_S_IFMT  0xf000
 
+#define lseek _lseeki64
+
 #endif


### PR DESCRIPTION
 
Previously it was not possible to handle files larger than 2GB on
Windows as discussed in #2208.

The fix is archived by migrating each vairable and function to be
explicitly 64-bit ready.
 
Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
