### PR TITLE
build: use docker buildx to build images

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -75,7 +75,18 @@ jobs:
       max-parallel: 48
       fail-fast: true
       matrix:
-        arch: [ x86_64, arm64v8, arm32v7, x86_64-debug ]
+        arch: [ amd64, arm64v8, arm32v7 ]
+        suffix: [ x86_64, arm64v8, arm32v7, x86_64-debug ]
+        os: [ linux ]
+        exclude:
+          - {arch: amd64, suffix: arm64v8}
+          - {arch: amd64, suffix: arm32v7}
+          - {arch: arm64v8, suffix: x86_64}
+          - {arch: arm64v8, suffix: arm32v7}
+          - {arch: arm64v8, suffix: x86_64-debug}
+          - {arch: arm32v7, suffix: x86_64}
+          - {arch: arm32v7, suffix: arm64v8}
+          - {arch: arm32v7, suffix: x86_64-debug}
     runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
     steps:
       - uses: actions/checkout@master
@@ -98,10 +109,12 @@ jobs:
           flags: 'g'
 
       - name: Build the docker images
-        run: docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }} -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ env.release }} .
+        run: docker buildx build --no-cache -f ./dockerfiles/Dockerfile.${{ env.suffix }} -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.suffix }}-${{ env.release }} --platform ${{ env.os }}/${{ env.arch }} .
         env:
           release: ${{ steps.formatted_version.outputs.replaced }}
           arch: ${{ matrix.arch }}
+          suffix: ${{ matrix.suffix }}
+          os: ${{ matrix.os }}
           dockerhub_organization: ${{ secrets.DOCKERHUB_ORGANIZATION }}
 
       - name: Archive the docker images

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,7 +635,7 @@ if(FLB_BACKTRACE)
   FLB_DEFINITION(FLB_HAVE_LIBBACKTRACE)
   ExternalProject_Add(backtrace
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/configure ${AUTOCONF_HOST_OPT} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/configure ${AUTOCONF_HOST_OPT} --host=${HOST} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
     BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
     INSTALL_COMMAND $(MAKE) DESTDIR= install
     )

--- a/cmake/linux-arm64.cmake
+++ b/cmake/linux-arm64.cmake
@@ -1,12 +1,17 @@
 SET(HOST aarch64-linux-gnu)
 
 SET(CROSS_PREFIX ${HOST}-)
+SET(CMAKE_SYSROOT /)
 
 SET(CMAKE_SYSTEM_NAME Linux)
 SET(CMAKE_C_COMPILER ${CROSS_PREFIX}gcc)
 SET(CMAKE_CXX_COMPILER ${CROSS_PREFIX}g++)
 
-SET(CMAKE_FIND_ROOT_PATH /usr/lib/aarch64-linux-gnu /usr/aarch64-linux-gnu)
+SET(CMAKE_FIND_ROOT_PATH /usr/lib/aarch64-linux-gnu /usr/aarch64-linux-gnu /lib/aarch64-linux-gnu)
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+SET(PKG_CONFIG_EXECUTABLE "/usr/bin/aarch64-linux-gnu-pkg-config" CACHE FILEPATH "pkg-config executable")
+SET(PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig)

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -1,84 +1,90 @@
-FROM arm64v8/debian:buster-slim as builder
+FROM --platform=linux/arm64 debian:buster as dep
 
-COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+RUN apt update && \
+    apt install -y --no-install-recommends \
+    libssl-dev \
+    libsasl2-dev \
+    libsystemd-dev \
+    libzstd-dev \
+    zlib1g-dev \
+    libpq-dev \
+    postgresql-server-dev-all
+
+# Build on amd64 and cross-compile to arch for max speed
+FROM --platform=linux/amd64 debian:buster as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
-ENV FLB_MINOR 7
-ENV FLB_PATCH 1
-ENV FLB_VERSION 1.7.1
-
-ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
-ENV FLB_SOURCE $FLB_TARBALL
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+ENV FLB_MINOR 8
+ENV FLB_PATCH 0
+ENV FLB_VERSION 1.8.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt update && \
+    apt install -y --no-install-recommends \
     build-essential \
+    g++-aarch64-linux-gnu \
+    gcc-aarch64-linux-gnu \
     curl \
     ca-certificates \
+    pkg-config \
     cmake \
     make \
     tar \
-    libssl-dev \
-    libsasl2-dev \
-    pkg-config \
-    libsystemd-dev \
-    zlib1g-dev \
-    libpq-dev \
-    postgresql-server-dev-all \
     flex \
-    bison \
-    && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
-    && cd tmp/ && mkdir fluent-bit \
-    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
-    && cd fluent-bit/build/ \
-    && rm -rf /tmp/fluent-bit/build/*
+    bison
 
-WORKDIR /tmp/fluent-bit/build/
+COPY --from=dep /usr/lib/aarch64-linux-gnu /usr/lib
+COPY --from=dep /lib/aarch64-linux-gnu /lib
+COPY --from=dep /usr/include /usr/include
+
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
+COPY . /tmp/src/
+RUN rm -rf /tmp/src/build/*
+
+WORKDIR /tmp/src/build/
 RUN cmake -DFLB_RELEASE=On \
-          -DFLB_TRACE=Off \
-          -DFLB_JEMALLOC=On \
-          -DFLB_TLS=On \
-          -DFLB_SHARED_LIB=Off \
-          -DFLB_EXAMPLES=Off \
-          -DFLB_HTTP_SERVER=On \
-          -DFLB_IN_SYSTEMD=On \
-          -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+    -DFLB_TRACE=Off \
+    -DFLB_JEMALLOC=On \
+    -DFLB_TLS=On \
+    -DFLB_SHARED_LIB=Off \
+    -DFLB_EXAMPLES=Off \
+    -DFLB_HTTP_SERVER=On \
+    -DFLB_IN_SYSTEMD=On \
+    -DFLB_OUT_KAFKA=On \
+    -DFLB_OUT_PGSQL=On \
+    -DCMAKE_TOOLCHAIN_FILE=/tmp/src/cmake/linux-arm64.cmake ../
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
-# Configuration files
-COPY conf/fluent-bit.conf \
-     conf/parsers.conf \
-     conf/parsers_ambassador.conf \
-     conf/parsers_java.conf \
-     conf/parsers_extra.conf \
-     conf/parsers_openstack.conf \
-     conf/parsers_cinder.conf \
-     conf/plugins.conf \
-     /fluent-bit/etc/
+FROM --platform=linux/arm64 debian:buster-slim
+LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
+LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
-FROM arm64v8/debian:buster-slim
-COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      libssl1.1 \
-      libsasl2-2 \
-      pkg-config \
-      libpq5 \
-      libsystemd0 \
-      zlib1g \
-      ca-certificates
+RUN apt update && \
+    apt install -y --no-install-recommends \
+    libssl1.1 \
+    libsasl2-2 \
+    pkg-config \
+    libpq5 \
+    libsystemd0 \
+    zlib1g \
+    ca-certificates
 
 COPY --from=builder /fluent-bit /fluent-bit
 
-RUN rm /usr/bin/qemu-aarch64-static
+# Configuration files
+COPY conf/fluent-bit.conf \
+    conf/parsers.conf \
+    conf/parsers_ambassador.conf \
+    conf/parsers_java.conf \
+    conf/parsers_extra.conf \
+    conf/parsers_openstack.conf \
+    conf/parsers_cinder.conf \
+    conf/plugins.conf \
+    /fluent-bit/etc/
 
 #
 EXPOSE 2020


### PR DESCRIPTION
Updated the build-release file to use docker buildx. This way, we
can natively cross-compile multi-arch docker images. Updated
dockerfiles/Dockerfile.arm64v8 to use native cross-compilation instead
of QEMU emulation.

Docker buildx is compatible with docker build commands, so existing
builds should not be affected.

#3119

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

This change is about the configuration file(s) so no example configuration is needed.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
