### PR TITLE
support network configuration for kafka rest output plugin

### DIFF
--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -24,11 +24,64 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_config_map.h>
 #include <msgpack.h>
 
 #include "kafka.h"
 #include "kafka_conf.h"
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "message_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, message_key),
+     "Specify a message key. "
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "time_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, time_key),
+     "Specify the name of the field that holds the record timestamp. "
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "topic", "fluent-bit",
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, topic),
+     "Specify the kafka topic. "
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "url_path", NULL,
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, url_path),
+     "Specify an optional HTTP URL path for the target web server, e.g: /something"
+    },
+
+    {
+     FLB_CONFIG_MAP_DOUBLE, "partition", "-1",
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, partition),
+     "Specify kafka partition number. "
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "time_key_format", FLB_KAFKA_TIME_KEYF,
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, time_key_format),
+     "Specify the format of the timestamp. "
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "include_tag_key", "false",
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, include_tag_key),
+     "Specify whether to append tag name to final record. "
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "tag_key", "_flb-key",
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, tag_key),
+     "Specify the key name of the record if include_tag_key is enabled. "
+    },
+
+    /* EOF */
+    {0}
+};
 /*
  * Convert the internal Fluent Bit data representation to the required
  * one by Kafka REST Proxy.
@@ -283,5 +336,6 @@ struct flb_output_plugin out_kafka_rest_plugin = {
     .cb_init      = cb_kafka_init,
     .cb_flush     = cb_kafka_flush,
     .cb_exit      = cb_kafka_exit,
+    .config_map   = config_map,
     .flags        = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };

--- a/plugins/out_kafka_rest/kafka.h
+++ b/plugins/out_kafka_rest/kafka.h
@@ -51,6 +51,7 @@ struct flb_kafka_rest {
 
     /* HTTP URI */
     char uri[256];
+    char *url_path;
 
     /* Upstream connection to the backend server */
     struct flb_upstream *u;


### PR DESCRIPTION
<!-- Provide summary of changes -->
1. Moved the kafka configuration to config map. 
2. Added network configuration support.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes https://github.com/fluent/fluent-bit/issues/2841
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ x] Example configuration file for the change
- [x] Debug log output from testing the change
```
  19 ^[[1m[^[[0m2020/12/09 15:34:57^[[1m]^[[0m [^[[94mtrace^[[0m] [upstream] get new connecti     on for 127.0.0.1:8082, net setup:
  20 net.connect_timeout        = 10 seconds
  21 net.source_address         = 10.204.48.252
  22 net.keepalive              = enabled
  23 net.keepalive_idle_timeout = 30 seconds

```
<
[val.txt](https://github.com/fluent/fluent-bit/files/5665080/val.txt)
[test_conf.txt](https://github.com/fluent/fluent-bit/files/5665087/test_conf.txt)


!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
