### PR TITLE
pack: fix type confusion bugs. Amongst other OSS-Fuzz 5136174263566336

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -840,6 +840,9 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
     while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
         /* Each array must have two entries: time and record */
         root = result.data;
+        if (root.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
         if (root.via.array.size != 2) {
             continue;
         }
@@ -849,6 +852,9 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
 
         /* Get the record/map */
         map = root.via.array.ptr[1];
+        if (map.type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
         map_size = map.via.map.size;
 
         if (date_key != NULL) {


### PR DESCRIPTION
This a fairly important fix, in that many plugins call `flb_pack_msgpack_to_json_format`, however there are some important bugs in this function due to missing checking of the type of msgpack objects. This leads to type confusion bugs that interprets whatever is on the stack as msgpack maps and arrays. This leads to all sorts of trouble.

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
