### PR TITLE
parser_decoder: fix memory leak.

### DIFF
--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -392,6 +392,10 @@ int flb_parser_decoder_do(struct mk_list *decoders,
          * The content of this buffer is just a serialized number of maps.
          */
         if (dec->add_extra_keys == FLB_TRUE) {
+            /* We need to clean up already allocated extra buffers */
+            if (extra_keys == FLB_TRUE) {
+                msgpack_sbuffer_destroy(&extra_mp_sbuf);
+            }
             extra_keys = FLB_TRUE;
             msgpack_sbuffer_init(&extra_mp_sbuf);
             msgpack_packer_init(&extra_mp_pck, &extra_mp_sbuf,


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes memory leak https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30091

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
