### PR TITLE
kafka: check only for first val.via.str.size chars

### DIFF
--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -58,4 +58,17 @@ static inline char *flb_strndup(const char *s, size_t n)
     return str;
 }
 
+static inline const char *flb_strnchr(const char *s, int c, size_t n)
+{
+    for (size_t i = 0; i < n; i++) {
+        if (s[i] == '\0') {
+            return NULL;
+        }
+        if (s[i] == c) {
+            return &s[i];
+        }
+    }
+    return NULL;
+}
+
 #endif

--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -58,17 +58,4 @@ static inline char *flb_strndup(const char *s, size_t n)
     return str;
 }
 
-static inline const char *flb_strnchr(const char *s, int c, size_t n)
-{
-    for (size_t i = 0; i < n; i++) {
-        if (s[i] == '\0') {
-            return NULL;
-        }
-        if (s[i] == c) {
-            return &s[i];
-        }
-    }
-    return NULL;
-}
-
 #endif

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -178,7 +178,7 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
                     /* Only if default topic is set and this topicname is not set for this message */
                     if (strncmp(topic->name, flb_kafka_topic_default(ctx)->name, val.via.str.size) == 0 &&
                         (strncmp(topic->name, val.via.str.ptr, val.via.str.size) != 0) ) {
-                        if (flb_strnchr(val.via.str.ptr, ',', val.via.str.size)) {
+                        if (memchr(val.via.str.ptr, ',', val.via.str.size)) {
                             /* Don't allow commas in kafkatopic name */
                             flb_warn("',' not allowed in dynamic_kafka topic names");
                             continue;

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -178,7 +178,7 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
                     /* Only if default topic is set and this topicname is not set for this message */
                     if (strncmp(topic->name, flb_kafka_topic_default(ctx)->name, val.via.str.size) == 0 &&
                         (strncmp(topic->name, val.via.str.ptr, val.via.str.size) != 0) ) {
-                        if (strstr(val.via.str.ptr, ",")) {
+                        if (flb_strnchr(val.via.str.ptr, ',', val.via.str.size)) {
                             /* Don't allow commas in kafkatopic name */
                             flb_warn("',' not allowed in dynamic_kafka topic names");
                             continue;


### PR DESCRIPTION
`val.via.str.ptr` here is not a regular C string - it is not `\0`
terminated as it comes from `msgpack`. Thus, using the regular `strstr`
here is bad as we might "jump over" to other content in memory.
Introduce a new `flb_strnchr` which operates on possibly NULL-terminated
strings.  Use it in the `kafka` output plugin.

Using `strncmp` is fine because the char arrays need not be
NULL-terminated.

Fixes #2836. Cannot reproduce it locally after this fix.

Huge, huge kudos to @deimantastumas for a lot of investigation and a
very good test case. <3

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>
Co-authored-by: Deimantas Tumas <d.tumas@adform.com>

Before:
```
./fluent-bit --config=fluent-bit.conf
Fluent Bit v1.7.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/12/09 22:29:12] [ info] [engine] started (pid=100095)
[2020/12/09 22:29:12] [ info] [storage] version=1.1.0, initializing...
[2020/12/09 22:29:12] [ info] [storage] in-memory
[2020/12/09 22:29:12] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/12/09 22:29:12] [ info] [output:kafka:kafka.1] brokers='localhost:9092' topics='laas-dlq'
[2020/12/09 22:29:12] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020/12/09 22:29:12] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2020/12/09 22:29:12] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: 1/1 brokers are down
[2020/12/09 22:29:12] [ info] [sp] stream processor started
[2020/12/09 22:29:13] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
[0] kube.sanity.log: [1607545752.410602400, {"stream"=>"stdout", "@version"=>"1", "topic"=>"teama", "@timestamp"=>"2020-11-27T14:51:14.651Z", "kubernetes"=>{"host"=>"cskwrk003pppjay.lin.pp.com", "container_name"=>"connector", "pod_id"=>"12345", "pod_name"=>"sink-dimstore", "annotations"=>{"prometheus.io/label-consumer"=>",DimStore", "prometheus.io/port"=>"8080", "prometheus.io/tenant"=>"Team A", "prometheus.io/scrape"=>"true", "prometheus.io/label-producer"=>",Classifier,Advertiser,Site Tracking,Campaigns,Inventory", "tenant"=>"Team A", "checksum/secrets"=>"12345", "checksum/environment"=>"12345", "prometheus.io/label-is_ddp"=>"true"}, "labels"=>{"laas-format"=>"json", "pod-template-hash"=>"12345", "release"=>"sink-dimstore-k8s-psgdst-postgres", "laas"=>"true"}, "namespace_name"=>"ddp", "container_image"=>"docker.artifactory.etc", "docker_id"=>"12345", "container_hash"=>"docker.artifactory.etc"}, "log"=>"log_content", "time"=>"2020-11-27T14:51:14.651934011Z"}]
[2020/12/09 22:29:13] [ warn] ',' not allowed in dynamic_kafka topic names
[2020/12/09 22:29:13] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:app]: fluent-bit#producer-1: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020/12/09 22:29:13] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:app]: fluent-bit#producer-1: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
[0] kube.sanity.log: [1607545753.410732878, {"stream"=>"stdout", "@version"=>"1", "topic"=>"teama", "@timestamp"=>"2020-11-27T14:51:14.651Z", "kubernetes"=>{"host"=>"cskwrk003pppjay.lin.pp.com", "container_name"=>"connector", "pod_id"=>"12345", "pod_name"=>"sink-dimstore", "annotations"=>{"prometheus.io/label-consumer"=>",DimStore", "prometheus.io/port"=>"8080", "prometheus.io/tenant"=>"Team A", "prometheus.io/scrape"=>"true", "prometheus.io/label-producer"=>",Classifier,Advertiser,Site Tracking,Campaigns,Inventory", "tenant"=>"Team A", "checksum/secrets"=>"12345", "checksum/environment"=>"12345", "prometheus.io/label-is_ddp"=>"true"}, "labels"=>{"laas-format"=>"json", "pod-template-hash"=>"12345", "release"=>"sink-dimstore-k8s-psgdst-postgres", "laas"=>"true"}, "namespace_name"=>"ddp", "container_image"=>"docker.artifactory.etc", "docker_id"=>"12345", "container_hash"=>"docker.artifactory.etc"}, "log"=>"log_content", "time"=>"2020-11-27T14:51:14.651934011Z"}]
[2020/12/09 22:29:14] [ warn] ',' not allowed in dynamic_kafka topic names
```

After:
```
/fluent-bit --config=fluent-bit.conf
Fluent Bit v1.7.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/12/09 22:23:52] [ info] [engine] started (pid=93187)
[2020/12/09 22:23:52] [ info] [storage] version=1.1.0, initializing...
[2020/12/09 22:23:52] [ info] [storage] in-memory
[2020/12/09 22:23:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/12/09 22:23:52] [ info] [output:kafka:kafka.1] brokers='localhost:9092' topics='laas-dlq'
[2020/12/09 22:23:52] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020/12/09 22:23:52] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: 1/1 brokers are down
[2020/12/09 22:23:52] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2020/12/09 22:23:52] [ info] [sp] stream processor started
[2020/12/09 22:23:53] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
[0] kube.sanity.log: [1607545433.410610498, {"stream"=>"stdout", "@version"=>"1", "topic"=>"teama", "@timestamp"=>"2020-11-27T14:51:14.651Z", "kubernetes"=>{"host"=>"cskwrk003pppjay.lin.pp.com", "container_name"=>"connector", "pod_id"=>"12345", "pod_name"=>"sink-dimstore", "annotations"=>{"prometheus.io/label-consumer"=>",DimStore", "prometheus.io/port"=>"8080", "prometheus.io/tenant"=>"Team A", "prometheus.io/scrape"=>"true", "prometheus.io/label-producer"=>",Classifier,Advertiser,Site Tracking,Campaigns,Inventory", "tenant"=>"Team A", "checksum/secrets"=>"12345", "checksum/environment"=>"12345", "prometheus.io/label-is_ddp"=>"true"}, "labels"=>{"laas-format"=>"json", "pod-template-hash"=>"12345", "release"=>"sink-dimstore-k8s-psgdst-postgres", "laas"=>"true"}, "namespace_name"=>"ddp", "container_image"=>"docker.artifactory.etc", "docker_id"=>"12345", "container_hash"=>"docker.artifactory.etc"}, "log"=>"log_content", "time"=>"2020-11-27T14:51:14.651934011Z"}]
[2020/12/09 22:23:54] [ info] [out_kafka] new topic added: teama
[2020/12/09 22:23:54] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:app]: fluent-bit#producer-1: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020/12/09 22:23:54] [error] [output:kafka:kafka.1] fluent-bit#producer-1: [thrd:app]: fluent-bit#producer-1: localhost:9092/bootstrap: Connect to ipv4#127.0.0.1:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

