### PR TITLE
aws: ECS comes before EC2 in standard chain

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -368,6 +368,13 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
         }
     }
 
+    sub_provider = flb_ecs_provider_create(config, generator);
+    if (sub_provider) {
+        /* ECS Provider will fail creation if we are not running in ECS */
+        mk_list_add(&sub_provider->_head, &implementation->sub_providers);
+        flb_debug("[aws_credentials] Initialized ECS Provider in standard chain");
+    }
+
     sub_provider = flb_ec2_provider_create(config, generator);
     if (!sub_provider) {
         /* EC2 provider will only fail creation if a memory alloc failed */
@@ -376,13 +383,6 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
     }
     mk_list_add(&sub_provider->_head, &implementation->sub_providers);
     flb_debug("[aws_credentials] Initialized EC2 Provider in standard chain");
-
-    sub_provider = flb_ecs_provider_create(config, generator);
-    if (sub_provider) {
-        /* ECS Provider will fail creation if we are not running in ECS */
-        mk_list_add(&sub_provider->_head, &implementation->sub_providers);
-        flb_debug("[aws_credentials] Initialized ECS Provider in standard chain");
-    }
 
     return provider;
 }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
