### PR TITLE
http_server: api: metrics: use flb_time for prometheus

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_version.h>
+#include <fluent-bit/flb_time.h>
 #include "metrics.h"
 
 #include <fluent-bit/flb_http_server.h>
@@ -239,7 +240,7 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     char time_str[64];
     char start_time_str[64];
     char* *metrics_arr;
-    struct timeval tp;
+    struct flb_time tp;
     struct flb_hs *hs = data;
     struct flb_config *config = hs->config;
 
@@ -274,8 +275,8 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     metric_helptxt_head = FLB_SDS_HEADER(metric_helptxt);
 
     /* current time */
-    gettimeofday(&tp, NULL);
-    now = tp.tv_sec * 1000 + tp.tv_usec / 1000;
+    flb_time_get(&tp);
+    now = flb_time_to_nanosec(&tp) / 1000000; /* in milliseconds */
     time_len = snprintf(time_str, sizeof(time_str) - 1, "%lu", now);
     start_time_len = snprintf(start_time_str, sizeof(start_time_str) - 1, "%lu", config->init_time);
 


### PR DESCRIPTION
This patch is to fix warning of metrics.c
```
[ 32%] Building C object src/http_server/api/v1/CMakeFiles/api-v1.dir/metrics.c.o
/home/taka/git/fluent-bit/src/http_server/api/v1/metrics.c: In function ‘cb_metrics_prometheus’:
/home/taka/git/fluent-bit/src/http_server/api/v1/metrics.c:277:5: warning: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]
  277 |     gettimeofday(&tp, NULL);
      |     ^~~~~~~~~~~~
```

This patch is to use flb_time to handle time information.
Note: 1 millisecond = 1 * 1000 * 1000 nanoseconds

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
