### PR TITLE
win32: fix 'error LNK2001: unresolved external symbol config'

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -58,6 +58,7 @@ extern void win32_started(void);
 #endif
 
 flb_ctx_t *ctx;
+struct flb_config *config;
 
 #ifdef FLB_HAVE_LIBBACKTRACE
 struct flb_stacktrace flb_st;
@@ -760,7 +761,6 @@ int flb_main(int argc, char **argv)
     struct flb_input_instance *in = NULL;
     struct flb_output_instance *out = NULL;
     struct flb_filter_instance *filter = NULL;
-    struct flb_config *config;
 
 #ifdef FLB_HAVE_LIBBACKTRACE
     flb_stacktrace_init(argv[0], &flb_st);


### PR DESCRIPTION
f303cdb5c has removed the global symbol "config" on which winsvc.c
depends. This ended up producing the following error:

    error LNK2001: unresolved external symbol config

Bring back the symbol to make Windows Service working again.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>