### PR TITLE
out_cloudwatch_logs: fix memory leak when using cpu or mem input

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -770,6 +770,7 @@ struct msgpack_object pack_emf_payload(struct flb_cloudwatch *ctx,
     msgpack_unpack(mp_sbuf.data, mp_sbuf.size, NULL, &mempool, 
                    &deserialized_emf_object);
 
+    /* free allocated memory */
     msgpack_zone_destroy(&mempool);
     msgpack_sbuffer_destroy(&mp_sbuf);
 
@@ -911,6 +912,7 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                                                                 input_plugin, 
                                                                 tms);
             
+            /* free the intermediate metric list */
             struct mk_list *tmp;
             struct mk_list *head;
             struct flb_intermediate_metric *a_metric;

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -770,6 +770,9 @@ struct msgpack_object pack_emf_payload(struct flb_cloudwatch *ctx,
     msgpack_unpack(mp_sbuf.data, mp_sbuf.size, NULL, &mempool, 
                    &deserialized_emf_object);
 
+    msgpack_zone_destroy(&mempool);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
     return deserialized_emf_object;
 }
 
@@ -900,13 +903,13 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                 metric->timestamp = tms;
 
                 mk_list_add(&metric->_head, &flb_intermediate_metrics);
+                flb_free(metric);
             }  
 
             struct msgpack_object emf_payload = pack_emf_payload(ctx, 
                                                                 &flb_intermediate_metrics, 
                                                                 input_plugin, 
                                                                 tms);
-            flb_free(metric);
             ret = add_event(ctx, buf, stream, &emf_payload, &tms);
         } else {
             ret = add_event(ctx, buf, stream, &map, &tms);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -903,13 +903,22 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                 metric->timestamp = tms;
 
                 mk_list_add(&metric->_head, &flb_intermediate_metrics);
-                flb_free(metric);
+                
             }  
 
             struct msgpack_object emf_payload = pack_emf_payload(ctx, 
                                                                 &flb_intermediate_metrics, 
                                                                 input_plugin, 
                                                                 tms);
+            struct mk_list *tmp;
+            struct mk_list *head;
+            mk_list_foreach_safe(head, tmp, &flb_intermediate_metrics) {
+                a_metric = mk_list_entry(head, struct flb_intermediate_metric, _head)
+                mk_list_del(&a_metric->_head);
+                flb_free(a_metric);
+            }
+
+
             ret = add_event(ctx, buf, stream, &emf_payload, &tms);
         } else {
             ret = add_event(ctx, buf, stream, &map, &tms);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -802,6 +802,9 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
     int check = FLB_FALSE;
     int found = FLB_FALSE;
     struct flb_time tms;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_intermediate_metric *an_item;
 
     /* Added for EMF support */
     struct flb_intermediate_metric *metric;
@@ -913,13 +916,11 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                                                                 tms);
             
             /* free the intermediate metric list */
-            struct mk_list *tmp;
-            struct mk_list *head;
-            struct flb_intermediate_metric *a_metric;
+            
             mk_list_foreach_safe(head, tmp, &flb_intermediate_metrics) {
-                a_metric = mk_list_entry(head, struct flb_intermediate_metric, _head);
-                mk_list_del(&a_metric->_head);
-                flb_free(a_metric);
+                an_item = mk_list_entry(head, struct flb_intermediate_metric, _head);
+                mk_list_del(&an_item->_head);
+                flb_free(an_item);
             }
 
             ret = add_event(ctx, buf, stream, &emf_payload, &tms);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -915,7 +915,7 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
             struct mk_list *head;
             struct flb_intermediate_metric *a_metric;
             mk_list_foreach_safe(head, tmp, &flb_intermediate_metrics) {
-                a_metric = mk_list_entry(head, struct flb_intermediate_metric, _head)
+                a_metric = mk_list_entry(head, struct flb_intermediate_metric, _head);
                 mk_list_del(&a_metric->_head);
                 flb_free(a_metric);
             }

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -910,14 +910,15 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                                                                 &flb_intermediate_metrics, 
                                                                 input_plugin, 
                                                                 tms);
+            
             struct mk_list *tmp;
             struct mk_list *head;
+            struct flb_intermediate_metric *a_metric;
             mk_list_foreach_safe(head, tmp, &flb_intermediate_metrics) {
                 a_metric = mk_list_entry(head, struct flb_intermediate_metric, _head)
                 mk_list_del(&a_metric->_head);
                 flb_free(a_metric);
             }
-
 
             ret = add_event(ctx, buf, stream, &emf_payload, &tms);
         } else {


### PR DESCRIPTION
Signed-off-by: Ade Fisher <adrian.fisher@montvieux.com>

Fixes memory leak in out_cloudwatch_logs when using cpu or mem input

Fixes #3145 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Valgrind output after change
```
[2021/03/31 08:52:04] [ info] [engine] service stopped
==85211== 
==85211== HEAP SUMMARY:
==85211==     in use at exit: 0 bytes in 0 blocks
==85211==   total heap usage: 193,370 allocs, 193,370 frees, 33,548,850 bytes allocated
==85211== 
==85211== All heap blocks were freed -- no leaks are possible
==85211== 
==85211== For lists of detected and suppressed errors, rerun with: -s
==85211== ERROR SUMMARY: 23679 errors from 132 contexts (suppressed: 0 from 0)
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
