### PR TITLE
http_server: Add Health Check Endpoint

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -34,6 +34,9 @@
 #define FLB_CONFIG_FLUSH_SECS   5
 #define FLB_CONFIG_HTTP_LISTEN  "0.0.0.0"
 #define FLB_CONFIG_HTTP_PORT    "2020"
+#define HC_ERRORS_COUNT_DEFAULT 5
+#define HC_RETRY_FAILURE_COUNTS_DEFAULT 5
+#define HEALTH_CHECK_PERIOD 60
 #define FLB_CONFIG_DEFAULT_TAG  "fluent_bit"
 
 /* Main struct to hold the configuration of the runtime service */
@@ -137,10 +140,14 @@ struct flb_config {
 
     /* HTTP Server */
 #ifdef FLB_HAVE_HTTP_SERVER
-    int http_server;          /* HTTP Server running    */
-    char *http_port;          /* HTTP Port / TCP number */
-    char *http_listen;        /* Interface Address      */
-    void *http_ctx;           /* Monkey HTTP context    */
+    int http_server;                /* HTTP Server running    */
+    char *http_port;                /* HTTP Port / TCP number */
+    char *http_listen;              /* Interface Address      */
+    void *http_ctx;                 /* Monkey HTTP context    */
+    int health_check;               /* health check enable    */
+    int hc_errors_count;               /* health check error counts as unhealthy*/
+    int hc_retry_failure_count;        /* health check retry failures count as unhealthy*/
+    int health_check_period;           /* period by second for health status check */
 #endif
 
     /*
@@ -254,9 +261,13 @@ enum conf_type {
 
 /* FLB_HAVE_HTTP_SERVER */
 #ifdef FLB_HAVE_HTTP_SERVER
-#define FLB_CONF_STR_HTTP_SERVER     "HTTP_Server"
-#define FLB_CONF_STR_HTTP_LISTEN     "HTTP_Listen"
-#define FLB_CONF_STR_HTTP_PORT       "HTTP_Port"
+#define FLB_CONF_STR_HTTP_SERVER                            "HTTP_Server"
+#define FLB_CONF_STR_HTTP_LISTEN                            "HTTP_Listen"
+#define FLB_CONF_STR_HTTP_PORT                              "HTTP_Port"
+#define FLB_CONF_STR_HEALTH_CHECK                           "Health_Check"
+#define FLB_CONF_STR_HC_ERRORS_COUNT                        "HC_Errors_Count"
+#define FLB_CONF_STR_HC_RETRIES_FAILURE_COUNT               "HC_Retry_Failure_Count"
+#define FLB_CONF_STR_HC_PERIOD                              "HC_Period"
 #endif /* !FLB_HAVE_HTTP_SERVER */
 
 /* Storage / Chunk I/O */

--- a/include/fluent-bit/http_server/flb_hs.h
+++ b/include/fluent-bit/http_server/flb_hs.h
@@ -43,6 +43,7 @@ struct flb_hs {
     int vid;                   /* Virtual Host ID     */
     int qid_metrics;           /* Metrics Message Queue ID    */
     int qid_storage;           /* Storage Message Queue ID    */
+    int qid_health;            /* health Message Queue ID    */
 
     pthread_t tid;             /* Server Thread */
     struct flb_config *config; /* Fluent Bit context */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -79,6 +79,7 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STR_HTTP_SERVER,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, http_server)},
+
     {FLB_CONF_STR_HTTP_LISTEN,
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, http_listen)},
@@ -86,6 +87,23 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STR_HTTP_PORT,
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, http_port)},
+
+     {FLB_CONF_STR_HEALTH_CHECK,
+      FLB_CONF_TYPE_BOOL,
+      offsetof(struct flb_config, health_check)},
+
+    {FLB_CONF_STR_HC_ERRORS_COUNT,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, hc_errors_count)},
+
+    {FLB_CONF_STR_HC_RETRIES_FAILURE_COUNT,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, hc_retry_failure_count)},
+
+    {FLB_CONF_STR_HC_PERIOD,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, health_check_period)},
+
 #endif
 
     /* Storage */
@@ -154,10 +172,14 @@ struct flb_config *flb_config_init()
     config->exit_status_code = 0;
 
 #ifdef FLB_HAVE_HTTP_SERVER
-    config->http_ctx     = NULL;
-    config->http_server  = FLB_FALSE;
-    config->http_listen  = flb_strdup(FLB_CONFIG_HTTP_LISTEN);
-    config->http_port    = flb_strdup(FLB_CONFIG_HTTP_PORT);
+    config->http_ctx                     = NULL;
+    config->http_server                  = FLB_FALSE;
+    config->http_listen                  = flb_strdup(FLB_CONFIG_HTTP_LISTEN);
+    config->http_port                    = flb_strdup(FLB_CONFIG_HTTP_PORT);
+    config->health_check                 = FLB_FALSE;
+    config->hc_errors_count              = HC_ERRORS_COUNT_DEFAULT;
+    config->hc_retry_failure_count       = HC_RETRY_FAILURE_COUNTS_DEFAULT;
+    config->health_check_period          = HEALTH_CHECK_PERIOD;
 #endif
 
     config->http_proxy = getenv("HTTP_PROXY");

--- a/src/http_server/api/v1/CMakeLists.txt
+++ b/src/http_server/api/v1/CMakeLists.txt
@@ -5,6 +5,7 @@ set(src
   storage.c
   plugins.c
   register.c
+  health.c
   )
 
 include_directories(${MONKEY_INCLUDE_DIR})

--- a/src/http_server/api/v1/health.c
+++ b/src/http_server/api/v1/health.c
@@ -1,0 +1,302 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include<stdio.h>
+#include <stdlib.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_macros.h>
+#include <fluent-bit/flb_http_server.h>
+#include <msgpack.h>
+
+#include "health.h"
+
+struct flb_health_check_metrics_counter *metrics_counter;
+
+pthread_key_t hs_health_key;
+
+/* initialize the metrics counters */
+static void counter_init(struct flb_hs *hs) {
+
+   metrics_counter = flb_malloc(sizeof(struct flb_health_check_metrics_counter));
+
+   if (!metrics_counter) {
+       flb_errno();
+       return;
+   }
+
+    metrics_counter->error_counter = 0;
+    metrics_counter->retry_failure_counter = 0;
+    metrics_counter->error_limit = hs->config->hc_errors_count;
+    metrics_counter->retry_failure_limit = hs->config->hc_retry_failure_count;
+    metrics_counter->period_counter = 0;
+    metrics_counter->period_limit = hs->config->health_check_period;
+
+}
+
+/*
+* tell what's the current status for health check
+* One default background is that the metrics received and saved into
+* message queue every time is a accumulation of error numbers,
+* not a error number in recent second. So to get the error number
+* in a period, we need to use:
+* the error number of the newest metrics message  minus
+* the error number in oldest metrics of period
+*/
+static int is_healthy() {
+
+    struct mk_list *metrics_list;
+    struct flb_hs_hc_buf *buf;
+    int period_errors;
+    int period_retry_failure;
+
+
+    metrics_list = pthread_getspecific(hs_health_key);
+
+    if (mk_list_is_empty(metrics_list) == 0) {
+        return FLB_TRUE;
+    }
+
+    /* Get the error metrics entry from the start time of current period */
+    buf = mk_list_entry_first(metrics_list, struct flb_hs_hc_buf, _head);
+
+    /*
+    * increase user so clean up function won't
+    * free the memory and delete the data
+    */
+    buf->users++;
+
+    /* the error count saved in message queue is the number of
+    * error count at that time. So the math is that:
+    * the error count in current period = (current error count in total) -
+    * (begin error count in the period)
+    */
+    period_errors = metrics_counter->error_counter -  buf->error_count;
+    period_retry_failure = metrics_counter->retry_failure_counter -
+                                                buf->retry_failure_count;
+    buf->users--;
+
+    if (period_errors > metrics_counter->error_limit ||
+        period_retry_failure >  metrics_counter->retry_failure_limit) {
+
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+}
+
+/* read the metrics from message queue and update the counter*/
+static void read_metrics(void *data, size_t size, int* error_count,
+                         int* retry_failure_count)
+{
+    int i;
+    int j;
+    int m;
+    msgpack_unpacked result;
+    msgpack_object map;
+    size_t off = 0;
+    int errors = 0;
+    int retry_failure = 0;
+    char *raw_data;
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, data, size, &off);
+    map = result.data;
+
+    for (i = 0; i < map.via.map.size; i++) {
+        msgpack_object k;
+        msgpack_object v;
+
+        /* Keys: input, output */
+        k = map.via.map.ptr[i].key;
+        v = map.via.map.ptr[i].val;
+        if (k.via.str.size != sizeof("output") - 1 ||
+            strncmp(k.via.str.ptr, "output", k.via.str.size) != 0) {
+
+            continue;
+        }
+        /* Iterate sub-map */
+        for (j = 0; j < v.via.map.size; j++) {
+            msgpack_object sk;
+            msgpack_object sv;
+
+            /* Keys: plugin name , values: metrics */
+            sk = v.via.map.ptr[j].key;
+            sv = v.via.map.ptr[j].val;
+
+            for (m = 0; m < sv.via.map.size; m++) {
+                msgpack_object mk;
+                msgpack_object mv;
+
+                mk = sv.via.map.ptr[m].key;
+                mv = sv.via.map.ptr[m].val;
+
+                if (mk.via.str.size == sizeof("errors") - 1 &&
+                    strncmp(mk.via.str.ptr, "errors", mk.via.str.size) == 0) {
+                    errors += mv.via.u64;
+                }
+                else if (mk.via.str.size == sizeof("retries_failed") - 1 &&
+                    strncmp(mk.via.str.ptr, "retries_failed",
+                            mk.via.str.size) == 0) {
+                    retry_failure += mv.via.u64;
+                }
+            }
+        }
+    }
+
+    *error_count = errors;
+    *retry_failure_count = retry_failure;
+    msgpack_unpacked_destroy(&result);
+}
+
+/*
+* Delete unused metrics, note that we only care about the latest node
+* we use this function to maintain the metrics queue only save the metrics
+* in a period. The old metrics which is out of period will be removed
+*/
+static int cleanup_metrics()
+{
+    int c = 0;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct mk_list *metrics_list;
+    struct flb_hs_hc_buf *last;
+    struct flb_hs_hc_buf *entry;
+
+    metrics_list = pthread_getspecific(hs_health_key);
+    if (!metrics_list) {
+        return -1;
+    }
+
+    if (metrics_counter->period_counter < metrics_counter->period_limit) {
+        return 0;
+    }
+
+    /* remove the oldest metrics if it's out of period*/
+    mk_list_foreach_safe(head, tmp, metrics_list) {
+        entry = mk_list_entry(head, struct flb_hs_hc_buf, _head);
+        if (metrics_counter->period_counter > metrics_counter->period_limit &&
+                entry->users == 0) {
+            metrics_counter->period_counter--;
+            mk_list_del(&entry->_head);
+            flb_free(entry);
+            c++;
+        }
+        else {
+            break;
+        }
+    }
+
+    return c;
+}
+
+/*
+ * Callback invoked every time some metrics are received through a
+ * message queue channel. This function runs in a Monkey HTTP thread
+ * worker and it purpose is to take the metrics data and record the health
+ * status based on the metrics.
+ * This happens every second based on the event config.
+ * So we treat period_counter to count the time.
+ * And we maintain a message queue with the size of period limit number
+ * so every time we get a new metrics data in, if the message queue size is
+ * large than period limit, we will do the clean up func to
+ * remove the oldest metrics.
+ */
+static void cb_mq_health(mk_mq_t *queue, void *data, size_t size)
+{
+    struct flb_hs_hc_buf *buf;
+    struct mk_list *metrics_list = NULL;
+    int error_count = 0;
+    int retry_failure_count = 0;
+
+    metrics_list = pthread_getspecific(hs_health_key);
+
+    if (!metrics_list) {
+        metrics_list = flb_malloc(sizeof(struct mk_list));
+        if (!metrics_list) {
+            flb_errno();
+            return;
+        }
+        mk_list_init(metrics_list);
+        pthread_setspecific(hs_health_key, metrics_list);
+    }
+
+    metrics_counter->period_counter++;
+
+    /* this is to remove the metrics out of period*/
+    cleanup_metrics();
+
+    buf = flb_malloc(sizeof(struct flb_hs_hc_buf));
+    if (!buf) {
+        flb_errno();
+        return;
+    }
+
+    buf->users = 0;
+
+    read_metrics(data, size, &error_count, &retry_failure_count);
+
+    metrics_counter->error_counter = error_count;
+    metrics_counter->retry_failure_counter = retry_failure_count;
+
+    buf->error_count = error_count;
+    buf->retry_failure_count = retry_failure_count;
+
+    mk_list_add(&buf->_head, metrics_list);
+}
+
+/* API: Get fluent Bit Health Status */
+static void cb_health(mk_request_t *request, void *data)
+{
+    int status = is_healthy();
+
+    if (status == FLB_TRUE) {
+       mk_http_status(request, 200);
+       mk_http_send(request, "ok\n", strlen("ok\n"), NULL);
+       mk_http_done(request);
+    }
+    else {
+        mk_http_status(request, 500);
+        mk_http_send(request, "error\n", strlen("error\n"), NULL);
+        mk_http_done(request);
+    }
+}
+
+/* Perform registration */
+int api_v1_health(struct flb_hs *hs)
+{
+
+    pthread_key_create(&hs_health_key, NULL);
+
+    counter_init(hs);
+    /* Create a message queue */
+    hs->qid_metrics = mk_mq_create(hs->ctx, "/health",
+                                   cb_mq_health, NULL);
+
+    mk_vhost_handler(hs->ctx, hs->vid, "/api/v1/health", cb_health, hs);
+    return 0;
+}
+
+void flb_hs_health_destroy()
+{
+    flb_free(metrics_counter);
+}

--- a/src/http_server/api/v1/health.h
+++ b/src/http_server/api/v1/health.h
@@ -1,0 +1,74 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2017 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+
+#ifndef FLB_HS_API_V1_HEALTH_H
+#define FLB_HS_API_V1_HEALTH_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_server.h>
+
+struct flb_health_check_metrics_counter {
+
+     /*
+     * health check error limit,
+     * setup by customer through config: HC_Errors_Count
+     */
+    int error_limit;
+
+    /* counter the error number in metrics*/
+    int error_counter;
+
+    /*
+    * health check retry failed limit,
+    * setup by customer through config: HC_Retry_Failure_Count
+    */
+    int retry_failure_limit;
+
+    /* count the retry failed number in metrics*/
+    int retry_failure_counter;
+
+    /*period limit, setup by customer through config: HC_Period*/
+    int period_limit;
+
+    /* count the seconds in one period*/
+    int period_counter;
+
+};
+
+
+/*
+ * error and retry failure buffers that contains certain cached data to be used
+ * by health check.
+ */
+struct flb_hs_hc_buf {
+    int users;
+    int error_count;
+    int retry_failure_count;
+    struct mk_list _head;
+};
+
+/* health endpoint*/
+int api_v1_health(struct flb_hs *hs);
+
+/* clean up health resource when shutdown*/
+void flb_hs_health_destroy();
+#endif

--- a/src/http_server/api/v1/register.c
+++ b/src/http_server/api/v1/register.c
@@ -25,12 +25,17 @@
 #include "metrics.h"
 #include "storage.h"
 #include "plugins.h"
+#include "health.h"
 
 int api_v1_registration(struct flb_hs *hs)
 {
     api_v1_uptime(hs);
     api_v1_metrics(hs);
     api_v1_plugins(hs);
+
+    if (hs->config->health_check == FLB_TRUE) {
+        api_v1_health(hs);
+    }
 
     if (hs->config->storage_metrics == FLB_TRUE) {
         api_v1_storage_metrics(hs);

--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -26,6 +26,7 @@
 
 #include <monkey/mk_lib.h>
 #include "api/v1/register.h"
+#include "api/v1/health.h"
 
 static void cb_root(mk_request_t *request, void *data)
 {
@@ -39,6 +40,7 @@ static void cb_root(mk_request_t *request, void *data)
 /* Ingest pipeline metrics into the web service context */
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size)
 {
+    mk_mq_send(hs->ctx, hs->qid_health, data, size);
     return mk_mq_send(hs->ctx, hs->qid_metrics, data, size);
 }
 
@@ -114,12 +116,13 @@ int flb_hs_destroy(struct flb_hs *hs)
     if (!hs) {
         return 0;
     }
-
+    flb_hs_health_destroy();
     mk_stop(hs->ctx);
     mk_destroy(hs->ctx);
 
     flb_hs_endpoints_free(hs);
     flb_free(hs);
+
 
     return 0;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
**Add Health check Endpoint for HTTP Server in Fluent bit.**
List the config below.
So based on the config, when customer ping `http://127.0.0.1:2020/api/v1/health` endpoint,
fluent bit will return "ok" with http 200 for healthy and "error" with http 500 for unhealthy.

This feature check errors and retry_failed in output plugin metrics. And it use or logic to determine the status.
For example: if (real error number > customer config error number OR real retry_failed number > customer config retry_failed number) we take this as unhealthy.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
```
[SERVICE]
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_PORT    2020
    Health_Check On
    HC_Errors_Count 1
    HC_Retry_Failure_Count 1
    HC_Period 20
[INPUT]
    Name              forward
    Listen            0.0.0.0
    Port              24224
    Buffer_Chunk_Size 1M
    Buffer_Max_Size   6M
[OUTPUT]
    Name   stdout
    Match  *
```

Test
change the return value to `FLB_OUTPUT_RETURN(FLB_ERROR)` for this line:
https://github.com/fluent/fluent-bit/blob/master/plugins/out_stdout/stdout.c#L152

Installed fluentd and using the forward as input and using this CLI to create error data metrics:
`echo '{"key 1": 123456789, "key 2": "abcdefg"}' | fluent-cat my_tag`

Then using the CLI to track the health status:
`curl -s http://127.0.0.1:2020/api/v1/health`
Below is the testing result. (curl request is basically 1 r/s)

```
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
ok
[ec2-user@ip-172-31-1-146 ~]echo '{"message":"hello"}' | fluent-cat debug.log
[ec2-user@ip-172-31-1-146 ~]$ echo '{"message":"hello"}' | fluent-cat debug.log
[ec2-user@ip-172-31-1-146 ~]$ echo '{"message":"hello"}' | fluent-cat debug.log
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
ok
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
ok
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
error
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
ok
[ec2-user@ip-172-31-1-146 ~]$ curl -s http://127.0.0.1:2020/api/v1/health
ok
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
$ valgrind bin/fluent-bit -c ../../conf/fluent-bit.conf
==18563== Memcheck, a memory error detector
==18563== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18563== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==18563== Command: bin/fluent-bit -c ../../conf/fluent-bit.conf
==18563== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/17 14:23:15] [ info] [engine] started (pid=18563)
[2021/05/17 14:23:15] [ info] [storage] version=1.1.1, initializing...
[2021/05/17 14:23:15] [ info] [storage] in-memory
[2021/05/17 14:23:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/17 14:23:15] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/05/17 14:23:15] [ info] [sp] stream processor started

==18563== 
==18563== HEAP SUMMARY:
==18563==     in use at exit: 103,673 bytes in 65 blocks
==18563==   total heap usage: 608 allocs, 543 frees, 1,368,328 bytes allocated
==18563== 
==18563== LEAK SUMMARY:
==18563==    definitely lost: 0 bytes in 0 blocks
==18563==    indirectly lost: 0 bytes in 0 blocks
==18563==      possibly lost: 52,218 bytes in 27 blocks
==18563==    still reachable: 51,455 bytes in 38 blocks
==18563==         suppressed: 0 bytes in 0 blocks
==18563== Rerun with --leak-check=full to see details of leaked memory
==18563== 
==18563== For counts of detected and suppressed errors, rerun with: -v
==18563== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/536
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
