### PR TITLE
sp: Revert "sp: add necessary check to prevent potential SIGSEGV (#3053)"

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1707,7 +1707,6 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         else {
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
-                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1729,12 +1728,10 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         if (!mk_list_size(&task->window.aggr_list)) {
             aggr_node = flb_calloc(1, sizeof(struct aggr_node));
             if (!aggr_node) {
-                flb_errno();
                 return NULL;
             }
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
-                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1742,11 +1739,6 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
             aggr_node->nums_size = map_entries;
             aggr_node->records = 1;
             aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
-            if (!aggr_node->ts) {
-                flb_errno();
-                flb_sp_aggr_node_destroy(cmd, aggr_node);
-                return NULL;
-            }
             mk_list_add(&aggr_node->_head, &task->window.aggr_list);
         }
         else {


### PR DESCRIPTION
This PR reverts PR #3053 (7672e86) as it breaks the CI.

See https://github.com/fluent/fluent-bit/pull/3053#issuecomment-777349176

cc @edsiper @l2dy 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
