### PR TITLE
input_chunk: change log level to avoid noisy logs

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -836,7 +836,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     }
 
     if (buf_size == 0) {
-        flb_info("[input chunk] skip ingesting data with 0 bytes");
+        flb_debug("[input chunk] skip ingesting data with 0 bytes");
         return -1;
     }
 


### PR DESCRIPTION
Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
