### PR TITLE
parser: fix inconsistent memory allocation in parser creation

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -111,7 +111,7 @@ int flb_parser_logfmt_do(struct flb_parser *parser,
  * Specifically, this function frees all but parser.types and
  * parser.decoders from a parser.
  *
- * This function is only to be used in parser creation routines
+ * This function is only to be used in parser creation routines.
  */
 static void flb_interim_parser_destroy(struct flb_parser *parser)
 {

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -105,6 +105,38 @@ int flb_parser_logfmt_do(struct flb_parser *parser,
                          void **out_buf, size_t *out_size,
                          struct flb_time *out_time);
 
+/*
+ * This function is used to free all aspects of a parser
+ * which is provided by the caller of flb_create_parser.
+ * Specifically, this function frees all but parser.types and
+ * parser.decoders from a parser.
+ *
+ * This function is only to be used in parser creation routines
+ */
+static void flb_interim_parser_destroy(struct flb_parser *parser)
+{
+    int i = 0;
+    if (parser->type == FLB_PARSER_REGEX) {
+        flb_regex_destroy(parser->regex);
+        flb_free(parser->p_regex);
+    }
+
+    flb_free(parser->name);
+    if (parser->time_fmt) {
+        flb_free(parser->time_fmt);
+        flb_free(parser->time_fmt_full);
+    }
+    if (parser->time_fmt_year) {
+        flb_free(parser->time_fmt_year);
+    }
+    if (parser->time_key) {
+        flb_free(parser->time_key);
+    }
+
+    mk_list_del(&parser->_head);
+    flb_free(parser);
+}
+
 struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *p_regex,
                                      const char *time_fmt, const char *time_key,
@@ -201,7 +233,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
             p->time_fmt_year = flb_malloc(size + 4);
             if (!p->time_fmt_year) {
                 flb_errno();
-                flb_parser_destroy(p);
+                flb_interim_parser_destroy(p);
                 return NULL;
             }
 
@@ -224,7 +256,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
 #else
             flb_error("[parser] timezone offset not supported");
             flb_error("[parser] you cannot use %%z/%%Z on this platform");
-            flb_parser_destroy(p);
+            flb_interim_parser_destroy(p);
             return NULL;
 #endif
         }
@@ -261,7 +293,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
             len = strlen(time_offset);
             ret = flb_parser_tzone_offset(time_offset, len, &diff);
             if (ret == -1) {
-                flb_parser_destroy(p);
+                flb_interim_parser_destroy(p);
                 return NULL;
             }
             p->time_offset = diff;


### PR DESCRIPTION
parser: fix inconsistent memory allocation in parser creation (oss-fuzz 26345)

This solves issue https://github.com/fluent/fluent-bit/issues/2686

The approach taken is to avoid any freeing of memory provided by the caller inside of `flb_parser_create`. The issues is well-explained in the link so I won't go into detail with it here, but please ask if clarification is needed.

The current approach in the `flb_parser_create` routine will inevitably lead to either use-after-frees, double-frees or memory leakage. 

This commit fixes https://github.com/fluent/fluent-bit/issues/2686 by
avoiding any free of memory provided by the caller in flb_parser_create.

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
