### PR TITLE
out_s3: Support MinIO

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -119,6 +119,8 @@ struct flb_s3 {
     int send_content_md5;
     int static_file_path;
     int compression;
+    int port;
+    int insecure;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;


### PR DESCRIPTION
Fixes #3188 
Fixes #2986

I added the MinIO support which allows HTTP access or TLS w/o verification. I'm not sure if we can just add `tls_verify` option in the output/s3 config because it might be confusing as we have [the global TLS configuration](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/tcp-and-tls.md#tls-configuration-parameters). Please tell me a better way if any.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

<details>
<summary>valgrind log</summary>

```
==17380== Memcheck, a memory error detector
==17380== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17380== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==17380== Command: ./bin/fluent-bit -c /src/fluent.conf
==17380==
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/11 16:08:08] [ info] [engine] started (pid=17380)
[2021/03/11 16:08:08] [ info] [storage] version=1.1.1, initializing...
[2021/03/11 16:08:08] [ info] [storage] in-memory
[2021/03/11 16:08:08] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/11 16:08:08] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2021/03/11 16:08:08] [ info] [output:s3:s3.0] S3 endpoint: host.docker.internal
[2021/03/11 16:08:08] [ info] [output:s3:s3.0] S3 port: 9000
[2021/03/11 16:08:08] [ info] [output:s3:s3.0] S3 insecure: 0
[2021/03/11 16:08:08] [ info] [output:s3:s3.0] S3 veirfy TLS: 0
[2021/03/11 16:08:08] [ info] [sp] stream processor started
==17380== Warning: client switching stacks?  SP change: 0x71f56b8 --> 0x5ef7180
==17380==          to suppress, use: --max-stackframe=19916088 or greater
==17380== Warning: client switching stacks?  SP change: 0x5ef70f8 --> 0x71f56b8
==17380==          to suppress, use: --max-stackframe=19916224 or greater
==17380== Warning: client switching stacks?  SP change: 0x71f56b8 --> 0x5ef70f8
==17380==          to suppress, use: --max-stackframe=19916224 or greater
==17380==          further instances of this message will not be shown.
[2021/03/11 16:08:19] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/16/08/13-objectLDg07cYH
^C[2021/03/11 16:08:28] [engine] caught signal (SIGINT)
[2021/03/11 16:08:28] [ info] [input] pausing cpu.0
[2021/03/11 16:08:28] [ warn] [engine] service will stop in 5 seconds
[2021/03/11 16:08:31] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/16/08/23-object5AZlAS8j
[2021/03/11 16:08:33] [ info] [engine] service stopped
==17380== Thread 2 flb-pipeline:
==17380== Invalid read of size 8
==17380==    at 0x22EEB5: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Address 0x5e7d518 is 24 bytes inside a block of size 32 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22E877: flb_tls_destroy (flb_tls.c:169)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22E787: flb_tls_create (flb_tls.c:132)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x48536C0: pthread_mutex_lock (pthread_mutex_lock.c:67)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0d0 is 32 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x48536ED: pthread_mutex_lock (pthread_mutex_lock.c:80)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0d0 is 32 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x48536FE: pthread_mutex_lock (pthread_mutex_lock.c:80)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0c0 is 16 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x485371B: pthread_mutex_lock (pthread_mutex_lock.c:81)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0c8 is 24 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x485372F: pthread_mutex_lock (pthread_mutex_lock.c:161)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0cc is 28 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid write of size 4
==17380==    at 0x4853734: pthread_mutex_lock (pthread_mutex_lock.c:159)
==17380==    by 0x22E31C: tls_session_destroy (openssl.c:332)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0c8 is 24 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x4854EA0: __pthread_mutex_unlock_usercnt (pthread_mutex_unlock.c:40)
==17380==    by 0x22E377: tls_session_destroy (openssl.c:341)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0d0 is 32 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid write of size 4
==17380==    at 0x4854EBA: __pthread_mutex_unlock_usercnt (pthread_mutex_unlock.c:50)
==17380==    by 0x22E377: tls_session_destroy (openssl.c:341)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0c8 is 24 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x4854EF0: __pthread_mutex_unlock_usercnt (pthread_mutex_unlock.c:53)
==17380==    by 0x22E377: tls_session_destroy (openssl.c:341)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0cc is 28 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x4854EC5: __pthread_mutex_unlock_usercnt (pthread_mutex_unlock.c:56)
==17380==    by 0x22E377: tls_session_destroy (openssl.c:341)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0d0 is 32 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Invalid read of size 4
==17380==    at 0x4854ECE: __pthread_mutex_unlock_usercnt (pthread_mutex_unlock.c:56)
==17380==    by 0x22E377: tls_session_destroy (openssl.c:341)
==17380==    by 0x22EECC: flb_tls_session_destroy (flb_tls.c:394)
==17380==    by 0x220E11: destroy_conn (flb_upstream.c:345)
==17380==    by 0x221229: flb_upstream_destroy (flb_upstream.c:461)
==17380==    by 0x2F3A62: flb_aws_client_destroy (flb_aws_util.c:217)
==17380==    by 0x2C48EF: s3_context_destroy (s3.c:299)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==  Address 0x5e7d0c0 is 16 bytes inside a block of size 56 free'd
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x22D92E: flb_free (flb_mem.h:122)
==17380==    by 0x22DD14: tls_context_destroy (openssl.c:134)
==17380==    by 0x22E84E: flb_tls_destroy (flb_tls.c:164)
==17380==    by 0x2C48CC: s3_context_destroy (s3.c:295)
==17380==    by 0x2C8ED2: cb_s3_exit (s3.c:1505)
==17380==    by 0x20CE19: flb_output_exit (flb_output.c:310)
==17380==    by 0x21B0CB: flb_engine_shutdown (flb_engine.c:720)
==17380==    by 0x21AEE2: flb_engine_start (flb_engine.c:651)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==  Block was alloc'd at
==17380==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==17380==    by 0x22D8F5: flb_calloc (flb_mem.h:78)
==17380==    by 0x22DE2D: tls_context_create (openssl.c:194)
==17380==    by 0x22E731: flb_tls_create (flb_tls.c:125)
==17380==    by 0x2C5AD6: cb_s3_init (s3.c:535)
==17380==    by 0x20E510: flb_output_init_all (flb_output.c:930)
==17380==    by 0x21A863: flb_engine_start (flb_engine.c:516)
==17380==    by 0x200A62: flb_lib_worker (flb_lib.c:493)
==17380==    by 0x4850FA2: start_thread (pthread_create.c:486)
==17380==    by 0x51B54CE: clone (clone.S:95)
==17380==
==17380== Thread 1:
==17380== Invalid free() / delete / delete[] / realloc()
==17380==    at 0x48369AB: free (vg_replace_malloc.c:530)
==17380==    by 0x509CAB9: free_key_mem (dlerror.c:223)
==17380==    by 0x509CAB9: __dlerror_main_freeres (dlerror.c:239)
==17380==    by 0x5224B71: __libc_freeres (in /lib/x86_64-linux-gnu/libc-2.28.so)
==17380==    by 0x482B19E: _vgnU_freeres (vg_preloaded.c:77)
==17380==    by 0x18536F: flb_signal_handler (fluent-bit.c:501)
==17380==    by 0x50F383F: ??? (in /lib/x86_64-linux-gnu/libc-2.28.so)
==17380==    by 0x518271F: nanosleep (nanosleep.c:28)
==17380==    by 0x5182629: sleep (sleep.c:55)
==17380==    by 0x200CA4: flb_loop (flb_lib.c:558)
==17380==    by 0x18672C: flb_main (fluent-bit.c:1159)
==17380==    by 0x186764: main (fluent-bit.c:1170)
==17380==  Address 0x5d9baa0 is in a rw- anonymous segment
==17380==
==17380==
==17380== HEAP SUMMARY:
==17380==     in use at exit: 195,972 bytes in 4,324 blocks
==17380==   total heap usage: 7,684 allocs, 3,361 frees, 3,479,317 bytes allocated
==17380==
==17380== LEAK SUMMARY:
==17380==    definitely lost: 0 bytes in 0 blocks
==17380==    indirectly lost: 0 bytes in 0 blocks
==17380==      possibly lost: 0 bytes in 0 blocks
==17380==    still reachable: 195,972 bytes in 4,324 blocks
==17380==         suppressed: 0 bytes in 0 blocks
==17380== Rerun with --leak-check=full to see details of leaked memory
==17380==
==17380== For counts of detected and suppressed errors, rerun with: -v
==17380== ERROR SUMMARY: 18 errors from 13 contexts (suppressed: 0 from 0)
```

</details>

This is my first time using valgrind, so I'm not sure whether the leak comes from my change...

### No TLS Verification

Run MinIO w/ a self-signed certificate.

```bash
$ openssl req -batch -new -x509 -newkey rsa:2048 -nodes -sha256 -subj /CN=example.com/O=foo -days 365 -keyout config/certs/private.key -out config/certs/public.crt
$ docker run --rm -p 9000:9000 --name minio -e MINIO_ACCESS_KEY=$AWS_ACCESS_KEY_ID -e MINIO_SECRET_KEY=$AWS_SECRET_ACCESS_KEY -v $PWD/export:/export -v $PWD/config:/root/.minio minio/minio server /export
```

Example config
```
[INPUT]
  Name        cpu

[OUTPUT]
  Name s3
  Match *
  bucket example
  endpoint http://host.docker.internal:9000
```

Log
```
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/11 16:02:57] [ info] [engine] started (pid=17023)
[2021/03/11 16:02:57] [ info] [storage] version=1.1.1, initializing...
[2021/03/11 16:02:57] [ info] [storage] in-memory
[2021/03/11 16:02:57] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/11 16:02:57] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2021/03/11 16:02:57] [ info] [output:s3:s3.0] S3 endpoint: host.docker.internal
[2021/03/11 16:02:57] [ info] [output:s3:s3.0] S3 port: 9000
[2021/03/11 16:02:57] [ info] [output:s3:s3.0] S3 insecure: 0
[2021/03/11 16:02:57] [ info] [output:s3:s3.0] S3 veirfy TLS: 0
[2021/03/11 16:02:57] [ info] [sp] stream processor started
[2021/03/11 16:03:07] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/16/03/01-objectLChO5R4s
^C[2021/03/11 16:03:09] [engine] caught signal (SIGINT)
[2021/03/11 16:03:09] [ info] [input] pausing cpu.0
[2021/03/11 16:03:09] [ warn] [engine] service will stop in 5 seconds
[2021/03/11 16:03:13] [ info] [engine] service stopped
[2021/03/11 16:03:13] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2021/03/11 16:03:13] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/16/03/09-objectP69b7aTs
```

### Insecure

Run MinIO w/o TLS.

```bash
$ docker run --rm -p 9000:9000 --name minio -e MINIO_ACCESS_KEY=$AWS_ACCESS_KEY_ID -e MINIO_SECRET_KEY=$AWS_SECRET_ACCESS_KEY -v $PWD/export:/export -v $PWD/config:/root/.minio minio/minio server /export
```

Example config
```
[INPUT]
  Name        cpu

[OUTPUT]
  Name s3
  Match *
  bucket example
  endpoint https://host.docker.internal:9000
  tls_verify false
```

Log
```
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/11 15:58:34] [ info] [engine] started (pid=17020)
[2021/03/11 15:58:34] [ info] [storage] version=1.1.1, initializing...
[2021/03/11 15:58:34] [ info] [storage] in-memory
[2021/03/11 15:58:34] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/11 15:58:34] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2021/03/11 15:58:34] [ info] [output:s3:s3.0] S3 endpoint: host.docker.internal
[2021/03/11 15:58:34] [ info] [output:s3:s3.0] S3 port: 9000
[2021/03/11 15:58:34] [ info] [output:s3:s3.0] S3 insecure: 1
[2021/03/11 15:58:34] [ info] [output:s3:s3.0] S3 veirfy TLS: 1
[2021/03/11 15:58:34] [ info] [sp] stream processor started
[2021/03/11 15:58:44] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/15/58/38-objectiok7s4vD
^C[2021/03/11 15:58:54] [engine] caught signal (SIGINT)
[2021/03/11 15:58:54] [ info] [input] pausing cpu.0
[2021/03/11 15:58:54] [ info] [output:s3:s3.0] upload_timeout reached for cpu.0
[2021/03/11 15:58:54] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/cpu.0/2021/03/11/15/58/48-objectFnUaPKf3
[2021/03/11 15:58:54] [ warn] [engine] service will stop in 5 seconds
[2021/03/11 15:58:58] [ info] [engine] service stopped
```

**Documentation**
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/489

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
