### PR TITLE
fstore: fix null dereference (CID 309455)

### DIFF
--- a/src/flb_fstore.c
+++ b/src/flb_fstore.c
@@ -207,7 +207,7 @@ struct flb_fstore *flb_fstore_create(char *path, char *stream_name)
     /* create file-system based stream */
     stream = cio_stream_create(cio, stream_name, CIO_STORE_FS);
     if (!stream) {
-        flb_error("[fstore] cannot create stream %s/%s", path, stream->name);
+        flb_error("[fstore] cannot create stream %s/%s", path, stream_name);
         flb_free(fs);
         cio_destroy(cio);
         return NULL;


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
