### PR TITLE
filter_lua: support new option "type_array_key"

### DIFF
--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -131,6 +131,26 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
 
             tmp_key = flb_strndup(sentry->value, sentry->len);
             l2c->key = flb_sds_create(tmp_key);
+            l2c->type = L2C_TYPE_INT;
+            flb_free(tmp_key);
+
+            mk_list_add(&l2c->_head, &lf->l2c_types);
+            lf->l2c_types_num++;
+        }
+        flb_utils_split_free(split);
+    }
+
+    tmp = flb_filter_get_property("type_array_key", ins);
+    if (tmp) {
+        split = flb_utils_split(tmp, ' ', L2C_TYPES_NUM_MAX);
+        mk_list_foreach_safe(head, tmp_list, split) {
+            l2c = flb_malloc(sizeof(struct l2c_type));
+
+            sentry = mk_list_entry(head, struct flb_split_entry, _head);
+
+            tmp_key = flb_strndup(sentry->value, sentry->len);
+            l2c->key = flb_sds_create(tmp_key);
+            l2c->type = L2C_TYPE_ARRAY;
             flb_free(tmp_key);
 
             mk_list_add(&l2c->_head, &lf->l2c_types);

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -29,8 +29,14 @@
 #define LUA_BUFFER_CHUNK    1024 * 8  /* 8K should be enough to get started */
 #define L2C_TYPES_NUM_MAX   16
 
+enum l2c_type_enum {
+    L2C_TYPE_INT,
+    L2C_TYPE_ARRAY
+};
+
 struct l2c_type {
     flb_sds_t key;
+    int type;
     struct mk_list _head;
 };
 

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -92,7 +92,7 @@ void flb_test_type_int_key(void)
     char *script_body = ""
       "function lua_main(tag, timestamp, record)\n"
       "    new_record = record\n"
-      "    new_record[\"lua_int\"] = 10\n"
+      "    new_record[\"lua_int\"] = 10.2\n"
       "    return 1, timestamp, new_record\n"
       "end\n";
 
@@ -136,9 +136,13 @@ void flb_test_type_int_key(void)
     sleep(1);
     output = get_output();
     result = strstr(output, "\"lua_int\":10.");
-    TEST_CHECK(result == NULL);
+    if(!TEST_CHECK(result == NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
     result = strstr(output, "\"lua_int\":10");
-    TEST_CHECK(result != NULL);
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
 
     /* clean up */
     flb_lib_free(output);
@@ -355,10 +359,88 @@ void flb_test_helloworld(void)
     flb_destroy(ctx);
 }
 
+// https://github.com/fluent/fluent-bit/issues/3343
+void flb_test_type_array_key(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *output = NULL;
+    char *input = "[0, {\"key\":\"val\"}]";
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    new_record = record\n"
+      "    new_record[\"lua_array\"] = {};\n"
+      "    new_record[\"lua_array2\"] = {1,2,3};\n"
+      "    return 1, timestamp, new_record\n"
+      "end\n";
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "type_array_key", "lua_array lua_array2",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret==0);
+
+    flb_lib_push(ctx, in_ffd, input, strlen(input));
+    sleep(1);
+    output = get_output();
+    result = strstr(output, "\"lua_array\":[]");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"lua_array2\":[1,2,3]");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* clean up */
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
     {"type_int_key_multi", flb_test_type_int_key_multi},
+    {"type_array_key", flb_test_type_array_key},
     {NULL, NULL}
 };


### PR DESCRIPTION
Fixes #3343 

This PR is to support new option "type_array_key".
If set, the value of the key is treated as array.

It is useful to handle empty array.

|key|description|
|----|------------|
|type_array_key|If these keys are matched, the fields are handled as array. If more than one key, delimit by space. It is useful the array can be empty.|

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature


## Example Configuration and Lua Script

a.conf:
```
[INPUT]
    Name dummy
    dummy {"key":"val", "arr":[]}

[FILTER]
    Name lua
    Match *
    script a.lua
    call test
    type_array_key arr

[OUTPUT]
    Name stdout
```

a.lua
```lua
function test(tag, timestamp, record)
    return 2, timestamp, record
end
```

## Debug log

The output is `"arr"=>[]`. It means the value is array. (If it is map, the output will be `"arr"=>{}`)

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/15 12:20:58] [ info] [engine] started (pid=71308)
[2021/05/15 12:20:58] [ info] [storage] version=1.1.1, initializing...
[2021/05/15 12:20:58] [ info] [storage] in-memory
[2021/05/15 12:20:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/15 12:20:58] [ info] [sp] stream processor started
[0] dummy.0: [1621048858.739427582, {"key"=>"val", "arr"=>[]}]
[1] dummy.0: [1621048859.739428720, {"key"=>"val", "arr"=>[]}]
[2] dummy.0: [1621048860.738808132, {"key"=>"val", "arr"=>[]}]
[3] dummy.0: [1621048861.739546137, {"key"=>"val", "arr"=>[]}]
^C[2021/05/15 12:21:03] [engine] caught signal (SIGINT)
[0] dummy.0: [1621048862.740256764, {"key"=>"val", "arr"=>[]}]
[2021/05/15 12:21:03] [ warn] [engine] service will stop in 5 seconds
[2021/05/15 12:21:07] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind ../bin/fluent-bit -c a.conf 
==71305== Memcheck, a memory error detector
==71305== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==71305== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==71305== Command: ../bin/fluent-bit -c a.conf
==71305== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/15 12:20:16] [ info] [engine] started (pid=71305)
[2021/05/15 12:20:16] [ info] [storage] version=1.1.1, initializing...
[2021/05/15 12:20:16] [ info] [storage] in-memory
[2021/05/15 12:20:16] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/15 12:20:16] [ info] [sp] stream processor started
==71305== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ca2fd0
==71305==          to suppress, use: --max-stackframe=11802856 or greater
==71305== Warning: client switching stacks?  SP change: 0x4ca2f48 --> 0x57e48b8
==71305==          to suppress, use: --max-stackframe=11802992 or greater
==71305== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ca2f48
==71305==          to suppress, use: --max-stackframe=11802992 or greater
==71305==          further instances of this message will not be shown.
[0] dummy.0: [1621048817.751136544, {"arr"=>[], "key"=>"val"}]
[1] dummy.0: [1621048818.739255498, {"arr"=>[], "key"=>"val"}]
[2] dummy.0: [1621048819.739230886, {"arr"=>[], "key"=>"val"}]
[3] dummy.0: [1621048820.739480818, {"arr"=>[], "key"=>"val"}]
^C[2021/05/15 12:20:22] [engine] caught signal (SIGINT)
[0] dummy.0: [1621048821.766185409, {"arr"=>[], "key"=>"val"}]
[2021/05/15 12:20:22] [ warn] [engine] service will stop in 5 seconds
[2021/05/15 12:20:26] [ info] [engine] service stopped
==71305== 
==71305== HEAP SUMMARY:
==71305==     in use at exit: 0 bytes in 0 blocks
==71305==   total heap usage: 465 allocs, 465 frees, 1,360,336 bytes allocated
==71305== 
==71305== All heap blocks were freed -- no leaks are possible
==71305== 
==71305== For lists of detected and suppressed errors, rerun with: -s
==71305== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
