### PR TITLE
workflows: add grafana cloud creds to integration tests

### DIFF
--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -162,4 +162,6 @@ jobs:
         env:
           IMAGE_REPOSITORY: fluentbitdev/fluent-bit
           IMAGE_TAG: x86_64-master
+          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
         working-directory: ci/

--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -182,6 +182,8 @@ jobs:
         env:
           IMAGE_REPOSITORY: fluentbitdev/fluent-bit
           IMAGE_TAG: x86_64-master-pr-${{ github.event.pull_request.number }}
+          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
         working-directory: ci/
 
       - uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
This is a follow-up PR to https://github.com/calyptia/fluent-bit-ci/pull/6

**Testing**

Testing has been performed on https://github.com/calyptia/fluent-bit-ci/pull/6

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
