### PR TITLE
workflows: do not make Windows-related issues stale

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -16,5 +16,6 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           days-before-pr-close: -1
+          exempt-issue-labels: 'Windows'
           exempt-all-pr-assignees: true
           exempt-all-pr-milestones: true


### PR DESCRIPTION
This stale bot is useful. But it sometimes closes long-term stuffs
which do not expect an immediate update, but still are not dead.

This teaches stale bots to exempt Windows issues (which I manage)
from automatic cleanups.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>
