### PR TITLE
Set Time_Keep On for cri parser (fix #3085)

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -109,6 +109,7 @@
     Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
     Time_Key    time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
 
 [PARSER]
     Name    kube-custom


### PR DESCRIPTION
The default cri parser @ parsers.conf should probably contain
Time_Keep On, otherwise the time tag does not exist at output at all.

Fixes #3085

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
