### PR TITLE
win32: Set the working directory for Windows Services

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,11 +196,12 @@ include(CheckSymbolExists)
 check_symbol_exists(accept4 "sys/socket.h" HAVE_ACCEPT4)
 
 # Core dependencies
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+if(FLB_SYSTEM_WINDOWS)
   set(FLB_DEPS
     "ws2_32.lib"
     "crypt32.lib"
     "Bcrypt.lib"
+    "Shlwapi.lib"
     )
 else()
   set(FLB_DEPS


### PR DESCRIPTION
Windows Services are launched by services.exe. For this reason,
Fluent Bit works in `C:\Windows\System32` when launched as a
Windows service.

This behaviour can be confusing, since all the relative paths in
config files will be interpreted as relative to the system dir.
(e.g. `Path test.log` will mean `C:\Windows\System32\test.log`)

Use a more intuitive default workdir to avoid such confusion.

Fix #2943.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
