### PR TITLE
hash: fix broken hash computation due to incoherent types

### DIFF
--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -181,7 +181,7 @@ static struct flb_hash_entry *hash_get_entry(struct flb_hash *ht,
                                              const char *key, int key_len, int *out_id)
 {
     int id;
-    unsigned int hash;
+    uint64_t hash;
     struct mk_list *head;
     struct flb_hash_table *table;
     struct flb_hash_entry *entry;
@@ -430,7 +430,7 @@ int flb_hash_del(struct flb_hash *ht, const char *key)
 {
     int id;
     int len;
-    unsigned int hash;
+    uint64_t hash;
     struct mk_list *head;
     struct flb_hash_entry *entry = NULL;
     struct flb_hash_table *table;


### PR DESCRIPTION
Commit 1b2559409 introduced a new hash routine `XXH3_64bits()`,
but did not migrate all the hash variables to 64 bit.
    
For this reason, `flb_hash_get()` and `flb_hash_del()` was using
truncated hash values as lookup keys.
    
Avoid that issue by always using 64-bit type to store hashes
    
Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
