### PR TITLE
out_syslog: correctly select the rfc 3164 for syslog

### DIFF
--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -702,7 +702,7 @@ static flb_sds_t syslog_format(struct flb_syslog *ctx, msgpack_object *o,
             msg.facility = 1;
         }
 
-        if (ctx->format == FLB_SYSLOG_RFC3164) {
+        if (ctx->parsed_format == FLB_SYSLOG_RFC3164) {
             tmp = syslog_rfc3164(s, tm, &msg);
         }
         else {
@@ -849,9 +849,10 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
         flb_plg_error(ins, "error configuring plugin");
         return -1;
     }
+    ctx->ins = ins;
 
     if (ctx->maxsize < 0) {
-        if (ctx->format == FLB_SYSLOG_RFC3164) {
+        if (ctx->parsed_format == FLB_SYSLOG_RFC3164) {
             ctx->maxsize = RFC3164_MAXSIZE;
         }
         else {
@@ -893,6 +894,7 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
 
     flb_plg_info(ctx->ins, "setup done for %s:%i",
                  ins->host.name, ins->host.port);
+
     return 0;
 }
 
@@ -927,7 +929,7 @@ static struct flb_config_map config_map[] = {
 
     {
      FLB_CONFIG_MAP_STR, "syslog_format", "rfc5424",
-     0, FLB_TRUE, offsetof(struct flb_syslog, format),
+     0, FLB_TRUE, offsetof(struct flb_syslog, parsed_format),
      "Specify the Syslog protocol format to use, the available options are rfc3164 "
      "and rfc5424."
     },

--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -849,7 +849,6 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
         flb_plg_error(ins, "error configuring plugin");
         return -1;
     }
-    ctx->ins = ins;
 
     if (ctx->maxsize < 0) {
         if (ctx->parsed_format == FLB_SYSLOG_RFC3164) {
@@ -894,7 +893,6 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
 
     flb_plg_info(ctx->ins, "setup done for %s:%i",
                  ins->host.name, ins->host.port);
-
     return 0;
 }
 
@@ -929,7 +927,7 @@ static struct flb_config_map config_map[] = {
 
     {
      FLB_CONFIG_MAP_STR, "syslog_format", "rfc5424",
-     0, FLB_TRUE, offsetof(struct flb_syslog, parsed_format),
+     0, FLB_TRUE, offsetof(struct flb_syslog, format),
      "Specify the Syslog protocol format to use, the available options are rfc3164 "
      "and rfc5424."
     },

--- a/plugins/out_syslog/syslog_conf.h
+++ b/plugins/out_syslog/syslog_conf.h
@@ -31,7 +31,6 @@ struct flb_syslog {
     flb_sockfd_t fd;
     struct flb_upstream *u;
     flb_sds_t mode;
-    int format;
     size_t maxsize;
     flb_sds_t severity_key;
     flb_sds_t facility_key;

--- a/plugins/out_syslog/syslog_conf.h
+++ b/plugins/out_syslog/syslog_conf.h
@@ -31,6 +31,7 @@ struct flb_syslog {
     flb_sockfd_t fd;
     struct flb_upstream *u;
     flb_sds_t mode;
+    flb_sds_t format;
     size_t maxsize;
     flb_sds_t severity_key;
     flb_sds_t facility_key;


### PR DESCRIPTION
<!-- Provide summary of changes -->
The rfc 3164 is not selected even if I specify it in the output section.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3263

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

** Example configuration file for the change **
```
[SERVICE]
    flush           1
    daemon          off
#    log_level       info
    parsers_file    parsers.conf
    plugins_file    plugins.conf
    http_server     off
    http_listen     0.0.0.0
    http_port       2020
    storage.metrics off

[INPUT]
    Name              tail
    Path              /home/YYYYY/tmp/*.log
    Path_Key          filename
    Parser            rawlog
    Mem_Buf_Limit     16MB
    Skip_Long_Lines   off
    Refresh_Interval  1

[FILTER]
    Name record_modifier
    Match *
    Record hostname ${HOSTNAME}

[OUTPUT]
    name stdout
    match *

[OUTPUT]
    name              syslog
    match             *
    host              localhost
    port              514
    mode              udp
    syslog_format     rfc3164
    syslog_maxsize    1024
```

** Debug log output from testing the change **
From fluent-bit
```
[2021/04/18 12:25:19] [ info] [filter:syslog:] setup done for localhost:514
[2021/04/18 12:25:19] [ info] [sp] stream processor started
[2021/04/18 12:25:19] [ info] [input:tail:tail.0] inotify_fs_add(): inode=784141 watch_fd=1 name=/home/YYYYY/tmp/xxx.log
[0] fb.cdm: [1618741567.905278925, {"filename"=>"/home/YYYYY/tmp/xxx.log", "log"=>"test it 3", "hostname"=>"WX-OR6141864"}]
```

From rsyslog:
```
1568.262834748:imudp.c        : imudp.c: imudp: epoll_wait() returned with 1 fds
1568.263638695:imudp.c        : imudp.c: imudp: recvmmsg returned 1
1568.264147417:imudp.c        : imudp.c: recv(8,20),acl:1,msg:<14>Apr 18 10:26:07 
1568.264498405:imudp.c        : parser.c: msg parser: flags 70, from '~NOTRESOLVED~', msg '<14>Apr 18 10:26:07 '
1568.264694422:imudp.c        : parser.c: parse using parser list 0x55db942bf3a0 (the default list).
1568.265073912:imudp.c        : parser.c: Parser 'rsyslog.rfc5424' returned -2160
1568.265491260:imudp.c        : pmrfc3164.c: Message will now be parsed by the legacy syslog parser (offAfterPRI=4, lenMsg=16.
1568.265817394:imudp.c        : datetime.c: ParseTIMESTAMP3339: invalid year: 0, pszTS: 'p'
1568.266212020:imudp.c        : parser.c: Parser 'rsyslog.rfc3164' returned 0
1568.266531938:imudp.c        : imudp.c: imudp: recvmmsg returned -1
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
