### PR TITLE
filter: add total processing volume metrics

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -87,6 +87,8 @@ struct flb_filter_instance {
      * --------
      */
     struct cmt *cmt;                      /* parent context               */
+    struct cmt_counter *cmt_records;      /* m: filter_records_total      */
+    struct cmt_counter *cmt_bytes;        /* m: filter_bytes_total        */
     struct cmt_counter *cmt_add_records;  /* m: filter_add_records_total  */
     struct cmt_counter *cmt_drop_records; /* m: filter_drop_records_total */
 


### PR DESCRIPTION
Instead of just having metrics for number of records added/dropped, we
now also have metrics for the total number of records and bytes
processed by each filter.

We want to have insight into this to check whether our filters match the correct things.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
