### PR TITLE
http_client: fix NO_PROXY matching condition

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -279,7 +279,7 @@ int flb_upstream_needs_proxy(const char *host, const char *proxy,
     ret = FLB_TRUE;
     mk_list_foreach(head, &no_proxy_list) {
         e = mk_list_entry(head, struct flb_slist_entry, _head);
-         if (strcmp(host, e->str)) {
+         if (strcmp(host, e->str) == 0) {
             ret = FLB_FALSE;
             break;
         }


### PR DESCRIPTION
Signed-off-by: Jie WU <wujie@google.com>

fix NO_PROXY matching condition
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
