### PR TITLE
input_chunk: remove unused variables

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -690,10 +690,7 @@ static inline int flb_input_chunk_is_overlimit(struct flb_input_instance *i)
  */
 size_t flb_input_chunk_total_size(struct flb_input_instance *in)
 {
-    ssize_t bytes;
     size_t total = 0;
-    struct mk_list *head;
-    struct flb_input_chunk *ic;
     struct flb_storage_input *storage;
 
     storage = (struct flb_storage_input *) in->storage;

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -452,7 +452,6 @@ static struct addrinfo *flb_net_translate_ares_addrinfo(struct ares_addrinfo *in
     struct ares_addrinfo_node *current_ares_record;
     struct addrinfo *previous_output_record;
     struct addrinfo *current_output_record;
-    struct addrinfo *next_output_record;
     struct addrinfo *output;
     int failure_detected;
 


### PR DESCRIPTION
Remove unused variables to fix warning.

- input_chunk: remove unused variables
- network: remove unused variable


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
