### PR TITLE
Fix Windows CI Build and CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
-else()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 endif()
 
 include(GNUInstallDirs)

--- a/Dockerfile.windows.devel
+++ b/Dockerfile.windows.devel
@@ -15,16 +15,16 @@ ARG IMAGE_SOURCE_REVISION
 # Metadata as defined in OCI image spec annotations
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.title="Fluent Bit" `
-      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
-      org.opencontainers.image.created=$IMAGE_CREATE_DATE `
-      org.opencontainers.image.version=$FLUENTBIT_VERSION `
-      org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>" `
-      org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
-      org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
-      org.opencontainers.image.vendor="Fluent Organization" `
-      org.opencontainers.image.licenses="Apache-2.0" `
-      org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
-      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+    org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+    org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+    org.opencontainers.image.version=$FLUENTBIT_VERSION `
+    org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>" `
+    org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+    org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+    org.opencontainers.image.vendor="Fluent Organization" `
+    org.opencontainers.image.licenses="Apache-2.0" `
+    org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+    org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
 
 #
 # Basic setup
@@ -81,7 +81,7 @@ COPY . /src/
 
 WORKDIR /src/build
 
-RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=Release ../;
+RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=Release -DFLB_HTTP_SERVER=No ../;
 
 RUN cmake --build . --config Release;
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ make
 bin/fluent-bit -i cpu -o stdout -f 1
 ```
 
+To build on Windows
+
+```powershell
+cd build
+cmake -D FLB_HTTP_SERVER=No -D FLB_RELEASE=Yes -D FLB_DEBUG=No ..
+cmake --build . --config Release
+cmake --build . --config Release --target package
+```
+
 If you are interested into more details, please refer to the [Build & Install](https://docs.fluentbit.io/manual/installation/sources/build-and-install) section.
 
 #### Linux Packages

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -1,35 +1,35 @@
-cd build
+Set-Location build
 
 if ( "x64" -eq $env:PLATFORM ) {
-    $OPENSSL_DIR = "C:\OpenSSL-v11-Win64"
+    $OPENSSL_DIR = "C:\OpenSSL-v111-Win64"
 }
 else {
-    $OPENSSL_DIR = "C:\OpenSSL-v11-Win32"
+    $OPENSSL_DIR = "C:\OpenSSL-v111-Win32"
 }
-
 
 # CACHE GENERATION
 cmake -G "NMake Makefiles" `
-                     -D FLB_TESTS_INTERNAL=On `
-                     -D OPENSSL_ROOT_DIR=$OPENSSL_DIR `
-                     -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
-                     -D FLB_WITHOUT_flb-rt-out_td=On `
-                     -D FLB_WITHOUT_flb-rt-out_forward=On `
-                     -D FLB_WITHOUT_flb-rt-in_disk=On `
-                     -D FLB_WITHOUT_flb-rt-in_proc=On `
-                     -D FLB_WITHOUT_flb-it-parser=On `
-                     -D FLB_WITHOUT_flb-it-unit_sizes=On `
-                     -D FLB_WITHOUT_flb-it-network=On `
-                     -D FLB_WITHOUT_flb-it-pack=On `
-                     -D FLB_WITHOUT_flb-it-signv4=On `
-                     -D FLB_WITHOUT_flb-it-aws_credentials=On `
-                     -D FLB_WITHOUT_flb-it-aws_credentials_ec2=On `
-                     -D FLB_WITHOUT_flb-it-aws_credentials_http=On `
-                     -D FLB_WITHOUT_flb-it-aws_credentials_profile=On `
-                     -D FLB_WITHOUT_flb-it-aws_credentials_sts=On `
-                     -D FLB_WITHOUT_flb-it-aws_util=On `
-                     -D FLB_WITHOUT_flb-it-input_chunk=On `
-                     ../
+    -D FLB_TESTS_INTERNAL=On `
+    -D FLB_HTTP_SERVER=No `
+    -D OPENSSL_ROOT_DIR=$OPENSSL_DIR `
+    -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
+    -D FLB_WITHOUT_flb-rt-out_td=On `
+    -D FLB_WITHOUT_flb-rt-out_forward=On `
+    -D FLB_WITHOUT_flb-rt-in_disk=On `
+    -D FLB_WITHOUT_flb-rt-in_proc=On `
+    -D FLB_WITHOUT_flb-it-parser=On `
+    -D FLB_WITHOUT_flb-it-unit_sizes=On `
+    -D FLB_WITHOUT_flb-it-network=On `
+    -D FLB_WITHOUT_flb-it-pack=On `
+    -D FLB_WITHOUT_flb-it-signv4=On `
+    -D FLB_WITHOUT_flb-it-aws_credentials=On `
+    -D FLB_WITHOUT_flb-it-aws_credentials_ec2=On `
+    -D FLB_WITHOUT_flb-it-aws_credentials_http=On `
+    -D FLB_WITHOUT_flb-it-aws_credentials_profile=On `
+    -D FLB_WITHOUT_flb-it-aws_credentials_sts=On `
+    -D FLB_WITHOUT_flb-it-aws_util=On `
+    -D FLB_WITHOUT_flb-it-input_chunk=On `
+    ../
 
 # COMPILE
 cmake --build .

--- a/lib/chunkio/CMakeLists.txt
+++ b/lib/chunkio/CMakeLists.txt
@@ -15,10 +15,10 @@ else()
 endif()
 
 # Set __FILENAME__
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
-else()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 endif()
 
 # ChunkIO options

--- a/lib/mbedtls-2.24.0/CMakeLists.txt
+++ b/lib/mbedtls-2.24.0/CMakeLists.txt
@@ -154,7 +154,11 @@ string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 
 include(CheckCCompilerFlag)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+endif()
+
 
 if(CMAKE_COMPILER_IS_GNU)
     # some warnings we want are not available with old GCC versions

--- a/lib/monkey/CMakeLists.txt
+++ b/lib/monkey/CMakeLists.txt
@@ -13,8 +13,13 @@ include(ExternalProject)
 include(GNUInstallDirs)
 
 # Set default compiler options
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+endif()
 
 # Monkey Version
 set(MK_VERSION_MAJOR  1)

--- a/lib/mpack-amalgamation-1.0/CMakeLists.txt
+++ b/lib/mpack-amalgamation-1.0/CMakeLists.txt
@@ -2,6 +2,10 @@ set(src
   src/mpack/mpack.c
   )
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+endif()
+
 add_definitions(-DMPACK_EXTENSIONS=1)
 add_library(mpack-static STATIC ${src})

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -63,7 +63,7 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
 
-FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
+int flb_io_net_connect(struct flb_upstream_conn *u_conn,
                                   struct flb_coro *coro)
 {
     int ret;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fluent-bit in it's current state does not build on Windows. This can be verified by simply running `docker build -f Dockerfile.windows.devel`.

There were a few issues:

* `flb_io_net_connect` was marked as inline, so it couldn't be used outside the `flb_io.c` file in Visual Studio.
* `CMakeLists.txt` had some compiler flags that were Linux only passed to Windows as well.
* The `if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")` was not effective. I removed the `NOT` and flipped the statement.
* Upgrade OpenSSL to 1.11 from AppVeyor because 1.10 is no longer supported. (Could not run it locally)
* Disabled `FLB_HTTP_SERVER` in CI because Monkey does not build on Windows. Looking at the website there's no indication that it's Windows compatible. It tries to include #include <arpa/inet.h>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
