### PR TITLE
gzip: fix upper-bound decompression calculation. 

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -77,23 +77,12 @@ int flb_gzip_compress(void *in_data, size_t in_len,
     z_stream strm;
     mz_ulong crc;
 
-
     /*
-     * GZIP relies on an algorithm with worst-case expansion
-     * of 5 bytes per 32KB data. This means we need to create a variable
-     * length output, that depends on the input length.
-     * See RFC 1951 for details.
+     * Calculating the upper bound for a gzip compression is
+     * non-trivial, so we rely on miniz's own calculation
+     * to guarantee memory safety.
      */
-    int max_input_expansion = ((int)(in_len / 32000) + 1) * 5;
-
-    /*
-     * Max compressed size is equal to sum of:
-     *   10 byte header
-     *   8 byte foot
-     *   max input expansion
-     *   size of input
-     */
-    out_size = 10 + 8 + max_input_expansion + in_len;
+    out_size = compressBound(in_len);
     out_buf = flb_malloc(out_size);
 
     if (!out_buf) {


### PR DESCRIPTION
Fix OSS-Fuzz 5072671825723392

Fixes an upper-bound decompression calculation. This is non-trivial so we use Miniz's own feature:
https://github.com/richgel999/miniz/blob/5ebed8288278fc0ff75d5f93ba95afc0416afe02/miniz.c#L309

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
