### PR TITLE
lib: fix cleanup function to relase flb_config (#3353)

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -208,8 +208,10 @@ void flb_destroy(flb_ctx_t *ctx)
     mk_event_loop_destroy(ctx->event_loop);
 
     /* cfg->is_running is set to false when flb_engine_shutdown has been invoked (event loop) */
-    if(ctx->config && ctx->config->is_running == FLB_TRUE) {
-        flb_engine_shutdown(ctx->config);
+    if(ctx->config) {
+        if (ctx->config->is_running == FLB_TRUE) {
+            flb_engine_shutdown(ctx->config);
+        }
         flb_config_exit(ctx->config);
     }
 
@@ -694,6 +696,6 @@ int flb_stop(flb_ctx_t *ctx)
     flb_engine_exit(ctx->config);
     ret = pthread_join(tid, NULL);
     flb_debug("[lib] Fluent Bit engine stopped");
-    ctx->config = NULL;
+
     return ret;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes #3353 

The issue is leak of `flb_config`.

I fixed 
* Remove `ctx->config = NULL` to release flb_config at `flb_destroy`
* Change condition to release `flb_config`.

In some cases, engine is not running at `flb_destroy`.
It may be stopped at https://github.com/fluent/fluent-bit/blob/d34838d641a3e88a17290c429b0b9a7d2af08a04/src/flb_engine.c#L651

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Valgrind Output

```
$ valgrind bin/fluent-bit -i cpu -o null
==22809== Memcheck, a memory error detector
==22809== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22809== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==22809== Command: bin/fluent-bit -i cpu -o null
==22809== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/16 21:31:05] [ info] [engine] started (pid=22809)
[2021/04/16 21:31:05] [ info] [storage] version=1.1.1, initializing...
[2021/04/16 21:31:05] [ info] [storage] in-memory
[2021/04/16 21:31:05] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/16 21:31:05] [ info] [sp] stream processor started
==22809== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c662a0
==22809==          to suppress, use: --max-stackframe=12051992 or greater
==22809== Warning: client switching stacks?  SP change: 0x4c66218 --> 0x57e48b8
==22809==          to suppress, use: --max-stackframe=12052128 or greater
==22809== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c66218
==22809==          to suppress, use: --max-stackframe=12052128 or greater
==22809==          further instances of this message will not be shown.
^C[2021/04/16 21:31:10] [engine] caught signal (SIGINT)
[2021/04/16 21:31:10] [ info] [input] pausing cpu.0
[2021/04/16 21:31:10] [ warn] [engine] service will stop in 5 seconds
[2021/04/16 21:31:15] [ info] [engine] service stopped
==22809== 
==22809== HEAP SUMMARY:
==22809==     in use at exit: 0 bytes in 0 blocks
==22809==   total heap usage: 263 allocs, 263 frees, 934,160 bytes allocated
==22809== 
==22809== All heap blocks were freed -- no leaks are possible
==22809== 
==22809== For lists of detected and suppressed errors, rerun with: -s
==22809== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
