### PR TITLE
tail: Fix handling of long lines

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -202,7 +202,6 @@ int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
 static int process_content(struct flb_tail_file *file, size_t *bytes)
 {
     size_t len;
-    int has_data = FLB_FALSE;
     int lines = 0;
     int ret;
     size_t processed_bytes = 0;
@@ -236,15 +235,15 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
 
     /* Skip null characters from the head (sometimes introduced by copy-truncate log rotation) */
     while (data < end && *data == '\0') {
-        ++data;
+        data++;
+        processed_bytes++;
     }
 
     while (data < end && (p = memchr(data, '\n', end - data))) {
-        has_data = FLB_TRUE;
         len = (p - data);
         if (file->skip_next == FLB_TRUE) {
             data += len + 1;
-            processed_bytes += len;
+            processed_bytes += len + 1;
             file->skip_next = FLB_FALSE;
             continue;
         }
@@ -361,7 +360,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
     }
     file->parsed = file->buf_len;
 
-    if (has_data) {
+    if (lines > 0) {
         /* Append buffer content to a chunk */
         *bytes = processed_bytes;
         flb_input_chunk_append_raw(ctx->ins,
@@ -370,7 +369,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
                                    out_sbuf->data,
                                    out_sbuf->size);
     }
-    else {
+    else if (file->skip_next) {
         *bytes = file->buf_len;
     }
 
@@ -950,6 +949,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
             }
 
             /* Do buffer adjustments */
+            file->offset += file->buf_len;
             file->buf_len = 0;
             file->skip_next = FLB_TRUE;
         }

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -372,6 +372,9 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
     else if (file->skip_next) {
         *bytes = file->buf_len;
     }
+    else {
+        *bytes = processed_bytes;
+    }
 
     msgpack_sbuffer_destroy(out_sbuf);
     return lines;


### PR DESCRIPTION
This patch restores the behavior of skipping a line that is longer than buffer_max_size. A recent change (dab53392096f2764af85a5230d0ac0de9879f74f) modified the behavior of long line handling and prevented buffer sizes from growing to accommodate long lines and caused the end portion of the line to be ingested rather than skipped. This patch also ensures that the file offset is properly maintained when skipping long lines.

Signed-off-by: Joaquin Luna <jlunavtgrad@gmail.com>

Fixes #3491

----
**Testing**

- Generate test log file
```bash
# null chars at the beginning
printf "\0\0\0hello world\n" > test.log
# 50 regular lines
for i in `seq 1 50`; do openssl rand -hex 100 >> test.log; done
# One very long line
openssl rand -hex 320000 >> test.log
# 25 more lines of data
for i in `seq 1 25`; do openssl rand -hex 100 >> test.log; done
```
- config file
```
[INPUT]
  Name tail
  Path test.log
  DB fluent-bit.db
  Skip_Long_Lines On
  Read_From_Head On

[OUTPUT]
  Name counter
  Match *
```
- Verify offsets after test
```bash
stat -c%s test.log
180470921
sqlite3 fluent-bit.db "select offset from in_tail_files"
180470921
```

- Test logs
```
[2021/05/16 04:29:45] [ info] Configuration:
[2021/05/16 04:29:45] [ info]  flush time     | 5.000000 seconds
[2021/05/16 04:29:45] [ info]  grace          | 5 seconds
[2021/05/16 04:29:45] [ info]  daemon         | 0
[2021/05/16 04:29:45] [ info] ___________
[2021/05/16 04:29:45] [ info]  inputs:
[2021/05/16 04:29:45] [ info]      tail
[2021/05/16 04:29:45] [ info] ___________
[2021/05/16 04:29:45] [ info]  filters:
[2021/05/16 04:29:45] [ info] ___________
[2021/05/16 04:29:45] [ info]  outputs:
[2021/05/16 04:29:45] [ info]      counter.0
[2021/05/16 04:29:45] [ info] ___________
[2021/05/16 04:29:45] [ info]  collectors:
[2021/05/16 04:29:45] [ info] [engine] started (pid=18893)
[2021/05/16 04:29:45] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/05/16 04:29:45] [debug] [storage] [cio stream] new stream registered: tail.0
[2021/05/16 04:29:45] [ info] [storage] version=1.1.1, initializing...
[2021/05/16 04:29:45] [ info] [storage] in-memory
[2021/05/16 04:29:45] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] inotify watch fd=23
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] scanning path test.log
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] inode=2951839 with offset=0 appended as test.log
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] scan_glob add(): test.log, inode 2951839
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] 1 new files found on path 'test.log'
[2021/05/16 04:29:45] [debug] [counter:counter.0] created event channels: read=27 write=28
[2021/05/16 04:29:45] [debug] [router] match rule tail.0:counter.0
[2021/05/16 04:29:45] [ info] [sp] stream processor started
[2021/05/16 04:29:45] [ warn] [input:tail:tail.0] file=test.log have long lines. Skipping long lines.
[2021/05/16 04:29:45] [debug] [input:tail:tail.0] inode=2951839 file=test.log promote to TAIL_EVENT
[2021/05/16 04:29:45] [ info] [input:tail:tail.0] inotify_fs_add(): inode=2951839 watch_fd=1 name=test.log
[2021/05/16 04:29:49] [debug] [task] created task=0x7f44a9037960 id=0 OK
1621139389.708933,30 (total = 76)
[2021/05/16 04:29:49] [debug] [out coro] cb_destroy coro_id=0
[2021/05/16 04:29:49] [debug] [task] destroy task=0x7f44a9037960 (task_id=0)
^C[2021/05/16 04:29:51] [engine] caught signal (SIGINT)
[2021/05/16 04:29:51] [ info] [input] pausing tail.0
[2021/05/16 04:29:51] [ warn] [engine] service will stop in 5 seconds
^[[A[2021/05/16 04:29:55] [ info] [engine] service stopped
[2021/05/16 04:29:55] [debug] [input:tail:tail.0] inode=2951839 removing file name test.log
[2021/05/16 04:29:55] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=2951839 watch_fd=1