### PR TITLE
loki output plugin: escape keys when auto_kubernetes_labels is set

### DIFF
--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -31,10 +31,13 @@
 #define FLB_LOKI_HOST            "127.0.0.1"
 #define FLB_LOKI_PORT            3100
 #define FLB_LOKI_HEADER_SCOPE    "X-Scope-OrgID"
+#define FLB_LOKI_ESCAPE_KUBERNETES_AUTO_KEYS 1
 
 #define FLB_LOKI_KV_STR    0     /* sds string */
 #define FLB_LOKI_KV_RA     1     /* record accessor */
 #define FLB_LOKI_KV_K8S    2     /* kubernetes label */
+
+static const char *flb_loki_escape_chars = "/-.";
 
 struct flb_loki_kv {
     int val_type;                       /* FLB_LOKI_KV_STR or FLB_LOKI_KV_RA */


### PR DESCRIPTION
Escaping keys generated by auto_kubernetes_labels feature in loki output plugin. Possible key delimiters generated by kubernetes like `.`, `/`, `-` are replaced to `_`, since loki doesn't support delimiters like that.

**Testing**
[configandlogs.zip](https://github.com/fluent/fluent-bit/files/5518719/configandlogs.zip)

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [x] Documentation required for this feature
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
