### PR TITLE
input: remove unused FLB_INPUT_RETURN

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -478,13 +478,6 @@ static inline int flb_input_buf_paused(struct flb_input_instance *i)
     return FLB_FALSE;
 }
 
-static inline void FLB_INPUT_RETURN()
-{
-    struct flb_coro *coro = flb_coro_get();
-    flb_input_return(coro);
-    flb_coro_return(coro);
-}
-
 static inline int flb_input_config_map_set(struct flb_input_instance *ins,
                                            void *context)
 {


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/pull/3629#issuecomment-860128741
Refer to the comment, I sent a patch to remove unused function FLB_INPUT_RETURN.

No one uses on [current master](https://github.com/fluent/fluent-bit/tree/363d88cf85b05515e04a2c4314fb0ab12e5ee337).
```
taka@locals:~/git/fluent-bit$ find . -name "*.[ch]"|xargs grep FLB_INPUT_RETURN
taka@locals:~/git/fluent-bit$ 
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
