### PR TITLE
workflows: allow single quote in commit message

### DIFF
--- a/.github/workflows/pr-commit-message.yaml
+++ b/.github/workflows/pr-commit-message.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check commit subject complies with https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z0-9A-Z\-_\s\,\.\/]+\:[ ]{0,1}[a-zA-Z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/\"\,><\+\[\]\!\*\\]+$'
+          pattern: '^[a-z0-9A-Z\-_\s\,\.\/]+\:[ ]{0,1}[a-zA-Z]+[a-zA-Z0-9 \-\.\:_\#\(\)=\/''\"\,><\+\[\]\!\*\\]+$'
           error: 'Invalid commit subject. Please refer to: https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#commit-changes'
           checkAllCommitMessages: 'false'
           excludeDescription: 'true'


### PR DESCRIPTION
This patch is to allow single quote of commit message. Note: #3697 #3465 

Single quote needs to be escaped `''`.
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals
`You must use single quotes. Escape literal single-quotes with a single quote.`

I tested my repository.
[Test result](https://github.com/nokute78/gh-actions-test/runs/2951151476?check_suite_focus=true)
[Actions configuration](https://github.com/nokute78/gh-actions-test/blob/main/.github/workflows/fluent-bit-pr-commit-message.yaml)


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
