### PR TITLE
upstream: rename flb_should_proxy_for_host -> flb_upstream_needs_proxy

### DIFF
--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -105,6 +105,6 @@ int flb_upstream_set_property(struct flb_config *config,
 int flb_upstream_is_async(struct flb_upstream *u);
 void flb_upstream_thread_safe(struct flb_upstream *u);
 struct mk_list *flb_upstream_get_config_map(struct flb_config *config);
-int flb_should_proxy_for_host(const char *host, const char *proxy, const char *no_proxy);
+int flb_upstream_needs_proxy(const char *host, const char *proxy, const char *no_proxy);
 
 #endif


### PR DESCRIPTION
Fixes #3530 

`flb_should_proxy_for_host` is old function name and it is renamed `flb_upstream_needs_proxy`.
It causes warning.
```
/home/taka/git/fluent-bit/src/flb_upstream.c: In function ‘flb_upstream_create’:
/home/taka/git/fluent-bit/src/flb_upstream.c:189:9: warning: implicit declaration of function ‘flb_upstream_needs_proxy’; did you mean ‘flb_upstream_destroy’? [-Wimplicit-function-declaration]
  189 |     if (flb_upstream_needs_proxy(host, config->http_proxy, config->no_proxy) == FLB_TRUE) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
      |         flb_upstream_destroy
```


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
