### PR TITLE
pack-gelf: fix OSS-Fuzz issue 5076752961110016

### DIFF
--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -719,8 +719,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
                 }
                 else if (v->type == MSGPACK_OBJECT_EXT) {
                     quote   = FLB_TRUE;
-                    val     = o->via.ext.ptr;
-                    val_len = o->via.ext.size;
+                    val     = v->via.ext.ptr;
+                    val_len = v->via.ext.size;
                 }
 
                 if (!val || !key) {


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
This solves an issue in parsing an msgpack-c object related to gelf data. The main problem is that a wrong variable is used to get the msgpack data, and this results in various bugs, amongst other things a heap overflow in `flb_msgpack_gelf_value_ext` (OSS-Fuzz issue 5076752961110016)


@edsiper please verify this one, i.e. that we need to use `v` instead of `o`. `v` is the variable used all other places for getting the `val` and `val_len` variables. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
