### PR TITLE
out_s3: support 'false' value to disable json_date_key

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -348,6 +348,16 @@ static int cb_s3_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    /* Date key */
+    ctx->date_key = ctx->json_date_key;
+    tmp = flb_output_get_property("json_date_key", ins);
+    if (tmp) {
+        /* Just check if we have to disable it */
+        if (flb_utils_bool(tmp) == FLB_FALSE) {
+            ctx->date_key = NULL;
+        }
+    }
+
     /* Date format for JSON output */
     ctx->json_date_format = FLB_PACK_JSON_DATE_ISO8601;
     tmp = flb_output_get_property("json_date_format", ins);
@@ -1339,7 +1349,7 @@ static void cb_s3_flush(const void *data, size_t bytes,
     json = flb_pack_msgpack_to_json_format(data, bytes,
                                            FLB_PACK_JSON_FORMAT_LINES,
                                            ctx->json_date_format,
-                                           ctx->json_date_key);
+                                           ctx->date_key);
 
     if (json == NULL) {
         flb_plg_error(ctx->ins, "Could not marshal msgpack to JSON");

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -111,6 +111,7 @@ struct flb_s3 {
     struct flb_aws_client *s3_client;
     int json_date_format;
     flb_sds_t json_date_key;
+    flb_sds_t date_key;
 
     flb_sds_t buffer_dir;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Allow `json_date_key` to be disabled when outputting to S3, similarly to how it can be disabled when outputting to stdout.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Requested [here](https://github.com/fluent/fluent-bit/issues/2700#issuecomment-763430048), but I needed this functionality too.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
