### PR TITLE
out_s3: add support for canned ACL

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -94,6 +94,7 @@ struct flb_s3 {
     char *tag_delimiters;
     char *endpoint;
     char *sts_endpoint;
+    char *canned_acl;
     int free_endpoint;
     int use_put_object;
 
@@ -150,6 +151,7 @@ void multipart_read_uploads_from_fs(struct flb_s3 *ctx);
 void multipart_upload_destroy(struct multipart_upload *m_upload);
 
 struct flb_http_client *mock_s3_call(char *error_env_var, char *api);
+struct flb_aws_header *create_canned_acl_header(char *canned_acl);
 int s3_plugin_under_test();
 
 #endif


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
add support for canned ACL
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Part of #2700 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
