### PR TITLE
out_s3: log_key configuration option implemented

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -109,6 +109,7 @@ struct flb_s3 {
     char *canned_acl;
     char *compression;
     char *content_type;
+    char *log_key;
     int free_endpoint;
     int use_put_object;
     int send_content_md5;


### PR DESCRIPTION
Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/552

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

By default, the whole log record will be sent to S3.

If you specify a key name with this option, then only the value of that key
will be sent to S3.

For example, if you are using the Fluentd Docker log driver, you can specify
log_key log and only the log message will be sent  to S3. If the key is not
found, it will skip that record.

This patch has been tested using test configuration files and various
input plugins (random, exec, etc) as well as valgrind. The resulting output, 
as expected, only contained values of the specified log_key.

#### Record without ```log_key```
```
{"date":"2021-06-16T19:56:28.441428Z","log":"Pi is roughly 3.141605814119434"}
```

#### Record with ```log_key log```
```
Pi is roughly 3.141605814119434
```

### Example Configuration File
```
[INPUT]
    name exec
    command date +"%Y-%m-%d %H:%M:%S,%3N"

[OUTPUT]
    name s3
    match *
    region us-west-2
    bucket bucket-name
    s3_key_format /test/$UUID.gz
    use_put_object true
    total_file_size 2M
    upload_timeout 10s
    compression gzip
    store_dir /tmp/fluent-bit/s3-output-buffer
    retry_limit 5
    log_key exec
```