### PR TITLE
in_mqtt: add pause and resume

### DIFF
--- a/plugins/in_mqtt/mqtt.c
+++ b/plugins/in_mqtt/mqtt.c
@@ -116,6 +116,19 @@ static int in_mqtt_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static void in_mqtt_pause(void *data, struct flb_config *config)
+{
+    struct flb_in_mqtt_config *ctx = data;
+    flb_input_collector_pause(ctx->server_fd, ctx->ins);
+}
+
+
+static void in_mqtt_resume(void *data, struct flb_config *config)
+{
+    struct flb_in_mqtt_config *ctx = data;
+    flb_input_collector_resume(ctx->server_fd, ctx->ins);
+}
+
 /* Configuration properties map */	
 static struct flb_config_map config_map[] = {	
         	
@@ -131,6 +144,8 @@ struct flb_input_plugin in_mqtt_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_mqtt_collect,
     .cb_flush_buf = NULL,
+    .cb_pause     = in_mqtt_pause,
+    .cb_resume    = in_mqtt_resume,
     .cb_exit      = in_mqtt_exit,
     .config_map   = config_map,
     .flags        = FLB_INPUT_NET,


### PR DESCRIPTION
Add pause and resume support for the MQTT input plugin

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
