### PR TITLE
io: add connection backoff

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -38,6 +38,12 @@ struct flb_net_setup {
     /* max time in seconds to wait for a established connection */
     int connect_timeout;
 
+    /* backoff time in seconds after the first connection failure */
+    int backoff_init;
+
+    /* maximum connection backoff time in seconds */
+    int backoff_max;
+
     /* network interface to bind and use to send data */
     flb_sds_t source_address;
 

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -83,6 +83,10 @@ struct flb_upstream {
 #endif
 
     struct mk_list _head;
+
+    /* Backoff state. */
+    time_t backoff_next_attempt_time;
+    int backoff_last_duration;
 };
 
 void flb_upstream_queue_init(struct flb_upstream_queue *uq);

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -63,9 +63,56 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
 
+/* Increase backoff time of an upstream */
+static void flb_io_backoff_upstream(struct flb_upstream *u)
+{
+    time_t now = time(NULL);
+    int max_jitter, jitter = 0;
+
+    if (u->net.backoff_max < 1 || u->backoff_next_attempt_time > now) {
+        return;
+    }
+
+    if (u->backoff_last_duration > 0) {
+        u->backoff_last_duration = 2 * u->backoff_last_duration;
+    } else {
+        srand(now);
+        u->backoff_last_duration = u->net.backoff_init;
+    }
+    if (u->backoff_last_duration > u->net.backoff_max) {
+        u->backoff_last_duration = u->net.backoff_max;
+    }
+
+    if (u->backoff_last_duration > 2) {
+        /* Add plus/minus 10% jitter */
+        max_jitter = u->backoff_last_duration % 10 + 1;
+        /* Random int from -max_jitter to +max_jitter */
+        jitter = rand() % (2*max_jitter) - max_jitter;
+    }
+
+    u->backoff_next_attempt_time = now + u->backoff_last_duration + jitter;
+    flb_debug("[io] backoff connecting to %s:%i for %i seconds with jitter %i seconds",
+        u->tcp_host, u->tcp_port, u->backoff_last_duration, jitter);
+}
+
+/* Returns true if upstream should be skipped. */
+static int flb_io_in_backoff(struct flb_upstream *u)
+{
+    if (u->backoff_next_attempt_time > time(NULL)) {
+        flb_debug("[io] skipping connection to %s:%i because of backoff for another %i seconds",
+                    u->tcp_host, u->tcp_port, u->backoff_next_attempt_time - time(NULL));
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
 int flb_io_net_connect(struct flb_upstream_conn *u_conn,
                        struct flb_coro *coro)
 {
+    if (flb_io_in_backoff(u_conn->u) == FLB_TRUE) {
+        return -1;
+    }
+
     int ret;
     int async = FLB_FALSE;
     flb_sockfd_t fd = -1;
@@ -87,16 +134,18 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     fd = flb_net_tcp_connect(u->tcp_host, u->tcp_port, u->net.source_address,
                              u->net.connect_timeout, async, coro, u_conn);
     if (fd == -1) {
+        flb_io_backoff_upstream(u);
         return -1;
     }
 
     if (u->proxied_host) {
         ret = flb_http_client_proxy_connect(u_conn);
         if (ret == -1) {
+            flb_io_backoff_upstream(u);
             flb_debug("[http_client] flb_http_client_proxy_connect connection #%i failed to %s:%i.",
                       u_conn->fd, u->tcp_host, u->tcp_port);
-          flb_socket_close(fd);
-          return -1;
+            flb_socket_close(fd);
+            return -1;
         }
         flb_debug("[http_client] flb_http_client_proxy_connect connection #%i connected to %s:%i.",
                   u_conn->fd, u->tcp_host, u->tcp_port);
@@ -107,6 +156,8 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     if (u->flags & FLB_IO_TLS) {
         ret = flb_tls_session_create(u->tls, u_conn, coro);
         if (ret != 0) {
+            flb_io_backoff_upstream(u);
+            flb_debug("[io] flb_tls_session_create failed on connection #%i", u_conn->fd);
             flb_socket_close(fd);
             return -1;
         }
@@ -342,6 +393,10 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
 int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
                      size_t len, size_t *out_len)
 {
+    if (flb_io_in_backoff(u_conn->u) == FLB_TRUE) {
+        return -1;
+    }
+
     int ret = -1;
     struct flb_upstream *u = u_conn->u;
     struct flb_coro *coro = flb_coro_get();
@@ -366,6 +421,15 @@ int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
         }
     }
 #endif
+
+    if (ret == -1) {
+        flb_io_backoff_upstream(u);
+        flb_debug("[io] cannot write data to connection #%i at %s:%i",
+            u_conn->fd, u->tcp_host, u->tcp_port);
+    } else if (u->backoff_next_attempt_time < time(NULL) && u->backoff_last_duration > 0) {
+        flb_debug("[io] connection #%i was successful, reset backoff duration", u_conn->fd);
+        u->backoff_last_duration = 0;
+    }
 
     if (ret == -1 && u_conn->fd > 0) {
         flb_socket_close(u_conn->fd);

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -58,6 +58,8 @@ void flb_net_setup_init(struct flb_net_setup *net)
     net->keepalive_max_recycle = 0;
     net->connect_timeout = 10;
     net->source_address = NULL;
+    net->backoff_init = 0;
+    net->backoff_max = 0;
 }
 
 int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address)

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -65,6 +65,18 @@ struct flb_config_map upstream_net[] = {
      "before it is retired."
     },
 
+    {
+     FLB_CONFIG_MAP_TIME, "net.backoff_init", "0s",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, backoff_init),
+     "Set backoff time in seconds after the first connection failure."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "net.backoff_max", "0s",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, backoff_max),
+     "Set maximal connection backoff time in seconds."
+    },
+
     /* EOF */
     {0}
 };
@@ -363,6 +375,12 @@ static struct flb_upstream_conn *create_conn(struct flb_upstream *u)
 
     now = time(NULL);
 
+    if (u->backoff_next_attempt_time > now) {
+        flb_debug("[upstream] skipping connection to %s:%i because of connection backoff for another %i seconds",
+                  u->tcp_host, u->tcp_port, u->backoff_next_attempt_time - now);
+        return NULL;
+    }
+
     conn = flb_calloc(1, sizeof(struct flb_upstream_conn));
     if (!conn) {
         flb_errno();
@@ -495,12 +513,16 @@ struct flb_upstream_conn *flb_upstream_conn_get(struct flb_upstream *u)
               "net.connect_timeout        = %i seconds\n"
               "net.source_address         = %s\n"
               "net.keepalive              = %s\n"
-              "net.keepalive_idle_timeout = %i seconds",
+              "net.keepalive_idle_timeout = %i seconds\n"
+              "net.backoff_init           = %i seconds\n"
+              "net.backoff_max            = %i seconds",
               u->tcp_host, u->tcp_port,
               u->net.connect_timeout,
               u->net.source_address ? u->net.source_address: "any",
               u->net.keepalive ? "enabled": "disabled",
-              u->net.keepalive_idle_timeout);
+              u->net.keepalive_idle_timeout,
+              u->net.backoff_init,
+              u->net.backoff_max);
 
     /* On non Keepalive mode, always create a new TCP connection */
     if (u->net.keepalive == FLB_FALSE) {


### PR DESCRIPTION
In normal operation, `fluent-bit` reuses TCP connections, hence new messages are flushed without sending a TCP SYN.
But if an output connection cannot be established, then each `flb_io_net_write()` call will trigger connection setup and will send a series of TCP SYN packets (one per thread?).

The actual issue is described in [#3103](https://github.com/fluent/fluent-bit/issues/3103).

We observed this issue when hundreds of `fluent-bit` agents tried to send logs via `forward` to a set of receiving `fluent-bit`s, which were all down due to config error. The receiving FLB was hosted behind an openstack load balancer, a Linux stateful firewall and a `traefik` ingress controller.

Apart from high load, the flood of SYN packets may exhaust the connection tracking table, impacting the whole network infrastructure.

Fixes #3103.

This PR is inspired by [GRPC backoff implementation](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md).

Backoff is disabled by default.

If enabled, backoff will limit the number of TCP SYN packets during an output destination outage [(raw data)](https://gist.github.com/kabakaev/323b417bf3b1433d7969dff20badfb45#file-tcpdump-csv):
![image](https://user-images.githubusercontent.com/6826176/110437201-682abf80-80b5-11eb-9e30-aff3edc21ada.png)

This chart shows rate of TCP SYN packets. The data is collected by `tcpdump` as described in `How to test` section below.

**Testing**

Example of backoff configuration is given below.

Valgrind output is [uploaded to my gist](https://gist.github.com/kabakaev/323b417bf3b1433d7969dff20badfb45#file-valgrind-log).


**Documentation**

Documentation for this feature [is submitted as docs PR491](https://github.com/fluent/fluent-bit-docs/pull/491).


**How to test**

Compile this version:
```bash
cd build
cmake -DFLB_RELEASE=On \
          -DFLB_TRACE=On \
          -DFLB_JEMALLOC=On \
          -DFLB_TLS=On \
          -DFLB_SHARED_LIB=Off \
          -DFLB_EXAMPLES=Off \
          -DFLB_HTTP_SERVER=On \
          -DFLB_IN_SYSTEMD=On ../ \
&& make -j$(getconf _NPROCESSORS_ONLN)
```

**Collect SYN packets without backoff**

Simulate connection timeout and run `tcpdump` on a separate console:
```bash
iptables -I INPUT -p tcp --dport 24224 -j DROP
timeout 6m tcpdump -lnn -i any dst host 127.0.0.1 and dst port 24224 and tcp[tcpflags] == tcp-syn | tee run5m_backoff0.tcpdump
# 1802 packets captured
iptables -D INPUT -p tcp --dport 24224 -j DROP
```

and start `fluent-bit` without backoff settings:
```bash
timeout -s SIGKILL 5m \
  bin/fluent-bit -vv \
    -i dummy -p 'rate=1000000' \
    -o forward://127.0.0.1:24224 -p 'retry_limit=1' \
  2>&1 | tee run5m_backoff0.log
# Fluent Bit v1.8.0
# ...
# [2021/03/08 18:27:32] [ warn] [engine] failed to flush chunk '869680-1615224452.505695198.flb', retry in 6 seconds: task_id=189, input=dummy.0 > output=forward.0 (out_id=0)
# Killed
```

**Collect SYN packets with initial backoff of 1 second**

Simulate connection timeout and run `tcpdump` on a separate console:
```bash
iptables -I INPUT -p tcp --dport 24224 -j DROP
timeout 6m tcpdump -lnn -i any dst host 127.0.0.1 and dst port 24224 and tcp[tcpflags] == tcp-syn | tee run5m_backoff1.tcpdump
# 360 packets captured
iptables -D INPUT -p tcp --dport 24224 -j DROP
```

and start `fluent-bit` with backoff settings:
```bash
timeout -s SIGKILL 5m \
  bin/fluent-bit -vv \
    -i dummy -p 'rate=1000000' \
    -o forward://127.0.0.1:24224 -p 'retry_limit=1' -p 'net.backoff_init=1' -p 'net.backoff_max=60' \
  2>&1 | tee run5m_backoff1.log
# Fluent Bit v1.8.0
# ...
# [2021/03/08 18:27:31] [debug] [upstream] skipping connection to 127.0.0.1:24224 because of connection backoff for another 28 seconds
# [2021/03/08 18:27:32] [ warn] [engine] failed to flush chunk '869680-1615224452.505695198.flb', retry in 6 seconds: task_id=189, input=dummy.0 > output=forward.0 (out_id=0)
# Killed
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

Alexander Kabakaev [alexander.kabakaev@daimler.com](mailto:alexander.kabakaev@daimler.com@daimler.com), Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)
