### PR TITLE
conf: Add a parser for IP Tables firewall rules

### DIFF
--- a/conf/parsers_extra.conf
+++ b/conf/parsers_extra.conf
@@ -75,4 +75,9 @@
 #UUID v5 :
 #/^[0-9A-F]{8}-[0-9A-F]{4}-[5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
 
-
+# Parse IP Tables rules - this one regex should capture pretty much any IP Tables rule and split it into the various fields
+[PARSER]
+    Name iptables
+    Format regex
+    Regex \[(?<rule_chain>\w*)-(?<rule_name>\w*)-(?<accept_or_drop>\w*)\]IN=(?<in_interface>[\w.]+)? OUT=(?<out_interface>[\w.]+)? MAC=(?<mac_address>[\w:]+)? SRC=(?<source>(?:[0-9]{1,3}\.){3}[0-9]{1,3}) DST=(?<dest>(?:[0-9]{1,3}\.){3}[0-9]{1,3}) LEN=(?<pkt_len>\d+) TOS=(?<pkt_tos>[\w\d]+) PREC=(?<pkt_prec>[\w\d]+) TTL=(?<pkt_ttl>\d+) ID=(?<pkt_id>\d+)\s?(?<pkg_frg>[A-Z\s].?)\s?PROTO=(?<protocol>[\w\d]+) (SPT=(?<source_port>.*) DPT=(?<dest_port>.*) (LEN=(?<proto_pkt_len>\w+)?)?(WINDOW=(?<proto_window_size>\d+) RES=(?<pkt_res>\w+)? (?<pkt_type>\w+)\s((?<pkt_flag>\w+)?)\s?URGP=(?<pkg_urgency>\d))? )?(TYPE=(?<pkt_icmp_type>\d+) CODE=(?<pkt_icmp_code>\d+) ID=(?<pkt_icmp_id>\d+) SEQ=(?<pkt_icmp_seq>\d+) )?$
+    Types source_port:integer,dest_port:integer,pkt_ttl:integer,pkt_tos:integer,pkt_len:integer


### PR DESCRIPTION
This regex captures all IP Tables rule output log lines, with the exception of the details of Martian packets.

The output in Grafana explorer looks like this:

![filtered](https://user-images.githubusercontent.com/262545/108819650-06496080-75b3-11eb-9271-1e8faf6528e1.png)

Example config:

```
[FILTER]
    Name parser
    Match *
    Key_Name message
    Parser iptables
    Preserve_Key On
    Tag iptables
```
```
# Sample IP Tables log lines, addresses have been sanitised where appropriate
[LAN_IN-2001-A]IN=eth1.40 OUT=eth1 MAC=fc:ec:da:47:47:e6:64:5d:86:dd:43:66:08:00:45:00:00:4c SRC=192.168.40.102 DST=192.168.1.21 LEN=76 TOS=0x00 PREC=0x00 TTL=63 ID=47001 DF PROTO=UDP SPT=52295 DPT=53 LEN=56 
[LAN_LOCAL-default-A]IN=eth1 OUT= MAC= SRC=192.168.1.1 DST=224.0.0.251 LEN=257 TOS=0x00 PREC=0x00 TTL=255 ID=19888 PROTO=UDP SPT=5353 DPT=5353 LEN=237 
[LAN_IN-2005-A]IN=eth1 OUT=eth1.20 MAC=fc:ec:da:47:47:e6:b4:2e:99:19:8e:79:08:00 SRC=192.168.1.21 DST=192.168.20.2 LEN=60 TOS=0x00 PREC=0x00 TTL=62 ID=47505 DF PROTO=TCP SPT=54668 DPT=80 WINDOW=64240 RES=0x00 SYN URGP=0 
[LAN_IN-2001-A]IN=eth1.40 OUT=eth1 MAC=fc:ec:da:47:47:e6:3e:28:89:63:06:05:08:00:45:00:00:50 SRC=192.168.40.100 DST=192.168.1.21 LEN=80 TOS=0x00 PREC=0x00 TTL=63 ID=39238 PROTO=UDP SPT=50915 DPT=53 LEN=60 
[LAN_LOCAL-default-A]IN=eth1 OUT= MAC=ff:ff:ff:ff:ff:ff:68:54:5a:6f:b9:c7:08:00 SRC=192.168.1.135 DST=192.168.1.255 LEN=72 TOS=0x00 PREC=0x00 TTL=64 ID=19104 DF PROTO=UDP SPT=57621 DPT=57621 LEN=52 
[LAN_LOCAL-default-A]IN=eth1 OUT= MAC= SRC=192.168.1.1 DST=224.0.0.251 LEN=257 TOS=0x00 PREC=0x00 TTL=255 ID=32703 DF PROTO=UDP SPT=5353 DPT=5353 LEN=237 
[LAN_LOCAL-default-A]IN=eth1 OUT= MAC= SRC=192.168.1.1 DST=224.0.0.251 LEN=810 TOS=0x00 PREC=0x00 TTL=255 ID=33948 DF PROTO=UDP SPT=5353 DPT=5353 LEN=790 
[WAN_LOCAL-default-D]IN=pppoe0 OUT= MAC= SRC=111.50.82.233 DST=127.29.241.19 LEN=52 TOS=0x00 PREC=0x00 TTL=110 ID=28588 DF PROTO=TCP SPT=61114 DPT=1433 WINDOW=8192 RES=0x00 SYN URGP=0 
[LAN_LOCAL-default-A]IN=eth1.20 OUT= MAC= SRC=192.168.20.1 DST=224.0.0.2 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
[LAN_LOCAL-default-A]IN=eth1 OUT= MAC=fc:ec:da:47:47:e6:74:83:c2:d3:96:c9:08:00 SRC=192.168.1.2 DST=192.168.1.1 LEN=52 TOS=0x00 PREC=0x00 TTL=64 ID=13257 DF PROTO=TCP SPT=8080 DPT=55045 WINDOW=348 RES=0x00 ACK FIN URGP=0 
[LAN_LOCAL-default-A]IN=eth1.20 OUT= MAC=fc:ec:da:47:47:e6:14:0a:c5:8c:ae:e6:08:00:45:00:00:54 SRC=192.168.20.52 DST=192.168.20.1 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=44298 DF PROTO=ICMP TYPE=8 CODE=0 ID=56026 SEQ=47360 
```

Interactive regex available at https://regex101.com/r/VBRq81/1

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ X ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
