### PR TITLE
health: remove old apis(#3615)

### DIFF
--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -80,7 +80,7 @@ static int in_health_collect(struct flb_input_instance *ins,
     }
 
     if (alive == FLB_TRUE && ctx->alert == FLB_TRUE) {
-        FLB_INPUT_RETURN();
+        return 0;
     }
 
     /* Initialize local msgpack buffer */
@@ -129,7 +129,6 @@ static int in_health_collect(struct flb_input_instance *ins,
     flb_input_chunk_append_raw(ins, NULL, 0, mp_sbuf.data, mp_sbuf.size);
     msgpack_sbuffer_destroy(&mp_sbuf);
 
-    FLB_INPUT_RETURN();
     return 0;
 }
 
@@ -255,5 +254,5 @@ struct flb_input_plugin in_health_plugin = {
     .cb_collect   = in_health_collect,
     .cb_flush_buf = NULL,
     .cb_exit      = in_health_exit,
-    .flags        = FLB_INPUT_NET | FLB_INPUT_CORO,
+    .flags        = FLB_INPUT_NET
 };


### PR DESCRIPTION
`FLB_INPUT_RETURN` and `FLB_INPUT_CORO` causes SIGSEGV.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
## Configuration
```
[INPUT]
    Name health
    Host 127.0.0.1
    Port 80

[OUTPUT]
    Name stdout
```

## Debug output
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/12 10:05:06] [ info] [engine] started (pid=28918)
[2021/06/12 10:05:06] [ info] [storage] version=1.1.1, initializing...
[2021/06/12 10:05:06] [ info] [storage] in-memory
[2021/06/12 10:05:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/12 10:05:06] [ info] [sp] stream processor started
[0] health.0: [1623459906.696954181, {"alive"=>true}]
[1] health.0: [1623459907.696688139, {"alive"=>true}]
[2] health.0: [1623459908.696568205, {"alive"=>true}]
[3] health.0: [1623459909.696265676, {"alive"=>true}]
[0] health.0: [1623459910.696673269, {"alive"=>true}]
[1] health.0: [1623459911.696328541, {"alive"=>true}]
[2] health.0: [1623459912.696422037, {"alive"=>true}]
[3] health.0: [1623459913.696586519, {"alive"=>true}]
[4] health.0: [1623459914.696302238, {"alive"=>true}]
^C[2021/06/12 10:05:16] [engine] caught signal (SIGINT)
[0] health.0: [1623459915.698325850, {"alive"=>true}]
[2021/06/12 10:05:16] [ warn] [engine] service will stop in 5 seconds
[2021/06/12 10:05:20] [ info] [engine] service stopped
```

## Valgrind output
```
$ valgrind ../bin/fluent-bit -c a.conf 
==28935== Memcheck, a memory error detector
==28935== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28935== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==28935== Command: ../bin/fluent-bit -c a.conf
==28935== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/12 10:06:47] [ info] [engine] started (pid=28935)
[2021/06/12 10:06:47] [ info] [storage] version=1.1.1, initializing...
[2021/06/12 10:06:47] [ info] [storage] in-memory
[2021/06/12 10:06:47] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/12 10:06:47] [ info] [sp] stream processor started
==28935== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c68970
==28935==          to suppress, use: --max-stackframe=12042056 or greater
==28935== Warning: client switching stacks?  SP change: 0x4c688e8 --> 0x57e48b8
==28935==          to suppress, use: --max-stackframe=12042192 or greater
==28935== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c688e8
==28935==          to suppress, use: --max-stackframe=12042192 or greater
==28935==          further instances of this message will not be shown.
[0] health.0: [1623460007.742220367, {"alive"=>true}]
[1] health.0: [1623460008.700478709, {"alive"=>true}]
[2] health.0: [1623460009.697232016, {"alive"=>true}]
[3] health.0: [1623460010.697332017, {"alive"=>true}]
^C[2021/06/12 10:06:53] [engine] caught signal (SIGINT)
[0] health.0: [1623460011.798448262, {"alive"=>true}]
[1] health.0: [1623460012.696583458, {"alive"=>true}]
[2021/06/12 10:06:53] [ warn] [engine] service will stop in 5 seconds
[2021/06/12 10:06:57] [ info] [engine] service stopped
==28935== 
==28935== HEAP SUMMARY:
==28935==     in use at exit: 0 bytes in 0 blocks
==28935==   total heap usage: 332 allocs, 332 frees, 1,055,363 bytes allocated
==28935== 
==28935== All heap blocks were freed -- no leaks are possible
==28935== 
==28935== For lists of detected and suppressed errors, rerun with: -s
==28935== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
