### PR TITLE
Added apache error log parser compatibility for remote entry.

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -15,7 +15,7 @@
 [PARSER]
     Name   apache_error
     Format regex
-    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[(client|remote) (?<client>[^\]]*)\])? (?<message>.*)$
 
 [PARSER]
     Name   nginx


### PR DESCRIPTION
Depending on the setup and configuration of Apache, it is possible to get a `[remote <ip>:<port>]` entry in the Apache error logs instead of `[client <ip>:<port>]`.

This pull request makes sure to add that compatibility, while keeping the old behavior as well.

Log example:
```
[Fri Nov 13 04:46:15.018574 2020] [wsgi:error] [pid 1371565:tid 140664112514816] [remote 10.0.25.244:7948] WARNING: request '/9624302_398x600.jpg' took 2.030s to process {'download': 1.777, 'rescale': 0.253}
```