### PR TITLE
in_docker_events: re-initialize docker socket when dockerd is restarted(#3439)

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -508,6 +508,7 @@ int flb_input_collector_start(int coll_id, struct flb_input_instance *ins);
 int flb_input_collectors_start(struct flb_config *config);
 int flb_input_collector_pause(int coll_id, struct flb_input_instance *ins);
 int flb_input_collector_resume(int coll_id, struct flb_input_instance *ins);
+int flb_input_collector_delete(int coll_id, struct flb_input_instance *ins);
 int flb_input_collector_fd(flb_pipefd_t fd, struct flb_config *config);
 int flb_input_set_collector_time(struct flb_input_instance *ins,
                                  int (*cb_collect) (struct flb_input_instance *,

--- a/plugins/in_docker_events/docker_events.h
+++ b/plugins/in_docker_events/docker_events.h
@@ -38,8 +38,15 @@ struct flb_in_de_config
     char *buf;
     size_t buf_size;
     flb_sds_t key;
+
+    /* retries */
     int reconnect_retry_limits;
     int reconnect_retry_interval;
+
+    /* retries (internal) */
+    int current_retries;
+    int retry_coll_id;
+
     struct flb_parser *parser;
     struct flb_input_instance *ins; /* Input plugin instace */
 

--- a/plugins/in_docker_events/docker_events.h
+++ b/plugins/in_docker_events/docker_events.h
@@ -38,6 +38,8 @@ struct flb_in_de_config
     char *buf;
     size_t buf_size;
     flb_sds_t key;
+    int reconnect_retry_limits;
+    int reconnect_retry_interval;
     struct flb_parser *parser;
     struct flb_input_instance *ins; /* Input plugin instace */
 

--- a/plugins/in_docker_events/docker_events.h
+++ b/plugins/in_docker_events/docker_events.h
@@ -33,6 +33,7 @@
 struct flb_in_de_config
 {
     int fd;                         /* File descriptor */
+    int coll_id;                    /* collector id */
     flb_sds_t unix_path;            /* Unix path for socket */
     char *buf;
     size_t buf_size;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -876,6 +876,24 @@ int flb_input_collector_pause(int coll_id, struct flb_input_instance *in)
     return 0;
 }
 
+int flb_input_collector_delete(int coll_id, struct flb_input_instance *in)
+{
+    struct flb_input_collector *coll;
+
+    coll = get_collector(coll_id, in);
+    if (!coll) {
+        return -1;
+    }
+    if (flb_input_collector_pause(coll_id, in) < 0) {
+        return -1;
+    }
+
+    mk_list_del(&coll->_head);
+    mk_list_del(&coll->_head_ins);
+    flb_free(coll);
+    return 0;
+}
+
 int flb_input_collector_resume(int coll_id, struct flb_input_instance *in)
 {
     int fd;


### PR DESCRIPTION
Fixes #3439 

This patch is 
- Add new api `flb_input_collector_delete`
   -  It is to delete specific collector event from plugin instance.
- Re-initialize docker socket and collector event when dockerd is restarted

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example configuration

```
[INPUT]
    Name docker_events

[OUTPUT]
    Name stdout
```

## Debug log

1. Exec fluent-bit `sudo fluent-bit -c a.conf`
2. Restart docker `sudo systemctl restart docker`
3. Docker run. e.g. `sudo docker run -it --rm ubuntu`

```
$ sudo ../bin/fluent-bit -c a.conf 
[sudo] password for taka: 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/01 14:16:08] [ info] [engine] started (pid=54300)
[2021/05/01 14:16:08] [ info] [storage] version=1.1.1, initializing...
[2021/05/01 14:16:08] [ info] [storage] in-memory
[2021/05/01 14:16:08] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/01 14:16:08] [ info] [input:docker_events:docker_events.0] listening for events on /var/run/docker.sock
[2021/05/01 14:16:08] [ info] [sp] stream processor started
[2021/05/01 14:17:15] [ info] [input:docker_events:docker_events.0] EOF detected. Re-initialize
[0] docker_events.0: [1619846285.408147542, {"message"=>"{"status":"create","id":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","from":"ubuntu","Type":"container","Action":"create","Actor":{"ID":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","Attributes":{"image":"ubuntu","name":"vigorous_agnesi"}},"scope":"local","time":1619846285,"timeNano":1619846285407895145}
"}]
[1] docker_events.0: [1619846285.409072590, {"message"=>"{"status":"attach","id":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","from":"ubuntu","Type":"container","Action":"attach","Actor":{"ID":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","Attributes":{"image":"ubuntu","name":"vigorous_agnesi"}},"scope":"local","time":1619846285,"timeNano":1619846285408974871}
"}]
[2] docker_events.0: [1619846285.492730679, {"message"=>"{"Type":"network","Action":"connect","Actor":{"ID":"2dac3f973aa4f6f917ad48eea6e768111888b3e4df68a90c868f278cfc6ae3f5","Attributes":{"container":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","name":"bridge","type":"bridge"}},"scope":"local","time":1619846285,"timeNano":1619846285492314514}
"}]
[3] docker_events.0: [1619846285.904044998, {"message"=>"{"status":"start","id":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","from":"ubuntu","Type":"container","Action":"start","Actor":{"ID":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","Attributes":{"image":"ubuntu","name":"vigorous_agnesi"}},"scope":"local","time":1619846285,"timeNano":1619846285903525922}
"}]
[4] docker_events.0: [1619846285.906679025, {"message"=>"{"status":"resize","id":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","from":"ubuntu","Type":"container","Action":"resize","Actor":{"ID":"3073fe3e9cf2fe9946abceefcf0e299a0d3edc6d42f18c51ed700b501aa93407","Attributes":{"height":"23","image":"ubuntu","name":"vigorous_agnesi","width":"79"}},"scope":"local","time":1619846285,"timeNano":1619846285906205732}
"}]
```

## Valgrind output

```
$ sudo valgrind ../bin/fluent-bit -c a.conf 
==54639== Memcheck, a memory error detector
==54639== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==54639== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==54639== Command: ../bin/fluent-bit -c a.conf
==54639== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/01 14:19:16] [ info] [engine] started (pid=54639)
[2021/05/01 14:19:16] [ info] [storage] version=1.1.1, initializing...
[2021/05/01 14:19:16] [ info] [storage] in-memory
[2021/05/01 14:19:16] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/01 14:19:16] [ info] [input:docker_events:docker_events.0] listening for events on /var/run/docker.sock
[2021/05/01 14:19:16] [ info] [sp] stream processor started
[2021/05/01 14:19:19] [ info] [input:docker_events:docker_events.0] EOF detected. Re-initialize
==54639== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c88be0
==54639==          to suppress, use: --max-stackframe=11910360 or greater
==54639== Warning: client switching stacks?  SP change: 0x4c88b58 --> 0x57e48b8
==54639==          to suppress, use: --max-stackframe=11910496 or greater
==54639== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c88b58
==54639==          to suppress, use: --max-stackframe=11910496 or greater
==54639==          further instances of this message will not be shown.
[0] docker_events.0: [1619846362.018934707, {"message"=>"{"status":"create","id":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","from":"ubuntu","Type":"container","Action":"create","Actor":{"ID":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","Attributes":{"image":"ubuntu","name":"strange_proskuriakova"}},"scope":"local","time":1619846362,"timeNano":1619846362013127638}
"}]
[1] docker_events.0: [1619846362.129677329, {"message"=>"{"status":"attach","id":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","from":"ubuntu","Type":"container","Action":"attach","Actor":{"ID":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","Attributes":{"image":"ubuntu","name":"strange_proskuriakova"}},"scope":"local","time":1619846362,"timeNano":1619846362029205169}
{"Type":"network","Action":"connect","Actor":{"ID":"f8b3b92be36d36a843b11cb89c03b6881a19da226f3ac25622c998509c8305b2","Attributes":{"container":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","name":"bridge","type":"bridge"}},"scope":"local","time":1619846362,"timeNano":1619846362114320257}
"}]
[2] docker_events.0: [1619846362.759425227, {"message"=>"{"status":"start","id":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","from":"ubuntu","Type":"container","Action":"start","Actor":{"ID":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","Attributes":{"image":"ubuntu","name":"strange_proskuriakova"}},"scope":"local","time":1619846362,"timeNano":1619846362759094459}
"}]
[3] docker_events.0: [1619846362.762086460, {"message"=>"{"status":"resize","id":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","from":"ubuntu","Type":"container","Action":"resize","Actor":{"ID":"8cfc888175821f91691c6f9b8afba19a679fb7fe9630bb602c066e181e14f762","Attributes":{"height":"23","image":"ubuntu","name":"strange_proskuriakova","width":"79"}},"scope":"local","time":1619846362,"timeNano":1619846362761838688}
"}]
^C[2021/05/01 14:19:26] [engine] caught signal (SIGINT)
[2021/05/01 14:19:26] [ warn] [engine] service will stop in 5 seconds
[2021/05/01 14:19:31] [ info] [engine] service stopped
==54639== 
==54639== HEAP SUMMARY:
==54639==     in use at exit: 0 bytes in 0 blocks
==54639==   total heap usage: 318 allocs, 318 frees, 808,218 bytes allocated
==54639== 
==54639== All heap blocks were freed -- no leaks are possible
==54639== 
==54639== For lists of detected and suppressed errors, rerun with: -s
==54639== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
