### PR TITLE
workflow: allow equal and slash

### DIFF
--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)]+$'
+          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'

--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/]+$'
+          pattern: '^[a-z0-9A-Z\-_\s\,\.\/]+\:[ ]{0,1}[a-zA-Z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/\'\"\,><\+\[\]\!\*\\]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION

<!-- Provide summary of changes -->

This patch allows `=` and `/` for commit message.
e.g. 
- `=`
   -  `build: fix build failure with -DFLB_SHARED_LIB=OFF (#3042) ` [patch](https://github.com/fluent/fluent-bit/commit/f1ac53ed0e53ab48d54fb5d53bd7dbbcdf8b6a0e#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a)
-  `/`
   - `build: fix cpack rules and validate flex/bison` [patch](https://github.com/fluent/fluent-bit/commit/e6c9468df5bb709d52bd4ec7a155517c2d1903c5#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug output

equal case.
```ruby
irb(main):001:0> str = 'build: fix build failure with -DFLB_SHARED_LIB=OFF (#3042)'
irb(main):002:0> str.match /^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/]+$/
=> #<MatchData "build: fix build failure with -DFLB_SHARED_LIB=OFF (#3042)">
```

slash case.
```ruby
irb(main):001:0> str = 'build: fix cpack rules and validate flex/bison'
irb(main):002:0> str.match /^[a-z0-9\-_]+\:[ ]{0,1}[a-z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/]+$/
=> #<MatchData "build: fix cpack rules and validate flex/bison">
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
