### PR TITLE
tests: runtime: in_tail: add testcase for skip_long_lines

### DIFF
--- a/tests/runtime/data/tail/out/skip_long_lines.out
+++ b/tests/runtime/data/tail/out/skip_long_lines.out
@@ -1,0 +1,2 @@
+{"log":"before_long_line"}
+{"log":"after_long_line"}

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -26,6 +26,9 @@ Approach for this tests is basing on filter_kubernetes tests
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <string.h>
 #include "flb_tests_runtime.h"
 
 
@@ -37,6 +40,8 @@ int64_t result_time;
 struct tail_test_result {
     const char *target;
     int   nMatched;
+    int   nNotMatched;
+    int   nLines;
 };
 
 struct tail_file_lines {
@@ -70,7 +75,7 @@ static int file_to_buf(const char *path, char **out_buf, size_t *out_size)
         return -1;
     }
 
-    buf = flb_malloc(st.st_size);
+    buf = flb_malloc(st.st_size+1);
     if (!buf) {
         flb_errno();
         fclose(fp);
@@ -86,6 +91,7 @@ static int file_to_buf(const char *path, char **out_buf, size_t *out_size)
     }
 
     fclose(fp);
+    buf[st.st_size] = '\0';
     *out_buf = buf;
     *out_size = st.st_size;
 
@@ -152,6 +158,7 @@ static int cb_check_result(void *record, size_t size, void *data)
       * in the output record.
       */
     int i;
+    result->nLines = out->lines_c;
     for (i=0; i<out->lines_c; i++) {
       check = strstr(record, out->lines[i]);
       if (check != NULL) {
@@ -159,7 +166,7 @@ static int cb_check_result(void *record, size_t size, void *data)
           goto exit;
       }
     }
-
+    result->nNotMatched++;
 exit:
     if (size > 0) {
         flb_free(record);
@@ -289,9 +296,128 @@ void flb_test_in_tail_dockermode_firstline_detection()
             NULL);
 }
 
+int write_long_lines(int fd) {
+    ssize_t ret;
+    int i;
+    const char* data = "0123456789abcdef" "0123456789abcdef";
+    size_t len = strlen(data);
+
+    for (i=0; i<1024; i++) {
+        ret = write(fd, data, strlen(data));
+        if (ret < 0) {
+            flb_errno();
+            return -1;
+        }
+        else if(ret != len) {
+            write(fd, &data[ret], len-ret);
+        }
+    }
+
+    write(fd, "\n", 1);
+    return 0;
+}
+
+void flb_test_in_tail_skip_long_lines()
+{
+    int64_t ret;
+    flb_ctx_t    *ctx    = NULL;
+    int in_ffd;
+    int out_ffd;
+    char path[PATH_MAX];
+    struct tail_test_result result = {0};
+    int fd;
+
+    char *target = "skip_long_lines";
+    int nExpected = 2;
+    int nExpectedNotMatched = 0;
+    int nExpectedLines = 2;
+
+    result.nMatched = 0;
+    result.target = target;
+
+    struct flb_lib_out_cb cb;
+    cb.cb   = cb_check_result;
+    cb.data = &result;
+
+    /* initialize */
+    set_result(0);
+
+    ctx = flb_create();
+
+    ret = flb_service_set(ctx,
+                          "Log_Level", "error",
+                          NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    in_ffd = flb_input(ctx, "tail", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    TEST_CHECK(flb_input_set(ctx, in_ffd, "tag", "test", NULL) == 0);
+
+    /* Compose path based on target */
+    snprintf(path, sizeof(path) - 1, DPATH "/log/%s.log", target);
+    fd = creat(path, S_IRWXU | S_IRGRP);
+    TEST_CHECK(fd >= 0);
+
+    /* Write log
+         =======
+         before_long_line
+         (long line which should be skipped)
+         after_long_line
+         =======
+
+      Output should be "before_long_line" and "after_long_line"
+     */
+    write(fd, "before_long_line\n", strlen("before_long_line\n"));
+    write_long_lines(fd);
+    write(fd, "after_long_line\n", strlen("after_long_line\n"));
+    close(fd);
+
+    TEST_CHECK_(access(path, R_OK) == 0, "accessing log file: %s", path);
+
+    TEST_CHECK(flb_input_set(ctx, in_ffd,
+                             "path"          , path,
+                             "read_from_head", "true",
+                             "skip_long_lines", "on",
+                             NULL) == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd,
+                              "match", "test",
+                              "format", "json",
+                              NULL) == 0);
+
+    TEST_CHECK(flb_service_set(ctx, "Flush", "0.5",
+                                    "Grace", "1",
+                                    NULL) == 0);
+
+    /* Start test */
+    /* Start the engine */
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "starting engine");
+
+    sleep(2);
+
+    TEST_CHECK(result.nMatched == nExpected);
+    TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, nExpected);
+    TEST_CHECK(result.nNotMatched == nExpectedNotMatched);
+    TEST_MSG("result.nNotMatched: %i\nnExpectedNotMatched: %i", result.nNotMatched, nExpectedNotMatched);
+    TEST_CHECK(result.nLines == nExpectedLines);
+    TEST_MSG("result.nLines: %i\nnExpectedLines: %i", result.nLines, nExpectedLines);
+
+    ret = flb_stop(ctx);
+    TEST_CHECK_(ret == 0, "stopping engine");
+
+    if (ctx) {
+        flb_destroy(ctx);
+    }
+
+    unlink(path);
+}
 
 /* Test list */
 TEST_LIST = {
+    {"skip_long_lines", flb_test_in_tail_skip_long_lines},
 #ifdef in_tail
     {"in_tail_dockermode",                          flb_test_in_tail_dockermode},
     {"in_tail_dockermode_splitted_line",            flb_test_in_tail_dockermode_splitted_line},


### PR DESCRIPTION
This patch is to add test for `skip_long_lines on`.
It is to prevent regression of the option.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Debug output

This is output at [master](https://github.com/fluent/fluent-bit/tree/f30e1389d3715947db9191d7dc0e9cef310e3d2c)
```
$ bin/flb-rt-in_tail 
Test skip_long_lines...                         [2021/05/21 14:59:33] [ info] [input] pausing tail.0
[ OK ]
```

This is output at v1.7.5 (the patch is cherry picked)
The issue #3491 of v1.7.5 is about `skip_long_lines`.
```
$ bin/flb-rt-in_tail 
Test skip_long_lines...                         [ FAILED ]
  in_tail.c:402: Check result.nNotMatched == nExpectedNotMatched... failed
    result.nNotMatched: 1
    nExpectedNotMatched: 0
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
