### PR TITLE
bin: fix SIGSEGV caused by using flb_free instead of mk_mem_free

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -557,7 +557,7 @@ static int input_set_property(struct flb_input_instance *in, char *kv)
                 in->p->name, key);
     }
 
-    flb_free(key);
+    mk_mem_free(key);
     return ret;
 }
 
@@ -582,7 +582,7 @@ static int output_set_property(struct flb_output_instance *out, char *kv)
     }
 
     ret = flb_output_set_property(out, key, value);
-    flb_free(key);
+    mk_mem_free(key);
     return ret;
 }
 
@@ -608,7 +608,7 @@ static int filter_set_property(struct flb_filter_instance *filter, char *kv)
     }
 
     ret = flb_filter_set_property(filter, key, value);
-    flb_free(key);
+    mk_mem_free(key);
     return ret;
 }
 


### PR DESCRIPTION
mk_string_copy_substr is allocating memory using mk_mem_alloc
deallocate with the matching function.

Signed-off-by: Ramon Fried <ramon@neureality.ai>

Issue was discovered on fluentbit v1.3.5, but is still relevant in master. on Yocto build on ARM64.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
NA
----

