### PR TITLE
lib: add option/property checks for input/output/filters.

### DIFF
--- a/examples/out_lib/out_lib.c
+++ b/examples/out_lib/out_lib.c
@@ -20,13 +20,13 @@
 #include <fluent-bit.h>
 #include <msgpack.h>
 
-int my_stdout_json(void* data, size_t size)
+int my_stdout_json(void *record, size_t size, void *data)
 {
     printf("[%s]",__FUNCTION__);
-    printf("%s",(char*)data);
+    printf("%s",(char*)record);
     printf("\n");
 
-    flb_lib_free(data);
+    flb_lib_free(record);
     return 0;
 }
 
@@ -46,6 +46,7 @@ int main()
     int n;
     char tmp[256];
     flb_ctx_t *ctx;
+    struct flb_lib_out_cb callback;
     int in_ffd;
     int out_ffd;
 
@@ -61,7 +62,10 @@ int main()
     /* Register my callback function */
 
     /* JSON format */
-    out_ffd = flb_output(ctx, "lib", my_stdout_json);
+    callback.cb = my_stdout_json;
+    callback.data = NULL;
+
+    out_ffd = flb_output(ctx, "lib", &callback);
     flb_output_set(ctx, out_ffd, "match", "test", "format", "json", NULL);
 
     /* Msgpack format */

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -28,6 +28,7 @@
 #define FLB_LIB_ERROR     -1
 #define FLB_LIB_NONE       0
 #define FLB_LIB_OK         1
+#define FLB_LIB_NO_CONFIG_MAP 2
 
 /* Library mode context data */
 struct flb_lib_ctx {
@@ -50,9 +51,12 @@ FLB_EXPORT void flb_init_env();
 FLB_EXPORT flb_ctx_t *flb_create();
 FLB_EXPORT void flb_destroy(flb_ctx_t *ctx);
 FLB_EXPORT int flb_input(flb_ctx_t *ctx, const char *input, void *data);
-FLB_EXPORT int flb_output(flb_ctx_t *ctx, const char *output, void *data);
+FLB_EXPORT int flb_output(flb_ctx_t *ctx, const char *output, struct flb_lib_out_cb *cb);
 FLB_EXPORT int flb_filter(flb_ctx_t *ctx, const char *filter, void *data);
 FLB_EXPORT int flb_input_set(flb_ctx_t *ctx, int ffd, ...);
+FLB_EXPORT int flb_input_property_check(flb_ctx_t *ctx, int ffd, char *key, char *val);
+FLB_EXPORT int flb_output_property_check(flb_ctx_t *ctx, int ffd, char *key, char *val);
+FLB_EXPORT int flb_filter_property_check(flb_ctx_t *ctx, int ffd, char *key, char *val);
 FLB_EXPORT int flb_output_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                                    void (*out_callback) (void *, int, int,

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -735,8 +735,6 @@ int flb_engine_shutdown(struct flb_config *config)
     }
 #endif
 
-    flb_config_exit(config);
-
     return 0;
 }
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -421,7 +421,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     struct mk_list *config_map;
     struct flb_input_plugin *p = ins->p;
 
-    if (ins->log_level == -1) {
+    if (ins->log_level == -1 && config->log != NULL) {
         ins->log_level = config->log->level;
     }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 # Output Plugins
 if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_LIB              "core_engine.c")
+  FLB_RT_TEST(FLB_OUT_LIB              "config_map_opts.c")
   FLB_RT_TEST(FLB_OUT_COUNTER          "out_counter.c")
   FLB_RT_TEST(FLB_OUT_DATADOG          "out_datadog.c")
   FLB_RT_TEST(FLB_OUT_ES               "out_elasticsearch.c")

--- a/tests/runtime/config_map_opts.c
+++ b/tests/runtime/config_map_opts.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+#include <fluent-bit.h>
+#include "flb_tests_runtime.h"
+
+/* Test functions */
+void flb_test_config_map_opts(void);
+
+/* Test list */
+TEST_LIST = {
+    {"config_map_opts",    flb_test_config_map_opts },
+    {NULL, NULL}
+};
+
+void flb_test_config_map_opts(void)
+{
+    flb_ctx_t    *ctx    = NULL;
+    int in_ffd, r;
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "tail", NULL);
+    r = flb_input_property_check(ctx, in_ffd, "invalid_option", "invalid value");
+    TEST_CHECK(r != 0);
+
+    in_ffd = flb_filter(ctx, (char *) "kubernetes", NULL);
+    r = flb_filter_property_check(ctx, in_ffd, "invalid_option", "invalid value");
+    TEST_CHECK(r != 0);
+
+    in_ffd = flb_output(ctx, (char *) "stdout", NULL);
+    r = flb_output_property_check(ctx, in_ffd, "invalid_option", "invalid value");
+    TEST_CHECK(r != 0);
+
+    flb_destroy(ctx);
+}


### PR DESCRIPTION
**Description**

This patch implements helper methods in the library to validate if a given k, v option is valid as a config option 
for a input/output/filter plugin.

**Testing**

Compile the following code with

```sh
gcc simple-test.c -lfluent-bit -O0 -w -o simple
```

```c
#include <fluent-bit.h>
#include <stdlib.h>

void main(void)
{
    int ret;
    flb_ctx_t    *ctx    = NULL;
    int in_ffd, r;

    ctx = flb_create();

    in_ffd = flb_input(ctx, (char *) "tail", NULL);
    r = flb_input_property_check(ctx, in_ffd, "pathxxx", "/var/log/syslog");
    printf("%d", r);

    in_ffd = flb_filter(ctx, (char *) "kubernetes", NULL);
    r = flb_filter_property_check(ctx, in_ffd, "invalid_option", "invalid value");
    printf("%d", r);

    in_ffd = flb_output(ctx, (char *) "stdout", NULL);
    r = flb_output_property_check(ctx, in_ffd, "invalid_option", "invalid value");
    printf("%d", r);

}
```
Results in the following output:

```bash
[2021/04/01 16:37:02] [error] [config] tail: unknown configuration property 'pathxxx'. The following properties are allowed: path, exclude_path, key, read_from_head, refresh_interval, watcher_interval, rotate_wait, docker_mode, docker_mode_flush, docker_mode_parser, path_key, offset_key, ignore_older, buffer_chunk_size, buffer_max_size, skip_long_lines, exit_on_eof, parser, tag_regex, db, db.sync, db.locking, db.wal, multiline, multiline_flush, parser_firstline, and parser_.

[2021/04/01 16:37:02] [error] [config] kubernetes: unknown configuration property 'invalid_option'. The following properties are allowed: buffer_size, tls.debug, tls.verify, tls.vhost, merge_log, merge_parser, merge_log_key, merge_log_trim, keep_log, kube_url, kube_meta_preload_cache_dir, kube_ca_file, kube_ca_path, kube_tag_prefix, kube_token_file, labels, annotations, k8s-logging.parser, k8s-logging.exclude, use_journal, regex_parser, dummy_meta, dns_retries, dns_wait_time, cache_use_docker_

[2021/04/01 17:35:00] [error] [config] stdout: unknown configuration property 'invalid_option'. The following properties are allowed: format, json_date_format, and json_date_key.

```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
