### PR TITLE
Replace `select` by `poll` to fix the 1024 fd limit

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -233,7 +233,6 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
     int ret;
     int err;
     int socket_errno;
-    fd_set wait_set;
     struct pollfd pfd_read;
 
     /* Set socket to non-blocking mode */
@@ -270,8 +269,6 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          * extra file descriptor, the poll(2) call is straightforward
          * for this use case.
          */
-        FD_ZERO(&wait_set);
-        FD_SET(fd, &wait_set);
 
         pfd_read.fd = fd + 1;
         pfd_read.events = POLLIN;


### PR DESCRIPTION
Seems like the implementation of select define a limit about the maximum amount of fd to monitor. As the documentation recommend, we could use `poll` or `epoll`.

Signed-off-by: Adrien Carreira <adrien.carreira@ovhcloud.com>

<!-- Provide summary of changes -->

Fixes #2508

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
I dont know how I could test it with a real kubernetes configuration, maybe some tips here ?



Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
