### PR TITLE
filter_expect: Fix expect plugin not exiting with 255

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -629,6 +629,7 @@ static void flb_lib_worker(void *data)
         flb_engine_failed(config);
         flb_engine_shutdown(config);
     }
+    config->exit_status_code = ret;
     ctx->status = FLB_LIB_NONE;
 }
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1288,6 +1288,7 @@ int flb_main(int argc, char **argv)
     if (exit_signal) {
         flb_signal_exit(exit_signal);
     }
+    ret = config->exit_status_code;
     flb_destroy(ctx);
 
 


### PR DESCRIPTION
The expect plugin docs contains the following description:

> **configuration parameters**
>
> * action: using `exit` makes Fluent Bit abort with status code `255`

However, the actual behavior was returning `0`, so this patch fixes it to return `255`.

## Steps to reproduce

```console
$ cat issue.conf
[SERVICE]
    Flush      1
    Grace      0
    Log_Level  error

[INPUT]
    Name   dummy
    Tag    dummy.log

[FILTER]
    name        expect
    match       *
    key_val_eq  message foo
    action      exit

[OUTPUT]
    name        null
    match       *

$ docker run --rm -v `pwd`/issue.conf:/issue.conf fluent/fluent-bit:1.7.0 /fluent-bit/bin/fluent-bit -c /issue.conf -q
[2021/02/16 14:42:11] [error] [filter:expect:expect.0] exception on rule #0 'key_val_eq', key value 'dummy' is different than expected: 'foo'. Record content:
{"message":"dummy"}

$ echo $?
0
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
