### PR TITLE
workflows: allow the use of an underscore ('_') in commit message

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z\-]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:]+$'
+          pattern: '^[a-z\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION
We needed this in order to allow a commit message like this:

    out_splunk: prioritize http basic auth over splunk token

In general, we refer to each plugin by "(in|out)_[a-z]*", so an
underscore should be included in the allowed list.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>