### PR TITLE
out_file: exit when format is unknown (#3573)

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -122,6 +122,11 @@ static int cb_file_init(struct flb_output_instance *ins,
         else if (!strcasecmp(tmp, "template")) {
             ctx->format    = FLB_OUT_FILE_FMT_TEMPLATE;
         }
+        else {
+            flb_plg_error(ctx->ins, "unknown format %s. abort.", tmp);
+            flb_free(ctx);
+            return -1;
+        }
     }
 
     tmp = flb_output_get_property("delimiter", ins);

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -266,10 +266,7 @@ void flb_test_file_format_ltsv(void)
 
 void flb_test_file_format_invalid(void)
 {
-    int i;
     int ret;
-    int bytes;
-    char *p = (char *) JSON_SMALL;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -278,7 +275,7 @@ void flb_test_file_format_invalid(void)
     remove(TEST_LOGFILE);
 
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "off", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(in_ffd >= 0);
@@ -293,22 +290,16 @@ void flb_test_file_format_invalid(void)
     flb_output_set(ctx, out_ffd, "label_delimiter", "zzz", NULL);
 
     ret = flb_start(ctx);
-    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("invalid format should be error");
 
-    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
-        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
-        TEST_CHECK(bytes == 1);
-    }
-
-    sleep(1); /* waiting flush */
-
-    flb_stop(ctx);
-    flb_destroy(ctx);
-
-    fp = fopen(TEST_LOGFILE, "r");
-    TEST_CHECK(fp != NULL);
-    if (fp != NULL) {
-        fclose(fp);
-        remove(TEST_LOGFILE);
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        fp = fopen(TEST_LOGFILE, "r");
+        TEST_CHECK(fp != NULL);
+        if (fp != NULL) {
+            fclose(fp);
+            remove(TEST_LOGFILE);
+        }
     }
 }

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -302,4 +302,7 @@ void flb_test_file_format_invalid(void)
             remove(TEST_LOGFILE);
         }
     }
+    else {
+        flb_destroy(ctx);
+    }
 }


### PR DESCRIPTION
Fixes #3573 

This patch is to exit when format is unknown.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->


## Debug log 

```
$ bin/fluent-bit -i cpu -o file -p format=hoge
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/29 09:40:07] [error] [lib] backend failed
[2021/05/29 09:40:07] [ info] [engine] started (pid=26879)
```

## Valgrind output

So many leaks are reported, but I think they are not related this patch.

<details>

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o file -p format=hoge
==26882== Memcheck, a memory error detector
==26882== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26882== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==26882== Command: bin/fluent-bit -i cpu -o file -p format=hoge
==26882== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/29 09:40:31] [ info] [engine] started (pid=26882)
[2021/05/29 09:40:31] [ info] [storage] version=1.1.1, initializing...
[2021/05/29 09:40:31] [ info] [storage] in-memory
[2021/05/29 09:40:31] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/29 09:40:31] [error] [output:file:file.0] unknown format hoge. abort.
[2021/05/29 09:40:31] [error] [output] Failed to initialize 'file' plugin
[2021/05/29 09:40:31] [error] [lib] backend failed
[2021/05/29 09:40:31] [ info] [input] pausing cpu.0
[2021/05/29 09:40:31] [ info] [input] pausing cpu.0
==26882== Invalid read of size 8
==26882==    at 0x173FC3: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf1f38 is 72 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid read of size 8
==26882==    at 0x173FCF: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf2060 is 368 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid read of size 8
==26882==    at 0x173FDA: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf1f30 is 64 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid read of size 8
==26882==    at 0x1AC54B: cb_cpu_pause (cpu.c:588)
==26882==    by 0x173FE5: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bfbc30 is 48 bytes inside a block of size 56 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1AABFA: flb_free (flb_mem.h:122)
==26882==    by 0x1AC5EE: cb_cpu_exit (cpu.c:609)
==26882==    by 0x173835: flb_input_instance_exit (flb_input.c:556)
==26882==    by 0x1738A0: flb_input_exit_all (flb_input.c:576)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1AABC1: flb_calloc (flb_mem.h:78)
==26882==    by 0x1AC226: cb_cpu_init (cpu.c:502)
==26882==    by 0x173627: flb_input_instance_init (flb_input.c:483)
==26882==    by 0x173708: flb_input_init_all (flb_input.c:519)
==26882==    by 0x18529F: flb_engine_start (flb_engine.c:508)
==26882==    by 0x16997B: flb_lib_worker (flb_lib.c:605)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882== 
==26882== Invalid read of size 4
==26882==    at 0x1AC553: cb_cpu_pause (cpu.c:588)
==26882==    by 0x173FE5: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bfbc0c is 12 bytes inside a block of size 56 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1AABFA: flb_free (flb_mem.h:122)
==26882==    by 0x1AC5EE: cb_cpu_exit (cpu.c:609)
==26882==    by 0x173835: flb_input_instance_exit (flb_input.c:556)
==26882==    by 0x1738A0: flb_input_exit_all (flb_input.c:576)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1AABC1: flb_calloc (flb_mem.h:78)
==26882==    by 0x1AC226: cb_cpu_init (cpu.c:502)
==26882==    by 0x173627: flb_input_instance_init (flb_input.c:483)
==26882==    by 0x173708: flb_input_init_all (flb_input.c:519)
==26882==    by 0x18529F: flb_engine_start (flb_engine.c:508)
==26882==    by 0x16997B: flb_lib_worker (flb_lib.c:605)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882== 
==26882== Invalid read of size 8
==26882==    at 0x173E7B: get_collector (flb_input.c:791)
==26882==    by 0x174040: flb_input_collector_pause (flb_input.c:842)
==26882==    by 0x1AC55F: cb_cpu_pause (cpu.c:588)
==26882==    by 0x173FE5: flb_input_pause_all (flb_input.c:825)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf1ff8 is 264 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid write of size 4
==26882==    at 0x173FEE: flb_input_pause_all (flb_input.c:829)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf1fa8 is 184 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid read of size 8
==26882==    at 0x173FFC: flb_input_pause_all (flb_input.c:820)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0x4bf1fc8 is 216 bytes inside a block of size 376 free'd
==26882==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x1726D2: flb_free (flb_mem.h:122)
==26882==    by 0x1733CE: flb_input_instance_destroy (flb_input.c:411)
==26882==    by 0x1738AC: flb_input_exit_all (flb_input.c:577)
==26882==    by 0x185B57: flb_engine_shutdown (flb_engine.c:721)
==26882==    by 0x16999C: flb_lib_worker (flb_lib.c:608)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882==  Block was alloc'd at
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172699: flb_calloc (flb_mem.h:78)
==26882==    by 0x172A23: flb_input_new (flb_input.c:135)
==26882==    by 0x15DA4F: flb_main (fluent-bit.c:952)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== Invalid read of size 4
==26882==    at 0x1727C6: flb_input_buf_paused (flb_input.h:474)
==26882==    by 0x173F5B: flb_input_pause_all (flb_input.c:822)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882==  Address 0xffffffffffffffe8 is not stack'd, malloc'd or (recently) free'd
==26882== 
[2021/05/29 09:40:31] [engine] caught signal (SIGSEGV)
#0  0x1727c6            in  flb_input_buf_paused() at include/fluent-bit/flb_input.h:474
#1  0x173f5b            in  flb_input_pause_all() at src/flb_input.c:822
#2  0x185b10            in  flb_engine_shutdown() at src/flb_engine.c:708
#3  0x168b58            in  flb_destroy() at src/flb_lib.c:213
#4  0x15e0b5            in  flb_main() at src/fluent-bit.c:1159
#5  0x15e105            in  main() at src/fluent-bit.c:1174
#6  0x4a150b2           in  ???() at ???:0
#7  0x15b3ed            in  ???() at ???:0
#8  0xffffffffffffffff  in  ???() at ???:0
==26882== 
==26882== Process terminating with default action of signal 6 (SIGABRT)
==26882==    at 0x4A3418B: raise (raise.c:51)
==26882==    by 0x4A13858: abort (abort.c:79)
==26882==    by 0x15CC68: flb_signal_handler (fluent-bit.c:514)
==26882==    by 0x4A3420F: ??? (in /usr/lib/x86_64-linux-gnu/libc-2.31.so)
==26882==    by 0x1727C5: flb_input_buf_paused (flb_input.h:474)
==26882==    by 0x173F5B: flb_input_pause_all (flb_input.c:822)
==26882==    by 0x185B10: flb_engine_shutdown (flb_engine.c:708)
==26882==    by 0x168B58: flb_destroy (flb_lib.c:213)
==26882==    by 0x15E0B5: flb_main (fluent-bit.c:1159)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== HEAP SUMMARY:
==26882==     in use at exit: 49,708 bytes in 104 blocks
==26882==   total heap usage: 205 allocs, 101 frees, 89,566 bytes allocated
==26882== 
==26882== 7 bytes in 1 blocks are possibly lost in loss record 2 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x16B791: flb_malloc (flb_mem.h:62)
==26882==    by 0x16BFD2: entry_set_value (flb_hash.c:252)
==26882==    by 0x16C24F: flb_hash_add (flb_hash.c:344)
==26882==    by 0x16B173: flb_env_set (flb_env.c:121)
==26882==    by 0x16AFE2: env_preset (flb_env.c:63)
==26882==    by 0x16B093: flb_env_create (flb_env.c:90)
==26882==    by 0x17C7DA: flb_config_init (flb_config.c:210)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 9 bytes in 1 blocks are possibly lost in loss record 4 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x16B791: flb_malloc (flb_mem.h:62)
==26882==    by 0x16B84F: flb_strndup (flb_str.h:51)
==26882==    by 0x16C216: flb_hash_add (flb_hash.c:339)
==26882==    by 0x16B173: flb_env_set (flb_env.c:121)
==26882==    by 0x16AFE2: env_preset (flb_env.c:63)
==26882==    by 0x16B093: flb_env_create (flb_env.c:90)
==26882==    by 0x17C7DA: flb_config_init (flb_config.c:210)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 31 bytes in 1 blocks are possibly lost in loss record 12 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x170E0E: flb_malloc (flb_mem.h:62)
==26882==    by 0x171031: sds_alloc (flb_sds.c:40)
==26882==    by 0x1710B5: flb_sds_create_len (flb_sds.c:61)
==26882==    by 0x17115B: flb_sds_create (flb_sds.c:87)
==26882==    by 0x17D385: flb_config_set_program_name (flb_config.c:535)
==26882==    by 0x15DEC0: flb_main (fluent-bit.c:1082)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 16 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BCFC: flb_plugins_register (flb_plugins.h:614)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 17 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BD6E: flb_plugins_register (flb_plugins.h:622)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 18 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BDE0: flb_plugins_register (flb_plugins.h:630)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 19 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BE52: flb_plugins_register (flb_plugins.h:638)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 20 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BEC4: flb_plugins_register (flb_plugins.h:646)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 21 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BF36: flb_plugins_register (flb_plugins.h:654)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 22 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BFA8: flb_plugins_register (flb_plugins.h:662)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 23 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C01A: flb_plugins_register (flb_plugins.h:670)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 24 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C08C: flb_plugins_register (flb_plugins.h:678)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 25 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C0FE: flb_plugins_register (flb_plugins.h:686)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 26 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C170: flb_plugins_register (flb_plugins.h:694)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 27 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C1E2: flb_plugins_register (flb_plugins.h:702)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 28 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C254: flb_plugins_register (flb_plugins.h:710)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 72 bytes in 1 blocks are possibly lost in loss record 29 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17C2C6: flb_plugins_register (flb_plugins.h:718)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 88 bytes in 1 blocks are possibly lost in loss record 30 of 104
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x16B7F3: flb_calloc (flb_mem.h:78)
==26882==    by 0x16C1B5: flb_hash_add (flb_hash.c:330)
==26882==    by 0x16B173: flb_env_set (flb_env.c:121)
==26882==    by 0x16AFE2: env_preset (flb_env.c:63)
==26882==    by 0x16B093: flb_env_create (flb_env.c:90)
==26882==    by 0x17C7DA: flb_config_init (flb_config.c:210)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 31 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A11C: flb_plugins_register (flb_plugins.h:116)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 32 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A18E: flb_plugins_register (flb_plugins.h:124)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 33 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A200: flb_plugins_register (flb_plugins.h:132)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 34 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A272: flb_plugins_register (flb_plugins.h:140)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 35 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A2E4: flb_plugins_register (flb_plugins.h:148)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 36 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A356: flb_plugins_register (flb_plugins.h:156)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 37 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A3C8: flb_plugins_register (flb_plugins.h:164)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 38 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A43A: flb_plugins_register (flb_plugins.h:172)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 39 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A4AC: flb_plugins_register (flb_plugins.h:180)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 40 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A51E: flb_plugins_register (flb_plugins.h:188)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 41 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A590: flb_plugins_register (flb_plugins.h:196)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 42 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A602: flb_plugins_register (flb_plugins.h:204)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 43 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A674: flb_plugins_register (flb_plugins.h:212)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 44 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A6E6: flb_plugins_register (flb_plugins.h:220)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 45 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A758: flb_plugins_register (flb_plugins.h:228)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 46 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A7CA: flb_plugins_register (flb_plugins.h:236)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 47 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A83C: flb_plugins_register (flb_plugins.h:244)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 48 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A8AE: flb_plugins_register (flb_plugins.h:252)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 49 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A920: flb_plugins_register (flb_plugins.h:260)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 50 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17A992: flb_plugins_register (flb_plugins.h:268)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 51 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AA04: flb_plugins_register (flb_plugins.h:276)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 52 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AA76: flb_plugins_register (flb_plugins.h:284)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 53 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AAE8: flb_plugins_register (flb_plugins.h:292)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 54 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AB5A: flb_plugins_register (flb_plugins.h:300)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 55 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17ABCC: flb_plugins_register (flb_plugins.h:308)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 56 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AC3E: flb_plugins_register (flb_plugins.h:316)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 57 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17ACB0: flb_plugins_register (flb_plugins.h:324)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 128 bytes in 1 blocks are possibly lost in loss record 58 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AD22: flb_plugins_register (flb_plugins.h:332)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 136 bytes in 1 blocks are possibly lost in loss record 59 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x172637: flb_malloc (flb_mem.h:62)
==26882==    by 0x173975: flb_input_set_collector_time (flb_input.c:648)
==26882==    by 0x1AC4A5: cb_cpu_init (cpu.c:571)
==26882==    by 0x173627: flb_input_instance_init (flb_input.c:483)
==26882==    by 0x173708: flb_input_init_all (flb_input.c:519)
==26882==    by 0x18529F: flb_engine_start (flb_engine.c:508)
==26882==    by 0x16997B: flb_lib_worker (flb_lib.c:605)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 63 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AD94: flb_plugins_register (flb_plugins.h:341)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 64 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AE08: flb_plugins_register (flb_plugins.h:349)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 65 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AE7C: flb_plugins_register (flb_plugins.h:357)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 66 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AEF0: flb_plugins_register (flb_plugins.h:365)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 67 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AF64: flb_plugins_register (flb_plugins.h:373)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 68 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17AFD8: flb_plugins_register (flb_plugins.h:381)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 69 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B04C: flb_plugins_register (flb_plugins.h:389)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 70 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B0C0: flb_plugins_register (flb_plugins.h:397)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 71 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B134: flb_plugins_register (flb_plugins.h:405)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 72 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B1A8: flb_plugins_register (flb_plugins.h:413)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 73 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B21C: flb_plugins_register (flb_plugins.h:421)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 74 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B290: flb_plugins_register (flb_plugins.h:429)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 75 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B304: flb_plugins_register (flb_plugins.h:437)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 76 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B378: flb_plugins_register (flb_plugins.h:445)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 77 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B3EC: flb_plugins_register (flb_plugins.h:453)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 78 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B460: flb_plugins_register (flb_plugins.h:461)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 79 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B4D4: flb_plugins_register (flb_plugins.h:469)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 80 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B548: flb_plugins_register (flb_plugins.h:477)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 81 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B5BC: flb_plugins_register (flb_plugins.h:485)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 82 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B630: flb_plugins_register (flb_plugins.h:493)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 83 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B6A4: flb_plugins_register (flb_plugins.h:501)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 84 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B718: flb_plugins_register (flb_plugins.h:509)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 85 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B78C: flb_plugins_register (flb_plugins.h:517)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 86 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B800: flb_plugins_register (flb_plugins.h:525)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 87 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B874: flb_plugins_register (flb_plugins.h:533)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 88 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B8E8: flb_plugins_register (flb_plugins.h:541)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 89 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B95C: flb_plugins_register (flb_plugins.h:549)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 90 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17B9D0: flb_plugins_register (flb_plugins.h:557)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 91 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BA44: flb_plugins_register (flb_plugins.h:565)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 92 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BAB8: flb_plugins_register (flb_plugins.h:573)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 93 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BB2C: flb_plugins_register (flb_plugins.h:581)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 94 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BBA0: flb_plugins_register (flb_plugins.h:589)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 95 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BC14: flb_plugins_register (flb_plugins.h:597)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 192 bytes in 1 blocks are possibly lost in loss record 96 of 104
==26882==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x179F1C: flb_malloc (flb_mem.h:62)
==26882==    by 0x17BC88: flb_plugins_register (flb_plugins.h:605)
==26882==    by 0x17C7F1: flb_config_init (flb_config.c:213)
==26882==    by 0x1688F1: flb_create (flb_lib.c:141)
==26882==    by 0x15D912: flb_main (fluent-bit.c:913)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 288 bytes in 1 blocks are possibly lost in loss record 97 of 104
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==26882==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==26882==    by 0x4865322: allocate_stack (allocatestack.c:622)
==26882==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==26882==    by 0x4B1508: mk_utils_worker_spawn (mk_utils.c:284)
==26882==    by 0x169A4A: flb_start (flb_lib.c:636)
==26882==    by 0x15E09D: flb_main (fluent-bit.c:1157)
==26882==    by 0x15E105: main (fluent-bit.c:1174)
==26882== 
==26882== 288 bytes in 1 blocks are possibly lost in loss record 98 of 104
==26882==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==26882==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==26882==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==26882==    by 0x4865322: allocate_stack (allocatestack.c:622)
==26882==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==26882==    by 0x4B1508: mk_utils_worker_spawn (mk_utils.c:284)
==26882==    by 0x18D8B5: flb_worker_create (flb_worker.c:97)
==26882==    by 0x16A7BF: flb_log_create (flb_log.c:302)
==26882==    by 0x1850AB: flb_engine_log_start (flb_engine.c:443)
==26882==    by 0x185143: flb_engine_start (flb_engine.c:474)
==26882==    by 0x16997B: flb_lib_worker (flb_lib.c:605)
==26882==    by 0x4864608: start_thread (pthread_create.c:477)
==26882==    by 0x4B10292: clone (clone.S:95)
==26882== 
==26882== LEAK SUMMARY:
==26882==    definitely lost: 0 bytes in 0 blocks
==26882==    indirectly lost: 0 bytes in 0 blocks
==26882==      possibly lost: 11,967 bytes in 83 blocks
==26882==    still reachable: 37,741 bytes in 21 blocks
==26882==         suppressed: 0 bytes in 0 blocks
==26882== Reachable blocks (those to which a pointer was found) are not shown.
==26882== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==26882== 
==26882== For lists of detected and suppressed errors, rerun with: -s
==26882== ERROR SUMMARY: 92 errors from 92 contexts (suppressed: 0 from 0)
Aborted (core dumped)
taka@locals:~/git/fluent-bit/build$ 
```
</details>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
