### PR TITLE
workflow: allow reference message

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
+          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION

<!-- Provide summary of changes -->

We often use `aaa: hoge(#XXXX)` to reference issue as a commit message.
Current pattern doesn't allow it.
```ruby
$ irb
irb(main):001:0> str = 'filter_record_modifier: use bias-free words. (#3179)'
irb(main):002:0> str.match /^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$/
=> nil
irb(main):003:0> 
```

This patch is to allow this style.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

## Example output

```ruby
$ irb
irb(main):001:0> str = 'filter_record_modifier: use bias-free words. (#3179)'
irb(main):002:0> str.match /^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)]+$/
=> #<MatchData "filter_record_modifier: use bias-free words. (#3179)">
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
