### PR TITLE
Fix OSS-Fuzz build. 

### DIFF
--- a/lib/mbedtls-2.24.0/library/md5.c
+++ b/lib/mbedtls-2.24.0/library/md5.c
@@ -422,8 +422,8 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md5_test_buflen[7] =

--- a/lib/mbedtls-2.24.0/library/ripemd160.c
+++ b/lib/mbedtls-2.24.0/library/ripemd160.c
@@ -478,8 +478,8 @@ static const unsigned char ripemd160_test_str[TESTS][81] =
     { "abcdefghijklmnopqrstuvwxyz" },
     { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" },
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") },
 };
 
 static const size_t ripemd160_test_strlen[TESTS] =

--- a/lib/mbedtls-2.24.0/library/sha512.c
+++ b/lib/mbedtls-2.24.0/library/sha512.c
@@ -516,8 +516,8 @@ void mbedtls_sha512( const unsigned char *input,
 static const unsigned char sha512_test_buf[3][113] =
 {
     { "abc" },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
+    { ("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") },
     { "" }
 };
 


### PR DESCRIPTION
This fixes the OSS-Fuzz build.

<!-- Provide summary of changes -->
Wraps multi-line strings in parentheses in mbedtls-2.24.0

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
