### PR TITLE
tests: internal: fuzzers: http: fix memory leak

### DIFF
--- a/tests/internal/fuzzers/http_fuzzer.c
+++ b/tests/internal/fuzzers/http_fuzzer.c
@@ -62,12 +62,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         flb_http_buffer_size(c, (int)data[0]);
         MOVE_INPUT(1)
         flb_http_buffer_available(c);
-        size_t out_size = 0;
-        flb_http_buffer_increase(c, (*(size_t *)data) & 0xfff, &out_size);
-        MOVE_INPUT(4)
 
         size_t b_sent;
         flb_http_do(c, &b_sent);
+
+        size_t out_size = 0;
+        if (flb_http_buffer_increase(c, (*(size_t *)data) & 0xfff, &out_size) == 0) {
+            flb_free(c->resp.data);
+        }
+        MOVE_INPUT(4)
 
         /* Now we need to simulate the reading of data */
         c->resp.status = 200;


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

Fixes a memory leak in the http fuzzer. 
This PR only modifies fuzzer code.
Fixes OSS-Fuzz issue 5068770146123776
Bug tracker ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28233

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
