### PR TITLE
Double-free fix

### DIFF
--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -681,7 +681,7 @@ int flb_config_map_set(struct mk_list *properties, struct mk_list *map, void *co
 
             /* Populate value */
             if (m->type == FLB_CONFIG_MAP_STR) {
-                entry->val.str = kv->val;
+                entry->val.str = flb_sds_create(kv->val);
             }
             else if (m->type == FLB_CONFIG_MAP_INT) {
                 entry->val.i_num = atoi(kv->val);


### PR DESCRIPTION
A fix to ensure proper memory allocation to avoid double-free (oss-fuzz 27025).

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
