### PR TITLE
build: Use static linking with OpenSSL on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,12 @@ if(FLB_TLS)
   option(INSTALL_MBEDTLS_HEADERS OFF)
   add_subdirectory(${FLB_PATH_LIB_MBEDTLS} EXCLUDE_FROM_ALL)
 
+  # Link OpenSSL statically on Windows.
+  if (FLB_SYSTEM_WINDOWS)
+    set(OPENSSL_USE_STATIC_LIBS ON)
+    set(OPENSSL_MSVC_STATIC_RT  ON)
+  endif()
+
   # find OpenSSL (our preferred choice now)
   find_package(OpenSSL)
   if(OPENSSL_FOUND)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 version: v1-winbuild-{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 platform:
   - Win32
   - x64
 
 environment:
-  vspath: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community'
+  vspath: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community'
   winflexbison: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
   PATH: '%PATH%;C:\WinFlexBison'
 

--- a/ci/do-ut.ps1
+++ b/ci/do-ut.ps1
@@ -1,10 +1,10 @@
 cd build
 
 if ( "x64" -eq $env:PLATFORM ) {
-    $OPENSSL_DIR = "C:\OpenSSL-v11-Win64"
+    $OPENSSL_DIR = "C:\OpenSSL-v111-Win64"
 }
 else {
-    $OPENSSL_DIR = "C:\OpenSSL-v11-Win32"
+    $OPENSSL_DIR = "C:\OpenSSL-v111-Win32"
 }
 
 


### PR DESCRIPTION
Do not assume the existence of OpenSSL on Windows machines,
but rather includes it in the binary using static linking.

This resolves the issue "Fluent Bit fails to start up due to
missing libcrypto/libssl DLLs".

Fix #3160 and fluent/fluent-bit-docs#480.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
