### PR TITLE
Fix CI build on master HEAD

### DIFF
--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -1,8 +1,17 @@
 cd build
 
+if ( "x64" -eq $env:PLATFORM ) {
+    $OPENSSL_DIR = "C:\OpenSSL-v11-Win64"
+}
+else {
+    $OPENSSL_DIR = "C:\OpenSSL-v11-Win32"
+}
+
+
 # CACHE GENERATION
 cmake -G "NMake Makefiles" `
                      -D FLB_TESTS_INTERNAL=On `
+                     -D OPENSSL_ROOT_DIR=$OPENSSL_DIR `
                      -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
                      -D FLB_WITHOUT_flb-rt-out_td=On `
                      -D FLB_WITHOUT_flb-rt-out_forward=On `

--- a/include/fluent-bit/flb_thread_pool.h
+++ b/include/fluent-bit/flb_thread_pool.h
@@ -28,7 +28,11 @@
 #define FLB_THREAD_POOL_STOPPED   2
 
 #include <fluent-bit/flb_info.h>
+#ifdef FLB_SYSTEM_WINDOWS
+#include <monkey/mk_core/external/winpthreads.h>
+#else
 #include <pthread.h>
+#endif
 
 struct worker_params {
     void (*func) (void *);

--- a/include/fluent-bit/flb_thread_storage.h
+++ b/include/fluent-bit/flb_thread_storage.h
@@ -23,6 +23,10 @@
 
 #include <fluent-bit/flb_info.h>
 
+#ifdef FLB_SYSTEM_WINDOWS
+#include <monkey/mk_core/external/winpthreads.h>
+#endif
+
 /* Ideal case when the compiler support direct storage through __thread */
 #ifdef FLB_HAVE_C_TLS
 #define FLB_TLS_SET(key, val)      key=val

--- a/plugins/filter_geoip2/CMakeLists.txt
+++ b/plugins/filter_geoip2/CMakeLists.txt
@@ -10,6 +10,7 @@
 #
 option(BUILD_TESTING "" OFF)
 add_subdirectory(libmaxminddb EXCLUDE_FROM_ALL)
+include_directories(libmaxminddb/include/)
 
 set(src
   geoip2.c)

--- a/plugins/filter_geoip2/libmaxminddb/CMakeLists.txt
+++ b/plugins/filter_geoip2/libmaxminddb/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 configure_file(${PROJECT_SOURCE_DIR}/include/maxminddb_config.h.cmake.in 
                ${PROJECT_SOURCE_DIR}/include/maxminddb_config.h)
 
-add_library(maxminddb
+add_library(maxminddb STATIC
   src/maxminddb.c
   src/data-pool.c
 )
@@ -81,17 +81,17 @@ set(MAXMINDB_HEADERS
 )
 set_target_properties(maxminddb PROPERTIES PUBLIC_HEADER "${MAXMINDB_HEADERS}")
 
-install(TARGETS maxminddb
-        EXPORT maxminddb
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/
-)
-
-# This is required to work with FetchContent
-install(EXPORT maxminddb
-        FILE maxminddb-config.cmake
-        NAMESPACE maxminddb::
-        DESTINATION lib/cmake/maxminddb)
+#install(TARGETS maxminddb
+#        EXPORT maxminddb
+#        ARCHIVE DESTINATION lib
+#        PUBLIC_HEADER DESTINATION include/
+#)
+#
+## This is required to work with FetchContent
+#install(EXPORT maxminddb
+#        FILE maxminddb-config.cmake
+#        NAMESPACE maxminddb::
+#        DESTINATION lib/cmake/maxminddb)
 
 # We always want to build mmdblookup
 add_subdirectory(bin)


### PR DESCRIPTION
This contains a set of patches to fix CI build on the current master branch.

 * Set `OPENSSL_ROOT_DIR` to link against the correct OpenSSL library on AppVeyor.
 * Tweak libmaxmind's CMakeFile to resolve errors within GeoIP2 plugin.
 * Fix compilation error due to `pthread.h` on Windows.

With this patch merged, I can confirm AppVeyor runs green on HEAD.