### PR TITLE
out_loki: implement remove_keys

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -690,6 +690,7 @@ static int pack_record(struct flb_loki *ctx,
                        msgpack_packer *mp_pck, msgpack_object *rec)
 {
     int i;
+    int skip = 0;
     int len;
     int size_hint = 1024;
     char *line;
@@ -722,10 +723,11 @@ static int pack_record(struct flb_loki *ctx,
             val = rec->via.map.ptr[i].val;
 
             if (key.type != MSGPACK_OBJECT_STR) {
+                skip++;
                 continue;
             }
 
-            if (i > 0) {
+            if (i > skip) {
                 safe_sds_cat(&buf, " ", 1);
             }
 

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -63,6 +63,7 @@ struct flb_loki {
     /* Labels */
     struct mk_list *labels;
     struct mk_list *label_keys;
+    struct mk_list *remove_keys;
 
     /* Private */
     int tcp_port;
@@ -71,6 +72,8 @@ struct flb_loki {
     int ra_used;                        /* number of record accessor label keys */
     struct flb_record_accessor *ra_k8s; /* kubernetes record accessor */
     struct mk_list labels_list;         /* list of flb_loki_kv nodes */
+    struct mk_list remove_keys_derived; /* remove_keys with label RAs */
+    struct flb_mp_accessor *remove_mpa; /* remove_keys multi-pattern accessor */
 
     /* Upstream Context */
     struct flb_upstream *u;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Workaround for #2821.

flb_ra_translate() is too complicated to implement automatic removal of matching fields. This PR implements simple key removal with flb_hash instead.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
