### PR TITLE
in_forward: support config map

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -206,6 +206,26 @@ static int in_fw_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_STR, "unix_path", NULL,
+    0, FLB_TRUE, offsetof(struct flb_in_fw_config, unix_path),
+    "The path to unix socket to receive a Forward message."
+   },
+   {
+    FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", FLB_IN_FW_CHUNK_SIZE,
+    0, FLB_TRUE, offsetof(struct flb_in_fw_config, buffer_chunk_size),
+    "The buffer memory size used to receive a Forward message."
+   },
+   {
+    FLB_CONFIG_MAP_SIZE, "buffer_max_size", FLB_IN_FW_CHUNK_MAX_SIZE,
+    0, FLB_TRUE, offsetof(struct flb_in_fw_config, buffer_max_size),
+    "The maximum buffer memory size used to receive a Forward message."
+   },
+   {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_forward_plugin = {
     .name         = "forward",
@@ -216,5 +236,6 @@ struct flb_input_plugin in_forward_plugin = {
     .cb_flush_buf = NULL,
     .cb_pause     = in_fw_pause,
     .cb_exit      = in_fw_exit,
+    .config_map   = config_map,
     .flags        = FLB_INPUT_NET
 };

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_input_plugin.h>
 
 #include "fw.h"
 #include "fw_conn.h"
@@ -28,8 +29,7 @@
 struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
 {
     char tmp[16];
-    const char *buffer_size;
-    const char *chunk_size;
+    int ret = -1;
     const char *p;
     struct flb_in_fw_config *config;
 
@@ -39,36 +39,20 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         return NULL;
     }
 
-    p = flb_input_get_property("unix_path", i_ins);
-    if (p) {
-        config->unix_path = flb_strdup(p);
+    ret = flb_input_config_map_set(i_ins, (void *)config);
+    if (ret == -1) {
+        flb_plg_error(i_ins, "config map set error");
+        flb_free(config);
+        return NULL;
     }
-    else {
+
+    p = flb_input_get_property("unix_path", i_ins);
+    if (p == NULL) {
         /* Listen interface (if not set, defaults to 0.0.0.0:24224) */
         flb_input_net_default_listener("0.0.0.0", 24224, i_ins);
         config->listen = i_ins->host.listen;
         snprintf(tmp, sizeof(tmp) - 1, "%d", i_ins->host.port);
         config->tcp_port = flb_strdup(tmp);
-    }
-
-    /* Chunk size */
-    chunk_size = flb_input_get_property("buffer_chunk_size", i_ins);
-    if (!chunk_size) {
-        config->buffer_chunk_size = FLB_IN_FW_CHUNK_SIZE; /* 1MB */
-    }
-    else {
-        /* Convert KB unit to Bytes */
-        config->buffer_chunk_size  = flb_utils_size_to_bytes(chunk_size);
-    }
-
-    /* Buffer size */
-    buffer_size = flb_input_get_property("buffer_max_size", i_ins);
-    if (!buffer_size) {
-        config->buffer_max_size = FLB_IN_FW_CHUNK_MAX_SIZE; /* 6MB */
-    }
-    else {
-        /* Convert unit to bytes */
-        config->buffer_max_size  = flb_utils_size_to_bytes(buffer_size);
     }
 
     if (!config->unix_path) {
@@ -82,7 +66,6 @@ int fw_config_destroy(struct flb_in_fw_config *config)
 {
     if (config->unix_path) {
         unlink(config->unix_path);
-        flb_free(config->unix_path);
     }
     else {
         flb_free(config->tcp_port);

--- a/plugins/in_forward/fw_conn.h
+++ b/plugins/in_forward/fw_conn.h
@@ -21,8 +21,8 @@
 #ifndef FLB_IN_FW_CONN_H
 #define FLB_IN_FW_CONN_H
 
-#define FLB_IN_FW_CHUNK_SIZE      1024000 /* 1MB */
-#define FLB_IN_FW_CHUNK_MAX_SIZE  FLB_IN_FW_CHUNK_SIZE * 6 /* 6M */
+#define FLB_IN_FW_CHUNK_SIZE      "1024000" /* 1MB */
+#define FLB_IN_FW_CHUNK_MAX_SIZE  "6144000" /* =FLB_IN_FW_CHUNK_SIZE * 6.  6MB */
 
 enum {
     FW_NEW        = 1,  /* it's a new connection                */


### PR DESCRIPTION
This patch is to support config map.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration

```
[INPUT]
    Name forward
    Buffer_chunk_size 500
    Buffer_max_size 1000
#   unix_path fluent.sock

[OUTPUT]
    Name stdout
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/30 19:27:41] [ info] [engine] started (pid=42185)
[2021/04/30 19:27:41] [ info] [storage] version=1.1.1, initializing...
[2021/04/30 19:27:41] [ info] [storage] in-memory
[2021/04/30 19:27:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/30 19:27:41] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2021/04/30 19:27:41] [ info] [sp] stream processor started
[0] cpu.0: [1619778456.807480346, {"cpu_p"=>56.000000, "user_p"=>54.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>56.000000, "cpu0.p_user"=>54.000000, "cpu0.p_system"=>2.000000}]
[1] cpu.0: [1619778457.807233624, {"cpu_p"=>7.000000, "user_p"=>7.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>7.000000, "cpu0.p_system"=>0.000000}]
[2] cpu.0: [1619778458.807291265, {"cpu_p"=>4.000000, "user_p"=>3.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>4.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>1.000000}]
[3] cpu.0: [1619778459.807503583, {"cpu_p"=>7.000000, "user_p"=>6.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>6.000000, "cpu0.p_system"=>1.000000}]
[4] cpu.0: [1619778460.807601331, {"cpu_p"=>5.000000, "user_p"=>4.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>5.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>1.000000}]
[5] cpu.0: [1619778451.807891777, {"cpu_p"=>20.000000, "user_p"=>19.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>20.000000, "cpu0.p_user"=>19.000000, "cpu0.p_system"=>1.000000}]
[6] cpu.0: [1619778452.807121489, {"cpu_p"=>19.000000, "user_p"=>18.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>19.000000, "cpu0.p_user"=>18.000000, "cpu0.p_system"=>1.000000}]
[7] cpu.0: [1619778453.808184497, {"cpu_p"=>47.000000, "user_p"=>45.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>47.000000, "cpu0.p_user"=>45.000000, "cpu0.p_system"=>2.000000}]
[8] cpu.0: [1619778454.807303677, {"cpu_p"=>68.000000, "user_p"=>65.000000, "system_p"=>3.000000, "cpu0.p_cpu"=>68.000000, "cpu0.p_user"=>65.000000, "cpu0.p_system"=>3.000000}]
[9] cpu.0: [1619778455.807796013, {"cpu_p"=>19.000000, "user_p"=>18.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>19.000000, "cpu0.p_user"=>18.000000, "cpu0.p_system"=>1.000000}]
^C[2021/04/30 19:27:46] [engine] caught signal (SIGINT)
[2021/04/30 19:27:46] [ info] [input] pausing forward.0
[2021/04/30 19:27:46] [ warn] [engine] service will stop in 5 seconds
[2021/04/30 19:27:50] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c a.conf 
==42188== Memcheck, a memory error detector
==42188== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==42188== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==42188== Command: bin/fluent-bit -c a.conf
==42188== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/04/30 19:28:19] [ info] [engine] started (pid=42188)
[2021/04/30 19:28:19] [ info] [storage] version=1.1.1, initializing...
[2021/04/30 19:28:19] [ info] [storage] in-memory
[2021/04/30 19:28:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/04/30 19:28:19] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2021/04/30 19:28:20] [ info] [sp] stream processor started
==42188== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c68ec0
==42188==          to suppress, use: --max-stackframe=12040696 or greater
==42188== Warning: client switching stacks?  SP change: 0x4c68e38 --> 0x57e48b8
==42188==          to suppress, use: --max-stackframe=12040832 or greater
==42188== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c68e38
==42188==          to suppress, use: --max-stackframe=12040832 or greater
==42188==          further instances of this message will not be shown.
[0] cpu.0: [1619778496.807551202, {"cpu_p"=>3.000000, "user_p"=>3.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>0.000000}]
[1] cpu.0: [1619778497.807341140, {"cpu_p"=>45.000000, "user_p"=>41.000000, "system_p"=>4.000000, "cpu0.p_cpu"=>45.000000, "cpu0.p_user"=>41.000000, "cpu0.p_system"=>4.000000}]
[2] cpu.0: [1619778498.807705440, {"cpu_p"=>99.000000, "user_p"=>94.000000, "system_p"=>5.000000, "cpu0.p_cpu"=>99.000000, "cpu0.p_user"=>94.000000, "cpu0.p_system"=>5.000000}]
[3] cpu.0: [1619778499.808333804, {"cpu_p"=>100.000000, "user_p"=>98.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>100.000000, "cpu0.p_user"=>98.000000, "cpu0.p_system"=>2.000000}]
[4] cpu.0: [1619778500.807158649, {"cpu_p"=>24.000000, "user_p"=>22.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>24.000000, "cpu0.p_user"=>22.000000, "cpu0.p_system"=>2.000000}]
^C[2021/04/30 19:28:25] [engine] caught signal (SIGINT)
[2021/04/30 19:28:25] [ info] [input] pausing forward.0
[0] cpu.0: [1619778491.807296095, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000}]
[1] cpu.0: [1619778492.807049031, {"cpu_p"=>1.000000, "user_p"=>0.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>1.000000}]
[2] cpu.0: [1619778493.807607469, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000}]
[3] cpu.0: [1619778494.807679531, {"cpu_p"=>2.000000, "user_p"=>2.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>0.000000}]
[4] cpu.0: [1619778495.807054926, {"cpu_p"=>9.000000, "user_p"=>9.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>9.000000, "cpu0.p_user"=>9.000000, "cpu0.p_system"=>0.000000}]
[2021/04/30 19:28:25] [ warn] [engine] service will stop in 5 seconds
[2021/04/30 19:28:29] [ info] [engine] service stopped
==42188== 
==42188== HEAP SUMMARY:
==42188==     in use at exit: 0 bytes in 0 blocks
==42188==   total heap usage: 365 allocs, 365 frees, 1,054,003 bytes allocated
==42188== 
==42188== All heap blocks were freed -- no leaks are possible
==42188== 
==42188== For lists of detected and suppressed errors, rerun with: -s
==42188== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
