### PR TITLE
out_es: support 'id_key' to get id from record(#3303)

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -100,6 +100,11 @@ struct flb_elasticsearch {
     /* time key nanoseconds */
     int time_key_nanos;
 
+
+    /* id_key */
+    flb_sds_t id_key;
+    struct flb_record_accessor *ra_id_key;
+    
     /* include_tag_key */
     int include_tag_key;
     flb_sds_t tag_key;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -233,6 +233,17 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     }
 
 
+    if (ctx->id_key) {
+        ctx->ra_id_key = flb_ra_create(ctx->id_key, FLB_FALSE);
+        if (ctx->ra_id_key == NULL) {
+            flb_plg_error(ins, "could not create record accessor for Id Key");
+        }
+        if (ctx->generate_id == FLB_TRUE) {
+            flb_plg_warn(ins, "Generate_ID is ignored when ID_key is set");
+            ctx->generate_id = FLB_FALSE;
+        }
+    }
+
     if (ctx->logstash_prefix_key) {
         if (ctx->logstash_prefix_key[0] != '$') {
             len = flb_sds_len(ctx->logstash_prefix_key);
@@ -386,6 +397,10 @@ int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 
     if (ctx->u) {
         flb_upstream_destroy(ctx->u);
+    }
+    if (ctx->ra_id_key) {
+        flb_ra_destroy(ctx->ra_id_key);
+        ctx->ra_id_key = NULL;
     }
 
 #ifdef FLB_HAVE_AWS


### PR DESCRIPTION

<!-- Provide summary of changes -->
Fixes #3303 
New property `id_key` is supported by this patch.
It is to get id from record and to set id dynamically. 

If this option is enabled, `generate_id` is disabled.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

## Example Configuration

This configuration means the value of `request_id` is `_id`.
```
[INPUT]
    Name dummy
    dummy {"val":"hoge", "nest":{"request_id":"12345678","val":"moge"}}

[OUTPUT]
    Name es
    ID_key $nest['request_id']
```

## Debug log output

1. launch elasticsearch
```
sudo docker run --rm -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.11.1
```

2. exec fluent-bit
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/04 10:04:31] [ info] [engine] started (pid=19218)
[2021/04/04 10:04:31] [ info] [storage] version=1.1.1, initializing...
[2021/04/04 10:04:31] [ info] [storage] in-memory
[2021/04/04 10:04:31] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/04 10:04:31] [ info] [sp] stream processor started
^C[2021/04/04 10:04:36] [engine] caught signal (SIGINT)
[2021/04/04 10:04:36] [ warn] [engine] service will stop in 5 seconds
[2021/04/04 10:04:40] [ info] [engine] service stopped
```

3. check doc

`"_id": "12345678"` means we can set `_id` from records.
```
$ curl -X GET 'localhost:9200/fluent-bit/_search' |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   340  100   340    0     0   2328      0 --:--:-- --:--:-- --:--:--  2328
{
  "took": 116,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "fluent-bit",
        "_type": "_doc",
        "_id": "12345678",
        "_score": 1,
        "_source": {
          "@timestamp": "2021-04-04T01:04:35.967Z",
          "val": "hoge",
          "nest": {
            "request_id": "12345678",
            "val": "moge"
          }
        }
      }
    ]
  }
}
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==18123== Memcheck, a memory error detector
==18123== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18123== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18123== Command: ../bin/fluent-bit -c a.conf
==18123== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/04 09:55:47] [ info] [engine] started (pid=18123)
[2021/04/04 09:55:47] [ info] [storage] version=1.1.1, initializing...
[2021/04/04 09:55:47] [ info] [storage] in-memory
[2021/04/04 09:55:47] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/04 09:55:47] [ info] [sp] stream processor started
==18123== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c78a20
==18123==          to suppress, use: --max-stackframe=11976344 or greater
==18123== Warning: client switching stacks?  SP change: 0x4c78998 --> 0x57e48b8
==18123==          to suppress, use: --max-stackframe=11976480 or greater
==18123== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c78998
==18123==          to suppress, use: --max-stackframe=11976480 or greater
==18123==          further instances of this message will not be shown.
^C[2021/04/04 09:55:52] [engine] caught signal (SIGINT)
[2021/04/04 09:55:52] [ warn] [engine] service will stop in 5 seconds
[2021/04/04 09:55:57] [ info] [engine] service stopped
==18123== 
==18123== HEAP SUMMARY:
==18123==     in use at exit: 0 bytes in 0 blocks
==18123==   total heap usage: 547 allocs, 547 frees, 1,287,240 bytes allocated
==18123== 
==18123== All heap blocks were freed -- no leaks are possible
==18123== 
==18123== For lists of detected and suppressed errors, rerun with: -s
==18123== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
