### PR TITLE
[Question] Fix CVE-2019-18224, CVE-2019-12290, CVE-2018-1000654

### DIFF
--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -35,6 +35,18 @@ RUN apt-get update && \
     && cd fluent-bit/build/ \
     && rm -rf /tmp/fluent-bit/build/*
 
+RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
+
+RUN /bin/bash -c "echo $'\n\
+Package: * \n\
+Pin: release a=testing \n\
+Pin-Priority: 450' >> /etc/apt/preferences"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends -t testing \
+    libidn2-0 \
+    libtasn1-bin
+
 WORKDIR /tmp/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \


### PR DESCRIPTION
I see some vulnerabilities reported for the fluent-bit image and want to fix it by pulling latest package from Debian testing.
By this PR I'm just asking if this is an acceptable way of doing this?

https://nvd.nist.gov/vuln/detail/CVE-2019-18224
https://nvd.nist.gov/vuln/detail/CVE-2019-12290
https://nvd.nist.gov/vuln/detail/CVE-2018-1000654
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
