### PR TITLE
gzip: fix size check leading to overflow. OSS-Fuzz 6354610792693760

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -275,6 +275,11 @@ int flb_gzip_uncompress(void *in_data, size_t in_len,
     }
     out_size = dlen;
 
+    /* Ensure size is above 0 */
+    if (((p + in_len) - start - 8) <= 0) {
+        return -1;
+    }
+
     /* Map zip content */
     zip_data = (uint8_t *) start;
     zip_len = (p + in_len) - start - 8;


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28285

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
