### PR TITLE
out_prometheus_exporter: disable http stop on exit

### DIFF
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -106,7 +106,7 @@ static int cb_prom_exit(void *data, struct flb_config *config)
 {
     struct prom_exporter *ctx = data;
 
-    prom_http_server_stop(ctx->http);
+    //FIXME: prom_http_server_stop(ctx->http);
     prom_http_server_destroy(ctx->http);
     flb_free(ctx);
 


### PR DESCRIPTION
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
