### PR TITLE
http_client: fail early when ingesting an invalid HTTP status

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -392,6 +392,9 @@ static int process_data(struct flb_http_client *c)
         memcpy(code, c->resp.data + 9, 3);
         code[3] = '\0';
         c->resp.status = atoi(code);
+        if (c->resp.status < 100 || c->resp.status > 599) {
+            return FLB_HTTP_ERROR;
+        }
     }
 
     /* Try to lookup content length */


### PR DESCRIPTION
Currently `process_data()` will generate an error when various header fields are invalid, but not if the HTTP status itself is. This PR adds verification of the status, which provides a very early signal if the HTTP response itself is valid. In this scenario `flb_http_do()` will return much earlier than before.

This also prevents a potential denial-of-service when the HTTP response is *totally invalid* (which has been observed in the wild, see discussion in #3301). Currently, Fluent Bit will fill its entire buffer (and potentially resize it up to the maximum) while looking for the end of the header block. After this change it will fail much earlier.

Of course, it's still possible to encounter an invalid HTTP response that just happens to have a valid HTTP status code in the right byte range.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- `[N/A]` Example configuration file for the change
- `[N/A]` Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- `[N/A]` Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- `[N/A]` Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
