### PR TITLE
src: strptime: fix overflow in conv_num

### DIFF
--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -709,6 +709,12 @@ _conv_num64(const unsigned char **buf, int64_t *dest, int64_t llim, int64_t ulim
 		result *= 10;
 		result += *(*buf)++ - '0';
 		rulim /= 10;
+        /* watch out for overflows. If value gets above
+         * ((2**64)/2.0)/10.0 then we will overflow. So instead
+         * we return 0 */
+        if (result >= 922337203685477632) {
+            return (0);
+        }
 	} while ((result * 10 <= ulim) && rulim && **buf >= '0' && **buf <= '9');
 
 	if (result < llim || result > ulim)


### PR DESCRIPTION
Fixes OSS-Fuzz issue 6263409412800512
Bugtracker: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29464


Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
