### PR TITLE
sds: fix length check. OSS-Fuzz 6227554268741632

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -284,9 +284,9 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
         }
         else if (c >= 0x80) {
             hex_bytes = flb_utf8_len(str + i);
-			if (hex_bytes + i >= str_len) {
-				return NULL;
-			}
+            if (hex_bytes + i >= str_len) {
+                return NULL;
+            }
             state = FLB_UTF8_ACCEPT;
             cp = 0;
             for (b = 0; b < hex_bytes; b++) {

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -284,6 +284,9 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
         }
         else if (c >= 0x80) {
             hex_bytes = flb_utf8_len(str + i);
+			if (hex_bytes + i >= str_len) {
+				return NULL;
+			}
             state = FLB_UTF8_ACCEPT;
             cp = 0;
             for (b = 0; b < hex_bytes; b++) {


### PR DESCRIPTION
Fixes a heap overflow in flb_sds. 

Cross-referencing: 
https://oss-fuzz.com/testcase-detail/6227554268741632
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28222

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
