### PR TITLE
out_splunk: add new property "channel" to set channel identifier

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -230,6 +230,13 @@ static void cb_splunk_flush(const void *data, size_t bytes,
                             ctx->auth_header, flb_sds_len(ctx->auth_header));
     }
 
+    /* Append Channel identifier header */
+    if (ctx->channel) {
+        flb_http_add_header(c, FLB_SPLUNK_CHANNEL_IDENTIFIER_HEADER,
+                            strlen(FLB_SPLUNK_CHANNEL_IDENTIFIER_HEADER),
+                            ctx->channel, ctx->channel_len);
+    }
+
     /* Content Encoding: gzip */
     if (compressed == FLB_TRUE) {
         flb_http_set_content_encoding_gzip(c);
@@ -325,6 +332,12 @@ static struct flb_config_map config_map[] = {
      "When enabled, the record keys and values are set in the top level of the "
      "map instead of under the event key. Refer to the Sending Raw Events section "
      "from the docs for more details to make this option work properly."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "channel", NULL,
+     0, FLB_TRUE, offsetof(struct flb_splunk, channel),
+     "Specify X-Splunk-Request-Channel Header for the HTTP Event Collector interface."
     },
 
     /* EOF */

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -27,6 +27,8 @@
 #define FLB_SPLUNK_DEFAULT_TIME       "time"
 #define FLB_SPLUNK_DEFAULT_EVENT      "event"
 
+#define FLB_SPLUNK_CHANNEL_IDENTIFIER_HEADER "X-Splunk-Request-Channel"
+
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_sds.h>
 
@@ -40,6 +42,10 @@ struct flb_splunk {
 
     /* Token Auth */
     flb_sds_t auth_header;
+
+    /* Channel identifier */
+    flb_sds_t channel;
+    size_t channel_len;
 
     /* Send fields directly or pack data into "event" object */
     int splunk_send_raw;

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -98,6 +98,9 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
             ctx->http_passwd = flb_strdup("");
         }
     }
+    if (ctx->channel) {
+        ctx->channel_len = flb_sds_len(ctx->channel);
+    }
 
     /* No http_user is set, fallback to splunk_token, if splunk_token is unset, fail. */
     if(!ctx->http_user) {


### PR DESCRIPTION


<!-- Provide summary of changes -->
disclaimer: I don't have splunk account. I tested dummy http server, so the output log may be invalid.
Waiting for testing by user.

Fixes #3314  


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Refer to the splunk doc, we need to set `X-Splunk-Request-Channel` header.
This PR is to add new property `channel` to set the header.
https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/FormateventsforHTTPEventCollector#Channel_identifier_header


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name dummy
    Samples 1

[OUTPUT]
    Name splunk
    Http_User nanashi
    Channel bd3b4270-3c26-4127-a677-8643d44f3984
```

## Debug log output

disclaimer: I don't have splunk account. I tested dummy http server, so the output log may be invalid.

This is `nc -l 8088` outputs.
It reports `X-Splunk-Request-Channel: bd3b4270-3c26-4127-a677-8643d44f3984`.
```
$ nc -l 8088
POST /services/collector/event HTTP/1.1
Host: 127.0.0.1:8088
Content-Length: 54
User-Agent: Fluent-Bit
Authorization: Basic bmFuYXNoaTo=
X-Splunk-Request-Channel: bd3b4270-3c26-4127-a677-8643d44f3984

{"time":1617326861.963734,"event":{"message":"dummy"}}
```

Fluent-bit's log
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/02 10:48:15] [ info] [engine] started (pid=8495)
[2021/04/02 10:48:15] [ info] [storage] version=1.1.1, initializing...
[2021/04/02 10:48:15] [ info] [storage] in-memory
[2021/04/02 10:48:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/02 10:48:15] [ info] [sp] stream processor started
^C[2021/04/02 10:48:21] [engine] caught signal (SIGINT)
[2021/04/02 10:48:21] [ warn] [engine] service will stop in 5 seconds
[2021/04/02 10:48:25] [ info] [engine] service stopped
[2021/04/02 10:48:25] [ warn] [engine] shutdown delayed, grace period has finished but some tasks are still running.
[2021/04/02 10:48:25] [ info] [task] dummy/dummy.0 has 1 pending task(s):
[2021/04/02 10:48:25] [ info] [task]   task_id=0 still running on route(s): splunk/splunk.0 
[2021/04/02 10:48:25] [ warn] [engine] service will stop in 5 seconds
[2021/04/02 10:48:30] [ info] [engine] service stopped
[2021/04/02 10:48:30] [ warn] [engine] shutdown delayed, grace period has finished but some tasks are still running.
[2021/04/02 10:48:30] [ info] [task] dummy/dummy.0 has 1 pending task(s):
[2021/04/02 10:48:30] [ info] [task]   task_id=0 still running on route(s): splunk/splunk.0 
[2021/04/02 10:48:30] [ warn] [engine] service will stop in 5 seconds
^C[2021/04/02 10:48:31] [engine] caught signal (SIGINT)
```

## Valgrind output

Note: valgrind reports leak, but it is not related this PR.
It reports `http_user` and `http_passwd` are leaked. (they are overwritten by flb_strdup)
```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==8319== Memcheck, a memory error detector
==8319== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8319== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==8319== Command: ../bin/fluent-bit -c a.conf
==8319== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/02 10:40:09] [ info] [engine] started (pid=8319)
[2021/04/02 10:40:09] [ info] [storage] version=1.1.1, initializing...
[2021/04/02 10:40:09] [ info] [storage] in-memory
[2021/04/02 10:40:09] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/02 10:40:09] [ info] [sp] stream processor started
^C[2021/04/02 10:40:10] [engine] caught signal (SIGINT)
==8319== Warning: client switching stacks?  SP change: 0x57e4818 --> 0x4c57da0
==8319==          to suppress, use: --max-stackframe=12110456 or greater
==8319== Warning: client switching stacks?  SP change: 0x4c57d18 --> 0x57e4818
==8319==          to suppress, use: --max-stackframe=12110592 or greater
==8319== Warning: client switching stacks?  SP change: 0x57e4818 --> 0x4c57d18
==8319==          to suppress, use: --max-stackframe=12110592 or greater
==8319==          further instances of this message will not be shown.
[2021/04/02 10:40:10] [ warn] [engine] service will stop in 5 seconds
[2021/04/02 10:40:10] [error] [src/flb_http_client.c:1156 errno=32] Broken pipe
[2021/04/02 10:40:10] [ warn] [output:splunk:splunk.0] http_do=-1
[2021/04/02 10:40:10] [ warn] [engine] failed to flush chunk '8319-1617327609.959640794.flb', retry in 11 seconds: task_id=0, input=dummy.0 > output=splunk.0 (out_id=0)
[2021/04/02 10:40:14] [ info] [engine] service stopped
==8319== Warning: invalid file descriptor -1 in syscall close()
==8319== 
==8319== HEAP SUMMARY:
==8319==     in use at exit: 9 bytes in 2 blocks
==8319==   total heap usage: 353 allocs, 351 frees, 580,886 bytes allocated
==8319== 
==8319== 1 bytes in 1 blocks are definitely lost in loss record 1 of 2
==8319==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8319==    by 0x209576: flb_malloc (flb_mem.h:62)
==8319==    by 0x20963F: flb_strdup (flb_str.h:37)
==8319==    by 0x209968: flb_splunk_conf_create (splunk_conf.c:98)
==8319==    by 0x208A0E: cb_splunk_init (splunk.c:37)
==8319==    by 0x1759B8: flb_output_init_all (flb_output.c:930)
==8319==    by 0x182276: flb_engine_start (flb_engine.c:516)
==8319==    by 0x16748C: flb_lib_worker (flb_lib.c:493)
==8319==    by 0x4864608: start_thread (pthread_create.c:477)
==8319==    by 0x4B10292: clone (clone.S:95)
==8319== 
==8319== 8 bytes in 1 blocks are definitely lost in loss record 2 of 2
==8319==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8319==    by 0x209576: flb_malloc (flb_mem.h:62)
==8319==    by 0x20963F: flb_strdup (flb_str.h:37)
==8319==    by 0x209920: flb_splunk_conf_create (splunk_conf.c:92)
==8319==    by 0x208A0E: cb_splunk_init (splunk.c:37)
==8319==    by 0x1759B8: flb_output_init_all (flb_output.c:930)
==8319==    by 0x182276: flb_engine_start (flb_engine.c:516)
==8319==    by 0x16748C: flb_lib_worker (flb_lib.c:493)
==8319==    by 0x4864608: start_thread (pthread_create.c:477)
==8319==    by 0x4B10292: clone (clone.S:95)
==8319== 
==8319== LEAK SUMMARY:
==8319==    definitely lost: 9 bytes in 2 blocks
==8319==    indirectly lost: 0 bytes in 0 blocks
==8319==      possibly lost: 0 bytes in 0 blocks
==8319==    still reachable: 0 bytes in 0 blocks
==8319==         suppressed: 0 bytes in 0 blocks
==8319== 
==8319== For lists of detected and suppressed errors, rerun with: -s
==8319== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
