### PR TITLE
input: release instance when init failed and fix typo

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -454,8 +454,9 @@ int flb_input_instance_init(struct flb_input_instance *ins,
          */
         config_map = flb_config_map_create(config, p->config_map);
         if (!config_map) {
-            flb_error("[filter] error loading config map for '%s' plugin",
+            flb_error("[input] error loading config map for '%s' plugin",
                       p->name);
+            flb_input_instance_destroy(ins);
             return -1;
         }
         ins->config_map = config_map;


### PR DESCRIPTION
Input instance is not released when config_map is invalid.
This patch is to release the instance on the case.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o stdout
==51348== Memcheck, a memory error detector
==51348== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==51348== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==51348== Command: bin/fluent-bit -i cpu -o stdout
==51348== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/05/30 21:07:36] [ info] [engine] started (pid=51348)
[2021/05/30 21:07:36] [ info] [storage] version=1.1.1, initializing...
[2021/05/30 21:07:36] [ info] [storage] in-memory
[2021/05/30 21:07:36] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/05/30 21:07:37] [ info] [sp] stream processor started
==51348== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c66830
==51348==          to suppress, use: --max-stackframe=12050568 or greater
==51348== Warning: client switching stacks?  SP change: 0x4c667a8 --> 0x57e48b8
==51348==          to suppress, use: --max-stackframe=12050704 or greater
==51348== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c667a8
==51348==          to suppress, use: --max-stackframe=12050704 or greater
==51348==          further instances of this message will not be shown.
[0] cpu.0: [1622376457.094512959, {"cpu_p"=>5.000000, "user_p"=>4.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>5.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>1.000000}]
[1] cpu.0: [1622376458.083491357, {"cpu_p"=>8.000000, "user_p"=>8.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>8.000000, "cpu0.p_user"=>8.000000, "cpu0.p_system"=>0.000000}]
[2] cpu.0: [1622376459.082608786, {"cpu_p"=>3.000000, "user_p"=>3.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>0.000000}]
[3] cpu.0: [1622376460.083437132, {"cpu_p"=>3.000000, "user_p"=>2.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>1.000000}]
^C[2021/05/30 21:07:41] [engine] caught signal (SIGINT)
[2021/05/30 21:07:41] [ info] [input] pausing cpu.0
[0] cpu.0: [1622376461.135638332, {"cpu_p"=>7.000000, "user_p"=>7.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>7.000000, "cpu0.p_user"=>7.000000, "cpu0.p_system"=>0.000000}]
[2021/05/30 21:07:41] [ warn] [engine] service will stop in 5 seconds
[2021/05/30 21:07:46] [ info] [engine] service stopped
==51348== 
==51348== HEAP SUMMARY:
==51348==     in use at exit: 0 bytes in 0 blocks
==51348==   total heap usage: 287 allocs, 287 frees, 977,140 bytes allocated
==51348== 
==51348== All heap blocks were freed -- no leaks are possible
==51348== 
==51348== For lists of detected and suppressed errors, rerun with: -s
==51348== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
