### PR TITLE
network: Fix an invalid reference to `u_conn`

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -240,7 +240,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          * socket status, getting a EINPROGRESS is expected, but any other case
          * means a failure.
          */
-        err = flb_socket_error(u_conn->fd);
+        err = flb_socket_error(fd);
         if (!FLB_EINPROGRESS(err)) {
             flb_error("[net] connection #%i failed to: %s:%i",
                       fd, host, port);


### PR DESCRIPTION
Windows build is failing with the following error:

    flb_network.c(243): error C2065: 'u_conn': undeclared identifier

This is because `u_conn` is not defined within the scope of this
function (net_connect_sync).

With this patch, master HEAD becomes compilable on Windows again.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>