### PR TITLE
out_loki: release ra_kv at error case

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -830,6 +830,7 @@ static int get_tenant_id_from_record(struct flb_loki *ctx, msgpack_object *map)
     else if (rval->o.type != MSGPACK_OBJECT_STR) {
         flb_plg_warn(ctx->ins, "the value of %s is not string",
                      ctx->tenant_id_key_config);
+        flb_ra_key_value_destroy(rval);
         return -1;
     }
 


### PR DESCRIPTION
When `tenant_id_key` is set, out_loki will leak in some cases.
The configuration is below "Example Configuration" section.

```
$ valgrind --leak-check=full bin/fluent-bit  -c a.conf 
==47268== Memcheck, a memory error detector
==47268== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==47268== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==47268== Command: bin/fluent-bit -c a.conf
==47268== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/13 16:04:44] [ info] [engine] started (pid=47268)
[2021/06/13 16:04:44] [ info] [storage] version=1.1.1, initializing...
[2021/06/13 16:04:44] [ info] [storage] in-memory
[2021/06/13 16:04:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/13 16:04:44] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/06/13 16:04:44] [ info] [sp] stream processor started
==47268== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c76a60
==47268==          to suppress, use: --max-stackframe=11984472 or greater
==47268== Warning: client switching stacks?  SP change: 0x4c769d8 --> 0x57e48b8
==47268==          to suppress, use: --max-stackframe=11984608 or greater
==47268== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c769d8
==47268==          to suppress, use: --max-stackframe=11984608 or greater
==47268==          further instances of this message will not be shown.
[2021/06/13 16:04:49] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:04:49] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:04:49] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:04:49] [ warn] [output:loki:loki.0] the value of msg is not string
^C[2021/06/13 16:04:49] [engine] caught signal (SIGINT)
[2021/06/13 16:04:49] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:04:49] [ warn] [engine] service will stop in 5 seconds
[2021/06/13 16:04:53] [ info] [engine] service stopped
==47268== 
==47268== HEAP SUMMARY:
==47268==     in use at exit: 200 bytes in 5 blocks
==47268==   total heap usage: 515 allocs, 510 frees, 1,257,308 bytes allocated
==47268== 
==47268== 200 bytes in 5 blocks are definitely lost in loss record 1 of 1
==47268==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==47268==    by 0x1A072D: flb_calloc (flb_mem.h:78)
==47268==    by 0x1A0C58: flb_ra_key_to_value (flb_ra_key.c:220)
==47268==    by 0x1A05FD: flb_ra_get_value_object (flb_record_accessor.c:643)
==47268==    by 0x20AAB9: get_tenant_id_from_record (loki.c:823)
==47268==    by 0x20AFA0: pack_record (loki.c:902)
==47268==    by 0x20B7DC: loki_compose_payload (loki.c:1107)
==47268==    by 0x20BA16: cb_loki_flush (loki.c:1169)
==47268==    by 0x176DDB: output_pre_cb_flush (flb_output.h:470)
==47268==    by 0x4B7A8A: co_init (amd64.c:117)
==47268== 
==47268== LEAK SUMMARY:
==47268==    definitely lost: 200 bytes in 5 blocks
==47268==    indirectly lost: 0 bytes in 0 blocks
==47268==      possibly lost: 0 bytes in 0 blocks
==47268==    still reachable: 0 bytes in 0 blocks
==47268==         suppressed: 0 bytes in 0 blocks
==47268== 
==47268== For lists of detected and suppressed errors, rerun with: -s
==47268== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[INPUT]
    Name dummy
    Dummy {"msg":10}

[OUTPUT]
    Name loki
    Match *
    tenant_id_key msg
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit  -c a.conf 
==45555== Memcheck, a memory error detector
==45555== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==45555== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==45555== Command: bin/fluent-bit -c a.conf
==45555== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/13 16:00:39] [ info] [engine] started (pid=45555)
[2021/06/13 16:00:39] [ info] [storage] version=1.1.1, initializing...
[2021/06/13 16:00:39] [ info] [storage] in-memory
[2021/06/13 16:00:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/13 16:00:39] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/06/13 16:00:39] [ info] [sp] stream processor started
==45555== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c76a60
==45555==          to suppress, use: --max-stackframe=11984472 or greater
==45555== Warning: client switching stacks?  SP change: 0x4c769d8 --> 0x57e48b8
==45555==          to suppress, use: --max-stackframe=11984608 or greater
==45555== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c769d8
==45555==          to suppress, use: --max-stackframe=11984608 or greater
==45555==          further instances of this message will not be shown.
[2021/06/13 16:00:44] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:00:44] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:00:44] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:00:44] [ warn] [output:loki:loki.0] the value of msg is not string
^C[2021/06/13 16:00:44] [engine] caught signal (SIGINT)
[2021/06/13 16:00:44] [ warn] [output:loki:loki.0] the value of msg is not string
[2021/06/13 16:00:44] [ warn] [engine] service will stop in 5 seconds
[2021/06/13 16:00:48] [ info] [engine] service stopped
==45555== 
==45555== HEAP SUMMARY:
==45555==     in use at exit: 0 bytes in 0 blocks
==45555==   total heap usage: 515 allocs, 515 frees, 1,257,308 bytes allocated
==45555== 
==45555== All heap blocks were freed -- no leaks are possible
==45555== 
==45555== For lists of detected and suppressed errors, rerun with: -s
==45555== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
