### PR TITLE
Libraries backtrace and luajit does not compile with PIC correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,7 +641,7 @@ if(FLB_BACKTRACE)
   FLB_DEFINITION(FLB_HAVE_LIBBACKTRACE)
   ExternalProject_Add(backtrace
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/configure ${AUTOCONF_HOST_OPT} --host=${HOST} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/configure ${AUTOCONF_HOST_OPT} --host=${HOST} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes --with-pic
     BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
     INSTALL_COMMAND $(MAKE) DESTDIR= install
     )

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -15,6 +15,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
 endif()
 
+if (UNIX)
+  set(CFLAGS "${CFLAGS} -fpic")
+endif()
+
 # luajit (UNIX)
 # =============
 ExternalProject_Add(luajit


### PR DESCRIPTION
<!-- Provide summary of changes -->
This was disproved when compiling fluent-bit with PIE by setting
CMAKE_EXE_LINKER_FLAGS=-pie

The backtrace project seems to require to explicitly set --with-fpic to
be compiled with PIC support.
The luajit has a wierd construct of setting fpic in the XCFLAGS. XCFLAGS is
inteded to be used when compiling the compiler itself - not for this purspose.
Instead this commit sets CFLAGS=-fpic for UNIX builds. The XCFLAGS is kept
since other platforrms/compilers may depend on it.

Signed-off-by: sirwio <sirwio@hotmail.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
