### PR TITLE
filter_kubernetes: add configurable TTL option for cached metadata

### DIFF
--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -54,12 +54,15 @@ struct flb_hash {
     int evict_mode;
     int max_entries;
     int total_count;
+    int cache_ttl;
     size_t size;
     struct mk_list entries;
     struct flb_hash_table *table;
 };
 
 struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries);
+struct flb_hash *flb_hash_create_with_ttl(int cache_ttl, int evict_mode, 
+                                          size_t size, int max_entries);
 void flb_hash_destroy(struct flb_hash *ht);
 
 int flb_hash_add(struct flb_hash *ht,

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -128,9 +128,18 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
              ctx->api_https ? "https" : "http",
              ctx->api_host, ctx->api_port);
 
-    ctx->hash_table = flb_hash_create(FLB_HASH_EVICT_RANDOM,
-                                      FLB_HASH_TABLE_SIZE,
-                                      FLB_HASH_TABLE_SIZE);
+    if (ctx->kube_meta_cache_ttl > 0) {
+        ctx->hash_table = flb_hash_create_with_ttl(ctx->kube_meta_cache_ttl,
+                                                   FLB_HASH_EVICT_OLDER,
+                                                   FLB_HASH_TABLE_SIZE,
+                                                   FLB_HASH_TABLE_SIZE);
+    }
+    else {
+        ctx->hash_table = flb_hash_create(FLB_HASH_EVICT_RANDOM,
+                                          FLB_HASH_TABLE_SIZE,
+                                          FLB_HASH_TABLE_SIZE);
+    }
+    
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -154,6 +154,8 @@ struct flb_kube {
     int use_kubelet;
     int kubelet_port;
 
+    int kube_meta_cache_ttl;
+
     struct flb_tls *tls;
 
     struct flb_config *config;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -833,6 +833,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kube, kubelet_port),
      "kubelet port to connect with when using kubelet"
     },
+    /*
+     * Set TTL for K8s cached metadata 
+     */
+    {
+     FLB_CONFIG_MAP_TIME, "kube_meta_cache_ttl", "0",
+     0, FLB_TRUE, offsetof(struct flb_kube, kube_meta_cache_ttl),
+     "configurable TTL for K8s cached metadata"
+    },
     /* EOF */
     {0}
 };


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Add configurable TTL option for kubernetes cached metadata

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
