### PR TITLE
output: release instance when init failed

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -841,6 +841,7 @@ int flb_output_init_all(struct flb_config *config)
         if (p->type == FLB_OUTPUT_PLUGIN_PROXY) {
             ret = flb_plugin_proxy_init(p->proxy, ins, config);
             if (ret == -1) {
+                flb_output_instance_destroy(ins);
                 return -1;
             }
             continue;
@@ -878,6 +879,7 @@ int flb_output_init_all(struct flb_config *config)
             if (!config_map) {
                 flb_error("[output] error loading config map for '%s' plugin",
                           p->name);
+                flb_output_instance_destroy(ins);
                 return -1;
             }
             ins->config_map = config_map;
@@ -940,6 +942,7 @@ int flb_output_init_all(struct flb_config *config)
         if (ret == -1) {
             flb_error("[output] Failed to initialize '%s' plugin",
                       p->name);
+            flb_output_instance_destroy(ins);
             return -1;
         }
 
@@ -949,6 +952,7 @@ int flb_output_init_all(struct flb_config *config)
             if (ret == -1) {
                 flb_error("[output] could not start thread pool for '%s' plugin",
                           p->name);
+                flb_output_instance_destroy(ins);
                 return -1;
             }
 


### PR DESCRIPTION
Some error cases at `flb_output_init_all`, instance is not released.
This patch is to release the instance on these cases.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -i cpu -o stdout
==49522== Memcheck, a memory error detector
==49522== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==49522== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==49522== Command: ../bin/fluent-bit -i cpu -o stdout
==49522== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/30 20:43:23] [ info] [engine] started (pid=49522)
[2021/05/30 20:43:23] [ info] [storage] version=1.1.1, initializing...
[2021/05/30 20:43:23] [ info] [storage] in-memory
[2021/05/30 20:43:23] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/30 20:43:23] [ info] [sp] stream processor started
==49522== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c66840
==49522==          to suppress, use: --max-stackframe=12050552 or greater
==49522== Warning: client switching stacks?  SP change: 0x4c667b8 --> 0x57e48b8
==49522==          to suppress, use: --max-stackframe=12050688 or greater
==49522== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c667b8
==49522==          to suppress, use: --max-stackframe=12050688 or greater
==49522==          further instances of this message will not be shown.
[0] cpu.0: [1622375004.134126815, {"cpu_p"=>4.000000, "user_p"=>3.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>4.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>1.000000}]
[1] cpu.0: [1622375005.121508633, {"cpu_p"=>8.000000, "user_p"=>7.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>8.000000, "cpu0.p_user"=>7.000000, "cpu0.p_system"=>1.000000}]
[2] cpu.0: [1622375006.121929391, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000}]
[3] cpu.0: [1622375007.121601192, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000}]
^C[2021/05/30 20:43:28] [engine] caught signal (SIGINT)
[2021/05/30 20:43:28] [ info] [input] pausing cpu.0
[0] cpu.0: [1622375008.172850773, {"cpu_p"=>7.000000, "user_p"=>6.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>6.000000, "cpu0.p_system"=>1.000000}]
[2021/05/30 20:43:28] [ warn] [engine] service will stop in 5 seconds
[2021/05/30 20:43:33] [ info] [engine] service stopped
==49522== 
==49522== HEAP SUMMARY:
==49522==     in use at exit: 0 bytes in 0 blocks
==49522==   total heap usage: 287 allocs, 287 frees, 977,143 bytes allocated
==49522== 
==49522== All heap blocks were freed -- no leaks are possible
==49522== 
==49522== For lists of detected and suppressed errors, rerun with: -s
==49522== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
