### PR TITLE
[1.7]Allow 0 as Retry_Limit to disable retrying 

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -184,6 +184,10 @@ struct flb_output_plugin {
     struct mk_list _head;
 };
 
+// constants for retry_limit
+#define FLB_OUT_RETRY_UNLIMITED -1
+#define FLB_OUT_RETRY_NONE       0
+
 /*
  * Each initialized plugin must have an instance, same plugin may be
  * loaded more than one time.

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -215,6 +215,17 @@ static inline int handle_output_event(flb_pipefd_t fd, struct flb_config *config
         flb_task_users_dec(task, FLB_TRUE);
     }
     else if (ret == FLB_RETRY) {
+        if (ins->retry_limit == FLB_OUT_RETRY_NONE) {
+            flb_info("[engine] chunk '%s' is not retried (no retry config): "
+                     "task_id=%i, input=%s > output=%s (out_id=%i)",
+                     flb_input_chunk_get_name(task->ic),
+                     task_id,
+                     flb_input_name(task->i_ins),
+                     flb_output_name(ins), out_id);
+            flb_task_users_dec(task, FLB_TRUE);
+            return 0;
+        }
+
         /* Create a Task-Retry */
         retry = flb_task_retry_create(task, ins);
         if (!retry) {

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -609,7 +609,7 @@ int flb_output_set_property(struct flb_output_instance *ins,
             flb_sds_destroy(tmp);
         }
         else {
-            ins->retry_limit = FLB_OUT_RETRY_NONE;
+            ins->retry_limit = 1;
         }
     }
     else if (strncasecmp("net.", k, 4) == 0 && tmp) {

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -601,7 +601,7 @@ int flb_output_set_property(struct flb_output_instance *ins,
             if (strcasecmp(tmp, "false") == 0 ||
                 strcasecmp(tmp, "off") == 0) {
                 /* No limits for retries */
-                ins->retry_limit = -1;
+                ins->retry_limit = FLB_OUT_RETRY_UNLIMITED;
             }
             else {
                 ins->retry_limit = atoi(tmp);
@@ -609,7 +609,7 @@ int flb_output_set_property(struct flb_output_instance *ins,
             flb_sds_destroy(tmp);
         }
         else {
-            ins->retry_limit = 0;
+            ins->retry_limit = FLB_OUT_RETRY_NONE;
         }
     }
     else if (strncasecmp("net.", k, 4) == 0 && tmp) {

--- a/src/flb_sosreport.c
+++ b/src/flb_sosreport.c
@@ -308,7 +308,7 @@ int flb_sosreport(struct flb_config *config)
                    ins_out->tls_key_passwd ? "*****" : "(not set)");
         }
 #endif
-        if (ins_out->retry_limit == -1) {
+        if (ins_out->retry_limit == FLB_OUT_RETRY_UNLIMITED) {
             printf("    Retry Limit\t\tno limit\n");
         }
         else {


### PR DESCRIPTION
 #3219 for v1.7 branch.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->


## Example Configuration
```
[INPUT]
    Name dummy
    Samples 1

[OUTPUT]
    Name es
    Retry_Limit 0
```

## Debug output 

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.7.3
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/20 11:13:06] [ info] [engine] started (pid=32500)
[2021/03/20 11:13:06] [ info] [storage] version=1.1.1, initializing...
[2021/03/20 11:13:06] [ info] [storage] in-memory
[2021/03/20 11:13:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/20 11:13:06] [ info] [sp] stream processor started
[2021/03/20 11:13:10] [error] [src/flb_http_client.c:1153 errno=32] Broken pipe
[2021/03/20 11:13:10] [ warn] [output:es:es.0] http_do=-1 URI=/_bulk
[2021/03/20 11:13:10] [ info] [engine] chunk '32500-1616206386.901598454.flb' is not retried (no retry config): task_id=0, input=dummy.0 > output=es.0 (out_id=0)
^C[2021/03/20 11:13:11] [engine] caught signal (SIGINT)
[2021/03/20 11:13:11] [ warn] [engine] service will stop in 5 seconds
[2021/03/20 11:13:15] [ info] [engine] service stopped
```

## Vargrind output

```
$ valgrind ../bin/fluent-bit -c a.conf 
==32475== Memcheck, a memory error detector
==32475== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32475== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==32475== Command: ../bin/fluent-bit -c a.conf
==32475== 
Fluent Bit v1.7.3
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/20 11:09:19] [ info] [engine] started (pid=32475)
[2021/03/20 11:09:19] [ info] [storage] version=1.1.1, initializing...
[2021/03/20 11:09:19] [ info] [storage] in-memory
[2021/03/20 11:09:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/03/20 11:09:20] [ info] [sp] stream processor started
==32475== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6bd20
==32475==          to suppress, use: --max-stackframe=12028824 or greater
==32475== Warning: client switching stacks?  SP change: 0x4c6bc98 --> 0x57e48b8
==32475==          to suppress, use: --max-stackframe=12028960 or greater
==32475== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6bc98
==32475==          to suppress, use: --max-stackframe=12028960 or greater
==32475==          further instances of this message will not be shown.
[2021/03/20 11:09:25] [error] [src/flb_http_client.c:1153 errno=32] Broken pipe
[2021/03/20 11:09:25] [ warn] [output:es:es.0] http_do=-1 URI=/_bulk
[2021/03/20 11:09:25] [ info] [engine] chunk '32475-1616206160.940163777.flb' is not retried (no retry config): task_id=0, input=dummy.0 > output=es.0 (out_id=0)
^C[2021/03/20 11:09:25] [engine] caught signal (SIGINT)
[2021/03/20 11:09:25] [ warn] [engine] service will stop in 5 seconds
[2021/03/20 11:09:29] [ info] [engine] service stopped
==32475== 
==32475== HEAP SUMMARY:
==32475==     in use at exit: 0 bytes in 0 blocks
==32475==   total heap usage: 417 allocs, 417 frees, 694,308 bytes allocated
==32475== 
==32475== All heap blocks were freed -- no leaks are possible
==32475== 
==32475== For lists of detected and suppressed errors, rerun with: -s
==32475== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
