### PR TITLE
in_storage_backlog: Add Windows file storage support

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -37,7 +37,7 @@ set(FLB_IN_NETIF               No)
 set(FLB_IN_WINLOG             Yes)
 set(FLB_IN_COLLECTD            No)
 set(FLB_IN_STATSD             Yes)
-set(FLB_IN_STORAGE_BACKLOG     No)
+set(FLB_IN_STORAGE_BACKLOG    Yes)
 set(FLB_IN_EMITTER            Yes)
 
 # OUTPUT plugins

--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -25,7 +25,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
 #include <unistd.h>
+#endif
 
 struct sb_chunk {
     struct cio_chunk *chunk;


### PR DESCRIPTION
This patch is what is needed in Fluent Bit's side to allow
Windows users to start using filesystem storage.

With this and edsiper/chunkio/pull/59 merged, I can confirm that
Fluent Bit can persist input data on disks.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
