### PR TITLE
in_http: support "successful_response_code" (#3644)

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -91,6 +91,14 @@ static int in_http_init(struct flb_input_instance *ins,
         return -1;
     }
 
+    if (ctx->successful_response_code != 200 &&
+        ctx->successful_response_code != 201 &&
+        ctx->successful_response_code != 204) {
+        flb_plg_error(ctx->ins, "%d is not supported response code. Use default 201",
+                      ctx->successful_response_code);
+        ctx->successful_response_code = 201;
+    }
+
     /* Set the socket non-blocking */
     flb_net_socket_nonblocking(ctx->server_fd);
 
@@ -140,6 +148,12 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_http, tag_key),
      ""
     },
+    {
+     FLB_CONFIG_MAP_INT, "successful_response_code", "201",
+     0, FLB_TRUE, offsetof(struct flb_http, successful_response_code),
+     "Set successful response code. 200, 201 and 204 are supported."
+    },
+
 
     /* EOF */
     {0}

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -32,6 +32,7 @@
 
 struct flb_http {
     int server_fd;
+    int successful_response_code;
     flb_sds_t listen;
     flb_sds_t tcp_port;
     const char *tag_key;

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -55,6 +55,20 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
                        "Content-Length: 0\r\n\r\n",
                        FLB_VERSION_STR);
     }
+    else if (http_status == 200) {
+        flb_sds_printf(&out,
+                       "HTTP/1.1 200 OK\r\n"
+                       "Server: Fluent Bit v%s\r\n"
+                       "Content-Length: 0\r\n\r\n",
+                       FLB_VERSION_STR);
+    }
+    else if (http_status == 204) {
+        flb_sds_printf(&out,
+                       "HTTP/1.1 204 No Content\r\n"
+                       "Server: Fluent Bit v%s\r\n"
+                       "Content-Length: 0\r\n\r\n",
+                       FLB_VERSION_STR);
+    }
     else if (http_status == 400) {
         flb_sds_printf(&out,
                        "HTTP/1.1 400 Forbidden\r\n"
@@ -428,6 +442,6 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
 
     ret = process_payload(ctx, conn, tag, session, request);
     flb_sds_destroy(tag);
-    send_response(conn, 201, NULL);
+    send_response(conn, ctx->successful_response_code, NULL);
     return ret;
 }


### PR DESCRIPTION
Fixes #3644.
This patch is to add `successful_response_code` to modify response code.

|Name| Description| Default|
|----|---------|----------|
|successful_response_code` | It allows to set successful response code. 200, 201 and 204 are supported.| 201 |

Note: Fluentd supports 200 and 204 (by `use_204_response` https://github.com/fluent/fluentd/pull/2640)

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name http
    Successful_Response_Code 200

[OUTPUT]
    Name stdout
```

## Debug output 

I tested using curl.
```
curl -D -  --data '{"data":"sample"}' -XPOST -H "content-type: application/json" http://localhost:9880/app.log
```

Curl output:
```
$ curl -D -  --data '{"data":"sample"}' -XPOST -H "content-type: application/json" http://localhost:9880/app.log
HTTP/1.1 200 OK
Server: Fluent Bit v1.8.0
Content-Length: 0
```

Fluent-bit output:
```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/19 14:36:54] [ info] [engine] started (pid=50919)
[2021/06/19 14:36:54] [ info] [storage] version=1.1.1, initializing...
[2021/06/19 14:36:54] [ info] [storage] in-memory
[2021/06/19 14:36:54] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/19 14:36:54] [ info] [input:http:http.0] listening on 0.0.0.0:9880
[2021/06/19 14:36:54] [ info] [sp] stream processor started
[0] app.log: [1624081018.298772515, {"data"=>"sample"}]
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==50927== Memcheck, a memory error detector
==50927== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==50927== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==50927== Command: bin/fluent-bit -c a.conf
==50927== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/19 14:38:44] [ info] [engine] started (pid=50927)
[2021/06/19 14:38:44] [ info] [storage] version=1.1.1, initializing...
[2021/06/19 14:38:44] [ info] [storage] in-memory
[2021/06/19 14:38:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/19 14:38:44] [ info] [input:http:http.0] listening on 0.0.0.0:9880
[2021/06/19 14:38:44] [ info] [sp] stream processor started
==50927== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ce99a0
==50927==          to suppress, use: --max-stackframe=11513624 or greater
==50927== Warning: client switching stacks?  SP change: 0x4ce9918 --> 0x57e48b8
==50927==          to suppress, use: --max-stackframe=11513760 or greater
==50927== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4ce9918
==50927==          to suppress, use: --max-stackframe=11513760 or greater
==50927==          further instances of this message will not be shown.
[0] app.log: [1624081127.358894744, {"data"=>"sample"}]
^C[2021/06/19 14:38:50] [engine] caught signal (SIGINT)
[2021/06/19 14:38:50] [ warn] [engine] service will stop in 5 seconds
[2021/06/19 14:38:55] [ info] [engine] service stopped
==50927== 
==50927== HEAP SUMMARY:
==50927==     in use at exit: 0 bytes in 0 blocks
==50927==   total heap usage: 316 allocs, 316 frees, 1,204,488 bytes allocated
==50927== 
==50927== All heap blocks were freed -- no leaks are possible
==50927== 
==50927== For lists of detected and suppressed errors, rerun with: -s
==50927== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
