### PR TITLE
input_chunk: fix 'no available chunk' error with `filter_rewrite_tag`

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -550,7 +550,8 @@ static struct flb_input_chunk *input_chunk_get(const char *tag, int tag_len,
      * that the chunk will flush to, we need to modify the routes_mask of the oldest chunks
      * (based in creation time) to get enough space for the incoming chunk.
      */
-    if (flb_input_chunk_place_new_chunk(ic, chunk_size) == 0) {
+    if (!flb_routes_mask_is_empty(ic->routes_mask)
+        && flb_input_chunk_place_new_chunk(ic, chunk_size) == 0) {
         /*
          * If the chunk is not newly created, the chunk might already have logs inside.
          * We cannot delete (reused) chunks here.


### PR DESCRIPTION
What used to happen is that input plugins were discarding chunks
that do not have a corresponding output plugin. EXCEPT that such
a receiving output endpoint did exist, listening to the stream
indirectly via `filter_rewrite_tag`.

This changes it so that:

 - Let input_chunk_get() return successfully even when there is no
   direct output receiver for that chunk (just as it had been doing
   before a183b57e).

 - And hence resolves the 'no available chunk' error reported by
   Sophie Fang.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>