### PR TITLE
network: fix type mismatch with format string

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -275,7 +275,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
             /* Timeout */
             flb_error("[net] connection #%i timeout after %i seconds to: "
                       "%s:%i",
-                      fd, timeout, host, port);
+                      fd, connect_timeout, host, port);
             goto exit_error;
         }
         else if (ret < 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

`timeout` is a `struct timeval`, not an `int`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
