### PR TITLE
build: macos: Specify sdk sysroot more cleaner on macos big sur intel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,14 +648,17 @@ endif()
 # =========================================
 if(FLB_BACKTRACE)
   FLB_DEFINITION(FLB_HAVE_LIBBACKTRACE)
-  if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  if (CMAKE_OSX_SYSROOT)
     # From macOS Mojave, /usr/include does not store C SDK headers.
-    set(CFLAGS "${CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
+    # For libbacktrace building on macOS, we have to tell C headers where they are located.
+    set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT}")
+  else()
+    set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
   endif()
   ExternalProject_Add(backtrace
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/
     CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-ca0de05/configure ${AUTOCONF_HOST_OPT} --host=${HOST} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
-    BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
+    BUILD_COMMAND $(MAKE) CC=${DEPS_C_COMPILER}
     INSTALL_COMMAND $(MAKE) DESTDIR= install
     )
   add_library(libbacktrace STATIC IMPORTED GLOBAL)

--- a/cmake/onigmo.cmake
+++ b/cmake/onigmo.cmake
@@ -17,6 +17,14 @@ else()
   set(ONIGMO_ARCH "x86")
 endif()
 
+if (CMAKE_OSX_SYSROOT)
+  # From macOS Mojave, /usr/include does not store C SDK headers.
+  # For libbacktrace building on macOS, we have to tell C headers where they are located.
+  set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT}")
+else()
+  set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
+endif()
+
 # Onigmo (UNIX)
 # =============
 if(FLB_SMALL)
@@ -27,7 +35,7 @@ ExternalProject_Add(onigmo
   INSTALL_DIR ${ONIGMO_DEST}
   CONFIGURE_COMMAND ./configure ${AUTOCONF_HOST_OPT} --host=${HOST} --with-pic --disable-shared --enable-static --prefix=${ONIGMO_DEST}
   CFLAGS=-std=gnu99\ -Wall\ -pipe\ -Os\ -g0\ -s\ -fno-stack-protector\ -fomit-frame-pointer\ -DNDEBUG\ -U_FORTIFY_SOURCE
-  BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
+  BUILD_COMMAND $(MAKE) CC=${DEPS_C_COMPILER}
   INSTALL_COMMAND $(MAKE) DESTDIR= install)
 else()
 ExternalProject_Add(onigmo
@@ -37,7 +45,7 @@ ExternalProject_Add(onigmo
   INSTALL_DIR ${ONIGMO_DEST}
   CONFIGURE_COMMAND ./configure ${AUTOCONF_HOST_OPT} --host=${HOST} --with-pic --disable-shared --enable-static --prefix=${ONIGMO_DEST}
   CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
-  BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
+  BUILD_COMMAND $(MAKE) CC=${DEPS_C_COMPILER}
   INSTALL_COMMAND $(MAKE) DESTDIR= install)
 endif()
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Follows up #3622.

**Background**

I'd once got succeeded to build fluent-bit on macOS Big Sur.
But this succeeded build was not clean build actually.
I found that the previous succeeded building with `SYSROOT` environment variable which should tell C header location for CC compilers.
This PR should handle this environment variable internally and makes macOS building more easily.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
