### PR TITLE
out_splunk: prioritize http_user/password over splunk_token.

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -221,8 +221,14 @@ static void cb_splunk_flush(const void *data, size_t bytes,
     flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX);
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
 
-    flb_http_add_header(c, "Authorization", 13,
-                        ctx->auth_header, flb_sds_len(ctx->auth_header));
+    /* Try to use http_user and http_passwd if not, fallback to auth_header */
+    if (ctx->http_user && ctx->http_passwd) {
+        flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    }
+    else if (ctx->auth_header) {
+        flb_http_add_header(c, "Authorization", 13,
+                            ctx->auth_header, flb_sds_len(ctx->auth_header));
+    }
 
     /* Content Encoding: gzip */
     if (compressed == FLB_TRUE) {


### PR DESCRIPTION
This patch makes http_user/password configuration the priority, if unset, it will default to splunk_token.

If splunk_token && http_user is unset, it will return an error.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [X] Debug log output from testing the change

$ ./bin/fluent-bit -i random -o splunk
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/16 19:15:47] [ info] [engine] started (pid=36038)
[2021/03/16 19:15:47] [ info] [storage] version=1.1.1, initializing...
[2021/03/16 19:15:47] [ info] [storage] in-memory
[2021/03/16 19:15:47] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/16 19:15:47] [error] [output:splunk:splunk.0] either splunk_token or http_user should be set
[2021/03/16 19:15:47] [error] [output:splunk:splunk.0] configuration failed
[2021/03/16 19:15:47] [error] [output] Failed to initialize 'splunk' plugin
[2021/03/16 19:15:47] [error] [lib] backend failed


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
