### PR TITLE
[ci/workflows] switch to pull_request_target

### DIFF
--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -1,6 +1,6 @@
 name: Run integration tests for PR
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
     types: [ labeled ]


### PR DESCRIPTION
Use pull_request_target for accessing secrets.

* integration-run-pr.yaml: switch to pull_request_target.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
