### PR TITLE
flb: gzip: fix memory leak.

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -283,6 +283,7 @@ int flb_gzip_uncompress(void *in_data, size_t in_len,
 
     /* Ensure size is above 0 */
     if (((p + in_len) - start - 8) <= 0) {
+        flb_free(out_buf);
         return -1;
     }
 


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes the memory leak: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34569

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
