### PR TITLE
out_cloudwatch_logs: add extra_user_agent option

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -79,6 +79,7 @@ struct flb_aws_client {
     int port;
     char *proxy;
     int flags;
+    char *extra_user_agent;
 
     /*
      * Additional headers which will be added to all requests.

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -128,6 +128,11 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->log_key = tmp;
     }
 
+    tmp = flb_output_get_property("extra_user_agent", ins);
+    if (tmp) {
+        ctx->extra_user_agent = tmp;
+    }
+    
     tmp = flb_output_get_property("region", ins);
     if (tmp) {
         ctx->region = tmp;
@@ -289,6 +294,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     ctx->cw_client->proxy = NULL;
     ctx->cw_client->static_headers = &content_type_header;
     ctx->cw_client->static_headers_len = 1;
+    ctx->cw_client->extra_user_agent = (char *) ctx->extra_user_agent;
 
     struct flb_upstream *upstream = flb_upstream_create(config, ctx->endpoint,
                                                         443, FLB_IO_TLS,
@@ -505,6 +511,15 @@ static struct flb_config_map config_map[] = {
      "that key will be sent to CloudWatch. For example, if you are using "
      "the Fluentd Docker log driver, you can specify log_key log and only "
      "the log message will be sent to CloudWatch."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "extra_user_agent", NULL,
+     0, FLB_FALSE, 0,
+     "This option appends a string to the default user agent. "
+     "AWS asks that you not manually set this field yourself, "
+     "it is reserved for use in our vended configurations, "
+     "for example, EKS Container Insights."
     },
 
     {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -117,6 +117,7 @@ struct flb_cloudwatch {
     const char *log_format;
     const char *role_arn;
     const char *log_key;
+    const char *extra_user_agent;
     int custom_endpoint;
     /* Should the plugin create the log group */
     int create_group;

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -267,6 +267,8 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
     int normalize_uri;
     struct flb_aws_header header;
     struct flb_http_client *c = NULL;
+    flb_sds_t tmp;
+    flb_sds_t user_agent_prefix;
 
     u_conn = flb_upstream_conn_get(aws_client->upstream);
     if (!u_conn) {
@@ -296,8 +298,27 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
     }
 
     /* Add AWS Fluent Bit user agent */
-    ret = flb_http_add_header(c, "User-Agent", 10,
-                              "aws-fluent-bit-plugin", 21);
+    if (aws_client->extra_user_agent == NULL) {
+        ret = flb_http_add_header(c, "User-Agent", 10,
+                                  "aws-fluent-bit-plugin", 21);
+    } 
+    else {
+        user_agent_prefix = flb_sds_create_size(64);
+        tmp = flb_sds_printf(&user_agent_prefix, "aws-fluent-bit-plugin-%s", 
+                             aws_client->extra_user_agent);
+        if (!tmp) {
+            flb_errno();
+            flb_sds_destroy(user_agent_prefix);
+            flb_error("[aws_client] failed to fetch user agent");
+            goto error;
+        }
+        user_agent_prefix = tmp;
+
+        ret = flb_http_add_header(c, "User-Agent", 10, user_agent_prefix, 
+                                  flb_sds_len(user_agent_prefix));
+        flb_sds_destroy(user_agent_prefix);
+    }
+    
     if (ret < 0) {
         if (aws_client->debug_only == FLB_TRUE) {
             flb_debug("[aws_client] failed to add header to request");


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Add extra_user_agent option to append strings to the user agent.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
