### PR TITLE
Http-client fuzzer, strp fuzzer and minor refactoring. 

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -7,6 +7,8 @@ set(UNIT_TESTS_FILES
   msgpack_parse_fuzzer.c
   msgpack_to_gelf_fuzzer.c
   pack_json_state_fuzzer.c
+  http_fuzzer.c
+  strp_fuzzer.c
   )
 
 # Prepare list of unit tests

--- a/tests/internal/fuzzers/flb_fuzz_header.h
+++ b/tests/internal/fuzzers/flb_fuzz_header.h
@@ -1,0 +1,19 @@
+#include <stdint.h>
+#include <string.h>
+
+#define GET_MOD_EQ(max, idx) (data[0] % max) == idx
+#define MOVE_INPUT(offset) data += offset; size -= offset;
+
+char *get_null_terminated(size_t size, const uint8_t **data, 
+                          size_t *total_data_size) 
+{
+  char *tmp = flb_malloc(size+1);
+  memcpy(tmp, *data, size);
+  tmp[size] = '\0';
+
+  /* Modify the fuzz variables */
+  *total_data_size -= size;
+  *data += size;
+
+  return tmp;
+}

--- a/tests/internal/fuzzers/flb_fuzz_header.h
+++ b/tests/internal/fuzzers/flb_fuzz_header.h
@@ -4,8 +4,8 @@
 #define GET_MOD_EQ(max, idx) (data[0] % max) == idx
 #define MOVE_INPUT(offset) data += offset; size -= offset;
 
-char *get_null_terminated(size_t size, const uint8_t **data, 
-                          size_t *total_data_size) 
+char *get_null_terminated(size_t size, const uint8_t **data,
+                          size_t *total_data_size)
 {
   char *tmp = flb_malloc(size+1);
   memcpy(tmp, *data, size);

--- a/tests/internal/fuzzers/http_fuzzer.c
+++ b/tests/internal/fuzzers/http_fuzzer.c
@@ -1,0 +1,88 @@
+//#include <stdint.h>
+//#include <string.h>
+#include <stdlib.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_http_client.h>
+
+#include "flb_fuzz_header.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	struct flb_upstream *u;
+	struct flb_upstream_conn *u_conn = NULL;
+	struct flb_http_client *c;
+	struct flb_config *config;
+    char *uri = NULL;
+
+    if (size < 120) {
+		return 0;
+    }
+
+	config = flb_config_init();
+	if (config == NULL) {
+		return 0;
+    }
+
+	u = flb_upstream_create(config, "127.0.0.1", 8001, 0, NULL);
+	u_conn = flb_malloc(sizeof(struct flb_upstream_conn));
+	if (u_conn == NULL)
+		return 0;
+	u_conn->u = u;
+
+    char *proxy = NULL;
+    if (GET_MOD_EQ(2,1)) {
+	    proxy = get_null_terminated(50, &data, &size);
+    }
+
+    uri = get_null_terminated(20, &data, &size);
+
+    int method = (int)data[0];
+	c = flb_http_client(u_conn, method, uri, NULL, 0,
+					"127.0.0.1", 8001, proxy, 0);
+
+    if (c != NULL) {
+        char *null_terminated = get_null_terminated(size-20, &data, &size);
+
+        /* Perform a set of operations on the http_client */
+		flb_http_basic_auth(c, null_terminated, null_terminated);
+		flb_http_set_content_encoding_gzip(c);
+		flb_http_set_keepalive(c);
+		flb_http_strip_port_from_host(c);
+		flb_http_allow_duplicated_headers(c, 0);
+
+        
+		flb_http_buffer_size(c, (*(size_t *)data) & 0xfff);
+        MOVE_INPUT(4)
+		flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+		flb_http_add_header(c, (char*)data, size, "Fluent-Bit", 10);
+        flb_http_buffer_size(c, (int)data[0]);
+        MOVE_INPUT(1)
+        flb_http_buffer_available(c);
+        size_t out_size = 0;
+        flb_http_buffer_increase(c, (*(size_t *)data) & 0xfff, &out_size);
+        MOVE_INPUT(4)
+
+		size_t b_sent;
+		flb_http_do(c, &b_sent);
+		flb_http_client_destroy(c);
+
+        flb_free(null_terminated);
+    }
+
+	flb_free(u_conn);
+	flb_upstream_destroy(u);
+	flb_config_exit(config);
+    if (uri != NULL) {
+        flb_free(uri);
+    }
+    if (proxy != NULL) {
+        flb_free(proxy);
+    }
+
+	return 0;
+}

--- a/tests/internal/fuzzers/http_fuzzer.c
+++ b/tests/internal/fuzzers/http_fuzzer.c
@@ -1,5 +1,3 @@
-//#include <stdint.h>
-//#include <string.h>
 #include <stdlib.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
@@ -13,53 +11,52 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	struct flb_upstream *u;
-	struct flb_upstream_conn *u_conn = NULL;
-	struct flb_http_client *c;
-	struct flb_config *config;
+    struct flb_upstream *u;
+    struct flb_upstream_conn *u_conn = NULL;
+    struct flb_http_client *c;
+    struct flb_config *config;
     char *uri = NULL;
 
     if (size < 120) {
-		return 0;
+        return 0;
     }
 
-	config = flb_config_init();
-	if (config == NULL) {
-		return 0;
+    config = flb_config_init();
+    if (config == NULL) {
+        return 0;
     }
 
-	u = flb_upstream_create(config, "127.0.0.1", 8001, 0, NULL);
-	u_conn = flb_malloc(sizeof(struct flb_upstream_conn));
-	if (u_conn == NULL)
-		return 0;
-	u_conn->u = u;
+    u = flb_upstream_create(config, "127.0.0.1", 8001, 0, NULL);
+    u_conn = flb_malloc(sizeof(struct flb_upstream_conn));
+    if (u_conn == NULL)
+        return 0;
+    u_conn->u = u;
 
     char *proxy = NULL;
     if (GET_MOD_EQ(2,1)) {
-	    proxy = get_null_terminated(50, &data, &size);
+        proxy = get_null_terminated(50, &data, &size);
     }
 
     uri = get_null_terminated(20, &data, &size);
 
     int method = (int)data[0];
-	c = flb_http_client(u_conn, method, uri, NULL, 0,
-					"127.0.0.1", 8001, proxy, 0);
+    c = flb_http_client(u_conn, method, uri, NULL, 0,
+                    "127.0.0.1", 8001, proxy, 0);
 
     if (c != NULL) {
         char *null_terminated = get_null_terminated(size-20, &data, &size);
 
         /* Perform a set of operations on the http_client */
-		flb_http_basic_auth(c, null_terminated, null_terminated);
-		flb_http_set_content_encoding_gzip(c);
-		flb_http_set_keepalive(c);
-		flb_http_strip_port_from_host(c);
-		flb_http_allow_duplicated_headers(c, 0);
+        flb_http_basic_auth(c, null_terminated, null_terminated);
+        flb_http_set_content_encoding_gzip(c);
+        flb_http_set_keepalive(c);
+        flb_http_strip_port_from_host(c);
+        flb_http_allow_duplicated_headers(c, 0);
 
-        
-		flb_http_buffer_size(c, (*(size_t *)data) & 0xfff);
+        flb_http_buffer_size(c, (*(size_t *)data) & 0xfff);
         MOVE_INPUT(4)
-		flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
-		flb_http_add_header(c, (char*)data, size, "Fluent-Bit", 10);
+        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c, (char*)data, size, "Fluent-Bit", 10);
         flb_http_buffer_size(c, (int)data[0]);
         MOVE_INPUT(1)
         flb_http_buffer_available(c);
@@ -67,16 +64,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         flb_http_buffer_increase(c, (*(size_t *)data) & 0xfff, &out_size);
         MOVE_INPUT(4)
 
-		size_t b_sent;
-		flb_http_do(c, &b_sent);
-		flb_http_client_destroy(c);
+        size_t b_sent;
+        flb_http_do(c, &b_sent);
+        flb_http_client_destroy(c);
 
         flb_free(null_terminated);
     }
 
-	flb_free(u_conn);
-	flb_upstream_destroy(u);
-	flb_config_exit(config);
+    flb_free(u_conn);
+    flb_upstream_destroy(u);
+    flb_config_exit(config);
     if (uri != NULL) {
         flb_free(uri);
     }
@@ -84,5 +81,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         flb_free(proxy);
     }
 
-	return 0;
+    return 0;
 }

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -5,24 +5,12 @@
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_parser_decoder.h>
 
+#include "flb_fuzz_header.h"
+
 #define TYPES_LEN 5
-#define GET_MOD_EQ(max, idx) (data[0] % max) == idx
-#define MOVE_INPUT(offset) data += offset; size -= offset;
 
-char *get_null_terminated(size_t size, char **data, size_t *total_data_size)
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-  char *tmp = flb_malloc(size+1);
-  memcpy(tmp, *data, size);
-  tmp[size] = '\0';
-
-  // Modify the fuzz variables
-  *total_data_size -= size;
-  *data += size;
-
-  return tmp;
-}
-
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     char *format      = NULL;
     char *time_fmt    = NULL;
     char *time_key    = NULL;

--- a/tests/internal/fuzzers/strp_fuzzer.c
+++ b/tests/internal/fuzzers/strp_fuzzer.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_parser.h>
+#include <msgpack.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_version.h>
+#include <fluent-bit/flb_strptime.h>
+
+#include "flb_fuzz_header.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 40) {
+        return 0;
+    }
+
+    char *fmt = get_null_terminated(size - 30, &data, &size);
+    char *buf = get_null_terminated(size, &data, &size);
+
+    struct tm tt;
+    flb_strptime(buf, fmt, &tt);
+
+    flb_free(buf);
+    flb_free(fmt); 
+}

--- a/tests/internal/fuzzers/strp_fuzzer.c
+++ b/tests/internal/fuzzers/strp_fuzzer.c
@@ -26,5 +26,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     flb_strptime(buf, fmt, &tt);
 
     flb_free(buf);
-    flb_free(fmt); 
+    flb_free(fmt);
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Two new fuzzers and a minor bit of refactoring to use a central fuzzer header for common code. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
