### PR TITLE
input_chunk: Update tag value extraction for backoff logs

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -309,9 +309,11 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
 {
     uint64_t chunk_routes_mask;
     ssize_t bytes;
+    const char *tag_buf;
+    int tag_len;
+    int ret;
 
 #ifdef FLB_HAVE_METRICS
-    int ret;
     char *buf_data;
     size_t buf_size;
 #endif
@@ -345,7 +347,14 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
     }
 #endif
 
-    chunk_routes_mask = flb_router_get_routes_mask_by_tag(in->tag, in->tag_len, in);
+    /* Get the the tag reference (chunk metadata) */
+    ret = flb_input_chunk_get_tag(ic, &tag_buf, &tag_len);
+    if (ret == -1) {
+	flb_error("[input chunk] error retrieving tag of input chunk");
+	return ic;
+    }
+
+    chunk_routes_mask = flb_router_get_routes_mask_by_tag(tag_buf, tag_len, in);
     if (chunk_routes_mask == 0) {
         flb_warn("[input chunk] no matching route for backoff log chunk %s",
                  flb_input_chunk_get_name(ic));


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jefflpj@outlook.com>

<!-- Provide summary of changes -->
Backoff logs are pulled by a input plugin that users are not able to config. And also the plugin doesn't have the tag value that can be used to route the input chunks to their destination. I found that there is a function `flb_input_chunk_get_tag` that can be used to extract the tag value of the input chunk from metadata.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#2765 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
