### PR TITLE
workflows: add gcp sa key to long running tests

### DIFF
--- a/.github/workflows/3398.yaml
+++ b/.github/workflows/3398.yaml
@@ -156,3 +156,4 @@ jobs:
           GCP_DISK_ID: ${{ steps.get-gcp-disk-id.outputs.stdout }}
           GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
* add gcp sa key to long running tests.