### PR TITLE
output: change maskid type to prevent overflow

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -398,7 +398,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
                                            const char *output, void *data)
 {
     int ret = -1;
-    int mask_id;
+    uint64_t mask_id;
     int flags = 0;
     struct mk_list *head;
     struct flb_output_plugin *plugin;


### PR DESCRIPTION

<!-- Provide summary of changes -->
Fixes #2914

This change prevents overflow.

In `flb_output_new` the type of local variable `mask_id`  is "int".
However `flb_output_instance.mask_id` is `uint64_t`.

This local variable uses like this. It will causes overflow of local `mask_id`.
```c
    /* Get the last mask_id reported by an output instance plugin */
    if (mk_list_is_empty(&config->outputs) == 0) {
        mask_id = 0;
    }
    else {
        instance = mk_list_entry_last(&config->outputs,
                                      struct flb_output_instance,
                                      _head);
        mask_id = (instance->mask_id);
    }
// snip
    if (mask_id == 0) {
        instance->mask_id = 1;
    }
    else {
        instance->mask_id = (mask_id * 2); // Overflow!
    }
```



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->


## log
The routing of id=32 is OK.  (error log refs: https://github.com/fluent/fluent-bit/issues/2914#issuecomment-770840219)

```
[2021/02/01 22:12:59] [debug] [task] created task=0x7fbe2c11b900 id=28 OK
[2021/02/01 22:12:59] [debug] [task] created task=0x7fbe2c121c60 id=29 OK
[2021/02/01 22:12:59] [debug] [task] created task=0x7fbe2c127fc0 id=30 OK
[2021/02/01 22:12:59] [debug] [task] created task=0x7fbe2c12e320 id=31 OK
[2021/02/01 22:12:59] [debug] [task] created task=0x7fbe2c134680 id=32 OK
[2021/02/01 22:12:59] [debug] [out coro] cb_destroy coro_id=0
```

## valgrind output
```
$ valgrind ../bin/fluent-bit -c conf/a.conf -vvvv
==117027== Memcheck, a memory error detector
==117027== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==117027== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==117027== Command: ../bin/fluent-bit -c conf/a.conf -vvvv
==117027== 
Fluent Bit v1.7.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io
<snip>
==117027== 
==117027== HEAP SUMMARY:
==117027==     in use at exit: 0 bytes in 0 blocks
==117027==   total heap usage: 5,050 allocs, 5,050 frees, 13,912,795 bytes allocated
==117027== 
==117027== All heap blocks were freed -- no leaks are possible
==117027== 
==117027== For counts of detected and suppressed errors, rerun with: -v
==117027== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

## configuration file
```python
[INPUT]
    Name dummy
    Dummy {"a":"0"}
    Tag 0

[OUTPUT]
    Name file
    Match 0

[INPUT]
    Name dummy
    Dummy {"a":"1"}
    Tag 1

[OUTPUT]
    Name file
    Match 1

[INPUT]
    Name dummy
    Dummy {"a":"2"}
    Tag 2

[OUTPUT]
    Name file
    Match 2

[INPUT]
    Name dummy
    Dummy {"a":"3"}
    Tag 3

[OUTPUT]
    Name file
    Match 3

[INPUT]
    Name dummy
    Dummy {"a":"4"}
    Tag 4

[OUTPUT]
    Name file
    Match 4

[INPUT]
    Name dummy
    Dummy {"a":"5"}
    Tag 5

[OUTPUT]
    Name file
    Match 5

[INPUT]
    Name dummy
    Dummy {"a":"6"}
    Tag 6

[OUTPUT]
    Name file
    Match 6

[INPUT]
    Name dummy
    Dummy {"a":"7"}
    Tag 7

[OUTPUT]
    Name file
    Match 7

[INPUT]
    Name dummy
    Dummy {"a":"8"}
    Tag 8

[OUTPUT]
    Name file
    Match 8

[INPUT]
    Name dummy
    Dummy {"a":"9"}
    Tag 9

[OUTPUT]
    Name file
    Match 9

[INPUT]
    Name dummy
    Dummy {"a":"10"}
    Tag 10

[OUTPUT]
    Name file
    Match 10

[INPUT]
    Name dummy
    Dummy {"a":"11"}
    Tag 11

[OUTPUT]
    Name file
    Match 11

[INPUT]
    Name dummy
    Dummy {"a":"12"}
    Tag 12

[OUTPUT]
    Name file
    Match 12

[INPUT]
    Name dummy
    Dummy {"a":"13"}
    Tag 13

[OUTPUT]
    Name file
    Match 13

[INPUT]
    Name dummy
    Dummy {"a":"14"}
    Tag 14

[OUTPUT]
    Name file
    Match 14

[INPUT]
    Name dummy
    Dummy {"a":"15"}
    Tag 15

[OUTPUT]
    Name file
    Match 15

[INPUT]
    Name dummy
    Dummy {"a":"16"}
    Tag 16

[OUTPUT]
    Name file
    Match 16

[INPUT]
    Name dummy
    Dummy {"a":"17"}
    Tag 17

[OUTPUT]
    Name file
    Match 17

[INPUT]
    Name dummy
    Dummy {"a":"18"}
    Tag 18

[OUTPUT]
    Name file
    Match 18

[INPUT]
    Name dummy
    Dummy {"a":"19"}
    Tag 19

[OUTPUT]
    Name file
    Match 19

[INPUT]
    Name dummy
    Dummy {"a":"20"}
    Tag 20

[OUTPUT]
    Name file
    Match 20

[INPUT]
    Name dummy
    Dummy {"a":"21"}
    Tag 21

[OUTPUT]
    Name file
    Match 21

[INPUT]
    Name dummy
    Dummy {"a":"22"}
    Tag 22

[OUTPUT]
    Name file
    Match 22

[INPUT]
    Name dummy
    Dummy {"a":"23"}
    Tag 23

[OUTPUT]
    Name file
    Match 23

[INPUT]
    Name dummy
    Dummy {"a":"24"}
    Tag 24

[OUTPUT]
    Name file
    Match 24

[INPUT]
    Name dummy
    Dummy {"a":"25"}
    Tag 25

[OUTPUT]
    Name file
    Match 25

[INPUT]
    Name dummy
    Dummy {"a":"26"}
    Tag 26

[OUTPUT]
    Name file
    Match 26

[INPUT]
    Name dummy
    Dummy {"a":"27"}
    Tag 27

[OUTPUT]
    Name file
    Match 27

[INPUT]
    Name dummy
    Dummy {"a":"28"}
    Tag 28

[OUTPUT]
    Name file
    Match 28

[INPUT]
    Name dummy
    Dummy {"a":"29"}
    Tag 29

[OUTPUT]
    Name file
    Match 29

[INPUT]
    Name dummy
    Dummy {"a":"30"}
    Tag 30

[OUTPUT]
    Name file
    Match 30

[INPUT]
    Name dummy
    Dummy {"a":"31"}
    Tag 31

[OUTPUT]
    Name file
    Match 31

[INPUT]
    Name dummy
    Dummy {"a":"32"}
    Tag 32

[OUTPUT]
    Name file
    Match 32
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
