### PR TITLE
out_stackdriver: Ensure URL encoding for the OAuth2 request, and send to the more modern endpoint.

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -291,8 +291,8 @@ static int get_oauth2_token(struct flb_stackdriver *ctx)
 
     ret = flb_oauth2_payload_append(ctx->o,
                                     "grant_type", -1,
-                                    "urn:ietf:params:oauth:"
-                                    "grant-type:jwt-bearer", -1);
+                                    "urn%3Aietf%3Aparams%3Aoauth%3A"
+                                    "grant-type%3Ajwt-bearer", -1);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error appending oauth2 params");
         flb_sds_destroy(sig_data);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -34,12 +34,11 @@
 #define FLB_STD_SCOPE     "https://www.googleapis.com/auth/logging.write"
 
 /* Stackdriver authorization URL */
-#define FLB_STD_AUTH_URL  "https://www.googleapis.com/oauth2/v4/token"
+#define FLB_STD_AUTH_URL  "https://oauth2.googleapis.com/token"
 
 /* Stackdriver Logging 'write' end-point */
 #define FLB_STD_WRITE_URI "/v2/entries:write"
-#define FLB_STD_WRITE_URL \
-    "https://logging.googleapis.com" FLB_STD_WRITE_URI
+#define FLB_STD_WRITE_URL "https://logging.googleapis.com" FLB_STD_WRITE_URI
 
 /* Timestamp format */
 #define FLB_STD_TIME_FMT  "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
Ensure that the OAuth2 request body is URL-encoded, to match the [header value](https://github.com/fluent/fluent-bit/blob/master/include/fluent-bit/flb_oauth2.h#L29).
Also replace the old URL for retrieving OAuth2 tokens with the newer one. The new token URL is what's listed in the [well-known OAuth2 config](https://accounts.google.com/.well-known/openid-configuration).

Fixes #5284.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.