### PR TITLE
out_stackdriver: added export_to_project_id

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -927,6 +927,10 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    if (!ctx->export_to_project_id) {
+        ctx->export_to_project_id = flb_sds_create(ctx->project_id);
+    }
+
     return 0;
 }
 
@@ -1877,7 +1881,7 @@ static int stackdriver_format(struct flb_config *config,
 
         /* logName */
         len = snprintf(path, sizeof(path) - 1,
-                       "projects/%s/logs/%s", ctx->project_id, new_log_name);
+                       "projects/%s/logs/%s", ctx->export_to_project_id, new_log_name);
 
         if (log_name_extracted == FLB_TRUE) {
             flb_sds_destroy(log_name);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -124,6 +124,7 @@ struct flb_stackdriver {
 
 
     /* other */
+    flb_sds_t export_to_project_id;
     flb_sds_t resource;
     flb_sds_t severity_key;
     flb_sds_t trace_key;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -273,6 +273,12 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->metadata_server_auth = true;
     }
 
+    tmp = flb_output_get_property("export_to_project_id", ins);
+    if (tmp) {
+        ctx->export_to_project_id = flb_sds_create(tmp);
+        flb_plg_info(ctx->ins, "export_to_project_id set to %s", ctx->export_to_project_id);
+    }
+
     tmp = flb_output_get_property("resource", ins);
     if (tmp) {
         ctx->resource = flb_sds_create(tmp);
@@ -452,6 +458,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->credentials_file);
     flb_sds_destroy(ctx->type);
     flb_sds_destroy(ctx->project_id);
+    flb_sds_destroy(ctx->export_to_project_id);
     flb_sds_destroy(ctx->private_key_id);
     flb_sds_destroy(ctx->private_key);
     flb_sds_destroy(ctx->client_email);


### PR DESCRIPTION
`export_to_project_id` allows for a separate output project to be
written to. Since logName controls the which stackdriver log router is to
be written to, we write to the project as delineated in `export_to_project_id` 
instead of `project_id`, since 
project_id could also be useful when recording metadata (which cluster
project did this log come from).

If `export_to_project_id` is not defined, it defaults to the value of
project_id.

Fixes #3106 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation for this feature: fluent/fluent-bit-docs#473

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
