### PR TITLE
workflows: add benchmark suite

### DIFF
--- a/.github/workflows/benchmark-run-master.yaml
+++ b/.github/workflows/benchmark-run-master.yaml
@@ -1,0 +1,118 @@
+name: Run benchmark tests for master
+on:
+  workflow_run:
+    workflows: [ 'Run integration tests for master' ]
+    types:
+      - completed
+jobs:
+  run-benchmark-gcp:
+    name: run-benchmark on GCP - k8s ${{ matrix.k8s-release }}
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix:
+        k8s-release: [ '1.19', '1.20' ] #, 1.19/stable, 1.18/stable ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: calyptia/fluent-bit-ci
+          path: ci
+
+      - uses: frabert/replace-string-action@master
+        id: formatted_release
+        with:
+          pattern: '(.*)\.(.*)$'
+          string: ${{ matrix.k8s-release }}
+          replace-with: '$1-$2'
+          flags: 'g'
+
+      - name: Replace the k8s release
+        run: |
+          sed -i -e "s/\$K8S_RELEASE/${{ env.k8s_release }}/g" default.auto.tfvars
+          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" default.auto.tfvars
+          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" config.tf
+        working-directory: ci/terraform/gcp/
+        env:
+          k8s_release: ${{ matrix.k8s-release }}
+          k8s_release_formatted: ${{ steps.formatted_release.outputs.replaced }}
+
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Replace the GCP service account key
+        run: |
+          cat <<EOT >> default.auto.tfvars
+          gcp-sa-key    =  <<-EOF
+          ${{ secrets.GCP_SA_KEY }}
+          EOF
+          EOT
+        working-directory: ci/terraform/gcp/
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+        working-directory: ci/terraform/gcp/
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: ci/terraform/gcp/
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: ci/terraform/gcp/
+
+      - name: Terraform Apply
+        id: apply
+        run: |
+          terraform apply -input=false -auto-approve
+        working-directory: ci/terraform/gcp/
+
+      - name: Get the k8s cluster name from terraform output
+        id: get-k8s-cluster-name
+        run: terraform output -no-color -raw k8s-cluster-name
+        working-directory: ci/terraform/gcp/
+
+      - name: Get the k8s cluster location from terraform output
+        id: get-k8s-cluster-location
+        run: terraform output -no-color -raw k8s-cluster-location
+        working-directory: ci/terraform/gcp/
+
+      - name: Get the k8s project id from terraform output
+        id: get-gcp-project-id
+        run: terraform output -no-color -raw gcp-project-id
+        working-directory: ci/terraform/gcp/
+
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+
+      - uses: google-github-actions/get-gke-credentials@main
+        with:
+          cluster_name: ${{ steps.get-k8s-cluster-name.outputs.stdout }}
+          location: ${{ steps.get-k8s-cluster-location.outputs.stdout }}
+          credentials: ${{ secrets.GCP_SA_KEY }}
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15' # The Go version to download (if necessary) and use.
+
+      - uses: azure/setup-helm@v1
+        id: install
+
+      - run: go mod download
+        working-directory: ci/integration/
+
+      - run: make benchmark
+        env:
+          IMAGE_REPOSITORY: fluentbitdev/fluent-bit
+          IMAGE_TAG: x86_64-master
+          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+        working-directory: ci/


### PR DESCRIPTION
This commit enables the benchmark suite on master branch.

**Testing**

Tested on https://github.com/calyptia/fluent-bit-ci/pull/7/files

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
