### PR TITLE
Fix typo in cmakelists for fuzzers.

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(UNIT_TESTS_FILES
   flb_json_fuzzer.c
-  parser_fuzzer.c .
+  parser_fuzzer.c
   parse_json_fuzzer.c
   parse_logfmt_fuzzer.c
   parse_ltsv_fuzzer.c


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes typo in CMakeLists.txt

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
