### PR TITLE
fstore: remove unused stream field in flb_fstore_file

### DIFF
--- a/include/fluent-bit/flb_fstore.h
+++ b/include/fluent-bit/flb_fstore.h
@@ -38,7 +38,6 @@ struct flb_fstore_file {
     size_t meta_size;               /* metadata size */
     void *data;                     /* opaque data type for user/caller context */
     struct cio_chunk *chunk;        /* chunk context */
-    struct cio_chunk *stream;       /* parent stream that owns this file */
     struct mk_list _head;           /* link to parent flb_fstore->files */
 };
 

--- a/src/flb_fstore.c
+++ b/src/flb_fstore.c
@@ -55,8 +55,8 @@ static int meta_set(struct flb_fstore_file *fsf, void *meta, size_t size)
     p = flb_calloc(1, size + 1);
     if (!p) {
         flb_errno();
-        flb_error("[fstore] could not cache metadata in file: %s:%s",
-                  fsf->stream->name, fsf->chunk->name);
+        flb_error("[fstore] could not cache metadata in file: %s",
+                  fsf->chunk->name);
         return -1;
     }
 
@@ -79,8 +79,8 @@ int flb_fstore_file_meta_set(struct flb_fstore *fs,
 
     ret = cio_meta_write(fsf->chunk, meta, size);
     if (ret == -1) {
-        flb_error("[fstore] could not write metadata to file: %s:%s",
-                  fsf->stream->name, fsf->chunk->name);
+        flb_error("[fstore] could not write metadata to file: %s, root_dir=%s",
+                  fsf->chunk->name, fs->root_path);
         return -1;
     }
 
@@ -145,8 +145,8 @@ struct flb_fstore_file *flb_fstore_file_create(struct flb_fstore *fs,
     }
     fsf->name = flb_sds_create(name);
     if (!fsf->name) {
-        flb_error("[fstore] could not create file: %s:%s",
-                  fsf->stream->name, name);
+        flb_error("[fstore] could not create file: %s:%s", 
+                  fs_stream->path, name);
         flb_free(fsf);
         return NULL;
     }
@@ -155,7 +155,7 @@ struct flb_fstore_file *flb_fstore_file_create(struct flb_fstore *fs,
                            CIO_OPEN, size, &err);
     if (!chunk) {
         flb_error("[fstore] could not create file: %s:%s",
-                  fsf->stream->name, name);
+                  fs_stream->path, name);
         flb_sds_destroy(fsf->name);
         flb_free(fsf);
         return NULL;


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Same patch as #2909 which should be reviewed first

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
