### PR TITLE
config: support "Log_Level off" to suppress log 

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -416,6 +416,9 @@ static int set_log_level(struct flb_config *config, const char *v_str)
         else if (strcasecmp(v_str, "trace") == 0) {
             config->verbose = 5;
         }
+        else if (strcasecmp(v_str, "off") == 0) {
+            config->verbose = FLB_LOG_OFF;
+        }
         else {
             return -1;
         }


### PR DESCRIPTION
This patch is to support `Log_Level off` to suppress log.
This configuration may be useful to failing test case.
(CI seeks the string "error" to validate test result)


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

## Example Configuration

```
[SERVICE]
    Log_Level off

[INPUT]
    Name dummy

[OUTPUT]
    Name stdout
```

## Debug Log 

```
$ fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

^C[2021/05/09 15:58:49] [engine] caught signal (SIGINT)
[0] dummy.0: [1620543528.448549131, {"message"=>"dummy"}]
[1] dummy.0: [1620543529.448458297, {"message"=>"dummy"}]
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c a.conf 
==58708== Memcheck, a memory error detector
==58708== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==58708== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==58708== Command: bin/fluent-bit -c a.conf
==58708== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

==58708== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6a270
==58708==          to suppress, use: --max-stackframe=12035656 or greater
==58708== Warning: client switching stacks?  SP change: 0x4c6a1e8 --> 0x57e48b8
==58708==          to suppress, use: --max-stackframe=12035792 or greater
==58708== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c6a1e8
==58708==          to suppress, use: --max-stackframe=12035792 or greater
==58708==          further instances of this message will not be shown.
[0] dummy.0: [1620543730.459177387, {"message"=>"dummy"}]
[1] dummy.0: [1620543731.447985350, {"message"=>"dummy"}]
[2] dummy.0: [1620543732.448168489, {"message"=>"dummy"}]
^C[2021/05/09 16:02:13] [engine] caught signal (SIGINT)
[0] dummy.0: [1620543733.476094797, {"message"=>"dummy"}]
==58708== 
==58708== HEAP SUMMARY:
==58708==     in use at exit: 0 bytes in 0 blocks
==58708==   total heap usage: 346 allocs, 346 frees, 1,058,001 bytes allocated
==58708== 
==58708== All heap blocks were freed -- no leaks are possible
==58708== 
==58708== For lists of detected and suppressed errors, rerun with: -s
==58708== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
