### PR TITLE
out_stackdriver: clean up buffer before return

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1275,6 +1275,7 @@ static int stackdriver_format(struct flb_config *config,
         ret = extract_local_resource_id(data, bytes, ctx, tag);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "fail to construct local_resource_id");
+            msgpack_sbuffer_destroy(&mp_sbuf);
             return -1;
         }
     }


### PR DESCRIPTION
Signed-off-by: Yen-Cheng Chou <ycchou@google.com>

This is spun off from #2616 . See https://github.com/fluent/fluent-bit/pull/2616#discussion_r498461447 for details.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
