### PR TITLE
tests: internal: fuzzers: fix issue in engine fuzzer.

### DIFF
--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -64,6 +64,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct mk_list *head;
                 struct flb_input_instance *entry;
                 mk_list_foreach(head, &ctx->config->inputs) {
+                    entry = mk_list_entry(head, struct flb_input_instance, _head);
                     if (entry->storage != NULL) {
                         char bufbuf[100];
                         flb_input_chunk_append_raw(entry, "A", 1, "\0", 0);


### PR DESCRIPTION
Fixes OSS-Fuzz issue 4872368874586112
Cross-referencing: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28260
Note that fix only touches fuzzers.  

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
