### PR TITLE
in_tail: Fixes tail input "offset_key"

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -146,7 +146,7 @@ int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     }
     if (file->config->offset_key != NULL) {
         append_record_to_map(data, data_size,
-                             file->config->path_key,
+                             file->config->offset_key,
                              flb_sds_len(file->config->offset_key),
                              NULL, 0, file->offset + processed_bytes);
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently the `offset_key` field in the tail input is having its field mapped incorrectly to the `path_key` value.

This means when your setup is like so:
```
[INPUT]
    Name tail
    Path /var/log/containers/*.log
    Path_Key log_file
    Offset_Key log_offset

[OUTPUT]
    Name stdout
    Match *
```

The logged output appears as:
```
{ "log_file\u0000\u0000": 23875, "log_file": "/var/log/containers/<file_name>.log", ... }
```

Whereas with this PR the new output appears as:
```
{ "log_offset": 23875, "log_file": "/var/log/containers/<file_name>.log", ... }
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
