### PR TITLE
network: modify flb_net_getaddrinfo error code

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -526,7 +526,8 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
         context->result = flb_net_translate_ares_addrinfo(res);
 
         if (NULL == context->result) {
-            context->result_code = 2;
+            // Currently, translation fails when malloc error occured.
+            context->result_code = EAI_MEMORY;
         }
         else {
             context->result_code = 0;
@@ -534,7 +535,44 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
         ares_freeaddrinfo(res);
     }
     else {
-        context->result_code = 1;
+        // status is set at ares_getaddrinfo.
+        // see https://c-ares.haxx.se/ares_getaddrinfo.html
+        switch(status) {
+        case ARES_ENOTIMP:
+            // family should be AF_INET, AF_INET6 or AF_UNSPEC.
+            // If not, ares returns ARES_ENOTIMP.
+            context->result_code = EAI_FAMILY;
+            break;
+        case ARES_ENOTFOUND:
+            // c-ares returns this status when domain is onion.
+            context->result_code = EAI_FAIL;
+            break;
+        case ARES_ESERVICE:
+            // Failed to strtoul(service, ..);
+            context->result_code = EAI_NONAME;
+            break;
+        case ARES_ENOMEM:
+            context->result_code = EAI_MEMORY;
+            break;
+        case ARES_ECANCELLED:
+            context->result_code = EAI_AGAIN;
+            break;
+        case ARES_EDESTRUCTION:
+            // ares channel is destroyed.
+#ifdef FLB_SYSTEM_WINDOWS
+            context->result_code = EAI_FAIL;
+#else
+            context->result_code = EAI_SYSTEM;
+#endif
+            break;
+        default:
+            // other error.
+#ifdef FLB_SYSTEM_WINDOWS
+            context->result_code = EAI_FAIL;
+#else
+            context->result_code = EAI_SYSTEM;
+#endif
+        }
     }
 
     context->finished = 1;
@@ -779,7 +817,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
     }
 
     if (ret != 0) {
-        flb_warn("[net] getaddrinfo(host='%s'): %s", host, gai_strerror(ret));
+        flb_warn("[net] getaddrinfo(host='%s', err=%d): %s", host, ret, gai_strerror(ret));
         return -1;
     }
 

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -526,7 +526,7 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
         context->result = flb_net_translate_ares_addrinfo(res);
 
         if (NULL == context->result) {
-            // Currently, translation fails when malloc error occured.
+            /* Currently, translation fails when malloc error occured. */
             context->result_code = EAI_MEMORY;
         }
         else {
@@ -535,20 +535,24 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
         ares_freeaddrinfo(res);
     }
     else {
-        // status is set at ares_getaddrinfo.
-        // see https://c-ares.haxx.se/ares_getaddrinfo.html
+        /* 
+         * status is set at ares_getaddrinfo.
+         * see https://c-ares.haxx.se/ares_getaddrinfo.html
+         */
         switch(status) {
         case ARES_ENOTIMP:
-            // family should be AF_INET, AF_INET6 or AF_UNSPEC.
-            // If not, ares returns ARES_ENOTIMP.
+            /*
+             * family should be AF_INET, AF_INET6 or AF_UNSPEC.
+             * If not, ares returns ARES_ENOTIMP.
+             */
             context->result_code = EAI_FAMILY;
             break;
         case ARES_ENOTFOUND:
-            // c-ares returns this status when domain is onion.
+            /* c-ares returns this status when domain is onion. */
             context->result_code = EAI_FAIL;
             break;
         case ARES_ESERVICE:
-            // Failed to strtoul(service, ..);
+            /* Failed to strtoul(service, ..); */
             context->result_code = EAI_NONAME;
             break;
         case ARES_ENOMEM:
@@ -558,7 +562,7 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
             context->result_code = EAI_AGAIN;
             break;
         case ARES_EDESTRUCTION:
-            // ares channel is destroyed.
+            /* ares channel is destroyed. */
 #ifdef FLB_SYSTEM_WINDOWS
             context->result_code = EAI_FAIL;
 #else
@@ -566,7 +570,7 @@ static void flb_net_getaddrinfo_callback(void *arg, int status, int timeouts,
 #endif
             break;
         default:
-            // other error.
+            /* other error. */
 #ifdef FLB_SYSTEM_WINDOWS
             context->result_code = EAI_FAIL;
 #else


### PR DESCRIPTION
The error code of `flb_net_getaddrinfo` is not compatible with getaddrinfo(3).
On Linux system, the error code should be negative, but it returns 0-2.
So,   `gai_strerror` reports useless error log. Note:#3661
This patch is to fix it.

The error code is set at `flb_net_getaddrinfo_callback` and it is came from `ares_getaddrinfo`.
https://c-ares.haxx.se/ares_getaddrinfo.html

undocumented error ARES_ESERVICE is returned when strtoul(service, ..) failed.
https://github.com/fluent/fluent-bit/blob/a11cb4abc6b9dac16a2065b0182a962b215ba353/lib/c-ares-809d5e84/src/lib/ares_getaddrinfo.c#L617


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Valgrind output
```
$ valgrind --leak-check=full bin/fluent-bit  -i http -p host=localhost -o stdout
==51893== Memcheck, a memory error detector
==51893== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==51893== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==51893== Command: bin/fluent-bit -i http -p host=localhost -o stdout
==51893== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/19 17:20:29] [ info] [engine] started (pid=51893)
[2021/06/19 17:20:29] [ info] [storage] version=1.1.1, initializing...
[2021/06/19 17:20:29] [ info] [storage] in-memory
[2021/06/19 17:20:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/19 17:20:29] [ info] [input:http:http.0] listening on 0.0.0.0:9880
[2021/06/19 17:20:29] [ info] [sp] stream processor started
^C[2021/06/19 17:20:32] [engine] caught signal (SIGINT)
[2021/06/19 17:20:32] [ warn] [engine] service will stop in 5 seconds
[2021/06/19 17:20:37] [ info] [engine] service stopped
==51893== 
==51893== HEAP SUMMARY:
==51893==     in use at exit: 0 bytes in 0 blocks
==51893==   total heap usage: 238 allocs, 238 frees, 261,269 bytes allocated
==51893== 
==51893== All heap blocks were freed -- no leaks are possible
==51893== 
==51893== For lists of detected and suppressed errors, rerun with: -s
==51893== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
