### PR TITLE
out_loki: support new option tenant_id_key(#2935)

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -599,6 +599,13 @@ static void loki_config_destroy(struct flb_loki *ctx)
     if (ctx->ra_k8s) {
         flb_ra_destroy(ctx->ra_k8s);
     }
+    if (ctx->ra_tenant_id_key) {
+        flb_ra_destroy(ctx->ra_tenant_id_key);
+        if (ctx->dynamic_tenant_id) {
+            flb_sds_destroy(ctx->dynamic_tenant_id);
+            ctx->dynamic_tenant_id = NULL;
+        }
+    }
 
     if (ctx->remove_mpa) {
         flb_mp_accessor_destroy(ctx->remove_mpa);
@@ -651,6 +658,16 @@ static struct flb_loki *loki_config_create(struct flb_output_instance *ins,
     ret = prepare_remove_keys(ctx);
     if (ret == -1) {
         return NULL;
+    }
+
+    /* tenant_id_key */
+    if (ctx->tenant_id_key_config) {
+        ctx->ra_tenant_id_key = flb_ra_create(ctx->tenant_id_key_config, FLB_FALSE);
+        if (!ctx->ra_tenant_id_key) {
+            flb_plg_error(ctx->ins,
+                          "could not create record accessor for Tenant ID");
+        }
+        ctx->dynamic_tenant_id = NULL;
     }
 
     /* Line Format */
@@ -796,6 +813,57 @@ static void pack_format_line_value(flb_sds_t buf, msgpack_object *val)
     }
 }
 
+// seek tenant id from map and set it to ctx->dynamic_tenant_id
+static int get_tenant_id_from_record(struct flb_loki *ctx, msgpack_object *map)
+{
+    struct flb_ra_value *rval = NULL;
+    flb_sds_t tmp_str;
+    int cmp_len;
+
+    rval = flb_ra_get_value_object(ctx->ra_tenant_id_key, *map);
+
+    if (rval == NULL) {
+        flb_plg_warn(ctx->ins, "the value of %s is missing",
+                     ctx->tenant_id_key_config);
+        return -1;
+    }
+    else if (rval->o.type != MSGPACK_OBJECT_STR) {
+        flb_plg_warn(ctx->ins, "the value of %s is not string",
+                     ctx->tenant_id_key_config);
+        return -1;
+    }
+
+    tmp_str = flb_sds_create_len(rval->o.via.str.ptr,
+                                 rval->o.via.str.size);
+    if (tmp_str == NULL) {
+        flb_plg_warn(ctx->ins, "cannot create tenant ID string from record");
+        flb_ra_key_value_destroy(rval);
+        return -1;
+    }
+
+    // check if already dynamic_tenant_id is set.
+    if (ctx->dynamic_tenant_id) {
+        cmp_len = flb_sds_len(ctx->dynamic_tenant_id);
+        if ((rval->o.via.str.size == cmp_len) &&
+            flb_sds_cmp(tmp_str, ctx->dynamic_tenant_id, cmp_len) == 0) {
+            // tenant_id is same. nothing to do.
+            flb_ra_key_value_destroy(rval);
+            flb_sds_destroy(tmp_str);
+            return 0;
+        }
+        flb_plg_warn(ctx->ins, "Tenant ID is overwritten %s -> %s",
+                     ctx->dynamic_tenant_id, tmp_str);
+        flb_sds_destroy(ctx->dynamic_tenant_id);
+    }
+
+    // this sds will be released after setting http header.
+    ctx->dynamic_tenant_id = tmp_str;
+    flb_plg_debug(ctx->ins, "Tenant ID is %s", ctx->dynamic_tenant_id);
+
+    flb_ra_key_value_destroy(rval);
+    return 0;
+}
+
 static int pack_record(struct flb_loki *ctx,
                        msgpack_packer *mp_pck, msgpack_object *rec)
 {
@@ -827,6 +895,11 @@ static int pack_record(struct flb_loki *ctx,
             }
             rec = &mp_buffer.data;
         }
+    }
+
+    // Get tenant id from record.
+    if (ctx->ra_tenant_id_key && rec->type == MSGPACK_OBJECT_MAP) {
+        get_tenant_id_from_record(ctx, rec);
     }
 
     if (ctx->out_line_format == FLB_LOKI_FMT_JSON) {
@@ -1103,7 +1176,15 @@ static void cb_loki_flush(const void *data, size_t bytes,
                         FLB_LOKI_CT_JSON, sizeof(FLB_LOKI_CT_JSON) - 1);
 
     /* Add X-Scope-OrgID header */
-    if (ctx->tenant_id) {
+    if (ctx->dynamic_tenant_id) {
+        flb_http_add_header(c,
+                            FLB_LOKI_HEADER_SCOPE, sizeof(FLB_LOKI_HEADER_SCOPE) - 1,
+                            ctx->dynamic_tenant_id,
+                            flb_sds_len(ctx->dynamic_tenant_id));
+        flb_sds_destroy(ctx->dynamic_tenant_id);
+        ctx->dynamic_tenant_id = NULL; // clear for next flush
+    }
+    else if (ctx->tenant_id) {
         flb_http_add_header(c,
                             FLB_LOKI_HEADER_SCOPE, sizeof(FLB_LOKI_HEADER_SCOPE) - 1,
                             ctx->tenant_id, flb_sds_len(ctx->tenant_id));
@@ -1182,6 +1263,12 @@ static struct flb_config_map config_map[] = {
      "Tenant ID used by default to push logs to Loki. If omitted or empty "
      "it assumes Loki is running in single-tenant mode and no X-Scope-OrgID "
      "header is sent."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "tenant_id_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_loki, tenant_id_key_config),
+     "If set, X-Scope-OrgID will be the value of the key from incoming record. "
+     "It is useful to set X-Scode-OrgID dynamically."
     },
 
     {

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -55,6 +55,7 @@ struct flb_loki {
     int auto_kubernetes_labels;
     flb_sds_t line_format;
     flb_sds_t tenant_id;
+    flb_sds_t tenant_id_key_config;
 
     /* HTTP Auth */
     flb_sds_t http_user;
@@ -74,6 +75,8 @@ struct flb_loki {
     struct mk_list labels_list;         /* list of flb_loki_kv nodes */
     struct mk_list remove_keys_derived; /* remove_keys with label RAs */
     struct flb_mp_accessor *remove_mpa; /* remove_keys multi-pattern accessor */
+    struct flb_record_accessor *ra_tenant_id_key; /* dynamic tenant id key */
+    flb_sds_t dynamic_tenant_id; /* temporary buffer for tenant id */
 
     /* Upstream Context */
     struct flb_upstream *u;


### PR DESCRIPTION

<!-- Provide summary of changes -->
Fixes #2935

This patch support new option `tenant_id_key`.
The option allows record accessor for nested value.

Note:
If different values are sent to a loki plugin at once, `X-Scope-OrdID` will be set the value of last record.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Cofiguration

Fluent-bit will send a dummy record which has `"tenant_id":"MyTenant"`.
This configuration is to set `tenant_id_key` and fluent-bit will set `MyTenant` as X-Scope-OrgID.

a.conf:
```
[INPUT]
    name dummy
    dummy    {"tenant_id":"MyTenant", "data":"hoge", "nested":{"key":"MyTenant2"}}

[OUTPUT]
    name loki
    tenant_id_key tenant_id

## also support nested key
#    tenant_id_key $nested['key']
```

## Debug log

This testing log using nc to check `X-Scope-OrgID`.
1. exec `nc -l 3100`
2. exec fluent-bit to send nc

```
nc -l 3100
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/20 09:41:19] [ info] [engine] started (pid=24809)
[2021/03/20 09:41:19] [ info] [storage] version=1.1.1, initializing...
[2021/03/20 09:41:19] [ info] [storage] in-memory
[2021/03/20 09:41:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/20 09:41:19] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/03/20 09:41:19] [ info] [sp] stream processor started
^C[2021/03/20 09:41:27] [engine] caught signal (SIGINT)
[2021/03/20 09:41:27] [ warn] [engine] service will stop in 5 seconds
[2021/03/20 09:41:32] [ info] [engine] service stopped
[2021/03/20 09:41:32] [ warn] [engine] shutdown delayed, grace period has finished but some tasks are still running.
[2021/03/20 09:41:32] [ info] [task] dummy/dummy.0 has 2 pending task(s):
[2021/03/20 09:41:32] [ info] [task]   task_id=0 still running on route(s): loki/loki.0 
[2021/03/20 09:41:32] [ info] [task]   task_id=1 still running on route(s): loki/loki.0 
[2021/03/20 09:41:32] [ warn] [engine] service will stop in 5 seconds
^C[2021/03/20 09:41:33] [engine] caught signal (SIGINT)
```

nc ouput is here. The point is `X-Scope-OrgID: MyTenant`
```
$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 488
User-Agent: Fluent-Bit
Content-Type: application/json
X-Scope-OrgID: MyTenant

{"streams":[{"stream":{"job":"fluent-bit"},"values":[["1616200879944358396","{\"tenant_id\":\"MyTenant\",\"data\":\"hoge\",\"nested\":{\"key\":\"MyTenant2\"}}"],["1616200880944288024","{\"tenant_id\":\"MyTenant\",\"data\":\"hoge\",\"nested\":{\"key\":\"MyTenant2\"}}"],["1616200881944318795","{\"tenant_id\":\"MyTenant\",\"data\":\"hoge\",\"nested\":{\"key\":\"MyTenant2\"}}"],["1616200882944294999","{\"tenant_id\":\"MyTenant\",\"data\":\"hoge\",\"nested\":{\"key\":\"MyTenant2\"}}"]]}]}
```



## Valgrind output

Launch loki using docker before testing.
```
wget https://raw.githubusercontent.com/grafana/loki/v2.2.0/cmd/loki/loki-local-config.yaml -O loki-config.yaml
docker run -v $(pwd):/mnt/config -p 3100:3100 grafana/loki:2.2.0 -config.file=/mnt/config/loki-config.yaml
```

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==24737== Memcheck, a memory error detector
==24737== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24737== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==24737== Command: ../bin/fluent-bit -c a.conf
==24737== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/20 09:39:29] [ info] [engine] started (pid=24737)
[2021/03/20 09:39:29] [ info] [storage] version=1.1.1, initializing...
[2021/03/20 09:39:29] [ info] [storage] in-memory
[2021/03/20 09:39:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/20 09:39:29] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/03/20 09:39:29] [ info] [sp] stream processor started
==24737== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c76750
==24737==          to suppress, use: --max-stackframe=11985256 or greater
==24737== Warning: client switching stacks?  SP change: 0x4c766c8 --> 0x57e48b8
==24737==          to suppress, use: --max-stackframe=11985392 or greater
==24737== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c766c8
==24737==          to suppress, use: --max-stackframe=11985392 or greater
==24737==          further instances of this message will not be shown.
[2021/03/20 09:39:34] [ info] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
^C[2021/03/20 09:39:35] [engine] caught signal (SIGINT)
[2021/03/20 09:39:35] [ info] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
[2021/03/20 09:39:35] [ warn] [engine] service will stop in 5 seconds
[2021/03/20 09:39:39] [ info] [engine] service stopped
==24737== 
==24737== HEAP SUMMARY:
==24737==     in use at exit: 0 bytes in 0 blocks
==24737==   total heap usage: 468 allocs, 468 frees, 1,211,941 bytes allocated
==24737== 
==24737== All heap blocks were freed -- no leaks are possible
==24737== 
==24737== For lists of detected and suppressed errors, rerun with: -s
==24737== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
