### PR TITLE
in_dummy: support config map

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
@@ -127,10 +128,9 @@ static int configure(struct flb_dummy *ctx,
 
     ctx->ref_msgpack = NULL;
 
-    /* samples */
-    str = flb_input_get_property("samples", in);
-    if (str != NULL && atoi(str) >= 0) {
-        ctx->samples = atoi(str);
+    ret = flb_input_config_map_set(in, (void *) ctx);
+    if (ret == -1) {
+        return -1;
     }
 
     /* the message */
@@ -246,6 +246,37 @@ static int in_dummy_exit(void *data, struct flb_config *config)
 }
 
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_INT, "samples", "0",
+    0, FLB_TRUE, offsetof(struct flb_dummy, samples),
+    "set a number of times to generate event."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "dummy", DEFAULT_DUMMY_MESSAGE,
+    0, FLB_FALSE, 0,
+    "set the sample record to be generated. It should be a JSON object."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "rate", "1",
+    0, FLB_FALSE, 0,
+    "set a number of events per second."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "start_time_sec", "1",
+    0, FLB_FALSE, 0,
+    "set a dummy base timestamp in seconds."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "start_time_nsec", "0",
+    0, FLB_FALSE, 0,
+    "set a dummy base timestamp in nanoseconds."
+   },
+   {0}
+};
+
+
 struct flb_input_plugin in_dummy_plugin = {
     .name         = "dummy",
     .description  = "Generate dummy data",
@@ -253,5 +284,6 @@ struct flb_input_plugin in_dummy_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_dummy_collect,
     .cb_flush_buf = NULL,
+    .config_map   = config_map,
     .cb_exit      = in_dummy_exit
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is to support config map framework. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Help of in_dummy plugin

```
$ bin/fluent-bit -i dummy -h
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

HELP
dummy input plugin

DESCRIPTION
Generate dummy data

OPTIONS
samples          set a number of times to generate event.
                 > default: 0, type: integer

dummy            set the sample record to be generated. It should be a JSON object.
                 > default: {"message":"dummy"}, type: string

rate             set a number of events per second.
                 > default: 1, type: integer

start_time_sec   set a dummy base timestamp in seconds.
                 > default: 1, type: integer

start_time_nsec  set a dummy base timestamp in nanoseconds.
                 > default: 0, type: integer

taka@locals:~/git/fluent-bit/build$ 
```

## valgrind output

There are no leaks.

```
$ valgrind bin/fluent-bit -i dummy -p dummy={\"test\":\"example\"} -p samples=3 -o stdout
==29707== Memcheck, a memory error detector
==29707== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==29707== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==29707== Command: bin/fluent-bit -i dummy -p dummy={"test":"example"} -p samples=3 -o stdout
==29707== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/02/27 17:15:49] [ info] [engine] started (pid=29707)
[2021/02/27 17:15:49] [ info] [storage] version=1.1.1, initializing...
[2021/02/27 17:15:49] [ info] [storage] in-memory
[2021/02/27 17:15:49] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/02/27 17:15:49] [ info] [sp] stream processor started
==29707== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6d9a0
==29707==          to suppress, use: --max-stackframe=12021528 or greater
==29707== Warning: client switching stacks?  SP change: 0x4c6d918 --> 0x57e48b8
==29707==          to suppress, use: --max-stackframe=12021664 or greater
==29707== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6d918
==29707==          to suppress, use: --max-stackframe=12021664 or greater
==29707==          further instances of this message will not be shown.
[0] dummy.0: [1614413750.381299683, {"test"=>"example"}]
[1] dummy.0: [1614413751.365830737, {"test"=>"example"}]
[2] dummy.0: [1614413752.365926245, {"test"=>"example"}]
^C[2021/02/27 17:15:54] [engine] caught signal (SIGINT)
[2021/02/27 17:15:54] [ warn] [engine] service will stop in 5 seconds
[2021/02/27 17:15:59] [ info] [engine] service stopped
==29707== 
==29707== HEAP SUMMARY:
==29707==     in use at exit: 0 bytes in 0 blocks
==29707==   total heap usage: 285 allocs, 285 frees, 690,820 bytes allocated
==29707== 
==29707== All heap blocks were freed -- no leaks are possible
==29707== 
==29707== For lists of detected and suppressed errors, rerun with: -s
==29707== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
