### PR TITLE
tests: internal: fuzzer: config: fix upper bound on config file size.

### DIFF
--- a/tests/internal/fuzzers/config_fuzzer.c
+++ b/tests/internal/fuzzers/config_fuzzer.c
@@ -314,6 +314,11 @@ char conf_file[] = "# Parser: no_year\n"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Limit the size of the config files to 32KB. */
+    if (size > 32768) {
+        return 0;
+    }
+
     /* Write the config file to a location we know OSS-Fuzz has */
     char filename[256];
     sprintf(filename, "/tmp/libfuzzer.%d", getpid());


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Limits the size of config files to be used during fuzzing to 32KB.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27741

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
