### PR TITLE
expand the EC2 metedata fields

### DIFF
--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -36,6 +36,13 @@
 
 #define FLB_FILTER_AWS_IMDS_INSTANCE_ID_PATH              "/latest/meta-data/instance-id/"
 #define FLB_FILTER_AWS_IMDS_AZ_PATH                       "/latest/meta-data/placement/availability-zone/"
+#define FLB_FILTER_AWS_IMDS_INSTANCE_TYPE_PATH            "/latest/meta-data/instance-type/"
+#define FLB_FILTER_AWS_IMDS_PRIVATE_IP_PATH               "/latest/meta-data/local-ipv4/"
+#define FLB_FILTER_AWS_IMDS_VPC_ID_PATH_PREFIX            "/latest/meta-data/network/interfaces/macs/"
+#define FLB_FILTER_AWS_IMDS_AMI_ID_PATH                   "/latest/meta-data/ami-id/"
+#define FLB_FILTER_AWS_IMDS_ACCOUNT_ID_PATH               "/latest/dynamic/instance-identity/document/"
+#define FLB_FILTER_AWS_IMDS_HOSTNAME_PATH                 "/latest/meta-data/hostname/"
+#define FLB_FILTER_AWS_IMDS_MAC_PATH                      "/latest/meta-data/mac/"
 
 #define FLB_FILTER_AWS_IMDS_V2_TOKEN_HEADER               "X-aws-ec2-metadata-token"
 #define FLB_FILTER_AWS_IMDS_V2_TOKEN_HEADER_LEN           24
@@ -44,6 +51,18 @@
 #define FLB_FILTER_AWS_AVAILABILITY_ZONE_KEY_LEN          2
 #define FLB_FILTER_AWS_INSTANCE_ID_KEY                    "ec2_instance_id"
 #define FLB_FILTER_AWS_INSTANCE_ID_KEY_LEN                15
+#define FLB_FILTER_AWS_INSTANCE_TYPE_KEY                  "ec2_instance_type"
+#define FLB_FILTER_AWS_INSTANCE_TYPE_KEY_LEN              17
+#define FLB_FILTER_AWS_PRIVATE_IP_KEY                     "private_ip"
+#define FLB_FILTER_AWS_PRIVATE_IP_KEY_LEN                 10
+#define FLB_FILTER_AWS_VPC_ID_KEY                         "vpc_id"
+#define FLB_FILTER_AWS_VPC_ID_KEY_LEN                     6
+#define FLB_FILTER_AWS_AMI_ID_KEY                         "ami_id"
+#define FLB_FILTER_AWS_AMI_ID_KEY_LEN                     6
+#define FLB_FILTER_AWS_ACCOUNT_ID_KEY                     "account_id"
+#define FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN                 10
+#define FLB_FILTER_AWS_HOSTNAME_KEY                       "hostname"
+#define FLB_FILTER_AWS_HOSTNAME_KEY_LEN                   8
 
 struct flb_filter_aws {
     /* upstream connection to ec2 IMDS */
@@ -66,6 +85,31 @@ struct flb_filter_aws {
     flb_sds_t instance_id;
     size_t instance_id_len;
     int instance_id_include;
+
+    flb_sds_t instance_type;
+    size_t instance_type_len;
+    int instance_type_include;
+
+    flb_sds_t private_ip;
+    size_t private_ip_len;
+    int private_ip_include;
+
+    flb_sds_t vpc_id;
+    size_t vpc_id_len;
+    int vpc_id_include;
+
+    flb_sds_t ami_id;
+    size_t ami_id_len;
+    int ami_id_include;
+
+    flb_sds_t account_id;
+    size_t account_id_len;
+    int account_id_include;
+
+
+    flb_sds_t hostname;
+    size_t hostname_len;
+    int hostname_include;
 
     /* number of new keys added by this plugin */
     int new_keys;

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -567,7 +567,7 @@ flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key)
     const jsmntok_t *t = NULL;
     char *current_token = NULL;
     jsmn_parser parser;
-    int tokens_size = 10;
+    int tokens_size = 50;
     size_t size;
     int ret;
     int i = 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->
This commit is for expand the AWS filter for supporting more EC2 metadata.
The default two fields:
* az            ${availability_zone}
* ec2_instance_id    ${instance_id}

The new fields are:
* hostname      ${hostname}
* ec2_instance_type ${instance_type}
* private_ip    ${private_ip}
* vpc_id        ${vpc_id}
* ami_id        ${image_id}
* account_id    ${account_id}
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
AWS Metadata Filter Plugin for EC2/ECS Metadata #1780

----

**Testing**
Example configuration
```
[FILTER]
    Name aws
    Match *
    imds_version v2
    az true
    ec2_instance_id true
    ec2_instance_type true
    private_ip true
    ami_id true
    account_id true
    hostname true
    vpc_id true
```
Debug log output
```
[ec2-user@ip-172-31-6-59 build]$ bin/fluent-bit -c ../../config/fluent-bit.conf
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/28 07:08:44] [ info] Configuration:
[2020/09/28 07:08:44] [ info]  flush time     | 1.000000 seconds
[2020/09/28 07:08:44] [ info]  grace          | 5 seconds
[2020/09/28 07:08:44] [ info]  daemon         | 0
[2020/09/28 07:08:44] [ info] ___________
[2020/09/28 07:08:44] [ info]  inputs:
[2020/09/28 07:08:44] [ info]      dummy
[2020/09/28 07:08:44] [ info] ___________
[2020/09/28 07:08:44] [ info]  filters:
[2020/09/28 07:08:44] [ info]      aws.0
[2020/09/28 07:08:44] [ info] ___________
[2020/09/28 07:08:44] [ info]  outputs:
[2020/09/28 07:08:44] [ info]      stdout.0
[2020/09/28 07:08:44] [ info] ___________
[2020/09/28 07:08:44] [ info]  collectors:
[2020/09/28 07:08:44] [ info] [engine] started (pid=20300)
[2020/09/28 07:08:44] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/28 07:08:44] [debug] [storage] [cio stream] new stream registered: dummy.0
[2020/09/28 07:08:44] [ info] [storage] version=1.0.5, initializing...
[2020/09/28 07:08:44] [ info] [storage] in-memory
[2020/09/28 07:08:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/28 07:08:44] [debug] [router] match rule dummy.0:stdout.0
[2020/09/28 07:08:44] [ info] [sp] stream processor started
[2020/09/28 07:08:45] [debug] [task] created task=0xc6d6f0 id=0 OK
[0] dummy: [1601276924.970099555, {"message"=>"dummy", "az"=>"us-west-2c", "ec2_instance_id"=>"i-0c862eca9038f5aae", "ec2_instance_type"=>"t2.medium", "private_ip"=>"172.31.6.59", "vpc_id"=>"vpc-7ea11c06", "ami_id"=>"ami-0841edc20334f9287", "account_id"=>"953271681497", "hostname"=>"ip-172-31-6-59.us-west-2.compute.internal"}]
^C[engine] caught signal (SIGINT)
```

Valgrind
```
[2020/09/28 06:28:28] [debug] [task] destroy task=0x5f031f0 (task_id=0)
[0] dummy: [1601274509.970235760, {"message"=>"dummy", "az"=>"us-west-2c", "ec2_instance_id"=>"i-0c862eca9038f5aae", "ec2_instance_type"=>"t2.medium", "private_ip"=>"172.31.6.59", "vpc_id"=>"vpc-7ea11c06", "ami_id"=>"ami-0841edc20334f9287", "account_id"=>"953271681497", "hostname"=>"ip-172-31-6-59.us-west-2.compute.internal"}]
[2020/09/28 06:28:29] [debug] [task] created task=0x5f55d50 id=0 OK
[2020/09/28 06:28:29] [debug] [task] destroy task=0x5f55d50 (task_id=0)
^C[engine] caught signal (SIGINT)
==20167== 
==20167== HEAP SUMMARY:
==20167==     in use at exit: 0 bytes in 0 blocks
==20167==   total heap usage: 629 allocs, 629 frees, 2,169,054 bytes allocated
==20167== 
==20167== All heap blocks were freed -- no leaks are possible
==20167== 
==20167== For counts of detected and suppressed errors, rerun with: -v
==20167== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
