### PR TITLE
io: Fix flb_io_net_connect only opening sync connections

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -257,6 +257,14 @@ FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
         flb_socket_close(u_conn->fd);
     }
 
+    /* Check which connection mode must be done */
+    if (th) {
+        async = flb_upstream_is_async(u);
+    }
+    else {
+        async = FLB_FALSE;
+    }
+
     /*
      * If the net.source_address was set, we need to determinate the address
      * type (for socket type creation) and bind it.
@@ -279,10 +287,10 @@ FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
         }
 
         if (res->ai_family == AF_INET) {
-            fd = flb_net_socket_create(AF_INET, FLB_FALSE);
+            fd = flb_net_socket_create(AF_INET, async);
         }
         else if (res->ai_family == AF_INET6) {
-            fd = flb_net_socket_create(AF_INET6, FLB_FALSE);
+            fd = flb_net_socket_create(AF_INET6, async);
         }
         else {
             flb_error("[io] could not create socket for "
@@ -316,10 +324,10 @@ FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     else {
         /* Create the socket */
         if (u_conn->u->flags & FLB_IO_IPV6) {
-            fd = flb_net_socket_create(AF_INET6, FLB_FALSE);
+            fd = flb_net_socket_create(AF_INET6, async);
         }
         else {
-            fd = flb_net_socket_create(AF_INET, FLB_FALSE);
+            fd = flb_net_socket_create(AF_INET, async);
         }
         if (fd == -1) {
             flb_error("[io] could not create socket");
@@ -332,14 +340,6 @@ FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
 
     /* Disable Nagle's algorithm */
     flb_net_socket_tcp_nodelay(fd);
-
-    /* Check which connection mode must be done */
-    if (th) {
-        async = flb_upstream_is_async(u);
-    }
-    else {
-        async = FLB_FALSE;
-    }
 
     /* Connect */
     if (async == FLB_TRUE) {


### PR DESCRIPTION
Sockets were always initialized to synchronous mode in flb_io_net_connect.
This caused a large performance cost when using http_do in async mode.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
