### PR TITLE
ra: remove unnecessary funtion to simplify

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -45,18 +45,6 @@ static struct flb_ra_parser *ra_parse_string(struct flb_record_accessor *ra,
     return rp;
 }
 
-static struct flb_ra_parser *ra_parse_regex_id(struct flb_record_accessor *ra,
-                                               int c)
-{
-    struct flb_ra_parser *rp;
-
-    rp = flb_ra_parser_regex_id_create(c);
-    if (!rp) {
-        return NULL;
-    }
-    return rp;
-}
-
 /* Create a parser context for a key map or function definition */
 static struct flb_ra_parser *ra_parse_meta(struct flb_record_accessor *ra,
                                            flb_sds_t buf, int start, int end)
@@ -130,7 +118,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
         if (isdigit(buf[n])) {
             /* Add REGEX_ID entry */
             c = atoi(buf + n);
-            rp = ra_parse_regex_id(ra, c);
+            rp = flb_ra_parser_regex_id_create(c);
             if (!rp) {
                 return -1;
             }


### PR DESCRIPTION

<!-- Provide summary of changes -->

I removed static function `ra_parse_regex_id` .
The arg `ra` is not used in this function and it can be replaced with `flb_ra_parser_regex_id_create`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Unit test

All unit tests have passed.

```
$ bin/flb-it-record_accessor 
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a

type       : STRING
string     : ' extra '

type       : KEYMAP
key name   : bbb
 - subkey  : b

type       : STRING
string     : ' final access'

=== test ===
type       : KEYMAP
key name   : b
 - subkey  : x
 - subkey  : y

=== test ===
type       : KEYMAP
key name   : z

=== test ===
type       : STRING
string     : 'abc'
[2021/03/10 17:18:12] [error] [record accessor] syntax error, unexpected $end, expecting ']' at '$abc['a''
[ OK ]
Test translate...                               == input ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
== output ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
[ OK ]
Test dots_subkeys...                            == input ==
thetag
== output ==
thetag
[ OK ]
Test array_id...                                == input ==
thetag
== output ==
thetag
[ OK ]
Test get_kv_pair...                             [ OK ]
SUCCESS: All unit tests have passed.
```


## Valgrind output
I tested https://github.com/fluent/fluent-bit/issues/3185#issuecomment-795080171 configuration.
```
$ valgrind ../bin/fluent-bit -c a.conf 
==4377== Memcheck, a memory error detector
==4377== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4377== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4377== Command: ../bin/fluent-bit -c a.conf
==4377== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/10 17:30:53] [ info] Configuration:
[2021/03/10 17:30:53] [ info]  flush time     | 1.000000 seconds
[2021/03/10 17:30:53] [ info]  grace          | 5 seconds
[2021/03/10 17:30:53] [ info]  daemon         | 0
[2021/03/10 17:30:53] [ info] ___________
[2021/03/10 17:30:53] [ info]  inputs:
[2021/03/10 17:30:53] [ info]      tail
[2021/03/10 17:30:53] [ info] ___________
[2021/03/10 17:30:53] [ info]  filters:
[2021/03/10 17:30:53] [ info]      grep.0
[2021/03/10 17:30:53] [ info] ___________
[2021/03/10 17:30:53] [ info]  outputs:
[2021/03/10 17:30:53] [ info]      stdout.0
[2021/03/10 17:30:53] [ info] ___________
[2021/03/10 17:30:53] [ info]  collectors:
[2021/03/10 17:30:53] [ info] [engine] started (pid=4377)
[2021/03/10 17:30:53] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/03/10 17:30:53] [debug] [storage] [cio stream] new stream registered: tail.0
[2021/03/10 17:30:53] [ info] [storage] version=1.1.1, initializing...
[2021/03/10 17:30:53] [ info] [storage] in-memory
[2021/03/10 17:30:53] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] inotify watch fd=22
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] scanning path a.log
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] inode=1450580 with offset=0 appended as a.log
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] scan_glob add(): a.log, inode 1450580
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] 1 new files found on path 'a.log'
[2021/03/10 17:30:53] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2021/03/10 17:30:53] [debug] [router] match rule tail.0:stdout.0
[2021/03/10 17:30:53] [ info] [sp] stream processor started
[2021/03/10 17:30:53] [debug] [input:tail:tail.0] inode=1450580 file=a.log promote to TAIL_EVENT
[2021/03/10 17:30:53] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1450580 watch_fd=1 name=a.log
[2021/03/10 17:30:54] [debug] [task] created task=0x4cbb290 id=0 OK
==4377== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4cc16e0
==4377==          to suppress, use: --max-stackframe=11678168 or greater
==4377== Warning: client switching stacks?  SP change: 0x4cc1658 --> 0x57e48b8
==4377==          to suppress, use: --max-stackframe=11678304 or greater
==4377== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4cc1658
==4377==          to suppress, use: --max-stackframe=11678304 or greater
==4377==          further instances of this message will not be shown.
[0] tail.0: [1615365053.692571984, {"kind"=>"Event", "apiVersion"=>"audit.k8s.io/v1", "level"=>"Metadata", "auditID"=>"26cc75b8-2406-4423-8d67-822e284338d4", "stage"=>"ResponseStarted", "requestURI"=>"/api/v1/secrets?includeObject=Object&resourceVersion=72118354&timeout=30m0s&timeoutSeconds=1800&watch=true", "verb"=>"watch", "user"=>{"username"=>"system:serviceaccount:cattle-system:cattle", "uid"=>"90652f83-7689-45b2-b1aa-98116139785e", "groups"=>["system:serviceaccounts", "system:serviceaccounts:cattle-system", "system:authenticated"]}, "impersonatedUser"=>{"username"=>"u-toto", "groups"=>["googleoauth_group://tata", "system:authenticated", "system:cattle:authenticated"]}, "sourceIPs"=>["172.16.20.1"], "userAgent"=>"agent/v0.0.0 (linux/amd64) kubernetes/$Format", "objectRef"=>{"resource"=>"secrets", "apiVersion"=>"v1"}, "responseStatus"=>{"metadata"=>{}, "status"=>"Success", "message"=>"Connection closed early", "code"=>200}, "requestReceivedTimestamp"=>"2021-02-25T17:37:22.861878Z", "stageTimestamp"=>"2021-02-25T17:37:22.862892Z", "annotations"=>{"authorization.k8s.io/decision"=>"allow", "authorization.k8s.io/reason"=>"RBAC: allowed by ClusterRoleBinding "clusterrolebinding-66jsq" of ClusterRole "cluster-owner" to Group "googleoauth_group://tata""}}]
[1] tail.0: [1615365053.696819881, {"kind"=>"Event", "apiVersion"=>"audit.k8s.io/v1", "level"=>"Metadata", "auditID"=>"26cc75b8-2406-4423-8d67-822e284338d4", "stage"=>"ResponseStarted", "requestURI"=>"/api/v1/secrets?includeObject=Object&resourceVersion=72118354&timeout=30m0s&timeoutSeconds=1800&watch=true", "verb"=>"watch", "user"=>{"username"=>"system:serviceaccount:cattle-system:cattle", "uid"=>"90652f83-7689-45b2-b1aa-98116139785e", "groups"=>["system:serviceaccounts", "system:serviceaccounts:cattle-system", "system:authenticated"]}, "impersonatedUser"=>{"username"=>"u-toto", "groups"=>["googleoauth_group://tata", "system:authenticated", "system:cattle:authenticated"]}, "sourceIPs"=>["172.16.20.1"], "userAgent"=>"agent/v0.0.0 (linux/amd64) kubernetes/$Format", "objectRef"=>{"resource"=>"secrets", "apiVersion"=>"v1"}, "responseStatus"=>{"metadata"=>{}, "status"=>"Success", "message"=>"Connection closed early", "code"=>200}, "requestReceivedTimestamp"=>"2021-02-25T17:37:22.861878Z", "stageTimestamp"=>"2021-02-25T17:37:22.862892Z", "annotations"=>{"authorization.k8s.io/decision"=>"allow", "authorization.k8s.io/reason"=>"RBAC: allowed by ClusterRoleBinding "clusterrolebinding-66jsq" of ClusterRole "cluster-owner" to Group "googleoauth_group://tata""}}]
[2021/03/10 17:30:54] [debug] [out coro] cb_destroy coro_id=0
[2021/03/10 17:30:54] [debug] [task] destroy task=0x4cbb290 (task_id=0)
^C[2021/03/10 17:30:55] [engine] caught signal (SIGINT)
[2021/03/10 17:30:55] [ info] [input] pausing tail.0
[2021/03/10 17:30:55] [ warn] [engine] service will stop in 5 seconds
[2021/03/10 17:30:59] [ info] [engine] service stopped
[2021/03/10 17:30:59] [debug] [input:tail:tail.0] inode=1450580 removing file name a.log
[2021/03/10 17:30:59] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1450580 watch_fd=1
==4377== 
==4377== HEAP SUMMARY:
==4377==     in use at exit: 0 bytes in 0 blocks
==4377==   total heap usage: 2,608 allocs, 2,608 frees, 901,833 bytes allocated
==4377== 
==4377== All heap blocks were freed -- no leaks are possible
==4377== 
==4377== For lists of detected and suppressed errors, rerun with: -s
==4377== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
