### PR TITLE
out_kinesis_streams: fix too few arguments problem

### DIFF
--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -171,7 +171,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                                            (char *) ctx->region,
                                                            ctx->sts_endpoint,
                                                            NULL,
-                                                           flb_aws_client_generator());
+                                                           flb_aws_client_generator(),
+                                                           ctx->ins);
     if (!ctx->aws_provider) {
         flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");
         goto error;
@@ -218,7 +219,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                                     (char *) ctx->region,
                                                     ctx->sts_endpoint,
                                                     NULL,
-                                                    flb_aws_client_generator());
+                                                    flb_aws_client_generator(),
+                                                    ctx->ins);
         if (!ctx->aws_provider) {
             flb_plg_error(ctx->ins,
                           "Failed to create AWS STS Credential Provider");


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Add one more input in some functions in `kinesis.c`.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
fix the too few arguments problem in #2983 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
