### PR TITLE
oauth2: fix token expires time not updated

### DIFF
--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -390,6 +390,8 @@ char *flb_oauth2_token_get(struct flb_oauth2 *ctx)
             flb_info("[oauth2] access token from '%s:%s' retrieved",
                      ctx->host, ctx->port);
             flb_http_client_destroy(c);
+            ctx->issued = time(NULL);
+            ctx->expires = ctx->issued + ctx->expires_in;
             return ctx->access_token;
         }
     }


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
In v1.6.10, Fluent Bit is generating a new token when expired: https://github.com/fluent/fluent-bit/blob/v1.6.10/plugins/out_stackdriver/stackdriver.c#L206 and each time the `ctx->expires` will be updated.

In v1.7.4, only token get is called: https://github.com/fluent/fluent-bit/blob/v1.7.4/plugins/out_stackdriver/stackdriver.c#L253 and the `ctx->expires` is not updated.

However, the `flb_oauth2_token_expired(1)` is using `ctx->expires` to check whether the token is expired. This will result in an endless retrieving of token.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3324 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
