### PR TITLE
in_winlog: Reopen channels on ERROR_EVENTLOG_FILE_CHANGED

### DIFF
--- a/plugins/in_winlog/in_winlog.c
+++ b/plugins/in_winlog/in_winlog.c
@@ -142,7 +142,6 @@ static int in_winlog_read_channel(struct flb_input_instance *ins,
         return -1;
     }
     if (read == 0) {
-        flb_plg_trace(ctx->ins, "EOF reached on '%s'", ch->name);
         return 0;
     }
     flb_plg_debug(ctx->ins, "read %u bytes from '%s'", read, ch->name);

--- a/plugins/in_winlog/winlog.c
+++ b/plugins/in_winlog/winlog.c
@@ -61,6 +61,33 @@ void winlog_close(struct winlog_channel *ch)
 }
 
 /*
+ * This routine is called when Windows Event Log was cleared
+ * while reading (e.g. running Clear-EventLog on PowerShell).
+ *
+ * In such a case, the only neat thing to do is to reopen the
+ * channel and start reading from the beginning.
+ */
+int winlog_on_cleared(struct winlog_channel *ch)
+{
+    HANDLE h;
+
+    h = OpenEventLogA(NULL, ch->name);
+    if (!h) {
+        flb_error("[in_winlog] cannot open '%s' (%i)", ch->name, GetLastError());
+        return -1;
+    }
+
+    if (ch->h) {
+        CloseEventLog(ch->h);
+    }
+
+    ch->h = h;
+    ch->seek = 0;
+    return 0;
+}
+
+
+/*
  * ReadEventLog() has a known bug that SEEK_READ fails when the log file
  * is too big.
  *
@@ -138,12 +165,19 @@ int winlog_read(struct winlog_channel *ch, char *buf, unsigned int size,
         flags = EVENTLOG_SEQUENTIAL_READ | EVENTLOG_FORWARDS_READ;
     }
 
+    /*
+     * Note: ReadEventLogW() ignores `ch->record_number` (dwRecordOffset)
+     * if EVENTLOG_SEEK_READ is not set.
+     */
     if (!ReadEventLogW(ch->h, flags, ch->record_number, buf, size, read, &req)) {
         switch (err = GetLastError()) {
             case ERROR_HANDLE_EOF:
                 break;
             case ERROR_INVALID_PARAMETER:
                 return winlog_seek(ch, buf, size, read);
+            case ERROR_EVENTLOG_FILE_CHANGED:
+                flb_info("[in_winlog] channel '%s' is cleared. reopen it.", ch->name);
+                return winlog_on_cleared(ch);
             default:
                 flb_error("[in_winlog] cannot read '%s' (%i)", ch->name, err);
                 return -1;


### PR DESCRIPTION
When event log is cleared while reading, `ReadEventLogW()`
starts failing with ERROR_EVENTLOG_FILE_CHANGED.

This teaches in_winlog to reopen the channel on such occasions,
and read from the beginning.

This should fix the bug #2873 "Reading winlog events fails if logs
are cleared using EventViewer"

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>