### PR TITLE
out_logdna: added log_key confguration option

### DIFF
--- a/plugins/out_logdna/logdna.h
+++ b/plugins/out_logdna/logdna.h
@@ -39,6 +39,7 @@ struct flb_logdna {
     flb_sds_t ip_addr;
     flb_sds_t file;
     flb_sds_t app;
+    flb_sds_t log_key;
     struct mk_list *tags;
 
     /* Internal */


### PR DESCRIPTION
Adding log_key optional configuration option to LogDNA output plugin in case you want to log one field only and not the whole record.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

fluent/fluent-bit-docs#561

Example configuration:

```
[INPUT]
    Name dummy
    dummy {"log": "Sample log message XYZ"}

[OUTPUT]
    Name logdna
    api_key API_KEY
    log_key log
```

Valgrind output (the same error is present even if running on master branch):

```
==123== Memcheck, a memory error detector
==123== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==123== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==123== Command: ./bin/fluent-bit -c ../conf/fluent-bit.conf
==123== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/06/27 13:21:34] [ info] [engine] started (pid=123)
[2021/06/27 13:21:34] [ info] [storage] version=1.1.1, initializing...
[2021/06/27 13:21:34] [ info] [storage] in-memory
[2021/06/27 13:21:34] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/06/27 13:21:34] [ info] [output:logdna:logdna.0] configured, hostname=(null)
[2021/06/27 13:21:34] [ info] [sp] stream processor started
==123== Warning: client switching stacks?  SP change: 0x71f5678 --> 0x5ef0360
==123==          to suppress, use: --max-stackframe=19944216 or greater
==123== Warning: client switching stacks?  SP change: 0x5ef02d8 --> 0x71f5678
==123==          to suppress, use: --max-stackframe=19944352 or greater
==123== Warning: client switching stacks?  SP change: 0x71f5678 --> 0x5ef02d8
==123==          to suppress, use: --max-stackframe=19944352 or greater
==123==          further instances of this message will not be shown.
[2021/06/27 13:21:41] [ info] [output:logdna:logdna.0] logs.logdna.com:443, HTTP status=200
{"status":"ok","batchID":"4030907a-5a0e-4f4f-9a1b-563c674abf83:13617:ld71"}
^C[2021/06/27 13:21:42] [engine] caught signal (SIGINT)
[2021/06/27 13:21:42] [ warn] [engine] service will stop in 5 seconds
[2021/06/27 13:21:46] [ info] [engine] service stopped
==123== Invalid free() / delete / delete[] / realloc()
==123==    at 0x48369AB: free (vg_replace_malloc.c:530)
==123==    by 0x509CAB9: free_key_mem (dlerror.c:223)
==123==    by 0x509CAB9: __dlerror_main_freeres (dlerror.c:239)
==123==    by 0x5224B71: __libc_freeres (in /lib/x86_64-linux-gnu/libc-2.28.so)
==123==    by 0x482B19E: _vgnU_freeres (vg_preloaded.c:77)
==123==    by 0x18E7D0: flb_signal_exit (fluent-bit.c:513)
==123==    by 0x18FD62: flb_main (fluent-bit.c:1208)
==123==    by 0x18FD9A: main (fluent-bit.c:1221)
==123==  Address 0x5d9c100 is in a rw- anonymous segment
==123== 
==123== 
==123== HEAP SUMMARY:
==123==     in use at exit: 195,972 bytes in 4,324 blocks
==123==   total heap usage: 8,249 allocs, 3,926 frees, 1,358,656 bytes allocated
==123== 
==123== LEAK SUMMARY:
==123==    definitely lost: 0 bytes in 0 blocks
==123==    indirectly lost: 0 bytes in 0 blocks
==123==      possibly lost: 0 bytes in 0 blocks
==123==    still reachable: 195,972 bytes in 4,324 blocks
==123==         suppressed: 0 bytes in 0 blocks
==123== Rerun with --leak-check=full to see details of leaked memory
==123== 
==123== For counts of detected and suppressed errors, rerun with: -v
==123== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
