### PR TITLE
in_winlog: Add a new configuration option "StringInserts"

### DIFF
--- a/plugins/in_winlog/winlog.h
+++ b/plugins/in_winlog/winlog.h
@@ -25,6 +25,7 @@ struct winlog_config {
     unsigned int interval_sec;
     unsigned int interval_nsec;
     unsigned int bufsize;
+    int string_inserts;
     char *buf;
     struct mk_list *active_channel;
     struct flb_sqldb *db;


### PR DESCRIPTION
A user (jsubirat) requested that in_winlog should be able to output
StringInserts in log records.

This patch implements that feature, which enables you to write the
plugin configuration like:

    [INPUT]
    Name winlog
    StringInserts true

... and here is an example record after this patch:

    {
        "RecordNumber"=>333,
        "TimeGenerated"=>"2020-08-11 10:56:41 -0000",
        "TimeWritten"=>"2020-08-11 10:56:41 -0000",
        "EventType"=>"Information",
        "Message"=>"Starting session 0 - 2020-08-11T10:56:41.595894000Z.",
        "StringInserts"=>["0", "2020-08-11T10:56:41.595894000Z"]
    }

Fixes #2427 

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>