### PR TITLE
out_stackdriver: increase auth token size limit

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -69,7 +69,7 @@ static int fetch_metadata(struct flb_stackdriver *ctx,
     c = flb_http_client(metadata_conn, FLB_HTTP_GET, uri,
                         "", 0, NULL, 0, NULL, 0);
 
-    flb_http_buffer_size(c, 4096);
+    flb_http_buffer_size(c, FLB_STD_METADATA_TOKEN_SIZE_MAX);
 
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
     flb_http_add_header(c, "Content-Type", 12, "application/text", 16);
@@ -113,7 +113,7 @@ int gce_metadata_read_token(struct flb_stackdriver *ctx)
 {
     int ret;
     flb_sds_t uri = flb_sds_create(FLB_STD_METADATA_SERVICE_ACCOUNT_URI);
-    flb_sds_t payload = flb_sds_create_size(4096);
+    flb_sds_t payload = flb_sds_create_size(FLB_STD_METADATA_TOKEN_SIZE_MAX);
 
     uri = flb_sds_cat(uri, ctx->client_email, flb_sds_len(ctx->client_email));
     uri = flb_sds_cat(uri, "/token", 6);

--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -37,6 +37,9 @@
 /* Service account metadata URI */
 #define FLB_STD_METADATA_SERVICE_ACCOUNT_URI "/computeMetadata/v1/instance/service-accounts/"
 
+/* Max size of token response from metadata server */
+#define FLB_STD_METADATA_TOKEN_SIZE_MAX 14336
+
 int gce_metadata_read_token(struct flb_stackdriver *ctx);
 int gce_metadata_read_zone(struct flb_stackdriver *ctx);
 int gce_metadata_read_project_id(struct flb_stackdriver *ctx);


### PR DESCRIPTION
Increase the token size limit from 512Bytes to 14KB in out_stackdriver

- When fetching token from metadata server, increase the payload buffer to 14KB (12KB for token, 2KB for other fields in the response and json overhead)
- Removed the string copy step of `set_authorization_header` and directly use the sds string from `get_google_token` with added token type.

This is to accommodate GCP [federated access token](https://cloud.google.com/iam/docs/workload-identity-federation), usually in the size of 700-900 bytes for the example tokens in my test environment.

Fixes #3316
 
----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Example Configuration**
```
[SERVICE]
    Flush                     1
    Log_Level                 debug
    Parsers_File              parsers.conf
    storage.path              /var/log/flb-storage/
    storage.sync              normal
    storage.checksum           off
    storage.backlog.mem_limit  10M

[INPUT]
    Name               tail
    Tag                k8s_container.test1.test2.test3
    Path               /var/log/containers/*.log 
    Parser             docker
    Buffer_Chunk_Size  512KB
    Buffer_Max_Size    5M
    Rotate_Wait        30
    Mem_Buf_Limit      30MB
    Skip_Long_Lines    On
    Refresh_Interval   10
    storage.type       filesystem
    
[FILTER]
    Name    record_modifier
    Match   *
    Record  gke.googleapis.com/log_type system
    
[OUTPUT]
    Name        stackdriver
    Match       k8s_container.*
    Resource    k8s_container
    k8s_cluster_name test_cluster_name
    k8s_cluster_location  test_cluster_location
    # a METADATA_SERVER env var is set to retrieve project ID and auth token 
```

**Debug log output**
```
[2021/04/06 20:30:22] [debug] [http_client] not using http_proxy for header
[2021/04/06 20:30:22] [debug] [http_client] header=POST /v2/entries:write HTTP/1.1
Host: logging.googleapis.com
Content-Length: 34685
User-Agent: Fluent-Bit
Content-Type: application/json
Authorization: Bearer *****token string of length 790 is omitted. Before the change, this string was truncated*****
```

**Documentation**
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
