### PR TITLE
filter_modify : support nested key condition

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -28,6 +28,9 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_ra_key.h>
 #include <msgpack.h>
 
 #include "modify.h"
@@ -37,7 +40,7 @@
 
 static void condition_free(struct modify_condition *condition)
 {
-    flb_free(condition->a);
+    flb_sds_destroy(condition->a);
     flb_free(condition->b);
     flb_free(condition->raw_k);
     flb_free(condition->raw_v);
@@ -47,6 +50,10 @@ static void condition_free(struct modify_condition *condition)
     }
     if (condition->b_is_regex) {
         flb_regex_destroy(condition->b_regex);
+    }
+    if (condition->ra_a) {
+        flb_ra_destroy(condition->ra_a);
+        condition->ra_a = NULL;
     }
     flb_free(condition);
 }
@@ -147,6 +154,7 @@ static int setup(struct filter_modify_ctx *ctx,
 
             condition->a_is_regex = false;
             condition->b_is_regex = false;
+            condition->ra_a = NULL;
             condition->raw_k = flb_strndup(kv->key, flb_sds_len(kv->key));
             condition->raw_v = flb_strndup(kv->val, flb_sds_len(kv->val));
 
@@ -210,9 +218,9 @@ static int setup(struct filter_modify_ctx *ctx,
             sentry =
                 mk_list_entry_next(&sentry->_head, struct flb_split_entry,
                                    _head, split);
-            condition->a = flb_strndup(sentry->value, sentry->len);
+            condition->a = flb_sds_create_len(sentry->value, sentry->len);
             condition->a_len = sentry->len;
-
+            condition->ra_a = flb_ra_create(condition->a, FLB_FALSE);
             if (list_size == 3) {
                 sentry =
                     mk_list_entry_last(split, struct flb_split_entry, _head);
@@ -608,8 +616,15 @@ static inline bool evaluate_condition_KEY_EXISTS(msgpack_object * map,
                                                  struct modify_condition
                                                  *condition)
 {
-    return (map_count_keys_matching_str(map, condition->a, condition->a_len) >
-            0);
+    msgpack_object *skey = NULL;
+    msgpack_object *okey = NULL;
+    msgpack_object *oval = NULL;
+
+    flb_ra_get_kv_pair(condition->ra_a, *map, &skey, &okey, &oval);
+    if (skey == NULL || okey == NULL || oval == NULL) {
+        return false;
+    }
+    return true;
 }
 
 static inline bool evaluate_condition_KEY_DOES_NOT_EXIST(msgpack_object * map,
@@ -641,22 +656,21 @@ static inline bool evaluate_condition_KEY_VALUE_EQUALS(struct filter_modify_ctx 
                                                        modify_condition
                                                        *condition)
 {
-    int i;
-    bool match = false;
-    msgpack_object_kv *kv;
+    msgpack_object *skey = NULL;
+    msgpack_object *okey = NULL;
+    msgpack_object *oval = NULL;
+    bool ret = false;
 
-    for (i = 0; i < map->via.map.size; i++) {
-        kv = &map->via.map.ptr[i];
-        if (kv_key_matches_str(kv, condition->a, condition->a_len)) {
-            if (kv_val_matches_str(kv, condition->b, condition->b_len)) {
-                flb_plg_debug(ctx->ins, "Match for condition KEY_VALUE_EQUALS %s",
-                              condition->b);
-                match = true;
-                break;
-            }
-        }
+    flb_ra_get_kv_pair(condition->ra_a, *map, &skey, &okey, &oval);
+    if (skey == NULL || okey == NULL || oval == NULL) {
+        return false;
     }
-    return match;
+    ret = helper_msgpack_object_matches_str(oval, condition->b, condition->b_len);
+    if (ret) {
+        flb_plg_debug(ctx->ins, "Match for condition KEY_VALUE_EQUALS %s",
+                      condition->b);
+    }
+    return ret;
 }
 
 static inline
@@ -676,22 +690,21 @@ static inline bool evaluate_condition_KEY_VALUE_MATCHES(struct filter_modify_ctx
                                                         modify_condition
                                                         *condition)
 {
-    int i;
-    bool match = false;
-    msgpack_object_kv *kv;
+    msgpack_object *skey = NULL;
+    msgpack_object *okey = NULL;
+    msgpack_object *oval = NULL;
+    bool ret = false;
 
-    for (i = 0; i < map->via.map.size; i++) {
-        kv = &map->via.map.ptr[i];
-        if (kv_key_matches_str(kv, condition->a, condition->a_len)) {
-            if (kv_val_matches_regex(kv, condition->b_regex)) {
-                flb_plg_debug(ctx->ins, "Match for condition KEY_VALUE_MATCHES "
-                              "%s", condition->b);
-                match = true;
-                break;
-            }
-        }
+    flb_ra_get_kv_pair(condition->ra_a, *map, &skey, &okey, &oval);
+    if (skey == NULL || okey == NULL || oval == NULL) {
+        return false;
     }
-    return match;
+    ret = helper_msgpack_object_matches_regex(oval, condition->b_regex);
+    if (ret) {
+        flb_plg_debug(ctx->ins, "Match for condition KEY_VALUE_MATCHES "
+                      "%s", condition->b);
+    }
+    return ret;
 }
 
 static inline

--- a/plugins/filter_modify/modify.h
+++ b/plugins/filter_modify/modify.h
@@ -23,6 +23,8 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_sds.h>
 
 enum FLB_FILTER_MODIFY_RULETYPE {
   RENAME,
@@ -79,12 +81,13 @@ struct modify_condition
     enum FLB_FILTER_MODIFY_CONDITIONTYPE conditiontype;
     int a_len;
     int b_len;
-    char *a;
+    flb_sds_t a;
     char *b;
     bool a_is_regex;
     bool b_is_regex;
     struct flb_regex *a_regex;
     struct flb_regex *b_regex;
+    struct flb_record_accessor *ra_a;
     char *raw_k;
     char *raw_v;
     struct mk_list _head;

--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -642,6 +642,46 @@ static void flb_test_cond_key_exists()
     filter_test_destroy(ctx);
 }
 
+/* Condition: KEY_EXISTS / If nested key exists, make a copy */
+static void flb_test_cond_key_exists_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_exists $nest['k1']",
+                         "add", "key found",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"key\":\"found\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"k1\":\"sample1\",\"k2\":\"sample2\", \"nest\":{\"k1\":\"nest\"}}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
 /* Condition: KEY_DOES_NOT_EXISTS / If key does not exists, add a dummy key */
 static void flb_test_cond_key_does_not_exist()
 {
@@ -675,6 +715,46 @@ static void flb_test_cond_key_does_not_exist()
 
     /* Ingest data samples */
     p = "[0,{\"k1\":\"sample1\",\"k2\":\"sample2\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+/* Condition: KEY_DOES_NOT_EXISTS / If key does not exists, add a dummy key */
+static void flb_test_cond_key_does_not_exist_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_does_not_exist $nest['k1']",
+                         "add", "key not_found",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"key\":\"not_found\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"k1\":\"sample1\",\"k2\":\"sample2\", \"nest\":{\"k\":\"sample\"}}]";
     len = strlen(p);
     bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
     TEST_CHECK(bytes == len);
@@ -802,6 +882,46 @@ static void flb_test_cond_key_value_equals()
     filter_test_destroy(ctx);
 }
 
+/* Condition: KEY_VALUE_EQUALS / If key value matches, add a dummy key */
+static void flb_test_cond_key_value_equals_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_value_equals $nest['k1'] sample2",
+                         "add", "key found",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"key\":\"found\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"aa\":\"sample1\",\"bb\":\"sample2\",\"c1\":\"sample3\", \"nest\":{\"k1\":\"sample2\"}}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
 /* Condition: KEY_VALUE_DOES_NOT_EQUAL / If key value mismatch, add a key */
 static void flb_test_cond_key_value_does_not_equal()
 {
@@ -835,6 +955,46 @@ static void flb_test_cond_key_value_does_not_equal()
 
     /* Ingest data samples */
     p = "[0,{\"aa\":\"sample1\",\"bb\":\"sample2\",\"c1\":\"sample3\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+/* Condition: KEY_VALUE_DOES_NOT_EQUAL / If key value mismatch, add a key */
+static void flb_test_cond_key_value_does_not_equal_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_value_does_not_equal $nest['k1'] sample2",
+                         "add", "key not_found",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"key\":\"not_found\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"aa\":\"sample1\",\"bb\":\"sample2\",\"c1\":\"sample3\", \"nest\":{\"k1\":\"sample3\"}}]";
     len = strlen(p);
     bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
     TEST_CHECK(bytes == len);
@@ -882,6 +1042,46 @@ static void flb_test_cond_key_value_matches()
     filter_test_destroy(ctx);
 }
 
+/* Condition: KEY_VALUE_MATCHES / If key match, add a key */
+static void flb_test_cond_key_value_matches_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_value_matches $nest['k2'] ^[a-z][0-9]$",
+                         "add", "kv matches",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"kv\":\"matches\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"k1\":\"sample1\",\"k2\":\"z2\", \"nest\":{\"k2\":\"z2\"}}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
 /* Condition: KEY_VALUE_DOES_NOT_MATCH / If key mismatch, add a key */
 static void flb_test_cond_key_value_does_not_match()
 {
@@ -915,6 +1115,46 @@ static void flb_test_cond_key_value_does_not_match()
 
     /* Ingest data samples */
     p = "[0,{\"k1\":\"sample1\",\"k2\":\"22\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+/* Condition: KEY_VALUE_DOES_NOT_MATCH / If key mismatch, add a key */
+static void flb_test_cond_key_value_does_not_match_nest()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "condition", "key_value_does_not_match $nest['k2'] ^[a-z][0-9]$",
+                         "add", "kv no_matches",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"kv\":\"no_matches\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0,{\"k1\":\"sample1\",\"k2\":\"22\",\"nest\":{\"k2\":\"22\"}}]";
     len = strlen(p);
     bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
     TEST_CHECK(bytes == len);
@@ -1180,6 +1420,14 @@ TEST_LIST = {
     {"op_copy_no_exists"        , flb_test_op_copy_no_exists },
     {"op_hard_copy_exists"      , flb_test_op_hard_copy_exists },
     {"op_hard_copy_no_exists"   , flb_test_op_hard_copy_no_exists },
+
+    /* Conditions (nested) */
+    {"cond_key_value_matches_nest", flb_test_cond_key_value_matches_nest },
+    {"cond_key_value_does_not_match_nest", flb_test_cond_key_value_does_not_match_nest },
+    {"cond_key_exists_nest", flb_test_cond_key_exists_nest },
+    {"cond_key_does_not_exist_nest", flb_test_cond_key_does_not_exist_nest },
+    {"cond_key_value_equals_nest", flb_test_cond_key_value_equals_nest },
+    {"cond_key_value_does_not_equal_nest", flb_test_cond_key_value_does_not_equal_nest },
 
     /* Conditions */
     {"cond_key_exists", flb_test_cond_key_exists },


### PR DESCRIPTION
Many users request that filter_modify can handle nested key/value. #2152 
This PR is to fix the issue **partially**.

## Summary

This patch is to support record accessor for `Condition`. (`Rule` is not supported by this PR.)
https://docs.fluentbit.io/manual/pipeline/filters/modify#conditions

We can set record accessor as `STRING:KEY`. (`REGEXP:KEY` is not supported)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

## Example Configuration

This configuration to append `"nested_key":"found"` if the key `"nest":{"log"` is found.
```
[INPUT]
    Name dummy
    Dummy {"log": "message 1", "nest": {"log": "blue"}}

[FILTER]
    Name modify
    Match *
    Condition key_exists $nest['log']
    add nested_key found

[OUTPUT]
    Name stdout
```

## Debug output

`"nested_key"=>"found"` is appended.

```
$  bin/fluent-bit -c a.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/27 09:14:23] [ info] [engine] started (pid=26609)
[2021/06/27 09:14:23] [ info] [storage] version=1.1.1, initializing...
[2021/06/27 09:14:23] [ info] [storage] in-memory
[2021/06/27 09:14:23] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/27 09:14:23] [ info] [sp] stream processor started
[0] dummy.0: [1624752863.782360136, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[1] dummy.0: [1624752864.781639237, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[2] dummy.0: [1624752865.781657481, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[3] dummy.0: [1624752866.781829268, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
^C[2021/06/27 09:14:28] [engine] caught signal (SIGINT)
[0] dummy.0: [1624752867.782343630, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[2021/06/27 09:14:28] [ warn] [engine] service will stop in 5 seconds
[2021/06/27 09:14:32] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind bin/fluent-bit -c a.conf 
==26571== Memcheck, a memory error detector
==26571== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26571== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==26571== Command: bin/fluent-bit -c a.conf
==26571== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/27 09:05:02] [ info] [engine] started (pid=26571)
[2021/06/27 09:05:02] [ info] [storage] version=1.1.1, initializing...
[2021/06/27 09:05:02] [ info] [storage] in-memory
[2021/06/27 09:05:02] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/27 09:05:02] [ info] [sp] stream processor started
[0] dummy.0: [1624752302.808974717, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[1] dummy.0: [1624752303.781909486, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[2] dummy.0: [1624752304.781982416, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[3] dummy.0: [1624752305.781916780, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
^C[2021/06/27 09:05:07] [engine] caught signal (SIGINT)
[0] dummy.0: [1624752306.848859194, {"log"=>"message 1", "nest"=>{"log"=>"blue"}, "nested_key"=>"found"}]
[2021/06/27 09:05:07] [ warn] [engine] service will stop in 5 seconds
[2021/06/27 09:05:11] [ info] [engine] service stopped
==26571== 
==26571== HEAP SUMMARY:
==26571==     in use at exit: 0 bytes in 0 blocks
==26571==   total heap usage: 1,096 allocs, 1,096 frees, 1,439,789 bytes allocated
==26571== 
==26571== All heap blocks were freed -- no leaks are possible
==26571== 
==26571== For lists of detected and suppressed errors, rerun with: -s
==26571== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
