### PR TITLE
in_tail: initialize mult_parsers list before parsing properties

### DIFF
--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -57,6 +57,8 @@ int flb_tail_mult_create(struct flb_tail_config *ctx,
         ctx->multiline_flush = 1;
     }
 
+    mk_list_init(&ctx->mult_parsers);
+
     /* Get firstline parser */
     tmp = flb_input_get_property("parser_firstline", ins);
     if (!tmp) {
@@ -70,7 +72,6 @@ int flb_tail_mult_create(struct flb_tail_config *ctx,
     }
 
     ctx->mult_parser_firstline = parser;
-    mk_list_init(&ctx->mult_parsers);
 
     /* Read all multiline rules */
     mk_list_foreach(head, &ins->properties) {


### PR DESCRIPTION
if the list is not initialized, any error during the parsing of options will cause the *mult_destroy function to segfault.

Example program:
```c
#include <fluent-bit.h>
#include <stdlib.h>

void main(void)
{
    int ret;
    flb_ctx_t    *ctx    = NULL;
    int in_ffd, r;

    ctx = flb_create();
    in_ffd = flb_input(ctx, (char *) "tail", NULL);
    r = flb_input_set(ctx, in_ffd, "multiline", "On");
    printf("%d\n", r);

    r = flb_input_set(ctx, in_ffd, "path", "/tmp/test");
    printf("%d\n", r);

    flb_start(ctx);
    flb_stop(ctx);
    flb_destroy(ctx);
}
```
Without this patch, the program segfaults with the following traceback

```c
[2021/04/20 12:10:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/20 12:10:15] [error] [input:tail:tail.0] multiline: no parser defined for firstline

Thread 2 "flb-pipeline" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff71a6700 (LWP 50649)]
0x00007ffff7be51eb in flb_tail_mult_destroy (ctx=0x7ffff00070b0) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/plugins/in_tail/tail_multiline.c:109
109         mk_list_foreach_safe(head, tmp, &ctx->mult_parsers) {
(gdb) bt
#0  0x00007ffff7be51eb in flb_tail_mult_destroy (ctx=0x7ffff00070b0) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/plugins/in_tail/tail_multiline.c:109
#1  0x00007ffff7bef210 in flb_tail_config_destroy (config=0x7ffff00070b0) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/plugins/in_tail/tail_config.c:321
#2  0x00007ffff7bee889 in flb_tail_config_create (ins=0x555555564de0, config=0x555555559300) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/plugins/in_tail/tail_config.c:148
#3  0x00007ffff7be3d8c in in_tail_init (in=0x555555564de0, config=0x555555559300, data=0x0) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/plugins/in_tail/tail.c:283
#4  0x00007ffff7b5378c in flb_input_instance_init (ins=0x555555564de0, config=0x555555559300) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/src/flb_input.c:483
#5  0x00007ffff7b5386d in flb_input_init_all (config=0x555555559300) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/src/flb_input.c:519
#6  0x00007ffff7b6868c in flb_engine_start (config=0x555555559300) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/src/flb_engine.c:505
#7  0x00007ffff7b460d9 in flb_lib_worker (data=0x5555555592d0) at /home/niedbalski/go/src/github.com/calyptia/fluent-bit/src/flb_lib.c:605
#8  0x00007ffff783e609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#9  0x00007ffff7a13293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) 

```
