### PR TITLE
Add the first cut at fixing compile warnings on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,17 @@ endif()
 # Update CFLAGS
 if (MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 
   # Use custom CFLAGS for MSVC
   #
-  #   /W3 ...... Show up to 'production quality' msgs.
   #   /Zi ...... Generate pdb files.
   #   /MT ...... Static link C runtimes.
+  #   /wd4711 .. C4711 (function selected for inline expansion)
+  #   /wd4100 .. C4100 (unreferenced formal parameter)
+  #   /wd5045 .. C5045 (Spectre mitigation)
   #
-  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /W3 /O2 /Zi")
+  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
   set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
   set(CMAKE_BUILD_TYPE None)
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -148,6 +148,7 @@ endif()
 
 if (FLB_SYSTEM_WINDOWS)
   REGISTER_IN_PLUGIN("in_winlog")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W2")
 else()
   REGISTER_IN_PLUGIN("in_serial")
 endif()

--- a/plugins/in_winlog/pack.c
+++ b/plugins/in_winlog/pack.c
@@ -435,6 +435,6 @@ void winlog_pack_event(msgpack_packer *mp_pck, PEVENTLOGRECORD evt,
     if (ctx->string_inserts) {
         msgpack_pack_str(mp_pck, 13);
         msgpack_pack_str_body(mp_pck, "StringInserts", 13);
-        pack_strings(mp_pck, evt, ch, ctx);
+        pack_strings(mp_pck, evt);
     }
 }

--- a/plugins/in_winlog/winlog.h
+++ b/plugins/in_winlog/winlog.h
@@ -102,7 +102,7 @@ int winlog_sqlite_save(struct winlog_channel *ch, struct flb_sqldb *db);
 #define SQL_UPDATE_CHANNEL                                          \
     "INSERT INTO in_winlog_channels"                                \
     "  (name, record_number, time_written, created)"                \
-    "  VALUES ('%s', %u, %u, %u)"                                   \
+    "  VALUES ('%s', %u, %u, %llu)"                                   \
     "  ON CONFLICT(name) DO UPDATE"                                 \
     "  SET record_number = excluded.record_number,"                 \
     "      time_written = excluded.time_written"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,11 +52,12 @@ set(src
   flb_fstore.c
   )
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-set(src
-  ${src}
-  flb_dlfcn_win32.c
-  )
+if(FLB_SYSTEM_WINDOWS)
+  set(src
+    ${src}
+    flb_dlfcn_win32.c
+    )
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W2")
 endif()
 
 if(FLB_PARSER)

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -667,7 +667,7 @@ flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
     flb_sds_t out_buf;
     flb_sds_t tmp_buf;
 
-    out_size = in_size * 1.5;
+    out_size = in_size * 3 / 2;
     out_buf = flb_sds_create_size(out_size);
     if (!out_buf) {
         flb_errno();
@@ -783,7 +783,7 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
     /* For json lines and streams mode we need a pre-allocated buffer */
     if (json_format == FLB_PACK_JSON_FORMAT_LINES ||
         json_format == FLB_PACK_JSON_FORMAT_STREAM) {
-        out_buf = flb_sds_create_size(bytes * 1.25);
+        out_buf = flb_sds_create_size(bytes + bytes / 4);
         if (!out_buf) {
             flb_errno();
             return NULL;


### PR DESCRIPTION
This adds the first cut at fixing compile warnings on Windows.
    
 * Move the `/W<n>` flag to sub-component level, so that external
   libraries can set their own warning level.
    
 * Suppress several informational warnings (e.g. notification
   about inlinization of functions)
    
 * Define `CRT_NONSTDC_NO_WARNINGS` to prevent warnings about
   POSIX function names.

 * Avoid floating arithmetic to avoid warnings about implicit type casting.

This PR is part of #2862.
