### PR TITLE
conf: added initial Couchbase parser regexes

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
+          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'

--- a/conf/parsers_extra.conf
+++ b/conf/parsers_extra.conf
@@ -81,3 +81,91 @@
     Format regex
     Regex \[(?<rule_chain>\w*)-(?<rule_name>\w*)-(?<accept_or_drop>\w*)\]IN=(?<in_interface>[\w.]+)? OUT=(?<out_interface>[\w.]+)? MAC=(?<mac_address>[\w:]+)? SRC=(?<source>(?:[0-9]{1,3}\.){3}[0-9]{1,3}) DST=(?<dest>(?:[0-9]{1,3}\.){3}[0-9]{1,3}) LEN=(?<pkt_len>\d+) TOS=(?<pkt_tos>[\w\d]+) PREC=(?<pkt_prec>[\w\d]+) TTL=(?<pkt_ttl>\d+) ID=(?<pkt_id>\d+)\s?(?<pkg_frg>[A-Z\s].?)\s?PROTO=(?<protocol>[\w\d]+) (SPT=(?<source_port>.*) DPT=(?<dest_port>.*) (LEN=(?<proto_pkt_len>\w+)?)?(WINDOW=(?<proto_window_size>\d+) RES=(?<pkt_res>\w+)? (?<pkt_type>\w+)\s((?<pkt_flag>\w+)?)\s?URGP=(?<pkg_urgency>\d))? )?(TYPE=(?<pkt_icmp_type>\d+) CODE=(?<pkt_icmp_code>\d+) ID=(?<pkt_icmp_id>\d+) SEQ=(?<pkt_icmp_seq>\d+) )?$
     Types source_port:integer,dest_port:integer,pkt_ttl:integer,pkt_tos:integer,pkt_len:integer
+
+# Couchbase parsers
+[PARSER]
+    Name         couchbase_json_log_nanoseconds
+    Format       json
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep    On 
+    # Do not remove the time field from the output we ship
+
+[PARSER]
+    Name         couchbase_rebalance_report
+    Format       json
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%SZ
+    Time_Keep    On 
+
+# The level may have optional brackets around it
+[PARSER]
+    Name         couchbase_simple_log
+    Format       regex
+    Regex        ^(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+(\+|-)\d+:\d+)\s+\[(?<level>\w+)\](?<message>.*)$
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep    On
+
+# Same as previous, just the level is not surrounded by brackets
+# https://regex101.com/r/D5lYJY/1
+[PARSER]
+    Name         couchbase_simple_log_space_separated
+    Format       regex
+    Regex        ^(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+(\+|-)\d+:\d+)\s+(?<level>\w+)\s+(?<message>.*)$
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep    On
+
+# Slight change in time format to use Z at end instead of offset:
+# 2021-03-09T17:32:02.136Z INFO ...
+# https://rubular.com/r/EpG3M1dHb5AnTC
+[PARSER]
+    Name         couchbase_simple_log_utc
+    Format       regex
+    Regex        ^(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z)\s+(?<level>\w+)(?<message>.*)$
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%LZ
+    Time_Keep    On
+
+# Cope with two different log formats, e.g.:
+# 2021/03/09 17:32:15 cbauth: ...
+# 2021-03-09T17:32:15.303+00:00 [INFO] ...
+# https://rubular.com/r/XUt7xQqEJnrF2M
+[PARSER]
+    Name         couchbase_simple_log_mixed
+    Format       regex
+    Regex        ^(?<timestamp>\d+(-|/)\d+(-|/)\d+(T|\s+)\d+:\d+:\d+(\.\d+(\+|-)\d+:\d+|))\s+((\[)?(?<level>\w+)(\]|:))(?<message>.*)$
+    Time_Key     timestamp
+    Time_Keep    On
+# We cannot parse the time as different formats directly, it could be done downstream and/or left as current time
+
+[PARSER]
+    Name         couchbase_erlang_multiline
+    Format       regex
+    # For some reason this cannot parse an ending close bracket ] followed by a new line immediately
+    #Regex        \[(?<logger>\w+):(?<level>\w+),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),.*\](?<message>.*)$
+    Regex        \[(?<logger>\w+):(?<level>\w+),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<message>.*)$
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%L   
+    Time_Keep    On
+
+# 2021-03-09T17:32:25.339+00:00 INFO CBAS.bootstrap.AnalyticsNCApplication [main] ...
+# https://rubular.com/r/9jh1oKtXBN5GEV
+# Can include an exception stack trace or a thread dump as well but ignoring these for now
+[PARSER]
+    Name         couchbase_java_multiline
+    Format       regex
+    Regex        ^(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+(\+|-)\d+:\d+)\s+(?<level>\w+)\s+(?<class>.*)\s+\[(?<thread>.*)\]\s+(?<message>.*)$
+    Time_Key     timestamp
+    Time_Format  %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep    On
+
+# A slight modification of the usual Apache/Apache2 parsers
+[PARSER]
+    Name         couchbase_http
+    Format       regex
+    Regex        ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<timestamp>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) - (?<client>.*)$
+    Time_Key     timestamp
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+    Time_Keep    On


### PR DESCRIPTION
These are regexes to cover the various Couchbase logs available.
A forked image is being provided for their full usage and configuration but these may be handy for others in OSS to reuse: https://github.com/couchbase/couchbase-operator-logging

Signed off by Patrick Stephens patrick.stephens@couchbase.com

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
N/A
No changes to code, just configuration.

**Documentation**
N/A

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
