### PR TITLE
out_loki: change log level to suppress 200-205 status log (#3363)

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1140,14 +1140,14 @@ static void cb_loki_flush(const void *data, size_t bytes,
         }
         else {
             if (c->resp.payload) {
-                flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i\n%s",
-                             ctx->tcp_host, ctx->tcp_port,
-                             c->resp.status, c->resp.payload);
+                flb_plg_debug(ctx->ins, "%s:%i, HTTP status=%i\n%s",
+                              ctx->tcp_host, ctx->tcp_port,
+                              c->resp.status, c->resp.payload);
             }
             else {
-                flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i",
-                             ctx->tcp_host, ctx->tcp_port,
-                             c->resp.status);
+                flb_plg_debug(ctx->ins, "%s:%i, HTTP status=%i",
+                              ctx->tcp_host, ctx->tcp_port,
+                              c->resp.status);
             }
         }
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #3363 

This patch is to suppress logs which reports http status is 200-205.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration file

```
[SERVICE]
    log_level debug

[INPUT]
    Name cpu
[OUTPUT]
    Name loki
```

## Debug log 

The log level of this log is changed. `info` -> `debug`
```
[2021/04/23 22:03:23] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
```

```
$ bin/fluent-bit -c 3363/a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/23 22:03:18] [ info] Configuration:
[2021/04/23 22:03:18] [ info]  flush time     | 5.000000 seconds
[2021/04/23 22:03:18] [ info]  grace          | 5 seconds
[2021/04/23 22:03:18] [ info]  daemon         | 0
[2021/04/23 22:03:18] [ info] ___________
[2021/04/23 22:03:18] [ info]  inputs:
[2021/04/23 22:03:18] [ info]      cpu
[2021/04/23 22:03:18] [ info] ___________
[2021/04/23 22:03:18] [ info]  filters:
[2021/04/23 22:03:18] [ info] ___________
[2021/04/23 22:03:18] [ info]  outputs:
[2021/04/23 22:03:18] [ info]      loki.0
[2021/04/23 22:03:18] [ info] ___________
[2021/04/23 22:03:18] [ info]  collectors:
[2021/04/23 22:03:18] [ info] [engine] started (pid=13426)
[2021/04/23 22:03:18] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/04/23 22:03:18] [debug] [storage] [cio stream] new stream registered: cpu.0
[2021/04/23 22:03:18] [ info] [storage] version=1.1.1, initializing...
[2021/04/23 22:03:18] [ info] [storage] in-memory
[2021/04/23 22:03:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/23 22:03:18] [debug] [loki:loki.0] created event channels: read=18 write=19
[2021/04/23 22:03:18] [debug] [output:loki:loki.0] remove_mpa size: 0
[2021/04/23 22:03:18] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/04/23 22:03:18] [debug] [router] default match rule cpu.0:loki.0
[2021/04/23 22:03:18] [ info] [sp] stream processor started
[2021/04/23 22:03:23] [debug] [task] created task=0x7f5ae80072f0 id=0 OK
[2021/04/23 22:03:23] [debug] [http_client] not using http_proxy for header
[2021/04/23 22:03:23] [debug] [http_client] header=POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 596
User-Agent: Fluent-Bit
Content-Type: application/json


[2021/04/23 22:03:23] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
[2021/04/23 22:03:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 is now available
[2021/04/23 22:03:23] [debug] [out coro] cb_destroy coro_id=0
[2021/04/23 22:03:23] [debug] [task] destroy task=0x7f5ae80072f0 (task_id=0)
^C[2021/04/23 22:03:23] [engine] caught signal (SIGINT)
[2021/04/23 22:03:23] [ info] [input] pausing cpu.0
[2021/04/23 22:03:23] [debug] [task] created task=0x7f5ae8007a70 id=0 OK
[2021/04/23 22:03:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 has been assigned (recycled)
[2021/04/23 22:03:23] [debug] [http_client] not using http_proxy for header
[2021/04/23 22:03:23] [debug] [http_client] header=POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 191
User-Agent: Fluent-Bit
Content-Type: application/json


[2021/04/23 22:03:23] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
[2021/04/23 22:03:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 is now available
[2021/04/23 22:03:23] [ warn] [engine] service will stop in 5 seconds
[2021/04/23 22:03:23] [debug] [out coro] cb_destroy coro_id=1
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c 3363/a.conf 
==13431== Memcheck, a memory error detector
==13431== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13431== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==13431== Command: bin/fluent-bit -c 3363/a.conf
==13431== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/23 22:05:18] [ info] Configuration:
[2021/04/23 22:05:18] [ info]  flush time     | 5.000000 seconds
[2021/04/23 22:05:18] [ info]  grace          | 5 seconds
[2021/04/23 22:05:18] [ info]  daemon         | 0
[2021/04/23 22:05:18] [ info] ___________
[2021/04/23 22:05:18] [ info]  inputs:
[2021/04/23 22:05:18] [ info]      cpu
[2021/04/23 22:05:18] [ info] ___________
[2021/04/23 22:05:18] [ info]  filters:
[2021/04/23 22:05:18] [ info] ___________
[2021/04/23 22:05:18] [ info]  outputs:
[2021/04/23 22:05:18] [ info]      loki.0
[2021/04/23 22:05:18] [ info] ___________
[2021/04/23 22:05:18] [ info]  collectors:
[2021/04/23 22:05:18] [ info] [engine] started (pid=13431)
[2021/04/23 22:05:18] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/04/23 22:05:18] [debug] [storage] [cio stream] new stream registered: cpu.0
[2021/04/23 22:05:18] [ info] [storage] version=1.1.1, initializing...
[2021/04/23 22:05:18] [ info] [storage] in-memory
[2021/04/23 22:05:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/23 22:05:18] [debug] [loki:loki.0] created event channels: read=18 write=19
[2021/04/23 22:05:18] [debug] [output:loki:loki.0] remove_mpa size: 0
[2021/04/23 22:05:18] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/04/23 22:05:18] [debug] [router] default match rule cpu.0:loki.0
[2021/04/23 22:05:18] [ info] [sp] stream processor started
[2021/04/23 22:05:23] [debug] [task] created task=0x4c64b00 id=0 OK
==13431== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6af50
==13431==          to suppress, use: --max-stackframe=12032360 or greater
==13431== Warning: client switching stacks?  SP change: 0x4c6aec8 --> 0x57e48b8
==13431==          to suppress, use: --max-stackframe=12032496 or greater
==13431== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6aec8
==13431==          to suppress, use: --max-stackframe=12032496 or greater
==13431==          further instances of this message will not be shown.
[2021/04/23 22:05:23] [debug] [http_client] not using http_proxy for header
[2021/04/23 22:05:23] [debug] [http_client] header=POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 600
User-Agent: Fluent-Bit
Content-Type: application/json


[2021/04/23 22:05:23] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
[2021/04/23 22:05:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 is now available
[2021/04/23 22:05:23] [debug] [out coro] cb_destroy coro_id=0
[2021/04/23 22:05:23] [debug] [task] destroy task=0x4c64b00 (task_id=0)
^C[2021/04/23 22:05:23] [engine] caught signal (SIGINT)
[2021/04/23 22:05:23] [ info] [input] pausing cpu.0
[2021/04/23 22:05:23] [debug] [task] created task=0x4cc34f0 id=0 OK
[2021/04/23 22:05:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 has been assigned (recycled)
[2021/04/23 22:05:23] [debug] [http_client] not using http_proxy for header
[2021/04/23 22:05:23] [debug] [http_client] header=POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 195
User-Agent: Fluent-Bit
Content-Type: application/json


[2021/04/23 22:05:23] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=204
[2021/04/23 22:05:23] [debug] [upstream] KA connection #25 to 127.0.0.1:3100 is now available
[2021/04/23 22:05:23] [ warn] [engine] service will stop in 5 seconds
[2021/04/23 22:05:23] [debug] [out coro] cb_destroy coro_id=1
[2021/04/23 22:05:23] [debug] [task] destroy task=0x4cc34f0 (task_id=0)
[2021/04/23 22:05:28] [ info] [engine] service stopped
==13431== 
==13431== HEAP SUMMARY:
==13431==     in use at exit: 0 bytes in 0 blocks
==13431==   total heap usage: 391 allocs, 391 frees, 1,043,486 bytes allocated
==13431== 
==13431== All heap blocks were freed -- no leaks are possible
==13431== 
==13431== For lists of detected and suppressed errors, rerun with: -s
==13431== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
