### PR TITLE
in_exec: Add a new option "Oneshot"

### DIFF
--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -39,6 +39,8 @@ struct flb_exec {
     char *buf;
     size_t buf_size;
     struct flb_input_instance *ins;
+    int oneshot;
+    flb_pipefd_t ch_manager[2];
 };
 
 #endif /* FLB_IN_EXEC_H */


### PR DESCRIPTION
Fluentd allows `in_exec` to run only once on startup. This feature
is often used for collecting data precedent to Fluentd's startup.

This adds the same functionality to Fluent Bit. With this patch,
we can set up `in_exec` as follows:

```ini
[INPUT]
  Name    exec
  Command dmesg --kernel --level=err,warn
  Oneshot true
  Parser  dmsg_parser
```

This PR should fix #2757.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
