### PR TITLE
drop conn from av_queue on keepalive_idle_timeout

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -622,6 +622,7 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
     int drop;
     struct mk_list *head;
     struct mk_list *u_head;
+    struct mk_list *tmp;
     struct flb_upstream *u;
     struct flb_upstream_conn *u_conn;
     struct flb_upstream_queue *uq;
@@ -667,10 +668,11 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
         }
 
         /* Check every available Keepalive connection */
-        mk_list_foreach(u_head, &uq->av_queue) {
+        mk_list_foreach_safe(u_head, tmp, &uq->av_queue) {
             u_conn = mk_list_entry(u_head, struct flb_upstream_conn, _head);
             if ((now - u_conn->ts_available) >= u->net.keepalive_idle_timeout) {
                 shutdown(u_conn->fd, SHUT_RDWR);
+                prepare_destroy_conn(u_conn);
                 flb_debug("[upstream] drop keepalive connection #%i to %s:%i "
                           "(keepalive idle timeout)",
                           u_conn->fd, u->tcp_host, u->tcp_port);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes #2972 

There's a long explanation in #2972, but the TL;DR is that there's a race when `flb_upstream_conn_timeouts` calls `shutdown` on the socket of a connection that has been idle for 30s.
The connection stays in `av_queue` until the remote endpoint closes its end of the connection.
If the connection is used before this occurs, the following errors occurs:

```
[2021/02/11 01:18:11] [error] [output:forward:forward.0] could not write forward header
[2021/02/11 01:18:11] [ warn] [engine] failed to flush chunk '1-1613006291.126624440.flb', retry in 6 seconds: task_id=0, input=tcp.0 > output=forward.0
[...]
[2021/02/11 01:18:17] [ info] [engine] flush chunk '1-1613006291.126624440.flb' succeeded at retry 1: task_id=1, input=tcp.0 > output=forward.0
```

With this fix, the connection is removed from `av_queue` right away and I haven't been able to reproduce the problem since.

(lowering the `net.keepalive_idle_timeout` to something like 2s really helps reproducing the issue in a time effective way...)