### PR TITLE
tests: internals: fuzzer: engine: fix broken API call

### DIFF
--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -57,7 +57,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                     flb_input_collector_resume(random_i2, entry);
                     flb_input_net_default_listener(nm4, random_i1, entry);
                     flb_input_collector_start(random_i2, entry);
-                    flb_router_get_routes_mask_by_tag(nm4, 10, entry);
                 }
             }
             break;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes broken API call

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
