### PR TITLE
storage_backlog: remove corrupted chunk from disk after validation

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -115,7 +115,7 @@ static int cb_queue_chunks(struct flb_input_instance *in,
             flb_plg_error(ctx->ins, "removing chunk %s:%s from the queue",
                           sbc->stream->name, sbc->chunk->name);
             cio_chunk_down(sbc->chunk);
-            cio_chunk_close(sbc->chunk, FLB_FALSE);
+            cio_chunk_close(sbc->chunk, FLB_TRUE);
             mk_list_del(&sbc->_head);
             flb_free(sbc);
             continue;


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
From user issue, Fluent bit continuously trying to load partially failed chunks from disk on each run of Fluent Bit. This patch is to remove the failed (corrupted) chunk from disk after validation.

Eventually we want to keep the valid logs from the corrupted chunk and drop the failed parts. This is just a temporary fix to remove the whole chunk.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3229 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
