### PR TITLE
lib: mbedtls: set compiler flag to c99

### DIFF
--- a/lib/mbedtls-2.26.0/CMakeLists.txt
+++ b/lib/mbedtls-2.26.0/CMakeLists.txt
@@ -173,6 +173,8 @@ string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 
 include(CheckCCompilerFlag)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+
 if(CMAKE_COMPILER_IS_GNU)
     # some warnings we want are not available with old GCC versions
     # note: starting with CMake 2.8 we could use CMAKE_C_COMPILER_VERSION


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <edsiper@gmail.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
