### PR TITLE
out_s3: fix create scheduled timer problem

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1204,6 +1204,7 @@ static void cb_s3_flush(const void *data, size_t bytes,
     flb_sds_t json = NULL;
     struct s3_file *chunk = NULL;
     struct multipart_upload *m_upload = NULL;
+    struct flb_sched *sched;
     char *buffer = NULL;
     size_t buffer_size;
     int timeout_check = FLB_FALSE;
@@ -1232,6 +1233,9 @@ static void cb_s3_flush(const void *data, size_t bytes,
         }
     }
 
+    /* Get the scheduler context */
+    sched = flb_sched_ctx_get();
+
     /*
      * create a timer that will run periodically and check if uploads
      * are ready for completion
@@ -1242,7 +1246,7 @@ static void cb_s3_flush(const void *data, size_t bytes,
                       "Creating upload timer with frequency %ds",
                       ctx->timer_ms / 1000);
 
-        ret = flb_sched_timer_cb_create(config, FLB_SCHED_TIMER_CB_PERM,
+        ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
                                         ctx->timer_ms,
                                         cb_s3_upload,
                                         ctx);


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Fix create scheduled timer problem on master branch
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
