### PR TITLE
out_azure: support using timestamp as timegenerated

### DIFF
--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -65,6 +65,10 @@ static int azure_format(const void *in_buf, size_t in_bytes,
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
     flb_sds_t record;
+    char time_formatted[32];
+    size_t s;
+    struct tm tms;
+    int len;
 
     /* Count number of items */
     array_size = flb_mp_count(in_buf, in_bytes);
@@ -81,7 +85,6 @@ static int azure_format(const void *in_buf, size_t in_bytes,
 
         /* Get timestamp */
         flb_time_pop_from_msgpack(&tm, &result, &obj);
-        t = flb_time_to_double(&tm);
 
         /* Create temporary msgpack buffer */
         msgpack_sbuffer_init(&tmp_sbuf);
@@ -95,9 +98,27 @@ static int azure_format(const void *in_buf, size_t in_bytes,
         /* Append the time key */
         msgpack_pack_str(&mp_pck, flb_sds_len(ctx->time_key));
         msgpack_pack_str_body(&mp_pck,
-                              ctx->time_key,
-                              flb_sds_len(ctx->time_key));
-        msgpack_pack_double(&mp_pck, t);
+                            ctx->time_key,
+                            flb_sds_len(ctx->time_key));
+
+        if (ctx->time_generated == FLB_TRUE) {
+            /* Append the time value as ISO 8601 */
+            gmtime_r(&tm.tm.tv_sec, &tms);
+            s = strftime(time_formatted, sizeof(time_formatted) - 1,
+                            FLB_PACK_JSON_DATE_ISO8601_FMT, &tms);
+
+            len = snprintf(time_formatted + s,
+                            sizeof(time_formatted) - 1 - s,
+                            ".%03" PRIu64 "Z",
+                            (uint64_t) tm.tm.tv_nsec / 1000000);
+            s += len;
+            msgpack_pack_str(&mp_pck, s);
+            msgpack_pack_str_body(&mp_pck, time_formatted, s);
+        } else {
+            /* Append the time value as millis.nanos */
+            t = flb_time_to_double(&tm);
+            msgpack_pack_double(&mp_pck, t);
+        }
 
         /* Append original map k/v */
         for (i = 0; i < map_size; i++) {
@@ -206,6 +227,10 @@ static int build_headers(struct flb_http_client *c,
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
     flb_http_add_header(c, "x-ms-date", 9, rfc1123date,
                         flb_sds_len(rfc1123date));
+    if (ctx->time_generated == FLB_TRUE) {
+        /* Use time value as time-generated within azure */
+        flb_http_add_header(c, "time-generated-field", 20, ctx->time_key, flb_sds_len(ctx->time_key));
+    }
 
     size = 32 + flb_sds_len(ctx->customer_id) + olen;
     auth = flb_malloc(size);

--- a/plugins/out_azure/azure.h
+++ b/plugins/out_azure/azure.h
@@ -47,6 +47,9 @@ struct flb_azure {
     /* records */
     flb_sds_t time_key;
 
+    /* time_generated: on/off */
+    int time_generated;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/plugins/out_azure/azure_conf.c
+++ b/plugins/out_azure/azure_conf.c
@@ -119,6 +119,15 @@ struct flb_azure *flb_azure_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    /* config: 'time_generated' */
+    tmp = flb_output_get_property("time_generated", ins);
+    if (tmp) {
+        ctx->time_generated = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->time_generated = FLB_FALSE;
+    }
+
     /* Validate hostname given by command line or 'Host' property */
     if (!ins->host.name && !cid) {
         flb_plg_error(ctx->ins, "property 'customer_id' is not defined");

--- a/plugins/out_azure/azure_conf.c
+++ b/plugins/out_azure/azure_conf.c
@@ -43,6 +43,15 @@ struct flb_azure *flb_azure_conf_create(struct flb_output_instance *ins,
     }
     ctx->ins = ins;
 
+    /* Set context */
+    flb_output_set_context(ins, ctx);
+
+    /* Load config map */
+    ret = flb_output_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        return NULL;
+    }
+
     /* config: 'customer_id' */
     cid = flb_output_get_property("customer_id", ins);
     if (cid) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

When supplied the timegenerated field can override the automatic generated
ingestion timestamp from azure. In order to support this usecase a new option
time_generated is introduced. If this setting gets enabled the already
present timestamp value will be formatted in accordance with the azure api
specification and during the api call the setting to override the
timegenerated field gets set.

The documentation is available at:
https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #1423

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

### Example
```
[INPUT]
    Name   dummy
    Tag    source.docker.test
    Rate 1000

[OUTPUT]
    Name        azure
    Match       source.docker.*
    Customer_ID ID_GOES_HERE
    Shared_Key  SHARED_KEY_HERE
    Log_Type test
    Time_Generated On
```

### Valgrind
```
==22492==
==22492== HEAP SUMMARY:
==22492==     in use at exit: 108,278 bytes in 3,682 blocks
==22492==   total heap usage: 247,268 allocs, 243,586 frees, 1,107,529,898 bytes allocated
==22492==
==22492== LEAK SUMMARY:
==22492==    definitely lost: 0 bytes in 0 blocks
==22492==    indirectly lost: 0 bytes in 0 blocks
==22492==      possibly lost: 0 bytes in 0 blocks
==22492==    still reachable: 108,278 bytes in 3,682 blocks
==22492==         suppressed: 0 bytes in 0 blocks
==22492== Reachable blocks (those to which a pointer was found) are not shown.
==22492== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==22492==
==22492== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

I will update the docs if this PR gets accepted in it's current state.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
