### PR TITLE
out_forward: add compress option for gzip compression

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_sha512.h>
 #include <fluent-bit/flb_config_map.h>
 #include <fluent-bit/flb_random.h>
+#include <fluent-bit/flb_gzip.h>
 #include <msgpack.h>
 
 #include "forward.h"
@@ -643,6 +644,39 @@ static int config_set_properties(struct flb_upstream_node *node,
 
     }
 
+    /* compress (implies send_options) */
+    tmp = config_get_property("compress", node, ctx);
+    if (tmp) {
+        if (!strcasecmp(tmp, "text")) {
+            fc->compress = COMPRESS_NONE;
+        }
+        else if (!strcasecmp(tmp, "gzip")) {
+            fc->compress = COMPRESS_GZIP;
+            fc->send_options = FLB_TRUE;
+        }
+        else {
+            flb_plg_error(ctx->ins, "invalid compress mode: %s", tmp);
+            return -1;
+        }
+    }
+    else {
+        fc->compress = COMPRESS_NONE;
+    }
+
+    if (fc->compress != COMPRESS_NONE && fc->time_as_integer == FLB_TRUE) {
+        flb_plg_error(ctx->ins, "compress mode %s is incompatible with "
+                      "time_as_integer", tmp);
+        return -1;
+    }
+
+#ifdef FLB_HAVE_RECORD_ACCESSOR
+    if (fc->compress != COMPRESS_NONE && fc->ra_static == FLB_FALSE) {
+        flb_plg_error(ctx->ins, "compress mode %s is incompatible with dynamic "
+                      "tags", tmp);
+        return -1;
+    }
+#endif
+
     return 0;
 }
 
@@ -933,6 +967,8 @@ static int flush_forward_mode(struct flb_forward *ctx,
     msgpack_unpacked result;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
+    void *final_data;
+    size_t final_bytes;
 
     /* Pack message header */
     msgpack_sbuffer_init(&mp_sbuf);
@@ -943,23 +979,51 @@ static int flush_forward_mode(struct flb_forward *ctx,
     /* Tag */
     flb_forward_format_append_tag(ctx, fc, &mp_pck, NULL, tag, tag_len);
 
-    entries = flb_mp_count(data, bytes);
-    msgpack_pack_array(&mp_pck, entries);
+    if (fc->compress == COMPRESS_GZIP) {
+        /* When compress is set, we switch from using Forward mode to using
+         * CompressedPackedForward mode.
+         */
+        ret = flb_gzip_compress((void *) data, bytes, &final_data, &final_bytes);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not compress entries");
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            return FLB_RETRY;
+        }
+
+        msgpack_pack_bin(&mp_pck, final_bytes);
+
+    } else {
+        final_data = (void *) data;
+        final_bytes = bytes;
+
+        entries = flb_mp_count(data, bytes);
+        msgpack_pack_array(&mp_pck, entries);
+    }
 
     /* Write message header */
     ret = flb_io_net_write(u_conn, mp_sbuf.data, mp_sbuf.size, &bytes_sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not write forward header");
         msgpack_sbuffer_destroy(&mp_sbuf);
+        if (fc->compress == COMPRESS_GZIP) {
+            flb_free(final_data);
+        }
         return FLB_RETRY;
     }
     msgpack_sbuffer_destroy(&mp_sbuf);
 
     /* Write entries */
-    ret = flb_io_net_write(u_conn, data, bytes, &bytes_sent);
+    ret = flb_io_net_write(u_conn, final_data, final_bytes, &bytes_sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not write forward entries");
+        if (fc->compress == COMPRESS_GZIP) {
+            flb_free(final_data);
+        }
         return FLB_RETRY;
+    }
+
+    if (fc->compress == COMPRESS_GZIP) {
+        flb_free(final_data);
     }
 
     /* Write options */
@@ -1249,6 +1313,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "tag", NULL,
      0, FLB_FALSE, 0,
      "Set a custom Tag for the outgoing records"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "compress", NULL,
+     0, FLB_FALSE, 0,
+     "Compression mode"
     },
     /* EOF */
     {0}

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -36,7 +36,10 @@
 #define MODE_MESSAGE               0
 #define MODE_FORWARD               1
 #define MODE_FORWARD_COMPAT        3
-#define MODE_FORWARD_GZIP          4
+
+/* Compression modes */
+#define COMPRESS_NONE              0
+#define COMPRESS_GZIP              1
 
 /*
  * Configuration: we put this separate from the main
@@ -49,6 +52,7 @@
  */
 struct flb_forward_config {
     int secured;              /* Using Secure Forward mode ?  */
+    int compress;             /* Using compression ? */
     int time_as_integer;      /* Use backward compatible timestamp ? */
 
     /* config */

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -105,6 +105,12 @@ static int append_options(struct flb_forward *ctx,
         opt_count++;
     }
 
+    if (entries > 0 &&                      /* not message mode */
+        fc->time_as_integer == FLB_FALSE && /* not compat mode */
+        fc->compress == COMPRESS_GZIP) {
+        opt_count++;
+    }
+
     /* options is map */
     msgpack_pack_map(mp_pck, opt_count);
 
@@ -121,6 +127,15 @@ static int append_options(struct flb_forward *ctx,
         msgpack_pack_str(mp_pck, 4);
         msgpack_pack_str_body(mp_pck, "size", 4);
         msgpack_pack_int64(mp_pck, entries);
+    }
+
+    if (entries > 0 &&                      /* not message mode */
+        fc->time_as_integer == FLB_FALSE && /* not compat mode */
+        fc->compress == COMPRESS_GZIP) {
+        msgpack_pack_str(mp_pck, 10);
+        msgpack_pack_str_body(mp_pck, "compressed", 10);
+        msgpack_pack_str(mp_pck, 4);
+        msgpack_pack_str_body(mp_pck, "gzip", 4);
     }
 
     flb_plg_debug(ctx->ins,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Enables optional gzip compression in out_forward plugin, compliant with https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #1497

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/417

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
