### PR TITLE
pack: new option `json.convert_nan_to_null`

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -46,6 +46,7 @@ struct flb_config {
     double flush;             /* Flush timeout                  */
     int grace;                /* Grace on shutdown              */
     flb_pipefd_t flush_fd;    /* Timer FD associated to flush   */
+    int convert_nan_to_null;  /* convert null to nan ?          */
 
     int daemon;               /* Run as a daemon ?              */
     flb_pipefd_t shutdown_fd; /* Shutdown FD, 5 seconds         */
@@ -241,6 +242,7 @@ enum conf_type {
 #define FLB_CONF_STR_PARSERS_FILE "Parsers_File"
 #define FLB_CONF_STR_PLUGINS_FILE "Plugins_File"
 #define FLB_CONF_STR_STREAMS_FILE "Streams_File"
+#define FLB_CONF_STR_CONV_NAN     "json.convert_nan_to_null"
 
 /* FLB_HAVE_HTTP_SERVER */
 #ifdef FLB_HAVE_HTTP_SERVER

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -68,6 +68,7 @@ int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size, int *
 int flb_pack_json_recs(const char *js, size_t len, char **buffer, size_t *size,
                        int *root_type, int *out_records);
 
+int flb_pack_set_null_as_nan(int b);
 int flb_pack_state_init(struct flb_pack_state *s);
 void flb_pack_state_reset(struct flb_pack_state *s);
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -55,6 +55,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, grace)},
 
+    {FLB_CONF_STR_CONV_NAN,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, convert_nan_to_null)},
+
     {FLB_CONF_STR_DAEMON,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, daemon)},
@@ -152,6 +156,9 @@ struct flb_config *flb_config_init()
     config->verbose      = 3;
     config->grace        = 5;
     config->exit_status_code = 0;
+
+    /* json */
+    config->convert_nan_to_null = FLB_FALSE;
 
 #ifdef FLB_HAVE_HTTP_SERVER
     config->http_ctx     = NULL;

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -43,6 +43,7 @@
 #include <fluent-bit/flb_sosreport.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_http_server.h>
+#include <fluent-bit/flb_pack.h>
 
 #ifdef FLB_HAVE_METRICS
 #include <fluent-bit/flb_metrics_exporter.h>
@@ -455,6 +456,8 @@ int flb_engine_start(struct flb_config *config)
     struct mk_event *event;
     struct mk_event_loop *evl;
     struct flb_sched *sched;
+
+    flb_pack_set_null_as_nan(config->convert_nan_to_null);
 
     /* Create the event loop and set it in the global configuration */
     evl = mk_event_loop_create(256);

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <math.h> /* for NAN */
 
 
 #include "flb_tests_internal.h"
@@ -626,6 +627,36 @@ void test_json_pack_bug1278()
     }
 }
 
+void test_json_pack_nan()
+{
+    int ret;
+    char json_str[128];
+    char *p = NULL;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    msgpack_object obj;
+    msgpack_zone mempool;
+
+    // initialize msgpack
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_double(&mp_pck, NAN);
+    msgpack_zone_init(&mempool, 2048);
+    msgpack_unpack(mp_sbuf.data, mp_sbuf.size, NULL, &mempool, &obj);
+    msgpack_zone_destroy(&mempool);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    // convert msgpack to json
+    ret = flb_msgpack_to_json(&json_str[0], sizeof(json_str), &obj);
+    TEST_CHECK(ret >= 0);
+
+    p = strstr(&json_str[0], "nan");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("json should be nan. json_str=%s", json_str);
+    }
+}
+
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "json_pack"          , test_json_pack },
@@ -635,6 +666,7 @@ TEST_LIST = {
     { "json_dup_keys"      , test_json_dup_keys},
     { "json_pack_bug342"   , test_json_pack_bug342},
     { "json_pack_bug1278"  , test_json_pack_bug1278},
+    { "json_pack_nan"      , test_json_pack_nan},
 
     /* Mixed bytes, check JSON encoding */
     { "utf8_to_json", test_utf8_to_json},

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -630,7 +630,7 @@ void test_json_pack_bug1278()
 void test_json_pack_nan()
 {
     int ret;
-    char json_str[128];
+    char json_str[128] = {0};
     char *p = NULL;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
@@ -654,6 +654,20 @@ void test_json_pack_nan()
     if (!TEST_CHECK(p != NULL)) {
         TEST_MSG("json should be nan. json_str=%s", json_str);
     }
+
+    // convert. nan -> null
+    memset(&json_str[0], 0, sizeof(json_str));
+    flb_pack_set_null_as_nan(FLB_TRUE);
+    ret = flb_msgpack_to_json(&json_str[0], sizeof(json_str), &obj);
+    TEST_CHECK(ret >= 0);
+
+    p = strstr(&json_str[0], "null");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("json should be null. json_str=%s", json_str);
+    }
+
+    // clear setting
+    flb_pack_set_null_as_nan(FLB_FALSE);
 }
 
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #1588 

This patch is to add `json.convert_nan_to_null` (Default: false)

| name | description | default|
|-------|-------------|----------|
|json.convert_nan_to_null| If enabled, NaN is converted to null when fluent-bit converts msgpack to json|false|

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

## Example configuration

a.conf:
```
[SERVICE]
    json.convert_nan_to_null true

[INPUT]
    Name forward
    Listen 127.0.0.1

[OUTPUT]
    Name stdout
    Format json
```

a.sh to send NaN.
```sh
printf "\x93\xa1a\x7f\x81\xa1a\xca\xff\xff\xff\xff" |nc 127.0.0.1 24224
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/21 20:16:17] [ info] [engine] started (pid=16167)
[2021/04/21 20:16:17] [ info] [storage] version=1.1.1, initializing...
[2021/04/21 20:16:17] [ info] [storage] in-memory
[2021/04/21 20:16:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/21 20:16:17] [ info] [input:forward:forward.0] listening on 127.0.0.1:24224
[2021/04/21 20:16:17] [ info] [sp] stream processor started
[{"date":127.0,"a":null}]
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c a.conf 
==16179== Memcheck, a memory error detector
==16179== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16179== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==16179== Command: bin/fluent-bit -c a.conf
==16179== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/21 20:17:28] [ info] [engine] started (pid=16179)
[2021/04/21 20:17:29] [ info] [storage] version=1.1.1, initializing...
[2021/04/21 20:17:29] [ info] [storage] in-memory
[2021/04/21 20:17:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/21 20:17:29] [ info] [input:forward:forward.0] listening on 127.0.0.1:24224
[2021/04/21 20:17:29] [ info] [sp] stream processor started
==16179== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4d5f860
==16179==          to suppress, use: --max-stackframe=11030616 or greater
==16179== Warning: client switching stacks?  SP change: 0x4d5f7d8 --> 0x57e48b8
==16179==          to suppress, use: --max-stackframe=11030752 or greater
==16179== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4d5f7d8
==16179==          to suppress, use: --max-stackframe=11030752 or greater
==16179==          further instances of this message will not be shown.
[{"date":127.0,"a":null}]
^C[2021/04/21 20:17:34] [engine] caught signal (SIGINT)
[2021/04/21 20:17:34] [ info] [input] pausing forward.0
[2021/04/21 20:17:34] [ warn] [engine] service will stop in 5 seconds
[2021/04/21 20:17:38] [ info] [engine] service stopped
==16179== 
==16179== HEAP SUMMARY:
==16179==     in use at exit: 0 bytes in 0 blocks
==16179==   total heap usage: 312 allocs, 312 frees, 1,679,663 bytes allocated
==16179== 
==16179== All heap blocks were freed -- no leaks are possible
==16179== 
==16179== For lists of detected and suppressed errors, rerun with: -s
==16179== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
