### PR TITLE
[ci/workflows] Split build/run for integration tests

### DIFF
--- a/.github/workflows/README.workflows.md
+++ b/.github/workflows/README.workflows.md
@@ -1,0 +1,12 @@
+### Available workflows
+
+
+| Workflow file                                         | Description               | Run event                                         |
+| :---------------------------------------------------- | ------------------------  | ------------------------------------------------- |
+| [build-release](./build-release.yaml)            | Builds the distro packages and docker images from a tagged release| on new release/tag|
+| [publish-release](./publish-release.yaml)        | Publishes the docker images/manifest on hub.docker.io/fluent/ and the distro packages | on new release/tag on build-release completes|
+| [pr-closed-docker](./pr-closed-docker.yaml)      | Removes docker images for PR on hub.docker.io/fluentbitdev/| on pr closed|
+| [pr-stale](./pr-stale.yaml)                      | Closes stale PR(s) with no activity in 30 days | scheduled daily 01:30 AM UTC|
+| [test-integration-master-microk8s](./test-integration-master-microk8s.yaml)            | Runs [fluent-bit-ci](https://github.com/calyptia/fluent-bit-ci/) integration tests on microk8s/x86| on new commit/push on master|
+| [test-integration-pr-microk8s](./test-integration-master-microk8s.yaml)            | Runs [fluent-bit-ci](https://github.com/calyptia/fluent-bit-ci/) integration tests on microk8s/x86| on new pr with the 'ok-to-test' label against master|
+

--- a/.github/workflows/integration-build-master.yaml
+++ b/.github/workflows/integration-build-master.yaml
@@ -1,0 +1,30 @@
+name: Build master docker images for integration tests
+on:
+  push:
+    branches:
+      - master
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get --yes update
+          sudo apt-get install --yes docker.io containerd runc
+          sudo systemctl unmask docker && sudo systemctl start docker
+
+      - uses: actions/checkout@v2
+      - name: Build a docker image for master branch
+        run: |
+          docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }}-master -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master .
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Archive the docker images
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev

--- a/.github/workflows/integration-build-pr.yaml
+++ b/.github/workflows/integration-build-pr.yaml
@@ -1,0 +1,37 @@
+name: Build PR docker images for integration tests
+on:
+  pull_request:
+    branches:
+      - master
+    types: [ labeled ]
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get --yes update
+          sudo apt-get install --yes docker.io containerd runc
+          sudo systemctl unmask docker && sudo systemctl start docker
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Build the docker images for PR ${{ github.event.number }}
+        run: |
+          docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }}-master -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.pr }} .
+        env:
+          pr: ${{ github.event.number }}
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Archive the docker images
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.pr }}
+        env:
+          pr: ${{ github.event.number }}
+          arch: x86_64
+          dockerhub_organization: fluentbitdev

--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -1,0 +1,119 @@
+name: Run integration tests for master
+on:
+  workflow_run:
+    workflows: [ 'Build master docker images for integration tests' ]
+    types:
+      - completed
+jobs:
+  publish-docker-images:
+    name: publish the docker images for master
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docker image from build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: integration-build-docker-master.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: action_image_artifact_${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-master
+          path: images
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Import docker image
+        run: |
+          docker load --input ./images/${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-master
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker push ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+  run-integration-microk8s:
+    name: run integration tests on ${{ matrix.k8s-release }} microk8s
+    needs: publish-docker-images
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        k8s-release: [ 1.20/stable ] #, 1.19/stable, 1.18/stable ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure LXD
+        run: |
+          sudo snap install lxd
+          sudo lxd.migrate -yes || true
+          sudo lxd waitready
+          sudo lxd init --auto
+          sudo usermod -a -G lxd ${USER}
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd ${USER}
+          newgrp lxd
+          sudo newgrp lxd
+          sudo systemctl start snap.lxd.daemon.service
+          sudo systemctl status snap.lxd.daemon.service
+          sudo systemctl start snap.lxd.daemon.unix.socket
+          sudo systemctl status snap.lxd.daemon.unix.socket
+          sudo chmod 0777 /var/snap/lxd/common/lxd/unix.socket
+
+      - uses: actions/checkout@v2
+        with:
+          repository: calyptia/fluent-bit-ci
+          path: ci
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Apply
+        id: apply
+        run: |
+          newgrp lxd
+          terraform apply -input=false -auto-approve -var k8s-version=${{ env.k8s_release }}
+        working-directory: ci/terraform/microk8s/
+        env:
+          k8s_release: ${{ matrix.k8s-release }}
+
+      - run: lxc exec mk8s-node-integration-0 -- microk8s enable dns
+      - run: lxc exec mk8s-node-integration-0 -- microk8s enable storage
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15' # The Go version to download (if necessary) and use.
+
+      - uses: azure/setup-helm@v1
+        id: install
+
+      - run: go mod download
+        working-directory: ci/integration/
+
+      - run: make integration
+        env:
+          IMAGE_REPOSITORY: fluentbitdev/fluent-bit
+          IMAGE_TAG: x86_64-master
+        working-directory: ci/

--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -1,0 +1,140 @@
+name: Run integration tests for PR
+on:
+  workflow_run:
+    workflows: [ 'Build PR docker images for integration tests' ]
+    types:
+      - completed
+jobs:
+  publish-docker-images:
+    name: publish the docker images for PR
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        run: |
+          PR=$(curl https://api.github.com/search/issues?q=${{ github.event.workflow_run.head_sha }} |
+          grep -Po "(?<=${{ github.event.workflow_run.repository.full_name }}\/pulls\/)\d*" | head -1)
+          echo "PR=$PR" >> $GITHUB_ENV
+
+      - name: Download docker image from build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: integration-build-docker-pr.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: action_image_artifact_${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-master-pr-${{ env.PR }}
+          path: images
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Import docker image
+        run: |
+          docker load --input ./images/${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-master-pr-${{ env.PR }}
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker push ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.PR }}
+        env:
+          arch: x86_64
+          dockerhub_organization: fluentbitdev
+
+  run-integration-microk8s:
+    name: run integration tests on ${{ matrix.k8s-release }} microk8s
+    needs: publish-docker-images
+    strategy:
+      max-parallel: 48
+      fail-fast: true
+      matrix:
+        k8s-release: [ 1.20/stable ] #, 1.19/stable, 1.18/stable ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        run: |
+          PR=$(curl https://api.github.com/search/issues?q=${{ github.event.workflow_run.head_sha }} |
+          grep -Po "(?<=${{ github.event.workflow_run.repository.full_name }}\/pulls\/)\d*" | head -1)
+          echo "PR=$PR" >> $GITHUB_ENV
+
+      - name: Configure LXD
+        run: |
+          sudo snap install lxd
+          sudo lxd.migrate -yes || true
+          sudo lxd waitready
+          sudo lxd init --auto
+          sudo usermod -a -G lxd ${USER}
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd ${USER}
+          newgrp lxd
+          sudo newgrp lxd
+          sudo systemctl start snap.lxd.daemon.service
+          sudo systemctl status snap.lxd.daemon.service
+          sudo systemctl start snap.lxd.daemon.unix.socket
+          sudo systemctl status snap.lxd.daemon.unix.socket
+          sudo chmod 0777 /var/snap/lxd/common/lxd/unix.socket
+
+      - uses: actions/checkout@v2
+        with:
+          repository: calyptia/fluent-bit-ci
+          path: ci
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: ci/terraform/microk8s/
+
+      - name: Terraform Apply
+        id: apply
+        run: |
+          newgrp lxd
+          terraform apply -input=false -auto-approve -var k8s-version=${{ env.k8s_release }}
+        working-directory: ci/terraform/microk8s/
+        env:
+          k8s_release: ${{ matrix.k8s-release }}
+
+      - run: lxc exec mk8s-node-integration-0 -- microk8s enable dns
+      - run: lxc exec mk8s-node-integration-0 -- microk8s enable storage
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15' # The Go version to download (if necessary) and use.
+
+      - uses: azure/setup-helm@v1
+        id: install
+
+      - run: go mod download
+        working-directory: ci/integration/
+
+      - run: make integration
+        env:
+          IMAGE_REPOSITORY: fluentbitdev/fluent-bit
+          IMAGE_TAG: x86_64-master-pr-${{ env.PR }}
+        working-directory: ci/
+
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: test-integration-ok
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ env.PR }}
+          repo: ${{ github.actor }}/fluent-bit

--- a/.github/workflows/pr-closed-docker.yaml
+++ b/.github/workflows/pr-closed-docker.yaml
@@ -1,0 +1,20 @@
+name: Remove docker images for stale/closed PR(s).
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+jobs:
+  docker_cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: addnab/docker-run-action@v2
+        with:
+          image: lumir/remove-dockerhub-tag
+          run: python3 remove-dockerhub-tag.py --user ${{ env.dockerhub_username }} --password ${{ env.dockerhub_password }} ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.pr }}
+        env:
+          pr: ${{ github.event.number }}
+          arch: x86_64
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          dockerhub_organization: ${{ secrets.DOCKERHUB_DEV_ORGANIZATION }}

--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PR(s)'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 30
+          days-before-close: 5
+          days-before-pr-close: -1
+          exempt-all-pr-assignees: true
+          exempt-all-pr-milestones: true

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,4 +10,5 @@ Fluent Bit is developed and supported by many individuals and companies.  The fo
 | [Wesley Pettit](https://github.com/PettitWesley)      | Amazon Plugins (AWS)     | [Amazon Web Services](https://aws.amazon.com/)    |
 | [Cedric Lamoriniere](https://github.com/clamoriniere) | Datadog Output Plugin    | [Datadog](https://www.datadoghq.com/)             |
 | [Jonathan Gonzalez V.](https://github.com/sxd)        | PostgreSQL Output Plugin | [2ndQuadrant](https://www.2ndquadrant.com/en/)    |
+| [Jorge Niedbalski](https://github.com/niedbalski)     | CI && Containers         | [Calyptia](https://www.calyptia.com/)             |
 


### PR DESCRIPTION
This patch splits the workflow definition for building docker images for master/PR(s) for  running integration tests.

* Build of docker images is split for master / PR(s)
* Integration runs are split into a separated workflow for master / PR(s)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
