### PR TITLE
prevent redeclare FLB_CORO_STACK_SIZE

### DIFF
--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -62,9 +62,7 @@ struct flb_coro {
     void *data;
 };
 
-#ifdef FLB_CORO_STACK_SIZE
-#define FLB_CORO_STACK_SIZE      FLB_CORO_STACK_SIZE
-#else
+#ifndef FLB_CORO_STACK_SIZE
 #define FLB_CORO_STACK_SIZE      ((3 * PTHREAD_STACK_MIN) / 2)
 #endif
 


### PR DESCRIPTION
cmake customized FLB_CORO_STACK_SIZE will build into flb info header throw FLB_BUILD_FLAGS

otherwise `cmake -DFLB_CORO_STACK_SIZE` build will fail

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
