### PR TITLE
tests: runtime: filter_parser: extend sleep time

### DIFF
--- a/tests/runtime/filter_grep.c
+++ b/tests/runtime/filter_grep.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
 #include "flb_tests_runtime.h"
 
 /* Test data */
@@ -49,7 +50,7 @@ void flb_test_filter_grep_regex(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -93,7 +94,7 @@ void flb_test_filter_grep_exclude(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
 #include "flb_tests_runtime.h"
 
 pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -147,7 +148,7 @@ void flb_test_filter_nest_multi_nest(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     count = get_output_num();
 
     TEST_CHECK_(count == expected, "Expected number of events %d, got %d", expected, count );
@@ -220,7 +221,7 @@ void flb_test_filter_nest_multi_lift(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     count = get_output_num();
 
     TEST_CHECK_(count == expected, "Expected number of events %d, got %d", expected, count );
@@ -285,7 +286,7 @@ void flb_test_filter_nest_single(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output();
 
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
 #include "flb_tests_runtime.h"
 
@@ -96,7 +97,7 @@ void flb_test_filter_parser_extract_fields()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -180,7 +181,7 @@ void flb_test_filter_parser_reserve_data_off()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -256,7 +257,7 @@ void flb_test_filter_parser_handle_time_key()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -332,7 +333,7 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -413,7 +414,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -489,7 +490,7 @@ void flb_test_filter_parser_preserve_original_field()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {
@@ -578,7 +579,7 @@ void flb_test_filter_parser_first_matched_when_mutilple_parser()
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    flb_time_msleep(1500); /* waiting flush */
     output = get_output(); /* 1sec passed, data should be flushed */
     TEST_CHECK_(output != NULL, "Expected output to not be NULL");
     if (output != NULL) {


### PR DESCRIPTION
Fixes #3520

These testcase sleeps 1second to wait flush.
However flush interval is also 1second.
So in somecases, records are not flushed after sleeping.

This patch is to extend sleep time 1s -> 1.5s for these tests.

- nest
- grep
- parser


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
