### PR TITLE
init: use network-online instead network

### DIFF
--- a/init/systemd.in
+++ b/init/systemd.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=@FLB_PROG_NAME@
-Requires=network.target
-After=network.target
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
init: use network-online insted network

In some case, if fluent-bit have resolve host to send to output and network does not start correctly, fluent-bit will not start.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
