### PR TITLE
tests: internal: fuzzers: json_fuzzer: fix leaks.

### DIFF
--- a/tests/internal/fuzzers/flb_json_fuzzer.c
+++ b/tests/internal/fuzzers/flb_json_fuzzer.c
@@ -35,13 +35,21 @@ int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
         int ret2 = msgpack_unpack_next(&result, out_buf, out_size, &off);
         if (ret2 == MSGPACK_UNPACK_SUCCESS) {
             msgpack_object root = result.data;
-            flb_msgpack_to_json_str(0, &root);
+            char *tmp = NULL;
+            tmp = flb_msgpack_to_json_str(0, &root);
+            if (tmp != NULL) {
+                flb_free(tmp);
+            }
         }
+        msgpack_unpacked_destroy(&result);
 
-        flb_pack_msgpack_to_json_format(out_buf, out_size,
+        flb_sds_t ret_s = flb_pack_msgpack_to_json_format(out_buf, out_size,
                 FLB_PACK_JSON_FORMAT_LINES,
                 FLB_PACK_JSON_DATE_EPOCH, NULL);
         free(out_buf);
+        if (ret_s != NULL) {
+            flb_sds_destroy(ret_s);
+        }
     }
 
     return 0;


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes leaks in `flb_json_fuzzer.c`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
- https://oss-fuzz.com/testcase-detail/5641062794264576
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28235
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] ] Example configuration file for the change
- [N/A] ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
