### PR TITLE
tests: internal: fuzzers: add timeout checks and add license.

### DIFF
--- a/tests/internal/fuzzers/flb_fuzz_header.h
+++ b/tests/internal/fuzzers/flb_fuzz_header.h
@@ -1,8 +1,28 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include <stdint.h>
 #include <string.h>
 
 #define GET_MOD_EQ(max, idx) (data[0] % max) == idx
 #define MOVE_INPUT(offset) data += offset; size -= offset;
+
+#define TIMEOUT_GUARD if (size > 32768) return 0;
 
 char *get_null_terminated(size_t size, const uint8_t **data,
                           size_t *total_data_size)

--- a/tests/internal/fuzzers/flb_json_fuzzer.c
+++ b/tests/internal/fuzzers/flb_json_fuzzer.c
@@ -1,6 +1,6 @@
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
  *  Copyright (C) 2015-2018 Treasure Data Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,12 @@
 #include <stdint.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_str.h>
+#include "flb_fuzz_header.h"
 
 int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
 {
+    TIMEOUT_GUARD
+
     /* json packer */
     char *out_buf = NULL;
     size_t out_size;

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -1,10 +1,30 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_parser.h>
+#include "flb_fuzz_header.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    TIMEOUT_GUARD
+
     void *out_buf = NULL;
     size_t out_size = 0;
     struct flb_time out_time;

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -1,3 +1,20 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
@@ -12,6 +29,8 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    TIMEOUT_GUARD
+
     char *format      = NULL;
     char *time_fmt    = NULL;
     char *time_key    = NULL;

--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -1,3 +1,21 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
@@ -9,10 +27,12 @@
 #include <fluent-bit/flb_uri.h>
 #include <fluent-bit/flb_sha512.h>
 #include <fluent-bit/flb_regex.h>
+#include "flb_fuzz_header.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    /* We need a bit of data in this fuzzer */
+    TIMEOUT_GUARD
+
     if (size < 600) {
         return 0;
     }


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
This PR only changes the fuzzer infrastructure.

It adds timeout checks as well as license headers. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
