### PR TITLE
filter_kubernetes: add configurable TTL for cached metadata

### DIFF
--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -54,12 +54,15 @@ struct flb_hash {
     int evict_mode;
     int max_entries;
     int total_count;
+    int cache_ttl;
     size_t size;
     struct mk_list entries;
     struct flb_hash_table *table;
 };
 
 struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries);
+struct flb_hash *flb_hash_create_with_ttl(int cache_ttl, int evict_mode, 
+                                          size_t size, int max_entries);
 void flb_hash_destroy(struct flb_hash *ht);
 
 int flb_hash_add(struct flb_hash *ht,

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -128,9 +128,18 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
              ctx->api_https ? "https" : "http",
              ctx->api_host, ctx->api_port);
 
-    ctx->hash_table = flb_hash_create(FLB_HASH_EVICT_RANDOM,
-                                      FLB_HASH_TABLE_SIZE,
-                                      FLB_HASH_TABLE_SIZE);
+    if (ctx->kube_meta_cache_ttl > 0) {
+        ctx->hash_table = flb_hash_create_with_ttl(ctx->kube_meta_cache_ttl,
+                                                   FLB_HASH_EVICT_OLDER,
+                                                   FLB_HASH_TABLE_SIZE,
+                                                   FLB_HASH_TABLE_SIZE);
+    }
+    else {
+        ctx->hash_table = flb_hash_create(FLB_HASH_EVICT_RANDOM,
+                                          FLB_HASH_TABLE_SIZE,
+                                          FLB_HASH_TABLE_SIZE);
+    }
+    
     if (!ctx->hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -154,6 +154,8 @@ struct flb_kube {
     int use_kubelet;
     int kubelet_port;
 
+    int kube_meta_cache_ttl;
+
     struct flb_tls *tls;
 
     struct flb_config *config;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -833,6 +833,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kube, kubelet_port),
      "kubelet port to connect with when using kubelet"
     },
+    /*
+     * Set TTL for K8s cached metadata 
+     */
+    {
+     FLB_CONFIG_MAP_TIME, "kube_meta_cache_ttl", "0",
+     0, FLB_TRUE, offsetof(struct flb_kube, kube_meta_cache_ttl),
+     "configurable TTL for K8s cached metadata"
+    },
     /* EOF */
     {0}
 };

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -60,6 +60,7 @@ struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries)
     ht->max_entries = max_entries;
     ht->size = size;
     ht->total_count = 0;
+    ht->cache_ttl = 0;
     ht->table = flb_calloc(1, sizeof(struct flb_hash_table) * size);
     if (!ht->table) {
         flb_errno();
@@ -73,6 +74,22 @@ struct flb_hash *flb_hash_create(int evict_mode, size_t size, int max_entries)
         tmp->count = 0;
         mk_list_init(&tmp->chains);
     }
+
+    return ht;
+}
+
+struct flb_hash *flb_hash_create_with_ttl(int cache_ttl, int evict_mode, 
+                                          size_t size, int max_entries)
+{
+    struct flb_hash *ht;
+
+    ht = flb_hash_create(evict_mode, size, max_entries);
+    if (!ht) {
+        flb_errno();
+        return NULL;
+    }
+
+    ht->cache_ttl = cache_ttl;
 
     return ht;
 }
@@ -270,6 +287,8 @@ static int entry_set_value(struct flb_hash_entry *entry, void *val, size_t val_s
         entry->val_size = -1;
     }
 
+    entry->created = time(NULL);
+
     return 0;
 }
 
@@ -368,10 +387,19 @@ int flb_hash_get(struct flb_hash *ht,
 {
     int id;
     struct flb_hash_entry *entry;
+    time_t expiration;
 
     entry = hash_get_entry(ht, key, key_len, &id);
     if (!entry) {
         return -1;
+    }
+
+    if (ht->cache_ttl > 0) {
+        expiration = entry->created + ht->cache_ttl;
+        if (time(NULL) > expiration) {
+            flb_hash_entry_free(ht, entry);
+            return -1;
+        }
     }
 
     entry->hits++;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Split the commits in https://github.com/fluent/fluent-bit/pull/3623.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
