### PR TITLE
aws: add support for credential_process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ option(FLB_BACKTRACE           "Enable stacktrace support"    Yes)
 option(FLB_LUAJIT              "Enable Lua Scripting support" Yes)
 option(FLB_RECORD_ACCESSOR     "Enable record accessor"       Yes)
 option(FLB_SIGNV4              "Enable AWS Signv4 support"    Yes)
-option(FLB_AWS                "Enable AWS support"            Yes)
+option(FLB_AWS                 "Enable AWS support"           Yes)
 option(FLB_STATIC_CONF         "Build binary using static configuration")
 option(FLB_STREAM_PROCESSOR    "Enable Stream Processor"      Yes)
 option(FLB_CORO_STACK_SIZE     "Set coroutine stack size")
@@ -459,6 +459,18 @@ endif()
 # AWS
 if (FLB_AWS)
   FLB_DEFINITION(FLB_HAVE_AWS)
+
+  # Support for credential_process in the AWS config file is currently Linux-only.
+  # The current implementation might work for other Unix systems, but would require
+  # further testing to confirm.
+  # Spawning a sub-process in Windows is very different and will require its own
+  # implementation.
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    FLB_OPTION(FLB_HAVE_AWS_CREDENTIAL_PROCESS ON)
+    FLB_DEFINITION(FLB_HAVE_AWS_CREDENTIAL_PROCESS)
+  else()
+    FLB_OPTION(FLB_HAVE_AWS_CREDENTIAL_PROCESS OFF)
+  endif()
 endif()
 
 # Signv4

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -251,6 +251,39 @@ struct flb_aws_credentials *flb_parse_http_credentials(char *response,
                                                        size_t response_len,
                                                        time_t *expiration);
 
+struct flb_aws_credentials *flb_parse_json_credentials(char *response,
+                                                       size_t response_len,
+                                                       char *session_token_field,
+                                                       time_t *expiration);
+
+#ifdef FLB_HAVE_AWS_CREDENTIAL_PROCESS
+
+/*
+ * Parses the input string, which is assumed to be the credential_process
+ * from the config file, into a sequence of tokens.
+ * Returns the array of tokens on success, and NULL on failure.
+ * The array of tokens will be terminated by NULL for use with `execvp`.
+ * The caller is responsible for calling `flb_free` on the return value.
+ * Note that this function modifies the input string.
+ */
+char** parse_credential_process(char* input);
+
+/*
+ * Executes the given credential_process, which is assumed to have come
+ * from the config file, and parses its result into *creds and *expiration.
+ * Returns 0 on success and < 0 on failure.
+ *
+ * If it succeeds, *creds and *expiration will be set appropriately, and the
+ * caller is responsible for calling `flb_aws_credentials_destroy(*creds)`.
+ * If the credentials do not expire, then *expiration will be 0.
+ *
+ * If it fails, then *creds will be NULL.
+ */
+int exec_credential_process(char* process, struct flb_aws_credentials** creds,
+                            time_t* expiration);
+
+#endif /* FLB_HAVE_AWS_CREDENTIAL_PROCESS */
+
 /*
  * Fluent Bit is single-threaded but asynchonous. Only one co-routine will
  * be running at a time, and they only pause/resume for IO.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,7 @@ endif()
 if(FLB_AWS)
   set(src
     ${src}
+    "aws/flb_aws_credentials_log.h"
     "aws/flb_aws_util.c"
     "aws/flb_aws_credentials.c"
     "aws/flb_aws_credentials_sts.c"
@@ -144,6 +145,12 @@ if(FLB_AWS)
     "aws/flb_aws_credentials_http.c"
     "aws/flb_aws_credentials_profile.c"
     )
+  if(FLB_HAVE_AWS_CREDENTIAL_PROCESS)
+    set(src
+      ${src}
+      "aws/flb_aws_credentials_process.c"
+      )
+  endif()
 endif()
 
 if(FLB_LUAJIT)

--- a/src/aws/flb_aws_credentials_log.h
+++ b/src/aws/flb_aws_credentials_log.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2021      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_AWS_CREDENTIALS_LOG_H
+
+#define FLB_AWS_CREDENTIALS_LOG_H
+
+#include <fluent-bit/flb_log.h>
+
+#define AWS_CREDS_ERROR(format, ...) flb_error("[aws_credentials] " format, ##__VA_ARGS__)
+#define AWS_CREDS_WARN(format, ...) flb_warn("[aws_credentials] " format, ##__VA_ARGS__)
+#define AWS_CREDS_DEBUG(format, ...) flb_debug("[aws_credentials] " format, ##__VA_ARGS__)
+
+#define AWS_CREDS_ERROR_OR_DEBUG(debug_only, format, ...) do {\
+    if (debug_only == FLB_TRUE) {\
+        AWS_CREDS_DEBUG(format, ##__VA_ARGS__);\
+    }\
+    else {\
+        AWS_CREDS_ERROR(format, ##__VA_ARGS__);\
+    }\
+} while (0)
+
+#endif

--- a/src/aws/flb_aws_credentials_process.c
+++ b/src/aws/flb_aws_credentials_process.c
@@ -1,0 +1,783 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2021      The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_aws_credentials.h>
+
+#include "flb_aws_credentials_log.h"
+
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_time.h>
+
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+
+#define DEV_NULL "/dev/null"
+
+#define MS_PER_SEC 1000
+#define MICROS_PER_MS 1000
+#define NS_PER_MS 1000000
+
+#define CREDENTIAL_PROCESS_TIMEOUT_MS 60000
+#define CREDENTIAL_PROCESS_BUFFER_SIZE 8 * 1024
+
+#define WAITPID_POLL_FREQUENCY_MS 20
+#define WAITPID_TIMEOUT_MS 10 * WAITPID_POLL_FREQUENCY_MS
+
+#define CREDENTIAL_PROCESS_RESPONSE_SESSION_TOKEN "SessionToken"
+
+/* Declarations */
+struct token_array;
+static int new_token_array(struct token_array *arr, int cap);
+static int append_token(struct token_array *arr, char* elem);
+
+struct readbuf;
+static int new_readbuf(struct readbuf* buf, int cap);
+
+static int get_monotonic_time(struct flb_time* tm);
+
+static char* ltrim(char* input);
+static int scan_credential_process_token_quoted(char *input);
+static int scan_credential_process_token_unquoted(char *input);
+static int credential_process_token_count(char* process);
+static int parse_credential_process_token(char **input, char** out_token);
+
+static int read_until_block(char* name, flb_pipefd_t fd, struct readbuf* buf);
+static int waitpid_timeout(char* name, pid_t pid, int* wstatus);
+
+struct process;
+static int new_process(struct process* p, char** args);
+static void exec_process_child(struct process* p);
+static int exec_process(struct process* p);
+static int read_from_process(struct process* p, struct readbuf* buf);
+static int wait_process(struct process* p);
+static void destroy_process(struct process* p);
+/* End Declarations */
+
+struct token_array {
+    char** tokens;
+    int len;
+    int cap;
+};
+
+/*
+ * Initializes a new token array with the given capacity.
+ * Returns 0 on success and < 0 on failure.
+ * The caller is responsible for calling `flb_free(arr->tokens)`.
+ */
+static int new_token_array(struct token_array *arr, int cap)
+{
+    *arr = (struct token_array) { .len = 0, .cap = cap };
+    arr->tokens = flb_malloc(cap * sizeof(char*));
+    if (!arr->tokens) {
+        flb_errno();
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * Appends the given token to the array, if there is capacity.
+ * Returns 0 on success and < 0 on failure.
+ */
+static int append_token(struct token_array *arr, char* token)
+{
+    if (arr->len >= arr->cap) {
+        /* This means there is a bug in credential_process_token_count. */
+        AWS_CREDS_ERROR("append_token called on full token_array");
+        return -1;
+    }
+
+    (arr->tokens)[arr->len] = token;
+    arr->len++;
+    return 0;
+}
+
+struct readbuf {
+    char* buf;
+    int len;
+    int cap;
+};
+
+/*
+ * Initializes a new buffer with the given capacity.
+ * Returns 0 on success and < 0 on failure.
+ * The caller is responsible for calling `flb_free(buf->buf)`.
+ */
+static int new_readbuf(struct readbuf* buf, int cap)
+{
+    *buf = (struct readbuf) { .len = 0, .cap = cap };
+    buf->buf = flb_malloc(cap * sizeof(char));
+    if (!buf->buf) {
+        flb_errno();
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * Fetches the current time from the monotonic clock.
+ * Returns 0 on success and < 0 on failure.
+ * This is useful for calculating deadlines that are not sensitive to changes
+ * in the system clock.
+ */
+static int get_monotonic_time(struct flb_time* tm)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) < 0) {
+        flb_errno();
+        return -1;
+    }
+    flb_time_set(tm, ts.tv_sec, ts.tv_nsec);
+    return 0;
+}
+
+/*
+ * Skips over any leading spaces in the input string, returning the remainder.
+ * If the entire string is consumed, returns the empty string (not NULL).
+ */
+static char* ltrim(char* input)
+{
+    while (*input == ' ') {
+        input++;
+    }
+    return input;
+}
+
+/*
+ * Scans the unquoted token string at the start of the input string.
+ * The input must be the start of an unquoted token.
+ * Returns the token length on success, and < 0 on failure.
+ * This function does not add a null terminator to the token.
+ * The token length is the index where the null terminator must be placed.
+ * If the entire input is consumed, returns the length of the input string
+ * (excluding the null terminator).
+ */
+static int scan_credential_process_token_unquoted(char *input)
+{
+    int i;
+
+    for (i = 0; input[i] != ' '; i++) {
+        if (input[i] == '\0') {
+            break;
+        }
+        if (input[i] == '"') {
+            AWS_CREDS_ERROR("unexpected quote in credential_process");
+            return -1;
+        }
+    }
+
+    return i;
+}
+
+/*
+ * Scans the quoted token at the start of the input string.
+ * The input must be the string after the opening quote.
+ * Returns the token length on success, and < 0 on failure.
+ * This function does not add a null terminator to the token.
+ * The token length is the index where the null terminator must be placed.
+ */
+static int scan_credential_process_token_quoted(char *input)
+{
+    int i;
+
+    for (i = 0; input[i] != '"'; i++) {
+        if (input[i] == '\0') {
+            AWS_CREDS_ERROR("unterminated quote in credential_process");
+            return -1;
+        }
+    }
+
+    if (input[i+1] != '\0' && input[i+1] != ' ') {
+        AWS_CREDS_ERROR("unexpected character %c after closing quote in "
+                        "credential_process", input[i+1]);
+        return -1;
+    }
+
+    return i;
+}
+
+/*
+ * Counts the number of tokens in the input string, which is assumed to be the
+ * credential_process from the config file.
+ * Returns < 0 on failure.
+ */
+static int credential_process_token_count(char* process)
+{
+    int count = 0;
+    int i;
+
+    while (1) {
+        process = ltrim(process);
+        if (*process == '\0') {
+            break;
+        }
+
+        count++;
+
+        if (*process == '"') {
+            process++;
+            i = scan_credential_process_token_quoted(process);
+        }
+        else {
+            i = scan_credential_process_token_unquoted(process);
+        }
+
+        if (i < 0) {
+            return -1;
+        }
+
+        process += i;
+        if (*process != '\0') {
+            process++;
+        }
+    }
+
+    return count;
+}
+
+/*
+ * Parses the input string, which is assumed to be the credential_process
+ * from the config file. The next token will be put in *out_token, and the
+ * remaining unprocessed input will be put in *input.
+ * Returns 0 on success and < 0 on failure.
+ * If there is an error, the value of *input and *out_token is not defined.
+ * If it succeeds and *out_token is NULL, then there are no more tokens,
+ * and this function should not be called again.
+ * *out_token will be some substring of the original *input, so it should not
+ * be freed.
+ */
+static int parse_credential_process_token(char** input, char** out_token)
+{
+    *out_token = NULL;
+    int i;
+
+    if (!*input) {
+        AWS_CREDS_ERROR("parse_credential_process_token called after yielding last token");
+        return -1;
+    }
+
+    *input = ltrim(*input);
+
+    if (**input == '\0') {
+        *input = NULL;
+        *out_token = NULL;
+        return 0;
+    }
+
+    if (**input == '"') {
+        (*input)++;
+        i = scan_credential_process_token_quoted(*input);
+    }
+    else {
+        i = scan_credential_process_token_unquoted(*input);
+    }
+
+    if (i < 0) {
+        return -1;
+    }
+
+    *out_token = *input;
+    *input += i;
+
+    if (**input != '\0') {
+        **input = '\0';
+        (*input)++;
+    }
+
+    return 0;
+}
+
+/* See <fluent-bit/flb_aws_credentials.h>. */
+char** parse_credential_process(char* input)
+{
+    char* next_token = NULL;
+    struct token_array arr = { 0 };
+    int token_count = credential_process_token_count(input);
+
+    if (token_count < 0) {
+        goto error;
+    }
+
+    /* Add one extra capacity for the NULL terminator. */
+    if (new_token_array(&arr, token_count + 1) < 0) {
+        goto error;
+    }
+
+    while (1) {
+        if (parse_credential_process_token(&input, &next_token) < 0) {
+            goto error;
+        }
+
+        if (!next_token) {
+            break;
+        }
+
+        if (append_token(&arr, next_token) < 0) {
+            goto error;
+        }
+    }
+
+    if (append_token(&arr, NULL) < 0) {
+        goto error;
+    }
+
+    return arr.tokens;
+
+error:
+    flb_free(arr.tokens);
+    return NULL;
+}
+
+/*
+ * Reads from the pipe into the buffer until no more input is available.
+ * If the input is exhausted (EOF), returns 0.
+ * If reading would block (EWOULDBLOCK/EAGAIN), returns > 0.
+ * If an error occurs or the buffer is full, returns < 0.
+ */
+static int read_until_block(char* name, flb_pipefd_t fd, struct readbuf* buf)
+{
+    int result = -1;
+
+    while (1) {
+        if (buf->len >= buf->cap) {
+            AWS_CREDS_ERROR("credential_process %s exceeded max buffer size", name);
+            return -1;
+        }
+
+        result = flb_pipe_r(fd, buf->buf + buf->len, buf->cap - buf->len);
+        if (result < 0) {
+            if (FLB_PIPE_WOULDBLOCK()) {
+                return 1;
+            }
+            flb_errno();
+            return -1;
+        }
+        else if (result == 0) {   /* EOF */
+            return 0;
+        }
+        else {
+            buf->len += result;
+        }
+    }
+}
+
+/*
+ * Polls waitpid until the given process exits, or the timeout is reached.
+ * Returns 0 on success and < 0 on failure.
+ */
+static int waitpid_timeout(char* name, pid_t pid, int* wstatus)
+{
+    int result = -1;
+    int retries = WAITPID_TIMEOUT_MS / WAITPID_POLL_FREQUENCY_MS;
+
+    while (1) {
+        result = waitpid(pid, wstatus, WNOHANG);
+        if (result < 0) {
+            flb_errno();
+            return -1;
+        }
+
+        if (result > 0) {
+            return 0;
+        }
+
+        if (retries <= 0) {
+            AWS_CREDS_ERROR("timed out waiting for credential_process %s to exit", name);
+            return -1;
+        }
+        retries--;
+
+        usleep(WAITPID_POLL_FREQUENCY_MS * MICROS_PER_MS);
+    }
+}
+
+struct process {
+    int initialized;
+    char** args;
+    int stdin;
+    flb_pipefd_t stdout[2];
+    int stderr;
+    pid_t pid;
+};
+
+/*
+ * Initializes a new process with the given args.
+ * args is assumed to be a NULL terminated array, for use with execvp.
+ * It must have a least one element, and the first element is assumed to be the
+ * name/path of the executable.
+ * Returns 0 on success and < 0 on failure.
+ * The caller is responsible for calling `destroy_process(p)`.
+ */
+static int new_process(struct process* p, char** args)
+{
+    *p = (struct process) {
+        .initialized = FLB_TRUE,
+        .args = args,
+        .stdin = -1,
+        .stdout = {-1, -1},
+        .stderr = -1,
+        .pid = -1,
+    };
+
+    while ((p->stdin = open(DEV_NULL, O_RDONLY|O_CLOEXEC)) < 0) {
+        if (errno != EINTR) {
+            flb_errno();
+            return -1;
+        }
+    }
+
+    if (flb_pipe_create(p->stdout) < 0) {;
+        flb_errno();
+        return -1;
+    }
+
+    if (fcntl(p->stdout[0], F_SETFL, O_CLOEXEC) < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    if (fcntl(p->stdout[1], F_SETFL, O_CLOEXEC) < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    while ((p->stderr = open(DEV_NULL, O_WRONLY|O_CLOEXEC)) < 0) {
+        if (errno != EINTR) {
+            flb_errno();
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Sets up the credential_process's stdin, stdout, and stderr, and exec's
+ * the actual process.
+ * For this function to return at all is an error.
+ * This function should not be called more than once.
+ */
+static void exec_process_child(struct process* p)
+{
+    while ((dup2(p->stdin, STDIN_FILENO) < 0)) {
+        if (errno != EINTR) {
+            return; 
+        }
+    }
+    while ((dup2(p->stdout[1], STDOUT_FILENO) < 0)) {
+        if (errno != EINTR) {
+            return;
+        }
+    }
+    while ((dup2(p->stderr, STDERR_FILENO) < 0)) {
+        if (errno != EINTR) {
+            return; 
+        }
+    }
+
+    close(p->stdin);
+    flb_pipe_close(p->stdout[0]);
+    flb_pipe_close(p->stdout[1]);
+    close(p->stderr);
+
+    execvp(p->args[0], p->args);
+}
+
+/*
+ * Forks the credential_process, but does not wait for it to finish.
+ * Returns 0 on success and < 0 on failure.
+ * This function should not be called more than once.
+ */
+static int exec_process(struct process* p)
+{
+    AWS_CREDS_DEBUG("executing credential_process %s", p->args[0]);
+
+    p->pid = fork();
+    if (p->pid < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    if (p->pid == 0) {
+        exec_process_child(p);
+
+        /* It should not be possible to reach this under normal circumstances. */
+        exit(EXIT_FAILURE);
+    }
+
+    close(p->stdin);
+    p->stdin = -1;
+
+    flb_pipe_close(p->stdout[1]);
+    p->stdout[1] = -1;
+
+    close(p->stderr);
+    p->stderr = -1;
+
+    return 0;
+}
+
+/*
+ * Reads from the credential_process's stdout into the given buffer.
+ * Returns 0 on success, and < 0 on failure or timeout.
+ * This function should not be called more than once.
+ */
+static int read_from_process(struct process* p, struct readbuf* buf)
+{
+    int result = -1;
+    struct pollfd pfd;
+    struct flb_time start, timeout, deadline, now, remaining;
+    int remaining_ms;
+
+    if (fcntl(p->stdout[0], F_SETFL, O_NONBLOCK) < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    if (get_monotonic_time(&start) < 0) {
+        return -1;
+    }
+
+    flb_time_set(&timeout, 
+        (time_t) (CREDENTIAL_PROCESS_TIMEOUT_MS / MS_PER_SEC),
+        ((long) (CREDENTIAL_PROCESS_TIMEOUT_MS % MS_PER_SEC)) * NS_PER_MS);
+
+    /* deadline = start + timeout */
+    flb_time_add(&start, &timeout, &deadline);
+
+    while (1) {
+        pfd = (struct pollfd) {
+            .fd = p->stdout[0],
+            .events = POLLIN,
+        };
+
+        if (get_monotonic_time(&now) < 0) {
+            return -1;
+        }
+
+        /* remaining = deadline - now */
+        if (flb_time_diff(&deadline, &now, &remaining) < 0) {
+            AWS_CREDS_ERROR("credential_process %s timed out", p->args[0]);
+            return -1;
+        }
+
+        /*
+         * poll uses millisecond resolution for the timeout.
+         * If there is less than a millisecond left, then for simplicity we'll just
+         * declare that it timed out.
+         */
+        remaining_ms = (int) (flb_time_to_nanosec(&remaining) / NS_PER_MS);
+        if (remaining_ms <= 0) {
+            AWS_CREDS_ERROR("credential_process %s timed out", p->args[0]);
+            return -1;
+        }
+
+        result = poll(&pfd, 1, remaining_ms);
+        if (result < 0) {
+            if (errno != EINTR) {
+                flb_errno();
+                return -1;
+            }
+            continue;
+        }
+
+        if (result == 0) {
+            AWS_CREDS_ERROR("credential_process %s timed out", p->args[0]);
+            return -1;
+        }
+
+        if ((pfd.revents & POLLNVAL) == POLLNVAL) {
+            AWS_CREDS_ERROR("credential_process %s POLLNVAL", p->args[0]);
+            return -1;
+        }
+
+        if ((pfd.revents & POLLERR) == POLLERR) {
+            AWS_CREDS_ERROR("credential_process %s POLLERR", p->args[0]);
+            return -1;
+        }
+
+        if ((pfd.revents & POLLIN) == POLLIN || (pfd.revents & POLLHUP) == POLLHUP) {
+            result = read_until_block(p->args[0], p->stdout[0], buf);
+            if (result <= 0) {
+                return result;
+            }
+        }
+    }
+}
+
+/*
+ * Waits for the process to exit, up to a timeout.
+ * Returns 0 on success and < 0 on failure.
+ * This function should not be called more than once.
+ */
+static int wait_process(struct process* p)
+{
+    int wstatus;
+
+    if (waitpid_timeout(p->args[0], p->pid, &wstatus) < 0) {
+        return -1;
+    }
+    p->pid = -1;
+
+    if (!WIFEXITED(wstatus)) {
+        AWS_CREDS_ERROR("credential_process %s did not terminate normally", p->args[0]);
+        return -1;
+    }
+
+    if (WEXITSTATUS(wstatus) != EXIT_SUCCESS) {
+        AWS_CREDS_ERROR("credential_process %s exited with status %d", p->args[0],
+                        WEXITSTATUS(wstatus));
+        return -1;
+    }
+
+    AWS_CREDS_DEBUG("credential_process %s exited successfully", p->args[0]);
+    return 0;
+}
+
+/*
+ * Release all resources associated with this process.
+ * Calling this function multiple times is a no-op.
+ * Since the process does not own p->args, it does not free it.
+ * Note that p->args will be set to NULL, so the caller must hold onto
+ * it separately in order to free it.
+ */
+static void destroy_process(struct process* p)
+{
+    if (p->initialized) {
+        if (p->stdin >= 0) {
+            close(p->stdin);
+            p->stdin = -1;
+        }
+        if (p->stdout[0] >= 0) {
+            close(p->stdout[0]);
+            p->stdout[0] = -1;
+        }
+        if (p->stdout[1] >= 0) {
+            close(p->stdout[1]);
+            p->stdout[1] = -1;
+        }
+        if (p->stderr >= 0) {
+            close(p->stderr);
+            p->stderr = -1;
+        }
+
+        if (p->pid > 0) {
+            if (kill(p->pid, SIGKILL) < 0) {
+                flb_errno();
+                AWS_CREDS_ERROR("could not kill credential_process %s (pid=%d) "
+                                "during cleanup", p->args[0], p->pid);
+            }
+            else {
+                while (waitpid(p->pid, NULL, 0) < 0) {
+                    if (errno != EINTR) {
+                        flb_errno();
+                        break;
+                    }
+                }
+            }
+            p->pid = -1;
+        }
+
+        p->args = NULL;
+
+        p->initialized = FLB_FALSE;
+    }
+}
+
+/* See <fluent-bit/flb_aws_credentials.h>. */
+int exec_credential_process(char* process, struct flb_aws_credentials** creds,
+                            time_t* expiration)
+{
+    char** args = NULL;
+    int result = -1;
+    struct process p = { 0 };
+    struct readbuf buf = { 0 };
+    *creds = NULL;
+    *expiration = 0;
+
+    args = parse_credential_process(process);
+    if (!args) {
+        result = -1;
+        goto end;
+    }
+
+    if (!args[0]) {
+        AWS_CREDS_ERROR("invalid credential_process");
+        result = -1;
+        goto end;
+    }
+
+    if (new_process(&p, args) < 0) {
+        result = -1;
+        goto end;
+    }
+
+    if (new_readbuf(&buf, CREDENTIAL_PROCESS_BUFFER_SIZE) < 0) {
+        result = -1;
+        goto end;
+    }
+
+    if (exec_process(&p) < 0) {
+        result = -1;
+        goto end;
+    }
+
+    if (read_from_process(&p, &buf) < 0) {
+        result = -1;
+        goto end;
+    }
+
+    if (wait_process(&p) < 0) {
+        result = -1;
+        goto end;
+    }
+
+    *creds = flb_parse_json_credentials(buf.buf, buf.len,
+                                        CREDENTIAL_PROCESS_RESPONSE_SESSION_TOKEN,
+                                        expiration);
+    if (!*creds) {
+        AWS_CREDS_ERROR("could not parse credentials from credential_process %s", args[0]);
+        result = -1;
+        goto end;
+    }
+
+    AWS_CREDS_DEBUG("successfully parsed credentials from credential_process %s", args[0]);
+
+    result = 0;
+
+end:
+    destroy_process(&p);
+
+    flb_free(buf.buf);
+    buf.buf = NULL;
+
+    flb_free(args);
+    args = NULL;
+
+    if (result < 0) {
+        flb_aws_credentials_destroy(*creds);
+        *creds = NULL;
+    }
+
+    return result;
+}

--- a/src/aws/flb_aws_credentials_profile.c
+++ b/src/aws/flb_aws_credentials_profile.c
@@ -17,14 +17,16 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_sds.h>
-#include <fluent-bit/flb_http_client.h>
+#include "flb_aws_credentials_log.h"
+
 #include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_aws_util.h>
-#include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
 
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -33,31 +35,56 @@
 #define ACCESS_KEY_PROPERTY_NAME            "aws_access_key_id"
 #define SECRET_KEY_PROPERTY_NAME            "aws_secret_access_key"
 #define SESSION_TOKEN_PROPERTY_NAME         "aws_session_token"
+#define CREDENTIAL_PROCESS_PROPERTY_NAME    "credential_process"
 
 #define AWS_PROFILE                         "AWS_PROFILE"
 #define AWS_DEFAULT_PROFILE                 "AWS_DEFAULT_PROFILE"
 
+#define AWS_CONFIG_FILE                     "AWS_CONFIG_FILE"
 #define AWS_SHARED_CREDENTIALS_FILE         "AWS_SHARED_CREDENTIALS_FILE"
+
+#define DEFAULT_PROFILE "default"
+#define CONFIG_PROFILE_PREFIX "profile "
+#define CONFIG_PROFILE_PREFIX_LEN (sizeof(CONFIG_PROFILE_PREFIX)-1)
 
 /* Declarations */
 struct flb_aws_provider_profile;
-static int get_profile(struct flb_aws_provider_profile *implementation,
-                       int debug_only);
-static int parse_file(char *buf, char *profile, struct flb_aws_credentials *creds,
-                      int debug_only);
+static int refresh_credentials(struct flb_aws_provider_profile *implementation,
+                               int debug_only);
+
+static int get_aws_shared_file_path(flb_sds_t* field, char* env_var, char* home_aws_path);
+
+static int parse_config_file(char *buf, char* profile, struct flb_aws_credentials** creds,
+                             time_t* expiration, int debug_only);
+static int parse_credentials_file(char *buf, char *profile,
+                                  struct flb_aws_credentials *creds, int debug_only);
+
+static int get_shared_config_credentials(char* config_path,
+                                         char*profile,
+                                         struct flb_aws_credentials** creds,
+                                         time_t* expiration,
+                                         int debug_only);
+static int get_shared_credentials(char* credentials_path,
+                                  char* profile,
+                                  struct flb_aws_credentials** creds,
+                                  int debug_only);
+
 static flb_sds_t parse_property_value(char *s, int debug_only);
 static char *parse_property_line(char *line);
 static int has_profile(char *line, char* profile, int debug_only);
 static int is_profile_line(char *line);
+static int config_file_profile_matches(char *line, char *profile);
 
 /*
  * A provider that reads from the shared credentials file.
  */
 struct flb_aws_provider_profile {
     struct flb_aws_credentials *creds;
+    time_t next_refresh;
 
     flb_sds_t profile;
-    flb_sds_t path;
+    flb_sds_t config_path;
+    flb_sds_t credentials_path;
 };
 
 struct flb_aws_credentials *get_credentials_fn_profile(struct flb_aws_provider
@@ -67,14 +94,19 @@ struct flb_aws_credentials *get_credentials_fn_profile(struct flb_aws_provider
     int ret;
     struct flb_aws_provider_profile *implementation = provider->implementation;
 
-    flb_debug("[aws_credentials] Retrieving credentials for "
-              "AWS Profile %s", implementation->profile);
-
-    if (!implementation->creds) {
-        ret = get_profile(implementation, FLB_FALSE);
+    /*
+     * If next_refresh <= 0, it means we don't know how long the credentials
+     * are valid for. So we won't refresh them unless explicitly asked
+     * via refresh_fn_profile.
+     */
+    if (!implementation->creds || (implementation->next_refresh > 0 &&
+        time(NULL) >= implementation->next_refresh)) {
+        AWS_CREDS_DEBUG("Retrieving credentials for AWS Profile %s",
+                        implementation->profile);
+        ret = refresh_credentials(implementation, FLB_FALSE);
         if (ret < 0) {
-            flb_error("[aws_credentials] Failed to retrieve credentials for "
-                      "AWS Profile %s", implementation->profile);
+            AWS_CREDS_ERROR("Failed to retrieve credentials for AWS Profile %s",
+                            implementation->profile);
             return NULL;
         }
     }
@@ -120,15 +152,15 @@ error:
 int refresh_fn_profile(struct flb_aws_provider *provider)
 {
     struct flb_aws_provider_profile *implementation = provider->implementation;
-    flb_debug("[aws_credentials] Refresh called on the profile provider");
-    return get_profile(implementation, FLB_FALSE);
+    AWS_CREDS_DEBUG("Refresh called on the profile provider");
+    return refresh_credentials(implementation, FLB_FALSE);
 }
 
 int init_fn_profile(struct flb_aws_provider *provider)
 {
     struct flb_aws_provider_profile *implementation = provider->implementation;
-    flb_debug("[aws_credentials] Init called on the profile provider");
-    return get_profile(implementation, FLB_TRUE);
+    AWS_CREDS_DEBUG("Init called on the profile provider");
+    return refresh_credentials(implementation, FLB_TRUE);
 }
 
 /*
@@ -164,8 +196,12 @@ void destroy_fn_profile(struct flb_aws_provider *provider)
             flb_sds_destroy(implementation->profile);
         }
 
-        if (implementation->path) {
-            flb_sds_destroy(implementation->path);
+        if (implementation->config_path) {
+            flb_sds_destroy(implementation->config_path);
+        }
+
+        if (implementation->credentials_path) {
+            flb_sds_destroy(implementation->credentials_path);
         }
 
         flb_free(implementation);
@@ -189,15 +225,14 @@ struct flb_aws_provider *flb_profile_provider_create()
 {
     struct flb_aws_provider *provider = NULL;
     struct flb_aws_provider_profile *implementation = NULL;
-    char *path;
-    char *profile;
-    char *home;
+    int result = -1;
+    char *profile = NULL;
 
     provider = flb_calloc(1, sizeof(struct flb_aws_provider));
 
     if (!provider) {
         flb_errno();
-        return NULL;
+        goto error;
     }
 
     implementation = flb_calloc(1,
@@ -212,45 +247,23 @@ struct flb_aws_provider *flb_profile_provider_create()
     provider->provider_vtable = &profile_provider_vtable;
     provider->implementation = implementation;
 
-    /* find the shared credentials file */
-    path = getenv(AWS_SHARED_CREDENTIALS_FILE);
-    if (path && strlen(path) > 0) {
-        implementation->path = flb_sds_create(path);
-        if (!implementation->path) {
-            flb_errno();
-            goto error;
-        }
-    } else {
-        /* default path: $HOME/.aws/credentials */
-        home = getenv("HOME");
-        if (!home || strlen(home) == 0) {
-            flb_warn("[aws_credentials] Failed to initialized profile provider: "
-            "$HOME not set and AWS_SHARED_CREDENTIALS_FILE not set.");
-            flb_aws_provider_destroy(provider);
-            return NULL;
-        }
+    result = get_aws_shared_file_path(&implementation->config_path, AWS_CONFIG_FILE,
+                                      "/.aws/config");
+    if (result < 0) {
+        goto error;
+    }
 
-        /* join file path */
-        implementation->path = flb_sds_create(home);
-        if (!implementation->path) {
-            flb_errno();
-            goto error;
-        }
-        if (home[strlen(home) - 1] == '/') {
-            implementation->path = flb_sds_cat(implementation->path,
-                                               ".aws/credentials", 16);
-            if (!implementation->path) {
-                flb_errno();
-                goto error;
-            }
-        } else {
-            implementation->path = flb_sds_cat(implementation->path,
-                                               "/.aws/credentials", 17);
-            if (!implementation->path) {
-                flb_errno();
-                goto error;
-            }
-        }
+    result = get_aws_shared_file_path(&implementation->credentials_path,
+                                      AWS_SHARED_CREDENTIALS_FILE, "/.aws/credentials");
+    if (result < 0) {
+        goto error;
+    }
+
+    if (!implementation->config_path && !implementation->credentials_path) {
+        AWS_CREDS_WARN("Failed to initialize profile provider: "
+                       "HOME, %s, and %s not set.",
+                       AWS_CONFIG_FILE, AWS_SHARED_CREDENTIALS_FILE);
+        goto error;
     }
 
     /* AWS profile name */
@@ -264,7 +277,7 @@ struct flb_aws_provider *flb_profile_provider_create()
         goto set_profile;
     }
 
-    profile = "default";
+    profile = DEFAULT_PROFILE;
 
 set_profile:
     implementation->profile = flb_sds_create(profile);
@@ -280,8 +293,62 @@ error:
     return NULL;
 }
 
+
+/*
+ * Fetches the path of either the shared config file or the shared credentials file.
+ * Returns 0 on success and < 0 on failure.
+ * On success, the result will be stored in *field.
+ * 
+ * If the given environment variable is set, then its value will be used verbatim.
+ * Else if $HOME is set, then it will be concatenated with home_aws_path.
+ * If neither is set, then *field will be set to NULL. This is not considered a failure.
+ * 
+ * In practice, env_var will be "AWS_CONFIG_FILE" or "AWS_SHARED_CREDENTIALS_FILE",
+ * and home_aws_path will be "/.aws/config" or "/.aws/credentials".
+ */
+static int get_aws_shared_file_path(flb_sds_t* field, char* env_var, char* home_aws_path)
+{
+    char* path = NULL;
+    int result = -1;
+    flb_sds_t value = NULL;
+
+    path = getenv(env_var);
+    if (path && *path) {
+        value = flb_sds_create(path);
+        if (!value) {
+            flb_errno();
+            goto error;
+        }
+    } else {
+        path = getenv("HOME");
+        if (path && *path) {
+            value = flb_sds_create(path);
+            if (!value) {
+                flb_errno();
+                goto error;
+            }
+
+            if (path[strlen(path) - 1] == '/') {
+                home_aws_path++;
+            }
+            result = flb_sds_cat_safe(&value, home_aws_path, strlen(home_aws_path));
+            if (result < 0) {
+                flb_errno();
+                goto error;
+            }
+        }
+    }
+
+    *field = value;
+    return 0;
+
+error:
+    flb_sds_destroy(value);
+    return -1;
+}
+
 static int is_profile_line(char *line) {
-    if (strlen(line) > 1 && line[0] == '[') {
+    if (line[0] == '[') {
         return FLB_TRUE;
     }
     return FLB_FALSE;
@@ -292,12 +359,10 @@ static int has_profile(char *line, char* profile, int debug_only) {
     char *end_bracket = strchr(line, ']');
     if (!end_bracket) {
         if (debug_only) {
-            flb_debug("[aws_credentials] Profile header has no ending bracket:\n %s",
-                     line);
+            AWS_CREDS_DEBUG("Profile header has no ending bracket:\n %s", line);
         }
         else {
-            flb_warn("[aws_credentials] Profile header has no ending bracket:\n %s",
-                     line);
+            AWS_CREDS_WARN("Profile header has no ending bracket:\n %s", line);
         }
         return FLB_FALSE;
     }
@@ -360,14 +425,7 @@ static flb_sds_t parse_property_value(char *s, int debug_only) {
     }
 
     if (!val) {
-        if (debug_only == FLB_TRUE) {
-            flb_debug("[aws_credentials] Could not parse credential value from"
-                      "%s", s);
-        }
-        else {
-            flb_error("[aws_credentials] Could not parse credential value from"
-                      "%s", s);
-        }
+        AWS_CREDS_ERROR_OR_DEBUG(debug_only, "Could not parse credential value from %s", s);
     }
 
     prop = flb_sds_create(val);
@@ -379,12 +437,96 @@ static flb_sds_t parse_property_value(char *s, int debug_only) {
     return prop;
 }
 
+static int config_file_profile_matches(char *line, char *profile) {
+    char *current_profile = line + 1;
+    char* current_profile_end = strchr(current_profile, ']');
+
+    if (!current_profile_end) {
+        return FLB_FALSE;
+    }
+    *current_profile_end = '\0';
+
+    /*
+     * Non-default profiles look like `[profile <name>]`.
+     * The default profile can look like `[profile default]` or just `[default]`.
+     * This is different than the credentials file, where everything is `[<name>]`.
+     */
+    if (strncmp(current_profile, CONFIG_PROFILE_PREFIX, CONFIG_PROFILE_PREFIX_LEN) != 0) {
+        if (strcmp(current_profile, DEFAULT_PROFILE) != 0) {
+            /* This is not a valid profile line. */
+            return FLB_FALSE;
+        }
+    } else {
+        current_profile += CONFIG_PROFILE_PREFIX_LEN;
+    }
+
+    if (strcmp(current_profile, profile) == 0) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
+static int parse_config_file(char *buf, char* profile, struct flb_aws_credentials** creds,
+                            time_t* expiration, int debug_only)
+{
+    char *line = NULL;
+    char *line_end = NULL;
+    char *prop_val = NULL;
+    char *credential_process = NULL;
+    int found_profile = FLB_FALSE;
+
+    for (line = buf; line[0] != '\0'; line = buf) {
+        /*
+         * Find the next newline and replace it with a null terminator.
+         * That way we can easily manipulate the current line as a string.
+         */
+        line_end = strchr(line, '\n');
+        if (line_end) {
+            *line_end = '\0';
+            buf = line_end + 1;
+        } else {
+            buf = "";
+        }
+
+        if (found_profile != FLB_TRUE) {
+            if (is_profile_line(line) != FLB_TRUE) {
+                continue;
+            }
+            if (config_file_profile_matches(line, profile) != FLB_TRUE) {
+                continue;
+            }
+            found_profile = FLB_TRUE;
+        } else {
+            if (is_profile_line(line) == FLB_TRUE) {
+                break;
+            }
+            prop_val = parse_property_line(line);
+            if (strcmp(line, CREDENTIAL_PROCESS_PROPERTY_NAME) == 0) {
+                credential_process = prop_val;
+            }
+        }
+    }
+
+    if (credential_process) {
+#ifdef FLB_HAVE_AWS_CREDENTIAL_PROCESS
+        if (exec_credential_process(credential_process, creds, expiration) < 0) {
+            return -1;
+        }
+#else
+        AWS_CREDS_WARN("credential_process not supported for this platform");
+        return -1;
+#endif
+    }
+
+    return 0;
+}
+
 /*
  * Parses a shared credentials file.
  * Expects the contents of 'creds' to be initialized to NULL (i.e use calloc).
  */
-static int parse_file(char *buf, char *profile, struct flb_aws_credentials *creds,
-                      int debug_only)
+static int parse_credentials_file(char *buf, char *profile,
+                                  struct flb_aws_credentials *creds, int debug_only)
 {
     char *line;
     char *line_end;
@@ -436,70 +578,152 @@ static int parse_file(char *buf, char *profile, struct flb_aws_credentials *cred
     if (creds->access_key_id && creds->secret_access_key) {
         return 0;
     }
-    if (debug_only == FLB_TRUE) {
-        flb_debug("[aws_credentials] %s and %s keys not parsed in shared "
+    AWS_CREDS_ERROR_OR_DEBUG(debug_only, "%s and %s keys not parsed in shared "
                   "credentials file for profile %s.", ACCESS_KEY_PROPERTY_NAME,
                   SECRET_KEY_PROPERTY_NAME, profile);
-    }
-    else {
-        flb_error("[aws_credentials] %s and %s keys not parsed in shared "
-                  "credentials file for profile %s.", ACCESS_KEY_PROPERTY_NAME,
-                  SECRET_KEY_PROPERTY_NAME, profile);
-    }
     return -1;
 }
 
-static int get_profile(struct flb_aws_provider_profile *implementation,
-                       int debug_only)
-{
-    struct flb_aws_credentials *creds = NULL;
-    int ret;
+static int get_shared_config_credentials(char* config_path,
+                                         char*profile,
+                                         struct flb_aws_credentials** creds,
+                                         time_t* expiration,
+                                         int debug_only) {
+    int result = -1;
     char* buf = NULL;
     size_t size;
+    *creds = NULL;
+    *expiration = 0;
 
-    flb_debug("[aws_credentials] Reading shared credentials file..");
+    AWS_CREDS_DEBUG("Reading shared config file.");
 
-    creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
-    if (!creds) {
+    if (flb_read_file(config_path, &buf, &size) < 0) {
+        if (errno == ENOENT) {
+            AWS_CREDS_DEBUG("Shared config file %s does not exist", config_path);
+            result = 0;
+            goto end;
+        }
         flb_errno();
-        return -1;
+        AWS_CREDS_ERROR_OR_DEBUG(debug_only, "Could not read shared config file %s",
+                                 config_path);
+        result = -1;
+        goto end;
     }
 
-    ret = flb_read_file(implementation->path, &buf, &size);
-    if (ret < 0) {
-        if (debug_only == FLB_TRUE) {
-            flb_debug("[aws_credentials] Could not read shared credentials file %s",
-                      implementation->path);
-        }
-        else {
-            flb_error("[aws_credentials] Could not read shared credentials file %s",
-                      implementation->path);
-        }
-        goto error;
+    if (parse_config_file(buf, profile, creds, expiration, debug_only) < 0) {
+        result = -1;
+        goto end;
     }
 
-    ret = parse_file(buf, implementation->profile, creds, debug_only);
+    result = 0;
+
+end:
+    flb_free(buf);
+    return result;
+}
+
+static int get_shared_credentials(char* credentials_path,
+                                  char* profile,
+                                  struct flb_aws_credentials** creds,
+                                  int debug_only) {
+    int result = -1;
+    char* buf = NULL;
+    size_t size;
+    *creds = NULL;
+
+    *creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
+    if (!*creds) {
+        flb_errno();
+        result = -1;
+        goto end;
+    }
+
+    AWS_CREDS_DEBUG("Reading shared credentials file.");
+
+    if (flb_read_file(credentials_path, &buf, &size) < 0) {
+        if (errno == ENOENT) {
+            AWS_CREDS_ERROR_OR_DEBUG(debug_only, "Shared credentials file %s does not exist",
+                                     credentials_path);
+        } else {
+            flb_errno();
+            AWS_CREDS_ERROR_OR_DEBUG(debug_only, "Could not read shared credentials file %s",
+                                     credentials_path);
+        }
+        result = -1;
+        goto end;
+    }
+
+    if (parse_credentials_file(buf, profile, *creds, debug_only) < 0) {
+        AWS_CREDS_ERROR_OR_DEBUG(debug_only, "Could not parse shared credentials file: "
+                                 "valid profile with name '%s' not found", profile);
+        result = -1;
+        goto end;
+    }
+
+    result = 0;
+
+end:
     flb_free(buf);
 
-    if (ret < 0) {
-        if (debug_only == FLB_TRUE) {
-            flb_debug("[aws_credentials] Could not parse shared credentials file: "
-                      "valid profile with name '%s' not found",
-                      implementation->profile);
+    if (result < 0) {
+        flb_aws_credentials_destroy(*creds);
+        *creds = NULL;
+    }
+
+    return result;
+}
+
+static int refresh_credentials(struct flb_aws_provider_profile *implementation,
+                               int debug_only)
+{
+    struct flb_aws_credentials *creds = NULL;
+    time_t expiration = 0;
+    int ret;
+
+    if (implementation->config_path) {
+        ret = get_shared_config_credentials(implementation->config_path,
+                                            implementation->profile,
+                                            &creds,
+                                            &expiration,
+                                            debug_only);
+        if (ret < 0) {
+            goto error;
         }
-        else {
-            flb_error("[aws_credentials] Could not parse shared credentials file: "
-                      "valid profile with name '%s' not found",
-                      implementation->profile);
+    }
+
+    /*
+     * If we did not find a credential_process in the shared config file, fall back to
+     * the shared credentials file.
+     */
+    if (!creds) {
+        if (!implementation->credentials_path) {
+            AWS_CREDS_ERROR("shared config file contains no credential_process and "
+                            "no shared credentials file was configured");
+            goto error;
         }
-        goto error;
+
+        ret = get_shared_credentials(implementation->credentials_path,
+                                     implementation->profile,
+                                     &creds,
+                                     debug_only);
+        if (ret < 0) {
+            goto error;
+        }
+
+        /* The shared credentials file does not record when the credentials expire. */
+        expiration = 0;
     }
 
     /* unset and free existing credentials */
     flb_aws_credentials_destroy(implementation->creds);
-    implementation->creds = NULL;
-
     implementation->creds = creds;
+
+    if (expiration > 0) {
+        implementation->next_refresh = expiration - FLB_AWS_REFRESH_WINDOW;
+    } else {
+        implementation->next_refresh = 0;
+    }
+
     return 0;
 
 error:

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -83,6 +83,12 @@ if(FLB_AWS)
     aws_credentials_http.c
     aws_credentials_profile.c
     )
+  if(FLB_HAVE_AWS_CREDENTIAL_PROCESS)
+    set(UNIT_TESTS_FILES
+      ${UNIT_TESTS_FILES}
+      aws_credentials_process.c
+      )
+  endif()
 endif()
 
 set(UNIT_TESTS_DATA

--- a/tests/internal/aws_credentials_process.c
+++ b/tests/internal/aws_credentials_process.c
@@ -1,0 +1,496 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_info.h>
+
+#include "aws_credentials_test_internal.h"
+
+#define _TOSTRING(X) #X
+#define TOSTRING(X) _TOSTRING(X)
+#define TESTCASE_NAME() "aws_credentials_process.c:" TOSTRING(__LINE__)
+
+#define MUST_SETENV(name, value) TEST_ASSERT(setenv(name, value, 1) == 0)
+#define MUST_UNSETENV(name) TEST_ASSERT(unsetenv(name) == 0)
+
+static int unset_process_env()
+{
+    int ret;
+
+    ret = unset_profile_env();
+    if (ret < 0) {
+        return -1;
+    }
+
+    ret = unsetenv("_AWS_SECRET_ACCESS_KEY");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = unsetenv("_AWS_SESSION_TOKEN");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = unsetenv("_AWS_EXPIRATION");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = unsetenv("_AWS_EXIT_CODE");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+
+    return 0;
+}
+
+static void test_credential_process_default(void)
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials* creds;
+    char* original_path = getenv("PATH");
+
+    /* Print a newline so the test output starts on its own line. */
+    fprintf(stderr, "\n");
+
+    TEST_CHECK(unset_process_env() == 0);
+
+    MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
+    MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
+
+    provider = flb_profile_provider_create();
+    TEST_ASSERT(provider != NULL);
+
+    /* These environment variables are used by the test credential_process. */
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token");
+    MUST_SETENV("_AWS_EXPIRATION", "+15 minutes");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("default", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Repeated calls to get_credentials should return the cached credentials. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_2");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token_2");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("default", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Calling refresh should fetch the new credentials. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_3");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token_3");
+
+    TEST_ASSERT(provider->provider_vtable->refresh(provider) == 0);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("default", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key_3", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token_3", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    flb_aws_provider_destroy(provider);
+    provider = NULL;
+
+    if (original_path) {
+        MUST_SETENV("PATH", original_path);
+    } else {
+        MUST_UNSETENV("PATH");
+    }
+}
+
+static void test_credential_process_no_expiration(void)
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials* creds;
+    char* original_path = getenv("PATH");
+
+    /* Print a newline so the test output starts on its own line. */
+    fprintf(stderr, "\n");
+
+    TEST_CHECK(unset_process_env() == 0);
+
+    MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
+    MUST_SETENV("AWS_PROFILE", "nondefault");
+    MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
+
+    provider = flb_profile_provider_create();
+    TEST_ASSERT(provider != NULL);
+
+    /* These environment variables are used by the test credential_process. */
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("nondefault", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Repeated calls to get_credentials should return the cached credentials. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_2");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token_2");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("nondefault", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Calling refresh should fetch the new credentials. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_3");
+    MUST_SETENV("_AWS_SESSION_TOKEN", "aws_session_token_3");
+
+    TEST_ASSERT(provider->provider_vtable->refresh(provider) == 0);
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+     TEST_CHECK(strcmp("nondefault", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key_3", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("aws_session_token_3", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    flb_aws_provider_destroy(provider);
+    provider = NULL;
+
+    if (original_path) {
+        MUST_SETENV("PATH", original_path);
+    } else {
+        MUST_UNSETENV("PATH");
+    }
+}
+
+struct credential_process_expired_testcase {
+    char* name;
+    char* expiration;
+};
+
+struct credential_process_expired_testcase credential_process_expired_testcases[] = {
+    /* Credentials that have already expired will be refreshed. */
+    {
+        .name = "expired",
+        .expiration = "-5 minutes",
+    },
+
+    /* Credentials that expire within the next minute will be refreshed. */
+    {
+        .name = "expiring soon",
+        .expiration = "+30 seconds",
+    },
+};
+
+static void test_credential_process_expired_helper(char* expiration)
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials* creds;
+    char* original_path = getenv("PATH");
+
+    TEST_CHECK(unset_process_env() == 0);
+
+    MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
+    MUST_SETENV("AWS_PROFILE", "nondefault");
+    MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
+
+    provider = flb_profile_provider_create();
+    TEST_ASSERT(provider != NULL);
+
+    /* These environment variable are used by the test credential_process. */
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key");
+    if (expiration) {
+        MUST_SETENV("_AWS_EXPIRATION", expiration);
+    }
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("nondefault", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key", creds->secret_access_key) == 0);
+    TEST_CHECK(creds->session_token == NULL);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Repeated calls to get_credentials should fetch new credentials. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_2");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("nondefault", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key_2", creds->secret_access_key) == 0);
+    TEST_CHECK(creds->session_token == NULL);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    flb_aws_provider_destroy(provider);
+    provider = NULL;
+
+    if (original_path) {
+        MUST_SETENV("PATH", original_path);
+    } else {
+        MUST_UNSETENV("PATH");
+    }
+}
+
+static void test_credential_process_expired(void)
+{
+    int i;
+    int num_testcases = sizeof(credential_process_expired_testcases) /
+                        sizeof(credential_process_expired_testcases[0]);
+    struct credential_process_expired_testcase* current_testcase = NULL;
+
+    /* Print a newline so the test output starts on its own line. */
+    fprintf(stderr, "\n");
+
+    for (i = 0; i < num_testcases; i++) {
+        current_testcase = &credential_process_expired_testcases[i];
+        TEST_CASE(current_testcase->name);
+        test_credential_process_expired_helper(current_testcase->expiration);
+    }
+}
+
+static void test_credential_process_failure(void)
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials* creds;
+    char* original_path = getenv("PATH");
+
+    /* Print a newline so the test output starts on its own line. */
+    fprintf(stderr, "\n");
+
+    TEST_CHECK(unset_process_env() == 0);
+
+    MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
+    MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
+
+    provider = flb_profile_provider_create();
+    TEST_ASSERT(provider != NULL);
+
+    /* These environment variables are used by the test credential_process. */
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key");
+    MUST_SETENV("_AWS_EXIT_CODE", "1");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds == NULL);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    /* Repeated calls to get_credentials should try to fetch the credentials again. */
+
+    MUST_SETENV("_AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_2");
+    MUST_UNSETENV("_AWS_EXIT_CODE");
+
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+
+    TEST_CHECK(strcmp("default", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("aws_secret_access_key_2", creds->secret_access_key) == 0);
+
+    flb_aws_credentials_destroy(creds);
+    creds = NULL;
+
+    flb_aws_provider_destroy(provider);
+    provider = NULL;
+
+    if (original_path) {
+        MUST_SETENV("PATH", original_path);
+    } else {
+        MUST_UNSETENV("PATH");
+    }
+}
+
+struct parse_credential_process_testcase {
+    char* name;
+    char* input;
+
+    /*
+     * NULL-terminated array of tokens that should be returned.
+     * The choice of 10 here is completely arbitrary.
+     * Since a char*[] cannot be NULL, we need a separate flag for the failure cases.
+     */
+    char* expected[10];
+    int should_fail;
+};
+
+struct parse_credential_process_testcase parse_credential_process_testcases[] = {
+    {
+        .name = TESTCASE_NAME(),
+        .input = "my-process",
+        .expected = { "my-process", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "   my-process ",
+        .expected = { "my-process", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "my-process arg1 arg2",
+        .expected = { "my-process", "arg1", "arg2", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = " my-process   arg1    arg2 ",
+        .expected = { "my-process", "arg1", "arg2", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "my-process \"arg1 \" arg2 \"\"",
+        .expected = { "my-process", "arg1 ", "arg2", "", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "\"my process\"",
+        .expected = { "my process", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = " \"my process\"    \" \" ",
+        .expected = { "my process", " ", NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "",
+        .expected = { NULL },
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "\"unterminated",
+        .should_fail = FLB_TRUE,
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = " \"unterminated ",
+        .should_fail = FLB_TRUE,
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "abc\"def\"",
+        .should_fail = FLB_TRUE,
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = " abc\"def\" ",
+        .should_fail = FLB_TRUE,
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = "\"abc\"def",
+        .should_fail = FLB_TRUE,
+    },
+    {
+        .name = TESTCASE_NAME(),
+        .input = " \"abc\"def ",
+        .should_fail = FLB_TRUE,
+    },
+};
+
+static void test_parse_credential_process_helper(char* input, char** expected)
+{
+    char* cpy = NULL;
+    char** tokens = NULL;
+    int i = 0;
+    int input_len = strlen(input) + 1;
+
+    /*
+     * String literals are immutable, but parse_credential_process modifies its input.
+     * To circumvent this, copy the literal into a mutable string.
+     * Note: Because the return value of parse_credential_process will contain pointers
+     * into this string, we cannot free the copy until we are done with the token array.
+     */
+    cpy = flb_malloc(input_len + 1);
+    TEST_ASSERT(cpy != NULL);
+    memcpy(cpy, input, input_len);
+
+    tokens = parse_credential_process(cpy);
+
+    if (expected) {
+        TEST_ASSERT(tokens != NULL);
+        for (i = 0; expected[i]; i++) {
+            TEST_ASSERT_(tokens[i] != NULL, "expected='%s', got=(null)", expected[i]);
+            TEST_CHECK_(strcmp(expected[i], tokens[i]) == 0, "expected='%s', got='%s'",
+                        expected[i], tokens[i]);
+        }
+        TEST_ASSERT_(tokens[i] == NULL, "expected=(null), got='%s'", tokens[i]);
+    }
+    else {
+        TEST_ASSERT(tokens == NULL);
+    }
+
+    flb_free(tokens);
+    flb_free(cpy);
+}
+
+static void test_parse_credential_process(void)
+{
+    int i;
+    int num_testcases = sizeof(parse_credential_process_testcases) /
+                        sizeof(parse_credential_process_testcases[0]);
+    struct parse_credential_process_testcase* current_testcase = NULL;
+    char** expected = NULL;
+
+    /* Print a newline so the test output starts on its own line. */
+    fprintf(stderr, "\n");
+
+    for (i = 0; i < num_testcases; i++) {
+        current_testcase = &parse_credential_process_testcases[i];
+        TEST_CASE(current_testcase->name);
+        if (current_testcase->should_fail) {
+            expected = NULL;
+        }
+        else {
+            expected = current_testcase->expected;
+        }
+        test_parse_credential_process_helper(current_testcase->input, expected);
+    }
+}
+
+TEST_LIST = {
+    { "test_credential_process_default", test_credential_process_default },
+    { "test_credential_process_no_expiration", test_credential_process_no_expiration },
+    { "test_credential_process_expired", test_credential_process_expired },
+    { "test_credential_process_failure", test_credential_process_failure },
+    { "test_parse_credential_process", test_parse_credential_process },
+    { 0 }
+};

--- a/tests/internal/aws_credentials_profile.c
+++ b/tests/internal/aws_credentials_profile.c
@@ -5,13 +5,11 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_info.h>
 
-#include "flb_tests_internal.h"
+#include "aws_credentials_test_internal.h"
 
-#define TEST_CREDENTIALS_FILE  FLB_TESTS_DATA_PATH "/data/aws_credentials/\
-shared_credentials_file.ini"
+#define TEST_CREDENTIALS_FILE AWS_TEST_DATA_PATH("shared_credentials_file.ini")
 
-#define TEST_CREDENTIALS_NODEFAULT  FLB_TESTS_DATA_PATH "/data/aws_credentials/\
-shared_credentials_file_nodefault.ini"
+#define TEST_CREDENTIALS_NODEFAULT AWS_TEST_DATA_PATH("shared_credentials_file_nodefault.ini")
 
 /* these credentials look real but are not */
 #define AKID_DEFAULT_PROFILE  "ASIASDMPIJWXJAXT3O3T"
@@ -39,27 +37,6 @@ HjefwKEk9HjZfejC5WuCS173qFrU9kNb4IrYhnK+wmRzzJfgpWUwerdiJKBz95j1iW9rP1a\
 #define SKID_WEIRDWHITESPACE_PROFILE "skidweird"
 #define TOKEN_WEIRDWHITESPACE_PROFILE "tokenweird///token=="
 
-static int unset_profile_env()
-{
-    int ret;
-    ret = unsetenv("AWS_SHARED_CREDENTIALS_FILE");
-    if (ret < 0) {
-        flb_errno();
-        return -1;
-    }
-    ret = unsetenv("AWS_DEFAULT_PROFILE");
-    if (ret < 0) {
-        flb_errno();
-        return -1;
-    }
-    ret = unsetenv("AWS_PROFILE");
-    if (ret < 0) {
-        flb_errno();
-        return -1;
-    }
-    return 0;
-}
-
 static void test_profile_default()
 {
     struct flb_aws_provider *provider;
@@ -68,25 +45,16 @@ static void test_profile_default()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_FILE, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_DEFAULT_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_DEFAULT_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(strcmp(TOKEN_DEFAULT_PROFILE, creds->session_token) == 0);
@@ -94,10 +62,8 @@ static void test_profile_default()
     flb_aws_credentials_destroy(creds);
 
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_DEFAULT_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_DEFAULT_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(strcmp(TOKEN_DEFAULT_PROFILE, creds->session_token) == 0);
@@ -121,31 +87,19 @@ static void test_profile_non_default()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_FILE, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     ret = setenv("AWS_PROFILE", "nondefault", 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_NONDEFAULT_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_NONDEFAULT_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(creds->session_token == NULL);
@@ -153,10 +107,8 @@ static void test_profile_non_default()
     flb_aws_credentials_destroy(creds);
 
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_NONDEFAULT_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_NONDEFAULT_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(creds->session_token == NULL);
@@ -180,31 +132,19 @@ static void test_profile_no_space()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_FILE, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     ret = setenv("AWS_DEFAULT_PROFILE", "nospace", 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_NOSPACE_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_NOSPACE_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(strcmp(TOKEN_NOSPACE_PROFILE, creds->session_token) == 0);
@@ -212,10 +152,8 @@ static void test_profile_no_space()
     flb_aws_credentials_destroy(creds);
 
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(creds != NULL);
+
     TEST_CHECK(strcmp(AKID_NOSPACE_PROFILE, creds->access_key_id) == 0);
     TEST_CHECK(strcmp(SKID_NOSPACE_PROFILE, creds->secret_access_key) == 0);
     TEST_CHECK(strcmp(TOKEN_NOSPACE_PROFILE, creds->session_token) == 0);
@@ -239,24 +177,14 @@ static void test_profile_weird_whitespace()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_FILE, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     ret = setenv("AWS_DEFAULT_PROFILE", "weirdwhitespace", 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -300,24 +228,14 @@ static void test_profile_missing()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_FILE, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     ret = setenv("AWS_DEFAULT_PROFILE", "missing", 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -347,18 +265,11 @@ static void test_profile_nodefault()
 
     TEST_CHECK(unset_profile_env() == 0);
 
-    /* set environment */
     ret = setenv("AWS_SHARED_CREDENTIALS_FILE", TEST_CREDENTIALS_NODEFAULT, 1);
-    if (ret < 0) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(ret == 0);
 
     provider = flb_profile_provider_create();
-    if (!provider) {
-        flb_errno();
-        return;
-    }
+    TEST_ASSERT(provider != NULL);
 
     /* repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -380,12 +291,13 @@ static void test_profile_nodefault()
     TEST_CHECK(unset_profile_env() == 0);
 }
 
+
 TEST_LIST = {
-    { "test_profile_default" , test_profile_default},
-    { "test_profile_non_default" , test_profile_non_default},
-    { "test_profile_no_space" , test_profile_no_space},
-    { "test_profile_weird_whitespace" , test_profile_weird_whitespace},
-    { "test_profile_missing" , test_profile_missing},
-    { "test_profile_nodefault" , test_profile_nodefault},
+    { "test_profile_default", test_profile_default },
+    { "test_profile_non_default", test_profile_non_default },
+    { "test_profile_no_space", test_profile_no_space },
+    { "test_profile_weird_whitespace", test_profile_weird_whitespace },
+    { "test_profile_missing", test_profile_missing },
+    { "test_profile_nodefault", test_profile_nodefault },
     { 0 }
 };

--- a/tests/internal/aws_credentials_test_internal.h
+++ b/tests/internal/aws_credentials_test_internal.h
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef AWS_CREDENTIALS_TEST_INTERNAL_H
+
+#define AWS_CREDENTIALS_TEST_INTERNAL_H
+
+#include "flb_tests_internal.h"
+
+#define AWS_TEST_DATA_PATH(FILE_PATH) FLB_TESTS_DATA_PATH "data/aws_credentials/" FILE_PATH
+
+static int unset_profile_env()
+{
+    int ret;
+    ret = unsetenv("HOME");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+    ret = unsetenv("AWS_CONFIG_FILE");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+    ret = unsetenv("AWS_SHARED_CREDENTIALS_FILE");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+    ret = unsetenv("AWS_DEFAULT_PROFILE");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+    ret = unsetenv("AWS_PROFILE");
+    if (ret < 0) {
+        flb_errno();
+        return -1;
+    }
+    return 0;
+}
+
+#endif /* AWS_CREDENTIALS_TEST_INTERNAL_H */

--- a/tests/internal/data/aws_credentials/credential_process/aws-credential-process
+++ b/tests/internal/data/aws_credentials/credential_process/aws-credential-process
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+printf '{"Version":1,"AccessKeyId":"%s","SecretAccessKey":"%s"' "${1}" "${_AWS_SECRET_ACCESS_KEY}"
+if [ -n "${_AWS_SESSION_TOKEN}" ]; then
+    printf ',"SessionToken":"%s"' "${_AWS_SESSION_TOKEN}"
+fi
+if [ -n "${_AWS_EXPIRATION}" ]; then
+    printf ',"Expiration":"%s"' "$(/bin/date -d "${_AWS_EXPIRATION}" --utc '+%Y-%m-%dT%H:%M:%SZ')"
+fi
+printf '}'
+
+if [ -n "${_AWS_EXIT_CODE}" ]; then
+    exit "${_AWS_EXIT_CODE}"
+fi

--- a/tests/internal/data/aws_credentials/shared_config.ini
+++ b/tests/internal/data/aws_credentials/shared_config.ini
@@ -1,0 +1,9 @@
+[default]
+region = us-east-1
+credential_process = aws-credential-process default
+output = json
+
+[profile nondefault]
+region = us-east-1
+credential_process = aws-credential-process nondefault
+output = json


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

<!-- Provide summary of changes -->

Adds support for credential_process in the AWS config file. https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html

This implementation adds support for Linux only.

cc @PettitWesley 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #3621.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

[fluent-bit-debug.txt](https://github.com/fluent/fluent-bit/files/6749989/fluent-bit-debug.txt)
[fb-valgrind-results.txt](https://github.com/fluent/fluent-bit/files/6736427/fb-valgrind-results.txt)

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
