### PR TITLE
out_kafka: prevent segfault in error path

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -295,17 +295,9 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
      */
     if (ctx->queue_full_retries > 0 &&
         queue_full_retries >= ctx->queue_full_retries) {
-        if (ctx->format == FLB_KAFKA_FMT_JSON) {
-            flb_free(out_buf);
-        }
-        if (ctx->format == FLB_KAFKA_FMT_GELF) {
+        if (ctx->format != FLB_KAFKA_FMT_MSGP) {
             flb_sds_destroy(s);
         }
-#ifdef FLB_HAVE_AVRO_ENCODER
-        if (ctx->format == FLB_KAFKA_FMT_AVRO) {
-            flb_sds_destroy(s);
-        }
-#endif
         msgpack_sbuffer_destroy(&mp_sbuf);
         return FLB_RETRY;
     }


### PR DESCRIPTION
Prevent a segfault in the error path when the JSON format is used:

```
[2020/12/24 00:38:33] [ warn] [engine] failed to flush chunk '683645-1608763112.630890670.flb', retry in 6 seconds: task_id=2, input=dummy.0 > output=kafka.0
[2020/12/24 00:38:33] [ warn] [engine] failed to flush chunk '683645-1608763113.173387901.flb', retry in 10 seconds: task_id=4, input=dummy.0 > output=kafka.0
[2020/12/24 00:38:33] [ warn] [engine] chunk '683645-1608763102.168779828.flb' cannot be retried: task_id=19, input=dummy.0 > output=kafka.0
munmap_chunk(): invalid pointer

Thread 2 "flb-pipeline" received signal SIGABRT, Aborted.
[Switching to Thread 0x7ffff7885700 (LWP 683649)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff78b6859 in __GI_abort () at abort.c:79
#2  0x00007ffff79213ee in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff7a4b285 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#3  0x00007ffff792947c in malloc_printerr (str=str@entry=0x7ffff7a4d1e0 "munmap_chunk(): invalid pointer") at malloc.c:5347
#4  0x00007ffff79296cc in munmap_chunk (p=<optimized out>) at malloc.c:2830
#5  0x00005555556607aa in flb_free (ptr=0x7ffff0011650) at /home/gstatkevicius/dev/fluent-bit/include/fluent-bit/flb_mem.h:122
#6  0x0000555555661f53 in produce_message (tm=0x7fffd27fd880, map=0x7fffd1eebe80, ctx=0x7ffff0005de0, config=0x555555be12d0) at /home/gstatkevicius/dev/fluent-bit/plugins/out_kafka/kafka.c:299
#7  0x00005555556623b3 in cb_kafka_flush (data=0x7fffd1799d00, bytes=1321142, tag=0x7ffff0011530 "kube.sanity.log", tag_len=15, i_ins=0x555555bee780, out_context=0x7ffff0005de0, config=0x555555be12d0)
    at /home/gstatkevicius/dev/fluent-bit/plugins/out_kafka/kafka.c:409
#8  0x00005555555e5f65 in output_pre_cb_flush () at /home/gstatkevicius/dev/fluent-bit/include/fluent-bit/flb_output.h:473
#9  0x0000555555a3164b in co_init () at /home/gstatkevicius/dev/fluent-bit/lib/monkey/deps/flb_libco/amd64.c:117
#10 0x0000000000000000 in ?? ()
```

All of the paths besides `FLB_KAFKA_FMT_MSGP` operate on `flb_sds_t` so
the appropriate function to use here is `flb_sds_destroy`.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>

Caught this while chasing another bug. This is not reproducible with these changes.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

`docker-compose.yml` for setting up a local Kafka cluster:

```yaml
version: '3'
services:
    zookeeper:
        image: wurstmeister/zookeeper
 
    kafka:
        image: wurstmeister/kafka
        ports:
        - "9092:9092"
        environment:
            KAFKA_ADVERTISED_HOST_NAME: localhost
            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 ```
 
`Pumba` for introducing network faults to induce this error path:
 ```
 docker run -it -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba -l info netem --tc-image gaiadocker/iproute2 --duration 120s delay --time 10000 bin_kafka_1
```

FLB config:

```
[SERVICE]
        Flush         1
        Log_Level     info
        Daemon        off
        Parsers_File  parsers.conf
        HTTP_Server   On
        HTTP_Listen   0.0.0.0
        HTTP_Port     2020

[PARSER]
    Name   json
    Format json
    Time_Key time
    Time_Format %d/%b/%Y:%H:%M:%S %z

[PARSER]
    Name        docker
    Format      json
    Time_Key    time
    Time_Format %Y-%m-%dT%H:%M:%S.%L
    Time_Keep   On

[INPUT]
    Name    Dummy
    Tag     kube.sanity.log
    Dummy   { "stream":"stdout", "@version":"1", "topic": "teama", "@timestamp":"2020-11-27T14:51:14.651Z", "kubernetes":{ "host":"cskwrk003pppjay.lin.pp.com", "container_name":"connector", "pod_id":"12345", "pod_name":"sink-dimstore", "annotations":{ "prometheus.io/label-consumer":",DimStore", "prometheus.io/port":"8080", "prometheus.io/tenant":"Team A", "prometheus.io/scrape":"true", "prometheus.io/label-producer":",Classifier,Advertiser,Site Tracking,Campaigns,Inventory", "tenant":"Team A", "checksum/secrets":"12345", "checksum/environment":"12345", "prometheus.io/label-is_ddp":"true" }, "labels":{ "laas-format":"json", "pod-template-hash":"12345", "release":"sink-dimstore-k8s-psgdst-postgres", "laas":"true" }, "namespace_name":"ddp", "container_image":"docker.artifactory.etc", "docker_id":"12345", "container_hash":"docker.artifactory.etc" }, "log":"log_content", "time":"2020-11-27T14:51:14.651934011Z" }
    Rate 5000

[OUTPUT]
    Name             kafka
    Match            *
    Brokers          localhost:9092
    Topics           laas-dlq
    Topic_key        topic
    Timestamp_Format iso8601
    Dynamic_topic    on

```


**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
