### PR TITLE
out_cloudwatch_logs: fix payload creation bugs

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -441,7 +441,7 @@ int process_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
         }
 
         tmp_buf_ptr++; /* pass over the opening quote */
-        buf->tmp_buf_offset += written;
+        buf->tmp_buf_offset += (written + 1);
         event = &buf->events[buf->event_index];
         event->json = tmp_buf_ptr;
         event->len = written;

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -36,6 +36,9 @@
 /* number of characters needed to 'end' a PutLogEvents payload */
 #define PUT_LOG_EVENTS_FOOTER_LEN      4
 
+/* 256KiB minus 26 bytes for the event */
+#define MAX_EVENT_LEN      262118
+
 #include "cloudwatch_logs.h"
 
 void cw_flush_destroy(struct cw_flush *buf);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -26,7 +26,7 @@
  * For reasons that are under investigation, using that number in this plugin
  * leads to API errors. No issues have been seen setting it to 1,000,000 bytes.
  */
-#define PUT_LOG_EVENTS_PAYLOAD_SIZE    1000000
+#define PUT_LOG_EVENTS_PAYLOAD_SIZE    1048576
 #define MAX_EVENTS_PER_PUT             10000
 
 /* number of characters needed to 'start' a PutLogEvents payload */


### PR DESCRIPTION

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
