### PR TITLE
metrics: add more metrics descriptions

### DIFF
--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -100,6 +100,7 @@ flb_sds_t flb_sds_create(const char *str);
 flb_sds_t flb_sds_create_len(const char *str, int len);
 flb_sds_t flb_sds_create_size(size_t size);
 flb_sds_t flb_sds_cat(flb_sds_t s, const char *str, int len);
+flb_sds_t flb_sds_cat_auto(flb_sds_t s, const char *str);
 flb_sds_t flb_sds_cat_esc(flb_sds_t s, const char *str, int len,
                                        char *esc, size_t esc_size);
 flb_sds_t flb_sds_cat_utf8(flb_sds_t *sds, const char *str, int len);

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -138,6 +138,14 @@ flb_sds_t flb_sds_cat(flb_sds_t s, const char *str, int len)
     return s;
 }
 
+flb_sds_t flb_sds_cat_auto(flb_sds_t s, const char *str)
+{
+    int len;
+
+    len = strlen(str);
+    return flb_sds_cat(s, str, len);
+}
+
 flb_sds_t flb_sds_cat_esc(flb_sds_t s, const char *str, int len,
                                        char *esc, size_t esc_size)
 {

--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -181,34 +181,49 @@ int is_same_metric(char *s1, char *s2) {
 flb_sds_t metrics_help_txt(char *metric_name, flb_sds_t *metric_helptxt)
 {
     if (strstr(metric_name, "input_bytes")) {
-        return flb_sds_cat(*metric_helptxt, " Number of input bytes.\n", 24);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of input bytes by Fluent Bit input plugin.\n");
     }
     else if (strstr(metric_name, "input_records")) {
-        return flb_sds_cat(*metric_helptxt, " Number of input records.\n", 26);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of input records by Fluent Bit input plugin.\n");
+    }
+    else if (strstr(metric_name, "input_files_opened")) {
+        return flb_sds_cat_auto(*metric_helptxt, "Number of files opened by Fluent Bit input plugin.\n");
+    }
+    else if (strstr(metric_name, "input_files_closed")) {
+        return flb_sds_cat_auto(*metric_helptxt, "Number of files closed by Fluent Bit input plugin.\n");
+    }
+    else if (strstr(metric_name, "input_files_rotated")) {
+        return flb_sds_cat_auto(*metric_helptxt, "Number of files rotated by Fluent Bit input plugin.\n");
     }
     else if (strstr(metric_name, "output_bytes")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output bytes.\n", 25);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of output bytes by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_records")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output records.\n", 27);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of output records by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_errors")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output errors.\n", 26);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of output errors by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_retries_failed")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output retries failed.\n", 34);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of output retries failed by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_retries")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output retries.\n", 27);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of output retries by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_proc_records")) {
-        return flb_sds_cat(*metric_helptxt, " Number of processed output records.\n", 37);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of processed output records by Fluent Bit output plugin.\n");
     }
     else if (strstr(metric_name, "output_proc_bytes")) {
-        return flb_sds_cat(*metric_helptxt, " Number of processed output bytes.\n", 35);
+        return flb_sds_cat_auto(*metric_helptxt, " Number of processed output bytes by Fluent Bit output plugin.\n");
+    }
+    else if (strstr(metric_name, "filter_add_records")) {
+        return flb_sds_cat_auto(*metric_helptxt, " Number of records added by Fluent Bit filter plugin.\n");
+    }
+    else if (strstr(metric_name, "filter_drop_records")) {
+        return flb_sds_cat_auto(*metric_helptxt, " Number of records dropped by Fluent Bit filter plugin.\n");
     }
     else {
-        return (flb_sds_cat(*metric_helptxt, " Fluentbit metrics.\n", 20));
+        return (flb_sds_cat_auto(*metric_helptxt, " Fluentbit metrics.\n"));
     }
 }
 

--- a/tests/internal/sds.c
+++ b/tests/internal/sds.c
@@ -49,9 +49,23 @@ static void test_sds_cat_utf8()
     flb_sds_destroy(s);
 }
 
+static void test_sds_cat_auto()
+{
+    flb_sds_t s;
+    char *str = "1234567890\n";
+
+    s = flb_sds_create("");
+    flb_sds_cat_auto(s, str);
+    TEST_CHECK(flb_sds_len(s) == 11);
+    TEST_CHECK(strcmp(s, "1234567890\n") == 0);
+
+    flb_sds_destroy(s);
+}
+
 TEST_LIST = {
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
     { "sds_cat_utf8", test_sds_cat_utf8},
+    { "sds_cat_auto", test_sds_cat_auto},
     { 0 }
 };


### PR DESCRIPTION
- also implemented flb_sds_cat_auto so that we don't need to manually
counting the length of the string.

Signed-off-by: Yu Yi <yiyu@google.com>


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
