### PR TITLE
snap: add permission to read config file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,12 @@ icon: ./fluent-bit.svg
 confinement: 'strict'
 grade: 'stable'
 
+plugs:
+    read-config:
+        interface: system-files
+        read:
+        - $SNAP/etc/fluent-bit
+
 apps:
   service:
     command: fluent-bit -c $SNAP/etc/fluent-bit/fluent-bit.conf
@@ -18,6 +24,7 @@ apps:
     plugs:
       - network
       - network-bind
+      - read-config
   fluent-bit:
     command: fluent-bit
     plugs:


### PR DESCRIPTION


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #2615 

I added permission to read fluent-bit.conf with system files interface.
https://snapcraft.io/docs/system-files-interface

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Create and install

```
cd snap
snapcraft
sudo snap install fluent-bit*.snap --dangerous
```

## Testing
Fluent-bit can read configuration file under snap directory.

```
$ which fluent-bit
/snap/bin/fluent-bit
$ fluent-bit -c /snap/fluent-bit/current/etc/fluent-bit/fluent-bit.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/06 08:34:41] [ info] [engine] started (pid=30166)
[2021/03/06 08:34:41] [ info] [storage] version=1.1.1, initializing...
[2021/03/06 08:34:41] [ info] [storage] in-memory
[2021/03/06 08:34:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/06 08:34:41] [ info] [sp] stream processor started
[0] cpu.local: [1614987281.475344833, {"cpu_p"=>1.000000, "user_p"=>0.500000, "system_p"=>0.500000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>2.000000, "cpu1.p_user"=>1.000000, "cpu1.p_system"=>1.000000}]
[1] cpu.local: [1614987282.475175703, {"cpu_p"=>2.500000, "user_p"=>2.500000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>4.000000, "cpu1.p_user"=>4.000000, "cpu1.p_system"=>0.000000}]
[2] cpu.local: [1614987283.474990118, {"cpu_p"=>3.500000, "user_p"=>3.000000, "system_p"=>0.500000, "cpu0.p_cpu"=>5.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>2.000000, "cpu1.p_cpu"=>4.000000, "cpu1.p_user"=>4.000000, "cpu1.p_system"=>0.000000}]
[3] cpu.local: [1614987284.475217726, {"cpu_p"=>5.000000, "user_p"=>3.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>6.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>2.000000, "cpu1.p_cpu"=>4.000000, "cpu1.p_user"=>2.000000, "cpu1.p_system"=>2.000000}]
^C[2021/03/06 08:34:45] [engine] caught signal (SIGINT)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
