### PR TITLE
Bug fixes

### DIFF
--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -647,6 +647,9 @@ int flb_config_map_set(struct mk_list *properties, struct mk_list *map, void *co
      */
     mk_list_foreach(head, properties) {
         kv = mk_list_entry(head, struct flb_kv, _head);
+        if (kv->val == NULL) {
+            continue;
+        }
 
         mk_list_foreach(m_head, map) {
             m = mk_list_entry(m_head, struct flb_config_map, _head);

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -866,10 +866,10 @@ int flb_parser_typecast(const char *key, int key_len,
                 }
                 break;
             case FLB_PARSER_TYPE_BOOL:
-                if (!strncasecmp(val, "true", 4)) {
+                if (val_len >= 4 && !strncasecmp(val, "true", 4)) {
                     msgpack_pack_true(pck);
                 }
-                else if(!strncasecmp(val, "false", 5)){
+                else if(val_len >= 5 && !strncasecmp(val, "false", 5)){
                     msgpack_pack_false(pck);
                 }
                 else {

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -168,6 +168,13 @@ _flb_strptime(const char *buf, const char *fmt, struct tm *tm, int initialize)
 			continue;
 		}
 
+        /*
+         * Having increased bp we need to ensure we are not
+         * moving beyond bounds.
+         */
+        if (*bp == '\0')
+           return (NULL);
+
 		if ((c = *fmt++) != '%')
 			goto literal;
 
@@ -177,6 +184,13 @@ again:		switch (c = *fmt++) {
 literal:
 		if (c != *bp++)
 			return (NULL);
+
+        /*
+         * Having increased bp we need to ensure we are not
+         * moving beyond bounds.
+         */
+        if (*bp == '\0')
+           return (NULL);
 
 		break;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes several issues found by fuzzing.

One that is particularly interesting is in the gzip compression logic where we have a fixed-size calculation on the output of the compression. However, this can vary as "the worst case expansion is 5 bytes per 32K" ref https://tools.ietf.org/html/rfc1951

The other ones seem to be more explicit and are related to bounds-checking as well as NULL-pointer dereferences.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

oss-fuzz issue 27261
oss-fuzz issue 27241
oss-fuzz issue 27023
oss-fuzz testcase 5200866812100608 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
