### PR TITLE
workflows: add mergebot and docs-required label.

### DIFF
--- a/.github/workflows/README.workflows.md
+++ b/.github/workflows/README.workflows.md
@@ -13,3 +13,12 @@
 | [integration-run-pr](./integration-run-pr.yaml)     | Runs the integration testing suite on a PR branch | pr opened / label created 'ok-to-test' |
 | [unit-tests](./unit-tests.yaml)     | Runs the unit tests suite on master push or new PR | PR opened, merge in master branch |
 
+### Available labels
+
+| Label name | Description | 
+| :----------|-------------|
+| docs-required| default tag used to request documentation, has to be removed before merge |
+| ok-to-test | run all integration tests |
+| ok-to-merge | run mergebot and merge (rebase) current PR |
+| ci/integration-docker-ok | integration test is able to build docker image |
+| ci/integration-gcp-ok | integration test is able to run on GCP |

--- a/.github/workflows/mergebot.yaml
+++ b/.github/workflows/mergebot.yaml
@@ -1,0 +1,31 @@
+name: Merge Bot
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - ready_for_review
+      - review_request_removed
+      - review_requested
+      - synchronize
+      - unlabeled
+  pull_request_review:
+    types:
+      - dismissed
+      - submitted
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    name: Merge pull request
+    steps:
+      - name: Checks for merging
+        uses: squalrus/merge-bot@v0.4.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          reviewers: false
+          labels: ok-to-merge
+          blocking_labels: docs-required, dont-merge
+          checks_enabled: false
+          method: rebase
+          delete_source_branch: true

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,4 +1,4 @@
-name: 'Commit Message Check'
+name: 'Pull requests checks'
 on:
   pull_request:
     types:
@@ -7,6 +7,19 @@ on:
       - reopened
       - synchronize
 jobs:
+  apply-default-labels:
+    name: apply default labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        name: Label the PR with 'docs-required' by default.
+        continue-on-error: true
+        with:
+          labels: docs-required
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          repo: fluent/fluent-bit
+
   check-commit-message:
     name: Check Commit Message
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR sets a default label named 'docs-required', if that label is set
then the automatic merge using 'ok-to-merge' label won't succeed.
