### PR TITLE
out_azure_bob: fix coroutine swap

### DIFF
--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -260,11 +260,11 @@ static int create_blob(struct flb_azure_blob *ctx, char *name)
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
     flb_sds_destroy(uri);
-    flb_upstream_conn_release(u_conn);
 
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error sending append_blob");
         flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_RETRY;
     }
 
@@ -281,10 +281,12 @@ static int create_blob(struct flb_azure_blob *ctx, char *name)
                           c->resp.status);
         }
         flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_RETRY;
     }
 
     flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
     return FLB_OK;
 }
 
@@ -334,8 +336,8 @@ static int create_container(struct flb_azure_blob *ctx, char *name)
     /* Validate http response */
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error requesting container creation");
-        flb_upstream_conn_release(u_conn);
         flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_FALSE;
     }
 

--- a/plugins/out_azure_blob/azure_blob_blockblob.c
+++ b/plugins/out_azure_blob/azure_blob_blockblob.c
@@ -211,11 +211,13 @@ int azb_block_blob_commit(struct flb_azure_blob *ctx, char *blockid, char *tag,
     if (c->resp.status == 201) {
         flb_plg_info(ctx->ins, "blob id %s committed successfully", blockid);
         flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_OK;
     }
     else if (c->resp.status == 404) {
         flb_plg_info(ctx->ins, "blob not found: %s", c->uri);
         flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_RETRY;
     }
     else if (c->resp.payload_size > 0) {
@@ -223,6 +225,7 @@ int azb_block_blob_commit(struct flb_azure_blob *ctx, char *blockid, char *tag,
                       blockid, c->resp.payload);
         if (strstr(c->resp.payload, "must be 0 for Create Append")) {
             flb_http_client_destroy(c);
+            flb_upstream_conn_release(u_conn);
             return FLB_RETRY;
         }
     }
@@ -230,6 +233,7 @@ int azb_block_blob_commit(struct flb_azure_blob *ctx, char *blockid, char *tag,
         flb_plg_error(ctx->ins, "cannot append content to blob");
     }
     flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
 
     return FLB_OK;
 }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -455,7 +455,7 @@ int64_t flb_utils_hex2int(char *hex, int len)
 
     while ((c = *hex++) && i < len) {
         /* Ensure no overflow */
-        if (res >= (int)((INT64_MAX/0x10) - 0xff)) {
+        if (res >= (int64_t)((INT64_MAX/0x10) - 0xff)) {
             return -1;
         }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
After successful / failed push to Azure Blob Storage, the socket FDs are not cleaned/unregistered which leads the process to crash at `flb_coro_resume` -> `co_switch()` because `rdi` becomes bogus.
The fix is to clean it.
It also addresses `int64_t` support issue for commit e70f759b which is necessary for the Azure Blob plugin.
 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #2839

**Sample Configuration to cause the issue**

100% reproducible after 3-4 mins on my Ubuntu20 amd64 VM

```
[SERVICE]
    Flush 10
    Daemon Off
    Log_Level info
    HTTP_Server On
    HTTP_Listen 0.0.0.0
    HTTP_Port 2020
[INPUT]
    Name              tail
    Tag               hoge.*
    Path              /var/tmp/*.log
    DB                /var/tmp/flb.db
    Mem_Buf_Limit     5MB
    Skip_Long_Lines   On
    Refresh_Interval  10
[OUTPUT]
    name                  azure_blob
    match                 *
    account_name          <replace-me>
    shared_key            <replace-me>
    path                  <replace-me>
    blob_type             blockblob
    container_name        logs
    auto_create_container on
    tls                   on
```

**Debug Log before the fix**

```
[2021/06/20 09:36:27] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:27] [debug] [input:tail:tail.0] scanning path /var/tmp/*.log
[2021/06/20 09:36:27] [debug] [input:tail:tail.0] scan_blog add(): dismissed: /var/tmp/hoge.log, inode 3408091
[2021/06/20 09:36:27] [debug] [input:tail:tail.0] 0 new files found on path '/var/tmp/*.log'
[2021/06/20 09:36:28] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:28] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:29] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:30] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:30] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:31] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:32] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:33] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:34] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:34] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:35] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:36] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:37] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:37] [debug] [input:tail:tail.0] scanning path /var/tmp/*.log
[2021/06/20 09:36:37] [debug] [input:tail:tail.0] scan_blog add(): dismissed: /var/tmp/hoge.log, inode 3408091
[2021/06/20 09:36:37] [debug] [input:tail:tail.0] 0 new files found on path '/var/tmp/*.log'
[2021/06/20 09:36:38] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY
[2021/06/20 09:36:39] [debug] [input:tail:tail.0] inode=3408091 events: IN_MODIFY

Thread 2 "flb-pipeline" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff78c9700 (LWP 271504)]
0x00005555558c5543 in co_swap_function ()
(gdb) bt
#0  0x00005555558c5543 in co_swap_function ()
#1  0x00005555558c6742 in co_switch (handle=0x957282780b) at /home/scott/repo/OSS/fluent-bit/lib/monkey/deps/flb_libco/amd64.c:158
#2  0x00005555555cbb33 in flb_coro_resume (coro=0x7ffff0062be0) at /home/scott/repo/OSS/fluent-bit/include/fluent-bit/flb_coro.h:103
#3  flb_engine_start (config=0x555555a002d0) at /home/scott/repo/OSS/fluent-bit/src/flb_engine.c:690
#4  0x00005555555af803 in flb_lib_worker (data=0x555555a002a0) at /home/scott/repo/OSS/fluent-bit/src/flb_lib.c:493
#5  0x00007ffff7fa3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#6  0x00007ffff79ef293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

(gdb) info threads
  Id   Target Id                                            Frame
  1    Thread 0x7ffff78caa00 (LWP 271493) "fluent-bit.flb_" 0x00007ffff79ad3bf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7fffffffdf20, rem=rem@entry=0x7fffffffdf20)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
* 2    Thread 0x7ffff78c9700 (LWP 271504) "flb-pipeline"    0x00005555558c5543 in co_swap_function ()
  3    Thread 0x7ffff70c8700 (LWP 271505) "flb-logger"      0x00007ffff79ef5ce in epoll_wait (epfd=9, events=0x7ffff00048b0, maxevents=32, timeout=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
  4    Thread 0x7ffff68c7700 (LWP 271506) "monkey: server"  0x00007ffff79ef5ce in epoll_wait (epfd=32, events=0x7ffff0055fc0, maxevents=8, timeout=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
  5    Thread 0x7ffff60c6700 (LWP 271507) "monkey: clock"   0x00007ffff79ad3bf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7ffff60c5bd0, rem=rem@entry=0x7ffff60c5bd0)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
  6    Thread 0x7ffff58c5700 (LWP 271508) "monkey: wrk/0"   0x00007ffff79ef5ce in epoll_wait (epfd=35, events=0x7fffec000ef0, maxevents=256, timeout=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30

(gdb) info registers
rax            0x957282780b        641871280139
rbx            0x7ffff78c94f8      140737346573560
rcx            0x7ffff79ef5ce      140737347777998
rdx            0x957282780b        641871280139
rsi            0x7ffff78c94f8      140737346573560
rdi            0x957282780b        641871280139
rbp            0x7ffff78c8b40      0x7ffff78c8b40
rsp            0x7ffff78c8b18      0x7ffff78c8b18
r8             0x0                 0
r9             0x7ffff0000780      140737219921792
r10            0xffffffff          4294967295
r11            0x0                 0
r12            0x5555558c5540      93824995841344
r13            0x7fffffffde2f      140737488346671
r14            0x7fffffffded0      140737488346832
r15            0x7ffff78c8d00      140737346571520
rip            0x5555558c5543      0x5555558c5543 <co_swap_function+3>
eflags         0x10202             [ IF RF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0

(gdb) disass
Dump of assembler code for function co_swap_function:
   0x00005555558c5540 <+0>:     mov    QWORD PTR [rsi],rsp
=> 0x00005555558c5543 <+3>:     mov    rsp,QWORD PTR [rdi]
   0x00005555558c5546 <+6>:     pop    rax
   0x00005555558c5547 <+7>:     mov    QWORD PTR [rsi+0x8],rbp
   0x00005555558c554b <+11>:    mov    QWORD PTR [rsi+0x10],rbx
   0x00005555558c554f <+15>:    mov    QWORD PTR [rsi+0x18],r12
   0x00005555558c5553 <+19>:    mov    QWORD PTR [rsi+0x20],r13
   0x00005555558c5557 <+23>:    mov    QWORD PTR [rsi+0x28],r14

(gdb) x $rdi
0x957282780b:   Cannot access memory at address 0x957282780b
```

**Log after the fix**

Without the fix, the process crashes within 3-4 mins. FDs for outgoing sockets were changing.
After the fix, it didn't crash for > 5 hrs. FDs for outgoing sockets were pooled and recycled as expected.

```
[2021/07/01 04:09:55] [ info] [engine] started (pid=2915132)
…
[2021/07/01 04:10:04] [ info] [output:azure_blob:azure_blob.0] container 'logs' not found, trying to create it
[2021/07/01 04:10:04] [ info] [output:azure_blob:azure_blob.0] container 'logs' created sucessfully
[2021/07/01 04:10:05] [ info] [output:azure_blob:azure_blob.0] content appended to blob successfully
[2021/07/01 04:10:05] [ info] [output:azure_blob:azure_blob.0] blob id Zmxi…. committed successfully
…
[2021/07/01 04:15:04] [ info] [output:azure_blob:azure_blob.0] content appended to blob successfully
[2021/07/01 04:15:04] [ info] [output:azure_blob:azure_blob.0] blob id Zmxi… committed successfully
…
[2021/07/01 09:56:34] [ info] [output:azure_blob:azure_blob.0] content appended to blob successfully
[2021/07/01 09:56:34] [ info] [output:azure_blob:azure_blob.0] blob id Zmxi… committed successfully
(survived for > 5hrs, no memory/handle leak)
```

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
