### PR TITLE
in_tail: Do not concatenate multiline logs in docker mode until first line is detected

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -622,6 +622,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->dmode_complete = true;
     file->dmode_buf = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 65536 : 0);
     file->dmode_lastline = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 20000 : 0);
+    file->dmode_firstline = false;
 #ifdef FLB_HAVE_SQLDB
     file->db_id     = 0;
 #endif

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -65,6 +65,7 @@ struct flb_tail_file {
     flb_sds_t dmode_buf;        /* buffer for docker mode                */
     flb_sds_t dmode_lastline;   /* last incomplete line                  */
     bool dmode_complete;        /* buffer contains completed log         */
+    bool dmode_firstline;       /* dmode mult firstline found ?          */
 
     /* buffering */
     size_t parsed;

--- a/tests/runtime/data/tail/log/dockermode_firstline_detection.log
+++ b/tests/runtime/data/tail/log/dockermode_firstline_detection.log
@@ -1,0 +1,9 @@
+{"log":"Single log\n"}
+{"log":"Second log\n"}
+{"log":"Third log\n"}
+{"log":"2020-03-24 Multiple lines: \n"}
+{"log":"first bullet point\n"}
+{"log":"second bullet point\n"}
+{"log":"third bullet point\n"}
+{"log":"fourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/data/tail/out/dockermode_firstline_detection.out
+++ b/tests/runtime/data/tail/out/dockermode_firstline_detection.out
@@ -1,0 +1,5 @@
+{"log":"Single log\n"}
+{"log":"Second log\n"}
+{"log":"Third log\n"}
+{"log":"2020-03-24 Multiple lines: \nfirst bullet point\nsecond bullet point\nthird bullet point\nfourth bullet point\n"}
+{"log":"2020-03-24 Single line\n"}

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -130,7 +130,6 @@ static struct tail_file_lines *get_out_file_content(const char *target)
       }
     }
 
-    // printf("Just before return: %s\n", file_lines.lines[0]);
     return file_lines;
 }
 
@@ -144,7 +143,6 @@ static int cb_check_result(void *record, size_t size, void *data)
     char *check;
 
     out = get_out_file_content(result->target);
-    // printf("What we got from function: %s\n", out.lines[0]);
     if (!out->lines_c) {
         goto exit;
     }
@@ -281,14 +279,22 @@ void flb_test_in_tail_dockermode_splitted_multiple_lines()
             NULL);
 }
 
+void flb_test_in_tail_dockermode_firstline_detection()
+{
+    do_test("tail", "dockermode_firstline_detection", 20000, 5,
+            "Docker_Mode_Parser", "docker_multiline",
+            NULL);
+}
+
 
 /* Test list */
 TEST_LIST = {
 #ifdef in_tail
-    {"in_tail_dockermode",    flb_test_in_tail_dockermode},
-    {"in_tail_dockermode_splitted_line",    flb_test_in_tail_dockermode_splitted_line},
-    {"in_tail_dockermode_multiple_lines",    flb_test_in_tail_dockermode_multiple_lines},
-    {"in_tail_dockermode_splitted_multiple_lines",    flb_test_in_tail_dockermode_splitted_multiple_lines},
+    {"in_tail_dockermode",                          flb_test_in_tail_dockermode},
+    {"in_tail_dockermode_splitted_line",            flb_test_in_tail_dockermode_splitted_line},
+    {"in_tail_dockermode_multiple_lines",           flb_test_in_tail_dockermode_multiple_lines},
+    {"in_tail_dockermode_splitted_multiple_lines",  flb_test_in_tail_dockermode_splitted_multiple_lines},
+    {"in_tail_dockermode_firstline_detection",      flb_test_in_tail_dockermode_firstline_detection},
 #endif
     {NULL, NULL}
 };


### PR DESCRIPTION
Do not concatenate multiline logs in docker mode until first line is detected

Update runtime tests with additional test for this change

Fixes #2585

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
