### PR TITLE
filter_geoip2: Add support for older Ubuntu systems

### DIFF
--- a/plugins/filter_geoip2/libmaxminddb/CMakeLists.txt
+++ b/plugins/filter_geoip2/libmaxminddb/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required (VERSION 3.9)
 project(maxminddb
   LANGUAGES C
-  VERSION 1.4.3
 )
 set(MAXMINDDB_SOVERSION 0.0.7)
 


### PR DESCRIPTION
This patch removes a bogus requirement of CMake version.

Actually `libmaxmindb` does not depend on recent CMake features,
so there is no "backword incompatiblle" issue here.
    
With this applied, `filter_geoip2` now can be compiled and linked on
Ubuntu Xenial.