### PR TITLE
support retention for cloudwatch_logs output

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -157,6 +157,12 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->create_group = FLB_TRUE;
     }
 
+    ctx->log_retention_days = 0;
+    tmp = flb_output_get_property("log_retention_days", ins);
+    if (tmp) {
+        ctx->log_retention_days = atoi(tmp);
+    }
+
     tmp = flb_output_get_property("role_arn", ins);
     if (tmp) {
         ctx->role_arn = tmp;
@@ -526,6 +532,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Automatically create the log group (log streams will always automatically"
      " be created)"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "log_retention_days", "0",
+     0, FLB_FALSE, 0,
+     "If set to a number greater than zero, and newly create log group's "
+     "retention policy is set to this many days. "
+     "Valid values are: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]"
     },
 
     {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -121,6 +121,9 @@ struct flb_cloudwatch {
     /* Should the plugin create the log group */
     int create_group;
 
+    /* If set to a number greater than zero, and newly create log group's retention policy is set to this many days. */
+    int log_retention_days;
+
     /* has the log group successfully been created */
     int group_created;
 

--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -231,6 +231,122 @@ void flb_test_cloudwatch_error_put_log_events(void)
     flb_destroy(ctx);
 }
 
+void flb_test_cloudwatch_put_retention_policy_success(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"log_retention_days", "14", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_cloudwatch_already_exists_create_group_put_retention_policy(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+    setenv("TEST_CREATE_LOG_GROUP_ERROR", ERROR_ALREADY_EXISTS, 1);
+
+    /* PutRetentionPolicy is not called if the group already exists */
+    setenv("TEST_PUT_RETENTION_POLICY_ERROR", ERROR_UNKNOWN, 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"log_retention_days", "14", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_cloudwatch_error_put_retention_policy(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+    setenv("TEST_PUT_RETENTION_POLICY_ERROR", ERROR_UNKNOWN, 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"log_retention_days", "14", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"success", flb_test_cloudwatch_success },
@@ -239,5 +355,8 @@ TEST_LIST = {
     {"create_group_error", flb_test_cloudwatch_error_create_group },
     {"create_stream_error", flb_test_cloudwatch_error_create_stream },
     {"put_log_events_error", flb_test_cloudwatch_error_put_log_events },
+    {"put_retention_policy_success", flb_test_cloudwatch_put_retention_policy_success },
+    {"already_exists_create_group_put_retention_policy", flb_test_cloudwatch_already_exists_create_group_put_retention_policy },
+    {"error_put_retention_policy", flb_test_cloudwatch_error_put_retention_policy },
     {NULL, NULL}
 };


### PR DESCRIPTION
support retention for `cloudwatch_logs` output plugin.
introduce a new property `log_retention_days`.

Addresses #2691

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
