### PR TITLE
out_prometheus_exporter: release resource on exit

### DIFF
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -82,6 +82,11 @@ static void cb_prom_flush(const void *data, size_t bytes,
 
 static int cb_prom_exit(void *data, struct flb_config *config)
 {
+    struct prom_exporter *ctx = data;
+    struct prom_http *ph = ctx->http;
+    if (ph) {
+        prom_http_server_destroy(ph);
+    }
     return 0;
 }
 

--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -220,7 +220,13 @@ struct prom_http *prom_http_server_create(struct prom_exporter *ctx,
 
 void prom_http_server_destroy(struct prom_http *ph)
 {
-
+    if (ph) {
+        /* TODO: release mk_vhost */
+        if (ph->ctx) {
+            mk_destroy(ph->ctx);
+        }
+        flb_free(ph);
+    }
 }
 
 int prom_http_server_start(struct prom_http *ph)


### PR DESCRIPTION
The patch is to release out_prometheus_exporter resources.

Note: However some resources which are allocated by monkey are not released. 
We need to fix monkey api. (e.g. add function to release mk_vhost)


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o prometheus_exporter 
==106455== Memcheck, a memory error detector
==106455== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==106455== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==106455== Command: bin/fluent-bit -i cpu -o prometheus_exporter
==106455== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/15 21:02:36] [ info] [engine] started (pid=106455)
[2021/05/15 21:02:36] [ info] [storage] version=1.1.1, initializing...
[2021/05/15 21:02:36] [ info] [storage] in-memory
[2021/05/15 21:02:36] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/15 21:02:36] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2021/05/15 21:02:36] [ info] [sp] stream processor started
==106455== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c78970
==106455==          to suppress, use: --max-stackframe=11976520 or greater
==106455== Warning: client switching stacks?  SP change: 0x4c788e8 --> 0x57e48b8
==106455==          to suppress, use: --max-stackframe=11976656 or greater
==106455== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c788e8
==106455==          to suppress, use: --max-stackframe=11976656 or greater
==106455==          further instances of this message will not be shown.
^C[2021/05/15 21:02:41] [engine] caught signal (SIGINT)
[2021/05/15 21:02:41] [ info] [input] pausing cpu.0
[2021/05/15 21:02:41] [ warn] [engine] service will stop in 5 seconds
[2021/05/15 21:02:46] [ info] [engine] service stopped
==106455== 
==106455== HEAP SUMMARY:
==106455==     in use at exit: 36,686 bytes in 50 blocks
==106455==   total heap usage: 343 allocs, 293 frees, 1,005,298 bytes allocated
==106455== 
==106455== 10 bytes in 1 blocks are possibly lost in loss record 5 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x49C488: mk_mem_alloc (mk_memory.h:53)
==106455==    by 0x49C943: mk_string_dup (mk_string.c:347)
==106455==    by 0x486072: mk_vhost_create (mk_lib.c:420)
==106455==    by 0x2359A1: prom_http_server_create (prom_http.c:203)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 32 bytes in 1 blocks are possibly lost in loss record 21 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x485083: mk_mem_alloc_z (mk_memory.h:70)
==106455==    by 0x486041: mk_vhost_create (mk_lib.c:412)
==106455==    by 0x2359A1: prom_http_server_create (prom_http.c:203)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 32 bytes in 1 blocks are definitely lost in loss record 22 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x234DFB: flb_calloc (flb_mem.h:78)
==106455==    by 0x23505E: cb_prom_init (prom.c:33)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 40 bytes in 1 blocks are possibly lost in loss record 24 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x235431: flb_malloc (flb_mem.h:62)
==106455==    by 0x235667: cb_mq_metrics (prom_http.c:105)
==106455==    by 0x4878B6: mk_fifo_worker_read (mk_fifo.c:431)
==106455==    by 0x49722E: mk_server_worker_loop (mk_server.c:569)
==106455==    by 0x48DDB6: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 80 bytes in 1 blocks are possibly lost in loss record 29 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x487930: mk_mem_alloc (mk_memory.h:53)
==106455==    by 0x4882D7: mk_vhost_handler_match (mk_vhost.c:320)
==106455==    by 0x4863E9: mk_vhost_handler (mk_lib.c:501)
==106455==    by 0x2359D4: prom_http_server_create (prom_http.c:207)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 80 bytes in 1 blocks are possibly lost in loss record 30 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x487930: mk_mem_alloc (mk_memory.h:53)
==106455==    by 0x4882D7: mk_vhost_handler_match (mk_vhost.c:320)
==106455==    by 0x4863E9: mk_vhost_handler (mk_lib.c:501)
==106455==    by 0x2359FA: prom_http_server_create (prom_http.c:208)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 120 bytes in 1 blocks are possibly lost in loss record 34 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x485083: mk_mem_alloc_z (mk_memory.h:70)
==106455==    by 0x485FD6: mk_vhost_create (mk_lib.c:400)
==106455==    by 0x2359A1: prom_http_server_create (prom_http.c:203)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 125 bytes in 1 blocks are possibly lost in loss record 35 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x235431: flb_malloc (flb_mem.h:62)
==106455==    by 0x2356A7: cb_mq_metrics (prom_http.c:111)
==106455==    by 0x4878B6: mk_fifo_worker_read (mk_fifo.c:431)
==106455==    by 0x49722E: mk_server_worker_loop (mk_server.c:569)
==106455==    by 0x48DDB6: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 288 bytes in 1 blocks are possibly lost in loss record 40 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==106455==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==106455==    by 0x4865322: allocate_stack (allocatestack.c:622)
==106455==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==106455==    by 0x49E452: mk_utils_worker_spawn (mk_utils.c:284)
==106455==    by 0x4857B5: mk_start (mk_lib.c:184)
==106455==    by 0x235AAB: prom_http_server_start (prom_http.c:233)
==106455==    by 0x23518E: cb_prom_init (prom.c:57)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 288 bytes in 1 blocks are possibly lost in loss record 41 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==106455==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==106455==    by 0x4865322: allocate_stack (allocatestack.c:622)
==106455==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==106455==    by 0x49E452: mk_utils_worker_spawn (mk_utils.c:284)
==106455==    by 0x49993B: mk_server_setup (monkey.c:180)
==106455==    by 0x485648: mk_lib_worker (mk_lib.c:142)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 288 bytes in 1 blocks are possibly lost in loss record 42 of 50
==106455==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==106455==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==106455==    by 0x4865322: allocate_stack (allocatestack.c:622)
==106455==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==106455==    by 0x48DE5E: mk_sched_launch_thread (mk_scheduler.c:444)
==106455==    by 0x496A95: mk_server_launch_workers (mk_server.c:279)
==106455==    by 0x499979: mk_server_setup (monkey.c:196)
==106455==    by 0x485648: mk_lib_worker (mk_lib.c:142)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 8,192 bytes in 1 blocks are possibly lost in loss record 48 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x487930: mk_mem_alloc (mk_memory.h:53)
==106455==    by 0x48831A: mk_vhost_handler_match (mk_vhost.c:327)
==106455==    by 0x4863E9: mk_vhost_handler (mk_lib.c:501)
==106455==    by 0x2359D4: prom_http_server_create (prom_http.c:207)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== 8,192 bytes in 1 blocks are possibly lost in loss record 49 of 50
==106455==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==106455==    by 0x487930: mk_mem_alloc (mk_memory.h:53)
==106455==    by 0x48831A: mk_vhost_handler_match (mk_vhost.c:327)
==106455==    by 0x4863E9: mk_vhost_handler (mk_lib.c:501)
==106455==    by 0x2359FA: prom_http_server_create (prom_http.c:208)
==106455==    by 0x2350F2: cb_prom_init (prom.c:48)
==106455==    by 0x176F91: flb_output_init_all (flb_output.c:939)
==106455==    by 0x183A4F: flb_engine_start (flb_engine.c:520)
==106455==    by 0x16893B: flb_lib_worker (flb_lib.c:605)
==106455==    by 0x4864608: start_thread (pthread_create.c:477)
==106455==    by 0x4B10292: clone (clone.S:95)
==106455== 
==106455== LEAK SUMMARY:
==106455==    definitely lost: 32 bytes in 1 blocks
==106455==    indirectly lost: 0 bytes in 0 blocks
==106455==      possibly lost: 17,735 bytes in 12 blocks
==106455==    still reachable: 18,919 bytes in 37 blocks
==106455==         suppressed: 0 bytes in 0 blocks
==106455== Reachable blocks (those to which a pointer was found) are not shown.
==106455== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==106455== 
==106455== For lists of detected and suppressed errors, rerun with: -s
==106455== ERROR SUMMARY: 13 errors from 13 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
