### PR TITLE
[ci/workflows] label the PR(s) when jobs are done

### DIFF
--- a/.github/workflows/integration-build-pr.yaml
+++ b/.github/workflows/integration-build-pr.yaml
@@ -35,3 +35,11 @@ jobs:
           pr: ${{ github.event.number }}
           arch: x86_64
           dockerhub_organization: fluentbitdev
+
+      - uses: actions-ecosystem/action-add-labels@v1
+        name: Label the PR
+        with:
+          labels: ci/integration-docker-ok
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.actor }}/fluent-bit

--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -20,12 +20,18 @@ jobs:
           intervalSeconds: 10
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Wait until artifacts are propagated
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '15s'
+
       - name: Download docker image from build artifacts
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: integration-build-pr.yaml
-          pr: ${{github.event.pull_request.number}}
+          pr: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}
           name: action_image_artifact_${{ env.dockerhub_organization }}_fluent-bit_${{ env.arch }}-master-pr-${{ env.pr }}
           path: images
         env:
@@ -128,12 +134,13 @@ jobs:
       - run: make integration
         env:
           IMAGE_REPOSITORY: fluentbitdev/fluent-bit
-          IMAGE_TAG: x86_64-master-pr-${{ github.event.number }}
+          IMAGE_TAG: x86_64-master-pr-${{ github.event.pull_request.number }}
         working-directory: ci/
 
       - uses: actions-ecosystem/action-add-labels@v1
+        name: Label the PR
         with:
-          labels: test-integration-ok
+          labels: ci/integration-test-ok
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
+          number: ${{ github.event.pull_request.number }}
           repo: ${{ github.actor }}/fluent-bit


### PR DESCRIPTION
Add the following labels to the PR(s):

* add ci/integration-docker-ok label when docker image build is done
* add ci/integration-integration-ok when integration tests are run succesfully

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
