### PR TITLE
Fix compilation error on Windows for v1.7.0 RC2

### DIFF
--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -300,7 +300,7 @@ static struct flush *new_flush_buffer(const char *tag, int tag_len)
     }
     buf->tmp_buf_size = PUT_RECORDS_PAYLOAD_SIZE;
 
-    buf->events = flb_malloc(sizeof(struct event) * MAX_EVENTS_PER_PUT);
+    buf->events = flb_malloc(sizeof(struct kinesis_event) * MAX_EVENTS_PER_PUT);
     if (!buf->events) {
         flb_errno();
         kinesis_flush_destroy(buf);

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -42,7 +42,7 @@ struct flush {
     size_t data_size;
 
     /* log records- each of these has a pointer to their message in tmp_buf */
-    struct event *events;
+    struct kinesis_event *events;
     int events_capacity;
     /* current event */
     int event_index;
@@ -62,7 +62,7 @@ struct flush {
     int tag_len;
 };
 
-struct event {
+struct kinesis_event {
     char *json;
     size_t len;
     struct timespec timestamp;

--- a/plugins/out_kinesis_streams/kinesis_api.c
+++ b/plugins/out_kinesis_streams/kinesis_api.c
@@ -137,7 +137,7 @@ static flb_sds_t random_partition_key(const char *tag)
  * Writes a log event to the output buffer
  */
 static int write_event(struct flb_kinesis *ctx, struct flush *buf,
-                       struct event *event, int *offset)
+                       struct kinesis_event *event, int *offset)
 {
     flb_sds_t tag_timestamp = NULL;
 
@@ -216,7 +216,7 @@ static int process_event(struct flb_kinesis *ctx, struct flush *buf,
     int ret;
     size_t size;
     size_t b64_len;
-    struct event *event;
+    struct kinesis_event *event;
     char *tmp_buf_ptr;
     char *time_key_ptr;
     struct tm time_stamp;
@@ -379,7 +379,7 @@ static int send_log_events(struct flb_kinesis *ctx, struct flush *buf) {
     int ret;
     int offset;
     int i;
-    struct event *event;
+    struct kinesis_event *event;
 
     if (buf->event_index <= 0) {
         /*
@@ -453,7 +453,7 @@ static int add_event(struct flb_kinesis *ctx, struct flush *buf,
                      const msgpack_object *obj, struct flb_time *tms)
 {
     int ret;
-    struct event *event;
+    struct kinesis_event *event;
     int retry_add = FLB_FALSE;
     size_t event_bytes = 0;
 

--- a/plugins/out_kinesis_streams/kinesis_api.c
+++ b/plugins/out_kinesis_streams/kinesis_api.c
@@ -41,8 +41,11 @@
 #include <msgpack.h>
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <unistd.h>
+#endif
 
 #include "kinesis_api.h"
 

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -63,8 +63,8 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
 
-FLB_INLINE int flb_io_net_connect(struct flb_upstream_conn *u_conn,
-                                  struct flb_coro *coro)
+int flb_io_net_connect(struct flb_upstream_conn *u_conn,
+                       struct flb_coro *coro)
 {
     int ret;
     int async = FLB_FALSE;


### PR DESCRIPTION
This is a series of patches to make the master HEAD compilable again
on Windows.

 * io: Avoid compilation error due to INLINE
 * out_kinesis_streams: Do not include <unistd.h> on Windows
 * out_kinesis_streams: Add 'kinesis' prefix to struct name

With this patch merged, Appveyor should become green again.
