### PR TITLE
http_client: log failures to resize the buffer

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1187,6 +1187,10 @@ int flb_http_do(struct flb_http_client *c, size_t *bytes)
                  * We could not allocate more space, let the caller handle
                  * this.
                  */
+                flb_warn("[http_client] cannot increase buffer: current=%zu "
+                         "requested=%zu max=%zu", c->resp.data_size,
+                         c->resp.data_size + FLB_HTTP_DATA_CHUNK,
+                         c->resp.data_size_max);
                 flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
                 return 0;
             }


### PR DESCRIPTION
At present `flb_http_do()` will not return an error when the client reads the maximum amount into the internal buffer, it will just return a partial response. This appears to be intentional given the comments in the source.

Most plugins which make use of this API do not check this error condition, leading to confusion when it occurs but existing logs report everything as fine. These issues can usually be resolved by simply increasing the configured buffer size for a given plugin, which is what the log message hints at:

```
[2021/04/06 21:30:06] [ warn] [http_client] cannot increase buffer: current=102400 requested=135168 max=102400
```

Fixes #2214, which suggested this change last year.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- `[N/A]` Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- `[N/A]` Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- `[N/A]` Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
