### PR TITLE
http_client: implement NO_PROXY support

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -154,6 +154,16 @@ struct flb_config {
      */
     char *http_proxy;
 
+    /*
+     * A comma-separated list of host names that shouldn't go through
+     * any proxy is set in (only an asterisk, * matches all hosts).
+     * As a convention (https://curl.se/docs/manual.html), this value can be set
+     * and respected by `NO_PROXY` environment variable when `HTTP_PROXY` is used.
+     * Example: NO_PROXY="127.0.0.1,localhost,kubernetes.default.svc"
+     * Note: only `,` is allowed as seperator between URLs.
+     */
+    char *no_proxy;
+
     /* Chunk I/O Buffering */
     void *cio;
     char *storage_path;

--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -58,4 +58,13 @@ static inline char *flb_strndup(const char *s, size_t n)
     return str;
 }
 
+/* emptyval checks whether a string has a non-null value "". */
+static inline int flb_str_emptyval(const char *s)
+{
+    if (s != NULL && strcmp(s, "") == 0) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
 #endif

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -105,6 +105,6 @@ int flb_upstream_set_property(struct flb_config *config,
 int flb_upstream_is_async(struct flb_upstream *u);
 void flb_upstream_thread_safe(struct flb_upstream *u);
 struct mk_list *flb_upstream_get_config_map(struct flb_config *config);
-
+int flb_should_proxy_for_host(const char *host, const char *proxy, const char *no_proxy);
 
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -161,9 +161,14 @@ struct flb_config *flb_config_init()
 #endif
 
     config->http_proxy = getenv("HTTP_PROXY");
-    if (config->http_proxy != NULL && strcmp(config->http_proxy, "") == 0) {
+    if (flb_str_emptyval(config->http_proxy) == FLB_TRUE) {
         /* Proxy should not be set when the `HTTP_PROXY` is set to "" */
         config->http_proxy = NULL;
+    }
+    config->no_proxy = getenv("NO_PROXY");
+    if (flb_str_emptyval(config->no_proxy) == FLB_TRUE || config->http_proxy == NULL) {
+        /* NoProxy  should not be set when the `NO_PROXYY` is set to "" or there is no Proxy. */
+        config->no_proxy = NULL;
     }
 
     config->cio          = NULL;


### PR DESCRIPTION
implement NO_PROXY support in fluent-bit:
- `NO_PROXY` is a standard environment variable for the URL should not go through the proxy, when `HTTP_PROXY` is used. 
- `NO_PROXY` is "A comma-separated list of host names that shouldn't go through any proxy is set in (only an asterisk, '*' matches all hosts)" ([reference](https://superuser.com/questions/944958/are-http-proxy-https-proxy-and-no-proxy-environment-variables-standard))

FIXES https://github.com/fluent/fluent-bit/issues/2805

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
