### PR TITLE
network: add support for tcp keepalive probes

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -43,6 +43,18 @@ struct flb_net_setup {
 
     /* maximum of times a keepalive connection can be used */
     int keepalive_max_recycle;
+
+    /* enable/disable tcp keepalive */
+    char tcp_keepalive;
+
+    /* interval between the last data packet sent and the first TCP keepalive probe */
+    int tcp_keepalive_time;
+
+    /* the interval between TCP keepalive probes */
+    int tcp_keepalive_interval;
+
+    /* number of unacknowledged probes to consider a connection dead */
+    int tcp_keepalive_probes;
 };
 
 /* Defines a host service and it properties */
@@ -69,6 +81,7 @@ int flb_net_socket_tcp_nodelay(flb_sockfd_t fd);
 int flb_net_socket_blocking(flb_sockfd_t fd);
 int flb_net_socket_nonblocking(flb_sockfd_t fd);
 int flb_net_socket_tcp_fastopen(flb_sockfd_t sockfd);
+int flb_net_socket_tcp_keepalive(flb_sockfd_t fd, struct flb_net_setup *net);
 
 /* Socket handling */
 flb_sockfd_t flb_net_socket_create(int family, int nonblock);

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -102,6 +102,15 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
                   u_conn->fd, u->tcp_host, u->tcp_port);
     }
 
+    /* set TCP keepalive and it's options */
+    if (u->net.tcp_keepalive != FLB_FALSE) {
+        ret = flb_net_socket_tcp_keepalive(fd, &u->net);
+        if (ret == -1) {
+            flb_socket_close(fd);
+            return -1;
+        }
+    }
+
 #ifdef FLB_HAVE_TLS
     /* Check if TLS was enabled, if so perform the handshake */
     if (u->flags & FLB_IO_TLS) {

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -65,6 +65,32 @@ struct flb_config_map upstream_net[] = {
      "before it is retired."
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "net.tcp_keepalive", "off",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, tcp_keepalive),
+     "Enable or disable the use of TCP keepalive probes"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "net.tcp_keepalive_time", "-1",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, tcp_keepalive_time),
+     "interval between the last data packet sent and the first "
+     "TCP keepalive probe"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "net.tcp_keepalive_interval", "-1",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, tcp_keepalive_interval),
+     "interval between TCP keepalive probes when no response is"
+     "received on a keepidle probe"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "net.tcp_keepalive_probes", "-1",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, tcp_keepalive_probes),
+     "number of unacknowledged probes to consider a connection dead"
+    },
+
     /* EOF */
     {0}
 };


### PR DESCRIPTION
Signed-off-by: Abilio Marques <abiliojr@gmail.com>

<!-- Provide summary of changes -->

The term TCP keepalive is been widely used in networking to describe a mechanism totally different than just "not closing the connection after a request". This PR adds support for real TCP keepalive probing. A matching PR with suggestions on how to make these changes clearer in the documentation is also available.

TCP keepalives have 2 potentially useful applications:
- To prevent disconnection due to network inactivity: any TCP connection is subject to be silently dropped by intermediate equipment in the network (e.g., routers) if it's quiet for too long.
- To detect dead connections, either because of a crash on the other side, or because the network channel has gone down.

All happens at the transport layer, without any intervention, and is transparent to upper (e.g., HTTP) layers.

For a more detailed description, please see: https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html

TCP-keepalive values could be configured system wide, but this is definitely not ideal, as it still needs to be enabled by the application. The other option is to do it per socket. For that, fluentbit needs to apply the values to the socket. This patch adds support for that. By default, it's disabled.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
Documentation provided here: https://github.com/fluent/fluent-bit-docs/pull/471
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
