### PR TITLE
workflows: allow numbers in the commit title

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
+          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION
This is required to allow commit messages on out_s3 plugins e.g.

    out_s3: support UUID in s3 key format

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
