### PR TITLE
out_stackdriver: use the correct project ID

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -44,7 +44,7 @@ static int fetch_metadata(struct flb_stackdriver *ctx,
     /* If runtime test mode is enabled, add test data */
     if (ctx->ins->test_mode == FLB_TRUE) {
         if (strcmp(uri, FLB_STD_METADATA_PROJECT_ID_URI) == 0) {
-            flb_sds_cat(payload, "111222333", 9);
+            flb_sds_cat(payload, "fluent-bit-test", 9);
             return 0;
         }
         else if (strcmp(uri, FLB_STD_METADATA_ZONE_URI) == 0) {

--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -23,7 +23,7 @@
 #include "stackdriver.h"
 
 /* Project ID metadata URI */
-#define FLB_STD_METADATA_PROJECT_ID_URI "/computeMetadata/v1/project/numeric-project-id"
+#define FLB_STD_METADATA_PROJECT_ID_URI "/computeMetadata/v1/project/project-id"
 
 /* Zone metadata URI */
 #define FLB_STD_METADATA_ZONE_URI "/computeMetadata/v1/instance/zone"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -313,7 +313,7 @@ static void cb_check_gce_instance(void *ctx, int ffd,
 
     /* project id */
     ret = mp_kv_cmp(res_data, res_size,
-                    "$resource['labels']['project_id']", "111222333");
+                    "$resource['labels']['project_id']", "fluent-bit-test");
     TEST_CHECK(ret == FLB_TRUE);
 
     /* zone */


### PR DESCRIPTION
The value for project ID of monitored resources of a LogEntry should be
project ID, not the project number, which is in numeric format.

The value of the project ID of Cloud Logging's Monitored Resources are
documented in
https://cloud.google.com/logging/docs/api/v2/resource-list.

The project ID to be retrived from instance metadata is documented in
https://cloud.google.com/compute/docs/storing-retrieving-metadata#default.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
