### PR TITLE
input_chunk: Include metadata bytes when creating new input chunk

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -890,8 +890,8 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
      * There is a case that rewrite_tag will modify the tag and keep rule is set
      * to drop the original record. The original record will still go through the
      * flb_input_chunk_update_output_instances(2) to update the fs_chunk_size by
-     * 35 bytes (consisted by metadata bytes of the file chunk). This condition
-     * set the diff to 0 in order to not update the fs_chunk_size. 
+     * metadata bytes (consisted by metadata bytes of the file chunk). This condition
+     * sets the diff to 0 in order to not update the fs_chunk_size. 
      */
     if (flb_input_chunk_get_size(ic) == 0) {
         diff = 0;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -781,6 +781,8 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     int ret;
     int set_down = FLB_FALSE;
     int min;
+    int meta_size;
+    int new_chunk = FLB_FALSE;
     size_t diff;
     size_t size;
     size_t pre_size;
@@ -817,6 +819,11 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     if (!ic) {
         flb_error("[input chunk] no available chunk");
         return -1;
+    }
+
+    /* newly created chunk */
+    if (flb_input_chunk_get_size(ic) == 0) {
+        new_chunk = FLB_TRUE;
     }
 
     /* We got the chunk, validate if is 'up' or 'down' */
@@ -864,8 +871,35 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     /* calculate the 'real' new bytes being added after the filtering phase */
     diff = llabs(size - pre_size);
 
-    /* Update output instance bytes counters */
-    flb_input_chunk_update_output_instances(ic, diff);
+    /*
+     * Update output instance bytes counters, note that bytes counter should
+     * always count the chunk size in the file system. Therefore, it should
+     * add the extra bytes for the metadata.
+     */
+    meta_size = cio_meta_size(ic->chunk);
+    if (new_chunk == FLB_TRUE) {
+        diff += meta_size
+            /* See https://github.com/edsiper/chunkio#file-layout for more details */
+            + 2    /* HEADER BYTES */
+            + 4    /* CRC32 */
+            + 16   /* PADDING */
+            + 2;   /* METADATA LENGTH BYTES */
+    }
+
+    /* 
+     * There is a case that rewrite_tag will modify the tag and keep rule is set
+     * to drop the original record. The original record will still go through the
+     * flb_input_chunk_update_output_instances(2) to update the fs_chunk_size by
+     * 35 bytes (consisted by metadata bytes of the file chunk). This condition
+     * set the diff to 0 in order to not update the fs_chunk_size. 
+     */
+    if (flb_input_chunk_get_size(ic) == 0) {
+        diff = 0;
+    }
+
+    if (diff != 0) {
+        flb_input_chunk_update_output_instances(ic, diff);
+    }
 
     /* Lock buffers where size > 2MB */
     if (size > FLB_INPUT_CHUNK_FS_MAX_SIZE) {


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
When Fluent Bit creates a new chunk to place incoming data, the chunk itself contains some metadata. Those metadata will take some space in the filesystem. Therefore, if we don't add those metadata bytes to the `fs_chunk_size`, it will make the update of the `fs_chunk_size` incorrect.

This patch is to add the metadata bytes to `fs_chunk_size` counter when creating a new chunk.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3094 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
