### PR TITLE
kafka: unblock engine after retries

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -307,6 +307,11 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
         }
 #endif
         msgpack_sbuffer_destroy(&mp_sbuf);
+        /*
+         * Unblock the flush requests so that the
+         * engine could try sending data again.
+         */
+        ctx->blocked = FLB_FALSE;
         return FLB_RETRY;
     }
 


### PR DESCRIPTION
Unblock the FLB engine after `queue_full_retries` so that it could
attempt to flush the data again. This fixes a bug where after the queue
gets permanently blocked due to a number of errors in a row. In such a
buggy situation, the user cannot do anything and FLB stops sending data.
The only resort is to restart the whole process. That is _really_ bad.

Another "fix" that has been merged here https://github.com/fluent/fluent-bit/pull/2553
is really not the best. Users would have to set `queue_full_retries` to a very high number
and have a monitoring system place so that they would know when to restart
their FLB instances. We can definitely do better!

With this fix in place, the engine retries sending data again after
`queue_full_retries` attempts. It takes only one failing send request
with the error that the queue is full to get back to the blocking mode
so I think that this is a reasonable fix.

I am able to get into the (previously) buggy situation and out of it:

```
[2020/12/28 17:52:23] [error] % Failed to produce to topic teama: Local: Queue full
[2020/12/28 17:52:23] [ warn] [output:kafka:kafka.0] internal queue is full, retrying in one second
[2020/12/28 17:52:23] [ warn] [engine] failed to flush chunk '2185514-1609170735.235197093.flb', retry in 66 seconds: task_id=46, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:23] [ warn] [engine] failed to flush chunk '2185514-1609170742.698304730.flb', retry in 11 seconds: task_id=61, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:23] [ warn] [engine] failed to flush chunk '2185514-1609170743.318591428.flb', retry in 6 seconds: task_id=62, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:24] [ warn] [engine] failed to flush chunk '2185514-1609170737.698230320.flb', retry in 66 seconds: task_id=51, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:24] [ info] [engine] flush chunk '2185514-1609170719.239591680.flb' succeeded at retry 2: task_id=2, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:24] [ info] [engine] flush chunk '2185514-1609170732.704565520.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:25] [ info] [engine] flush chunk '2185514-1609170720.698992017.flb' succeeded at retry 2: task_id=2, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:25] [ info] [engine] flush chunk '2185514-1609170733.702490297.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:26] [ info] [engine] flush chunk '2185514-1609170734.699015656.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:26] [ info] [engine] flush chunk '2185514-1609170735.698733693.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:26] [ info] [engine] flush chunk '2185514-1609170738.237794332.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
[2020/12/28 17:52:26] [ info] [engine] flush chunk '2185514-1609170739.240428252.flb' succeeded at retry 1: task_id=1, input=dummy.0 > output=kafka.0
```

At 17:52:22 in this log I have turned off `Pumba` and FLB was able to
communicate with Kafka again. Without this fix, FLB continuously prints
the same errors.

I have used the configuration files & troubleshooting instructions as in here:
https://github.com/fluent/fluent-bit/pull/2890.

Fixes https://github.com/fluent/fluent-bit/issues/2871.
Fixes https://github.com/fluent/fluent-bit/issues/2244.
Fixes https://github.com/fluent/fluent-bit/issues/2161.
Fixes https://github.com/fluent/fluent-bit/issues/514.

Signed-off-by: Giedrius Statkevičius <giedriuswork@gmail.com>


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
