### PR TITLE
Fix problem with SIGSEGV on FreeBSD 12+

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -45,7 +45,7 @@ static inline int consume_byte(flb_pipefd_t fd)
 
     /* We need to consume the byte */
     ret = flb_pipe_r(fd, &val, sizeof(val));
-#ifdef __APPLE__
+#if defined(__APPLE__) || __FreeBSD__ >= 12
     if (ret < 0) {
 #else
     if (ret <= 0) {


### PR DESCRIPTION
This is partly related to https://github.com/fluent/fluent-bit/pull/2463 for MacOS.

The first one is in  flb_pipe_r() function returning 0 on FreeBSD 12+ and that
brings up errors similar to "[error] [src/flb_scheduler.c:52 errno=0] No error:
0". This patch will fix it the same way as it was fixed by upstream code for
MacOS.

The second issue is a SIGSEGV that is caused by incorrect section
structure of the resulting binary file generated by clang due to some gcc
specific code in libco.  Since there are two copies of libco (flb_libco) code
in the fluent-bit sources - one in the lib/flb_libco folder and another one in
lib/monkey/deps/flb_libco - they are both patched the same way.

This patches were tested on FreeBSD 11.4 and 12.2 amd64.
The resulting binaries was tested with "elfdump -a" to contain only one ".text"
section and their startup logs were tested running "fluent-bit -v -i dummy -o
stdout".

Submitted by: Yuri Pankov and Artyom Davidov
Signed-off-by: Palle Girgensohn <girgen@FreeBSD.org>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
