### PR TITLE
tests: internals: fuzzers: record_ac: clean up fuzzer.

### DIFF
--- a/tests/internal/fuzzers/record_ac_fuzzer.c
+++ b/tests/internal/fuzzers/record_ac_fuzzer.c
@@ -10,6 +10,11 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Limit size to 32KB */
+    if (size > 32768) {
+        return 0;
+    }
+
     char *outbuf = NULL;
     size_t outsize;
     int type;
@@ -72,6 +77,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     flb_sds_destroy(str);
     flb_ra_destroy(ra);
     flb_sds_destroy(ra_str);
+    msgpack_unpacked_destroy(&result);
 
     /* General cleanup */
     flb_free(null_terminated);


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes a memory leak in record_ac fuzzer and also cleans up the fuzzer to avoid timeouts.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes the issues:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30904
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32543
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
