### PR TITLE
Fix compilation in MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,6 @@ if (MSVC)
   # Use add_compile_options() to set /MT since Visual Studio
   # Generator does not notice /MT in CMAKE_C_FLAGS.
   add_compile_options(/MT)
-elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fno-common")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/include/fluent-bit/flb_thread_storage.h
+++ b/include/fluent-bit/flb_thread_storage.h
@@ -36,6 +36,8 @@
 
 #else
 
+#include <pthread.h>
+
 /* Fallback mode using pthread_*() for Thread-Local-Storage usage */
 #define FLB_TLS_SET(key, val)      pthread_setspecific(key, (void *) val)
 #define FLB_TLS_GET(key)           pthread_getspecific(key)


### PR DESCRIPTION
<!-- Provide summary of changes -->
The current master doesn't compile with my MacOS (Big Sur, XCode 12.3) setup.

```
Apple clang version 12.0.0 (clang-1200.0.32.28)
Target: x86_64-apple-darwin20.2.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

1. Missing include prevents compilation:
```
[ 44%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_coro.c.o
In file included from /Users/a113889/Code/workspace/rofa/fluent-bit/src/flb_coro.c:22:
/Users/a113889/Code/workspace/rofa/fluent-bit/include/fluent-bit/flb_thread_storage.h:48:8: error: unknown type name 'pthread_key_t'
extern FLB_TLS_DEFINE(struct flb_worker, flb_worker_ctx)
       ^
/Users/a113889/Code/workspace/rofa/fluent-bit/include/fluent-bit/flb_thread_storage.h:43:36: note: expanded from macro 'FLB_TLS_DEFINE'
#define FLB_TLS_DEFINE(type, name) pthread_key_t name;
                                   ^
1 error generated.
make[2]: *** [src/CMakeFiles/fluent-bit-static.dir/flb_coro.c.o] Error 1
make[1]: *** [src/CMakeFiles/fluent-bit-static.dir/all] Error 2
make: *** [all] Error 2
```

2. Wrong compiler flags prevents linking:
```
[ 84%] Linking C executable ../bin/fluent-bit
duplicate symbol '_mk_tls_cache_gmtext' in:
    ../library/libfluent-bit.a(flb_config.c.o)
    ../library/libfluent-bit.a(flb_engine.c.o)
...
duplicate symbol '_mk_tls_sched_worker_node' in:
    ../library/libfluent-bit.a(flb_config.c.o)
    ../lib/monkey/library/monkey-liana.a(liana.c.o)
ld: 420 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [bin/fluent-bit] Error 1
make[1]: *** [src/CMakeFiles/fluent-bit-bin.dir/all] Error 2
make: *** [all] Error 2
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
