### PR TITLE
network: fix poll(2) call fd

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -270,7 +270,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          * for this use case.
          */
 
-        pfd_read.fd = fd + 1;
+        pfd_read.fd = fd;
         pfd_read.events = POLLIN;
         ret = poll(&pfd_read, 1, connect_timeout * 1000);
         if (ret == 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes small bug	for #2948.
One was	added accidentally to fd.

pfd_read.fd = fd + 1; => pfd_read.fd = fd;

Signed-off-by: Jukka Pihl <jukka.pihl@iki.fi>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes PR #2948.
commit b8689c0afbcf308f1844b8e1611381ada80c8f6d

----
Enter `[N/A]` in the box, if an item is not applicable to your change.
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
