### PR TITLE
Fix compliation failure in AppVeyor

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -10,6 +10,7 @@ set(FLB_EXAMPLES              Yes)
 set(FLB_PARSER                Yes)
 set(FLB_TLS                   Yes)
 set(FLB_AWS                   Yes)
+set(FLB_HTTP_SERVER            No)
 
 # INPUT plugins
 # =============

--- a/include/fluent-bit/flb_thread_storage.h
+++ b/include/fluent-bit/flb_thread_storage.h
@@ -25,6 +25,8 @@
 
 #ifdef FLB_SYSTEM_WINDOWS
 #include <monkey/mk_core/external/winpthreads.h>
+#else
+#include <pthread.h>
 #endif
 
 /* Ideal case when the compiler support direct storage through __thread */
@@ -35,8 +37,6 @@
 #define FLB_TLS_DEFINE(type, name) __thread type *name;
 
 #else
-
-#include <pthread.h>
 
 /* Fallback mode using pthread_*() for Thread-Local-Storage usage */
 #define FLB_TLS_SET(key, val)      pthread_setspecific(key, (void *) val)


### PR DESCRIPTION
This contains a set of fixes that we need to make AppVeyor happy.

 * Disable `FLB_HTTP_SERVER` on Windows buiild
 * Don't include `<pthreads.h>` on Windows.

With this merged, the master HEAD is compilable on Windows again.