### PR TITLE
sds: fix off-by-one overflow. OSS-Fuzz 5647136884654080

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -288,7 +288,7 @@ flb_sds_t flb_sds_cat_utf8 (flb_sds_t *sds, const char *str, int str_len)
             cp = 0;
             for (b = 0; b < hex_bytes; b++) {
                 p = (const unsigned char *) str + i + b;
-                if (p > (str + str_len)) {
+                if (p >= (str + str_len)) {
                     break;
                 }
                 ret = flb_utf8_decode(&state, &cp, *p);


### PR DESCRIPTION
Fixes the bug https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28254

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
