### PR TITLE
fix: handle absolute INCLUDE paths

### DIFF
--- a/lib/monkey/mk_core/mk_rconf.c
+++ b/lib/monkey/mk_core/mk_rconf.c
@@ -433,7 +433,7 @@ static int mk_rconf_read_glob(struct mk_rconf *conf, const char * path)
     size_t i;
     int ret_glb = -1;
 
-    if (conf->root_path) {
+    if (conf->root_path && path[0] != "/") {
         snprintf(tmp, PATH_MAX, "%s/%s", conf->root_path, path);
         glb_path = tmp;
     }


### PR DESCRIPTION
Fixes #1294

**Testing**

I have manually built fluent-bit in a docker image, and confirmed the change works with absolute paths as `@INCLUDE` arguments, as well as relative ones.

**Documentation**

I don't believe a documentation update is required here.
