### PR TITLE
filter_grep: respect all rules even when a match is found

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -165,9 +165,6 @@ static inline int grep_filter_data(msgpack_object map, struct grep_ctx *ctx)
             if (rule->type == GREP_EXCLUDE) {
                 return GREP_RET_EXCLUDE;
             }
-            else {
-                return GREP_RET_KEEP;
-            }
         }
     }
 

--- a/tests/runtime/filter_grep.c
+++ b/tests/runtime/filter_grep.c
@@ -3,13 +3,29 @@
 #include <fluent-bit.h>
 #include "flb_tests_runtime.h"
 
+/* Output callback to count events. */
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+int count = 0;
+
+int callback_count(void* data, size_t size, void* cb_data)
+{
+    if (size > 0) {
+        flb_debug("[test_filter_nest] received message: %s", data);
+        pthread_mutex_lock(&mutex);
+        count++;
+        pthread_mutex_unlock(&mutex);
+    }
+    return 0;
+}
+
 /* Test data */
 
 /* Test functions */
 void flb_test_filter_grep_regex(void);
 void flb_test_filter_grep_exclude(void);
 void flb_test_filter_grep_invalid(void);
-
+void flb_test_filter_grep_multi(void);
 
 void flb_test_filter_grep_regex(void)
 {
@@ -143,10 +159,88 @@ void flb_test_filter_grep_invalid(void)
     flb_destroy(ctx);
 }
 
+void flb_test_filter_grep_multi(void)
+{
+    int ret;
+    int bytes;
+    char* p;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb;
+    int expected = 1;
+
+    pthread_mutex_lock(&mutex);
+    count = 0;
+    pthread_mutex_unlock(&mutex);
+
+    cb.cb = callback_count;
+    cb.data = NULL;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace" "1", "Log_Level", "debug", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", "format", "json", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "Regex", "w 1", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "Regex", "x 1", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "Exclude", "y 1", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "Exclude", "z 1", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Matches rule 1 and 2 but not 3 or 4; should be included. */
+    p = "[1448403340, {\"w\":\"1\", \"x\":\"1\", \"y\":\"2\", \"z\":\"2\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    /* Matches rule 1 but not 2; should be excluded. */
+    p = "[1448403340, {\"w\":\"1\", \"x\":\"2\", \"y\":\"2\", \"z\":\"2\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    /* Matches rule 1, 2, and 3; should be excluded. */
+    p = "[1448403340, {\"w\":\"1\", \"x\":\"1\", \"y\":\"1\", \"z\":\"2\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    /* Matches rule 1, 2, and 4 but not 3; should be excluded. */
+    p = "[1448403340, {\"w\":\"1\", \"x\":\"1\", \"y\":\"2\", \"z\":\"1\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+
+    pthread_mutex_lock(&mutex);
+    TEST_CHECK_(count == expected, "Expected %d events, got %d", expected,
+                count);
+    pthread_mutex_unlock(&mutex);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"regex",   flb_test_filter_grep_regex   },
     {"exclude", flb_test_filter_grep_exclude },
     {"invalid", flb_test_filter_grep_invalid },
+    {"multi",   flb_test_filter_grep_multi   },
     {NULL, NULL}
 };


### PR DESCRIPTION
Currently the `grep` filter will keep data when the first positive match for a rule is found, regardless of whether the data would be excluded by another rule later on. An example is given in #3259.

This leads to surprising behaviour when combining `Regex` rules with one another or when combining `Regex` rules with `Exclude` rules:

* The order of `Regex` rules matters, but the order of `Exclude` rules does not.

* Mixing `Regex` and `Exclude` rules will result in the `Exclude` rules being ignored if *any* of the `Regex` rules match.

This commit changes the existing behaviour so that inputs must pass *all* rules.

I've also included new runtime tests for this behaviour.

This is a **breaking change** for users with multiple `Regex` rules in a single block that rely on the existing short-circuiting behaviour. However, I think the new behaviour is consistent with the existing documentation, so I'm not sure why anyone would be doing this.

Fixes #3259.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- `[N/A]` Example configuration file for the change
- `[N/A]` Debug log output from testing the change
- `[N/A]` Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- `[N/A]` Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
