### PR TITLE
out_s3: fix '\0' assignment

### DIFF
--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -138,7 +138,7 @@ static void parse_etags(struct multipart_upload *m_upload, char *data)
             flb_debug("[s3 restart parser] Did not find tab separator in line %s", start);
             return;
         }
-        end = '\0';
+        *end = '\0';
         part_num = atoi(start);
         if (part_num <= 0) {
             flb_debug("[s3 restart parser] Could not parse part_number from %s", start);


### PR DESCRIPTION
<!-- Provide summary of changes -->

This assignment is pointless without the `*`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
