### PR TITLE
aws_util: remove duplicated debug string

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -544,7 +544,7 @@ flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key)
     if (ret == JSMN_ERROR_INVAL || ret == JSMN_ERROR_PART) {
         flb_free(tokens);
         flb_debug("[aws_client] Unable to parse API response- response is not"
-                  "not valid JSON.");
+                  " valid JSON.");
         return NULL;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fix debug output.

- AS-IS: `[debug] [aws_client] Unable to parse API response- response is notnot valid JSON.`
  - Here is the screenshot of output
     ![image](https://user-images.githubusercontent.com/18085237/106770209-155a8400-6681-11eb-9595-365f049a56cb.png)

- TO-BE: `[debug] [aws_client] Unable to parse API response- response is not valid JSON.`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
