### PR TITLE
network: Fix poll(2) to wait for POLLOUT

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -271,7 +271,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          */
 
         pfd_read.fd = fd;
-        pfd_read.events = POLLIN;
+        pfd_read.events = POLLOUT;
         ret = poll(&pfd_read, 1, connect_timeout * 1000);
         if (ret == 0) {
             /* Timeout */


### PR DESCRIPTION
Commit b8689c0af modified `net_connect_sync()` to use poll(2). In that
process, the semantics was modfiied to wait for socket to be readable,
not writitable.

This seems to be causing #2976 "Fluent Bit always timeouts while
connecting to metadata.google.internal".

Fix the call for poll(2) to follow the original behaviour.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
