### PR TITLE
network: fix corner case in async dns lookup 

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -66,7 +66,7 @@ struct flb_dns_lookup_result_event {
 
 struct flb_dns_lookup_context {
     struct mk_event response_event;                  /* c-ares socket event */
-    // struct flb_dns_lookup_result_event result_event; /* result signaling event */
+    int ares_socket_created;
     void *ares_channel;
     int result_code;
     int finished;


### PR DESCRIPTION
…olve the query locally and return without creating a socket

There was a corner case where c-ares would resolve a name locally (in the reported case it was a ipv4 address) and dispatch the result callback immediately without creating a socket or sending a query (obvious). In that case, the lookup routine would hang after yielding waiting for the event loop handler to resume it after receiving the result.
This patch selectively calls yield only when a socket was created after the c-ares api call is issued.

This fix could fail if we tried to force c-ares to use TCP sockets and keep them alive and reuse them but in that case the whole thing fails so I don't think that is something to worry about (well, don't do that of course).

Additionaly, a leftover, commented field related to the previous signaling mechanism was removed and a line or two were fixed in terms of coding style.
