### PR TITLE
lib/flb_libco: Update to support M1/Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,28 @@ include(cmake/macros.cmake)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
+include(CheckSymbolExists)
+
+# Check for posix_memalign so that Apple Silicon can be supported
+check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN_IN_STDLIB)
+
+IF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined HAVE_POSIX_MEMALIGN_IN_STDLIB in order to avoid including in malloc.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in stdlib.h -DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+
+# Check for posix_memalign so that FreeBSD can be supported
+check_symbol_exists(posix_memalign "malloc_np.h" HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+
+IF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP in order to include malloc_np.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in malloc_np.h -DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+
 # Output paths
 set(FLB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")

--- a/lib/flb_libco/CMakeLists.txt
+++ b/lib/flb_libco/CMakeLists.txt
@@ -2,5 +2,27 @@ set(src
   libco.c
   )
 
+include(CheckSymbolExists)
+
+# Check for posix_memalign so that Apple Silicon can be supported
+check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN_IN_STDLIB)
+
+IF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined HAVE_POSIX_MEMALIGN_IN_STDLIB in order to avoid including in malloc.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in stdlib.h -DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+
+# Check for posix_memalign so that FreeBSD can be supported
+check_symbol_exists(posix_memalign "malloc_np.h" HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+
+IF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP in order to include malloc_np.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in malloc_np.h -DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/lib/flb_libco/aarch64.c
+++ b/lib/flb_libco/aarch64.c
@@ -12,7 +12,11 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifndef IOS
+#if defined(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+/* stdlib is already included */
+#elif defined(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+#include <malloc_np.h>
+#else
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
This patch adds support for fluent-bit to build on M1/Apple Silicon

Signed-off-by: Allen Reese <areese999@apple.com>

<!-- Provide summary of changes -->
This patch adds support for fluent-bit to build on M1/Apple Silicon

This  PR separates out the flb_libco patches from https://github.com/fluent/fluent-bit/pull/3564

The patches for libmonkey are here: https://github.com/monkey/monkey/pull/340
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found. (Valgrind requires linux).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

I've got the binary to run, and build it's easier under homebrew.

Testing still needs to be done, this is just a PR to make it build on M1/Apple Silicon

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.