### PR TITLE
out_splunk: remove allocation http_user/http_passwd

### DIFF
--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -86,19 +86,6 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         }
     }
 
-    /* HTTP Auth */
-    tmp = flb_output_get_property("http_user", ins);
-    if (tmp) {
-        ctx->http_user = flb_strdup(tmp);
-        tmp = flb_output_get_property("http_passwd", ins);
-        if (tmp) {
-            ctx->http_passwd = flb_strdup(tmp);
-        }
-        else {
-            ctx->http_passwd = flb_strdup("");
-        }
-    }
-
     /* No http_user is set, fallback to splunk_token, if splunk_token is unset, fail. */
     if(!ctx->http_user) {
         /* Splunk Auth Token */


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is to fix memory leak of out_splunk that I found when I was testing #3318 

`http_user` and `http_passwd` are allocated at plugin side.
However they are supported by config map and they should be allocated/freed by config map framework.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration
```
[INPUT]
    Name dummy
    Samples 1

[OUTPUT]
    Name splunk
    Http_User nanashi
    Http_passwd hoge
```

## Valgrind output
```
$ valgrind ../bin/fluent-bit -c a.conf 
==10165== Memcheck, a memory error detector
==10165== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10165== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==10165== Command: ../bin/fluent-bit -c a.conf
==10165== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/02 11:23:35] [ info] [engine] started (pid=10165)
[2021/04/02 11:23:35] [ info] [storage] version=1.1.1, initializing...
[2021/04/02 11:23:35] [ info] [storage] in-memory
[2021/04/02 11:23:35] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/02 11:23:35] [ info] [sp] stream processor started
^C[2021/04/02 11:23:36] [engine] caught signal (SIGINT)
==10165== Warning: client switching stacks?  SP change: 0x57e4818 --> 0x4c57b90
==10165==          to suppress, use: --max-stackframe=12110984 or greater
==10165== Warning: client switching stacks?  SP change: 0x4c57b08 --> 0x57e4818
==10165==          to suppress, use: --max-stackframe=12111120 or greater
==10165== Warning: client switching stacks?  SP change: 0x57e4818 --> 0x4c57b08
==10165==          to suppress, use: --max-stackframe=12111120 or greater
==10165==          further instances of this message will not be shown.
[2021/04/02 11:23:36] [ warn] [engine] service will stop in 5 seconds
[2021/04/02 11:23:36] [error] [src/flb_http_client.c:1156 errno=32] Broken pipe
[2021/04/02 11:23:36] [ warn] [output:splunk:splunk.0] http_do=-1
[2021/04/02 11:23:36] [ warn] [engine] failed to flush chunk '10165-1617330215.965745330.flb', retry in 9 seconds: task_id=0, input=dummy.0 > output=splunk.0 (out_id=0)
[2021/04/02 11:23:40] [ info] [engine] service stopped
==10165== 
==10165== HEAP SUMMARY:
==10165==     in use at exit: 0 bytes in 0 blocks
==10165==   total heap usage: 346 allocs, 346 frees, 580,540 bytes allocated
==10165== 
==10165== All heap blocks were freed -- no leaks are possible
==10165== 
==10165== For lists of detected and suppressed errors, rerun with: -s
==10165== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
