### PR TITLE
out_s3: Run upload callback without async mode

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1067,8 +1067,15 @@ static void cb_s3_upload(struct flb_config *config, void *data)
     int complete;
     int ret;
     time_t now;
+    int async_flags;
 
     flb_plg_debug(ctx->ins, "Running upload timer callback..");
+
+    /* upload timer must use sync mode */
+    if (ctx->use_put_object == FLB_TRUE) {
+        async_flags = ctx->s3_client->upstream->flags;
+        ctx->s3_client->upstream->flags &= ~(FLB_IO_ASYNC);
+    }
 
     now = time(NULL);
 
@@ -1141,6 +1148,10 @@ static void cb_s3_upload(struct flb_config *config, void *data)
                               m_upload->s3_key);
             }
         }
+    }
+
+    if (ctx->use_put_object == FLB_TRUE) {
+        ctx->s3_client->upstream->flags = async_flags;
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
