### PR TITLE
out_stackdriver: Support generic resources.

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -899,20 +899,22 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
         }
     }
 
-    if (ctx->metadata_server_auth) {
+    if (ctx->metadata_server_auth ) {
         ret = gce_metadata_read_project_id(ctx);
         if (ret == -1) {
             return -1;
         }
 
-        ret = gce_metadata_read_zone(ctx);
-        if (ret == -1) {
-            return -1;
-        }
+        if (!ctx->generic_resource_type) {
+            ret = gce_metadata_read_zone(ctx);
+            if (ret == -1) {
+                return -1;
+            }
 
-        ret = gce_metadata_read_instance_id(ctx);
-        if (ret == -1) {
-            return -1;
+            ret = gce_metadata_read_instance_id(ctx);
+            if (ret == -1) {
+                return -1;
+            }
         }
     }
 
@@ -1430,6 +1432,52 @@ static int stackdriver_format(struct flb_config *config,
             msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
             msgpack_pack_str_body(&mp_pck,
                                   ctx->project_id, flb_sds_len(ctx->project_id));
+        }
+        else if (ctx->generic_resource_type) {
+            if (strcmp(ctx->resource, "generic_node") == 0) {
+                /* generic_node has fields project_id, location, namespace, node_id */
+                msgpack_pack_map(&mp_pck, 4);
+
+                msgpack_pack_str(&mp_pck, 7);
+                msgpack_pack_str_body(&mp_pck, "node_id", 7);
+                msgpack_pack_str(&mp_pck, flb_sds_len(ctx->node_id));
+                msgpack_pack_str_body(&mp_pck,
+                                      ctx->node_id, flb_sds_len(ctx->node_id));
+            }
+            else {
+                 /* generic_task has fields project_id, location, namespace, job, task_id */
+                msgpack_pack_map(&mp_pck, 5);
+
+                msgpack_pack_str(&mp_pck, 3);
+                msgpack_pack_str_body(&mp_pck, "job", 3);
+                msgpack_pack_str(&mp_pck, flb_sds_len(ctx->job));
+                msgpack_pack_str_body(&mp_pck,
+                                      ctx->job, flb_sds_len(ctx->job));
+
+                msgpack_pack_str(&mp_pck, 7);
+                msgpack_pack_str_body(&mp_pck, "task_id", 7);
+                msgpack_pack_str(&mp_pck, flb_sds_len(ctx->task_id));
+                msgpack_pack_str_body(&mp_pck,
+                                      ctx->task_id, flb_sds_len(ctx->task_id));
+            }
+
+            msgpack_pack_str(&mp_pck, 10);
+            msgpack_pack_str_body(&mp_pck, "project_id", 10);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->project_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->project_id, flb_sds_len(ctx->project_id));
+
+            msgpack_pack_str(&mp_pck, 8);
+            msgpack_pack_str_body(&mp_pck, "location", 8);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->location));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->location, flb_sds_len(ctx->location));
+
+            msgpack_pack_str(&mp_pck, 9);
+            msgpack_pack_str_body(&mp_pck, "namespace", 9);
+            msgpack_pack_str(&mp_pck, flb_sds_len(ctx->namespace_id));
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->namespace_id, flb_sds_len(ctx->namespace_id));
         }
         else if (strcmp(ctx->resource, "gce_instance") == 0) {
             /* gce_instance resource has fields project_id, zone, instance_id */

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -905,7 +905,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
             return -1;
         }
 
-        if (!ctx->generic_resource_type) {
+        if (!ctx->is_generic_resource_type) {
             ret = gce_metadata_read_zone(ctx);
             if (ret == -1) {
                 return -1;
@@ -1413,7 +1413,7 @@ static int stackdriver_format(struct flb_config *config,
     msgpack_pack_str(&mp_pck, 6);
     msgpack_pack_str_body(&mp_pck, "labels", 6);
 
-    if (ctx->k8s_resource_type) {
+    if (ctx->is_k8s_resource_type) {
         ret = extract_local_resource_id(data, bytes, ctx, tag);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "fail to construct local_resource_id");
@@ -1433,7 +1433,7 @@ static int stackdriver_format(struct flb_config *config,
             msgpack_pack_str_body(&mp_pck,
                                   ctx->project_id, flb_sds_len(ctx->project_id));
         }
-        else if (ctx->generic_resource_type) {
+        else if (ctx->is_generic_resource_type) {
             if (strcmp(ctx->resource, "generic_node") == 0) {
                 /* generic_node has fields project_id, location, namespace, node_id */
                 msgpack_pack_map(&mp_pck, 4);
@@ -1852,7 +1852,7 @@ static int stackdriver_format(struct flb_config *config,
 
         /* avoid modifying the original tag */
         newtag = tag;
-        if (ctx->k8s_resource_type) {
+        if (ctx->is_k8s_resource_type) {
             stream = get_stream(result.data.via.array.ptr[1].via.map);
             if (stream == STREAM_STDOUT) {
                 newtag = "stdout";

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -899,7 +899,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
         }
     }
 
-    if (ctx->metadata_server_auth ) {
+    if (ctx->metadata_server_auth) {
         ret = gce_metadata_read_project_id(ctx);
         if (ret == -1) {
             return -1;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -110,6 +110,19 @@ struct flb_stackdriver {
     flb_sds_t local_resource_id;
     flb_sds_t tag_prefix;
 
+    /* generic resources */
+    flb_sds_t location;
+    flb_sds_t namespace_id;
+    bool generic_resource_type;
+
+    /* generic_node specific */
+    flb_sds_t node_id;
+
+    /* generic_task specific */
+    flb_sds_t job;
+    flb_sds_t task_id;
+
+
     /* other */
     flb_sds_t resource;
     flb_sds_t severity_key;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -104,7 +104,7 @@ struct flb_stackdriver {
     flb_sds_t pod_name;
     flb_sds_t container_name;
     flb_sds_t node_name;
-    bool k8s_resource_type;
+    bool is_k8s_resource_type;
 
     flb_sds_t labels_key;
     flb_sds_t local_resource_id;
@@ -113,7 +113,7 @@ struct flb_stackdriver {
     /* generic resources */
     flb_sds_t location;
     flb_sds_t namespace_id;
-    bool generic_resource_type;
+    bool is_generic_resource_type;
 
     /* generic_node specific */
     flb_sds_t node_id;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -440,7 +440,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     if (ctx->generic_resource_type){
         flb_sds_destroy(ctx->location);
         flb_sds_destroy(ctx->namespace_id);
-        if(flb_sds_cmp(ctx->resource, "generic_node", flb_sds_len(ctx->resource)) ){
+        if(ctx->node_id){
             flb_sds_destroy(ctx->node_id);
         }
         else {

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -340,7 +340,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         }
     }
 
-    if(flb_sds_cmp(ctx->resource, "generic_node",
+    if (flb_sds_cmp(ctx->resource, "generic_node",
                     flb_sds_len(ctx->resource)) == 0 ||
         flb_sds_cmp(ctx->resource, "generic_task",
                     flb_sds_len(ctx->resource)) == 0) {
@@ -348,14 +348,14 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->is_generic_resource_type = FLB_TRUE;
 
         tmp = flb_output_get_property("location", ins);
-        if(tmp) {
+        if (tmp) {
             ctx->location = flb_sds_create(tmp);
         } else {
             flb_plg_error(ctx->ins, "missing generic resource's location");
         }
 
         tmp = flb_output_get_property("namespace", ins);
-        if(tmp) {
+        if (tmp) {
             ctx->namespace_id = flb_sds_create(tmp);
         } else {
             flb_plg_error(ctx->ins, "missing generic resource's namespace");
@@ -364,7 +364,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         if (flb_sds_cmp(ctx->resource, "generic_node",
                     flb_sds_len(ctx->resource)) == 0) {
             tmp = flb_output_get_property("node_id", ins);
-            if(tmp) {
+            if (tmp) {
                 ctx->node_id = flb_sds_create(tmp);
             } else {
                 flb_plg_error(ctx->ins, "missing generic_node's node_id");
@@ -374,14 +374,14 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         }
         else {
             tmp = flb_output_get_property("job", ins);
-            if(tmp) {
+            if (tmp) {
                 ctx->job = flb_sds_create(tmp);
             } else {
                 flb_plg_error(ctx->ins, "missing generic_task's job");
             }
 
             tmp = flb_output_get_property("task_id", ins);
-            if(tmp) {
+            if (tmp) {
                 ctx->task_id = flb_sds_create(tmp);
             } else {
                 flb_plg_error(ctx->ins, "missing generic_task's task_id");

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -32,7 +32,6 @@
 #include "stackdriver.h"
 #include "stackdriver_conf.h"
 
-
 static inline int key_cmp(const char *str, int len, const char *cmp) {
 
     if (strlen(cmp) != len) {
@@ -321,7 +320,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         flb_sds_cmp(ctx->resource, "k8s_pod",
                     flb_sds_len(ctx->resource)) == 0) {
 
-        ctx->k8s_resource_type = FLB_TRUE;
+        ctx->is_k8s_resource_type = FLB_TRUE;
 
         tmp = flb_output_get_property("k8s_cluster_name", ins);
         if (tmp) {
@@ -346,7 +345,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         flb_sds_cmp(ctx->resource, "generic_task",
                     flb_sds_len(ctx->resource)) == 0) {
 
-        ctx->generic_resource_type = FLB_TRUE;
+        ctx->is_generic_resource_type = FLB_TRUE;
 
         tmp = flb_output_get_property("location", ins);
         if(tmp) {
@@ -413,7 +412,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->tag_prefix = flb_sds_create(tmp);
     }
     else {
-        if (ctx->k8s_resource_type == FLB_TRUE) {
+        if (ctx->is_k8s_resource_type == FLB_TRUE) {
             ctx->tag_prefix = flb_sds_create(ctx->resource);
         }
     }
@@ -427,7 +426,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         return -1;
     }
 
-    if (ctx->k8s_resource_type){
+    if (ctx->is_k8s_resource_type){
         flb_sds_destroy(ctx->namespace_name);
         flb_sds_destroy(ctx->pod_name);
         flb_sds_destroy(ctx->container_name);
@@ -437,7 +436,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         flb_sds_destroy(ctx->local_resource_id);
     }
 
-    if (ctx->generic_resource_type){
+    if (ctx->is_generic_resource_type){
         flb_sds_destroy(ctx->location);
         flb_sds_destroy(ctx->namespace_id);
         if(ctx->node_id){

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -16,6 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 #include <fluent-bit.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_record_accessor.h>

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -16,7 +16,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 #include <fluent-bit.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_record_accessor.h>
@@ -395,6 +394,148 @@ static void cb_check_global_resource(void *ctx, int ffd,
     int ret;
 
     ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "global");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_generic_node_creds(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+   /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "generic_node");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "fluent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace']", "test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* node_id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['node_id']", "333222111");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_generic_node_metadata(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+   /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "generic_node");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit-test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "fluent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace']", "test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* node_id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['node_id']", "333222111");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_generic_task_creds(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+   /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "generic_task");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "fluent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace']", "test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+     /* job */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['job']", "test-job");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* task_id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['task_id']", "333222111");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_generic_task_metadata(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    int ret;
+
+   /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "generic_task");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit-test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "fluent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* namespace */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['namespace']", "test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* job */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['job']", "test-job");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* task_id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['task_id']", "333222111");
     TEST_CHECK(ret == FLB_TRUE);
 
     flb_sds_destroy(res_data);
@@ -2128,6 +2269,182 @@ void flb_test_resource_global_custom_prefix()
     /* Enable test mode */
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
                               cb_check_global_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_generic_node_creds()
+{
+    int ret;
+    int size = sizeof(JSON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "generic_node",
+                   "location", "fluent",
+                   "namespace", "test",
+                   "node_id", "333222111",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_generic_node_creds,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_generic_node_metadata()
+{
+    int ret;
+    int size = sizeof(JSON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "generic_node",
+                   "location", "fluent",
+                   "namespace", "test",
+                   "node_id", "333222111",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_generic_node_metadata,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_generic_task_creds()
+{
+    int ret;
+    int size = sizeof(JSON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "resource", "generic_task",
+                   "location", "fluent",
+                   "namespace", "test",
+                   "job", "test-job",
+                   "task_id", "333222111",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_generic_task_creds,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_generic_task_metadata()
+{
+    int ret;
+    int size = sizeof(JSON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "generic_task",
+                   "location", "fluent",
+                   "namespace", "test",
+                   "job", "test-job",
+                   "task_id", "333222111",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_generic_task_metadata,
                               NULL, NULL);
 
     /* Start */
@@ -4169,6 +4486,12 @@ TEST_LIST = {
     {"resource_global", flb_test_resource_global },
     {"resource_global_custom_prefix", flb_test_resource_global_custom_prefix },
     {"resource_gce_instance", flb_test_resource_gce_instance },
+
+    /* generic resources */
+    {"resource_generic_node_creds", flb_test_resource_generic_node_creds},
+    {"resource_generic_node_metadata", flb_test_resource_generic_node_metadata},
+    {"resource_generic_task_creds", flb_test_resource_generic_task_creds},
+    {"resource_generic_task_metadata", flb_test_resource_generic_task_metadata},
 
     /* test trace */
     {"trace_no_autoformat", flb_test_trace_no_autoformat},


### PR DESCRIPTION
Added generic_node and generic_task as supported resources.

Of note:
Both credential files or custom metadata server work for auth.
Credential file is preferred, but if you choose the metadata server
then it will need to also return the call for project_id.

Testing covers both of those cases.

Apparently my client was also confused about an old change when I merged my branch which is why METADATA_SERVER_URL gets fixed again here.

Signed-off-by: Joey DeStefanis <jdestefanis@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
