### PR TITLE
tests: internal: fuzzers: fix broken call in utils fuzzer

### DIFF
--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -54,7 +54,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     char *split_host;
     char *split_port;
     if (flb_utils_proxy_url_split(null_terminated, &split_protocol,
-            split_username, split_password, split_host, split_port) == 0) {
+            &split_username, &split_password, &split_host, &split_port) == 0) {
         flb_free(split_protocol);
         flb_free(split_username);
         flb_free(split_password);


### PR DESCRIPTION
Fixes OSS-Fuzz issue 6489147372077056

To clarify, the failing travis issue is not due to this PR. This PR only modifies fuzzer code. 

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
