### PR TITLE
out_cloudwatch_logs: fix memory leak when using cpu or mem input

### DIFF
--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -23,12 +23,14 @@
 
 #define FLB_SPLUNK_DEFAULT_HOST       "127.0.0.1"
 #define FLB_SPLUNK_DEFAULT_PORT       8088
-#define FLB_SPLUNK_DEFAULT_URI        "/services/collector/event"
+#define FLB_SPLUNK_DEFAULT_URI_RAW    "/services/collector/raw"
+#define FLB_SPLUNK_DEFAULT_URI_EVENT  "/services/collector/event"
 #define FLB_SPLUNK_DEFAULT_TIME       "time"
 #define FLB_SPLUNK_DEFAULT_EVENT      "event"
 
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_record_accessor.h>
 
 struct flb_splunk {
     /* Payload compression */
@@ -37,6 +39,10 @@ struct flb_splunk {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+
+    /* Single value key */
+    flb_sds_t event_key;
+    struct flb_record_accessor *ra_event_key;
 
     /* Token Auth */
     flb_sds_t auth_header;


### PR DESCRIPTION
Signed-off-by: Ade Fisher <adrian.fisher@montvieux.com>

Fixes memory leak in out_cloudwatch_logs when using cpu or mem input

Replicates #3310 on to the 1.7 branch
Fixes #3145

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Valgrind output after change

```
[2021/03/31 08:52:04] [ info] [engine] service stopped
==85211== 
==85211== HEAP SUMMARY:
==85211==     in use at exit: 0 bytes in 0 blocks
==85211==   total heap usage: 193,370 allocs, 193,370 frees, 33,548,850 bytes allocated
==85211== 
==85211== All heap blocks were freed -- no leaks are possible
==85211== 
==85211== For lists of detected and suppressed errors, rerun with: -s
==85211== ERROR SUMMARY: 23679 errors from 132 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
