### PR TITLE
filter_record_modifier: use bias-free words.

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -45,7 +45,7 @@ static int configure(struct record_modifier_ctx *ctx,
 
     ctx->records_num = 0;
     ctx->remove_keys_num = 0;
-    ctx->whitelist_keys_num = 0;
+    ctx->allowlist_keys_num = 0;
 
     /* Iterate all filter properties */
     mk_list_foreach(head, &f_ins->properties) {
@@ -69,7 +69,8 @@ static int configure(struct record_modifier_ctx *ctx,
             mk_list_add(&mod_key->_head, &ctx->remove_keys);
             ctx->remove_keys_num++;
         }
-        else if (!strcasecmp(kv->key, "whitelist_key")) {
+        else if (!strcasecmp(kv->key, "allowlist_key") ||
+                 !strcasecmp(kv->key, "whitelist_key")) {
             mod_key = flb_malloc(sizeof(struct modifier_key));
             if (!mod_key) {
                 flb_errno();
@@ -84,8 +85,8 @@ static int configure(struct record_modifier_ctx *ctx,
             else {
                 mod_key->dynamic_key = FLB_FALSE;
             }
-            mk_list_add(&mod_key->_head, &ctx->whitelist_keys);
-            ctx->whitelist_keys_num++;
+            mk_list_add(&mod_key->_head, &ctx->allowlist_keys);
+            ctx->allowlist_keys_num++;
         }
         else if (!strcasecmp(kv->key, "record")) {
             mod_record = flb_malloc(sizeof(struct modifier_record));
@@ -116,8 +117,8 @@ static int configure(struct record_modifier_ctx *ctx,
         }
     }
 
-    if (ctx->remove_keys_num > 0 && ctx->whitelist_keys_num > 0) {
-        flb_plg_error(ctx->ins, "remove_keys and whitelist_keys are exclusive "
+    if (ctx->remove_keys_num > 0 && ctx->allowlist_keys_num > 0) {
+        flb_plg_error(ctx->ins, "remove_keys and allowlist_keys are exclusive "
                       "with each other.");
         return -1;
     }
@@ -136,7 +137,7 @@ static int delete_list(struct record_modifier_ctx *ctx)
         mk_list_del(&key->_head);
         flb_free(key);
     }
-    mk_list_foreach_safe(head, tmp, &ctx->whitelist_keys) {
+    mk_list_foreach_safe(head, tmp, &ctx->allowlist_keys) {
         key = mk_list_entry(head, struct modifier_key,  _head);
         mk_list_del(&key->_head);
         flb_free(key);
@@ -167,7 +168,7 @@ static int cb_modifier_init(struct flb_filter_instance *f_ins,
     }
     mk_list_init(&ctx->records);
     mk_list_init(&ctx->remove_keys);
-    mk_list_init(&ctx->whitelist_keys);
+    mk_list_init(&ctx->allowlist_keys);
     ctx->ins = f_ins;
 
     if ( configure(ctx, f_ins) < 0 ){
@@ -204,8 +205,8 @@ static int make_bool_map(struct record_modifier_ctx *ctx, msgpack_object *map,
         check = &(ctx->remove_keys);
         is_to_delete = FLB_TRUE;
     }
-    else if(ctx->whitelist_keys_num > 0) {
-        check = &(ctx->whitelist_keys);
+    else if(ctx->allowlist_keys_num > 0) {
+        check = &(ctx->allowlist_keys);
         is_to_delete = FLB_FALSE;
     }
 

--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -42,10 +42,10 @@ struct modifier_key {
 struct record_modifier_ctx {
     int records_num;
     int remove_keys_num;
-    int whitelist_keys_num;
+    int allowlist_keys_num;
     struct mk_list records;
     struct mk_list remove_keys;
-    struct mk_list whitelist_keys;
+    struct mk_list allowlist_keys;
     struct flb_filter_instance *ins;
 };
 


### PR DESCRIPTION


<!-- Provide summary of changes -->
Ref: #2701 
I modified to use bias-free words.
This PR also supports new option `Allowlist_key` which is an alias of `Whitelist_key`.

- replace whitelist with allowlist
- keep `Whitelist_key` option for backwards compatibility
- add `Allowlist_key` option as alias of `Whitelist_key`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
I will be modified like this.
| Key | Description |
| :--- | :--- |
| Allowlist\_key | If the key is **not** matched, that field is removed. |
| Whitelist\_key | An alias of `Allowlist_key` for backwards compatibility. |


## Example Configuration 

Note: Whitelist_key is also supported. You can confirm to modify comment  line.
```
[INPUT]
    name dummy
    dummy {"allow":"allowed", "deny":"denied"}

[FILTER]
    name record_modifier
    match *
#    Whitelist_key allow
    Allowlist_key allow

[OUTPUT]          
    name stdout
```

## Debug log output

It is the same output when `Whitelist_key` is enabled.
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/06 07:22:30] [ info] [engine] started (pid=27941)
[2021/03/06 07:22:30] [ info] [storage] version=1.1.1, initializing...
[2021/03/06 07:22:30] [ info] [storage] in-memory
[2021/03/06 07:22:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/06 07:22:30] [ info] [sp] stream processor started
[0] dummy.0: [1614982950.878021615, {"allow"=>"allowed"}]
[1] dummy.0: [1614982951.877963517, {"allow"=>"allowed"}]
[2] dummy.0: [1614982952.878185119, {"allow"=>"allowed"}]
[3] dummy.0: [1614982953.879783029, {"allow"=>"allowed"}]
^C[2021/03/06 07:22:35] [engine] caught signal (SIGINT)
```

## Valgrind output

```
$ valgrind ../bin/fluent-bit -c a.conf 
==27944== Memcheck, a memory error detector
==27944== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27944== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==27944== Command: ../bin/fluent-bit -c a.conf
==27944== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/06 07:23:00] [ info] [engine] started (pid=27944)
[2021/03/06 07:23:00] [ info] [storage] version=1.1.1, initializing...
[2021/03/06 07:23:00] [ info] [storage] in-memory
[2021/03/06 07:23:00] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/06 07:23:00] [ info] [sp] stream processor started
==27944== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c8e8f0
==27944==          to suppress, use: --max-stackframe=11886536 or greater
==27944== Warning: client switching stacks?  SP change: 0x4c8e868 --> 0x57e48b8
==27944==          to suppress, use: --max-stackframe=11886672 or greater
==27944== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c8e868
==27944==          to suppress, use: --max-stackframe=11886672 or greater
==27944==          further instances of this message will not be shown.
[0] dummy.0: [1614982981.888149818, {"allow"=>"allowed"}]
[1] dummy.0: [1614982982.878034496, {"allow"=>"allowed"}]
[2] dummy.0: [1614982983.878467825, {"allow"=>"allowed"}]
[3] dummy.0: [1614982984.877822490, {"allow"=>"allowed"}]
^C[2021/03/06 07:23:06] [engine] caught signal (SIGINT)
[0] dummy.0: [1614982985.904572168, {"allow"=>"allowed"}]
[2021/03/06 07:23:06] [ warn] [engine] service will stop in 5 seconds
[2021/03/06 07:23:10] [ info] [engine] service stopped
==27944== 
==27944== HEAP SUMMARY:
==27944==     in use at exit: 0 bytes in 0 blocks
==27944==   total heap usage: 408 allocs, 408 frees, 1,264,023 bytes allocated
==27944== 
==27944== All heap blocks were freed -- no leaks are possible
==27944== 
==27944== For lists of detected and suppressed errors, rerun with: -s
==27944== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
