### PR TITLE
Support OpenSSL v1.0.2

### DIFF
--- a/include/fluent-bit/flb_tls.h
+++ b/include/fluent-bit/flb_tls.h
@@ -28,6 +28,8 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_upstream.h>
 
+int flb_tls_init(void);
+
 int net_io_tls_write(struct flb_coro *co, struct flb_upstream_conn *u_conn,
                      const void *data, size_t len, size_t *out_len);
 int net_io_tls_read(struct flb_coro *co, struct flb_upstream_conn *u_conn,

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_callback.h>
+#include <fluent-bit/flb_tls.h>
 
 #include <signal.h>
 #include <stdarg.h>
@@ -106,6 +107,7 @@ static inline struct flb_filter_instance *filter_instance_get(flb_ctx_t *ctx,
 
 void flb_init_env()
 {
+    flb_tls_init();
     flb_coro_init();
     flb_output_prepare();
 }

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -89,6 +89,10 @@ struct flb_tls *flb_tls_create(int verify,
     return tls;
 }
 
+int flb_tls_init(void)
+{
+    return tls_init();
+}
 
 int flb_tls_destroy(struct flb_tls *tls)
 {

--- a/src/tls/mbedtls.c
+++ b/src/tls/mbedtls.c
@@ -66,6 +66,11 @@ static void tls_debug(void *ctx, int level,
               line, str);
 }
 
+static int tls_init(void)
+{
+    return 0;
+}
+
 #ifdef _MSC_VER
 static int windows_load_system_certificates(struct tls_context *ctx)
 {


### PR DESCRIPTION
This adds the first cut at supporting older versions of OpenSSL.

 * A new API flb_tls_init() is added so that we can initialize libssl safely.
 * Replace methods that do not exist in OpenSSL v1.0.x.
 * Explicitly tell OpenSSL to verify server certificates if `tls.verify` is enabled.

With this patch applied, I can confirm that Fluent Bit is compilable and runnabale
on Ubuntu Xenial (where OpenSSL 1.0.2g is installed)