### PR TITLE
workflows: master should run from arch-master

### DIFF
--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -149,5 +149,5 @@ jobs:
       - run: make integration
         env:
           IMAGE_REPOSITORY: fluentbitdev/fluent-bit
-          IMAGE_TAG: x86_64-master-pr-${{ github.event.pull_request.number }}
+          IMAGE_TAG: x86_64-master
         working-directory: ci/


### PR DESCRIPTION
Fixes master branch should run from x86_64-master tag, not from latest PR.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
