### PR TITLE
Add build/release workflows (ref: #3095)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,121 @@
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types: [created]
+name: Build release
+jobs:
+  build-distro-packages:
+    name: build packages
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        distro: [ amazonlinux/2, amazonlinux/2.arm64v8, centos/7, centos/7.arm64v8, debian/jessie,
+                  debian/jessie.arm64v8, debian/stretch, debian/stretch.arm64v8, debian/buster,
+                  debian/buster.arm64v8, ubuntu/16.04, ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8,
+                  ubuntu/20.04.arm64v8, raspbian/jessie, raspbian/stretch, raspbian/buster ]
+
+    runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
+    steps:
+      - name: Setup environment
+        run: |
+            sudo apt-get install --yes qemu binfmt-support qemu-user-static qemu-utils qemu-efi-aarch64 qemu-system-arm docker.io containerd runc
+            sudo systemctl unmask docker && sudo systemctl start docker
+            docker run --rm --privileged --name qemu multiarch/qemu-user-static:register --reset
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.VERSION }}"
+          replace-with: '$1'
+          flags: 'g'
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_distro
+        with:
+          pattern: '(.*)\/(.*)$'
+          string: "${{ matrix.distro }}"
+          replace-with: '$1-$2'
+          flags: 'g'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.actor }}/fluent-bit-packaging
+          fetch-depth: 1
+          path: packaging
+
+      - name: Build the distro artifacts
+        run: ./build.sh -v ${{ env.release }} -d ${{ env.distro }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          distro: ${{ matrix.distro }}
+        working-directory: packaging
+
+      - name: Archive the release artifacts (packages)
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-${{env.release}}-${{env.bucket-name}}-pkgs
+          path: |
+            packaging/packages/${{env.distro}}/${{env.release}}/**/*
+        env:
+          bucket-name: ${{ steps.formatted_distro.outputs.replaced }}
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          distro: ${{ matrix.distro }}
+
+  build-docker-images:
+    name: build docker images
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        arch: [ x86_64, arm64v8, arm32v7, x86_64-debug ]
+    runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup environment
+        run: |
+          sudo apt-get install --yes qemu binfmt-support qemu-user-static qemu-utils qemu-efi-aarch64 qemu-system-arm docker.io containerd runc
+          sudo systemctl unmask docker && sudo systemctl start docker
+          docker run --rm --privileged --name qemu multiarch/qemu-user-static:register --reset
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.VERSION }}"
+          replace-with: '$1'
+          flags: 'g'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.actor }}/fluent-bit-docker-image
+          ref: ${{ steps.formatted_version.outputs.replaced }}
+          path: docker-build
+
+      - name: Build the docker images
+        run: docker build --no-cache -f Dockerfile.${{ env.arch }} -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ env.release }} .
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          arch: ${{ matrix.arch }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+        working-directory: docker-build
+
+      - name: Archive the docker images
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          arch: ${{ matrix.arch }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,287 @@
+name: Publish release
+on:
+  workflow_run:
+    workflows: [ 'Build release' ]
+    types:
+      - completed
+jobs:
+  publish-docker-images:
+    name: publish docker images
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        arch: [ x86_64, arm64v8, arm32v7, x86_64-debug ]
+    runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
+    steps:
+      - if: github.event.workflow_run.conclusion != 'success'
+        name: Abort if build failed
+        run: |
+          echo "build failed"
+          exit 1
+
+      - uses: actions/checkout@v2
+
+      - name: Setup environment
+        run: |
+          sudo apt-get install --yes docker.io containerd runc
+          sudo systemctl unmask docker && sudo systemctl start docker
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get_version
+        with:
+          semver_only: true
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.tag }}"
+          replace-with: '$1'
+          flags: 'g'
+
+      - name: Download docker image from build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: build-release.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: action_image_artifact_${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-${{ env.release }}
+          path: images
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          arch: ${{ matrix.arch }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+
+      - name: Import docker image
+        run: |
+          docker load --input ./images/${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          arch: ${{ matrix.arch }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker push ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          arch: ${{ matrix.arch }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+
+  publish-docker-manifest:
+
+    name: publish docker manifest
+    needs: publish-docker-images
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup environment
+        run: |
+          sudo apt-get install --yes docker.io containerd runc
+          sudo rm -rf /etc/docker/daemon.json
+          sudo systemctl unmask docker && sudo systemctl start docker
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get_version
+        with:
+          semver_only: true
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.tag }}"
+          replace-with: '$1'
+          flags: 'g'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull docker images
+        run: |
+          docker pull ${{ env.dockerhub_organization }}/fluent-bit:x86_64-${{ env.release }} && docker pull ${{ env.dockerhub_organization }}/fluent-bit:arm64v8-${{ env.release }} && docker pull ${{ env.dockerhub_organization }}/fluent-bit:arm32v7-${{ env.release }} && docker pull ${{ env.dockerhub_organization }}/fluent-bit:x86_64-debug-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - name: Create manifests for docker release images
+        run: |
+          docker manifest create ${{ env.dockerhub_organization }}/fluent-bit:${{ env.release }} --amend ${{ env.dockerhub_organization }}/fluent-bit:x86_64-${{ env.release }} --amend ${{ env.dockerhub_organization}}/fluent-bit:arm64v8-${{ env.release }} --amend ${{ env.dockerhub_organization }}/fluent-bit:arm32v7-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - name: Create manifests for docker latest images
+        run: |
+          docker manifest create ${{ env.dockerhub_organization }}/fluent-bit:latest --amend ${{ env.dockerhub_organization }}/fluent-bit:x86_64-${{ env.release }} --amend ${{ env.dockerhub_organization }}/fluent-bit:arm64v8-${{ env.release }} --amend ${{ env.dockerhub_organization }}/fluent-bit:arm32v7-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - name: Create manifests for docker debug images
+        run: |
+          docker manifest create ${{ env.dockerhub_organization }}/fluent-bit:${{ env.release }}-debug --amend ${{ env.dockerhub_organization }}/fluent-bit:x86_64-debug-${{ env.release }}
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - name: Push docker manifests
+        run: |
+          docker manifest push --purge ${{ env.dockerhub_organization }}/fluent-bit:${{ env.release }} && docker manifest push --purge ${{ env.dockerhub_organization }}/fluent-bit:latest && docker manifest push --purge ${{ env.dockerhub_organization}}/fluent-bit:${{ env.release }}-debug
+        env:
+           release: ${{ steps.formatted_version.outputs.replaced }}
+           dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+           DOCKER_CLI_EXPERIMENTAL: enabled
+
+  publish-distro-artifacts:
+    name: publis distro artifacts
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        distro: [ amazonlinux/2, amazonlinux/2.arm64v8, centos/7, centos/7.arm64v8, debian/jessie,
+                  debian/jessie.arm64v8, debian/stretch, debian/stretch.arm64v8, debian/buster,
+                  debian/buster.arm64v8, ubuntu/16.04, ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8,
+                  ubuntu/20.04.arm64v8, raspbian/jessie, raspbian/stretch, raspbian/buster ]
+        include:
+          - distro: amazonlinux/2
+            target: amazonlinux/2/
+            format: rpm
+
+          - distro: amazonlinux/2.arm64v8
+            target: amazonlinux/2/
+            format: rpm
+
+          - distro: centos/7
+            target: centos/7/
+            format: rpm
+
+          - distro: centos/7.arm64v8
+            target: centos/7/
+            format: rpm
+
+          - distro: debian/jessie
+            target: debian/jessie/
+            format: deb
+
+          - distro: debian/jessie.arm64v8
+            target: debian/jessie/
+            format: deb
+
+          - distro: debian/stretch
+            target: debian/stretch/
+            format: deb
+
+          - distro: debian/stretch.arm64v8
+            target: debian/stretch/
+            format: deb
+
+          - distro: debian/buster
+            target: debian/buster/
+            format: deb
+
+          - distro: debian/buster.arm64v8
+            target: debian/buster/
+            format: deb
+
+          - distro: ubuntu/16.04
+            target: ubuntu/xenial/
+            format: deb
+
+          - distro: ubuntu/18.04
+            target: ubuntu/bionic/
+            format: deb
+
+          - distro: ubuntu/18.04.arm64v8
+            target: ubuntu/bionic/
+            format: deb
+
+          - distro: ubuntu/20.04
+            target: ubuntu/focal/
+            format: deb
+
+          - distro: ubuntu/20.04.arm64v8
+            target: ubuntu/focal/
+            format: deb
+
+          - distro: raspbian/jessie
+            target: raspbian/jessie/
+            format: deb
+
+          - distro: raspbian/stretch
+            target: raspbian/stretch/
+            format: deb
+
+          - distro: raspbian/buster
+            target: raspbian/buster/
+            format: deb
+
+    runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get_version
+        with:
+          semver_only: true
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_distro
+        with:
+          pattern: '(.*)\/(.*)$'
+          string: "${{ matrix.distro }}"
+          replace-with: '$1-$2'
+          flags: 'g'
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.tag }}"
+          replace-with: '$1'
+          flags: 'g'
+
+      - name: Download distro package from build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: build-release.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: release-${{ env.release }}-${{ env.distro}}-pkgs
+          path: packages
+        env:
+          release: ${{ steps.formatted_version.outputs.replaced }}
+          distro: ${{ steps.formatted_distro.outputs.replaced }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+
+      - name: Move artifacts to main packages folder
+        run: |
+          mv packages/**/*.${{ env.format }} .
+        env:
+          format: ${{ matrix.format }}
+
+      - name: Copy distro package to webserver
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.FLUENTBITIO_HOST }}
+          username: ${{ secrets.FLUENTBITIO_USERNAME }}
+          key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+          source: ${{ env.source_files }}
+          target: apt/${{ env.target }}
+        env:
+          source_files: "./*.${{ matrix.format }}"
+          target: ${{ matrix.target }}


### PR DESCRIPTION
**Description**

Fixes #3095 

This patch implements 2 base workflows as described on issue #3095.

1) build-release.yml: when a new release/tag is creates it will build the distribution packages
based on the matrix strategy defined as well as docker images for both architectures.

2) publish-release.yml: if 1) went good, then this step will download all the artifacts, copy the distro artifacts
into packages.fluentbit.io and publish new version/tag/latest/debug docker images and manifests on dockerhub.

***Steps for releasing a new version of fluent-bit***

1) Create a corresponding tag on the master branch of https://github.com/fluent/fluent-bit-docker-image that matches
the version to be released.

2) Create a tag on the fluent-bit repository

```bash
git tag 1.8.0
...
git push --tags
```
**Steps required before merging _THIS_ change**

***Define the following secrets variable in the repository secrets (github)***

secrets.FLUENTBITIO_HOST 
secrets.FLUENTBITIO_USERNAME 
secrets.FLUENTBITIO_SSHKEY
secrets.GITHUB_TOKEN
secrets.DOCKERHUB_ORGANIZATION
secrets.DOCKERHUB_TOKEN
secrets.DOCKERHUB_USERNAME

**Testing**

The following test runs were performed on top of a fake 1.7.0 tag release:

1) Build-release: https://github.com/niedbalski/fluent-bit/actions/runs/584381999
2) Publish-release: https://github.com/niedbalski/fluent-bit/actions/runs/584478620


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
