### PR TITLE
in_winlog: Increase the buffer size for ReadEventLogW()

### DIFF
--- a/plugins/in_winlog/in_winlog.c
+++ b/plugins/in_winlog/in_winlog.c
@@ -28,7 +28,7 @@
 
 #define DEFAULT_INTERVAL_SEC  1
 #define DEFAULT_INTERVAL_NSEC 0
-#define DEFAULT_BUFFER_SIZE 0x7fff /* Max size allowed by Win32 (32kb) */
+#define DEFAULT_BUFFER_SIZE 0x7ffff /* Max size allowed by Win32 (512kb) */
 
 static int in_winlog_collect(struct flb_input_instance *ins,
                              struct flb_config *config, void *in_context);


### PR DESCRIPTION
It is possible that a Windows event can contain data large
than 32kb. On such occations, in_winlog fails on `ReadEventLogW()`
with error code 122.
    
Fix that issue by expanding the event buffer to 512kb. This is
the maximum size allowed for Event Log API, so the bug should
never occur again with this patch applied.
    
Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
