### PR TITLE
lib/flb_libco: Update to support M1/Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,14 @@ include(cmake/macros.cmake)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
+# Check for posix_memalign so that Apple Silicon can be supported
+include(CheckSymbolExists)
+check_symbol_exists(posix_memalign "stdint.h" HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN)
+  add_definitions(-DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN)
+
 # Output paths
 set(FLB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")

--- a/lib/flb_libco/CMakeLists.txt
+++ b/lib/flb_libco/CMakeLists.txt
@@ -2,5 +2,13 @@ set(src
   libco.c
   )
 
+# Check for posix_memalign so that Apple Silicon can be supported
+include(CheckSymbolExists)
+check_symbol_exists(posix_memalign "stdint.h" HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN)
+  add_definitions(-DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN)
+
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/lib/flb_libco/aarch64.c
+++ b/lib/flb_libco/aarch64.c
@@ -12,8 +12,10 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __APPLE__
 #ifndef IOS
-#include <malloc.h>
+#include <malloc/malloc.h>
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/lib/monkey/deps/flb_libco/CMakeLists.txt
+++ b/lib/monkey/deps/flb_libco/CMakeLists.txt
@@ -2,5 +2,13 @@ set(src
   libco.c
   )
 
+# Check for posix_memalign so that Apple Silicon can be supported
+include(CheckSymbolExists)
+check_symbol_exists(posix_memalign "stdint.h" HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN)
+  add_definitions(-DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN)
+
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/lib/monkey/deps/flb_libco/aarch64.c
+++ b/lib/monkey/deps/flb_libco/aarch64.c
@@ -12,8 +12,10 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __APPLE__
 #ifndef IOS
-#include <malloc.h>
+#include <malloc/malloc.h>
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
lib/monkey: Update to support M1/Apple Silicon

This patch adds support for fluent-bit to build on M1/Apple Silicon

<!-- Provide summary of changes -->
This patch adds support for fluent-bit to build on M1/Apple Silicon

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found. (Valgrind requires linux).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

I've got the binary to run, and build it's easier under homebrew.

Testing still needs to be done, this is just a PR to make it build on M1/Apple Silicon

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
