### PR TITLE
tests: internal: fuzzers: record-ac-fuzzer: fix various leaks

### DIFF
--- a/tests/internal/fuzzers/record_ac_fuzzer.c
+++ b/tests/internal/fuzzers/record_ac_fuzzer.c
@@ -10,7 +10,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    char *outbuf;
+    char *outbuf = NULL;
     size_t outsize;
     int type;
     int len;
@@ -33,13 +33,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         flb_free(json_raw);
         return 0;
     }
+    flb_free(json_raw);
 
     char *null_terminated = get_null_terminated(size, &data, &size);
 
     char *ra_str = flb_sds_create(null_terminated);
     ra = flb_ra_create(ra_str, FLB_FALSE);
     if (!ra) {
+        flb_sds_destroy(ra_str);
         flb_free(null_terminated);
+        flb_free(outbuf);
         return 0;
     }
 
@@ -57,7 +60,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         /* General cleanup */
         flb_free(null_terminated);
-		flb_free(json_raw);
+        flb_free(outbuf);
         return 0;
     }
     flb_ra_dump(ra);
@@ -72,6 +75,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     /* General cleanup */
     flb_free(null_terminated);
-    flb_free(json_raw);
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->

Cleans up and fixes multiple leaks in record-ac-fuzzer
This PR only modifies fuzzer code.
OSS-Fuzz issue: 5447069940711424
Bugtracker ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30633

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
