### PR TITLE
output: add multiplex option for output plugin

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -718,6 +718,17 @@ int flb_output_set_property(struct flb_output_instance *ins,
         ins->tp_workers = atoi(tmp);
         flb_sds_destroy(tmp);
     }
+    else if (prop_key_check("multiplex", k, len) == 0 && tmp) {
+        if (strcasecmp(tmp, "off") == 0 ||
+            flb_utils_bool(tmp) == FLB_FALSE) {
+            /* disable multiplex for output plugin */
+            flb_info("[config] no multiplex for %s plugin", ins->name);
+            ins->flags = ins->flags | FLB_OUTPUT_NO_MULTIPLEX;
+        }
+        else {
+            ins->flags = ins->flags & ~FLB_OUTPUT_NO_MULTIPLEX;
+        }
+    }
     else {
         /*
          * Create the property, we don't pass the value since we will


### PR DESCRIPTION
Add keep order option for output plugin.

This option will help user send logs to the storage server which can not sort log lines according to timestamp.
Such as AzureBlob/S3.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
