### PR TITLE
out_stackdriver: drop log entries if http response code - 4xx

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2146,6 +2146,9 @@ static void cb_stackdriver_flush(const void *data, size_t bytes,
         if (c->resp.status == 200) {
             ret_code = FLB_OK;
         }
+        else if (c->resp.status >= 400 && c->resp.status < 500) {
+            ret_code = FLB_ERROR;
+        }
         else {
             if (c->resp.payload_size > 0) {
                 /* we got an error */


### PR DESCRIPTION
Drop log entries if client side error 4xx

Github Issue: https://github.com/fluent/fluent-bit/issues/3495

TODO: This shall just work but still i shall build an agent and verify it with a big size log entry


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- `[N/A]` Example configuration file for the change
- `[N/A]` Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- `[N/A]` Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- `[N/A]` Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.