### PR TITLE
out_stackdriver: Make metadata url configurable

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -22,6 +22,9 @@
 
 #include "stackdriver.h"
 
+/* Metadata server URL */
+#define FLB_STD_METADATA_SERVER "http://metadata.google.internal"
+
 /* Project ID metadata URI */
 #define FLB_STD_METADATA_PROJECT_ID_URI "/computeMetadata/v1/project/project-id"
 

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -866,7 +866,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     /* Create Upstream context for Stackdriver Logging (no oauth2 service) */
     ctx->u = flb_upstream_create_url(config, FLB_STD_WRITE_URL,
                                      io_flags, ins->tls);
-    ctx->metadata_u = flb_upstream_create_url(config, "http://metadata.google.internal",
+    ctx->metadata_u = flb_upstream_create_url(config, ctx->metadata_server,
                                               FLB_IO_TCP, NULL);
 
     /* Create oauth2 context */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -92,6 +92,7 @@ struct flb_stackdriver {
     bool metadata_server_auth;
 
     /* metadata server (GCP specific, WIP) */
+    flb_sds_t metadata_server;
     flb_sds_t zone;
     flb_sds_t instance_id;
     flb_sds_t instance_name;

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -597,9 +597,9 @@ static void cb_check_trace_stackdriver_autoformat(void *ctx, int ffd,
 
     /* trace in the entries */
     ret = mp_kv_cmp(
-        res_data, 
-        res_size, 
-        "$entries[0]['trace']", 
+        res_data,
+        res_size,
+        "$entries[0]['trace']",
         "projects/fluent-bit-test/traces/test-trace-id-xyz");
     TEST_CHECK(ret == FLB_TRUE);
 


### PR DESCRIPTION
Allows users to configure the metadata server url via config file
and environment variable. If neither are  supplied it will fall-back to
http://metadata.google.internal.

Evaluation order:
1. Config File via metadata_server_url
2. Environment Variable via METADATA_SERVER_URL
3. Internally set fallback variable FLB_STD_METADATA_SERVER_URL

Evaluating the config file before the environment variable is a
design decision in relation to security as it is easier for a bad
actor to set a environment variable than manipulate the config file.

Signed-off-by: Joey DeStefanis <jdestefanis@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
