### PR TITLE
workflows: force apt update

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Setup environment ubuntu-18.04
         if: matrix.os == 'ubuntu-18.04'
         run: |
+          sudo apt update
           sudo apt install -yyq gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr
           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 


### PR DESCRIPTION
force apt update on unit tests 18.04
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
