### PR TITLE
src: gzip: set a max decompression size.

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -258,6 +258,12 @@ int flb_gzip_uncompress(void *in_data, size_t in_len,
     /* Get decompressed length */
     dlen = read_le32(&p[in_len - 4]);
 
+    /* Limit decompressed length to 100MB */
+    if (dlen > 100000000) {
+        flb_error("[gzip] maximum decompression size is 100MB");
+        return -1;
+    }
+
     /* Get CRC32 checksum of original data */
     crc = read_le32(&p[in_len - 8]);
 


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Sets a max decompression size. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28048

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
