### PR TITLE
out_kinesis_firehose: add support for log_key

### DIFF
--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -95,6 +95,16 @@ static int cb_firehose_init(struct flb_output_instance *ins,
         ctx->time_key_format = DEFAULT_TIME_KEY_FORMAT;
     }
 
+    tmp = flb_output_get_property("log_key", ins);
+    if (tmp) {
+        ctx->log_key = tmp;
+    }
+
+    if (ctx->log_key && ctx->time_key) {
+        flb_plg_error(ctx->ins, "'time_key' and 'log_key' can not be used together");
+        goto error;
+    }
+
     tmp = flb_output_get_property("endpoint", ins);
     if (tmp) {
         ctx->custom_endpoint = FLB_TRUE;
@@ -411,6 +421,16 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
      0, FLB_FALSE, 0,
     "Custom endpoint for the STS API."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "log_key", NULL,
+     0, FLB_FALSE, 0,
+     "By default, the whole log record will be sent to Firehose. "
+     "If you specify a key name with this option, then only the value of "
+     "that key will be sent to Firehose. For example, if you are using "
+     "the Fluentd Docker log driver, you can specify `log_key log` and only "
+     "the log message will be sent to Firehose."
     },
 
     /* EOF */

--- a/plugins/out_kinesis_firehose/firehose_api.c
+++ b/plugins/out_kinesis_firehose/firehose_api.c
@@ -183,6 +183,17 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
         return 2;
     }
 
+    if (ctx->log_key) {
+        /*
+         * flb_msgpack_to_json will encase the value in quotes
+         * We don't want that for log_key, so we ignore the first
+         * and last character
+         */
+        written -= 2;
+        tmp_buf_ptr++; /* pass over the opening quote */
+        buf->tmp_buf_offset++;
+    }
+
     /* is (written + 1) because we still have to append newline */
     if ((written + 1) >= MAX_EVENT_SIZE) {
         flb_plg_warn(ctx->ins, "[size=%zu] Discarding record which is larger than "


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
