### PR TITLE
task: fix typo messages and variables name 'attemps' to 'attempts'

### DIFF
--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -65,7 +65,7 @@ struct flb_task_route {
  * task data to the desired output path.
  */
 struct flb_task_retry {
-    int attemps;                        /* number of attemps, default 1 */
+    int attempts;                       /* number of attempts, default 1 */
     struct flb_output_instance *o_ins;  /* route that we are retrying   */
     struct flb_task *parent;            /* parent task reference        */
     struct mk_list _head;               /* link to parent task list     */

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -234,7 +234,7 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
 
             /* Let the scheduler to retry the failed task/thread */
             retry_seconds = flb_sched_request_create(config,
-                                                     retry, retry->attemps);
+                                                     retry, retry->attempts);
 
             /*
              * If for some reason the Scheduler could not include this retry,

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -92,7 +92,7 @@ int flb_task_retry_reschedule(struct flb_task_retry *retry, struct flb_config *c
     struct flb_task *task;
 
     task = retry->parent;
-    seconds = flb_sched_request_create(config, retry, retry->attemps);
+    seconds = flb_sched_request_create(config, retry, retry->attempts);
     if (seconds == -1) {
         /*
          * This is the worse case scenario: 'cannot re-schedule a retry'. If the Chunk
@@ -128,9 +128,9 @@ struct flb_task_retry *flb_task_retry_create(struct flb_task *task,
     mk_list_foreach_safe(head, tmp, &task->retries) {
         retry = mk_list_entry(head, struct flb_task_retry, _head);
         if (retry->o_ins == o_ins) {
-            if (retry->attemps >= o_ins->retry_limit && o_ins->retry_limit >= 0) {
-                flb_debug("[task] task_id=%i reached retry-attemps limit %i/%i",
-                          task->id, retry->attemps, o_ins->retry_limit);
+            if (retry->attempts >= o_ins->retry_limit && o_ins->retry_limit >= 0) {
+                flb_debug("[task] task_id=%i reached retry-attempts limit %i/%i",
+                          task->id, retry->attempts, o_ins->retry_limit);
                 flb_task_retry_destroy(retry);
                 return NULL;
             }
@@ -147,18 +147,18 @@ struct flb_task_retry *flb_task_retry_create(struct flb_task *task,
             return NULL;
         }
 
-        retry->attemps = 1;
+        retry->attempts = 1;
         retry->o_ins   = o_ins;
         retry->parent  = task;
         mk_list_add(&retry->_head, &task->retries);
 
-        flb_debug("[retry] new retry created for task_id=%i attemps=%i",
-                  out_th->task->id, retry->attemps);
+        flb_debug("[retry] new retry created for task_id=%i attempts=%i",
+                  out_th->task->id, retry->attempts);
     }
     else {
-        retry->attemps++;
-        flb_debug("[retry] re-using retry for task_id=%i attemps=%i",
-                  out_th->task->id, retry->attemps);
+        retry->attempts++;
+        flb_debug("[retry] re-using retry for task_id=%i attempts=%i",
+                  out_th->task->id, retry->attempts);
     }
 
     /*
@@ -199,7 +199,7 @@ int flb_task_retry_count(struct flb_task *task, void *data)
     mk_list_foreach(head, &task->retries) {
         retry = mk_list_entry(head, struct flb_task_retry, _head);
         if (retry->o_ins == o_ins) {
-            return retry->attemps;
+            return retry->attempts;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Tanapol Rattanapichetkul <tanapol.raa@gmail.com>

This typo message make it a bit harder to investigating log message.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
