### PR TITLE
filter_lua: support config map

### DIFF
--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -568,11 +568,44 @@ static int cb_lua_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "script", NULL,
+     0, FLB_FALSE, 0,
+     "The path of lua script."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "call", NULL,
+     0, FLB_TRUE, offsetof(struct lua_filter, call),
+     "Lua function name that will be triggered to do filtering."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "type_int_key", NULL,
+     0, FLB_FALSE, 0,
+     "If these keys are matched, the fields are converted to integer. "
+     "If more than one key, delimit by space."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "protected_mode", "true",
+     0, FLB_TRUE, offsetof(struct lua_filter, protected_mode),
+     "If enabled, Lua script will be executed in protected mode. "
+     "It prevents to crash when invalid Lua script is executed."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "time_as_table", "false",
+     0, FLB_TRUE, offsetof(struct lua_filter, time_as_table),
+     "If enabled, Fluent-bit will pass the timestamp as a Lua table "
+     "with keys \"sec\" for seconds since epoch and \"nsec\" for nanoseconds."
+    },
+    {0}
+};
+
 struct flb_filter_plugin filter_lua_plugin = {
     .name         = "lua",
     .description  = "Lua Scripting Filter",
     .cb_init      = cb_lua_init,
     .cb_filter    = cb_lua_filter,
     .cb_exit      = cb_lua_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -37,10 +37,10 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
                                      struct flb_config *config)
 {
     int ret;
-    const char *tmp;
     char *tmp_key;
     char buf[PATH_MAX];
     const char *script = NULL;
+    const char *tmp = NULL;
     (void) config;
     struct stat st;
     struct lua_filter *lf;
@@ -56,30 +56,38 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         flb_errno();
         return NULL;
     }
+    ret = flb_filter_config_map_set(ins, (void*)lf);
+    if (ret < 0) {
+        flb_errno();
+        flb_plg_error(ins, "configuration error");
+        flb_free(lf);
+        return NULL;
+    }
+
     mk_list_init(&lf->l2c_types);
     lf->ins = ins;
+    lf->script = NULL;
 
     /* Config: script */
-    tmp = flb_filter_get_property("script", ins);
-    if (!tmp) {
+    script = flb_filter_get_property("script", ins);
+    if (!script) {
         flb_plg_error(lf->ins, "no script path defined");
         flb_free(lf);
         return NULL;
     }
-    script = tmp;
 
     /* Compose path */
-    ret = stat(tmp, &st);
+    ret = stat(script, &st);
     if (ret == -1 && errno == ENOENT) {
-        if (tmp[0] == '/') {
-            flb_plg_error(lf->ins, "cannot access script '%s'", tmp);
+        if (script[0] == '/') {
+            flb_plg_error(lf->ins, "cannot access script '%s'", script);
             flb_free(lf);
             return NULL;
         }
 
         if (config->conf_path) {
             snprintf(buf, sizeof(buf) - 1, "%s%s",
-                     config->conf_path, tmp);
+                     config->conf_path, script);
             script = buf;
         }
     }
@@ -99,15 +107,6 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         return NULL;
     }
 
-    /* Config: call */
-    tmp = flb_filter_get_property("call", ins);
-    if (!tmp) {
-        flb_plg_error(lf->ins, "no call property defined");
-        lua_config_destroy(lf);
-        return NULL;
-    }
-
-    lf->call = flb_sds_create(tmp);
     if (!lf->call) {
         flb_plg_error(lf->ins, "could not allocate call");
         lua_config_destroy(lf);
@@ -140,18 +139,6 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
         flb_utils_split_free(split);
     }
 
-    lf->protected_mode = FLB_TRUE;
-    tmp = flb_filter_get_property("protected_mode", ins);
-    if (tmp) {
-        lf->protected_mode = flb_utils_bool(tmp);
-    }
-
-    lf->time_as_table = FLB_FALSE;
-    tmp = flb_filter_get_property("time_as_table", ins);
-    if (tmp) {
-        lf->time_as_table = flb_utils_bool(tmp);
-    }
-
     return lf;
 }
 
@@ -167,9 +154,6 @@ void lua_config_destroy(struct lua_filter *lf)
 
     if (lf->script) {
         flb_sds_destroy(lf->script);
-    }
-    if (lf->call) {
-        flb_sds_destroy(lf->call);
     }
     if (lf->buffer) {
         flb_sds_destroy(lf->buffer);

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -148,6 +148,94 @@ void flb_test_type_int_key(void)
     flb_destroy(ctx);
 }
 
+void flb_test_type_int_key_multi(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *output = NULL;
+    char *input = "[0, {\"key\":\"val\"}]";
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    new_record = record\n"
+      "    new_record[\"lua_int_1\"] = 10.1\n"
+      "    new_record[\"lua_int_2\"] = 100.2\n"
+      "    return 1, timestamp, new_record\n"
+      "end\n";
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "type_int_key", "lua_int_1 lua_int_2",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret==0);
+
+    flb_lib_push(ctx, in_ffd, input, strlen(input));
+    sleep(1);
+    output = get_output();
+
+    /* check if float */
+    result = strstr(output, "\"lua_int_1\":10.");
+    if (!TEST_CHECK(result == NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"lua_int_2\":100.");
+    if (!TEST_CHECK(result == NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* check if int */
+    result = strstr(output, "\"lua_int_1\":10");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"lua_int_2\":100");
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* clean up */
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 
 void flb_test_append_tag(void)
 {
@@ -271,5 +359,6 @@ TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
+    {"type_int_key_multi", flb_test_type_int_key_multi},
     {NULL, NULL}
 };


### PR DESCRIPTION
This patch is to support config map for filter_lua and enrich test case.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration file
```
[INPUT]
    Name dummy

[FILTER]
    Name lua
    Match *
    Script append_tag.lua
    Call append_tag

[OUTPUT]
    Name stdout
```

## Debug output

```
$ fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/09 11:51:38] [ info] [engine] started (pid=47917)
[2021/05/09 11:51:38] [ info] [storage] version=1.1.1, initializing...
[2021/05/09 11:51:38] [ info] [storage] in-memory
[2021/05/09 11:51:38] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/09 11:51:38] [ info] [sp] stream processor started
[0] dummy.0: [1620528698.970737934, {"tag"=>"dummy.0", "message"=>"dummy"}]
[1] dummy.0: [1620528699.970615386, {"tag"=>"dummy.0", "message"=>"dummy"}]
[2] dummy.0: [1620528700.970202207, {"tag"=>"dummy.0", "message"=>"dummy"}]
[3] dummy.0: [1620528701.970242023, {"tag"=>"dummy.0", "message"=>"dummy"}]
^C[2021/05/09 11:51:43] [engine] caught signal (SIGINT)
[0] dummy.0: [1620528702.970846891, {"tag"=>"dummy.0", "message"=>"dummy"}]
[2021/05/09 11:51:43] [ warn] [engine] service will stop in 5 seconds
[2021/05/09 11:51:47] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c a.conf 
==47920== Memcheck, a memory error detector
==47920== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==47920== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==47920== Command: bin/fluent-bit -c a.conf
==47920== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/09 11:52:13] [ info] [engine] started (pid=47920)
[2021/05/09 11:52:13] [ info] [storage] version=1.1.1, initializing...
[2021/05/09 11:52:13] [ info] [storage] in-memory
[2021/05/09 11:52:13] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/09 11:52:13] [ info] [sp] stream processor started
==47920== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ca26f0
==47920==          to suppress, use: --max-stackframe=11805128 or greater
==47920== Warning: client switching stacks?  SP change: 0x4ca2668 --> 0x57e48b8
==47920==          to suppress, use: --max-stackframe=11805264 or greater
==47920== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ca2668
==47920==          to suppress, use: --max-stackframe=11805264 or greater
==47920==          further instances of this message will not be shown.
[0] dummy.0: [1620528733.995359659, {"tag"=>"dummy.0", "message"=>"dummy"}]
[1] dummy.0: [1620528734.970383644, {"tag"=>"dummy.0", "message"=>"dummy"}]
[2] dummy.0: [1620528735.970346450, {"tag"=>"dummy.0", "message"=>"dummy"}]
[3] dummy.0: [1620528736.971096038, {"tag"=>"dummy.0", "message"=>"dummy"}]
^C[2021/05/09 11:52:18] [engine] caught signal (SIGINT)
[0] dummy.0: [1620528738.077370643, {"tag"=>"dummy.0", "message"=>"dummy"}]
[2021/05/09 11:52:18] [ warn] [engine] service will stop in 5 seconds
[2021/05/09 11:52:22] [ info] [engine] service stopped
==47920== 
==47920== HEAP SUMMARY:
==47920==     in use at exit: 0 bytes in 0 blocks
==47920==   total heap usage: 441 allocs, 441 frees, 1,359,788 bytes allocated
==47920== 
==47920== All heap blocks were freed -- no leaks are possible
==47920== 
==47920== For lists of detected and suppressed errors, rerun with: -s
==47920== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
