### PR TITLE
tests: internal: fuzzers: engine: fix broken calls.

### DIFF
--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -72,8 +72,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                         ic = flb_input_chunk_create(entry, nm3, 10);
                         if (ic != NULL) {
                             flb_input_chunk_get_size(ic);
-                            //flb_input_chunk_find_space_new_data(ic, 0x00, 100);
-                            //flb_input_chunk_get_overlimit_routes_mask(ic, 100);
                             flb_input_chunk_set_up_down(ic);
                             flb_input_chunk_down(ic);
                             flb_input_chunk_set_up(ic);
@@ -102,9 +100,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 }
             }
             break;
-        //case 8:
-        //    flb_router_exit(ctx->config);
-        //    break;
         default:
             flb_lib_push(ctx, in_ffd, null_terminated, NM_SIZE);
             break;
@@ -162,9 +157,6 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
     flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
     flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
-
-    //flb_storage_create(ctx->config);
-    //ctx->config->storage_metrics = FLB_TRUE;
 
     /* start the engine */
     flb_start(ctx);

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -72,8 +72,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                         ic = flb_input_chunk_create(entry, nm3, 10);
                         if (ic != NULL) {
                             flb_input_chunk_get_size(ic);
-                            flb_input_chunk_find_space_new_data(ic, 0x00, 100);
-                            flb_input_chunk_get_overlimit_routes_mask(ic, 100);
+                            //flb_input_chunk_find_space_new_data(ic, 0x00, 100);
+                            //flb_input_chunk_get_overlimit_routes_mask(ic, 100);
                             flb_input_chunk_set_up_down(ic);
                             flb_input_chunk_down(ic);
                             flb_input_chunk_set_up(ic);
@@ -102,9 +102,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 }
             }
             break;
-        case 8:
-            flb_router_exit(ctx->config);
-            break;
+        //case 8:
+        //    flb_router_exit(ctx->config);
+        //    break;
         default:
             flb_lib_push(ctx, in_ffd, null_terminated, NM_SIZE);
             break;
@@ -163,8 +163,8 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
     flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
-    flb_storage_create(ctx->config);
-    ctx->config->storage_metrics = FLB_TRUE;
+    //flb_storage_create(ctx->config);
+    //ctx->config->storage_metrics = FLB_TRUE;
 
     /* start the engine */
     flb_start(ctx);


### PR DESCRIPTION
Fixes the engine fuzzer

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
