### PR TITLE
out_es: make aws_sts_endpoint optional

### DIFF
--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -163,12 +163,9 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             ctx->aws_region = (char *) tmp;
 
             tmp = flb_output_get_property("aws_sts_endpoint", ins);
-            if (!tmp) {
-                flb_error("[out_es] aws_sts_endpoint not set");
-                flb_es_conf_destroy(ctx);
-                return NULL;
+            if (tmp) {
+                ctx->aws_sts_endpoint = (char *) tmp;
             }
-            ctx->aws_sts_endpoint = (char *) tmp;
 
             ctx->aws_provider = flb_standard_chain_provider_create(config,
                                                                    &ctx->aws_tls,


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
