### PR TITLE
ci: travis: exclude always failing job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,11 @@ env:
 
 before_script:
 
-matrix:
+jobs:
+  exclude:
+    - arch: arm64
+      compiler: clang
+      env: FLB_OPT="-DSANITIZE_UNDEFINED=On"
   include:
     - os: osx
       osx_image: xcode12.2


### PR DESCRIPTION
This combination from the build matrix always fails. Unless you are willing to investigate, removing it would benefit the PR review process.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
