### PR TITLE
out_s3: optionally send Content-MD5 header to S3

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -99,6 +99,7 @@ struct flb_s3 {
     char *content_type;
     int free_endpoint;
     int use_put_object;
+    int send_content_md5;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;
@@ -156,5 +157,7 @@ void multipart_upload_destroy(struct multipart_upload *m_upload);
 
 struct flb_http_client *mock_s3_call(char *error_env_var, char *api);
 int s3_plugin_under_test();
+
+int get_md5_base64(char *buf, size_t buf_size, char *md5_str, size_t md5_str_size);
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

PutObject or UploadPart on a bucket with Object Lock enabled by default requires sending the Content-MD5 header on the request. This PR adds a `send_content_md5 <bool>` option to the S3 output. When true, the output will add Content-MD5 to PutObject and UploadPart requests.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Mentioned in #2700 

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

Docs are in fluent/fluent-bit-docs#505

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
