### PR TITLE
src: parser_json: fix double-free.

### DIFF
--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -141,8 +141,13 @@ int flb_parser_json_do(struct flb_parser *parser,
 
         /* Ensure the pointer we are about to read is not NULL */
         if (k->via.str.ptr == NULL) {
-            flb_free(mp_buf);
-            flb_free(tmp_out_buf);
+            if (mp_buf == tmp_out_buf) {
+                flb_free(mp_buf);
+            }
+            else {
+                flb_free(mp_buf);
+                flb_free(tmp_out_buf);
+            }
             *out_buf = NULL;
             msgpack_unpacked_destroy(&result);
             return -1;


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes the bug: 
- [bugtracker](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34116)
- [oss-fuzz report](https://oss-fuzz.com/testcase-detail/5874775835672576)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
