### PR TITLE
out_s3: added sequential indexing feature to s3_key_format

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -176,7 +176,8 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size);
 int flb_read_file(const char *path, char **out_buf, size_t *out_size);
 
 //* Constructs S3 object key as per the format. */
-flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char *tag_delimiter);
+flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
+                         char *tag_delimiter, uint64_t seq_index);
 
 #endif
 #endif /* FLB_HAVE_AWS */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -133,6 +133,7 @@ struct flb_s3 {
     struct flb_fstore *fs;
     struct flb_fstore_stream *stream_active;  /* default active stream */
     struct flb_fstore_stream *stream_upload;  /* multipart upload stream */
+    struct flb_fstore_stream *stream_metadata; /* s3 metadata stream */
 
     /*
      * used to track that unset buffers were found on startup that have not
@@ -156,6 +157,11 @@ struct flb_s3 {
     int timer_created;
     int timer_ms;
     int key_fmt_has_uuid;
+
+    uint64_t seq_index;
+    int key_fmt_has_seq_index;
+    flb_sds_t metadata_dir;
+    flb_sds_t seq_index_file;
 
     struct flb_output_instance *ins;
 };


### PR DESCRIPTION
Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/555

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

Specify `$INDEX` in `s3_key_format` to add an index that increments every time it uploads a
file. Sequential indexing is compatible with all other `s3_key_format features`, so `$UUID`
and `$TAG` can be specified at the same time as `$INDEX`. When `$INDEX` is specified but `$UUID`
is not, a random string will not be appended to the end of the key name.

If FluentBit crashes or fails to upload, the index will be preserved in the filesystem
in a metadata file located in `${store_dir}/index_metadata` and reused on startup. This
configuration option uses native C functions so is incompatible with multi-threading.

Tested through unit testing and various input plugins (exec, random, etc) as well as Valgrind.

### Example Configuration File
```
[INPUT]
    name exec
    command date +"%Y-%m-%d %H:%M:%S,%3N"

[OUTPUT]
    name s3
    match *
    region us-west-2
    bucket bucket-name
    s3_key_format /test/log-file-$INDEX.gz
    use_put_object true
    total_file_size 2M
    upload_timeout 10s
    compression gzip
    store_dir /tmp/fluent-bit/s3-output-buffer
    retry_limit 5
    log_key exec
```

### Output file names
```
...
log-file-3.gz
log-file-2.gz
log-file-1.gz
log-file-0.gz
```

## Valgrind
For some reason, when running with the example configuration file, the Valgrind is throwing many errors even on a clean master branch. For this reason, I believe it is not my code throwing these errors but the current master branch code. Below are the Valgrind logs for the clean master branch.
#### Clean Master Branch Valgrind Output Logs
```
==2337== HEAP SUMMARY:
==2337==     in use at exit: 701,635 bytes in 5,374 blocks
==2337==   total heap usage: 119,718 allocs, 114,344 frees, 13,844,281 bytes allocated
==2337==
==2337== LEAK SUMMARY:
==2337==    definitely lost: 0 bytes in 0 blocks
==2337==    indirectly lost: 0 bytes in 0 blocks
==2337==      possibly lost: 0 bytes in 0 blocks
==2337==    still reachable: 701,635 bytes in 5,374 blocks
==2337==         suppressed: 0 bytes in 0 blocks
==2337== Reachable blocks (those to which a pointer was found) are not shown.
==2337== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==2337==
==2337== For counts of detected and suppressed errors, rerun with: -v
==2337== ERROR SUMMARY: 16 errors from 11 contexts (suppressed: 0 from 0)
```
and here are the Valgrind logs for the example configuration file.
#### Example Configuration File Valgrind Logs
```
==5198== HEAP SUMMARY:
==5198==     in use at exit: 701,635 bytes in 5,374 blocks
==5198==   total heap usage: 119,741 allocs, 114,367 frees, 13,925,751 bytes allocated
==5198==
==5198== LEAK SUMMARY:
==5198==    definitely lost: 0 bytes in 0 blocks
==5198==    indirectly lost: 0 bytes in 0 blocks
==5198==      possibly lost: 0 bytes in 0 blocks
==5198==    still reachable: 701,635 bytes in 5,374 blocks
==5198==         suppressed: 0 bytes in 0 blocks
==5198== Reachable blocks (those to which a pointer was found) are not shown.
==5198== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==5198==
==5198== For counts of detected and suppressed errors, rerun with: -v
==5198== ERROR SUMMARY: 16 errors from 11 contexts (suppressed: 0 from 0)
```
They appear to be exactly the same.