### PR TITLE
utils: fix overflows when converting size to bytes. 

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -419,12 +419,24 @@ int64_t flb_utils_size_to_bytes(const char *size)
     }
 
     if (tmp[0] == 'K') {
+        /* set upper bound (2**64/KB)/2 to avoid overflows */
+        if (val >= 0x20c49ba5e353f8) {
+            return -1;
+        }
         return (val * KB);
     }
     else if (tmp[0] == 'M') {
+        /* set upper bound (2**64/MB)/2 to avoid overflows */
+        if (val >= 0x8637bd05af6) {
+            return -1;
+        }
         return (val * MB);
     }
     else if (tmp[0] == 'G') {
+        /* set upper bound (2**64/GB)/2 to avoid overflows */
+        if (val >= 0x225c17d04) {
+            return -1;
+        }
         return (val * GB);
     }
     else {


### PR DESCRIPTION
Fixes oss-fuzz issue 5736872495808512


Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
