### PR TITLE
http_client: use slist function for NO_PROXY parsing

### DIFF
--- a/tests/internal/slist.c
+++ b/tests/internal/slist.c
@@ -6,6 +6,34 @@
 
 #include "flb_tests_internal.h"
 
+void token_check(struct mk_list *list, int id, char *str)
+{
+    int i = 0;
+    int len;
+    int ret;
+    struct mk_list *head;
+    struct flb_slist_entry *e = NULL;
+
+    mk_list_foreach(head, list) {
+        if (i == id) {
+            e = mk_list_entry(head, struct flb_slist_entry, _head);
+            break;
+        }
+        e = NULL;
+        i++;
+    }
+    TEST_CHECK(e != NULL);
+
+    len = strlen(str);
+    ret = flb_sds_cmp(e->str, str, len);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        fprintf(stderr, "[token %i] expected '%s', got '%s'\n\n",
+                i, str, e->str);
+        exit(EXIT_FAILURE);
+    }
+}
+
 void test_slist_add()
 {
     int ret;
@@ -51,38 +79,53 @@ void test_slist_split_string()
     ret = flb_slist_split_string(&list, "abcdefg", ' ', -1);
     TEST_CHECK(ret == 1);
     TEST_CHECK(mk_list_size(&list) == 1);
-    e = mk_list_entry_last(&list, struct flb_slist_entry, _head);
-    TEST_CHECK(flb_sds_len(e->str) == 7);
+    token_check(&list, 0, "abcdefg");
     flb_slist_destroy(&list);
 
     /* Separated strings */
     ret = flb_slist_split_string(&list, "a bc defg", ' ', -1);
     TEST_CHECK(ret == 3);
     TEST_CHECK(mk_list_size(&list) == 3);
-    e = mk_list_entry_last(&list, struct flb_slist_entry, _head);
-    TEST_CHECK(flb_sds_len(e->str) == 4);
+    token_check(&list, 0, "a");
+    token_check(&list, 1, "bc");
+    token_check(&list, 2, "defg");
     flb_slist_destroy(&list);
 
     /* One char with empty spaces */
     ret = flb_slist_split_string(&list, "        a  ", ' ', 2);
     TEST_CHECK(ret == 1);
     TEST_CHECK(mk_list_size(&list) == 1);
-    e = mk_list_entry_last(&list, struct flb_slist_entry, _head);
-    TEST_CHECK(flb_sds_len(e->str) == 1);
+    token_check(&list, 0, "a");
     flb_slist_destroy(&list);
 
     /* Two separated characters */
     ret = flb_slist_split_string(&list, "        a        b    ", ' ', 2);
     TEST_CHECK(ret == 2);
     TEST_CHECK(mk_list_size(&list) == 2);
-    e = mk_list_entry_last(&list, struct flb_slist_entry, _head);
-    TEST_CHECK(flb_sds_len(e->str) == 1);
+    token_check(&list, 0, "a");
+    token_check(&list, 1, "b");
     flb_slist_destroy(&list);
 
     /* Comma separated strings */
     ret = flb_slist_split_string(&list, ",,,a ,,  b,c ,d,,e   ,f,g,  ,   ,", ',', -1);
     TEST_CHECK(ret == 7);
     TEST_CHECK(mk_list_size(&list) == 7);
+    token_check(&list, 0, "a");
+    token_check(&list, 1, "b");
+    token_check(&list, 2, "c");
+    token_check(&list, 3, "d");
+    token_check(&list, 4, "e");
+    token_check(&list, 5, "f");
+    token_check(&list, 6, "g");
+    flb_slist_destroy(&list);
+
+    /* Comma seperated strings for real world NO_PROXY example */
+    ret = flb_slist_split_string(&list, "127.0.0.1, localhost, kubernetes.default.svc.cluster.local", ',', -1);
+    TEST_CHECK(ret == 3);
+    TEST_CHECK(mk_list_size(&list) == 3);
+    token_check(&list, 0, "127.0.0.1");
+    token_check(&list, 1, "localhost");
+    token_check(&list, 2, "kubernetes.default.svc.cluster.local");
     flb_slist_destroy(&list);
 
     /* Comma separated strings with limit */
@@ -97,36 +140,6 @@ void test_slist_split_string()
     ret = flb_slist_split_string(&list, ",,, ,, , ,   , ", ',', 2);
     TEST_CHECK(ret == 0);
     TEST_CHECK(mk_list_size(&list) == 0);
-
-
-}
-
-void token_check(struct mk_list *list, int id, char *str)
-{
-    int i = 0;
-    int len;
-    int ret;
-    struct mk_list *head;
-    struct flb_slist_entry *e = NULL;
-
-    mk_list_foreach(head, list) {
-        if (i == id) {
-            e = mk_list_entry(head, struct flb_slist_entry, _head);
-            break;
-        }
-        e = NULL;
-        i++;
-    }
-    TEST_CHECK(e != NULL);
-
-    len = strlen(str);
-    ret = flb_sds_cmp(e->str, str, len);
-    TEST_CHECK(ret == 0);
-    if (ret != 0) {
-        fprintf(stderr, "[token %i] expected '%s', got '%s'\n\n",
-                i, str, e->str);
-        exit(EXIT_FAILURE);
-    }
 }
 
 void test_slist_split_tokens()


### PR DESCRIPTION
This is a follow up PR for https://github.com/fluent/fluent-bit/pull/3272
- make use the functions from `slist`
- enhance the unit tests for `slist`

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/532
