### PR TITLE
win32: Use SERVICE_WIN32_OWN_PROCESS for dwServiceType

### DIFF
--- a/src/win32/winsvc.c
+++ b/src/win32/winsvc.c
@@ -35,7 +35,7 @@ static void svc_notify(DWORD status)
 {
     SERVICE_STATUS ss;
 
-    ss.dwServiceType = SERVICE_USER_OWN_PROCESS;
+    ss.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
     ss.dwCurrentState = status;
     ss.dwWin32ExitCode = NO_ERROR;
     ss.dwServiceSpecificExitCode = NO_ERROR;


### PR DESCRIPTION
This fixes the bug "Fluent Bit is stuck pending on WinServer 2012".

Apparently, Windows Server 2012 imposes a strict parameter control
on SetServiceStatus() and it returns errors if the service type is
set differently than the creation-time flag.

Avoid that issue by using "SERVICE_WIN32_OWN_PROCESS".

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>