### PR TITLE
input_chunks: fix handling of corrupted chunks

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -115,7 +115,12 @@ static int cb_queue_chunks(struct flb_input_instance *in,
             flb_plg_error(ctx->ins, "removing chunk %s:%s from the queue",
                           sbc->stream->name, sbc->chunk->name);
             cio_chunk_down(sbc->chunk);
-            cio_chunk_close(sbc->chunk, FLB_FALSE);
+
+            /*
+             * If the file cannot be mapped, just drop it. Failures are all
+             * associated with data corruption.
+             */
+            cio_chunk_close(sbc->chunk, FLB_TRUE);
             mk_list_del(&sbc->_head);
             flb_free(sbc);
             continue;


### PR DESCRIPTION

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
