### PR TITLE
input_chunk: when hitting the limit, update fs_chunks_size by the size of last chunk

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -64,7 +64,7 @@ ssize_t flb_input_chunk_get_real_size(struct flb_input_chunk *ic)
     // Real size is not synced to chunk yet
     size = flb_input_chunk_get_size(ic);
     if (size == 0) {
-        flb_error("[input chunk] failed to load the size of chunk %s",
+        flb_debug("[input chunk] no data in the chunk %s",
                   flb_input_chunk_get_name(ic));
         return -1;
     }
@@ -564,6 +564,11 @@ int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del)
         }
 
         bytes = flb_input_chunk_get_real_size(ic);
+        if (bytes == -1) {
+            // no data in the chunk
+            continue;
+        }
+
         if (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) != 0) {
             o_ins->fs_chunks_size -= bytes;
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
When the Fluent Bit sets the limit `storage.total_limit_size`, chunk will go through this if condition and the routes_mask of the last chunk has chance to be cleared by call to the function `flb_input_chunk_place_new_chunk(2)`: https://github.com/fluent/fluent-bit/blob/master/src/flb_input_chunk.c#L606-L616. The routes_mask is cleared here: https://github.com/fluent/fluent-bit/blob/master/src/flb_input_chunk.c#L214. This will result in that when the chunk is destroyed in the flb_input_chunk_destroy(2), the `fs_chunks_size` is not reduced by the size of chunk. This patch is to fix the issue that `fs_chunks_size` is not updated correctly when the routes_mask is cleared.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
