### PR TITLE
stream_processor: add necessary check to prevent potential SIGSEGV

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1739,6 +1739,10 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
             aggr_node->nums_size = map_entries;
             aggr_node->records = 1;
             aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
+            if (!aggr_node->ts) {
+                flb_sp_aggr_node_destroy(cmd, aggr_node);
+                return NULL;
+            }
             mk_list_add(&aggr_node->_head, &task->window.aggr_list);
         }
         else {

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1707,6 +1707,7 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         else {
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1728,10 +1729,12 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         if (!mk_list_size(&task->window.aggr_list)) {
             aggr_node = flb_calloc(1, sizeof(struct aggr_node));
             if (!aggr_node) {
+                flb_errno();
                 return NULL;
             }
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1740,6 +1743,7 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
             aggr_node->records = 1;
             aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
             if (!aggr_node->ts) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }


### PR DESCRIPTION
While checking the stream processor code, noticed there is one
place where flb_calloc does not follow an appropriate null pointer
check.

This PR adds necessary check to prevent potential SIGSEGV.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
