### PR TITLE
network: optionally destroy keepalive connections after configured uses

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -39,6 +39,9 @@ struct flb_net_setup {
 
     /* network interface to bind and use to send data */
     flb_sds_t source_address;
+
+    /* maximum of times a keepalive connection can be used */
+    int keepalive_max_recycle;
 };
 
 /* Defines a host service and it properties */

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -48,6 +48,7 @@ void flb_net_setup_init(struct flb_net_setup *net)
 {
     net->keepalive = FLB_TRUE;
     net->keepalive_idle_timeout = 30;
+    net->keepalive_max_recycle = 0;
     net->connect_timeout = 10;
     net->source_address = NULL;
 }


### PR DESCRIPTION
Allow users to configure the max number of uses of a connection before it gets
thrown away. In cases where fluentbit is used with an upstream behind a
load-balancer, we can get better distribution amongst upstreams by tuning this
value.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

I'm happy to write documentation for this once the config file change is agreed upon.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

----

Sample config snippet of an output with this new option:

```ini
[OUTPUT]
    Name          forward
    Match         *
    Host          fluentd.cre.svc
    Port          24240

    net.keepalive_max_count 2000
```

---

```
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 626688 to 790528
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 790528 to 823296
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 823296 to 954368
[2020/10/19 20:24:30] [debug] [upstream] KA connection #80 to logging-operator-logging-fluentd.cre.svc:24240 is now available
[2020/10/19 20:24:30] [debug] [upstream] KA connection #96 to logging-operator-logging-fluentd.cre.svc:24240 is now available
[2020/10/19 20:24:30] [debug] [upstream] KA connection #76 to logging-operator-logging-fluentd.cre.svc:24240 is now available
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 954368 to 987136
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 987136 to 1150976
[2020/10/19 20:24:30] [debug] [task] destroy task=0x7fa069836a00 (task_id=5)
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1150976 to 1183744
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1183744 to 1347584
[2020/10/19 20:24:30] [debug] [upstream] KA connection #87 to logging-operator-logging-fluentd.cre.svc:24240 is now available
[2020/10/19 20:24:30] [debug] [task] destroy task=0x7fa069836d20 (task_id=16)
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1347584 to 1380352
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1380352 to 1544192
[2020/10/19 20:24:30] [debug] [task] destroy task=0x7fa069836140 (task_id=0)
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1544192 to 1576960
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1576960 to 1740800
[2020/10/19 20:24:30] [debug] [task] destroy task=0x7fa069836be0 (task_id=7)
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1740800 to 1773568
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1773568 to 1937408
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1937408 to 2101248
[2020/10/19 20:24:30] [debug] [storage] [cio file] synced at: tail.0/1-1603139070.209804973.flb
[2020/10/19 20:24:30] [debug] [storage] tail.0:1-1603139070.360857749.flb mapped OK
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 4096 to 36864
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 36864 to 200704
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 200704 to 233472
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 233472 to 397312
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 397312 to 430080
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 430080 to 593920
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 593920 to 626688
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 626688 to 790528
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 790528 to 823296
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 823296 to 954368
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 954368 to 987136
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 987136 to 1150976
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1150976 to 1183744
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1183744 to 1347584
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1347584 to 1380352
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1380352 to 1544192
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1544192 to 1576960
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1576960 to 1740800
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1740800 to 1773568
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1773568 to 1904640
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1904640 to 1937408
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 1937408 to 2101248
[2020/10/19 20:24:30] [debug] [storage] [cio file] synced at: tail.0/1-1603139070.360857749.flb
[2020/10/19 20:24:30] [debug] [storage] tail.0:1-1603139070.513716222.flb mapped OK
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 4096 to 36864
[2020/10/19 20:24:30] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:30] [debug] [storage] [cio file] alloc_size from 36864 to 200704
[2020/10/19 20:24:30] [debug] [task] created task=0x7fa069836be0 id=0 OK
[2020/10/19 20:24:30] [debug] [task] created task=0x7fa0698361e0 id=5 OK
[2020/10/19 20:24:30] [debug] [task] created task=0x7fa0698365a0 id=7 OK
[2020/10/19 20:24:30] [debug] [storage] [cio file] synced at: tail.0/1-1603139070.513716222.flb
[2020/10/19 20:24:30] [debug] [task] created task=0x7fa069836aa0 id=9 OK
[2020/10/19 20:24:30] [debug] [output:forward:forward.0] request 2079944 bytes to flush
[2020/10/19 20:24:30] [debug] [upstream] KA connection #91 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #103 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #88 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #106 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #110 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #117 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #118 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #120 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #80 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #96 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #76 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:30] [debug] [upstream] KA connection #87 is in a failed state to: logging-operator-logging-fluentd.cre.svc:24240, cleaning up
[2020/10/19 20:24:31] [debug] [output:forward:forward.0] protocol: received HELO
[2020/10/19 20:24:31] [debug] [output:forward:forward.0] PING sent: ret=0 bytes sent=294
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] handshake status = 0
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] request 2094766 bytes to flush
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] protocol: received HELO
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] PING sent: ret=0 bytes sent=294
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] handshake status = 0
[2020/10/19 20:24:32] [debug] [output:forward:forward.0] request 2093036 bytes to flush
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] protocol: received HELO
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] PING sent: ret=0 bytes sent=294
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] handshake status = 0
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] request 191152 bytes to flush
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] protocol: received HELO
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] PING sent: ret=0 bytes sent=294
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] handshake status = 0
[2020/10/19 20:24:34] [debug] [storage] tail.0:1-1603139074.558264871.flb mapped OK
[2020/10/19 20:24:34] [debug] [storage] [cio file] alloc_size from 4096 to 36864
[2020/10/19 20:24:34] [debug] [filter:kubernetes:kubernetes.0] could not merge JSON log as requested
[2020/10/19 20:24:34] [debug] [storage] [cio file] alloc_size from 36864 to 200704
[2020/10/19 20:24:34] [debug] [storage] [cio file] synced at: tail.0/1-1603139074.558264871.flb
[2020/10/19 20:24:34] [debug] [task] created task=0x7fa069837f40 id=13 OK
[2020/10/19 20:24:34] [debug] [output:forward:forward.0] request 190189 bytes to flush
```