### PR TITLE
sp: resubmit "sp: add necessary check to prevent potential SIGSEGV (#3053)"

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1739,6 +1739,10 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
             aggr_node->nums_size = map_entries;
             aggr_node->records = 1;
             aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
+            if (!aggr_node->ts) {
+                flb_sp_aggr_node_destroy(cmd, aggr_node);
+                return NULL;
+            }
             mk_list_add(&aggr_node->_head, &task->window.aggr_list);
         }
         else {

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1741,11 +1741,14 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
 
             aggr_node->nums_size = map_entries;
             aggr_node->records = 1;
-            aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
-            if (!aggr_node->ts) {
-                flb_errno();
-                flb_sp_aggr_node_destroy(cmd, aggr_node);
-                return NULL;
+            if (cmd->timeseries_num > 0) {
+                aggr_node->ts = (struct timeseries **)
+                                flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
+                if (!aggr_node->ts) {
+                    flb_errno();
+                    flb_sp_aggr_node_destroy(cmd, aggr_node);
+                    return NULL;
+                }
             }
             mk_list_add(&aggr_node->_head, &task->window.aggr_list);
         }

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -1707,6 +1707,7 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         else {
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1728,10 +1729,12 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
         if (!mk_list_size(&task->window.aggr_list)) {
             aggr_node = flb_calloc(1, sizeof(struct aggr_node));
             if (!aggr_node) {
+                flb_errno();
                 return NULL;
             }
             aggr_node->nums = flb_calloc(1, sizeof(struct aggr_num) * map_entries);
             if (!aggr_node->nums) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }
@@ -1740,6 +1743,7 @@ static struct aggr_node * sp_process_aggregation_data(struct flb_sp_task *task,
             aggr_node->records = 1;
             aggr_node->ts = (struct timeseries **) flb_calloc(1, sizeof(struct timeseries *) * cmd->timeseries_num);
             if (!aggr_node->ts) {
+                flb_errno();
                 flb_sp_aggr_node_destroy(cmd, aggr_node);
                 return NULL;
             }


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR is the resubmit of previous PR #3053.
    
After PR #3053 has been merged, it was revealed that it caused the CI failure 
and was reverted back in PR #3064
    
This PR is a resubmission, which, in addition of previous added:
* sp: add necessary check to prevent potential SIGSEGV
* sp: add flb_errno() after flb_calloc failure.
    
the following changes has also been added:
* sp: skip allocation of aggr_node->ts if cmd->timeseries_num == 0
    

Note similar check actually has already been in place in other parts of the code:
https://github.com/fluent/fluent-bit/blob/9c35c28f1078207b7dd6e2074f027a7ab17bd2b2/src/stream_processor/flb_sp.c#L1715-L1723

Tested locally for unit tests and all passed:
```
56/59 Test #43: flb-it-random ....................   Passed    0.00 sec
57/59 Test #30: in_tail_expect.sh ................   Passed    3.05 sec
58/59 Test #16: flb-rt-out_datadog ...............   Passed    4.00 sec
59/59 Test #29: in_dummy_expect.sh ...............   Passed    4.04 sec

100% tests passed, 0 tests failed out of 59

Label Time Summary:
internal    =  41.08 sec*proc (29 tests)
runtime     = 814.88 sec*proc (28 tests)

Total Test time (real) = 216.76 sec
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [n/a] Example configuration file for the change
- [n/a] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [n/a] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
