### PR TITLE
workflows: clone ci repository on publish_images

### DIFF
--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -10,6 +10,11 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: calyptia/fluent-bit-ci
+          path: ci
+      
       - name: Download docker image from build artifacts
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
* Add a task for clone ci repository on publish_images

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
