### PR TITLE
unescape: fix casting char to uint32_t on arm inconsistent with x86(#3142)

### DIFF
--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -178,13 +178,15 @@ int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf)
                     esc_in = u8_read_escape_sequence(next, size, &ch) + 1;
                 }
                 else {
-                    ch = (uint32_t) *in_buf;
+                    /* because char is unsigned char by default on arm, so we need to do a explicit conversion */
+                    ch = (uint32_t) (signed char) *in_buf;
                     esc_in = 1;
                 }
             }
         }
         else {
-            ch = (uint32_t) *in_buf;
+            /* explicit convert char to signed char */
+            ch = (uint32_t) (signed char) *in_buf;
             esc_in = 1;
         }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes special characters parsing error on arm
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
[Fixes 3142 ](https://github.com/fluent/fluent-bit/issues/3142)
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
