### PR TITLE
metrics: clarification of output_retries_failed metric

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -196,7 +196,7 @@ flb_sds_t metrics_help_txt(char *metric_name, flb_sds_t *metric_helptxt)
         return flb_sds_cat(*metric_helptxt, " Number of output errors.\n", 26);
     }
     else if (strstr(metric_name, "output_retries_failed")) {
-        return flb_sds_cat(*metric_helptxt, " Number of output retries failed.\n", 34);
+        return flb_sds_cat(*metric_helptxt, " Number of abandoned batches because the maximum number of re-tries was reached.\n", 81);
     }
     else if (strstr(metric_name, "output_retries")) {
         return flb_sds_cat(*metric_helptxt, " Number of output retries.\n", 27);


### PR DESCRIPTION
HELP for prometheus metric output_retries_failed was unclear to me, I found explaination in src/flb_engine.c:206 so I updated the HELP text of metric.


**Testing**
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
