### PR TITLE
ra: fix typo of log header

### DIFF
--- a/src/record_accessor/ra.l
+++ b/src/record_accessor/ra.l
@@ -65,6 +65,6 @@ static inline char *remove_dup_quotes(const char *s, size_t n)
 \n
 [ \t]+			/* ignore whitespace */;
 
-.	flb_error("[sp] bad input character '%s' at line %d", yytext, yylineno);
+.	flb_error("[record accessor] bad input character '%s' at line %d", yytext, yylineno);
 
 %%


### PR DESCRIPTION
```
[2021/06/27 08:20:05] [error] [sp] bad input character '\' at line 0
```
It should be `record accessor` not `sp`(stream processor)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"a":"b", "nest":{"aa":"bb"}}


[FILTER]
    Name grep
    Match *
    Exclude \\\ .+


[OUTPUT]
    Name stdout
```

## Valgrind output

It reports `record accessor` error.
Some errors are also reported , but I believe they are not related to this PR.
```
[2021/06/27 08:22:11] [error] [record accessor] bad input character '\' at line 0
```

<details>
```
$ valgrind --leak-check=full bin/fluent-bit -c b.conf 
==22292== Memcheck, a memory error detector
==22292== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22292== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==22292== Command: bin/fluent-bit -c b.conf
==22292== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/27 08:22:11] [ info] [engine] started (pid=22292)
[2021/06/27 08:22:11] [ info] [storage] version=1.1.1, initializing...
[2021/06/27 08:22:11] [ info] [storage] in-memory
[2021/06/27 08:22:11] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
==22292== Thread 2 flb-pipeline:
==22292== Conditional jump or move depends on uninitialised value(s)
==22292==    at 0x4A68AD8: __vfprintf_internal (vfprintf-internal.c:1687)
==22292==    by 0x4A7D119: __vsnprintf_internal (vsnprintf.c:114)
==22292==    by 0x16BDAF: flb_log_print (flb_log.c:400)
==22292==    by 0x47D5A2: flb_ra_lex (ra.l:68)
==22292==    by 0x47FDCC: flb_ra_parse (ra_parser.c:1279)
==22292==    by 0x47CDFB: flb_ra_parser_meta_create (flb_ra_parser.c:309)
==22292==    by 0x1A1C78: ra_parse_meta (flb_record_accessor.c:57)
==22292==    by 0x1A2022: ra_parse_buffer (flb_record_accessor.c:194)
==22292==    by 0x1A23FC: flb_ra_create (flb_record_accessor.c:310)
==22292==    by 0x25F9D5: set_rules (grep.c:122)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292==    by 0x176B31: flb_filter_init_all (flb_filter.c:430)
==22292== 
==22292== Use of uninitialised value of size 8
==22292==    at 0x4A4C81B: _itoa_word (_itoa.c:179)
==22292==    by 0x4A686F4: __vfprintf_internal (vfprintf-internal.c:1687)
==22292==    by 0x4A7D119: __vsnprintf_internal (vsnprintf.c:114)
==22292==    by 0x16BDAF: flb_log_print (flb_log.c:400)
==22292==    by 0x47D5A2: flb_ra_lex (ra.l:68)
==22292==    by 0x47FDCC: flb_ra_parse (ra_parser.c:1279)
==22292==    by 0x47CDFB: flb_ra_parser_meta_create (flb_ra_parser.c:309)
==22292==    by 0x1A1C78: ra_parse_meta (flb_record_accessor.c:57)
==22292==    by 0x1A2022: ra_parse_buffer (flb_record_accessor.c:194)
==22292==    by 0x1A23FC: flb_ra_create (flb_record_accessor.c:310)
==22292==    by 0x25F9D5: set_rules (grep.c:122)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292== 
==22292== Conditional jump or move depends on uninitialised value(s)
==22292==    at 0x4A4C82D: _itoa_word (_itoa.c:179)
==22292==    by 0x4A686F4: __vfprintf_internal (vfprintf-internal.c:1687)
==22292==    by 0x4A7D119: __vsnprintf_internal (vsnprintf.c:114)
==22292==    by 0x16BDAF: flb_log_print (flb_log.c:400)
==22292==    by 0x47D5A2: flb_ra_lex (ra.l:68)
==22292==    by 0x47FDCC: flb_ra_parse (ra_parser.c:1279)
==22292==    by 0x47CDFB: flb_ra_parser_meta_create (flb_ra_parser.c:309)
==22292==    by 0x1A1C78: ra_parse_meta (flb_record_accessor.c:57)
==22292==    by 0x1A2022: ra_parse_buffer (flb_record_accessor.c:194)
==22292==    by 0x1A23FC: flb_ra_create (flb_record_accessor.c:310)
==22292==    by 0x25F9D5: set_rules (grep.c:122)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292== 
==22292== Conditional jump or move depends on uninitialised value(s)
==22292==    at 0x4A693A8: __vfprintf_internal (vfprintf-internal.c:1687)
==22292==    by 0x4A7D119: __vsnprintf_internal (vsnprintf.c:114)
==22292==    by 0x16BDAF: flb_log_print (flb_log.c:400)
==22292==    by 0x47D5A2: flb_ra_lex (ra.l:68)
==22292==    by 0x47FDCC: flb_ra_parse (ra_parser.c:1279)
==22292==    by 0x47CDFB: flb_ra_parser_meta_create (flb_ra_parser.c:309)
==22292==    by 0x1A1C78: ra_parse_meta (flb_record_accessor.c:57)
==22292==    by 0x1A2022: ra_parse_buffer (flb_record_accessor.c:194)
==22292==    by 0x1A23FC: flb_ra_create (flb_record_accessor.c:310)
==22292==    by 0x25F9D5: set_rules (grep.c:122)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292==    by 0x176B31: flb_filter_init_all (flb_filter.c:430)
==22292== 
==22292== Conditional jump or move depends on uninitialised value(s)
==22292==    at 0x4A6886E: __vfprintf_internal (vfprintf-internal.c:1687)
==22292==    by 0x4A7D119: __vsnprintf_internal (vsnprintf.c:114)
==22292==    by 0x16BDAF: flb_log_print (flb_log.c:400)
==22292==    by 0x47D5A2: flb_ra_lex (ra.l:68)
==22292==    by 0x47FDCC: flb_ra_parse (ra_parser.c:1279)
==22292==    by 0x47CDFB: flb_ra_parser_meta_create (flb_ra_parser.c:309)
==22292==    by 0x1A1C78: ra_parse_meta (flb_record_accessor.c:57)
==22292==    by 0x1A2022: ra_parse_buffer (flb_record_accessor.c:194)
==22292==    by 0x1A23FC: flb_ra_create (flb_record_accessor.c:310)
==22292==    by 0x25F9D5: set_rules (grep.c:122)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292==    by 0x176B31: flb_filter_init_all (flb_filter.c:430)
==22292== 
[2021/06/27 08:22:11] [error] [record accessor] bad input character '\' at line 0
[2021/06/27 08:22:11] [error] [record accessor] bad input character '\' at line 0
[2021/06/27 08:22:11] [error] [record accessor] bad input character '\' at line 0
[2021/06/27 08:22:11] [error] [record accessor] syntax error, unexpected $end, expecting IDENTIFIER at '$\\\'
[2021/06/27 08:22:11] [error] [filter:grep:grep.0] invalid record accessor? '$\\\'
[2021/06/27 08:22:11] [error] Failed initialize filter grep.0
[2021/06/27 08:22:11] [error] [lib] backend failed
==22292== 
==22292== HEAP SUMMARY:
==22292==     in use at exit: 313 bytes in 3 blocks
==22292==   total heap usage: 847 allocs, 844 frees, 157,240 bytes allocated
==22292== 
==22292== Thread 1:
==22292== 3 bytes in 1 blocks are definitely lost in loss record 1 of 3
==22292==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22292==    by 0x25F26B: flb_malloc (flb_mem.h:62)
==22292==    by 0x25F2D7: flb_strndup (flb_str.h:51)
==22292==    by 0x25F9AC: set_rules (grep.c:116)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292==    by 0x176B31: flb_filter_init_all (flb_filter.c:430)
==22292==    by 0x18683C: flb_engine_start (flb_engine.c:533)
==22292==    by 0x16AB6B: flb_lib_worker (flb_lib.c:605)
==22292==    by 0x4864608: start_thread (pthread_create.c:477)
==22292==    by 0x4B10292: clone (clone.S:95)
==22292== 
==22292== 22 bytes in 1 blocks are definitely lost in loss record 2 of 3
==22292==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22292==    by 0x17211B: flb_malloc (flb_mem.h:62)
==22292==    by 0x17233E: sds_alloc (flb_sds.c:40)
==22292==    by 0x172486: flb_sds_create_size (flb_sds.c:92)
==22292==    by 0x25F914: set_rules (grep.c:106)
==22292==    by 0x25FCB6: cb_grep_init (grep.c:194)
==22292==    by 0x176B31: flb_filter_init_all (flb_filter.c:430)
==22292==    by 0x18683C: flb_engine_start (flb_engine.c:533)
==22292==    by 0x16AB6B: flb_lib_worker (flb_lib.c:605)
==22292==    by 0x4864608: start_thread (pthread_create.c:477)
==22292==    by 0x4B10292: clone (clone.S:95)
==22292== 
==22292== 288 bytes in 1 blocks are possibly lost in loss record 3 of 3
==22292==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==22292==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==22292==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==22292==    by 0x4865322: allocate_stack (allocatestack.c:622)
==22292==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==22292==    by 0x4B9F9D: mk_utils_worker_spawn (mk_utils.c:284)
==22292==    by 0x16AC3A: flb_start (flb_lib.c:636)
==22292==    by 0x15F261: flb_main (fluent-bit.c:1198)
==22292==    by 0x15F2F3: main (fluent-bit.c:1221)
==22292== 
==22292== LEAK SUMMARY:
==22292==    definitely lost: 25 bytes in 2 blocks
==22292==    indirectly lost: 0 bytes in 0 blocks
==22292==      possibly lost: 288 bytes in 1 blocks
==22292==    still reachable: 0 bytes in 0 blocks
==22292==         suppressed: 0 bytes in 0 blocks
==22292== 
==22292== Use --track-origins=yes to see where uninitialised values come from
==22292== For lists of detected and suppressed errors, rerun with: -s
==22292== ERROR SUMMARY: 18 errors from 8 contexts (suppressed: 0 from 0)
```
</details>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
