### PR TITLE
lib: monkey: fixes incorrect skipping of configuration parse error

### DIFF
--- a/lib/monkey/mk_core/mk_rconf.c
+++ b/lib/monkey/mk_core/mk_rconf.c
@@ -340,6 +340,9 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
         if (strncmp(buf, indent, indent_len) != 0 ||
             isblank(buf[indent_len]) != 0) {
             mk_config_error(path, line, "Invalid indentation level");
+            mk_mem_free(key);
+            mk_mem_free(val);
+            return -1;
         }
 
         if (buf[indent_len] == '#' || indent_len == len) {


### PR DESCRIPTION
This PR tries to address the issue raised in #3162 where
the invalid configuration file will not populate a non-zero code:
```
$ cat fluent-bit.conf
[INPUT]
    Name cpu

[OUTPUT]
    Name stdout

NONSENSE NONSENSE NONSENSE
$ bin/fluent-bit -c fluent-bit.conf --dry-run
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/08 16:33:03] [  Error] File fluent-bit.conf
[2021/03/08 16:33:03] [  Error] Error in line 7: Invalid indentation level
configuration test is successful
$ echo $?
0
```
This PR fixes the issue and below is the new output:
```
$ bin/fluent-bit -c fluent-bit.conf --dry-run
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/08 16:31:48] [  Error] File fluent-bit.conf
[2021/03/08 16:31:48] [  Error] Error in line 7: Invalid indentation level
Error: Configuration file contains errors. Aborting

$ echo $?
1
```
This PR fixes #3162.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [n/a] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
