### PR TITLE
lib: tutf8e: Resolve compiler warnings on Windows

### DIFF
--- a/lib/tutf8e/src/tutf8e.c
+++ b/lib/tutf8e/src/tutf8e.c
@@ -37,10 +37,14 @@ int tutf8e_string_encode(const uint16_t *table, const char *input, const char *i
   int ret;
   size_t input_length = 0;
   size_t encoded_length = 0;
-  if (!(ret = tutf8e_string_length(table, input, invalid, &input_length, &encoded_length)))
+
+  ret = tutf8e_string_length(table, input, invalid, &input_length, &encoded_length);
+  if (!ret)
   {
     if (encoded_length+1 > *output_length) return TUTF8E_TOOLONG;
-    if (!(ret = tutf8e_buffer_encode(table, input, input_length, invalid, output, output_length)))
+
+    ret = tutf8e_buffer_encode(table, input, input_length, invalid, output, output_length);
+    if (!ret)
     {
       output[encoded_length] = 0;
       return TUTF8E_OK;
@@ -104,14 +108,14 @@ int tutf8e_buffer_encode
     const uint16_t c = table[*i];
     if (c<0x80) {
       if (left<1) return TUTF8E_TOOLONG;
-      *(o++) = c;
+      *(o++) = (uint8_t) c;
       left -= 1;
       continue;
     }
     if (c<0x800) {
       if (left<2) return TUTF8E_TOOLONG;
-      *(o++) = 0xc0 | (c>>6);
-      *(o++) = 0x80 | (c&0x3f);
+      *(o++) = 0xc0 | (uint8_t) (c>>6);
+      *(o++) = 0x80 | (uint8_t) (c&0x3f);
       left -= 2;
       continue;
     }


### PR DESCRIPTION
This is a minor patch that resolves the following two warnings
on Microsoft Visual C++.

 * warning C4242: '=': conversion from 'const uint16_t'
   to 'unsigned char', possible loss of data

 * warning C4706: assignment within conditional expression

With this applied, tutf8e is warning-free on Windows.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>