### PR TITLE
out_cloudwatch: fix integer overflow in timestamps (issue #3640)

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -437,7 +437,7 @@ int process_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
         event = &buf->events[buf->event_index];
         event->json = tmp_buf_ptr;
         event->len = written;
-        event->timestamp = (unsigned long long) (tms->tm.tv_sec * 1000 +
+        event->timestamp = (unsigned long long) (tms->tm.tv_sec * 1000ull +
                                                  tms->tm.tv_nsec/1000000);
 
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is the simplest fix to avoid integer overflows when multiplying (32 bit) timestamp values by 1000 on 32 bit systems (ARMv7). See the related issue for context.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #3640 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [See issue] Example configuration file for the change
- [TODO] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [TODO] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
