### PR TITLE
filter_kubernetes: change the way of generating cache_key

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -842,6 +842,9 @@ static inline int extract_meta(struct flb_kube *ctx,
         if (meta->container_name) {
             n += meta->container_name_len + 1;
         }
+        if (meta->docker_id) {
+            n += meta->docker_id_len + 1;
+        }
         meta->cache_key = flb_malloc(n);
         if (!meta->cache_key) {
             flb_errno();
@@ -864,6 +867,14 @@ static inline int extract_meta(struct flb_kube *ctx,
             meta->cache_key[off++] = ':';
             memcpy(meta->cache_key + off, meta->container_name, meta->container_name_len);
             off += meta->container_name_len;
+        }
+
+        /* Copy docker_id if docker_id is not NULL*/
+        if (meta->docker_id) {
+            /* Separator */
+            meta->cache_key[off++] = ':';
+            memcpy(meta->cache_key + off, meta->docker_id, meta->docker_id_len);
+            off += meta->docker_id_len;
         }
 
         meta->cache_key[off] = '\0';


### PR DESCRIPTION
change the way of generating cache_key to fix the bug of recreating the same name Pod. If we create a Pod directly, then delete this Pod, and create the same name Pod, the logs of the new Pod will be tagged with the older Pod meta information.

Signed-off-by: EDGsheryl <edgsheryl@gmail.com>

<!-- Provide summary of changes -->

If we can get the docker_id, we can use it in the cache_key, and it can recognize different generations of Pod.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
