### PR TITLE
metrics: release unused sds in case of allocation error

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -263,6 +263,7 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     /* length of HELP text */
     metric_helptxt = flb_sds_create_size(128);
     if (!metric_helptxt) {
+        flb_sds_destroy(sds);
         mk_http_status(request, 500);
         mk_http_done(request);
         buf->users--;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Release unused sds buffer when `metric_helptxt` is not allocated. 


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
