### PR TITLE
network: net_connect_*() is broken on Windows

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -241,8 +241,13 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          * socket status, getting a EINPROGRESS is expected, but any other case
          * means a failure.
          */
+#ifdef FLB_SYSTEM_WINDOWS
+        socket_errno = flb_socket_error(fd);
+        err = -1;
+#else
         socket_errno = errno;
         err = flb_socket_error(fd);
+#endif
         if (!FLB_EINPROGRESS(socket_errno) && err != 0) {
             flb_error("[net] connection #%i failed to: %s:%i",
                       fd, host, port);
@@ -325,8 +330,13 @@ static int net_connect_async(int fd,
      * socket status, getting a EINPROGRESS is expected, but any other case
      * means a failure.
      */
+#ifdef FLB_SYSTEM_WINDOWS
+    socket_errno = flb_socket_error(fd);
+    err = -1;
+#else
     socket_errno = errno;
     err = flb_socket_error(fd);
+#endif
     if (!FLB_EINPROGRESS(socket_errno) && err != 0) {
         flb_error("[net] connection #%i failed to: %s:%i",
                   fd, host, port);


### PR DESCRIPTION
Commit 90b2354 changed `flb_net_tcp_connect()` to check for errno
to detect EINPROGRESS, which does not work on Windows simply
because Win32's `connect()` does not set errno.

This causes general network issues on Windows. The common issue
is that Fluent Bit returns fatal errors erratically while the connection is
actually in progress.

Fix this bug by checking the connection status correctly on Windows

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
