### PR TITLE
tests: internal: fuzzers: fix utils fuzzer.

### DIFF
--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -48,18 +48,28 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         flb_free(uri);
     }
 
-    char *split_protocol;
-    char *split_username;
-    char *split_password;
-    char *split_host;
-    char *split_port;
+    char *split_protocol = NULL;
+    char *split_username = NULL;
+    char *split_password = NULL;
+    char *split_host     = NULL;
+    char *split_port     = NULL;
     if (flb_utils_proxy_url_split(null_terminated, &split_protocol,
             &split_username, &split_password, &split_host, &split_port) == 0) {
-        flb_free(split_protocol);
-        flb_free(split_username);
-        flb_free(split_password);
-        flb_free(split_host);
-        flb_free(split_port);
+        if (split_protocol) {
+            flb_free(split_protocol);
+        }
+        if (split_username) {
+            flb_free(split_username);
+        }
+        if (split_password) {
+            flb_free(split_password);
+        }
+        if (split_host) {
+            flb_free(split_host);
+        }
+        if (split_port) {
+            flb_free(split_port);
+        }
     }
 
 


### PR DESCRIPTION
Fixes OSS-Fuzz issue 4562575602876416
bug tracker issue: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31636
Note that this fix only touches the fuzzers. 

Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
