### PR TITLE
workflows: check only last comment.

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -16,6 +16,6 @@ jobs:
         with:
           pattern: '^[a-z\-]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
-          checkAllCommitMessages: 'true'
+          checkAllCommitMessages: 'false'
           excludeDescription: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switches checkallcommitmessages to false  to only check last commit.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
