### PR TITLE
parser: fix double free

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -564,7 +564,6 @@ static int parser_conf_file(const char *cfg, struct mk_rconf *fconf,
         decoders = NULL;
     }
 
-    mk_rconf_free(fconf);
     return 0;
 
  fconf_error:
@@ -688,7 +687,6 @@ static int multiline_parser_conf_file(const char *cfg, struct mk_rconf *fconf,
         flb_sds_destroy(key_group);
     }
 
-    mk_rconf_free(fconf);
     return 0;
 
  fconf_error:


### PR DESCRIPTION
Current master has double free issue.
https://github.com/fluent/fluent-bit/runs/2750747278

https://github.com/fluent/fluent-bit/blob/3dd43eacdff109b4173ed8bfdb8a4cddcba29c7c/src/flb_parser.c#L740-L753
`fconf` is freed at `parser_conf_file` and `multiline_parser_conf_file` and end of the function.

This patch is to remove free function at `*parser_conf_file` functions.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log output

```
$ bin/flb-it-parser 
Test tzone_offset...                            [ OK ]
Test time_lookup...                             [ OK ]
Test json_time_lookup...                        [ OK ]
Test regex_time_lookup...                       [ OK ]
Test mysql_unquoted...                          [ OK ]
SUCCESS: All unit tests have passed.
```

Without this patch, double free is reported.
```
$ bin/flb-it-parser 
Test tzone_offset...                            [ OK ]
Test time_lookup...                             free(): double free detected in tcache 2
  Test interrupted by SIGABRT.
Test json_time_lookup...                        free(): double free detected in tcache 2
  Test interrupted by SIGABRT.
Test regex_time_lookup...                       free(): double free detected in tcache 2
  Test interrupted by SIGABRT.
Test mysql_unquoted...                          free(): double free detected in tcache 2
  Test interrupted by SIGABRT.
FAILED: 4 of 5 unit tests have failed.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
