### PR TITLE
workflows: update build master packages

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -1,5 +1,5 @@
 on:
-  push:
+  push:${{ github.actor }}
     branches:
       - master
 
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: ${{ github.actor }}/fluent-bit-packaging
+          repository: fluent/fluent-bit-packaging
           fetch-depth: 1
           path: packaging
 


### PR DESCRIPTION
* Use fluent/fluent-bit-packaging

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
