### PR TITLE
filter_kubernetes: fix coverity scan CID 161078 for code maintainabil…

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -802,7 +802,6 @@ static int merge_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
                 msgpack_unpacked_init(&meta_result);
                 for (i = 0; i < meta_val.via.map.size; i++) {
                     k = meta_val.via.map.ptr[i].key;
-                    v = meta_val.via.map.ptr[i].val;
 
                     char *ptr = (char *) k.via.str.ptr;
                     size_t size = k.via.str.size;


### PR DESCRIPTION
```
New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)   
CID 161078:  Code maintainability issues  (UNUSED_VALUE)
Assigning value from "meta_val.via.map.ptr[i].val" to "v" here, but that stored value is overwritten before it can be used.
    805                         v = meta_val.via.map.ptr[i].val;
```
This line was added for testing and debugging. It was committed by mistake and should be removed.  

Signed-off-by: Drew Zhang <zhayuzhu@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A] Debug log output from testing the change

```SUCCESS: All unit tests have passed.```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory 
```
==16617== 
==16617== HEAP SUMMARY:
==16617==     in use at exit: 1,424 bytes in 1 blocks
==16617==   total heap usage: 1,477 allocs, 1,476 frees, 897,395 bytes allocated
==16617== 
==16617== LEAK SUMMARY:
==16617==    definitely lost: 0 bytes in 0 blocks
==16617==    indirectly lost: 0 bytes in 0 blocks
==16617==      possibly lost: 0 bytes in 0 blocks
==16617==    still reachable: 1,424 bytes in 1 blocks
==16617==         suppressed: 0 bytes in 0 blocks
==16617== Rerun with --leak-check=full to see details of leaked memory
==16617== 
==16617== For counts of detected and suppressed errors, rerun with: -v
==16617== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==16337== 
==16337== HEAP SUMMARY:
==16337==     in use at exit: 0 bytes in 0 blocks
==16337==   total heap usage: 2 allocs, 2 frees, 2,448 bytes allocated
==16337== 
==16337== All heap blocks were freed -- no leaks are possible
==16337== 
==16337== For counts of detected and suppressed errors, rerun with: -v
==16337== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
