### PR TITLE
parser: Implement generic support for %L (subseconds)

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -104,7 +104,6 @@ int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
 
 void flb_parser_exit(struct flb_config *config);
 int flb_parser_tzone_offset(const char *str, int len, int *tmdiff);
-int flb_parser_frac(const char *str, int len, double *frac, const char **end);
 int flb_parser_time_lookup(const char *time, size_t tsize, time_t now,
                            struct flb_parser *parser,
                            struct tm *tm, double *ns);

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -121,6 +121,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     int size;
     int is_epoch = FLB_FALSE;
     char *tmp;
+    char *timeptr;
     struct mk_list *head;
     struct flb_parser *p;
     struct flb_regex *regex;
@@ -239,42 +240,18 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
          * - http://stackoverflow.com/questions/7114690/how-to-parse-syslog-timestamp
          * - http://code.activestate.com/lists/python-list/521885/
          */
-        if (is_epoch == FLB_TRUE) {
-            tmp = strstr(p->time_fmt, "%s.%L");
-        }
-        else if (p->time_with_year == FLB_TRUE) {
-            tmp = strstr(p->time_fmt, "%S.%L");
+        if (is_epoch == FLB_TRUE || p->time_with_year == FLB_TRUE) {
+            timeptr = p->time_fmt;
         }
         else {
-            tmp = strstr(p->time_fmt_year, "%s.%L");
-
-            if (tmp == NULL) {
-                tmp = strstr(p->time_fmt_year, "%S.%L");
-            }
+            timeptr = p->time_fmt_year;
         }
+
+        tmp = strstr(timeptr, "%L");
         if (tmp) {
-            tmp[2] = '\0';
-            p->time_frac_secs = (tmp + 5);
-        }
-        else {
-            /* same as above but with comma seperator */
-            if (p->time_with_year == FLB_TRUE) {
-                tmp = strstr(p->time_fmt, "%S,%L");
-            }
-            else {
-                tmp = strstr(p->time_fmt_year, "%s,%L");
-
-                if (tmp == NULL) {
-                    tmp = strstr(p->time_fmt_year, "%S,%L");
-                }
-            }
-            if (tmp) {
-                tmp[2] = '\0';
-                p->time_frac_secs = (tmp + 5);
-            }
-            else {
-                p->time_frac_secs = NULL;
-            }
+            tmp[0] = '\0';
+            tmp[1] = '\0';
+            p->time_frac_secs = (tmp + 2);
         }
 
         /* Optional fixed timezone offset */
@@ -694,21 +671,49 @@ int flb_parser_tzone_offset(const char *str, int len, int *tmdiff)
     return 0;
 }
 
+/*
+ * Parse the '%L' (subseconds) part into `subsec`.
+ *
+ *   2020-10-23 12:00:31.415213 JST
+ *                       ----------
+ *
+ * Return the number of characters consumed, or -1 on error.
+ */
+static int parse_subseconds(char *str, int len, double *subsec)
+{
+    char buf[16];
+    char *end;
+    int consumed;
+    int digits = 9;  /* 1 ns = 000000001 (9 digits) */
+
+    if (len < digits) {
+        digits = len;
+    }
+    memcpy(buf, "0.", 2);
+    memcpy(buf + 2, str, digits);
+    buf[digits + 2] = '\0';
+
+    *subsec = strtod(buf, &end);
+
+    consumed = end - buf - 2;
+    if (consumed <= 0) {
+        return -1;
+    }
+    return consumed;
+}
+
 int flb_parser_time_lookup(const char *time_str, size_t tsize,
                            time_t now,
                            struct flb_parser *parser,
                            struct tm *tm, double *ns)
 {
     int ret;
-    int slen;
     time_t time_now;
-    double tmfrac = 0;
     char *p = NULL;
     char *fmt;
     int time_len = tsize;
     const char *time_ptr = time_str;
     char tmp[64];
-    char fs_tmp[32];
     struct tm tmy;
 
     *ns = 0;
@@ -765,80 +770,34 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
         p = flb_strptime(time_ptr, parser->time_fmt, tm);
     }
 
-    if (p != NULL) {
-        /* Check if we have fractional seconds */
-        if (parser->time_frac_secs && (*p == '.' || *p == ',')) {
-            /*
-             * Further parser routines needs a null byte, for fractional seconds
-             * we make a safe copy of the content.
-             */
-            slen = time_len - (p - time_ptr);
-            if (slen > 31) {
-                slen = 31;
-            }
-            memcpy(fs_tmp, p, slen);
-            fs_tmp[slen] = '\0';
+    if (p == NULL) {
+        flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
+        return -1;
+    }
 
-            /* Parse fractional seconds */
-            ret = flb_parser_frac(fs_tmp, slen, &tmfrac, &time_ptr);
-            if (ret == -1) {
-                flb_warn("[parser] Error parsing time string");
-                return -1;
-            }
-            *ns = tmfrac;
-
-            p = flb_strptime(time_ptr, parser->time_frac_secs, tm);
-
-            if (p == NULL) {
-                return -1;
-            }
+    if (parser->time_frac_secs) {
+        ret = parse_subseconds(p, time_len - (p - time_ptr), ns);
+        if (ret < 0) {
+            flb_error("[parser] cannot parse %L for '%.*s'", tsize, time_str);
+            return -1;
         }
+        p += ret;
+
+        /* Parse the remaining part after %L */
+        p = flb_strptime(p, parser->time_frac_secs, tm);
+        if (p == NULL) {
+            flb_error("[parser] cannot parse '%.*s' after %L", tsize, time_str);
+            return -1;
+        }
+    }
 
 #ifdef FLB_HAVE_GMTOFF
-        if (parser->time_with_tz == FLB_FALSE) {
-            tm->tm_gmtoff = parser->time_offset;
-        }
+    if (parser->time_with_tz == FLB_FALSE) {
+        tm->tm_gmtoff = parser->time_offset;
+    }
 #endif
 
-        return 0;
-    }
-
-    return -1;
-}
-
-int flb_parser_frac(const char *str, int len, double *frac, const char **end)
-{
-    int ret = 0;
-    char *p;
-    double d;
-    const char *pstr;
-    char *tmp = NULL;
-
-    /* Fractional seconds */
-    /* Normalize the fractional seperator to be '.' since that's what strtod()
-     * expects in standard C locale */
-    if (*str == ',') {
-        tmp = flb_strdup(str);
-        tmp[0] = '.';
-        pstr = tmp;
-    }
-    else {
-        pstr = str;
-    }
-
-    d = strtod(pstr, &p);
-    if ((d == 0 && p == pstr) || !p) {
-        ret = -1;
-        goto free_and_return;
-    }
-    *frac = d;
-    *end = str + (p - pstr);
-
-free_and_return:
-    if (tmp != NULL) {
-        flb_free(tmp);
-    }
-    return ret;
+    return 0;
 }
 
 int flb_parser_typecast(const char *key, int key_len,

--- a/tests/internal/data/parser/json.conf
+++ b/tests/internal/data/parser/json.conf
@@ -177,6 +177,17 @@
     Time_Format %m/%d/%Y %H:%M:%S,%L %z
     Time_Keep   On
 
+# Parser: generic_NL_TZ
+# ====================
+# Generic date with nanoseconds with colon as fractional separator and timezone
+#
+[PARSER]
+    Name        generic_NL_TZ
+    Format      json
+    Time_Key    time
+    Time_Format %m/%d/%Y %H:%M:%S:%L %z
+    Time_Keep   On
+
 # Parser: apache_error
 # ====================
 # Apache error log time format

--- a/tests/internal/data/parser/regex.conf
+++ b/tests/internal/data/parser/regex.conf
@@ -193,6 +193,19 @@
     Time_Format %m/%d/%Y %H:%M:%S,%L %z
     Time_Keep   On
 
+# Parser: generic_NL_TZ
+# ====================
+# Generic date with nanoseconds with colon as fractional separator and timezone
+#
+[PARSER]
+    Name        generic_NL_TZ
+    Format      regex
+    Regex       ^(?<key001>[^ ]*) (?<key002>[^ ]*) (?<time>.+)$
+    Time_Key    time
+    Time_Format %m/%d/%Y %H:%M:%S:%L %z
+    Time_Keep   On
+
+
 # Parser: apache_error
 # ====================
 # Apache error log time format

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -91,6 +91,7 @@ struct time_check time_entries[] = {
     {"generic_TZ"   , "07/18/2017 01:47:03 +05:30"  , 1500322623, 0,   0},
     {"generic_N_TZ" , "07/17/2017 22:17:03.1 +02:00", 1500322623, 0.1, 0},
     {"generic_NC_TZ", "07/17/2017 22:17:03,1 +02:00", 1500322623, 0.1, 0},
+    {"generic_NL_TZ", "07/17/2017 22:17:03:1 +02:00", 1500322623, 0.1, 0},
 #endif
     /* Same date for different timezones, same timestamp w/ fixed UTC offset */
     {"generic"   , "07/18/2017 01:47:03"   , 1500322623, 0,   19800},


### PR DESCRIPTION
Previously our time parser only supports '%S.%L' (or '%S,%L') as
the sub-second time format.

This generalizes the support so that it can handle an arbitrary
occurance of %L (so for example '%S:%L' is now a valid format).

Closes #2210 and #2367.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
