### PR TITLE
out_stackdriver: fix invalid read of get_stream() function

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1132,37 +1132,6 @@ static int get_severity_level(severity_t * s, const msgpack_object * o,
     return -1;
 }
 
-
-static int get_stream(msgpack_object_map map)
-{
-    int i;
-    int len_stdout;
-    int val_size;
-    msgpack_object k;
-    msgpack_object v;
-
-    /* len(stdout) == len(stderr) */
-    len_stdout = sizeof(STDOUT) - 1;
-    for (i = 0; i < map.size; i++) {
-        k = map.ptr[i].key;
-        v = map.ptr[i].val;
-        if (k.type == MSGPACK_OBJECT_STR &&
-            strncmp(k.via.str.ptr, "stream", k.via.str.size) == 0) {
-            val_size = v.via.str.size;
-            if (val_size == len_stdout) {
-                if (strncmp(v.via.str.ptr, STDOUT, val_size) == 0) {
-                    return STREAM_STDOUT;
-                }
-                else if (strncmp(v.via.str.ptr, STDERR, val_size) == 0) {
-                    return STREAM_STDERR;
-                }
-            }
-        }
-    }
-
-    return STREAM_UNKNOWN;
-}
-
 static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
                                            const msgpack_object * obj)
 {
@@ -1390,7 +1359,6 @@ static int stackdriver_format(struct flb_config *config,
     int array_size = 0;
     /* The default value is 3: timestamp, jsonPayload, logName. */
     int entry_size = 3;
-    int stream;
     size_t s;
     size_t off = 0;
     char path[PATH_MAX];
@@ -1418,6 +1386,8 @@ static int stackdriver_format(struct flb_config *config,
     /* Parameters for log name */
     int log_name_extracted = FLB_FALSE;
     flb_sds_t log_name = NULL;
+    flb_sds_t stream = NULL;
+    flb_sds_t stream_key;
 
     /* Parameters for insertId */
     msgpack_object insert_id_obj;
@@ -1942,12 +1912,13 @@ static int stackdriver_format(struct flb_config *config,
 
         /* avoid modifying the original tag */
         newtag = tag;
-        if (ctx->is_k8s_resource_type) {
-            stream = get_stream(result.data.via.array.ptr[1].via.map);
-            if (stream == STREAM_STDOUT) {
+        stream_key = flb_sds_create("stream");
+        if (ctx->is_k8s_resource_type
+            && get_string(&stream, obj, stream_key) == 0) {
+            if (flb_sds_cmp(stream, STDOUT, flb_sds_len(stream)) == 0) {
                 newtag = "stdout";
             }
-            else if (stream == STREAM_STDERR) {
+            else if (flb_sds_cmp(stream, STDERR, flb_sds_len(stream)) == 0) {
                 newtag = "stderr";
             }
         }
@@ -1971,6 +1942,8 @@ static int stackdriver_format(struct flb_config *config,
         msgpack_pack_str_body(&mp_pck, "logName", 7);
         msgpack_pack_str(&mp_pck, len);
         msgpack_pack_str_body(&mp_pck, path, len);
+        flb_sds_destroy(stream_key);
+        flb_sds_destroy(stream);
 
         /* timestamp */
         msgpack_pack_str(&mp_pck, 9);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -68,10 +68,6 @@
 #define K8S_NODE      "k8s_node"
 #define K8S_POD       "k8s_pod"
 
-#define STREAM_STDOUT 1
-#define STREAM_STDERR 2
-#define STREAM_UNKNOWN 3
-
 #define STDOUT "stdout"
 #define STDERR "stderr"
 


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->
This patch is to fix the invalid read of the get_stream() function in out_stackdriver plugin. When there are backlogs chunks and Fluent Bit is meanwhile processing all other input plugins, there is a chance that `get_stream()` will have a invalid read of memory. Errors:
```
[2021/05/12 22:47:05] [engine] caught signal (SIGSEGV)
#0  0x2b5452            in  ???() at ???:0
#1  0x2b753d            in  ???() at ???:0
#2  0x2b7958            in  ???() at ???:0
#3  0x21f5ef            in  ???() at ???:0
#4  0x694506            in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
==2036377== Invalid read of size 8
==2036377==    at 0x4F3132F: _Unwind_Backtrace (in /usr/lib/x86_64-linux-gnu/libgcc_s.so.1)
==2036377==    by 0x1FF0D8: backtrace_full (backtrace.c:127)
==2036377==    by 0x186380: flb_stacktrace_print (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x1874C5: flb_signal_handler (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x4F75D5F: ??? (in /usr/lib/x86_64-linux-gnu/libc-2.31.so)
==2036377==    by 0x2B5451: get_stream (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x2B753D: stackdriver_format (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x2B7958: cb_stackdriver_flush (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x21F5EF: output_pre_cb_flush (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x694506: co_init (amd64.c:117)
==2036377==  Address 0x818dac0 is 0 bytes after a block of size 25,088 alloc'd
==2036377==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==2036377==    by 0x69461F: co_create (amd64.c:142)
==2036377==    by 0x21FFBB: tasks_start (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x2204AA: flb_engine_dispatch (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x21D356: flb_engine_flush (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x21EAFD: flb_engine_start (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x20A4AF: flb_lib_worker (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x4869EA6: start_thread (pthread_create.c:477)
==2036377==    by 0x5037DEE: clone (clone.S:95)
==2036377== 
#5  0xffffffffffffffff  in  ???() at ???:0
==2036377== 
==2036377== Process terminating with default action of signal 6 (SIGABRT)
==2036377==    at 0x4F75CE1: raise (raise.c:51)
==2036377==    by 0x4F5F536: abort (abort.c:79)
==2036377==    by 0x1874CA: flb_signal_handler (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x4F75D5F: ??? (in /usr/lib/x86_64-linux-gnu/libc-2.31.so)
==2036377==    by 0x2B5451: get_stream (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x2B753D: stackdriver_format (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x2B7958: cb_stackdriver_flush (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x21F5EF: output_pre_cb_flush (in /usr/local/google/home/jeffluoo/fluent-bit/build/bin/fluent-bit)
==2036377==    by 0x694506: co_init (amd64.c:117)
==2036377== 
==2036377== HEAP SUMMARY:
==2036377==     in use at exit: 3,417,560 bytes in 10,232 blocks
==2036377==   total heap usage: 93,600 allocs, 83,368 frees, 19,232,391 bytes allocated
==2036377== 
==2036377== LEAK SUMMARY:
==2036377==    definitely lost: 317 bytes in 6 blocks
==2036377==    indirectly lost: 0 bytes in 0 blocks
==2036377==      possibly lost: 864,683 bytes in 1,281 blocks
==2036377==    still reachable: 2,552,560 bytes in 8,945 blocks
==2036377==         suppressed: 0 bytes in 0 blocks
==2036377== Rerun with --leak-check=full to see details of leaked memory
==2036377== 
==2036377== For lists of detected and suppressed errors, rerun with: -s
==2036377== ERROR SUMMARY: 85002 errors from 119 contexts (suppressed: 0 from 0)
zsh: abort      sudo valgrind ./bin/fluent-bit -c ../conf/out_stackdriver.conf
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
