### PR TITLE
http_client: use HTTP_PROXY environment variable for proxy globally

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -144,14 +144,15 @@ struct flb_config {
     void *http_ctx;           /* Monkey HTTP context    */
 #endif
 
-    /* There are two ways to use proxy in fluent-bit:
-         #1 Similar with http and datadog plugin, passing proxy directly to
-            flb_http_client and use proxy host and port when creating upstream.
-            HTTPS traffic is not supported this way.
-         #2 Similar with stackdriver plugin, passing http_proxy in flb_config
-            (or by setting HTTP_PROXY env variable). HTTPS is supported this way. But
-            proxy shouldn't be passed when calling flb_http_client().
-    */
+    /*
+     * There are two ways to use proxy in fluent-bit:
+     * 1. Similar with http and datadog plugin, passing proxy directly to
+     *    flb_http_client and use proxy host and port when creating upstream.
+     *    HTTPS traffic is not supported this way.
+     * 2. Similar with stackdriver plugin, passing http_proxy in flb_config
+     *    (or by setting HTTP_PROXY env variable). HTTPS is supported this way. But
+     *    proxy shouldn't be passed when calling flb_http_client().
+     */
     char *http_proxy;
 
     /* Chunk I/O Buffering */

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -144,6 +144,16 @@ struct flb_config {
     void *http_ctx;           /* Monkey HTTP context    */
 #endif
 
+    /* There are two ways to use proxy in fluent-bit:
+         #1 Similar with http and datadog plugin, passing proxy directly to
+            flb_http_client and use proxy host and port when creating upstream.
+            HTTPS traffic is not supported this way.
+         #2 Similar with stackdriver plugin, passing http_proxy in flb_config
+            (or by setting HTTP_PROXY env variable). HTTPS is supported this way. But
+            proxy shouldn't be passed when calling flb_http_client().
+    */
+    char *http_proxy;
+
     /* Chunk I/O Buffering */
     void *cio;
     char *storage_path;

--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -54,6 +54,7 @@
 
 /* Useful headers */
 #define FLB_HTTP_HEADER_AUTH             "Authorization"
+#define FLB_HTTP_HEADER_PROXY_AUTH       "Proxy-Authorization"
 #define FLB_HTTP_HEADER_CONTENT_TYPE     "Content-Type"
 #define FLB_HTTP_HEADER_CONTENT_ENCODING "Content-Encoding"
 #define FLB_HTTP_HEADER_CONNECTION       "Connection"
@@ -145,6 +146,8 @@ int flb_http_add_header(struct flb_http_client *c,
                         const char *key, size_t key_len,
                         const char *val, size_t val_len);
 int flb_http_basic_auth(struct flb_http_client *c,
+                        const char *user, const char *passwd);
+int flb_http_proxy_auth(struct flb_http_client *c,
                         const char *user, const char *passwd);
 int flb_http_set_keepalive(struct flb_http_client *c);
 int flb_http_set_content_encoding_gzip(struct flb_http_client *c);

--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -152,6 +152,7 @@ int flb_http_set_callback_context(struct flb_http_client *c,
                                   struct flb_callback *cb_ctx);
 
 int flb_http_do(struct flb_http_client *c, size_t *bytes);
+int flb_http_client_proxy_connect(struct flb_upstream_conn *u_conn);
 void flb_http_client_destroy(struct flb_http_client *c);
 int flb_http_buffer_size(struct flb_http_client *c, size_t size);
 size_t flb_http_buffer_available(struct flb_http_client *c);

--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -34,6 +34,7 @@
 #define FLB_HTTP_POST        1
 #define FLB_HTTP_PUT         2
 #define FLB_HTTP_HEAD        3
+#define FLB_HTTP_CONNECT     4
 
 /* HTTP Flags */
 #define FLB_HTTP_10          1

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -55,6 +55,8 @@ struct flb_upstream {
     char *tcp_host;
     int proxied_port;
     char *proxied_host;
+    char *proxy_username;
+    char *proxy_password;
 
     int n_connections;
 

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -53,6 +53,8 @@ struct flb_upstream {
     int flags;
     int tcp_port;
     char *tcp_host;
+    int proxied_port;
+    char *proxied_host;
 
     int n_connections;
 

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -64,5 +64,6 @@ int flb_utils_write_str_buf(const char *str, size_t str_len,
 int flb_utils_url_split(const char *in_url, char **out_protocol,
                         char **out_host, char **out_port, char **out_uri);
 int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
-                              char **out_username, char **out_password, char **out_host, char **out_port);
+                              char **out_username, char **out_password,
+                              char **out_host, char **out_port);
 #endif

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -63,5 +63,6 @@ int flb_utils_write_str_buf(const char *str, size_t str_len,
 
 int flb_utils_url_split(const char *in_url, char **out_protocol,
                         char **out_host, char **out_port, char **out_uri);
-
+int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
+                              char **out_username, char **out_password, char **out_host, char **out_port);
 #endif

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -114,7 +114,7 @@ static int http_post(struct flb_out_http *ctx,
                         ctx->proxy, 0);
 
 
-    flb_debug("[HTTP_OUT] http_client proxy host: %s port: %i", c->proxy.host, c->proxy.port);
+    flb_debug("[http_client] proxy host: %s port: %i", c->proxy.host, c->proxy.port);
 
     /* Allow duplicated headers ? */
     flb_http_allow_duplicated_headers(c, ctx->allow_dup_headers);

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -113,6 +113,9 @@ static int http_post(struct flb_out_http *ctx,
                         ctx->host, ctx->port,
                         ctx->proxy, 0);
 
+
+    flb_debug("[HTTP_OUT] http_client proxy host: %s port: %i", c->proxy.host, c->proxy.port);
+
     /* Allow duplicated headers ? */
     flb_http_allow_duplicated_headers(c, ctx->allow_dup_headers);
 

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -114,7 +114,8 @@ static int http_post(struct flb_out_http *ctx,
                         ctx->proxy, 0);
 
 
-    flb_debug("[http_client] proxy host: %s port: %i", c->proxy.host, c->proxy.port);
+    flb_plg_debug(ctx->ins, "[http_client] proxy host: %s port: %i",
+                  c->proxy.host, c->proxy.port);
 
     /* Allow duplicated headers ? */
     flb_http_allow_duplicated_headers(c, ctx->allow_dup_headers);

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1862,7 +1862,6 @@ static void cb_stackdriver_flush(const void *data, size_t bytes,
     else {
         /* The request was issued successfully, validate the 'error' field */
         flb_plg_debug(ctx->ins, "HTTP Status=%i", c->resp.status);
-        flb_plg_debug(ctx->ins, "HTTP data=%s", c->resp.data);
         if (c->resp.status == 200) {
             ret_code = FLB_OK;
         }

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1862,6 +1862,7 @@ static void cb_stackdriver_flush(const void *data, size_t bytes,
     else {
         /* The request was issued successfully, validate the 'error' field */
         flb_plg_debug(ctx->ins, "HTTP Status=%i", c->resp.status);
+        flb_plg_debug(ctx->ins, "HTTP data=%s", c->resp.data);
         if (c->resp.status == 200) {
             ret_code = FLB_OK;
         }

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -161,6 +161,12 @@ struct flb_config *flb_config_init()
     config->http_port    = flb_strdup(FLB_CONFIG_HTTP_PORT);
 #endif
 
+    config->http_proxy = getenv("HTTP_PROXY");
+    if (strcmp(config->http_proxy, "")) {
+        /* Proxy should not be set when the `HTTP_PROXY` is set to "" */
+        config->http_proxy = NULL;
+    }
+
     config->cio          = NULL;
     config->storage_path = NULL;
     config->storage_input_plugin = NULL;

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -162,7 +162,7 @@ struct flb_config *flb_config_init()
 #endif
 
     config->http_proxy = getenv("HTTP_PROXY");
-    if (strcmp(config->http_proxy, "")) {
+    if (config->http_proxy != NULL && strcmp(config->http_proxy, "") == 0) {
         /* Proxy should not be set when the `HTTP_PROXY` is set to "" */
         config->http_proxy = NULL;
     }

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -998,6 +998,7 @@ int flb_http_add_auth_header(struct flb_http_client *c,
     int ret;
     int len_u;
     int len_p;
+    int len_h;
     int len_out;
     char tmp[1024];
     char *p;
@@ -1047,9 +1048,10 @@ int flb_http_add_auth_header(struct flb_http_client *c,
     flb_free(p);
     b64_len += 6;
 
+    len_h = strlen(header);
     ret = flb_http_add_header(c,
                               header,
-                              strlen(header),
+                              len_h,
                               tmp, b64_len);
     return ret;
 }

--- a/src/flb_io_tls.c
+++ b/src/flb_io_tls.c
@@ -337,6 +337,9 @@ int net_io_tls_handshake(void *_u_conn, void *_th)
     }
     if (!u->tls->context->vhost) {
         u->tls->context->vhost = u->tcp_host;
+        if (u->proxied_host) {
+            u->tls->context->vhost = u->proxied_host;
+        }
     }
     mbedtls_ssl_set_hostname(&session->ssl, u->tls->context->vhost);
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -102,9 +102,9 @@ struct flb_upstream *flb_upstream_create(struct flb_config *config,
     /* Set upstream to the http_proxy if it is specified. */
     if (config->http_proxy) {
         flb_debug("[upstream] config->http_proxy: %s", config->http_proxy);
-        ret = flb_utils_proxy_url_split(config->http_proxy, &proxy_protocol, &proxy_username, &proxy_password, &proxy_host, &proxy_port);
-        flb_debug("[upstream] parsed http_proxy: protocol %s, host %s port %s username %s password %s",
-                  proxy_protocol, proxy_host, proxy_port, proxy_username, proxy_password);
+        ret = flb_utils_proxy_url_split(config->http_proxy, &proxy_protocol,
+                                        &proxy_username, &proxy_password,
+                                        &proxy_host, &proxy_port);
         if (ret == -1) {
             flb_errno();
             return NULL;

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -890,7 +890,8 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
  * Note: currently only HTTP is supported.
  */
 int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
-                              char **out_username, char **out_password, char **out_host, char **out_port)
+                              char **out_username, char **out_password,
+                              char **out_host, char **out_port)
 {
     char *protocol = NULL;
     char *username = NULL;

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -146,9 +146,123 @@ void test_write_str()
     TEST_CHECK(ret == FLB_FALSE);
 }
 
+struct proxy_url_check {
+    int ret;
+    char *url;        /* full URL          */
+    char *prot;       /* expected protocol */
+    char *host;       /* expected host     */
+    char *port;       /* expected port     */
+    char *username;   /* expected username */
+    char *password;   /* expected password */
+};
+
+struct proxy_url_check proxy_url_checks[] = {
+    {0, "http://foo:bar@proxy.com:8080",
+     "http", "proxy.com", "8080", "foo", "bar"},
+    {0, "http://proxy.com",
+     "http", "proxy.com", "80", NULL, NULL},
+    {0, "http://proxy.com:8080",
+     "http", "proxy.com", "8080", NULL, NULL},
+    {-1, "https://proxy.com:8080",
+     NULL, NULL, NULL, NULL, NULL}
+
+};
+
+void test_proxy_url_split() {
+    int i;
+    int ret;
+    int size;
+    char *protocol;
+    char *host;
+    char *port;
+    char *username;
+    char *password;
+    struct proxy_url_check *u;
+
+    size = sizeof(proxy_url_checks) / sizeof(struct proxy_url_check);
+    for (i = 0; i < size; i++) {
+        u = &proxy_url_checks[i];
+
+        protocol = NULL;
+        host = NULL;
+        port = NULL;
+        username = NULL;
+        password = NULL;
+
+        ret = flb_utils_proxy_url_split(u->url, &protocol, &username, &password, &host, &port);
+        TEST_CHECK(ret == u->ret);
+        if (ret == -1) {
+            continue;
+        }
+
+        /* Protocol */
+        TEST_CHECK(protocol != NULL);
+        ret = strcmp(u->prot, protocol);
+        TEST_CHECK(ret == 0);
+        TEST_MSG("Expected protocol: %s", u->prot);
+        TEST_MSG("Produced protocol: %s", protocol);
+
+        /* Host */
+        TEST_CHECK(host != NULL);
+        ret = strcmp(u->host, host);
+        TEST_CHECK(ret == 0);
+        TEST_MSG("Expected host: %s", u->host);
+        TEST_MSG("Produced host: %s", host);
+
+        /* Port */
+        TEST_CHECK(port != NULL);
+        ret = strcmp(u->port, port);
+        TEST_CHECK(ret == 0);
+        TEST_MSG("Expected port: %s", u->port);
+        TEST_MSG("Produced port: %s", port);
+
+        /* Username */
+        if (u->username) {
+            TEST_CHECK(port != NULL);
+            ret = strcmp(u->port, port);
+            TEST_CHECK(ret == 0);
+            TEST_MSG("Expected username: %s", u->username);
+            TEST_MSG("Produced username: %s", username);
+
+        }
+        else {
+            TEST_CHECK(username == NULL);
+        }
+
+        /* Password */
+        if (u->password) {
+            TEST_CHECK(port != NULL);
+            ret = strcmp(u->port, port);
+            TEST_CHECK(ret == 0);
+            TEST_MSG("Expected password: %s", u->password);
+            TEST_MSG("Produced password: %s", password);
+        }
+        else {
+            TEST_CHECK(password == NULL);
+        }
+
+        if (protocol) {
+            flb_free(protocol);
+        }
+        if (host) {
+            flb_free(host);
+        }
+        if (port) {
+            flb_free(port);
+        }
+        if (username) {
+            flb_free(username);
+        }
+        if (password) {
+            flb_free(password);
+        }
+    }
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "url_split", test_url_split },
     { "write_str", test_write_str },
+    { "proxy_url_split", test_proxy_url_split },
     { 0 }
 };


### PR DESCRIPTION
- Add http_proxy in global config and set during upstream creation
- HTTP_PROXY url with username and password is also supported with this PR: `http://username:password@host:port`
- Implement `CONNECT` based HTTP support so that HTTPS can work over
  a HTTP proxy. This is important for stackdriver.
- The key is to do proxy negotiation before tls handshake. that's why
  proxy negotiation has to be in upstream.c.

Signed-off-by: Yu Yi <yiyu@google.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #2565 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/414
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
