### PR TITLE
out_s3: fix mem leak (CID 309438)

### DIFF
--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -197,10 +197,10 @@ static struct multipart_upload *upload_from_file(struct flb_s3 *ctx,
     }
 
     parse_etags(m_upload, buffered_data);
+    flb_free(buffered_data);
     if (m_upload->part_number == 0) {
         flb_plg_error(ctx->ins, "Could not extract upload data from %s",
                       chunk->file_path);
-        flb_free(buffered_data);
         multipart_upload_destroy(m_upload);
         return NULL;
     }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
