### PR TITLE
workflows: fix commit checker and pass branch to build distro.

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -36,7 +36,7 @@ jobs:
           path: packaging
 
       - name: Build the distro artifacts
-        run: ./build.sh -v master -d ${{ env.distro }}
+        run: ./build.sh -v master -d ${{ env.distro }} -b master
         env:
           distro: ${{ matrix.distro }}
         working-directory: packaging

--- a/.github/workflows/check-commit.yaml
+++ b/.github/workflows/check-commit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z0-9A-Z\-_\s\,\.\/]+\:[ ]{0,1}[a-zA-Z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/\'\"\,><\+\[\]\!\*\\]+$'
+          pattern: '^[a-z0-9A-Z\-_\s\,\.\/]+\:[ ]{0,1}[a-zA-Z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/\"\,><\+\[\]\!\*\\]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION
* Fixes commit checker regex.
* Adds the -b paramaeter to build.sh

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
