### PR TITLE
tests: runtime: out_splunk: add testcode for out_splunk

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -331,6 +331,19 @@ static struct flb_config_map config_map[] = {
     {0}
 };
 
+
+static int cb_splunk_format_test(struct flb_config *config,
+                                 struct flb_input_instance *ins,
+                                 void *plugin_context,
+                                 void *flush_ctx,
+                                 const char *tag, int tag_len,
+                                 const void *data, size_t bytes,
+                                 void **out_data, size_t *out_size)
+{
+    struct flb_splunk *ctx = plugin_context;
+    return splunk_format(data, bytes, (char**)out_data, out_size,ctx);
+}
+
 struct flb_output_plugin out_splunk_plugin = {
     .name         = "splunk",
     .description  = "Send events to Splunk HTTP Event Collector",
@@ -339,6 +352,8 @@ struct flb_output_plugin out_splunk_plugin = {
     .cb_exit      = cb_splunk_exit,
     .config_map   = config_map,
 
+    /* for testing */
+    .test_formatter.callback = cb_splunk_format_test,
     /* Plugin flags */
     .flags          = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -58,6 +58,7 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_NULL             "out_null.c")
   FLB_RT_TEST(FLB_OUT_PLOT             "out_plot.c")
   FLB_RT_TEST(FLB_OUT_RETRY            "out_retry.c")
+  FLB_RT_TEST(FLB_OUT_SPLUNK           "out_splunk.c")
   FLB_RT_TEST(FLB_OUT_STDOUT           "out_stdout.c")
 
   if (FLB_RECORD_ACCESSOR)

--- a/tests/runtime/out_splunk.c
+++ b/tests/runtime/out_splunk.c
@@ -1,0 +1,84 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include "flb_tests_runtime.h"
+
+#define JSON_BASIC "[12345678, {\"key\":\"value\"}]"
+static void cb_check_basic(void *ctx, int ffd,
+                           int res_ret, void *res_data, size_t res_size,
+                           void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "\"event\":{\"key\":\"value\"}";
+
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    flb_sds_destroy(out_js);
+}
+
+void flb_test_basic()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "splunk", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "http_user", "alice",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_basic,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"basic"           , flb_test_basic },
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
This patch is to add a test code for out_splunk.
I'll enrich testcases after this PR is merged.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log output
```
$ bin/flb-rt-out_splunk 
Test basic...                                   [2021/04/07 08:21:12] [ info] [engine] started (pid=27056)
[2021/04/07 08:21:12] [ info] [storage] version=1.1.1, initializing...
[2021/04/07 08:21:12] [ info] [storage] in-memory
[2021/04/07 08:21:12] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/07 08:21:12] [ info] [sp] stream processor started
[2021/04/07 08:21:12] [ info] [task] cleanup test task
[2021/04/07 08:21:14] [ warn] [engine] service will stop in 1 seconds
[2021/04/07 08:21:14] [ info] [engine] service stopped
[ OK ]
SUCCESS: All unit tests have passed.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
