### PR TITLE
in_tail: use the latest id when finding offset from the db

### DIFF
--- a/plugins/in_tail/tail_sql.h
+++ b/plugins/in_tail/tail_sql.h
@@ -38,7 +38,8 @@
     "  rotated INTEGER DEFAULT 0"                                       \
     ");"
 
-#define SQL_GET_FILE "SELECT * from in_tail_files WHERE inode=@inode;"
+#define SQL_GET_FILE                                                    \
+    "SELECT * from in_tail_files WHERE inode=@inode order by id desc;"
 
 #define SQL_INSERT_FILE                                             \
     "INSERT INTO in_tail_files (name, offset, inode, created)"      \


### PR DESCRIPTION
DB may have two or more records with the same inode values. The problem is that when restarting, if a resumed file has same inode of a DB record whose file is already deleted, in_tail uses the offset for deleted file. This leads to unexpected behavior.

We can ensure that when DB contains two records with the same inode value, the one with the smaller id can be ignored because file system cannot have two files with the same inode if we can ignores hard links. Thus, it is safe to query a record with the largest id.

Below is a part of DB from our server. I removed some sensitive information.
```bash
$ sqlite3 tail.db 'select * from in_tail_files where inode=6443043122'
9816|XXX_access_log.2.20200713|83636851|6443043122|1594479601|1
10582|XXX_access_log.3.20210121|3520016914|6443043122|1611068401|1
```

When I tried to upgrade (v1.3.6 -> v1.6.9) and restart fluent-bit, fluent-bit starts to process a too large amount of logs. Note that, at that time, the file corresponding to id 10582 was not rotated and resumed. For the old versions, it is not a problem because fluent-bit also checks the name of the file and that of the record.

If we do not check the name, I think we should check the id to prevent the above situation.

Signed-off-by: Lee Byeoksan <lee.byeoksan+github@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
