### PR TITLE
out_stackdriver: enable custom regex to parse local_resource_id for stackdriver meta labels

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_oauth2.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_pthread.h>
+#include <fluent-bit/flb_regex.h>
 
 /* refresh token every 50 minutes */
 #define FLB_STD_TOKEN_REFRESH 3000
@@ -122,7 +123,6 @@ struct flb_stackdriver {
     flb_sds_t job;
     flb_sds_t task_id;
 
-
     /* other */
     flb_sds_t export_to_project_id;
     flb_sds_t resource;
@@ -132,6 +132,10 @@ struct flb_stackdriver {
     bool autoformat_stackdriver_trace;
 
     flb_sds_t stackdriver_agent;
+    
+    /* Regex context to parse tags */
+    flb_sds_t custom_k8s_regex;
+    struct flb_regex *regex;
 
     /* oauth2 context */
     struct flb_oauth2 *o;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -420,12 +420,19 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     else {
         if (ctx->is_k8s_resource_type == FLB_TRUE) {
             ctx->tag_prefix = flb_sds_create(ctx->resource);
+            ctx->tag_prefix = flb_sds_cat(ctx->tag_prefix, ".", 1);
         }
     }
 
     tmp = flb_output_get_property("stackdriver_agent", ins);
     if (tmp) {
         ctx->stackdriver_agent = flb_sds_create(tmp);
+    }
+
+    /* Custom Regex */
+    tmp = flb_output_get_property("custom_k8s_regex", ins);
+    if (tmp) {
+        ctx->custom_k8s_regex = flb_sds_create(tmp);
     }
 
     return ctx;
@@ -476,6 +483,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->log_name_key);
     flb_sds_destroy(ctx->labels_key);
     flb_sds_destroy(ctx->tag_prefix);
+    flb_sds_destroy(ctx->custom_k8s_regex);
 
     if (ctx->stackdriver_agent) {
         flb_sds_destroy(ctx->stackdriver_agent);
@@ -498,6 +506,10 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         flb_oauth2_destroy(ctx->o);
     }
 
+    if (ctx->regex) {
+        flb_regex_destroy(ctx->regex);
+    }
+    
     flb_free(ctx);
 
     return 0;

--- a/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_k8s_resource.h
@@ -47,6 +47,19 @@
 	"\"END_KEY\": \"JSON_END\""		\
 	"}]"
 
+#define K8S_NODE_LOCAL_RESOURCE_ID_WITH_DOT	"["		\
+	"1591649196,"			\
+	"{"				\
+    "\"message\": \"K8S_NODE_LOCAL_RESOURCE_ID_WITH_DOT\","		\
+    "\"logging.googleapis.com/local_resource_id\": \"k8s_node.testnode.withdot.dot\","		\
+	"\"PRIORITY\": 6,"		\
+	"\"SYSLOG_FACILITY\": 3,"		\
+	"\"_CAP_EFFECTIVE\": \"3fffffffff\","		\
+	"\"_PID\": 1387,"		\
+	"\"_SYSTEMD_UNIT\": \"docker.service\","		\
+	"\"END_KEY\": \"JSON_END\""		\
+	"}]"
+
 /* k8s_pod */
 #define K8S_POD_COMMON	"["		\
 	"1591649196,"			\

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -822,6 +822,44 @@ static void cb_check_k8s_node_resource(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_k8s_node_custom_k8s_regex(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* resource type */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "k8s_node");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "test_cluster_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* cluster name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['cluster_name']", "test_cluster_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* node name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['node_name']", "testnode.withdot.dot");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `local_resource_id` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/local_resource_id']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_k8s_pod_resource(void *ctx, int ffd,
                                       int res_ret, void *res_data, size_t res_size,
                                       void *data)
@@ -1263,7 +1301,7 @@ static void cb_check_multi_entries_severity(void *ctx, int ffd,
 
     ret = mp_kv_cmp(res_data, res_size, "$entries[2]['severity']", "DEBUG");
     TEST_CHECK(ret == FLB_TRUE);
-
+    
     // verifies that severity is removed from jsonPayload
     ret = mp_kv_exists(res_data, res_size, "$entries[2]['jsonPayload']['severity']");
     TEST_CHECK(ret == FLB_FALSE);
@@ -3090,6 +3128,97 @@ void flb_test_resource_k8s_container_default_tag_regex()
     flb_destroy(ctx);
 }
 
+void flb_test_resource_k8s_container_custom_k8s_regex()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag",
+                  "k8s_container.testnamespace.testpod.testctr", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "k8s_container.*",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "custom_k8s_regex", "^(?<namespace_name>[^_]+)\\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\\.(?<container_name>.+)$",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_container_custom_k8s_regex_custom_prefix()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_NO_LOCAL_RESOURCE_ID) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag",
+                  "kube.var.log.containers.testnamespace.testpod.testctr", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "kube.var.log.containers.*",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "tag_prefix", "kube.var.log.containers.",
+                   "custom_k8s_regex", "^(?<namespace_name>[^_]+)\\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\\.(?<container_name>.+)$",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_resource,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_resource_k8s_node_common()
 {
     int ret;
@@ -3427,6 +3556,50 @@ void flb_test_resource_k8s_node_no_local_resource_id()
 
     /* Ingest data sample */
     flb_lib_push(ctx, in_ffd, (char *) K8S_NODE_NO_LOCAL_RESOURCE_ID, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_node_custom_k8s_regex_with_dot()
+{
+    int ret;
+    int size = sizeof(K8S_NODE_LOCAL_RESOURCE_ID_WITH_DOT) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "k8s_node",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "custom_k8s_regex", "^(?<node_name>.*)$",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_node_custom_k8s_regex,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_NODE_LOCAL_RESOURCE_ID_WITH_DOT, size);
 
     sleep(2);
     flb_stop(ctx);
@@ -4536,8 +4709,11 @@ TEST_LIST = {
     {"resource_k8s_container_custom_tag_prefix", flb_test_resource_k8s_container_custom_tag_prefix },
     {"resource_k8s_container_custom_tag_prefix_with_dot", flb_test_resource_k8s_container_custom_tag_prefix_with_dot },
     {"resource_k8s_container_default_tag_regex", flb_test_resource_k8s_container_default_tag_regex },
+    {"resource_k8s_container_custom_k8s_regex", flb_test_resource_k8s_container_custom_k8s_regex },
+    {"resource_k8s_container_custom_k8s_regex_custom_prefix", flb_test_resource_k8s_container_custom_k8s_regex_custom_prefix },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
     {"resource_k8s_node_no_local_resource_id", flb_test_resource_k8s_node_no_local_resource_id },
+    {"resource_k8s_node_custom_k8s_regex_with_dot", flb_test_resource_k8s_node_custom_k8s_regex_with_dot },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },
     {"resource_k8s_pod_no_local_resource_id", flb_test_resource_k8s_pod_no_local_resource_id },
     {"default_labels", flb_test_default_labels },


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
With this patch, we can set an alternative regex to process record Tag and extract pod_name, namespace_name, container_name.

Similar to `Regex_Parser` from [kubernetes filter ](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#workflow-of-tail-kubernetes-filter).

Rule:
1. If the tag (without prefix) matches the regex specified in the `custom_regex` field, then the `loca_resource_id` won't be parsed to extract the meta labels. Meta labels will be extracted from log tag based on regex.
2. If the tag (without prefix) doesn't match the regex specified, `local_resource_id` will be parsed to extract meta labels.

Default regex is:
`"(?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\\.log$"`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3189 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
