### PR TITLE
Add cloud settings for ES output

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -675,6 +675,9 @@ static void cb_es_flush(const void *data, size_t bytes,
     if (ctx->http_user && ctx->http_passwd) {
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
+    else if (ctx->cloud_user && ctx->cloud_passwd) {
+        flb_http_basic_auth(c, ctx->cloud_user, ctx->cloud_passwd);
+    }
 
 #ifdef FLB_HAVE_AWS
     if (ctx->has_aws_auth == FLB_TRUE) {
@@ -786,6 +789,18 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "http_passwd", "",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, http_passwd),
      NULL
+    },
+
+    /* Cloud Authentication */
+    {
+     FLB_CONFIG_MAP_STR, "cloud_id", NULL,
+     0, FLB_FALSE, 0,
+     "Elastic cloud ID of the cluster to connect to"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "cloud_auth", NULL,
+     0, FLB_FALSE, 0,
+     "Elastic cloud authentication credentials"
     },
 
     /* AWS Authentication */

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -41,6 +41,10 @@ struct flb_elasticsearch {
     char *http_user;
     char *http_passwd;
 
+    /* Elastic Cloud Auth */
+    char *cloud_user;
+    char *cloud_passwd;
+
     /* AWS Auth */
 #ifdef FLB_HAVE_AWS
     int has_aws_auth;


### PR DESCRIPTION
This PR adds `cloud_id` and `cloud_auth` settings so as to provide support for Fluent-bit shipping to ES cluster in Elastic cloud with an easily configurable manner.

Addresses https://github.com/fluent/fluent-bit/issues/2833

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature (https://github.com/fluent/fluent-bit-docs/pull/430)

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
