### PR TITLE
aws: port Amazon S3 plugin to Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -9,6 +9,7 @@ set(FLB_LUAJIT                Yes)
 set(FLB_EXAMPLES              Yes)
 set(FLB_PARSER                Yes)
 set(FLB_TLS                   Yes)
+set(FLB_AWS                   Yes)
 
 # INPUT plugins
 # =============
@@ -66,6 +67,8 @@ set(FLB_OUT_FLOWCOUNTER       Yes)
 set(FLB_OUT_KAFKA              No)
 set(FLB_OUT_KAFKA_REST         No)
 set(FLB_OUT_CLOUDWATCH_LOGS   Yes)
+set(FLB_OUT_S3                 No)
+set(FLB_OUT_KINESIS_FIREHOSE   No)
 
 # FILTER plugins
 # ==============


### PR DESCRIPTION
This patch ports the AWS core module (src/aws/flb_s3_local_buffer.c)
to Windows, and thereby allows Microsoft Visual Studio to compile
and link S3 plugin.

With this patch, #2631 and edsiper/chunkio/pull/53 combined, the master
HEAD can be compiled and run on Windows again.    
