### PR TITLE
pack: fix json floating point format regression

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -478,7 +478,12 @@ static int msgpack2json(char *buf, int *off, size_t left,
     case MSGPACK_OBJECT_FLOAT64:
         {
             char temp[512] = {0};
-            i = snprintf(temp, sizeof(temp)-1, "%.16g", o->via.f64);
+            if (o->via.f64 == (double)(long long int)o->via.f64) {
+                i = snprintf(temp, sizeof(temp)-1, "%.1f", o->via.f64);
+            }
+            else {
+                i = snprintf(temp, sizeof(temp)-1, "%.16g", o->via.f64);
+            }
             ret = try_to_write(buf, off, left, temp, i);
         }
         break;


### PR DESCRIPTION
The recent change to the JSON floating point formatting to use `%.16g` caused a
regression where values that have no fractional part are formatted as integers.
For example, `10.0` gets formatted as `10`. This patch uses the same approach
as https://github.com/ohler55/oj/blob/v3.10.13/ext/oj/dump_strict.c#L100-L101,
which is used in Fluentd. It checks if the double value is equal to the integer
part, and if so, will use `%.1f` as the format to ensure the decimal part is
still rendered (with a single decimal place of `.0`). This prevents downstream
datastores from having data type conflicts.

This was tested by building locally and running through different value using
the dummy input plugin and stdout output plugin with json_lines formatting.
Will include example outputs of tests in Pull Request.

Signed-off-by: Joey Paskhay <joey.paskhay@gmail.com>

Fixes #2482 

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
