### PR TITLE
out_kafka: fix avro support

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -107,6 +107,37 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     msgpack_object val;
     flb_sds_t s;
 
+#ifdef FLB_HAVE_AVRO_ENCODER
+    // used to flag when a buffer needs to be freed for avro
+    bool avro_fast_buffer = true;
+
+    // avro encoding uses a buffer
+    // the majority of lines are fairly small
+    // so using static buffer for these is much more efficient
+    // larger sizes will allocate
+#ifndef AVRO_DEFAULT_BUFFER_SIZE
+#define AVRO_DEFAULT_BUFFER_SIZE 2048
+#endif
+    static char avro_buff[AVRO_DEFAULT_BUFFER_SIZE];
+
+    // don't take lines that are too large
+    // these lines will log a warning
+    // this roughly a log line of 250000 chars
+#ifndef AVRO_LINE_MAX_LEN
+#define AVRO_LINE_MAX_LEN 1000000
+
+    // this is a convenience
+#define AVRO_FREE(X, Y) if (!X) { flb_free(Y); }
+#endif
+
+    // this is just to keep the code cleaner
+    // the avro encoding includes
+    // an embedded schemaid which is used
+    // the embedding is a null byte
+    // followed by a 16 byte schemaid
+#define AVRO_SCHEMA_OVERHEAD 16 + 1
+#endif
+
     flb_debug("in produce_message\n");
     if (flb_log_check(FLB_LOG_DEBUG))
         msgpack_object_print(stderr, *map);
@@ -256,19 +287,54 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     }
 #ifdef FLB_HAVE_AVRO_ENCODER
     else if (ctx->format == FLB_KAFKA_FMT_AVRO) {
-        flb_plg_debug(ctx->ins, "calling flb_msgpack_raw_to_avro_sds\n");
+
         flb_plg_debug(ctx->ins, "avro schema ID:%s:\n", ctx->avro_fields.schema_id);
         flb_plg_debug(ctx->ins, "avro schema string:%s:\n", ctx->avro_fields.schema_str);
-        s = flb_msgpack_raw_to_avro_sds(mp_sbuf.data, mp_sbuf.size, &ctx->avro_fields);
-        if(!s) {
+
+	// if there's no data then log it and return
+        if (mp_sbuf.size == 0) {
+            flb_plg_error(ctx->ins, "got zero bytes decoding to avro AVRO:schemaID:%s:\n", ctx->avro_fields.schema_id);
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            return FLB_OK;
+        }
+
+	// is the line is too long log it and return
+        if (mp_sbuf.size > AVRO_LINE_MAX_LEN) {
+            flb_plg_warn(ctx->ins, "skipping long line AVRO:len:%zu:limit:%zu:schemaID:%s:\n", (size_t)mp_sbuf.size, (size_t)AVRO_LINE_MAX_LEN, ctx->avro_fields.schema_id);
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            return FLB_OK;
+        }
+
+        flb_plg_debug(ctx->ins, "using default buffer AVRO:len:%zu:limit:%zu:schemaID:%s:\n", (size_t)mp_sbuf.size, (size_t)AVRO_DEFAULT_BUFFER_SIZE, ctx->avro_fields.schema_id);
+        out_buf = avro_buff;
+        out_size = AVRO_DEFAULT_BUFFER_SIZE;
+
+	if (mp_sbuf.size + AVRO_SCHEMA_OVERHEAD >= AVRO_DEFAULT_BUFFER_SIZE) {
+            flb_plg_info(ctx->ins, "upsizing to dynamic buffer AVRO:len:%zu:schemaID:%s:\n", (size_t)mp_sbuf.size, ctx->avro_fields.schema_id);
+            avro_fast_buffer = false;
+            // avro will always be  smaller than msgpack
+            // it contains no meta-info aside from the schemaid
+            // all the metadata is in the schema which is not part of the msg
+            // add schemaid + magic byte for safety buffer and allocate
+            // that's 16 byte schemaid and one byte magic byte
+            out_size = mp_sbuf.size + AVRO_SCHEMA_OVERHEAD;
+            out_buf = flb_malloc(out_size);
+            if (!out_buf) {
+                flb_plg_error(ctx->ins, "error allocating memory for decoding to AVRO:schema:%s:schemaID:%s:\n", ctx->avro_fields.schema_str, ctx->avro_fields.schema_id);
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return FLB_ERROR;
+            }
+	}
+
+        if(!flb_msgpack_raw_to_avro_sds(mp_sbuf.data, mp_sbuf.size, &ctx->avro_fields, out_buf, &out_size)) {
             flb_plg_error(ctx->ins, "error encoding to AVRO:schema:%s:schemaID:%s:\n", ctx->avro_fields.schema_str, ctx->avro_fields.schema_id);
             msgpack_sbuffer_destroy(&mp_sbuf);
+            if (!avro_fast_buffer) {
+                flb_free(out_buf);
+	    }
             return FLB_ERROR;
         }
-        out_buf = s;
-        out_size = flb_sds_len(s);
-        // schema_id is binary. skip it: schema_id + avro packaging
-        flb_debug("back from flb_msgpack_raw_to_avro_sds:out_size:%zu:val:%s:\n", out_size, out_buf+strlen(ctx->avro_fields.schema_id)+3);
+
     }
 #endif
 
@@ -283,6 +349,11 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     if (!topic) {
         flb_plg_error(ctx->ins, "no default topic found");
         msgpack_sbuffer_destroy(&mp_sbuf);
+#ifdef FLB_HAVE_AVRO_ENCODER
+        if (ctx->format == FLB_KAFKA_FMT_AVRO) {
+            AVRO_FREE(avro_fast_buffer, out_buf)
+        }
+#endif
         return FLB_ERROR;
     }
 
@@ -299,6 +370,11 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
             flb_sds_destroy(s);
         }
         msgpack_sbuffer_destroy(&mp_sbuf);
+#ifdef FLB_HAVE_AVRO_ENCODER
+        if (ctx->format == FLB_KAFKA_FMT_AVRO) {
+            AVRO_FREE(avro_fast_buffer, out_buf)
+        }
+#endif
         /*
          * Unblock the flush requests so that the
          * engine could try sending data again.
@@ -367,7 +443,7 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     }
 #ifdef FLB_HAVE_AVRO_ENCODER
     if (ctx->format == FLB_KAFKA_FMT_AVRO) {
-        flb_sds_destroy(s);
+        AVRO_FREE(avro_fast_buffer, out_buf)
     }
 #endif
 

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -43,7 +43,7 @@ msgpack_unpacked test_init(avro_value_t *aobject, avro_schema_t *aschema, const 
     msgpack_unpacked_init(&msg);
     TEST_CHECK(msgpack_unpack_next(&msg, out_buf, out_size, NULL) == MSGPACK_UNPACK_SUCCESS);
 
-	avro_value_iface_decref(aclass);
+    avro_value_iface_decref(aclass);
     flb_free(data);
     flb_free(out_buf);
 
@@ -187,7 +187,7 @@ void test_parse_reordered_schema()
         const char *pod_name = NULL;
         size_t pod_name_size = 0;
         TEST_CHECK(avro_value_get_string(&pn, &pod_name, &pod_name_size) == 0);
-        TEST_CHECK(strcmp(pod_name, "yali-bert-completion-tensorboard-6786c9c8-wj25m") == 0);
+        TEST_CHECK(strcmp(pod_name, "rrrr-bert-completion-tb1-6786c9c8-wj25m") == 0);
         TEST_CHECK(pod_name[pod_name_size] == '\0');
         TEST_CHECK(strlen(pod_name) == (pod_name_size-1));
 
@@ -197,7 +197,7 @@ void test_parse_reordered_schema()
         const char *namespace_name = NULL;
         size_t namespace_name_size = 0;
         TEST_CHECK(avro_value_get_string(&nn, &namespace_name, &namespace_name_size) == 0);
-        TEST_CHECK(strcmp(namespace_name, "k8s-pilot") == 0);
+        TEST_CHECK(strcmp(namespace_name, "k8s-fgg") == 0);
 
         avro_value_t mapX;
         TEST_CHECK(avro_value_get_by_name(&kubernetes0, "annotations", &mapX, NULL) == 0);
@@ -213,15 +213,15 @@ void test_parse_reordered_schema()
         const char *doaser = NULL;
         size_t doaser_size;
         TEST_CHECK(avro_value_get_string(&doas, &doaser, &doaser_size) == 0);
-        TEST_CHECK((strcmp(doaser, "stdemb") == 0));
+        TEST_CHECK((strcmp(doaser, "weeb") == 0));
 
         // check the second item in the map
         avro_value_t iddecorator;
-        TEST_CHECK(avro_value_get_by_name(&mapX, "iddecorator.grid.li.username", &iddecorator, NULL) == 0);
+        TEST_CHECK(avro_value_get_by_name(&mapX, "iddecorator.dkdk.username", &iddecorator, NULL) == 0);
         const char *idder = NULL;
         size_t idder_size;
         TEST_CHECK(avro_value_get_string(&iddecorator, &idder, &idder_size) == 0);
-        TEST_CHECK((strcmp(idder, "yali") == 0));
+        TEST_CHECK((strcmp(idder, "rrrr") == 0));
 
         avro_schema_decref(aschema);
         msgpack_unpacked_destroy(&msg);

--- a/tests/internal/data/avro/live-sample.json
+++ b/tests/internal/data/avro/live-sample.json
@@ -1,25 +1,25 @@
 {
-    "log": "2020-08-21T15:49:48.154291375ZstderrFhdfsExists:invokeMethod((Lorg/apache/hadoop/fs/Path;)Z)error:2020-08-21T15:49:48.154296328ZstderrForg.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken):token(HDFS_DELEGATION_TOKENtoken273964959forstdemb)can'tbefoundincache2020-08-21T15:49:48.154300089ZstderrFatorg.apache.hadoop.ipc.Client.call(Client.java:1475)2020-08-21T15:49:48.154303281ZstderrFatorg.apache.hadoop.ipc.Client.call(Client.java:1412)2020-08-21T15:49:48.154307503ZstderrFatorg.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)2020-08-21T15:49:48.154311268ZstderrFatcom.sun.proxy.$Proxy9.getFileInfo(UnknownSource)2020-08-21T15:49:48.154314514ZstderrFatorg.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:771)2020-08-21T15:49:48.154317916ZstderrFatsun.reflect.GeneratedMethodAccessor2.invoke(UnknownSource)2020-08-21T15:49:48.154328852ZstderrFatsun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)2020-08-21T15:49:48.154332363ZstderrFatjava.lang.reflect.Method.invoke(Method.java:498)2020-08-21T15:49:48.154335464ZstderrFatorg.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)2020-08-21T15:49:48.154338276ZstderrFatorg.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)2020-08-21T15:49:48.15434115ZstderrFatcom.sun.proxy.$Proxy10.getFileInfo(UnknownSource)2020-08-21T15:49:48.154344323ZstderrFatorg.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2108)2020-08-21T15:49:48.154347224ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305)2020-08-21T15:49:48.154350059ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301)2020-08-21T15:49:48.154352819ZstderrFatorg.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)2020-08-21T15:49:48.154355939ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1301)2020-08-21T15:49:48.154358773ZstderrFatorg.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1424)",
-    "capture": "2020-08-21T15:49:53.16823268ZstderrF20/08/2115:49:53WARNipc.Client:Exceptionencounteredwhileconnectingtotheserver:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken):token(HDFS_DELEGATION_TOKENtoken273964959forstdemb)can'tbefoundincache",
+    "log": "2020-08-21T15:49:48.154291375ZstderrFhdfsExists:invokeMethod((Lorg/apache/hadoop/fs/Path;)Z)error:2020-08-21T15:49:48.154296328ZstderrForg.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security..SecretManager$Invalid):(HDFS_DELEGATION_273964959forweeb)can'tbefoundincache2020-08-21T15:49:48.154300089ZstderrFatorg.apache.hadoop.ipc.Client.call(Client.java:1475)2020-08-21T15:49:48.154303281ZstderrFatorg.apache.hadoop.ipc.Client.call(Client.java:1412)2020-08-21T15:49:48.154307503ZstderrFatorg.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)2020-08-21T15:49:48.154311268ZstderrFatcom.sun.proxy.$Proxy9.getFileInfo(UnknownSource)2020-08-21T15:49:48.154314514ZstderrFatorg.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:771)2020-08-21T15:49:48.154317916ZstderrFatsun.reflect.GeneratedMethodAccessor2.invoke(UnknownSource)2020-08-21T15:49:48.154328852ZstderrFatsun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)2020-08-21T15:49:48.154332363ZstderrFatjava.lang.reflect.Method.invoke(Method.java:498)2020-08-21T15:49:48.154335464ZstderrFatorg.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)2020-08-21T15:49:48.154338276ZstderrFatorg.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)2020-08-21T15:49:48.15434115ZstderrFatcom.sun.proxy.$Proxy10.getFileInfo(UnknownSource)2020-08-21T15:49:48.154344323ZstderrFatorg.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2108)2020-08-21T15:49:48.154347224ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305)2020-08-21T15:49:48.154350059ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301)2020-08-21T15:49:48.154352819ZstderrFatorg.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)2020-08-21T15:49:48.154355939ZstderrFatorg.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1301)2020-08-21T15:49:48.154358773ZstderrFatorg.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1424)",
+    "capture": "2020-08-21T15:49:53.16823268ZstderrF20/08/2115:49:53WARNipc.Client:Exceptionencounteredwhileconnectingtotheserver:org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security..SecretManager$Invalid):(HDFS_DELEGATION_273964959forweeb)can'tbefoundincache",
     "kubernetes": {
-      "pod_name": "yali-bert-completion-tensorboard-6786c9c8-wj25m",
-      "namespace_name": "k8s-pilot",
+      "pod_name": "rrrr-bert-completion-tb1-6786c9c8-wj25m",
+      "namespace_name": "k8s-fgg",
       "pod_id": "50bfc67d-cd3c-410d-9369-8bda8f33b1c7",
       "labels": {
-        "app": "customized-tensorboard",
+        "app": "customized-tb1",
         "pod-template-hash": "6786c9c8"
       },
       "annotations": {
-        "doAs": "stdemb",
-        "iddecorator.grid.li.username": "yali",
-        "kubernetes.io/limit-ranger": "LimitRangerpluginset:cpu,memoryrequestforcontainertensorboard;cpu,memorylimitforcontainertensorboard;cpu,memoryrequestforinitcontainertokenfetcher;cpu,memorylimitforinitcontainertokenfetcher",
+        "doAs": "weeb",
+        "iddecorator.dkdk.username": "rrrr",
+        "kubernetes.io/limit-ranger": "LimitRangerpluginset:cpu,memoryrequestforcontainertensorboard;cpu,memorylimitforcontainertensorboard;cpu,memoryrequestforinitcontainerfetcher;cpu,memorylimitforinitcontainerfetcher",
         "kubernetes.io/psp": "katib-nfs-provisioner",
         "podpreset.admission.kubernetes.io/podpreset-kube-master": "60792473"
       },
-      "host": "ltx1-hcl15934.grid.linkedin.com",
-      "container_name": "tensorboard",
+      "host": "wedddd.dkdk.qqqq.com",
+      "container_name": "tb1",
       "docker_id": "50bfc67d-cd3c-410d-9369-8bda8f33b1c7",
-      "container_hash": "docker.artifactory-test.corp.linkedin.com/ai/centos/tf1.15.0-py3.7-horovod@sha256:68b6885f6d1d3fd87ce425a2b2aa687440b9578740d60996912a816ae67be85e",
-      "container_image": "docker.artifactory-test.corp.linkedin.com/ai/centos/tf1.15.0-py3.7-horovod:1.2"
+      "container_hash": "qqqq.corp.qqqq.com/ai/centos/tf1.15.0-py3.7-horovod@sha256:68b6885f6d1d3fd87ce425a2b2aa687440b9578740d60996912a816ae67be85e",
+      "container_image": "qqqq.corp.qqqq.com/ai/centos/tf1.15.0-py3.7-horovod:1.2"
     }
   }

--- a/tests/internal/data/avro/multiline.json
+++ b/tests/internal/data/avro/multiline.json
@@ -1,27 +1,27 @@
 [
   {
     "date": 1597871185.922652,
-    "log": "2020-08-19T21:06:24.337499838Z stderr F hdfsExists: invokeMethod((Lorg/apache/hadoop/fs/Path;)Z) error:\n2020-08-19T21:06:24.33754077Z stderr F org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.token.SecretManager$InvalidToken): token (HDFS_DELEGATION_TOKEN token 273964959 for stdemb) can't be found in cache\n2020-08-19T21:06:24.337544598Z stderr F \tat org.apache.hadoop.ipc.Client.call(Client.java:1475)\n2020-08-19T21:06:24.337547418Z stderr F \tat org.apache.hadoop.ipc.Client.call(Client.java:1412)\n2020-08-19T21:06:24.337550469Z stderr F \tat org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)\n2020-08-19T21:06:24.337553603Z stderr F \tat com.sun.proxy.$Proxy9.getFileInfo(Unknown Source)\n2020-08-19T21:06:24.337556408Z stderr F \tat org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:771)\n2020-08-19T21:06:24.337559359Z stderr F \tat sun.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)\n2020-08-19T21:06:24.337562715Z stderr F \tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n2020-08-19T21:06:24.337565488Z stderr F \tat java.lang.reflect.Method.invoke(Method.java:498)\n2020-08-19T21:06:24.337574315Z stderr F \tat org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)\n2020-08-19T21:06:24.337577049Z stderr F \tat org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)\n2020-08-19T21:06:24.33757971Z stderr F \tat com.sun.proxy.$Proxy10.getFileInfo(Unknown Source)\n2020-08-19T21:06:24.337582469Z stderr F \tat org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2108)\n2020-08-19T21:06:24.337585132Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305)\n2020-08-19T21:06:24.337587799Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301)\n2020-08-19T21:06:24.337590342Z stderr F \tat org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)\n2020-08-19T21:06:24.337592897Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1301)\n2020-08-19T21:06:24.337595578Z stderr F \tat org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1424)",
+    "log": "2020-08-19T21:06:24.337499838Z stderr F hdfsExists: invokeMethod((Lorg/apache/hadoop/fs/Path;)Z) error:\n2020-08-19T21:06:24.33754077Z stderr F org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security..SecretManager$Invalid):  (HDFS_DELEGATION_  273964959 for weeb) can't be found in cache\n2020-08-19T21:06:24.337544598Z stderr F \tat org.apache.hadoop.ipc.Client.call(Client.java:1475)\n2020-08-19T21:06:24.337547418Z stderr F \tat org.apache.hadoop.ipc.Client.call(Client.java:1412)\n2020-08-19T21:06:24.337550469Z stderr F \tat org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)\n2020-08-19T21:06:24.337553603Z stderr F \tat com.sun.proxy.$Proxy9.getFileInfo(Unknown Source)\n2020-08-19T21:06:24.337556408Z stderr F \tat org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:771)\n2020-08-19T21:06:24.337559359Z stderr F \tat sun.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)\n2020-08-19T21:06:24.337562715Z stderr F \tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n2020-08-19T21:06:24.337565488Z stderr F \tat java.lang.reflect.Method.invoke(Method.java:498)\n2020-08-19T21:06:24.337574315Z stderr F \tat org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)\n2020-08-19T21:06:24.337577049Z stderr F \tat org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)\n2020-08-19T21:06:24.33757971Z stderr F \tat com.sun.proxy.$Proxy10.getFileInfo(Unknown Source)\n2020-08-19T21:06:24.337582469Z stderr F \tat org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2108)\n2020-08-19T21:06:24.337585132Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305)\n2020-08-19T21:06:24.337587799Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301)\n2020-08-19T21:06:24.337590342Z stderr F \tat org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)\n2020-08-19T21:06:24.337592897Z stderr F \tat org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1301)\n2020-08-19T21:06:24.337595578Z stderr F \tat org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1424)",
     "kubernetes": {
-      "pod_name": "yali-bert-completion-tensorboard-6786c9c8-wj25m",
-      "namespace_name": "k8s-pilot",
+      "pod_name": "rrrr-bert-completion-tb1-6786c9c8-wj25m",
+      "namespace_name": "k8s-fgg",
       "pod_id": "50bfc67d-cd3c-410d-9369-8bda8f33b1c7",
       "labels": {
-        "app": "customized-tensorboard",
+        "app": "customized-tb1",
         "pod-template-hash": "6786c9c8"
       },
       "annotations": {
-        "doAs": "stdemb",
-        "iddecorator.grid.li.username": "yali",
+        "doAs": "weeb",
+        "iddecorator.dkdk.username": "rrrr",
         "kubernetes.io/limit-ranger": "LimitRanger",
         "kubernetes.io/psp": "katib-nfs-provisioner",
         "podpreset.admission.kubernetes.io/podpreset-kube-master": "60792473"
       },
-      "host": "ltx1-hcl15934.grid.linkedin.com",
-      "container_name": "tensorboard",
+      "host": "wedddd.dkdk.qqqq.com",
+      "container_name": "tb1",
       "docker_id": "50bfc67d-cd3c-410d-9369-8bda8f33b1c7",
-      "container_hash": "docker.artifactory-test.corp.linkedin.com/ai/centos/tf1.15.0-py3.7-horovod@sha256:68b6885f6d1d3fd87ce425a2b2aa687440b9578740d60996912a816ae67be85e",
-      "container_image": "docker.artifactory-test.corp.linkedin.com/ai/centos/tf1.15.0-py3.7-horovod:1.2"
+      "container_hash": "qqqq.corp.qqqq.com/ai/centos/tf1.15.0-py3.7-horovod@sha256:68b6885f6d1d3fd87ce425a2b2aa687440b9578740d60996912a816ae67be85e",
+      "container_image": "qqqq.corp.qqqq.com/ai/centos/tf1.15.0-py3.7-horovod:1.2"
     }
   }
 ]


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes avro support. Avro support was added in a previous as an build-time option, but the resulting merged build was not tested until sometime later, when we tried to get up-to-date. We found the upstream merge built perfectly, but got a segfault upon execution.

This PR fixes the main branch with the avro support activated. It works very well. Also included is an optimization to avoid unnecessary memory allocation by putting in a static buffer that covers the most common expected use-case, and dynamic allocation as-needed if the user's request is expected to exceed the size of the static buffer.

Test data is also cleaned up a bit.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#3568
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature
I'd like to get some docs going in this PR, but I'm not sure where I should put it. Should the avro documentation be included in the main out_kafka section of the web site. If not where should it go?

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
