### PR TITLE
aws: make sure TLS is disabled for ecs and ec2 providers

### DIFF
--- a/src/aws/flb_aws_credentials_ec2.c
+++ b/src/aws/flb_aws_credentials_ec2.c
@@ -172,8 +172,10 @@ void upstream_set_fn_ec2(struct flb_aws_provider *provider,
     struct flb_aws_provider_ec2 *implementation = provider->implementation;
 
     flb_debug("[aws_credentials] upstream_set called on the EC2 provider");
-    /* upstream_set */
+    /* Make sure TLS is set to false before setting upstream, then reset it */
+    ins->use_tls = FLB_FALSE;
     flb_output_upstream_set(implementation->client->upstream, ins);
+    ins->use_tls = FLB_TRUE;
 }
 
 void destroy_fn_ec2(struct flb_aws_provider *provider) {

--- a/src/aws/flb_aws_credentials_http.c
+++ b/src/aws/flb_aws_credentials_http.c
@@ -187,8 +187,10 @@ void upstream_set_fn_http(struct flb_aws_provider *provider,
     struct flb_aws_provider_http *implementation = provider->implementation;
 
     flb_debug("[aws_credentials] upstream_set called on the http provider");
-    /* set upstream on output */
+    /* Make sure TLS is set to false before setting upstream, then reset it */
+    ins->use_tls = FLB_FALSE;
     flb_output_upstream_set(implementation->client->upstream, ins);
+    ins->use_tls = FLB_TRUE;
 }
 
 void destroy_fn_http(struct flb_aws_provider *provider) {


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

#3110 
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
