### PR TITLE
tests: parser: fix a test failure due to leap years

### DIFF
--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -19,6 +19,9 @@
 #define JSON_FMT_01  "{\"key001\": 12345, \"key002\": 0.99, \"time\": \"%s\"}"
 #define REGEX_FMT_01 "12345 0.99 %s"
 
+#define isleap(y) ((y) % 4 == 0 && ((y) % 400 == 0 || (y) % 100 != 0))
+#define year2sec(y) (isleap(y) ? 31622400 : 31536000)
+
 /* Timezone */
 struct tz_check {
     char *val;
@@ -167,6 +170,7 @@ static void load_regex_parsers(struct flb_config *config)
 void test_parser_time_lookup()
 {
     int i;
+    int j;
     int len;
     int ret;
     int toff;
@@ -210,8 +214,9 @@ void test_parser_time_lookup()
             gmtime_r(&now, &tm_now);
             gmtime_r(&time_test, &tm_test);
 
-            if (tm_now.tm_year != tm_test.tm_year) {
-                year_diff = ((tm_now.tm_year - tm_test.tm_year) * 31536000);
+            year_diff = 0;
+            for (j = tm_test.tm_year; j < tm_now.tm_year; j++) {
+                year_diff += year2sec(tm_test.tm_mon < 2 ? j : j + 1);
             }
         }
         else {
@@ -244,6 +249,7 @@ void test_parser_time_lookup()
 void test_json_parser_time_lookup()
 {
     int i;
+    int j;
     int ret;
     int len;
     int toff;
@@ -289,8 +295,9 @@ void test_json_parser_time_lookup()
             gmtime_r(&time_now, &tm_now);
             gmtime_r(&time_test, &tm_test);
 
-            if (tm_now.tm_year != tm_test.tm_year) {
-                year_diff = ((tm_now.tm_year - tm_test.tm_year) * 31536000);
+            year_diff = 0;
+            for (j = tm_test.tm_year; j < tm_now.tm_year; j++) {
+                year_diff += year2sec(tm_test.tm_mon < 2 ? j : j + 1);
             }
         }
         else {
@@ -327,6 +334,7 @@ void test_json_parser_time_lookup()
 void test_regex_parser_time_lookup()
 {
     int i;
+    int j;
     int ret;
     int len;
     int toff;
@@ -372,8 +380,9 @@ void test_regex_parser_time_lookup()
             gmtime_r(&time_now, &tm_now);
             gmtime_r(&time_test, &tm_test);
 
-            if (tm_now.tm_year != tm_test.tm_year) {
-                year_diff = ((tm_now.tm_year - tm_test.tm_year) * 31536000);
+            year_diff = 0;
+            for (j = tm_test.tm_year; j < tm_now.tm_year; j++) {
+                year_diff += year2sec(tm_test.tm_mon < 2 ? j : j + 1);
             }
         }
         else {


### PR DESCRIPTION
The test computes the number of seconds since the dataset was
originally created, and uses the result to adjust the expected
result. But it fails to take leap years into calculation.

Teach it about leap years, and hence let `flb-it-parser` pass.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
