### PR TITLE
out_es: add option suppress_type_name for v7.0.0 or later(#2869)

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -36,6 +36,7 @@ struct flb_elasticsearch {
     /* Elasticsearch index (database) and type (table) */
     char *index;
     char *type;
+    char suppress_type_name;
 
     /* HTTP Auth */
     char *http_user;

--- a/plugins/out_es/es_bulk.h
+++ b/plugins/out_es/es_bulk.h
@@ -27,6 +27,8 @@
 #define ES_BULK_HEADER      165  /* ES Bulk API prefix line  */
 #define ES_BULK_INDEX_FMT    "{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\"}}\n"
 #define ES_BULK_INDEX_FMT_ID "{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}\n"
+#define ES_BULK_INDEX_FMT_WITHOUT_TYPE  "{\"index\":{\"_index\":\"%s\"}}\n"
+#define ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE "{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n"
 
 struct es_bulk {
     char *ptr;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #2869 
From v7.X, specifying types in requests is deprecated. 
　Refs: [es doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html) and [other information](https://github.com/fluent/fluent-bit/issues/2869#issuecomment-787761818)

I added a new option `suppress_type_name` for out_es to remove `_type` field.
The default is `false` for compatibility.
To suppress deprecation log, it should be `true`  or `on`.



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration

```
[INPUT]
    Name cpu

[OUTPUT]
    Name es
    Match *
    Suppress_Type_Name on
```

## Debug log output

I tested using elasticsearch containter `docker.elastic.co/elasticsearch/elasticsearch   7.11.1 ` on Ubuntu 20.04.

- Run es container and waiting it is ready.
  -  `sudo docker run --rm -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.11.1`
- Execute fluent-bit
  -  `bin/fluent-bit -c a.conf`

### ES log

There are no deprecation logs when fluent-bit sends logs.
```
{"type": "server", "timestamp": "2021-03-01T08:53:01,213Z", "level": "INFO", "component": "o.e.c.m.MetadataCreateIndexService", "cluster.name": "docker-cluster", "node.name": "f3d67902cad6", "message": "[fluent-bit] creating index, cause [auto(bulk api)], templates [], shards [1]/[1]", "cluster.uuid": "IEWRkhwKS-i7wNfV_hIUNA", "node.id": "n8DV9J9DRAqe2bD-MDmdBA"  }
{"type": "server", "timestamp": "2021-03-01T08:53:01,689Z", "level": "INFO", "component": "o.e.c.m.MetadataMappingService", "cluster.name": "docker-cluster", "node.name": "f3d67902cad6", "message": "[fluent-bit/59qoPCwcQ-C6dZeVx5odIw] create_mapping [_doc]", "cluster.uuid": "IEWRkhwKS-i7wNfV_hIUNA", "node.id": "n8DV9J9DRAqe2bD-MDmdBA"  }
```

## Valgrind log

```
$ valgrind ../bin/fluent-bit -c a.conf 
==29475== Memcheck, a memory error detector
==29475== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==29475== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==29475== Command: ../bin/fluent-bit -c a.conf
==29475== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/01 17:55:09] [ info] [engine] started (pid=29475)
[2021/03/01 17:55:09] [ info] [storage] version=1.1.1, initializing...
[2021/03/01 17:55:09] [ info] [storage] in-memory
[2021/03/01 17:55:09] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/01 17:55:09] [ info] [sp] stream processor started
==29475== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6cf80
==29475==          to suppress, use: --max-stackframe=12024120 or greater
==29475== Warning: client switching stacks?  SP change: 0x4c6cef8 --> 0x57e48b8
==29475==          to suppress, use: --max-stackframe=12024256 or greater
==29475== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6cef8
==29475==          to suppress, use: --max-stackframe=12024256 or greater
==29475==          further instances of this message will not be shown.
^C[2021/03/01 17:55:16] [engine] caught signal (SIGINT)
[2021/03/01 17:55:16] [ info] [input] pausing cpu.0
[2021/03/01 17:55:16] [ warn] [engine] service will stop in 5 seconds
[2021/03/01 17:55:21] [ info] [engine] service stopped
==29475== 
==29475== HEAP SUMMARY:
==29475==     in use at exit: 0 bytes in 0 blocks
==29475==   total heap usage: 510 allocs, 510 frees, 1,287,851 bytes allocated
==29475== 
==29475== All heap blocks were freed -- no leaks are possible
==29475== 
==29475== For lists of detected and suppressed errors, rerun with: -s
==29475== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
