### PR TITLE
strptime: fix regression

### DIFF
--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -185,13 +185,6 @@ literal:
 		if (c != *bp++)
 			return (NULL);
 
-        /*
-         * Having increased bp we need to ensure we are not
-         * moving beyond bounds.
-         */
-        if (*bp == '\0')
-           return (NULL);
-
 		break;
 
 		/*


### PR DESCRIPTION
This commit https://github.com/fluent/fluent-bit/commit/163af0b9c0513f31cc4cbfe8aeee26d22513163c introduced a regression that causes parser tests to fail.

We only need bounds checking in the first place added by this commit, not the second.

Tests passing now. 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
