### PR TITLE
out_loki: fix network setting is not applied.

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -568,6 +568,7 @@ static struct flb_loki *loki_config_create(struct flb_output_instance *ins,
         return NULL;
     }
     ctx->u = upstream;
+    flb_output_upstream_set(ctx->u, ins);
     ctx->tcp_port = ins->host.port;
     ctx->tcp_host = ins->host.name;
 


### PR DESCRIPTION
I followed [Loki](https://docs.fluentbit.io/manual/pipeline/outputs/loki#networking-and-tls-configuration) document to apply networking config but it didn't work.

I think this could work. 

Signed-off-by: PoYu Hsu <poyuhsu@synology.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
