### PR TITLE
ci: Skip 'tests/internal/input_chunk.c' on Windows

### DIFF
--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -19,6 +19,7 @@ cmake -G "NMake Makefiles" `
                      -D FLB_WITHOUT_flb-it-aws_credentials_profile=On `
                      -D FLB_WITHOUT_flb-it-aws_credentials_sts=On `
                      -D FLB_WITHOUT_flb-it-aws_util=On `
+                     -D FLB_WITHOUT_flb-it-input_chunk=On `
                      ../
 
 # COMPILE


### PR DESCRIPTION
This unittest relies on chunkio's file storage, which Windows port
does not support yet. Let's skip it for now.

This patch is required to build the Windows package for
Fluent Bit v1.6.0  on Appveyor.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>