### PR TITLE
Add additional check returned from flb_malloc

### DIFF
--- a/src/flb_avro.c
+++ b/src/flb_avro.c
@@ -269,6 +269,10 @@ flb_sds_t flb_msgpack_raw_to_avro_sds(const void *in_buf, size_t in_size, struct
 
     size_t avro_buffer_size = in_size * 3;
     char *out_buff = flb_malloc(avro_buffer_size);
+    if (!out_buff) {
+        flb_errno();
+        return NULL;
+    }
 
     avro_writer_t awriter;
     flb_debug("in flb_msgpack_raw_to_avro_sds\n");


### PR DESCRIPTION
This PR tries to address the issue raised in #3044 where
memory pointer returned from flb_malloc was not checked for NULL.
Credit to @raminfp.

This PR fixes the #3044.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

Example config:
```
$ cat fluent-bit.conf 
[INPUT]
    Name  cpu

[OUTPUT]
    Name        kafka
    Match       *
    Brokers     192.168.1.3:9092
    Topics      test
```

Valgrind:
```
$ valgrind --leak-check=full  bin/fluent-bit -c fluent-bit.conf 
==493573== Memcheck, a memory error detector
==493573== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==493573== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==493573== Command: bin/fluent-bit -c fluent-bit.conf
==493573== 
Fluent Bit v1.7.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/02/09 15:14:50] [ info] [engine] started (pid=493573)
[2021/02/09 15:14:50] [ info] [storage] version=1.1.0, initializing...
[2021/02/09 15:14:50] [ info] [storage] in-memory
[2021/02/09 15:14:50] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/02/09 15:14:50] [ info] [output:kafka:kafka.0] brokers='192.168.1.3:9092' topics='test'
[2021/02/09 15:14:50] [ info] [sp] stream processor started
^C[2021/02/09 15:14:53] [engine] caught signal (SIGINT)
[2021/02/09 15:14:53] [ info] [input] pausing cpu.0
[2021/02/09 15:14:53] [ warn] [engine] service will stop in 5 seconds
[2021/02/09 15:14:57] [ info] [engine] service stopped
==493573== 
==493573== HEAP SUMMARY:
==493573==     in use at exit: 0 bytes in 0 blocks
==493573==   total heap usage: 398 allocs, 398 frees, 688,865 bytes allocated
==493573== 
==493573== All heap blocks were freed -- no leaks are possible
==493573== 
==493573== For lists of detected and suppressed errors, rerun with: -s
==493573== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
