### PR TITLE
Fix build failure with -DFLB_SHARED_LIB=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,6 +744,10 @@ add_subdirectory(include)
 add_subdirectory(plugins)
 add_subdirectory(src)
 
+if(NOT FLB_SHARED_LIB)
+  set(FLB_EXAMPLES OFF)
+endif()
+
 if(FLB_EXAMPLES)
   add_subdirectory(examples)
 endif()


### PR DESCRIPTION
This PR is part of the effort in #2999.
When building fluent-bit with
```
cmake -DFLB_SHARED_LIB=OFF ..
```
the following error happens:
```
[ 98%] Linking C executable ../../bin/hello_world
/usr/bin/ld: cannot find -lfluent-bit-shared
collect2: error: ld returned 1 exit status
make[2]: *** [examples/hello_world/CMakeFiles/hello_world.dir/build.make:262: bin/hello_world] Error 1
make[1]: *** [CMakeFiles/Makefile2:5773: examples/hello_world/CMakeFiles/hello_world.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

The issue is that examples depend on share library of fluent-bit.

This PR fixes the CMakeList.txt isseu related to -DFLB_SHARED_LIB=OFF.

With the changes in this PR, it is possible to build with `cmake -DFLB_SHARED_LIB=OFF ..`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
