### PR TITLE
out_s3: support UUID in s3 key format

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -405,6 +405,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
             flb_plg_error(ctx->ins, "'s3_key_format' must start with a '/'");
             return -1;
         }
+        if (strstr((char *) tmp, "$UUID")) {
+            ctx->key_fmt_has_uuid = FLB_TRUE;
+        }
     }
 
     /* validate 'total_file_size' */
@@ -1033,7 +1036,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
     }
 
     len = strlen(s3_key);
-    if ((len + 16) <= 1024) {
+    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid) {
         append_random = FLB_TRUE;
         len += 16;
     }

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -136,6 +136,7 @@ struct flb_s3 {
 
     int timer_created;
     int timer_ms;
+    int key_fmt_has_uuid;
 
     struct flb_output_instance *ins;
 };


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
support UUID and key extensions in s3 key format in all cases
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Part of #2700 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
