### PR TITLE
build: add Wesley as code owner for all AWS code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,10 @@
 /src/flb_signv4.c        @pettitwesley
 /src/flb_lib.c           @edsiper @niedbalski
 
+@ Core: AWS Auth & Utils
+# ------------
+/src/aws                 @pettitwesley
+
 # Core: Stream Processor
 # ----------------
 /src/stream_processor/   @koleini
@@ -50,3 +54,8 @@
 /plugins/out_datadog     @clamoriniere
 /plugins/out_es          @pettitwesley @edsiper
 /plugins/out_pgsql       @sxd
+# AWS Plugins 
+/plugins/out_s3               @pettitwesley
+/plugins/out_cloudwatch_logs  @pettitwesley
+/plugins/out_kinesis_firehose @pettitwesley
+/plugins/out_kinesis_streams  @pettitwesley


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
