### PR TITLE
workflows: add tag right before image publish

### DIFF
--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -42,6 +42,13 @@ jobs:
           arch: x86_64
           dockerhub_organization: fluentbitdev
 
+      - run: |
+          ./scripts/grafana-add-tag.sh
+        env:
+          GRAFANA_CLOUD_TOKEN: ${{ secrets.GRAFANA_CLOUD_TOKEN }}
+          COMMIT_ID: ${{ github.event.workflow_run.head_sha }}
+        working-directory: ci/
+
   run-integration-gcp:
     name: run-integration on GCP - k8s ${{ matrix.k8s-release }}
     needs: publish-docker-images
@@ -151,11 +158,3 @@ jobs:
           IMAGE_REPOSITORY: fluentbitdev/fluent-bit
           IMAGE_TAG: x86_64-master
         working-directory: ci/
-
-      - run: |
-          ./scripts/grafana-add-tag.sh
-        env:
-          GRAFANA_CLOUD_TOKEN: ${{ secrets.GRAFANA_CLOUD_TOKEN }}
-          COMMIT_ID: ${{ github.event.workflow_run.head_sha }}
-        working-directory: ci/
-


### PR DESCRIPTION
* This patch prevents adding commit tag before running integration tests.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
