### PR TITLE
Use non-blocking writes for output tasks

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -557,7 +557,7 @@ static inline void flb_output_return(int ret, struct flb_thread *th) {
     set = FLB_TASK_SET(ret, task->id, out_th->id);
     val = FLB_BITS_U64_SET(2 /* FLB_ENGINE_TASK */, set);
 
-    n = flb_pipe_w(task->config->ch_manager[1], (void *) &val, sizeof(val));
+    n = flb_pipe_write_async(task->config->ch_manager[1], (void *) &val, sizeof(val), th);
     if (n == -1) {
         flb_errno();
     }

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -557,7 +557,7 @@ static inline void flb_output_return(int ret, struct flb_thread *th) {
     set = FLB_TASK_SET(ret, task->id, out_th->id);
     val = FLB_BITS_U64_SET(2 /* FLB_ENGINE_TASK */, set);
 
-    n = flb_pipe_write_async(task->config->ch_manager[1], (void *) &val, sizeof(val), th);
+    n = flb_pipe_write_async(task->config->evl, task->config->ch_manager[1], (void *) &val, sizeof(val), th);
     if (n == -1) {
         flb_errno();
     }

--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -45,4 +45,7 @@ int flb_pipe_set_nonblocking(flb_pipefd_t fd);
 ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
 ssize_t flb_pipe_write_all(int fd, const void *buf, size_t count);
 
+struct flb_thread;
+ssize_t flb_pipe_write_async(int fd, const void *buf, size_t count, struct flb_thread *th);
+
 #endif

--- a/include/fluent-bit/flb_pipe.h
+++ b/include/fluent-bit/flb_pipe.h
@@ -46,6 +46,6 @@ ssize_t flb_pipe_read_all(int fd, void *buf, size_t count);
 ssize_t flb_pipe_write_all(int fd, const void *buf, size_t count);
 
 struct flb_thread;
-ssize_t flb_pipe_write_async(int fd, const void *buf, size_t count, struct flb_thread *th);
+ssize_t flb_pipe_write_async(struct mk_event_loop *loop, int fd, const void *buf, size_t count, struct flb_thread *th);
 
 #endif

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -442,6 +442,12 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
 
+    ret = flb_pipe_set_nonblocking(config->ch_manager[1]);
+    if (ret == -1) {
+        flb_errno();
+        return -1;
+    }
+
     /* Start the Storage engine */
     ret = flb_storage_create(config);
     if (ret == -1) {


### PR DESCRIPTION
The PR proposes to use non-blocking pipe writes for output tasks.

We stumbled upon a problem with frozen Fluent Bit instances on some of the most high-loaded nodes of our clusters.
It turned out that the number of output tasks was too big and it resulted in Fluent Bit being frozen writing to a full pipe.

The problem was that coroutine reading from the pipe was running on the same thread (the main one).

The PR fixes this problem by using non-blocking pipes and yielding if the pipe is full.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
