### PR TITLE
ra_key: fix signed integer overflow

### DIFF
--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_ra_key.h>
 #include <fluent-bit/record_accessor/flb_ra_parser.h>
 #include <msgpack.h>
+#include <limits.h>
 
 /* Map msgpack object into flb_ra_value representation */
 static int msgpack_object_to_ra_value(msgpack_object o,
@@ -144,10 +145,8 @@ static int subkey_to_object(msgpack_object *map, struct mk_list *subkeys,
                 return -1;
             }
 
-            /* Index limit */
-            /* Ensure we do not oveflow signed numbers (holding 2**31-1) */
-            static int overflow_limit = 2147483647;
-            if (entry->array_id == overflow_limit ||
+            /* Index limit and ensure no overflow */
+            if (entry->array_id == INT_MAX ||
                 cur.via.array.size < entry->array_id + 1) {
                 return -1;
             }

--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -145,7 +145,8 @@ static int subkey_to_object(msgpack_object *map, struct mk_list *subkeys,
             }
 
             /* Index limit */
-            if (cur.via.array.size < entry->array_id + 1) {
+            if (entry->array_id == 2147483647 ||
+                cur.via.array.size < entry->array_id + 1) {
                 return -1;
             }
 

--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -145,7 +145,9 @@ static int subkey_to_object(msgpack_object *map, struct mk_list *subkeys,
             }
 
             /* Index limit */
-            if (entry->array_id == 2147483647 ||
+            /* Ensure we do not oveflow signed numbers (holding 2**31-1) */
+            static int overflow_limit = 2147483647;
+            if (entry->array_id == overflow_limit ||
                 cur.via.array.size < entry->array_id + 1) {
                 return -1;
             }


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30096

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
