### PR TITLE
filter_kubernetes: run command to get token to talk to api-server and refresh it if needed

### DIFF
--- a/plugins/filter_kubernetes/CMakeLists.txt
+++ b/plugins/filter_kubernetes/CMakeLists.txt
@@ -7,3 +7,8 @@ set(src
   )
 
 FLB_PLUGIN(filter_kubernetes "${src}" "")
+
+# K8s token command is currently Linux-only.
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  FLB_DEFINITION(FLB_HAVE_KUBE_TOKEN_COMMAND)
+endif()

--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -44,6 +44,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
     const char *url;
     const char *tmp;
     const char *p;
+    const char *cmd;
     struct flb_kube *ctx;
 
     ctx = flb_calloc(1, sizeof(struct flb_kube));
@@ -60,6 +61,16 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
         flb_free(ctx);
         return NULL;
     }
+
+    /* K8s Token Command */
+    cmd = flb_filter_get_property("kube_token_command", ins);
+    if (cmd) {
+        ctx->kube_token_command = cmd;
+    }
+    else {
+        ctx->kube_token_command = NULL;
+    }
+    ctx->kube_token_create = 0;  
 
     /* Merge Parser */
     tmp = flb_filter_get_property("merge_parser", ins);

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -143,6 +143,9 @@ struct flb_kube {
     char *token_file;
     char *token;
     size_t token_len;
+    /* Command to get Kubernetes Authorization Token */
+    const char *kube_token_command; 
+    int kube_token_create;
 
     /* Pre-formatted HTTP Authorization header value */
     char *auth;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -729,6 +729,13 @@ static struct flb_config_map config_map[] = {
      "Kubernetes authorization token file"
     },
 
+    /* Kubernetes Token command */
+    {
+     FLB_CONFIG_MAP_STR, "kube_token_command", NULL,
+     0, FLB_FALSE, 0,
+     "command to get Kubernetes authorization token"
+    },
+
     /* Include Kubernetes Labels in the final record ? */
     {
      FLB_CONFIG_MAP_BOOL, "labels", "true",


### PR DESCRIPTION
Add an option for users to run command to get EKS token

Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
