### PR TITLE
Update integration-build-pr.yaml

### DIFF
--- a/.github/workflows/integration-build-pr.yaml
+++ b/.github/workflows/integration-build-pr.yaml
@@ -35,11 +35,3 @@ jobs:
           pr: ${{ github.event.number }}
           arch: x86_64
           dockerhub_organization: fluentbitdev
-
-      - uses: actions-ecosystem/action-add-labels@v1
-        name: Label the PR
-        with:
-          labels: ci/integration-docker-ok
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          repo: fluent/fluent-bit

--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -61,6 +61,14 @@ jobs:
           arch: x86_64
           dockerhub_organization: fluentbitdev
 
+      - uses: actions-ecosystem/action-add-labels@v1
+        name: Label the PR
+        with:
+          labels: ci/integration-docker-ok
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          repo: fluent/fluent-bit
+
   run-integration-microk8s:
     name: run integration tests on ${{ matrix.k8s-release }} microk8s
     needs: publish-docker-images


### PR DESCRIPTION
* Remove labeling for building docker PR image.
* Moved to next workflow (publish images)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
