### PR TITLE
tls: Handle tls.ca_path and tls.ca_file correcty

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -147,8 +147,15 @@ static void *tls_context_create(int verify, int debug,
     }
 
     /* ca_path | ca_file */
-    if (!ca_path) {
-        load_system_certificates(ctx);
+    if (ca_path) {
+        ret = SSL_CTX_load_verify_locations(ctx->ctx, NULL, ca_path);
+        if (ret != 1) {
+            flb_error("[tls] ca_path'%s' %lu: %s",
+                      ca_path,
+                      ERR_get_error(),
+                      ERR_error_string(ERR_get_error(), NULL));
+            goto error;
+        }
     }
     else if (ca_file) {
         ret = SSL_CTX_load_verify_locations(ctx->ctx, ca_file, NULL);
@@ -159,6 +166,9 @@ static void *tls_context_create(int verify, int debug,
                       ERR_error_string(ERR_get_error(), NULL));
             goto error;
         }
+    }
+    else {
+        load_system_certificates(ctx);
     }
 
     /* crt_file */


### PR DESCRIPTION
Suppose we have the following configuration:

    [OUTPUT]
      Name http
      ...
      tls On
      tls.ca_file /var/cert/custom.crt

With the old code, tls.ca_file was simply ignored, because the old
code checks `ca_path` first, and just proceeds to load system certs
if ca_path was not provided.

Fix tls_context_create() to honor ca_path and ca_file properly.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
