### PR TITLE
workflows: add commit message check

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -1,0 +1,21 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[a-z\-]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:]+$'
+          error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
+          checkAllCommitMessages: 'true'
+          excludeDescription: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
***Description***

The following patch adds a linter to check commit message, according
to https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes

***Testing***

This has been tested on:
[ok] https://github.com/niedbalski/fluent-bit/actions/runs/641414633
[not-ok] https://github.com/niedbalski/fluent-bit/actions/runs/641416840

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
