### PR TITLE
out_stackdriver: support monitored resource ingestion from log entry

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -341,6 +341,93 @@ static flb_sds_t get_str_value_from_msgpack_map(msgpack_object_map map,
     return ptr;
 }
 
+/* parse_monitored_resource is to extract the monitoired resource labels
+ * from "logging.googleapis.com/monitored_resource" in log data
+ * and append to 'resource'/'labels' in log entry.
+ * Monitored resource type is already read from resource field in stackdriver
+ * output plugin configuration parameters.
+ *
+ * The structure of monitored_resource is:
+ * {
+ *   "logging.googleapis.com/monitored_resource": {
+ *      "labels": {
+ *         "resource_label": <label_value>,
+ *      }
+ *    }
+ * }
+ * See https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
+ * for required labels for each monitored resource.
+ */
+
+static int parse_monitored_resource(struct flb_stackdriver *ctx, const void *data, size_t bytes, msgpack_packer *mp_pck)
+{
+    int ret = -1;
+    size_t off = 0;
+    msgpack_object *obj;
+    msgpack_unpacked result;
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+        if (result.data.via.array.size != 2) {
+            continue;
+        }
+        obj = &result.data.via.array.ptr[1];
+        if (obj->type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
+        msgpack_object_kv *kv = obj->via.map.ptr;
+        msgpack_object_kv *const kvend = obj->via.map.ptr + obj->via.map.size;
+        for (; kv < kvend; ++kv) {
+          if (kv->val.type == MSGPACK_OBJECT_MAP && kv->key.type == MSGPACK_OBJECT_STR
+          && strncmp (MONITORED_RESOURCE_KEY, kv->key.via.str.ptr, kv->key.via.str.size) == 0) {
+            msgpack_object subobj = kv->val;
+            msgpack_object_kv *p = subobj.via.map.ptr;
+            msgpack_object_kv *pend = subobj.via.map.ptr + subobj.via.map.size;
+            for (; p < pend; ++p) {
+              if (p->key.type != MSGPACK_OBJECT_STR || p->val.type != MSGPACK_OBJECT_MAP) {
+                continue;
+              }
+              if (strncmp("labels", p->key.via.str.ptr, p->key.via.str.size) == 0) {
+                  msgpack_object labels = p->val;
+                  msgpack_object_kv *q = labels.via.map.ptr;
+                  msgpack_object_kv *qend = labels.via.map.ptr + labels.via.map.size;
+                  int fields = 0;
+                  for (; q < qend; ++q) {
+                    if (q->key.type != MSGPACK_OBJECT_STR || q->val.type != MSGPACK_OBJECT_STR) {
+                        flb_plg_error(ctx->ins, "Key and value should be string in the %s/labels", MONITORED_RESOURCE_KEY);
+                    }
+                    ++fields;
+                  }
+                  if (fields > 0) {
+                    msgpack_pack_map(mp_pck, fields);
+                    q = labels.via.map.ptr;
+                    for (; q < qend; ++q) {
+                      if (q->key.type != MSGPACK_OBJECT_STR || q->val.type != MSGPACK_OBJECT_STR) {
+                          continue;
+                      }
+                      flb_plg_debug(ctx->ins, "[%s] found in the payload", MONITORED_RESOURCE_KEY);
+                      msgpack_pack_str(mp_pck, q->key.via.str.size);
+                      msgpack_pack_str_body(mp_pck, q->key.via.str.ptr, q->key.via.str.size);
+                      msgpack_pack_str(mp_pck, q->val.via.str.size);
+                      msgpack_pack_str_body(mp_pck, q->val.via.str.ptr, q->val.via.str.size);
+                    }
+                    msgpack_unpacked_destroy(&result);
+                    ret = 0;
+                    return ret;
+                  }
+              }
+            }
+          }
+        }
+    }
+
+    msgpack_unpacked_destroy(&result);
+    flb_plg_debug(ctx->ins, "[%s] not found in the payload", MONITORED_RESOURCE_KEY);
+    return ret;
+}
+
 /*
  * Given a local_resource_id, split the content using the proper separator generating
  * a linked list to store the spliited string
@@ -999,11 +1086,13 @@ static int pack_json_payload(int insert_id_extracted,
     int len_to_be_removed;
     int key_not_found;
     flb_sds_t removed;
+    flb_sds_t monitored_resource_key;
     flb_sds_t local_resource_id_key;
     flb_sds_t stream;
     msgpack_object_kv *kv = obj->via.map.ptr;
     msgpack_object_kv *const kvend = obj->via.map.ptr + obj->via.map.size;
 
+    monitored_resource_key = flb_sds_create(MONITORED_RESOURCE_KEY);
     local_resource_id_key = flb_sds_create(LOCAL_RESOURCE_ID_KEY);
     stream = flb_sds_create("stream");
     /*
@@ -1012,6 +1101,7 @@ static int pack_json_payload(int insert_id_extracted,
      */
     flb_sds_t to_be_removed[] =
     {
+        monitored_resource_key,
         local_resource_id_key,
         ctx->labels_key,
         stream
@@ -1143,11 +1233,13 @@ static int pack_json_payload(int insert_id_extracted,
         }
     }
 
+    flb_sds_destroy(monitored_resource_key);
     flb_sds_destroy(local_resource_id_key);
     flb_sds_destroy(stream);
     return 0;
 
     error:
+        flb_sds_destroy(monitored_resource_key);
         flb_sds_destroy(local_resource_id_key);
         flb_sds_destroy(stream);
         return ret;
@@ -1279,186 +1371,194 @@ static int stackdriver_format(struct flb_config *config,
         }
     }
 
-    if (strcmp(ctx->resource, "global") == 0) {
-      /* global resource has field project_id */
-      msgpack_pack_map(&mp_pck, 1);
-      msgpack_pack_str(&mp_pck, 10);
-      msgpack_pack_str_body(&mp_pck, "project_id", 10);
-      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-      msgpack_pack_str_body(&mp_pck,
-                            ctx->project_id, flb_sds_len(ctx->project_id));
-    }
-    else if (strcmp(ctx->resource, "gce_instance") == 0) {
-      /* gce_instance resource has fields project_id, zone, instance_id */
-      msgpack_pack_map(&mp_pck, 3);
+    ret = parse_monitored_resource(ctx, data, bytes, &mp_pck);
+    if (ret != 0) {
+        if (strcmp(ctx->resource, "global") == 0) {
+            /* global resource has field project_id */
+            msgpack_pack_map(&mp_pck, 1);
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
+        }
+        else if (strcmp(ctx->resource, "gce_instance") == 0) {
+            /* gce_instance resource has fields project_id, zone, instance_id */
+            msgpack_pack_map(&mp_pck, 3);
 
-      msgpack_pack_str(&mp_pck, 10);
-      msgpack_pack_str_body(&mp_pck, "project_id", 10);
-      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-      msgpack_pack_str_body(&mp_pck,
-                            ctx->project_id, flb_sds_len(ctx->project_id));
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
 
-      msgpack_pack_str(&mp_pck, 4);
-      msgpack_pack_str_body(&mp_pck, "zone", 4);
-      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->zone));
-      msgpack_pack_str_body(&mp_pck, ctx->zone, flb_sds_len(ctx->zone));
+            msgpack_pack_str(&mp_pck, 4);
+            msgpack_pack_str_body(&mp_pck, "zone", 4);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->zone));
+            msgpack_pack_str_body(&mp_pck, ctx->zone, flb_sds_len(ctx->zone));
 
-      msgpack_pack_str(&mp_pck, 11);
-      msgpack_pack_str_body(&mp_pck, "instance_id", 11);
-      msgpack_pack_str(&mp_pck, flb_sds_len(ctx->instance_id));
-      msgpack_pack_str_body(&mp_pck,
-                            ctx->instance_id, flb_sds_len(ctx->instance_id));
-    }
-    else if (strcmp(ctx->resource, K8S_CONTAINER) == 0) {
-        /* k8s_container resource has fields project_id, location, cluster_name,
-         *                                   namespace_name, pod_name, container_name
-         *
-         * The local_resource_id for k8s_container is in format:
-         *    k8s_container.<namespace_name>.<pod_name>.<container_name>
-         */
+            msgpack_pack_str(&mp_pck, 11);
+            msgpack_pack_str_body(&mp_pck, "instance_id", 11);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->instance_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->instance_id, flb_sds_len(ctx->instance_id));
+        }
+        else if (strcmp(ctx->resource, K8S_CONTAINER) == 0) {
+            /* k8s_container resource has fields project_id, location, cluster_name,
+             *                                   namespace_name, pod_name, container_name
+             *
+             * The local_resource_id for k8s_container is in format:
+             *    k8s_container.<namespace_name>.<pod_name>.<container_name>
+             */
 
-        if (is_tag_match_regex(ctx, tag, tag_len) > 0) {
-            ret = extract_resource_labels_from_regex(ctx, tag, tag_len);
+            if (is_tag_match_regex(ctx, tag, tag_len) > 0) {
+                ret = extract_resource_labels_from_regex(ctx, tag, tag_len);
+            }
+            else {
+                ret = process_local_resource_id(ctx, K8S_CONTAINER);
+            }
+
+            if (ret == -1) {
+                flb_plg_error(ctx->ins, "fail to extract resource labels "
+                              "for k8s_container resource type");
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
+            }
+
+            msgpack_pack_map(&mp_pck, 6);
+
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "location", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_location, flb_sds_len(ctx->cluster_location));
+
+            msgpack_pack_str(&mp_pck, 12);
+            msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_name, flb_sds_len(ctx->cluster_name));
+
+            msgpack_pack_str(&mp_pck, 14);
+            msgpack_pack_str_body(&mp_pck, "namespace_name", 14);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->namespace_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->namespace_name, flb_sds_len(ctx->namespace_name));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "pod_name", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->pod_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->pod_name, flb_sds_len(ctx->pod_name));
+
+            msgpack_pack_str(&mp_pck, 14);
+            msgpack_pack_str_body(&mp_pck, "container_name", 14);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->container_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->container_name, flb_sds_len(ctx->container_name));
+        }
+        else if (strcmp(ctx->resource, K8S_NODE) == 0) {
+            /* k8s_node resource has fields project_id, location, cluster_name, node_name
+             *
+             * The local_resource_id for k8s_node is in format:
+             *      k8s_node.<node_name>
+             */
+
+            ret = process_local_resource_id(ctx, K8S_NODE);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "fail to process local_resource_id from "
+                              "log entry for k8s_node");
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
+            }
+
+            msgpack_pack_map(&mp_pck, 4);
+
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "location", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_location, flb_sds_len(ctx->cluster_location));
+
+            msgpack_pack_str(&mp_pck, 12);
+            msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_name, flb_sds_len(ctx->cluster_name));
+
+            msgpack_pack_str(&mp_pck, 9);
+            msgpack_pack_str_body(&mp_pck, "node_name", 9);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->node_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->node_name, flb_sds_len(ctx->node_name));
+        }
+        else if (strcmp(ctx->resource, K8S_POD) == 0) {
+            /* k8s_pod resource has fields project_id, location, cluster_name,
+             *                             namespace_name, pod_name.
+             *
+             * The local_resource_id for k8s_pod is in format:
+             *      k8s_pod.<namespace_name>.<pod_name>
+             */
+
+            ret = process_local_resource_id(ctx, K8S_POD);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "fail to process local_resource_id from "
+                              "log entry for k8s_pod");
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
+            }
+
+            msgpack_pack_map(&mp_pck, 5);
+
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "location", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_location, flb_sds_len(ctx->cluster_location));
+
+            msgpack_pack_str(&mp_pck, 12);
+            msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->cluster_name, flb_sds_len(ctx->cluster_name));
+
+            msgpack_pack_str(&mp_pck, 14);
+            msgpack_pack_str_body(&mp_pck, "namespace_name", 14);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->namespace_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->namespace_name, flb_sds_len(ctx->namespace_name));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "pod_name", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->pod_name));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->pod_name, flb_sds_len(ctx->pod_name));
         }
         else {
-            ret = process_local_resource_id(ctx, K8S_CONTAINER);
-        }
-
-        if (ret == -1) {
-            flb_plg_error(ctx->ins, "fail to extract resource labels "
-                          "for k8s_container resource type");
+            flb_plg_error(ctx->ins, "unsupported resource type '%s'",
+                          ctx->resource);
             msgpack_sbuffer_destroy(&mp_sbuf);
             return -1;
         }
-
-        msgpack_pack_map(&mp_pck, 6);
-
-        msgpack_pack_str(&mp_pck, 10);
-        msgpack_pack_str_body(&mp_pck, "project_id", 10);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->project_id, flb_sds_len(ctx->project_id));
-
-        msgpack_pack_str(&mp_pck, 8);
-        msgpack_pack_str_body(&mp_pck, "location", 8);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_location, flb_sds_len(ctx->cluster_location));
-
-        msgpack_pack_str(&mp_pck, 12);
-        msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_name, flb_sds_len(ctx->cluster_name));
-
-        msgpack_pack_str(&mp_pck, 14);
-        msgpack_pack_str_body(&mp_pck, "namespace_name", 14);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->namespace_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->namespace_name, flb_sds_len(ctx->namespace_name));
-
-        msgpack_pack_str(&mp_pck, 8);
-        msgpack_pack_str_body(&mp_pck, "pod_name", 8);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->pod_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->pod_name, flb_sds_len(ctx->pod_name));
-
-        msgpack_pack_str(&mp_pck, 14);
-        msgpack_pack_str_body(&mp_pck, "container_name", 14);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->container_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->container_name, flb_sds_len(ctx->container_name));
     }
-    else if (strcmp(ctx->resource, K8S_NODE) == 0) {
-        /* k8s_node resource has fields project_id, location, cluster_name, node_name
-         *
-         * The local_resource_id for k8s_node is in format:
-         *      k8s_node.<node_name>
-         */
-
-        ret = process_local_resource_id(ctx, K8S_NODE);
-        if (ret != 0) {
-            flb_plg_error(ctx->ins, "fail to process local_resource_id from "
-                          "log entry for k8s_node");
-            msgpack_sbuffer_destroy(&mp_sbuf);
-            return -1;
-        }
-
-        msgpack_pack_map(&mp_pck, 4);
-
-        msgpack_pack_str(&mp_pck, 10);
-        msgpack_pack_str_body(&mp_pck, "project_id", 10);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->project_id, flb_sds_len(ctx->project_id));
-
-        msgpack_pack_str(&mp_pck, 8);
-        msgpack_pack_str_body(&mp_pck, "location", 8);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_location, flb_sds_len(ctx->cluster_location));
-
-        msgpack_pack_str(&mp_pck, 12);
-        msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_name, flb_sds_len(ctx->cluster_name));
-
-        msgpack_pack_str(&mp_pck, 9);
-        msgpack_pack_str_body(&mp_pck, "node_name", 9);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->node_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->node_name, flb_sds_len(ctx->node_name));
-    }
-    else if (strcmp(ctx->resource, K8S_POD) == 0) {
-        /* k8s_pod resource has fields project_id, location, cluster_name,
-         *                             namespace_name, pod_name.
-         *
-         * The local_resource_id for k8s_pod is in format:
-         *      k8s_pod.<namespace_name>.<pod_name>
-         */
-
-        ret = process_local_resource_id(ctx, K8S_POD);
-        if (ret != 0) {
-            flb_plg_error(ctx->ins, "fail to process local_resource_id from "
-                          "log entry for k8s_pod");
-            msgpack_sbuffer_destroy(&mp_sbuf);
-            return -1;
-        }
-
-        msgpack_pack_map(&mp_pck, 5);
-
-        msgpack_pack_str(&mp_pck, 10);
-        msgpack_pack_str_body(&mp_pck, "project_id", 10);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->project_id, flb_sds_len(ctx->project_id));
-
-        msgpack_pack_str(&mp_pck, 8);
-        msgpack_pack_str_body(&mp_pck, "location", 8);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_location));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_location, flb_sds_len(ctx->cluster_location));
-
-        msgpack_pack_str(&mp_pck, 12);
-        msgpack_pack_str_body(&mp_pck, "cluster_name", 12);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->cluster_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->cluster_name, flb_sds_len(ctx->cluster_name));
-
-        msgpack_pack_str(&mp_pck, 14);
-        msgpack_pack_str_body(&mp_pck, "namespace_name", 14);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->namespace_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->namespace_name, flb_sds_len(ctx->namespace_name));
-
-        msgpack_pack_str(&mp_pck, 8);
-        msgpack_pack_str_body(&mp_pck, "pod_name", 8);
-        msgpack_pack_str(&mp_pck, flb_sds_len(ctx->pod_name));
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->pod_name, flb_sds_len(ctx->pod_name));
-    }
-
     msgpack_pack_str(&mp_pck, 7);
     msgpack_pack_str_body(&mp_pck, "entries", 7);
 

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -47,6 +47,7 @@
 #define FLB_SDS_RESOURCE_TYPE "global"
 
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
+#define MONITORED_RESOURCE_KEY "logging.googleapis.com/monitored_resource"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -40,19 +40,6 @@ static inline int key_cmp(const char *str, int len, const char *cmp) {
     return strncasecmp(str, cmp, len);
 }
 
-static int validate_resource(const char *res)
-{
-    if (strcasecmp(res, "global") != 0 &&
-        strcasecmp(res, "gce_instance") != 0 &&
-        strcasecmp(res, "k8s_container") != 0 &&
-        strcasecmp(res, "k8s_node") &&
-        strcasecmp(res, "k8s_pod")) {
-        return -1;
-    }
-
-    return 0;
-}
-
 static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
 {
     int i;
@@ -269,22 +256,8 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->metadata_server_auth = true;
     }
 
-    /* 
-    * Supported resource types:
-    * 'global'
-    * 'gce_instance'
-    * 'k8s_pod'
-    * 'k8s_node'
-    * 'k8s_container'
-    */
     tmp = flb_output_get_property("resource", ins);
     if (tmp) {
-        if (validate_resource(tmp) != 0) {
-            flb_plg_error(ctx->ins, "unsupported resource type '%s'",
-                          tmp);
-            flb_stackdriver_conf_destroy(ctx);
-            return NULL;
-        }
         ctx->resource = flb_sds_create(tmp);
     }
     else {
@@ -322,7 +295,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             return NULL;
         }
     }
-    
+
     tmp = flb_output_get_property("labels_key", ins);
     if (tmp) {
         ctx->labels_key = flb_sds_create(tmp);

--- a/tests/runtime/data/stackdriver/stackdriver_test_monitored_resource.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_monitored_resource.h
@@ -1,0 +1,46 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+#define MONITORED_RESOURCE_COMMON_CASE	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/monitored_resource\": "		\
+        "{"            \
+            "\"labels\": "        \
+            "{"               \
+                "\"project_id\": \"monitored_resource_project_id\","          \
+                "\"location\": \"monitored_resource_location\","          \
+                "\"testA\": \"valA\""      \
+            "}"       \
+        "}"     \
+	"}]"
+
+#define MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_LOCAL_RESOURCE_ID	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/monitored_resource\": "		\
+        "{"            \
+            "\"labels\": "        \
+            "{"               \
+                "\"project_id\": \"monitored_resource_project_id\","          \
+                "\"location\": \"monitored_resource_location\","          \
+                "\"cluster_name\": \"monitored_resource_cluster_name\","          \
+                "\"namespace_name\": \"monitored_resource_namespace_name\","          \
+                "\"pod_name\": \"monitored_resource_pod_name\","          \
+                "\"container_name\": \"monitored_resource_container_name\""          \
+            "}"       \
+        "},"     \
+        "\"logging.googleapis.com/local_resource_id\": \"k8s_container.testnamespace.testpod.testctr\""		\
+	"}]"
+
+#define MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_GCE_INSTANCE	"["		\
+	"1448403340,"                               \
+	"{"				\
+        "\"logging.googleapis.com/monitored_resource\": "		\
+        "{"            \
+            "\"labels\": "        \
+            "{"               \
+                "\"project_id\": \"monitored_resource_project_id\","          \
+                "\"zone\": \"monitored_resource_zone\","          \
+                "\"instance_id\": \"monitored_resource_instance_id\""          \
+            "}"       \
+        "}"     \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -38,6 +38,7 @@
 #include "data/stackdriver/stackdriver_test_source_location.h"
 #include "data/stackdriver/stackdriver_test_http_request.h"
 #include "data/stackdriver/stackdriver_test_timestamp.h"
+#include "data/stackdriver/stackdriver_test_monitored_resource.h"
 
 
 /*
@@ -287,6 +288,102 @@ static int mp_kv_exists(char *json_data, size_t json_len, char *key_accessor)
         flb_free(mp_buf);
     }
     return ret;
+}
+
+static void cb_check_monitored_resource(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "monitored_resource");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "monitored_resource_project_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "monitored_resource_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['testA']", "valA");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/monitored_resource']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_monitored_resource_priority_higher_than_local_resource_id(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "k8s_container");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "monitored_resource_project_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "monitored_resource_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['cluster_name']", "monitored_resource_cluster_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace_name']", "monitored_resource_namespace_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['pod_name']", "monitored_resource_pod_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['container_name']", "monitored_resource_container_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/monitored_resource']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_monitored_resource_priority_higher_than_gce_instance(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "gce_instance");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "monitored_resource_project_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['zone']", "monitored_resource_zone");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['instance_id']", "monitored_resource_instance_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/monitored_resource']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
 }
 
 static void cb_check_global_resource(void *ctx, int ffd,
@@ -1589,6 +1686,131 @@ static void cb_check_timestamp_format_duo_fields_incorrect_type(void *ctx, int f
     TEST_CHECK(ret == FLB_FALSE);
 
     flb_sds_destroy(res_data);
+}
+
+void flb_test_monitored_resource_common()
+{
+    int ret;
+    int size = sizeof(MONITORED_RESOURCE_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "monitored_resource",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_monitored_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) MONITORED_RESOURCE_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_monitored_resource_priority_higher_than_local_resource_id()
+{
+    int ret;
+    int size = sizeof(MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "k8s_container",
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_monitored_resource_priority_higher_than_local_resource_id,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_monitored_resource_priority_higher_than_gce_instance()
+{
+    int ret;
+    int size = sizeof(MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_GCE_INSTANCE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_monitored_resource_priority_higher_than_gce_instance,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) MONITORED_RESOURCE_PRIORITY_HIGHER_THAN_GCE_INSTANCE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
 }
 
 void flb_test_resource_global()
@@ -3723,6 +3945,11 @@ TEST_LIST = {
     {"sourceLocation_partial_subfields", flb_test_source_location_partial_subfields},
     {"sourceLocation_subfields_in_incorrect_type", flb_test_source_location_incorrect_type_subfields},
     {"sourceLocation_extra_subfields_exist", flb_test_source_location_extra_subfields},
+
+    /* test monitored resource */
+    {"monitored_resource_common", flb_test_monitored_resource_common},
+    {"monitored_resource_priority_higher_than_local_resource_id", flb_test_monitored_resource_priority_higher_than_local_resource_id},
+    {"monitored_resource_priority_higher_than_gce_instance", flb_test_monitored_resource_priority_higher_than_gce_instance},
 
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },


### PR DESCRIPTION
<!-- Provide summary of changes -->
Stackdriver output plugin only supports 'globel', 'gce_instance', 'k8s_container', 'k8s_node' and 'k8s_pod' monitored resource types. For 'k8s_*' resource types, the resource labels are put in logging.googleapis.com/local_resource_id with dot '.' as delimiter. 
To support more resource types, especially the label values of the resource type may container dot '.', this patch is provide monitored resource ingestion from the 'logging.googleapis.com/monitored_resource' in log entry.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
