### PR TITLE
out_loki: use flb_time_in_nanosec to prevent time convertion error

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -75,6 +75,7 @@ static inline int flb_time_equal(struct flb_time *t0, struct flb_time *t1) {
 int flb_time_get(struct flb_time *tm);
 int flb_time_msleep(uint32_t ms);
 double flb_time_to_double(struct flb_time *tm);
+uint64_t flb_time_to_nanosec(struct flb_time *tm);
 int flb_time_add(struct flb_time *base, struct flb_time *duration,
                  struct flb_time *result);
 int flb_time_diff(struct flb_time *time1,

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -706,7 +706,7 @@ static void pack_timestamp(msgpack_packer *mp_pck, struct flb_time *tms)
     uint64_t nanosecs;
 
     /* convert to nanoseconds */
-    nanosecs = ((tms->tm.tv_sec * 1000000000L) + tms->tm.tv_nsec);
+    nanosecs = flb_time_to_nanosec(tms);
 
     /* format as a string */
     len = snprintf(buf, sizeof(buf) - 1, "%" PRIu64, nanosecs);

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -89,6 +89,11 @@ double flb_time_to_double(struct flb_time *tm)
     return (double)(tm->tm.tv_sec) + ((double)tm->tm.tv_nsec/(double)ONESEC_IN_NSEC);
 }
 
+uint64_t flb_time_to_nanosec(struct flb_time *tm)
+{
+    return (((uint64_t)tm->tm.tv_sec * 1000000000L) + tm->tm.tv_nsec);
+}
+
 int flb_time_add(struct flb_time *base, struct flb_time *duration, struct flb_time *result)
 {
     if (base == NULL || duration == NULL|| result == NULL) {

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -19,6 +19,7 @@ set(UNIT_TESTS_FILES
   config_map.c
   mp.c
   input_chunk.c
+  flb_time.c
   )
 
 if (NOT WIN32)

--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_internal.h"
+
+
+void test_to_nanosec()
+{
+    uint64_t expect = 123000000456;
+    uint64_t ret;
+    struct flb_time tm;
+
+    flb_time_set(&tm, 123, 456);
+
+    ret = flb_time_to_nanosec(&tm);
+    if (!TEST_CHECK(ret == expect)) {
+      TEST_MSG("given  =%" PRIu64, ret);
+      TEST_MSG("expect =%" PRIu64, expect);
+    }
+}
+
+TEST_LIST = {
+    { "flb_time_to_nanosec"           , test_to_nanosec},
+    { NULL, NULL }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes #3350 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
On 32bit platform (e.g. some raspberry pi OS), out_loki fails to convert timestamp in nanosecond.

I added new function `flb_time_in_nanosec` and out_loki uses it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log output
```
$ bin/flb-it-flb_time 
Test flb_time_in_nanosec...                     [ OK ]
SUCCESS: All unit tests have passed.
```

output using #3350 configuration
```
fluentbit    | [2021/04/10 23:05:25] [trace] [input:forward:forward.0 at plugins/in_forward/fw.c:97] new TCP connection arrived FD=27
fluentbit    | [2021/04/10 23:05:25] [trace] [input:forward:forward.0 at plugins/in_forward/fw_conn.c:73] read()=172 pre_len=0 now_len=172
fluentbit    | [2021/04/10 23:05:25] [debug] [task] created task=0x7f14b7c30980 id=0 OK
fluentbit    | [2021/04/10 23:05:26] [debug] [http_client] not using http_proxy for header
fluentbit    | [2021/04/10 23:05:26] [debug] [http_client] header=POST /loki/api/v1/push HTTP/1.1
fluentbit    | Host: loki:3100
fluentbit    | Content-Length: 292
fluentbit    | User-Agent: Fluent-Bit
fluentbit    | Content-Type: application/json
fluentbit    | 
fluentbit    | 
fluentbit    | [2021/04/10 23:05:26] [debug] [out coro] cb_destroy coro_id=0
fluentbit    | [0] c70e888dc8b3: [1618095925.000000000, {"container_id"=>"c70e888dc8b3119be04a402a076bfec9ed4d2ed8aa7a871cb9bad74e35f6b9ed", "container_name"=>"/wizardly_fer"}], "source"=>"stdout", "log"=>"testing a log message
fluentbit    | [2021/04/10 23:05:26] [ info] [output:loki:loki.0] loki:3100, HTTP status=204
fluentbit    | [2021/04/10 23:05:26] [debug] [upstream] KA connection #28 to loki:3100 is now available
fluentbit    | [2021/04/10 23:05:26] [debug] [out coro] cb_destroy coro_id=0
fluentbit    | [2021/04/10 23:05:26] [debug] [task] destroy task=0x7f14b7c30980 (task_id=0)
fluentbit    | [2021/04/10 23:05:26] [trace] [input:forward:forward.0 at plugins/in_forward/fw_conn.c:84] fd=27 closed connection
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
