### PR TITLE
out_s3: s3_store: only store upload metadata once

### DIFF
--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -465,14 +465,14 @@ int s3_store_file_upload_put(struct flb_s3 *ctx,
             return -1;
         }
         flb_sds_destroy(name);
-    }
 
-    /* Write key as metadata */
-    ret = flb_fstore_file_meta_set(ctx->fs, fsf,
-                                   key, flb_sds_len(key));
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "error writing tag metadata");
-        return -1;
+        /* Write key as metadata */
+        ret = flb_fstore_file_meta_set(ctx->fs, fsf,
+                                    key, flb_sds_len(key));
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "error writing tag metadata");
+            return -1;
+        }
     }
 
     /* Append data to the target file */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Possibly will help with #2859 and #2753

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
