### PR TITLE
in_storage_backlog: update bytes counter for backoff logs

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -308,6 +308,7 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
                                             void *chunk)
 {
     uint64_t chunk_routes_mask;
+    ssize_t bytes;
 
 #ifdef FLB_HAVE_METRICS
     int ret;
@@ -350,6 +351,9 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
                  flb_input_chunk_get_name(ic));
     }
     ic->routes_mask = chunk_routes_mask;
+
+    bytes = flb_input_chunk_get_size(ic);
+    flb_input_chunk_update_output_instances(ic, bytes);
 
     return ic;
 }


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jefflpj@outlook.com>

<!-- Provide summary of changes -->
This change is to keep the bytes counter updated when there are backoff logs on the container before running Fluent-bit.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
