### PR TITLE
build: fix Dockerfile.arm64v8

### DIFF
--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -1,15 +1,3 @@
-FROM --platform=linux/arm64 debian:buster as dep
-
-RUN apt update && \
-    apt install -y --no-install-recommends \
-    libssl-dev \
-    libsasl2-dev \
-    libsystemd-dev \
-    libzstd-dev \
-    zlib1g-dev \
-    libpq-dev \
-    postgresql-server-dev-all
-
 # Build on amd64 and cross-compile to arch for max speed
 FROM --platform=linux/amd64 debian:buster as builder
 
@@ -21,72 +9,103 @@ ENV FLB_VERSION 1.8.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && \
-    apt install -y --no-install-recommends \
+RUN dpkg --add-architecture arm64
+RUN apt update && apt install -y --no-remove --no-install-recommends \
     build-essential \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu \
-    curl \
     ca-certificates \
     pkg-config \
     cmake \
     make \
-    tar \
     flex \
-    bison
+    bison \
+    dpkg-dev \
+    libssl-dev:arm64 \
+    libsasl2-dev:arm64 \
+    libsystemd-dev:arm64 \
+    libzstd-dev:arm64 \
+    zlib1g-dev:arm64 \
+    libpq-dev:arm64
 
-COPY --from=dep /usr/lib/aarch64-linux-gnu /usr/lib
-COPY --from=dep /lib/aarch64-linux-gnu /lib
-COPY --from=dep /usr/include /usr/include
+# postgresql-server-dev-11:arm64 has conflicts if installed using apt. hack here to manually force install with dpkg
+WORKDIR /tmp
+RUN apt download postgresql-server-dev-11:arm64
+RUN dpkg --force-all -i postgresql-server-*.deb
 
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
 COPY . /tmp/src/
 RUN rm -rf /tmp/src/build/*
-
 WORKDIR /tmp/src/build/
+
 RUN cmake -DFLB_RELEASE=On \
-    -DFLB_TRACE=Off \
-    -DFLB_JEMALLOC=On \
-    -DFLB_TLS=On \
-    -DFLB_SHARED_LIB=Off \
-    -DFLB_EXAMPLES=Off \
-    -DFLB_HTTP_SERVER=On \
-    -DFLB_IN_SYSTEMD=On \
-    -DFLB_OUT_KAFKA=On \
-    -DFLB_OUT_PGSQL=On \
-    -DCMAKE_TOOLCHAIN_FILE=/tmp/src/cmake/linux-arm64.cmake ../
+          -DFLB_TRACE=Off \
+          -DFLB_JEMALLOC=On \
+          -DFLB_TLS=On \
+          -DFLB_SHARED_LIB=Off \
+          -DFLB_EXAMPLES=Off \
+          -DFLB_HTTP_SERVER=On \
+          -DFLB_IN_SYSTEMD=On \
+          -DFLB_OUT_KAFKA=On \
+          -DFLB_OUT_PGSQL=On \
+          -DCMAKE_TOOLCHAIN_FILE=/tmp/src/cmake/linux-arm64.cmake ../
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 FROM --platform=linux/arm64 debian:buster-slim
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
-LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
+LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.8"
 
-RUN apt update && \
-    apt install -y --no-install-recommends \
-    libssl1.1 \
-    libsasl2-2 \
-    pkg-config \
-    libpq5 \
-    libsystemd0 \
-    zlib1g \
-    ca-certificates
+# Copy certificates
+COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
+COPY --from=builder /etc/ssl/ /etc/ssl/
 
+# SSL stuff
+COPY --from=builder /usr/lib/aarch64-linux-gnu/*sasl* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libz* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libz* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
+
+# These below are all needed for systemd
+COPY --from=builder /lib/aarch64-linux-gnu/libsystemd* /lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/liblz4.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libgcrypt.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libgpg-error.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libpq.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgssapi* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libldap* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libkrb* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libk5crypto* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/liblber* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgnutls* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libp11-kit* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libidn2* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libunistring* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libtasn1* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libnettle* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libhogweed* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgmp* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libffi* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libcom_err* /lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libkeyutils* /lib/aarch64-linux-gnu/
+
+# Build artifact
 COPY --from=builder /fluent-bit /fluent-bit
 
 # Configuration files
 COPY conf/fluent-bit.conf \
-    conf/parsers.conf \
-    conf/parsers_ambassador.conf \
-    conf/parsers_java.conf \
-    conf/parsers_extra.conf \
-    conf/parsers_openstack.conf \
-    conf/parsers_cinder.conf \
-    conf/plugins.conf \
-    /fluent-bit/etc/
+     conf/parsers.conf \
+     conf/parsers_ambassador.conf \
+     conf/parsers_java.conf \
+     conf/parsers_extra.conf \
+     conf/parsers_openstack.conf \
+     conf/parsers_cinder.conf \
+     conf/plugins.conf \
+     /fluent-bit/etc/
 
-#
 EXPOSE 2020
 
 # Entry point


### PR DESCRIPTION
PR #3210 didn't reflect our latest working copy because it was dropped
when rebasing on #3225. Re-submitting this tested working Dockerfile for
Arm64v8.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
