### PR TITLE
in_http: changes for lambda extension logs support

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -66,6 +66,14 @@ static int in_http_init(struct flb_input_instance *ins,
         return -1;
     }
 
+    /* Populate context with config map defaults and incoming properties */
+    ret = flb_input_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "configuration error");
+        http_config_destroy(ctx);
+        return -1;
+    }
+
     /* Set the context */
     flb_input_set_context(ins, ctx);
 
@@ -124,6 +132,12 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_http, buffer_chunk_size),
+     ""
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "tag_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_http, tag_key),
      ""
     },
 

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -34,6 +34,7 @@ struct flb_http {
     int server_fd;
     flb_sds_t listen;
     flb_sds_t tcp_port;
+    const char *tag_key;
 
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -69,6 +69,72 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
     return 0;
 }
 
+/* implements functionality to get tag from key in record */
+static flb_sds_t tag_key(struct flb_http *ctx, msgpack_object *map)
+{
+    size_t map_size = map->via.map.size;
+    msgpack_object_kv *kv;
+    msgpack_object  key;
+    msgpack_object  val;
+    char *key_str = NULL;
+    char *val_str = NULL;
+    size_t key_str_size = 0;
+    size_t val_str_size = 0;
+    int j;
+    int check = FLB_FALSE;
+    int found = FLB_FALSE;
+    flb_sds_t tag;
+
+    kv = map->via.map.ptr;
+
+    for(j=0; j < map_size; j++) {
+        check = FLB_FALSE;
+        found = FLB_FALSE;
+        key = (kv+j)->key;
+        if (key.type == MSGPACK_OBJECT_BIN) {
+            key_str  = (char *) key.via.bin.ptr;
+            key_str_size = key.via.bin.size;
+            check = FLB_TRUE;
+        }
+        if (key.type == MSGPACK_OBJECT_STR) {
+            key_str  = (char *) key.via.str.ptr;
+            key_str_size = key.via.str.size;
+            check = FLB_TRUE;
+        }
+
+        if (check == FLB_TRUE) {
+            if (strncmp(ctx->tag_key, key_str, key_str_size) == 0) {
+                val = (kv+j)->val;
+                if (val.type == MSGPACK_OBJECT_BIN) {
+                    val_str  = (char *) val.via.bin.ptr;
+                    val_str_size = val.via.str.size;
+                    found = FLB_TRUE;
+                    break;
+                }
+                if (val.type == MSGPACK_OBJECT_STR) {
+                    val_str  = (char *) val.via.str.ptr;
+                    val_str_size = val.via.str.size;
+                    found = FLB_TRUE;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (found == FLB_TRUE) {
+        tag = flb_sds_create_len(val_str, val_str_size);
+        if (!tag) {
+            flb_errno();
+            return NULL;
+        }
+        return tag;
+    }
+        
+        
+    flb_plg_error(ctx->ins, "Could not find tag_key %s in record", ctx->tag_key);
+    return NULL;
+}
+
 int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
 {
     size_t off = 0;
@@ -79,6 +145,7 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
     int i = 0;
     msgpack_object *obj;
     msgpack_object record;
+    flb_sds_t tag_from_record = NULL;
 
     flb_time_get(&tm);
 
@@ -88,13 +155,24 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
             msgpack_sbuffer_init(&mp_sbuf);
             msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
+            tag_from_record = NULL;
+            if (ctx->tag_key) {
+                obj = &result.data;
+                tag_from_record = tag_key(ctx, obj);
+            }
+
             /* Pack record with timestamp */
             msgpack_pack_array(&mp_pck, 2);
             flb_time_append_to_msgpack(&tm, &mp_pck, 0);
             msgpack_pack_object(&mp_pck, result.data);
 
             /* Ingest record into the engine */
-            if (tag) {
+            if (tag_from_record) {
+                flb_input_chunk_append_raw(ctx->ins, tag_from_record, flb_sds_len(tag_from_record),
+                                        mp_sbuf.data, mp_sbuf.size);
+                flb_sds_destroy(tag_from_record);
+            }
+            else if (tag) {
                 flb_input_chunk_append_raw(ctx->ins, tag, flb_sds_len(tag),
                                         mp_sbuf.data, mp_sbuf.size);
             }
@@ -115,13 +193,23 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
                 msgpack_sbuffer_init(&mp_sbuf);
                 msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
+                tag_from_record = NULL;
+                if (ctx->tag_key) {
+                    tag_from_record = tag_key(ctx, &record);
+                }
+
                 /* Pack record with timestamp */
                 msgpack_pack_array(&mp_pck, 2);
                 flb_time_append_to_msgpack(&tm, &mp_pck, 0);
                 msgpack_pack_object(&mp_pck, record); 
 
                 /* Ingest record into the engine */
-                if (tag) {
+                if (tag_from_record) {
+                    flb_input_chunk_append_raw(ctx->ins, tag_from_record, flb_sds_len(tag_from_record),
+                                            mp_sbuf.data, mp_sbuf.size);
+                    flb_sds_destroy(tag_from_record);
+                }
+                else if (tag) {
                     flb_input_chunk_append_raw(ctx->ins, tag, flb_sds_len(tag),
                                                mp_sbuf.data, mp_sbuf.size);
                 }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
