### PR TITLE
build: fix CMakeLists.txt for systemd and upstart init files 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,6 +745,13 @@ else()
   set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
   set(FLB_INSTALL_CONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
   set(FLB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+  if(${CMAKE_INSTALL_PREFIX} MATCHES "/usr/local")
+    set(FLB_INSTALL_SYSTEMDUNITDIR "/lib/systemd/system/")
+    set(FLB_INSTALL_UPSTARTUNITDIR "/etc/init")
+  else()
+    set(FLB_INSTALL_SYSTEMDUNITDIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/system/")
+    set(FLB_INSTALL_UPSTARTUNITDIR "${CMAKE_INSTALL_PREFIX}/etc/init")
+  endif()
 endif()
 
 # Instruct CMake to build the Fluent Bit Core

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -417,7 +417,7 @@ if(FLB_BINARY)
       "${PROJECT_SOURCE_DIR}/init/systemd.in"
       ${FLB_SYSTEMD_SCRIPT}
       )
-    install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION /lib/systemd/system)
+    install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${FLB_INSTALL_SYSTEMDUNITDIR})
     install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
   elseif(IS_DIRECTORY /usr/share/upstart)
     set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")
@@ -425,7 +425,7 @@ if(FLB_BINARY)
       "${PROJECT_SOURCE_DIR}/init/upstart.in"
       ${FLB_UPSTART_SCRIPT}
       )
-    install(FILES ${FLB_UPSTART_SCRIPT} COMPONENT binary DESTINATION /etc/init)
+    install(FILES ${FLB_UPSTART_SCRIPT} COMPONENT binary DESTINATION ${FLB_INSTALL_UPSTARTUNITDIR})
     install(DIRECTORY DESTINATION COMPONENT binary ${FLB_INSTALL_CONFDIR})
   else()
     # FIXME: should we support Sysv init script ?


### PR DESCRIPTION
<!-- Provide summary of changes -->
This commit enable the usage of CMAKE_INSTALL_PREFIX variable for systemd and upstart by writing these files in the provided directory.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #3393
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
```
usr@localhost:~/fluent-bit/build $ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/installtest && make install
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done

[...]

[ 98%] Built target out_lib
[100%] Linking CXX executable ../../bin/hello_world_cpp
[100%] Built target td
[100%] Built target hello_world_cpp
Install the project...
-- Install configuration: "Debug"
-- Installing: /tmp/installtest/include/fluent-bit.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_api.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_avro.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_aws_credentials.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_aws_util.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_bits.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_callback.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_compat.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_config.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_config_map.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_coro.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_dlfcn_win32.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_dump.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_endian.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_engine.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_engine_dispatch.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_env.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_error.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_filter.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_filter_plugin.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_fstore.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_gzip.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_hash.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_help.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_http_client.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_http_client_debug.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_http_server.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_info.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_input.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_input_chunk.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_input_plugin.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_intermediate_metric.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_io.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_jsmn.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_kernel.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_kv.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_langinfo.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_lib.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_log.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_luajit.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_macros.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_mem.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_meta.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_metrics.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_metrics_exporter.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_mp.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_network.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_oauth2.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_output.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_output_plugin.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_output_thread.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_pack.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_parser.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_parser_decoder.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_pipe.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_plugin.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_plugin_proxy.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_plugins.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_pthread.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_ra_key.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_random.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_record_accessor.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_regex.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_router.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_routes_mask.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_s3_local_buffer.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_scheduler.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_sds.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_sha512.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_signv4.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_slist.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_socket.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_sosreport.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_sqldb.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_stacktrace.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_storage.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_str.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_strptime.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_task.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_task_map.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_thread_pool.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_thread_storage.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_time.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_time_utils.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_tls.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_unescape.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_upstream.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_upstream_conn.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_upstream_ha.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_upstream_node.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_upstream_queue.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_uri.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_utf8.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_utils.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_version.h
-- Installing: /tmp/installtest/include/fluent-bit/flb_worker.h
-- Installing: /tmp/installtest/include/fluent-bit/tls/flb_tls.h
-- Installing: /tmp/installtest/include/monkey/mk_core.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_core_info.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_dep_unistd.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_dirent.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_event.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_event_epoll.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_event_kqueue.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_event_libevent.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_event_select.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_file.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_getopt.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_iov.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_limits.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_list.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_macros.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_memory.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_pipe.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_pthread.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_rconf.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_sleep.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_string.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_thread.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_thread_channel.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_uio.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_unistd.h
-- Installing: /tmp/installtest/include/monkey/mk_core/mk_utils.h
-- Installing: /tmp/installtest/include/libco.h
-- Installing: /tmp/installtest/include/settings.h
-- Installing: /tmp/installtest/lib/libfluent-bit.so
-- Installing: /tmp/installtest/bin/fluent-bit
-- Installing: /tmp/installtest/lib/systemd/system/fluent-bit.service
-- Installing: /tmp/installtest/etc/fluent-bit/
-- Installing: /tmp/installtest/etc/fluent-bit/fluent-bit.conf
-- Installing: /tmp/installtest/etc/fluent-bit/parsers.conf
-- Installing: /tmp/installtest/etc/fluent-bit/plugins.conf
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
