### PR TITLE
network: release ares_addrinfo after using(#3572)

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -532,6 +532,7 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
         else {
             context->result_code = 0;
         }
+        ares_freeaddrinfo(res);
     }
     else {
         context->result_code = 1;


### PR DESCRIPTION
Fixes #3572.
`struct ares_addrinfo` is allocated at `ares_getaddrinfo` and it is passed via callback function.
The callback function is `flb_net_getaddrinfo_callback`.
I think the struct should be released at callback function.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Valgrind output 
```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o loki
==48842== Memcheck, a memory error detector
==48842== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==48842== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==48842== Command: bin/fluent-bit -i cpu -o loki
==48842== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/29 14:25:48] [ info] [engine] started (pid=48842)
[2021/05/29 14:25:48] [ info] [storage] version=1.1.1, initializing...
[2021/05/29 14:25:48] [ info] [storage] in-memory
[2021/05/29 14:25:48] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/29 14:25:48] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/05/29 14:25:48] [ info] [sp] stream processor started
==48842== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c67310
==48842==          to suppress, use: --max-stackframe=12047784 or greater
==48842== Warning: client switching stacks?  SP change: 0x4c67288 --> 0x57e48b8
==48842==          to suppress, use: --max-stackframe=12047920 or greater
==48842== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c67288
==48842==          to suppress, use: --max-stackframe=12047920 or greater
==48842==          further instances of this message will not be shown.
^C[2021/05/29 14:25:55] [engine] caught signal (SIGINT)
[2021/05/29 14:25:55] [ info] [input] pausing cpu.0
[2021/05/29 14:25:55] [ warn] [engine] service will stop in 5 seconds
[2021/05/29 14:26:00] [ info] [engine] service stopped
==48842== 
==48842== HEAP SUMMARY:
==48842==     in use at exit: 0 bytes in 0 blocks
==48842==   total heap usage: 443 allocs, 443 frees, 1,214,694 bytes allocated
==48842== 
==48842== All heap blocks were freed -- no leaks are possible
==48842== 
==48842== For lists of detected and suppressed errors, rerun with: -s
==48842== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
