### PR TITLE
hash: implement flb_hash_get_ptr()

### DIFF
--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -426,6 +426,21 @@ int flb_hash_get_by_id(struct flb_hash *ht, int id,
     return 0;
 }
 
+void *flb_hash_get_ptr(struct flb_hash *ht,
+                 const char *key, int key_len)
+{
+    int id;
+    struct flb_hash_entry *entry;
+
+    entry = hash_get_entry(ht, key, key_len, &id);
+    if (!entry) {
+        return NULL;
+    }
+
+    entry->hits++;
+    return entry->val;
+}
+
 int flb_hash_del(struct flb_hash *ht, const char *key)
 {
     int id;

--- a/tests/internal/hashtable.c
+++ b/tests/internal/hashtable.c
@@ -344,6 +344,9 @@ void test_pointer()
     TEST_CHECK(ret >= 0);
     TEST_CHECK((void *) out_buf == (void *) val2);
 
+    out_buf = flb_hash_get_ptr(ht, "key2", 4);
+    TEST_CHECK((void *) out_buf == (void *) val2);
+
     ret = flb_hash_del_ptr(ht, "key2", 4, (void *) out_buf);
     TEST_CHECK(ret == 0);
 


### PR DESCRIPTION
The function is already declared in `flb_hash.h`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
