### PR TITLE
out_s3: do not use ':' in stream names on Windows

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -67,7 +67,7 @@ set(FLB_OUT_FLOWCOUNTER       Yes)
 set(FLB_OUT_KAFKA              No)
 set(FLB_OUT_KAFKA_REST         No)
 set(FLB_OUT_CLOUDWATCH_LOGS   Yes)
-set(FLB_OUT_S3                 No)
+set(FLB_OUT_S3                Yes)
 set(FLB_OUT_KINESIS_FIREHOSE   No)
 
 # FILTER plugins

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -261,7 +261,13 @@ int s3_store_init(struct flb_s3 *ctx)
      */
     now = time(NULL);
     tm = localtime(&now);
+
+#ifdef FLB_SYSTEM_WINDOWS
+    /* Windows does not allow ':' in directory names */
+    strftime(tmp, sizeof(tmp) - 1, "%Y-%m-%dT%H-%M-%S", tm);
+#else
     strftime(tmp, sizeof(tmp) - 1, "%Y-%m-%dT%H:%M:%S", tm);
+#endif
 
     /* Create the stream */
     fs_stream = flb_fstore_stream_create(ctx->fs, tmp);


### PR DESCRIPTION
Windows does not allow directory names to contain a colon. For this
reason, S3 plugin was unable to create the backlog directory.
    
This patch fixes it by changing the directory name from
    
        /tmp/fluent-bit/s3/bucket/2020-12-01T12:31:21
    
into:
    
        /tmp/fluent-bit/s3/bucket/2020-12-01T12-31-21
    
Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
