### PR TITLE
Issue 2734: Fix support for more than 32 output plugins

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -23,6 +23,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_routes_mask.h>
 #include <monkey/mk_core.h>
 #include <msgpack.h>
 
@@ -51,7 +52,8 @@ struct flb_input_chunk {
     msgpack_packer mp_pck;          /* msgpack packer */
     struct flb_input_instance *in;  /* reference to parent input instance */
     struct flb_task *task;          /* reference to the outgoing task */
-    uint64_t routes_mask;           /* track the output plugin the chunk routes to */
+    uint64_t routes_mask
+        [FLB_ROUTES_MASK_ELEMENTS]; /* track the output plugins the chunk routes to */
     struct mk_list _head;
 };
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -193,7 +193,6 @@ struct flb_output_plugin {
  */
 struct flb_output_instance {
     struct mk_event event;               /* events handler               */
-    uint64_t mask_id;                    /* internal bitmask for routing */
     int id;                              /* instance id                  */
     int log_level;                       /* instance log level           */
     char name[32];                       /* numbered name (cpu -> cpu.0) */

--- a/include/fluent-bit/flb_router.h
+++ b/include/fluent-bit/flb_router.h
@@ -33,6 +33,4 @@ int flb_router_match(const char *tag, int tag_len,
                      const char *match, void *match_regex);
 int flb_router_io_set(struct flb_config *config);
 void flb_router_exit(struct flb_config *config);
-uint64_t flb_router_get_routes_mask_by_tag(const char *tag, int tag_len,
-                                           struct flb_input_instance *in);
 #endif

--- a/include/fluent-bit/flb_routes_mask.h
+++ b/include/fluent-bit/flb_routes_mask.h
@@ -1,0 +1,66 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * This file defines a few utility methods for handling the routing masks
+ * used by input chunks to keep track of which output plugins they are
+ * routed to.
+ */
+#ifndef FLB_ROUTES_MASK_H
+#define FLB_ROUTES_MASK_H
+
+#include <limits.h>
+
+/*
+ * The routing mask is an array integers used to store a bitfield. Each
+ * bit represents the unique id of an output plugin. For example, the 9th
+ * bit in the routes_mask represents the output plugin with id = 9.
+ *
+ * A value of 1 in the bitfield means that output plugin is selected
+ * and a value of zero means that output is deselected.
+ *
+ * The size of the bitmask array limits the number of output plugins
+ * The router can route to. For example: with a value of 4 using
+ * 64-bit integers the bitmask can represent up to 256 output plugins
+ */
+#define FLB_ROUTES_MASK_ELEMENTS		4
+
+/*
+ * How many bits are in each element of the bitmask array
+ */
+#define FLB_ROUTES_MASK_ELEMENT_BITS 	(sizeof(uint64_t) * CHAR_BIT)
+
+/*
+ * The maximum number of routes that can be stored in the array
+ */
+#define FLB_ROUTES_MASK_MAX_VALUE		(FLB_ROUTES_MASK_ELEMENTS * FLB_ROUTES_MASK_ELEMENT_BITS)
+
+
+/* forward declaration */
+struct flb_input_instance;
+
+
+int flb_routes_mask_set_by_tag(uint64_t *routes_mask, const char *tag, int tag_len, struct flb_input_instance *in);
+int flb_routes_mask_get_bit(uint64_t *routes_mask, int value);
+void flb_routes_mask_set_bit(uint64_t *routes_mask, int value);
+void flb_routes_mask_clear_bit(uint64_t *routes_mask, int value);
+int flb_routes_mask_is_empty(uint64_t *routes_mask);
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(src
   flb_strptime.c
   flb_fstore.c
   flb_thread_pool.c
+  flb_routes_mask.c
   )
 
 if(FLB_SYSTEM_WINDOWS)

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_task.h>
+#include <fluent-bit/flb_routes_mask.h>
 #include <fluent-bit/stream_processor/flb_sp.h>
 
 static void generate_chunk_name(struct flb_input_instance *in,
@@ -94,7 +95,7 @@ static int flb_input_chunk_is_task_safe_delete(struct flb_task *task)
 
 int flb_input_chunk_safe_delete(struct flb_input_chunk *ic,
                                 struct flb_input_chunk *old_ic,
-                                uint64_t o_mask_id)
+                                uint64_t o_id)
 {
     /* The chunk we want to drop should not be the incoming chunk */
     if (ic == old_ic) {
@@ -104,9 +105,9 @@ int flb_input_chunk_safe_delete(struct flb_input_chunk *ic,
     /*
      * Even if chunks from same input plugin have same routes_mask when created,
      * the routes_mask could be modified when new chunks is ingested. Therefore,
-     * we still need to do the validation on the routes_mask with mask_id.
+     * we still need to do the validation on the routes_mask with o_id.
      */
-    if ((old_ic->routes_mask & o_mask_id) == 0) {
+    if (flb_routes_mask_get_bit(old_ic->routes_mask, o_id) == 0) {
         return FLB_FALSE;
     }
 
@@ -131,7 +132,7 @@ int flb_intput_chunk_count_dropped_chunks(struct flb_input_chunk *ic,
     mk_list_foreach(head, &ic->in->chunks) {
         old_ic = mk_list_entry(head, struct flb_input_chunk, _head);
 
-        if (flb_input_chunk_safe_delete(ic, old_ic, o_ins->mask_id) == FLB_FALSE ||
+        if (flb_input_chunk_safe_delete(ic, old_ic, o_ins->id) == FLB_FALSE ||
             flb_input_chunk_is_task_safe_delete(old_ic->task) == FLB_FALSE) {
             continue;
         }
@@ -162,12 +163,8 @@ int flb_intput_chunk_count_dropped_chunks(struct flb_input_chunk *ic,
 /*
  * Find a slot in the output instance to append the new data with size chunk_size, it
  * will drop the the oldest chunks when the limitation on local disk is reached.
- *
- * overlimit_routes_mask: A bit mask used to check whether the output instance will
- * reach the limit when buffering the new data
  */
 int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
-                                        uint64_t overlimit_routes_mask,
                                         size_t chunk_size)
 {
     int count;
@@ -188,7 +185,7 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
 
         if ((o_ins->total_limit_size == -1) ||
-            (ic->routes_mask & o_ins->mask_id) == 0) {
+            (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) == 0)) {
             continue;
         }
 
@@ -202,7 +199,7 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
              */
             flb_error("[input chunk] no enough space in filesystem to buffer "
                       "chunk %s in plugin %s", flb_input_chunk_get_name(ic), o_ins->name);
-            ic->routes_mask ^= o_ins->mask_id;
+            flb_routes_mask_clear_bit(ic->routes_mask, o_ins->id);
             continue;
         }
 
@@ -215,21 +212,21 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
         mk_list_foreach_safe(head_chunk, tmp, &ic->in->chunks) {
             old_ic = mk_list_entry(head_chunk, struct flb_input_chunk, _head);
 
-            if (flb_input_chunk_safe_delete(ic, old_ic, o_ins->mask_id) == FLB_FALSE ||
+            if (flb_input_chunk_safe_delete(ic, old_ic, o_ins->id) == FLB_FALSE ||
                 flb_input_chunk_is_task_safe_delete(old_ic->task) == FLB_FALSE) {
                 continue;
             }
 
             old_ic_bytes = flb_input_chunk_get_size(old_ic);
             /* drop chunk by adjusting the routes_mask */
-            old_ic->routes_mask ^= o_ins->mask_id;
+            flb_routes_mask_clear_bit(old_ic->routes_mask, o_ins->id);
             o_ins->fs_chunks_size -= old_ic_bytes;
 
             flb_debug("[input chunk] remove route of chunk %s with size %ld bytes to output plugin %s "
                       "to place the incoming data with size %ld bytes", flb_input_chunk_get_name(old_ic),
                       old_ic_bytes, o_ins->name, chunk_size);
 
-            if (old_ic->routes_mask == 0) {
+            if (flb_routes_mask_is_empty(old_ic->routes_mask)) {
                 if (old_ic->task != NULL) {
                     /*
                      * If the chunk is referenced by a task and task has no active route,
@@ -260,13 +257,13 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
 }
 
 /*
- * Returns routes_mask of output instances that will reach the limit
+ * Returns a non-zero result if any output instances will reach the limit
  * after buffering the new data
  */
-uint64_t flb_input_chunk_get_overlimit_routes_mask(struct flb_input_chunk *ic,
+int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
                                                    size_t chunk_size)
 {
-    uint64_t routes_mask = 0;
+    int overlimit = 0;
     struct mk_list *head;
     struct flb_output_instance *o_ins;
 
@@ -274,7 +271,7 @@ uint64_t flb_input_chunk_get_overlimit_routes_mask(struct flb_input_chunk *ic,
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
 
         if ((o_ins->total_limit_size == -1) ||
-            (ic->routes_mask & o_ins->mask_id) == 0) {
+            (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) == 0)) {
             continue;
         }
 
@@ -284,33 +281,35 @@ uint64_t flb_input_chunk_get_overlimit_routes_mask(struct flb_input_chunk *ic,
                   o_ins->name);
 
         if (o_ins->fs_chunks_size + chunk_size > o_ins->total_limit_size) {
-            routes_mask |= o_ins->mask_id;
+            overlimit = 1;
         }
     }
 
-    return routes_mask;
+    return overlimit;
 }
 
-/* Find a slot for the incoming data to buffer it in local file system */
-uint64_t flb_input_chunk_place_new_chunk(struct flb_input_chunk *ic, size_t chunk_size)
+/* Find a slot for the incoming data to buffer it in local file system
+ * returns 0 if none of the routes can be written to
+ */
+int flb_input_chunk_place_new_chunk(struct flb_input_chunk *ic, size_t chunk_size)
 {
-    uint64_t overlimit_routes_mask;
-    overlimit_routes_mask = flb_input_chunk_get_overlimit_routes_mask(ic, chunk_size);
-    if (overlimit_routes_mask != 0) {
-        flb_input_chunk_find_space_new_data(ic, overlimit_routes_mask, chunk_size);
+	int overlimit;
+    overlimit = flb_input_chunk_has_overlimit_routes(ic, chunk_size);
+    if (overlimit != 0) {
+        flb_input_chunk_find_space_new_data(ic, chunk_size);
     }
 
-    return ic->routes_mask;
+    return !flb_routes_mask_is_empty(ic->routes_mask);
 }
 
 /* Create an input chunk using a Chunk I/O */
 struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
                                             void *chunk)
 {
-    uint64_t chunk_routes_mask;
     ssize_t bytes;
     const char *tag_buf;
     int tag_len;
+    int has_routes;
     int ret;
 
 #ifdef FLB_HAVE_METRICS
@@ -354,12 +353,12 @@ struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
         return ic;
     }
 
-    chunk_routes_mask = flb_router_get_routes_mask_by_tag(tag_buf, tag_len, in);
-    if (chunk_routes_mask == 0) {
+
+    has_routes = flb_routes_mask_set_by_tag(ic->routes_mask, tag_buf, tag_len, in);
+    if (has_routes == 0) {
         flb_warn("[input chunk] no matching route for backoff log chunk %s",
                  flb_input_chunk_get_name(ic));
     }
-    ic->routes_mask = chunk_routes_mask;
 
     bytes = flb_input_chunk_get_size(ic);
     flb_input_chunk_update_output_instances(ic, bytes);
@@ -373,7 +372,7 @@ struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
     int ret;
     int err;
     int set_down = FLB_FALSE;
-    uint64_t chunk_routes_mask;
+    int has_routes;
     char name[64];
     struct cio_chunk *chunk;
     struct flb_storage_input *storage;
@@ -439,12 +438,11 @@ struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in,
 #endif
 
     /* Calculate the routes_mask for the input chunk */
-    chunk_routes_mask = flb_router_get_routes_mask_by_tag(tag, tag_len, in);
-    if (chunk_routes_mask == 0) {
+    has_routes = flb_routes_mask_set_by_tag(ic->routes_mask, tag, tag_len, in);
+    if (has_routes == 0) {
         flb_trace("[input chunk] no matching route for input chunk '%s' with tag '%s'",
                   flb_input_chunk_get_name(ic), tag);
     }
-    ic->routes_mask = chunk_routes_mask;
 
     msgpack_packer_init(&ic->mp_pck, ic, flb_input_chunk_write);
     mk_list_add(&ic->_head, &in->chunks);
@@ -477,7 +475,7 @@ int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del)
         }
 
         bytes = flb_input_chunk_get_size(ic);
-        if ((ic->routes_mask & o_ins->mask_id) > 0) {
+        if (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) != 0) {
             o_ins->fs_chunks_size -= bytes;
         }
     }
@@ -540,8 +538,7 @@ static struct flb_input_chunk *input_chunk_get(const char *tag, int tag_len,
      * that the chunk will flush to, we need to modify the routes_mask of the oldest chunks
      * (based in creation time) to get enough space for the incoming chunk.
      */
-    if (ic->routes_mask != 0 &&
-        flb_input_chunk_place_new_chunk(ic, chunk_size) == 0) {
+    if (flb_input_chunk_place_new_chunk(ic, chunk_size) == 0) {
         /*
          * If the chunk is not newly created, the chunk might already have logs inside.
          * We cannot delete (reused) chunks here.
@@ -978,7 +975,7 @@ void flb_input_chunk_update_output_instances(struct flb_input_chunk *ic,
             continue;
         }
 
-        if ((ic->routes_mask & o_ins->mask_id) > 0) {
+        if (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) != 0) {
             /*
              * if there is match on any index of 1's in the binary, it indicates
              * that the input chunk will flush to this output instance

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -261,7 +261,7 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
  * after buffering the new data
  */
 int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
-                                                   size_t chunk_size)
+                                         size_t chunk_size)
 {
     int overlimit = 0;
     struct mk_list *head;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -398,7 +398,6 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
                                            const char *output, void *data)
 {
     int ret = -1;
-    uint64_t mask_id;
     int flags = 0;
     struct mk_list *head;
     struct flb_output_plugin *plugin;
@@ -406,17 +405,6 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
 
     if (!output) {
         return NULL;
-    }
-
-    /* Get the last mask_id reported by an output instance plugin */
-    if (mk_list_is_empty(&config->outputs) == 0) {
-        mask_id = 0;
-    }
-    else {
-        instance = mk_list_entry_last(&config->outputs,
-                                      struct flb_output_instance,
-                                      _head);
-        mask_id = (instance->mask_id);
     }
 
     mk_list_foreach(head, &config->out_plugins) {
@@ -442,20 +430,6 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->test_mode = FLB_FALSE;
     instance->is_threaded = FLB_FALSE;
 
-    /*
-     * Set mask_id: the mask_id is an unique number assigned to this
-     * output instance that is used later to set in an 'unsigned 64
-     * bit number' where a specific task (buffer/records) should be
-     * routed.
-     *
-     * note: This value is different than instance id.
-     */
-    if (mask_id == 0) {
-        instance->mask_id = 1;
-    }
-    else {
-        instance->mask_id = (mask_id * 2);
-    }
 
     /* Retrieve an instance id for the output instance */
     instance->id = instance_id(config);

--- a/src/flb_router.c
+++ b/src/flb_router.c
@@ -251,55 +251,5 @@ void flb_router_exit(struct flb_config *config)
     }
 }
 
-/*
- * Calculate the routes_mask for input chunk with a router_match on tag
- */
-uint64_t flb_router_get_routes_mask_by_tag(const char *tag, int tag_len,
-                                           struct flb_input_instance *in) {
-    uint64_t routes_mask = 0;
-    struct mk_list *o_head;
-    struct flb_output_instance *o_ins;
-    if (!in) {
-        return -1;
-    }
 
-    /* Find all matching routes for the given tag */
-    mk_list_foreach(o_head, &in->config->outputs) {
-        o_ins = mk_list_entry(o_head,
-                              struct flb_output_instance, _head);
 
-        if (flb_router_match(tag, tag_len, o_ins->match
-#ifdef FLB_HAVE_REGEX
-                             , o_ins->match_regex
-#else
-                             , NULL
-#endif
-                             )) {
-            /*
-             * mask_id for each output instance is a unique number starting from 1
-             * and multple by 2 each time. (e.g 1, 2 ,4 ,8, 16 ...)
-             * Let's take a look of the binary of the mask_id:
-             *   1:   00000001
-             *   2:   00000010
-             *   4:   00000100
-             *   8:   00001000
-             *   16:  00010000
-             * We can notice that each binary has only one 1's bit and this also
-             * represents the postion of the output instance. Getting the OR of
-             * mask_id (given that tag is matched) will tell us the output instances
-             * that the given input chunk will flush to.
-             *
-             * For example: We have two matching output instances with mask_id 1 and 4
-             * There are two 1's in the binary with index 0 and 2 (starting from right)
-             * and this means that the input chunk will flush to first and third output
-             * instances configured in the Fluent Bit configuraion.
-             *
-             *    0 |= 1 -> 00000 |= 00001 -> 00001
-             *    00001 |= 4 -> 00001 |= 00100 -> 00101
-             */
-            routes_mask |= o_ins->mask_id;
-        }
-    }
-
-    return routes_mask;
-}

--- a/src/flb_routes_mask.c
+++ b/src/flb_routes_mask.c
@@ -1,0 +1,138 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_router.h>
+#include <fluent-bit/flb_routes_mask.h>
+
+
+/*
+ * Set the routes_mask for input chunk with a router_match on tag, return a
+ * non-zero value if any routes matched
+ */
+int flb_routes_mask_set_by_tag(uint64_t *routes_mask, const char *tag, int tag_len, struct flb_input_instance *in)
+{
+    int has_routes = 0;
+    struct mk_list *o_head;
+    struct flb_output_instance *o_ins;
+    if (!in) {
+        return 0;
+    }
+
+    /* Clear the bit field */
+    memset(routes_mask, 0, sizeof(uint64_t) * FLB_ROUTES_MASK_ELEMENTS);
+
+    /* Find all matching routes for the given tag */
+    mk_list_foreach(o_head, &in->config->outputs) {
+        o_ins = mk_list_entry(o_head,
+                              struct flb_output_instance, _head);
+
+        if (flb_router_match(tag, tag_len, o_ins->match
+#ifdef FLB_HAVE_REGEX
+                             , o_ins->match_regex
+#else
+                             , NULL
+#endif
+                             )) {
+            flb_routes_mask_set_bit(routes_mask, o_ins->id);
+            has_routes = 1;
+        }
+    }
+
+    return has_routes;
+}
+
+/*
+ * Sets a single bit in an array of bitfields
+ *
+ * For example: Given a value of 35 this routine will set the
+ * 4th bit in the 2nd value of the bitfield array.
+ *
+ */
+void flb_routes_mask_set_bit(uint64_t *routes_mask, int value)
+{
+    int index;
+    uint64_t bit;
+
+    if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
+        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield", value);
+        return;
+    }
+
+    index = value / FLB_ROUTES_MASK_ELEMENT_BITS;
+    bit = 1ULL << (value % FLB_ROUTES_MASK_ELEMENT_BITS);
+    routes_mask[index] |= bit;
+}
+
+/*
+ * Clears a single bit in an array of bitfields
+ *
+ * For example: Given a value of 68 this routine will clear the
+ * 4th bit in the 2nd value of the bitfield array.
+ *
+ */
+void flb_routes_mask_clear_bit(uint64_t *routes_mask, int value)
+{
+    int index;
+    uint64_t bit;
+
+    if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
+        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield", value);
+        return;
+    }
+
+    index = value / FLB_ROUTES_MASK_ELEMENT_BITS;
+    bit = 1ULL << (value % FLB_ROUTES_MASK_ELEMENT_BITS);
+    routes_mask[index] &= ~(bit);
+}
+
+/*
+ * Checks the value of a single bit in an array of bitfields and returns a
+ * non-zero value if that bit is set.
+ *
+ * For example: Given a value of 68 this routine will return a non-zero value
+ * if the 4th bit in the 2nd value of the bitfield array is set.
+ *
+ */
+int flb_routes_mask_get_bit(uint64_t *routes_mask, int value)
+{
+    int index;
+    uint64_t bit;
+
+    if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
+        flb_warn("[routes_mask] Can't get bit (%d) past limits of bitfield", value);
+        return 0;
+    }
+
+    index = value / FLB_ROUTES_MASK_ELEMENT_BITS;
+    bit = 1ULL << (value % FLB_ROUTES_MASK_ELEMENT_BITS);
+    return (routes_mask[index] & bit) != 0ULL;
+}
+
+int flb_routes_mask_is_empty(uint64_t *routes_mask)
+{
+    uint64_t empty[FLB_ROUTES_MASK_ELEMENTS];
+
+    /* Clear the tmp bitfield */
+    memset(empty, 0, sizeof(uint64_t) * FLB_ROUTES_MASK_ELEMENTS);
+    return memcmp(routes_mask, empty, sizeof(uint64_t) * FLB_ROUTES_MASK_ELEMENTS) == 0;
+}

--- a/src/flb_routes_mask.c
+++ b/src/flb_routes_mask.c
@@ -139,6 +139,6 @@ int flb_routes_mask_is_empty(uint64_t *routes_mask)
     uint64_t empty[FLB_ROUTES_MASK_ELEMENTS];
 
     /* Clear the tmp bitfield */
-    memset(empty, 0, sizeof(uint64_t) * FLB_ROUTES_MASK_ELEMENTS);
-    return memcmp(routes_mask, empty, sizeof(uint64_t) * FLB_ROUTES_MASK_ELEMENTS) == 0;
+    memset(empty, 0, sizeof(empty));
+    return memcmp(routes_mask, empty, sizeof(empty)) == 0;
 }

--- a/src/flb_routes_mask.c
+++ b/src/flb_routes_mask.c
@@ -29,7 +29,10 @@
  * Set the routes_mask for input chunk with a router_match on tag, return a
  * non-zero value if any routes matched
  */
-int flb_routes_mask_set_by_tag(uint64_t *routes_mask, const char *tag, int tag_len, struct flb_input_instance *in)
+int flb_routes_mask_set_by_tag(uint64_t *routes_mask,
+                               const char *tag,
+                               int tag_len,
+                               struct flb_input_instance *in)
 {
     int has_routes = 0;
     struct mk_list *o_head;
@@ -74,7 +77,8 @@ void flb_routes_mask_set_bit(uint64_t *routes_mask, int value)
     uint64_t bit;
 
     if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
-        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield", value);
+        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield",
+                 value);
         return;
     }
 
@@ -96,7 +100,8 @@ void flb_routes_mask_clear_bit(uint64_t *routes_mask, int value)
     uint64_t bit;
 
     if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
-        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield", value);
+        flb_warn("[routes_mask] Can't set bit (%d) past limits of bitfield",
+                 value);
         return;
     }
 
@@ -119,7 +124,8 @@ int flb_routes_mask_get_bit(uint64_t *routes_mask, int value)
     uint64_t bit;
 
     if (value < 0 || value > FLB_ROUTES_MASK_MAX_VALUE) {
-        flb_warn("[routes_mask] Can't get bit (%d) past limits of bitfield", value);
+        flb_warn("[routes_mask] Can't get bit (%d) past limits of bitfield",
+                 value);
         return 0;
     }
 

--- a/src/flb_sosreport.c
+++ b/src/flb_sosreport.c
@@ -293,8 +293,8 @@ int flb_sosreport(struct flb_config *config)
     mk_list_foreach(head, &config->outputs) {
         ins_out = mk_list_entry(head, struct flb_output_instance, _head);
         printf("[OUTPUT] Instance\n");
-        printf("    Name\t\t%s (%s, mask_id=%" PRIu64 ")\n", ins_out->name, ins_out->p->name,
-               ins_out->mask_id);
+        printf("    Name\t\t%s (%s, id=%" PRIu64 ")\n", ins_out->name, ins_out->p->name,
+               ins_out->id);
         printf("    Match\t\t%s\n", ins_out->match);
 
 #ifdef FLB_HAVE_TLS

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -335,7 +335,6 @@ struct flb_task *flb_task_create(uint64_t ref_id,
                                  int *err)
 {
     int count = 0;
-    uint64_t routes_mask = 0;
     struct flb_task *task;
     struct flb_task_route *route;
     struct flb_output_instance *o_ins;
@@ -383,8 +382,8 @@ struct flb_task *flb_task_create(uint64_t ref_id,
     mk_list_foreach(o_head, &config->outputs) {
         o_ins = mk_list_entry(o_head,
                               struct flb_output_instance, _head);
-
-        if ((((struct flb_input_chunk *) ic)->routes_mask & o_ins->mask_id) > 0) {
+        
+        if (flb_routes_mask_get_bit(task_ic->routes_mask, o_ins->id) != 0) {
             route = flb_malloc(sizeof(struct flb_task_route));
             if (!route) {
                 flb_errno();
@@ -394,9 +393,6 @@ struct flb_task *flb_task_create(uint64_t ref_id,
             route->out = o_ins;
             mk_list_add(&route->_head, &task->routes);
             count++;
-
-            /* set the routes as a mask */
-            routes_mask |= o_ins->mask_id;
         }
     }
 


### PR DESCRIPTION
This patch increases the size of the bitfield used to keep track of which
output plugins a chunk is routed to. The previous implementation used 
a single uint64_t bitfield which can support up to 64 output plugins,
but due to an implicit conversion to 32-bit values would fail if more than
32 outputs were specified. 

This implementation supports an arbitrary number of outputs, with the 
limit defined by `FLB_ROUTES_MASK_ELEMENTS`.

flb_routes_mask.c defines helper methods for getting, setting, and clearing 
bits in the router mask bitfield. The bitfield is stored as an array of uint64_t
values where each bit is used to determine if an input chunk is to be routed 
to a given output plugin. The output plugin's bit position is determined by 
the id given to the instance. Ids are assigned sequentially starting from 0.

This patch also removes `mask_id` from the `flb_output_instance` struct
which was previously used to keep track of which bit in the
`flb_input_chunk.routes_mask` an output instance was associated
with.

Fixes #2734

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
[fluentbit-reduced-inputs.txt](https://github.com/fluent/fluent-bit/files/5722292/fluentbit-reduced-inputs.txt)
- [ ] Debug log output from testing the change
[logs.txt](https://github.com/fluent/fluent-bit/files/5722287/logs.txt)
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
