### PR TITLE
parser: json: fix type confusion bug.

### DIFF
--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -168,6 +168,12 @@ int flb_parser_json_do(struct flb_parser *parser,
         return *out_size;
     }
 
+    /* Ensure we have an accurate type */
+    if (v->type != MSGPACK_OBJECT_STR) {
+        msgpack_unpacked_destroy(&result);
+        return *out_size;
+    }
+
     /* Lookup time */
     ret = flb_parser_time_lookup(v->via.str.ptr, v->via.str.size,
                                  0, parser, &tm, &tmfrac);


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes type confusion bug found by oss-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30090

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
