### PR TITLE
src: utils: fix integer overflow guard.

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -455,9 +455,10 @@ int64_t flb_utils_hex2int(char *hex, int len)
 
     while ((c = *hex++) && i < len) {
         /* Ensure no overflow */
-        if (res >= 0xccccccccccccd00) {
+        if (res >= (int)((INT64_MAX/0x10) - 0xff)) {
             return -1;
         }
+
         res *= 0x10;
 
         if (c >= 'a' && c <= 'f') {


### PR DESCRIPTION
Signed-off-by: davkor <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes a signed integer overflow guard we have in `flb_utils` that is too relaxed. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34503

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
