### PR TITLE
pack: fix a truncation bug on Windows

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -199,7 +199,7 @@ static char *tokens_to_msgpack(struct flb_pack_state *state,
                     msgpack_pack_double(&pck, atof(p));
                 }
                 else {
-                    msgpack_pack_int64(&pck, atol(p));
+                    msgpack_pack_int64(&pck, atoll(p));
                 }
             }
             break;


### PR DESCRIPTION
Fixes #3481.

`atol()` converts a numeric string into a long number. On Windows,
`long` means "32-bit integer":

https://docs.microsoft.com/en-us/cpp/cpp/data-type-ranges

For this reason, the current logic will misbehave if the incoming
number is bigger than 2147483647. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>

