### PR TITLE
error_reporter: new feature launch for supporting error reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ option(FLB_STATIC_CONF         "Build binary using static configuration")
 option(FLB_STREAM_PROCESSOR    "Enable Stream Processor"      Yes)
 option(FLB_CORO_STACK_SIZE     "Set coroutine stack size")
 option(FLB_AVRO_ENCODER        "Build with Avro encoding support" No)
+option(FLB_AWS_ERROR_REPORTER  "Build with aws error reporting support" No)
+
 
 # Metrics: Experimental Feature, disabled by default on 0.12 series
 # but enabled in the upcoming 0.13 release. Note that development
@@ -459,6 +461,10 @@ endif()
 # AWS
 if (FLB_AWS)
   FLB_DEFINITION(FLB_HAVE_AWS)
+endif()
+
+if (FLB_AWS_ERROR_REPORTER)
+  FLB_DEFINITION(FLB_HAVE_AWS_ERROR_REPORTER)
 endif()
 
 # Signv4

--- a/include/fluent-bit/aws/flb_aws_error_reporter.h
+++ b/include/fluent-bit/aws/flb_aws_error_reporter.h
@@ -1,0 +1,85 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef FLB_HAVE_AWS_ERROR_REPORTER
+
+#ifndef FLB_AWS_ERROR_REPORTER_H
+#define FLB_AWS_ERROR_REPORTER_H
+
+#include <monkey/mk_core/mk_list.h>
+#include <fluent-bit/flb_sds.h>
+
+#include <time.h>
+
+#define STATUS_MESSAGE_FILE_PATH_ENV "STATUS_MESSAGE_FILE_PATH"
+#define STATUS_MESSAGE_TTL_ENV "STATUS_MESSAGE_TTL"
+#define STATUS_MESSAGE_MAX_BYTE_LENGTH_ENV "STATUS_MESSAGE_MAX_BYTE_LENGTH"
+#define STATUS_MESSAGE_TTL_DEFAULT 20
+#define STATUS_MESSAGE_MAX_BYTE_LENGTH_DEFAULT 1024
+
+/*
+* error reporter
+*/
+struct flb_aws_error_reporter {
+    flb_sds_t file_path;
+    int ttl;
+    int file_size;
+    struct mk_list messages;
+    int max_size;
+};
+
+/*
+* error message which saved in memory
+*/
+struct flb_error_message {
+    time_t timestamp;
+    flb_sds_t data;
+    size_t len;
+    struct mk_list _head;
+};
+
+/*
+* create aws error reporter
+*/
+struct flb_aws_error_reporter *flb_aws_error_reporter_create();
+
+/*
+* error reporter write error log to file
+*/
+int flb_aws_error_reporter_write(struct flb_aws_error_reporter *error_reporter,
+                                 char *msg);
+
+/*
+* clean up the expired error message inside error log local file
+*/
+void flb_aws_error_reporter_clean(struct flb_aws_error_reporter *error_reporter);
+
+/*
+* clean up error reporter resource when fluent bit shutdown
+*/
+void flb_aws_error_reporter_destroy(struct flb_aws_error_reporter *error_reporter);
+
+/*
+* function used to tell if error reporting feature is enabled or not
+*/
+int is_error_reporting_enabled();
+
+#endif
+#endif /* FLB_HAVE_AWS_ERROR_REPORTER */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,13 @@ if(FLB_AWS)
     )
 endif()
 
+if (FLB_AWS_ERROR_REPORTER)
+  set(src
+    ${src}
+    "aws/flb_aws_error_reporter.c"
+    )
+endif()
+
 if(FLB_LUAJIT)
   set(src
     ${src}

--- a/src/aws/flb_aws_error_reporter.c
+++ b/src/aws/flb_aws_error_reporter.c
@@ -1,0 +1,277 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <monkey/mk_core/mk_list.h>
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/aws/flb_aws_error_reporter.h>
+
+/* helper function to get int type environment variable*/
+static int getenv_int(const char *name) {
+    char *value, *end;
+    long result;
+
+    value = getenv(name);
+    if (!value) {
+        return 0;
+    }
+
+    result = strtol(value, &end, 10);
+    if (*end != '\0') {
+        return 0;
+    }
+    return (int) result;
+}
+
+/* create an error reporter*/
+struct flb_aws_error_reporter *flb_aws_error_reporter_create()
+{
+    char *path_var = NULL;
+    int ttl_var, status_message_length;
+    struct flb_aws_error_reporter *error_reporter;
+    FILE *f;
+    int ret;
+
+    error_reporter = flb_calloc(1, sizeof(struct flb_aws_error_reporter));
+    if (!error_reporter) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* setup error report file path */
+    path_var = getenv(STATUS_MESSAGE_FILE_PATH_ENV);
+    if (path_var == NULL) {
+        flb_free(error_reporter);
+        flb_errno();
+        return NULL;
+    }
+
+    error_reporter->file_path = flb_sds_create(path_var);
+    if (!error_reporter->file_path) {
+        flb_free(error_reporter);
+        flb_errno();
+        return NULL;
+    }
+
+    /* clean up existing file*/
+    if ((f = fopen(error_reporter->file_path, "r")) != NULL) {
+        /* file exist, try delete it*/
+        if (remove(error_reporter->file_path)) {
+            flb_free(error_reporter);
+            flb_errno();
+            return NULL;
+        }
+    }
+
+    /* setup error reporter message TTL */
+    ttl_var = getenv_int(STATUS_MESSAGE_TTL_ENV);
+    if (ttl_var <= 0) {
+        ttl_var = STATUS_MESSAGE_TTL_DEFAULT;
+    }
+    error_reporter->ttl = ttl_var;
+
+    /* setup error reporter file size */
+    status_message_length = getenv_int(STATUS_MESSAGE_MAX_BYTE_LENGTH_ENV);
+    if(status_message_length <= 0) {
+        status_message_length = STATUS_MESSAGE_MAX_BYTE_LENGTH_DEFAULT;
+    }
+    error_reporter->max_size = status_message_length;
+
+    /* create the message Linked Lists */
+    mk_list_init(&error_reporter->messages);
+
+    return error_reporter;
+}
+
+/* error reporter write the error message into reporting file and memory*/
+int flb_aws_error_reporter_write(struct flb_aws_error_reporter *error_reporter, char *msg)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_error_message *message;
+    struct flb_error_message *tmp_message;
+    flb_sds_t buf;
+    flb_sds_t buf_tmp;
+    int deleted_message_count = 0;
+    FILE *f;
+
+    if (error_reporter == NULL) {
+        return -1;
+    }
+
+    buf = flb_sds_create(msg);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
+    /* check if the message is the same with latest one in queue*/
+    if (mk_list_is_empty(&error_reporter->messages) != 0) {
+        tmp_message = mk_list_entry_last(&error_reporter->messages,
+                                         struct flb_error_message, _head);
+        if (tmp_message->len == flb_sds_len(buf) &&
+                flb_sds_cmp(tmp_message->data, buf, tmp_message->len) == 0) {
+
+            tmp_message->timestamp = time(NULL);
+            flb_sds_destroy(buf);
+            return 0;
+        }
+    }
+
+    message = flb_malloc(sizeof(struct flb_error_message));
+    if (!message) {
+        flb_sds_destroy(buf);
+        flb_errno();
+        return -1;
+    }
+
+    /* check if new message is too large and truncate*/
+    if (flb_sds_len(buf) > error_reporter->max_size) {
+        // truncate message
+        buf_tmp = flb_sds_copy(buf, msg, error_reporter->max_size);
+        if (!buf_tmp) {
+            flb_sds_destroy(buf);
+            flb_free(message);
+            return -1;
+        }
+    }
+
+    message->data = flb_sds_create(buf);
+    if (!message->data) {
+        flb_sds_destroy(buf);
+        flb_free(message);
+        return -1;
+    }
+
+    message->len = flb_sds_len(buf);
+
+   /* clean up old message to provide enough space for new message*/
+    mk_list_foreach_safe(head, tmp, &error_reporter->messages) {
+        tmp_message = mk_list_entry(head, struct flb_error_message, _head);
+        if (error_reporter->file_size + flb_sds_len(buf) <= error_reporter->max_size) {
+            break;
+        }
+        else {
+            error_reporter->file_size -= tmp_message->len;
+            deleted_message_count++;
+            mk_list_del(&tmp_message->_head);
+            flb_sds_destroy(tmp_message->data);
+            flb_free(tmp_message);
+        }
+    }
+    message->timestamp = time(NULL);
+
+    mk_list_add(&message->_head, &error_reporter->messages);
+    error_reporter->file_size += message->len;
+
+    if (deleted_message_count == 0) {
+        f = fopen(error_reporter->file_path, "a");
+        fprintf(f, message->data);
+    }
+    else {
+        f = fopen(error_reporter->file_path, "w");
+        mk_list_foreach_safe(head, tmp, &error_reporter->messages) {
+            tmp_message = mk_list_entry(head, struct flb_error_message, _head);
+            fprintf(f, tmp_message->data);
+        }
+    }
+    fclose(f);
+
+    flb_sds_destroy(buf);
+
+    return 0;
+
+}
+
+/* error reporter clean up the expired message based on TTL*/
+void flb_aws_error_reporter_clean(struct flb_aws_error_reporter *error_reporter)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_error_message *message;
+    int expired_message_count = 0;
+    FILE *f;
+
+    if (error_reporter == NULL) {
+        return;
+    }
+
+    /* check the timestamp for every message and clean up expired messages*/
+    mk_list_foreach_safe(head, tmp, &error_reporter->messages) {
+        message = mk_list_entry(head, struct flb_error_message, _head);
+        if (error_reporter->ttl > time(NULL) - message->timestamp) {
+            break;
+        }
+        error_reporter->file_size -= message->len;
+        mk_list_del(&message->_head);
+        flb_sds_destroy(message->data);
+        flb_free(message);
+        expired_message_count++;
+    }
+
+    /* rewrite error report file if any message is cleaned up*/
+    if (expired_message_count > 0) {
+        f = fopen(error_reporter->file_path, "w");
+        mk_list_foreach_safe(head, tmp, &error_reporter->messages) {
+            message = mk_list_entry(head, struct flb_error_message, _head);
+            fprintf(f, message->data);
+        }
+        fclose(f);
+    }
+}
+
+/* error reporter clean up when fluent bit shutdown*/
+void flb_aws_error_reporter_destroy(struct flb_aws_error_reporter *error_reporter)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_error_message *message;
+
+    if (error_reporter == NULL) {
+        return;
+    }
+
+    if(error_reporter->file_path) {
+        flb_sds_destroy(error_reporter->file_path);
+    }
+    if (mk_list_is_empty(&error_reporter->messages) != 0) {
+
+        mk_list_foreach_safe(head, tmp, &error_reporter->messages) {
+           message = mk_list_entry(head, struct flb_error_message, _head);
+           mk_list_del(&message->_head);
+           flb_sds_destroy(message->data);
+           flb_free(message);
+        }
+        mk_list_del(&error_reporter->messages);
+    }
+
+    flb_free(error_reporter);
+}
+
+/*check if system enable error reporting*/
+int is_error_reporting_enabled()
+{
+    return getenv(STATUS_MESSAGE_FILE_PATH_ENV) != NULL;
+}

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -52,6 +52,12 @@
 #include <fluent-bit/stream_processor/flb_sp.h>
 #endif
 
+#ifdef FLB_HAVE_AWS_ERROR_REPORTER
+#include <fluent-bit/aws/flb_aws_error_reporter.h>
+
+extern struct flb_aws_error_reporter *error_reporter;
+#endif
+
 FLB_TLS_DEFINE(struct mk_event_loop, flb_engine_evl);
 
 
@@ -696,6 +702,16 @@ int flb_engine_start(struct flb_config *config)
         if (config->is_running == FLB_TRUE) {
             flb_sched_timer_cleanup(config->sched);
             flb_upstream_conn_pending_destroy_list(&config->upstreams);
+
+            /*
+            * depend on main thread to clean up expired message
+            * in aws error reporting message queue
+            */
+            #ifdef FLB_HAVE_AWS_ERROR_REPORTER
+            if (is_error_reporting_enabled()) {
+                flb_aws_error_reporter_clean(error_reporter);
+            }
+            #endif
         }
     }
 }

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -40,6 +40,12 @@
 #include <mcheck.h>
 #endif
 
+#ifdef FLB_HAVE_AWS_ERROR_REPORTER
+#include <fluent-bit/aws/flb_aws_error_reporter.h>
+
+struct flb_aws_error_reporter *error_reporter;
+#endif
+
 /* thread initializator */
 static pthread_once_t flb_lib_once = PTHREAD_ONCE_INIT;
 
@@ -189,6 +195,12 @@ flb_ctx_t *flb_create()
         return NULL;
     }
 
+    #ifdef FLB_HAVE_AWS_ERROR_REPORTER
+    if (is_error_reporting_enabled()) {
+        error_reporter = flb_aws_error_reporter_create();
+    }
+    #endif
+
     return ctx;
 }
 
@@ -214,6 +226,12 @@ void flb_destroy(flb_ctx_t *ctx)
         }
         flb_config_exit(ctx->config);
     }
+
+    #ifdef FLB_HAVE_AWS_ERROR_REPORTER
+    if (is_error_reporting_enabled()) {
+        flb_aws_error_reporter_destroy(error_reporter);
+    }
+    #endif
 
     flb_free(ctx);
     ctx = NULL;

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -37,6 +37,12 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_utf8.h>
 
+#ifdef FLB_HAVE_AWS_ERROR_REPORTER
+#include <fluent-bit/aws/flb_aws_error_reporter.h>
+
+extern struct flb_aws_error_reporter *error_reporter;
+#endif
+
 void flb_utils_error(int err)
 {
     char *msg = NULL;
@@ -99,11 +105,23 @@ void flb_utils_error(int err)
         fprintf(stderr,
                 "%sError%s: undefined. Aborting",
                 ANSI_BOLD ANSI_RED, ANSI_RESET);
+        #ifdef FLB_HAVE_AWS_ERROR_REPORTER
+        if (is_error_reporting_enabled()) {
+            flb_aws_error_reporter_write(error_reporter, "Error: undefined. Aborting\n");
+        }
+        #endif
+
     }
     else {
         fprintf(stderr,
                 "%sError%s: %s. Aborting\n\n",
                 ANSI_BOLD ANSI_RED, ANSI_RESET, msg);
+
+        #ifdef FLB_HAVE_AWS_ERROR_REPORTER
+        if (is_error_reporting_enabled()) {
+            flb_aws_error_reporter_write(error_reporter, msg);
+        }
+        #endif
     }
 
     if (err <= FLB_ERR_FILTER_INVALID) {

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -85,6 +85,13 @@ if(FLB_AWS)
     )
 endif()
 
+if(FLB_AWS_ERROR_REPORTER)
+  set(UNIT_TESTS_FILES
+    ${UNIT_TESTS_FILES}
+    error_reporter.c
+    )
+endif()
+
 set(UNIT_TESTS_DATA
   data/pack/json_single_map_001.json
   data/pack/json_single_map_002.json

--- a/tests/internal/error_reporter.c
+++ b/tests/internal/error_reporter.c
@@ -1,0 +1,82 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <monkey/mk_core/mk_list.h>
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/aws/flb_aws_error_reporter.h>
+
+#include "flb_tests_internal.h"
+
+const char* file_path = "/tmp/error.log";
+const char* error_message_1 = "[engine] scheduler could not start";
+const char* error_message_2 = "[engine] scheduler could not stop";
+
+
+void test_flb_aws_error_reporter_create() {
+
+    setenv(STATUS_MESSAGE_FILE_PATH_ENV, file_path, 1);
+    struct flb_aws_error_reporter *error_reporter = flb_aws_error_reporter_create();
+    TEST_CHECK((void*) error_reporter != NULL);
+    TEST_CHECK((void*)error_reporter->file_path != NULL);
+    TEST_CHECK(flb_sds_cmp(error_reporter->file_path, file_path, strlen(file_path)) == 0);
+    TEST_CHECK(error_reporter->ttl == STATUS_MESSAGE_TTL_DEFAULT);
+    TEST_CHECK(error_reporter->max_size == STATUS_MESSAGE_MAX_BYTE_LENGTH_DEFAULT);
+    flb_aws_error_reporter_destroy(error_reporter);
+}
+
+void test_flb_aws_error_reporter_write() {
+
+    int size;
+    char error_message_3[1041];
+    for (int i = 0; i < 1040; i++) {
+        error_message_3[i] = 'a';
+    }
+    error_message_3[1040] = '\0';
+
+    setenv(STATUS_MESSAGE_FILE_PATH_ENV, file_path, 1);
+
+    struct flb_aws_error_reporter *error_reporter = flb_aws_error_reporter_create();
+    flb_aws_error_reporter_write(error_reporter, error_message_1);
+    size = mk_list_size(&error_reporter->messages);
+    TEST_CHECK(size == 1);
+    /* message same with the latest one will be combined*/
+    flb_aws_error_reporter_write(error_reporter, error_message_1);
+    size = mk_list_size(&error_reporter->messages);
+    TEST_CHECK(size == 1);
+
+    /* message different of the latest one will be combined*/
+    flb_aws_error_reporter_write(error_reporter, error_message_2);
+    size = mk_list_size(&error_reporter->messages);
+    TEST_CHECK(size == 2);
+
+    /* message larger than max size limit*/
+    flb_aws_error_reporter_write(error_reporter, error_message_3);
+    size = mk_list_size(&error_reporter->messages);
+    TEST_CHECK(size == 1);
+
+    flb_aws_error_reporter_destroy(error_reporter);
+}
+
+void test_flb_aws_error_reporter_clean() {
+
+    setenv(STATUS_MESSAGE_FILE_PATH_ENV, file_path, 1);
+    struct flb_aws_error_reporter *error_reporter = flb_aws_error_reporter_create();
+    flb_aws_error_reporter_write(error_reporter, error_message_1);
+    time_t start = time(NULL);
+    while (time(NULL) - start <= error_reporter->ttl) {
+        flb_aws_error_reporter_clean(error_reporter);
+    }
+    TEST_CHECK(mk_list_size(&error_reporter->messages) == 0);
+
+    flb_aws_error_reporter_destroy(error_reporter);
+}
+
+TEST_LIST = {
+    { "test_flb_aws_error_reporter_create", test_flb_aws_error_reporter_create},
+    {"test_flb_aws_error_reporter_write", test_flb_aws_error_reporter_write},
+    {"test_flb_aws_error_reporter_clean", test_flb_aws_error_reporter_clean},
+    { 0 }
+};


### PR DESCRIPTION
Signer-off-by: Drew Zhang <zhayuzhu@amazon.com>

<!-- Provide summary of changes -->
This is a new feature for customer to do error reporting to a local file.

By setting environment variable: `STATUS_MESSAGE_FILE_PATH` to enable this feature.
There are two more environment variable could be config based on needed.
`STATUS_MESSAGE_TTL`

When feature enabled, customer could get the error message in a local file where the path is config through `STATUS_MESSAGE_FILE_PATH`.

 This is a AWS customized feature. In the CMAKE file, this feature is not enabled. 
To build with this feature in src or test, need to set

`-DFLB_AWS_ERROR_REPORTER=On` in CMAKE command.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
`export STATUS_MESSAGE_FILE_PATH=/home/ec2-user/log/env.txt`
`export STATUS_MESSAGE_TTL=20`
- [X] Debug log output from testing the change
```
$ bin/fluent-bit -c ../../conf/fluent-bit.conf
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/13 12:36:21] [ info] [engine] started (pid=3046)
[2021/05/13 12:36:21] [ info] [storage] version=1.1.1, initializing...
[2021/05/13 12:36:21] [ info] [storage] in-memory
[2021/05/13 12:36:21] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/13 12:36:21] [ info] [sp] stream processor started
```

```
$ ./bin/flb-it-error_reporter 
Test test_flb_error_reporter_create...          [ OK ]
Test test_flb_error_reporter_write...           [ OK ]
Test test_flb_error_reporter_clean...           [ OK ]
SUCCESS: All unit tests have passed.
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
$ valgrind ./bin/flb-it-error_reporter 
==4074== Memcheck, a memory error detector
==4074== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4074== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==4074== Command: ./bin/flb-it-error_reporter
==4074== 
Test test_flb_error_reporter_create...          [ OK ]
==4076== 
==4076== HEAP SUMMARY:
==4076==     in use at exit: 48 bytes in 1 blocks
==4076==   total heap usage: 8 allocs, 7 frees, 1,959 bytes allocated
==4076== 
==4076== LEAK SUMMARY:
==4076==    definitely lost: 0 bytes in 0 blocks
==4076==    indirectly lost: 0 bytes in 0 blocks
==4076==      possibly lost: 0 bytes in 0 blocks
==4076==    still reachable: 48 bytes in 1 blocks
==4076==         suppressed: 0 bytes in 0 blocks
==4076== Rerun with --leak-check=full to see details of leaked memory
==4076== 
==4076== For counts of detected and suppressed errors, rerun with: -v
==4076== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test test_flb_error_reporter_write...           ==4077== Conditional jump or move depends on uninitialised value(s)
==4077==    at 0x4C2EBA8: strlen (vg_replace_strmem.c:458)
==4077==    by 0x439025: flb_sds_create (flb_sds.c:84)
==4077==    by 0x438722: flb_error_reporter_write (flb_error_reporter.c:99)
==4077==    by 0x43824B: test_flb_error_reporter_write (error_reporter.c:55)
==4077==    by 0x436737: test_do_run_ (acutest.h:1007)
==4077==    by 0x4369A3: test_run_ (acutest.h:1103)
==4077==    by 0x437BF2: main (acutest.h:1700)
==4077== 
==4077== Invalid read of size 8
==4077==    at 0x4388E5: flb_error_reporter_write (flb_error_reporter.c:137)
==4077==    by 0x43824B: test_flb_error_reporter_write (error_reporter.c:55)
==4077==    by 0x436737: test_do_run_ (acutest.h:1007)
==4077==    by 0x4369A3: test_run_ (acutest.h:1103)
==4077==    by 0x437BF2: main (acutest.h:1700)
==4077==  Address 0x5d63aa0 is 16 bytes inside a block of size 40 free'd
==4077==    at 0x4C2CD28: free (vg_replace_malloc.c:530)
==4077==    by 0x438547: flb_free (flb_mem.h:122)
==4077==    by 0x4388D7: flb_error_reporter_write (flb_error_reporter.c:136)
==4077==    by 0x43824B: test_flb_error_reporter_write (error_reporter.c:55)
==4077==    by 0x436737: test_do_run_ (acutest.h:1007)
==4077==    by 0x4369A3: test_run_ (acutest.h:1103)
==4077==    by 0x437BF2: main (acutest.h:1700)
==4077==  Block was alloc'd at
==4077==    at 0x4C2BB7B: malloc (vg_replace_malloc.c:299)
==4077==    by 0x4384AC: flb_malloc (flb_mem.h:62)
==4077==    by 0x4387C8: flb_error_reporter_write (flb_error_reporter.c:114)
==4077==    by 0x438140: test_flb_error_reporter_write (error_reporter.c:41)
==4077==    by 0x436737: test_do_run_ (acutest.h:1007)
==4077==    by 0x4369A3: test_run_ (acutest.h:1103)
==4077==    by 0x437BF2: main (acutest.h:1700)
==4077== 
[ OK ]
==4077== 
==4077== HEAP SUMMARY:
==4077==     in use at exit: 48 bytes in 1 blocks
==4077==   total heap usage: 24 allocs, 23 frees, 18,374 bytes allocated
==4077== 
==4077== LEAK SUMMARY:
==4077==    definitely lost: 0 bytes in 0 blocks
==4077==    indirectly lost: 0 bytes in 0 blocks
==4077==      possibly lost: 0 bytes in 0 blocks
==4077==    still reachable: 48 bytes in 1 blocks
==4077==         suppressed: 0 bytes in 0 blocks
==4077== Rerun with --leak-check=full to see details of leaked memory
==4077== 
==4077== For counts of detected and suppressed errors, rerun with: -v
==4077== Use --track-origins=yes to see where uninitialised values come from
==4077== ERROR SUMMARY: 3 errors from 2 contexts (suppressed: 0 from 0)
Test test_flb_error_reporter_clean...           [ OK ]
==4078== 
==4078== HEAP SUMMARY:
==4078==     in use at exit: 48 bytes in 1 blocks
==4078==   total heap usage: 14 allocs, 13 frees, 7,301 bytes allocated
==4078== 
==4078== LEAK SUMMARY:
==4078==    definitely lost: 0 bytes in 0 blocks
==4078==    indirectly lost: 0 bytes in 0 blocks
==4078==      possibly lost: 0 bytes in 0 blocks
==4078==    still reachable: 48 bytes in 1 blocks
==4078==         suppressed: 0 bytes in 0 blocks
==4078== Rerun with --leak-check=full to see details of leaked memory
==4078== 
==4078== For counts of detected and suppressed errors, rerun with: -v
==4078== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==4074== 
==4074== HEAP SUMMARY:
==4074==     in use at exit: 0 bytes in 0 blocks
==4074==   total heap usage: 2 allocs, 2 frees, 1,072 bytes allocated
==4074== 
==4074== All heap blocks were freed -- no leaks are possible
==4074== 
==4074== For counts of detected and suppressed errors, rerun with: -v
==4074== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
