### PR TITLE
engine: fix handling of task status of non-multiplex mode

### DIFF
--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -201,6 +201,8 @@ static int tasks_start(struct flb_input_instance *in,
         if (hits == 0) {
             task->status = FLB_TASK_NEW;
         }
+
+        hits = 0;
     }
 
     return 0;


### PR DESCRIPTION
Fix the problem that the task cannot be executed due to the wrong status in non-multiplex mode. When it traverses the task queue, it resets the flag used to determine the task status

Signed-off-by: zhanghjster <zhanghjster@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
