### PR TITLE
aws_util: fix double free issues in get_s3_key (CID 309453 & 309443)

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -755,6 +755,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char 
     }
 
     flb_sds_destroy(tmp);
+    tmp = NULL;
 
     /* Split the string on the delimiters */
     tag_token = strtok(tmp_tag, tag_delimiter);
@@ -783,8 +784,10 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char 
         }
 
         flb_sds_destroy(tmp);
+        tmp = NULL;
         flb_sds_destroy(s3_key);
         s3_key = tmp_key;
+        tmp_key = NULL;
 
         tag_token = strtok(NULL, tag_delimiter);
         i++;
@@ -814,10 +817,12 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char 
 
     flb_sds_destroy(s3_key);
     s3_key = tmp_key;
+    tmp_key = NULL;
 
     gmt = gmtime(&time);
 
     flb_sds_destroy(tmp);
+    tmp = NULL;
 
     /* A string longer than S3_KEY_SIZE is created to store the formatted timestamp. */
     tmp = flb_sds_create_size(S3_KEY_SIZE);
@@ -835,6 +840,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char 
     FLB_SDS_HEADER(s3_key)->len = strlen(s3_key);
 
     flb_sds_destroy(tmp_tag);
+    tmp_tag = NULL;
     return s3_key;
 
     error:
@@ -853,9 +859,6 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char 
         }
         if (tmp_key){
             flb_sds_destroy(tmp_key);
-        }
-        if (tag_token){
-            flb_free(tag_token);
         }
         return NULL;
 }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
