### PR TITLE
out_s3: fix memory leak when gzip is on

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1128,6 +1128,9 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
         c = s3_client->client_vtable->request(s3_client, FLB_HTTP_PUT,
                                               uri, final_body, final_body_size,
                                               headers, num_headers);
+        if (ctx->compression != NULL) {
+             flb_free(compressed_body);
+        }
         flb_free(headers);
     }
     if (c) {


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Fix the memory leak problem when gzip is enabled.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
fixes #3204 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==20787== HEAP SUMMARY:
==20787==     in use at exit: 102,608 bytes in 3,429 blocks
==20787==   total heap usage: 91,100 allocs, 87,671 frees, 16,588,826 bytes allocated
==20787== 
==20787== LEAK SUMMARY:
==20787==    definitely lost: 0 bytes in 0 blocks
==20787==    indirectly lost: 0 bytes in 0 blocks
==20787==      possibly lost: 368 bytes in 1 blocks
==20787==    still reachable: 102,240 bytes in 3,428 blocks
==20787==         suppressed: 0 bytes in 0 blocks
==20787== Rerun with --leak-check=full to see details of leaked memory
==20787== 
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
