### PR TITLE
Add Offset_Key option in in_tail plugin

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -534,6 +534,11 @@ static struct flb_config_map config_map[] = {
      "set the 'key' name where the name of monitored file will be appended."
     },
     {
+     FLB_CONFIG_MAP_STR, "offset_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_tail_config, offset_key),
+     "set the 'key' name where the offset of monitored file will be appended."
+    },
+    {
      FLB_CONFIG_MAP_TIME, "ignore_older", "0",
      0, FLB_TRUE, offsetof(struct flb_tail_config, ignore_older),
      "ignore records older than 'ignore_older'. Supports m,h,d (minutes, "

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -78,6 +78,7 @@ struct flb_tail_config {
     flb_sds_t key;             /* key for unstructured record  */
     int   skip_long_lines;     /* skip long lines              */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+    flb_sds_t offset_key;      /* key name of file offset      */
 
     /* Database */
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -375,7 +375,7 @@ void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                 goto dmode_flush_end;
             }
             flb_tail_pack_line_map(mp_sbuf, mp_pck, &out_time,
-                                   (char**) &out_buf, &out_size, file);
+                                   (char**) &out_buf, &out_size, file, 0);
             goto dmode_flush_end;        }
     }
 #endif

--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -381,7 +381,7 @@ void flb_tail_dmode_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
 #endif
     flb_time_get(&out_time);
     flb_tail_file_pack_line(mp_sbuf, mp_pck, &out_time,
-                            repl_line, repl_line_len, file);
+                            repl_line, repl_line_len, file, 0);
 
  dmode_flush_end:
     flb_free(repl_line);

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -109,7 +109,8 @@ int flb_tail_file_purge(struct flb_input_instance *ins,
                         struct flb_config *config, void *context);
 int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                            struct flb_time *time, char **data,
-                           size_t *data_size, struct flb_tail_file *file);
+                           size_t *data_size, struct flb_tail_file *file,
+                           size_t processed_bytes);
 int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                             struct flb_time *time, char *data, size_t data_size,
                             struct flb_tail_file *file, size_t processed_bytes);

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -112,6 +112,6 @@ int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                            size_t *data_size, struct flb_tail_file *file);
 int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
                             struct flb_time *time, char *data, size_t data_size,
-                            struct flb_tail_file *file);
+                            struct flb_tail_file *file, size_t processed_bytes);
 
 #endif

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -120,7 +120,7 @@ int flb_tail_mult_destroy(struct flb_tail_config *ctx)
  * message.
  */
 static int pack_line(char *data, size_t data_size, struct flb_tail_file *file,
-                     struct flb_tail_config *ctx)
+                     struct flb_tail_config *ctx, size_t processed_bytes)
 {
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
@@ -130,7 +130,8 @@ static int pack_line(char *data, size_t data_size, struct flb_tail_file *file,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
     flb_time_get(&out_time);
 
-    flb_tail_file_pack_line(&mp_sbuf, &mp_pck, &out_time, data, data_size, file);
+    flb_tail_file_pack_line(&mp_sbuf, &mp_pck, &out_time,
+                            data, data_size, file, processed_bytes);
     flb_input_chunk_append_raw(ctx->ins,
                                file->tag_buf,
                                file->tag_len,
@@ -275,7 +276,8 @@ static inline int is_last_key_val_string(char *buf, size_t size)
 int flb_tail_mult_process_content(time_t now,
                                   char *buf, size_t len,
                                   struct flb_tail_file *file,
-                                  struct flb_tail_config *ctx)
+                                  struct flb_tail_config *ctx,
+                                  size_t processed_bytes)
 {
     int ret;
     size_t off;
@@ -345,7 +347,7 @@ int flb_tail_mult_process_content(time_t now,
             flb_tail_mult_append_raw(buf, len, file, ctx);
         }
         else {
-            pack_line(buf, len, file, ctx);
+            pack_line(buf, len, file, ctx, processed_bytes);
         }
         return FLB_TAIL_MULT_MORE;
     }

--- a/plugins/in_tail/tail_multiline.h
+++ b/plugins/in_tail/tail_multiline.h
@@ -46,7 +46,8 @@ int flb_tail_mult_destroy(struct flb_tail_config *ctx);
 int flb_tail_mult_process_content(time_t now,
                                   char *buf, size_t len,
                                   struct flb_tail_file *file,
-                                  struct flb_tail_config *ctx);
+                                  struct flb_tail_config *ctx,
+                                  size_t processed_bytes);
 int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf,
                         msgpack_packer *mp_pck,
                         struct flb_tail_file *file,


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR tries to add the Offset_Key feature requested in #2770.
With Offset_Key supported, the tail plugin will add the offset
to be part of the log.

This PR fixes #2770.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

Example configuration:
```
$ cat fluent-bit.conf 
[INPUT]
    Name           tail
    Path           lines.txt
    Read_from_Head true
    Path_Key       path
    Offset_Key     offset

[OUTPUT]
    Name   stdout
    Match  *
```

Example lines.txt:
```
$ cat lines.txt 
{"log": "aaa"}
{"log": "aab"}
{"log": "bbb"}
{"log": "ccc"}
{"log": "ddd"}
{"log": "eee"}
{"log": "fff"}
{"log": "ggg"}
```

Valgrind output:
```
$ valgrind --leak-check=full  bin/fluent-bit -c fluent-bit.conf 
==231140== Memcheck, a memory error detector
==231140== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==231140== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==231140== Command: bin/fluent-bit -c fluent-bit.conf
==231140== 
Fluent Bit v1.7.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/02/08 19:40:10] [ info] [engine] started (pid=231140)
[2021/02/08 19:40:10] [ info] [storage] version=1.1.0, initializing...
[2021/02/08 19:40:10] [ info] [storage] in-memory
[2021/02/08 19:40:10] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/02/08 19:40:10] [ info] [sp] stream processor started
[2021/02/08 19:40:10] [ info] [input:tail:tail.0] inotify_fs_add(): inode=2304839 watch_fd=1 name=lines.txt
[0] tail.0: [1612813210.738659435, {"path"=>"lines.txt", "offset"=>0, "log"=>"{"log": "aaa"}"}]
[1] tail.0: [1612813210.746207394, {"path"=>"lines.txt", "offset"=>15, "log"=>"{"log": "aab"}"}]
[2] tail.0: [1612813210.746231755, {"path"=>"lines.txt", "offset"=>30, "log"=>"{"log": "bbb"}"}]
[3] tail.0: [1612813210.746246605, {"path"=>"lines.txt", "offset"=>45, "log"=>"{"log": "ccc"}"}]
[4] tail.0: [1612813210.746260495, {"path"=>"lines.txt", "offset"=>60, "log"=>"{"log": "ddd"}"}]
[5] tail.0: [1612813210.746273985, {"path"=>"lines.txt", "offset"=>75, "log"=>"{"log": "eee"}"}]
[6] tail.0: [1612813210.746287236, {"path"=>"lines.txt", "offset"=>90, "log"=>"{"log": "fff"}"}]
[7] tail.0: [1612813210.746300346, {"path"=>"lines.txt", "offset"=>105, "log"=>"{"log": "ggg"}"}]
^C[2021/02/08 19:40:18] [engine] caught signal (SIGINT)
[2021/02/08 19:40:18] [ info] [input] pausing tail.0
[2021/02/08 19:40:18] [ warn] [engine] service will stop in 5 seconds
[2021/02/08 19:40:22] [ info] [engine] service stopped
[2021/02/08 19:40:22] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=2304839 watch_fd=1
==231140== 
==231140== HEAP SUMMARY:
==231140==     in use at exit: 0 bytes in 0 blocks
==231140==   total heap usage: 428 allocs, 428 frees, 809,442 bytes allocated
==231140== 
==231140== All heap blocks were freed -- no leaks are possible
==231140== 
==231140== For lists of detected and suppressed errors, rerun with: -s
==231140== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
