### PR TITLE
flb_oauth: add missing code to clear sds string

### DIFF
--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -242,6 +242,7 @@ struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
 /* Clear the current payload and token */
 void flb_oauth2_payload_clear(struct flb_oauth2 *ctx)
 {
+    flb_sds_len_set(ctx->payload, 0);
     ctx->payload[0] = '\0';
     ctx->expires_in = 0;
     if (ctx->access_token){


### PR DESCRIPTION
Addresses https://github.com/fluent/fluent-bit/issues/3267

Looks like one cause of the issue is that the `ctx->payload` string is not being cleared properly, as the sds metadata length is not being updated. This PR adds a call to `flb_sds_len_set(ctx->payload, 0)` as an attempted fix

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
