### PR TITLE
parser: Add a new option 'Time_Strict'

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -49,6 +49,7 @@ struct flb_parser {
     char *time_key;       /* field name that contains the time */
     int time_offset;      /* fixed UTC offset */
     int time_keep;        /* keep time field */
+    int time_strict;      /* parse time field strictly */
     char *time_frac_secs; /* time format have fractional seconds ? */
     struct flb_parser_types *types; /* type casting */
     int types_len;
@@ -92,6 +93,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *time_fmt, const char *time_key,
                                      const char *time_offset,
                                      int time_keep,
+                                     int time_strict,
                                      struct flb_parser_types *types,
                                      int types_len,
                                      struct mk_list *decoders,

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -142,6 +142,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *time_fmt, const char *time_key,
                                      const char *time_offset,
                                      int time_keep,
+                                     int time_strict,
                                      struct flb_parser_types *types,
                                      int types_len,
                                      struct mk_list *decoders,
@@ -305,6 +306,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
 
     p->time_keep = time_keep;
+    p->time_strict = time_strict;
     p->types = types;
     p->types_len = types_len;
     return p;
@@ -452,6 +454,7 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
     flb_sds_t types_str;
     flb_sds_t tmp_str;
     int time_keep;
+    int time_strict;
     int types_len;
     struct mk_rconf *fconf;
     struct mk_rconf_section *section;
@@ -539,6 +542,14 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
             flb_sds_destroy(tmp_str);
         }
 
+        /* Time_Strict */
+        time_strict = FLB_TRUE;
+        tmp_str = get_parser_key("Time_Strict", config, section);
+        if (tmp_str) {
+            time_strict = flb_utils_bool(tmp_str);
+            flb_sds_destroy(tmp_str);
+        }
+
         /* Time_Offset (UTC offset) */
         time_offset = get_parser_key("Time_Offset", config, section);
 
@@ -556,7 +567,7 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
 
         /* Create the parser context */
         if (!flb_parser_create(name, format, regex,
-                               time_fmt, time_key, time_offset, time_keep,
+                               time_fmt, time_key, time_offset, time_keep, time_strict,
                                types, types_len, decoders, config)) {
             goto fconf_error;
         }
@@ -814,23 +825,35 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
     }
 
     if (p == NULL) {
-        flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
-        return -1;
+        if (parser->time_strict) {
+            flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
+            return -1;
+        }
+        flb_debug("[parser] non-exact match '%.*s'", tsize, time_str);
+        return 0;
     }
 
     if (parser->time_frac_secs) {
         ret = parse_subseconds(p, time_len - (p - time_ptr), ns);
         if (ret < 0) {
-            flb_error("[parser] cannot parse %L for '%.*s'", tsize, time_str);
-            return -1;
+            if (parser->time_strict) {
+                flb_error("[parser] cannot parse %%L for '%.*s'", tsize, time_str);
+                return -1;
+            }
+            flb_debug("[parser] non-exact match on %%L '%.*s'", tsize, time_str);
+            return 0;
         }
         p += ret;
 
         /* Parse the remaining part after %L */
         p = flb_strptime(p, parser->time_frac_secs, tm);
         if (p == NULL) {
-            flb_error("[parser] cannot parse '%.*s' after %L", tsize, time_str);
-            return -1;
+            if (parser->time_strict) {
+                flb_error("[parser] cannot parse '%.*s' after %%L", tsize, time_str);
+                return -1;
+            }
+            flb_debug("[parser] non-exact match after %%L '%.*s'", tsize, time_str);
+            return 0;
         }
     }
 

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -14,8 +14,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     /* json parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "json", NULL, NULL,
-                                    NULL, NULL, MK_FALSE, NULL,
-                                    0, NULL, fuzz_config);
+                                    NULL, NULL, MK_FALSE, MK_TRUE,
+                                    NULL, 0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size, 
                   &out_buf, &out_size, &out_time);
 

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -15,7 +15,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL,
                                     NULL, NULL, NULL, MK_FALSE,
-                                    NULL, 0, NULL, fuzz_config);
+                                    MK_TRUE, NULL, 0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -15,7 +15,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL,
                                     NULL, NULL, NULL, MK_FALSE, 
-                                    NULL, 0, NULL, fuzz_config);
+                                    MK_TRUE, NULL, 0, NULL,
+                                    fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -63,7 +63,7 @@ void flb_test_filter_parser_extract_fields()
 
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
-                               NULL, NULL, NULL, MK_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -148,7 +148,7 @@ void flb_test_filter_parser_reserve_data_off()
 
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
-                               NULL, NULL, NULL, MK_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -224,7 +224,7 @@ void flb_test_filter_parser_handle_time_key()
     /* Parser */
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", "%Y-%m-%dT%H:%M:%S.%L",
                                "time",
-                               NULL, MK_FALSE,
+                               NULL, MK_FALSE, MK_TRUE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -300,7 +300,7 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     /* Parser */
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", "%s.%L",
                                "time",
-                               NULL, MK_FALSE,
+                               NULL, MK_FALSE, MK_TRUE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -380,7 +380,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     /* Parser */
     parser = flb_parser_create("timestamp", "regex",
                                "^(?<time>.*)$", "%Y-%m-%dT%H:%M:%S.%L", "time",
-                               NULL, FLB_FALSE,
+                               NULL, FLB_FALSE, MK_TRUE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -456,7 +456,7 @@ void flb_test_filter_parser_preserve_original_field()
 
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
-                               NULL, NULL, NULL, MK_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -539,13 +539,13 @@ void flb_test_filter_parser_first_matched_when_mutilple_parser()
 
     /* Parser */
     parser = flb_parser_create("one", "regex", "^(?<one>.+?)$",
-                               NULL, NULL, NULL, MK_FALSE, NULL, 0,
-                               NULL, ctx->config);
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE,
+                               NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
     parser = flb_parser_create("two", "regex", "^(?<two>.+?)$",
-                               NULL, NULL, NULL, MK_FALSE, NULL, 0,
-                               NULL, ctx->config);
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE,
+                               NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
     /* Filter */


### PR DESCRIPTION
The old behaviour was that it accepts time data only if the
format is specified exactly. If the format does not match, it
simply returns an error.

However, with the new `Time_Strict` option, a time parser can
behave in "best effort" mode, and be permissive on heterogeneous
time data.

For example, suppose you set up the following time format:

    Time_Format %Y-%m-%dT%H:%M:%S.%L

... and received the record like this:

    {"time":"2020-11-10T11:11:26+00:00"}

With `Time_Strict` turned off, you'll get the following result:

    "2020-11-10T11:11:26+00:00" => 2020-11-10T11:11:26.000000Z

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>