### PR TITLE
out_cloudwatch_logs: Don't include <unistd.h> on Windows

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -41,7 +41,10 @@
 #include <msgpack.h>
 #include <string.h>
 #include <stdio.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
 #include <unistd.h>
+#endif
 
 #include "cloudwatch_api.h"
 


### PR DESCRIPTION
MSVC++ does not provide <unistd.h>. For this reason, including
this header breaks the compilation on Windows.

Fix it by adding an ifdef block to the header.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>