### PR TITLE
in_node_exporter_metrics: sanitize meminfo metric names

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_meminfo_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_meminfo_linux.c
@@ -32,6 +32,8 @@ static int meminfo_configure(struct flb_ne *ctx)
 {
     int ret;
     int parts;
+    int len;
+    char *p;
     char desc[] = "Memory information field ";
     struct cmt_gauge *g;
     struct mk_list *head;
@@ -82,8 +84,20 @@ static int meminfo_configure(struct flb_ne *ctx)
         /* set metric name */
         entry = mk_list_entry_first(&split_list, struct flb_slist_entry, _head);
 
+        if ((p = strstr(entry->str, "(anon)")) ||
+            (p = strstr(entry->str, "(file)"))) {
+            *p = '_';
+            len = flb_sds_len(entry->str) - 2;
+            flb_sds_len_set(entry->str, len);
+        }
+        else {
+            len = flb_sds_len(entry->str) - 1;
+            flb_sds_len_set(entry->str, len);
+        }
+        entry->str[len] = '\0';
+
         flb_sds_len_set(metric_name, 0);
-        flb_sds_cat(metric_name, entry->str, flb_sds_len(entry->str) - 1);
+        flb_sds_cat(metric_name, entry->str, flb_sds_len(entry->str));
 
         /* Metric description */
         flb_sds_len_set(metric_desc, 0);
@@ -151,10 +165,12 @@ static int meminfo_update(struct flb_ne *ctx)
 {
     int i = 0;
     int ret;
+    int len;
     int parts;
     uint64_t ts;
     double val;
     size_t out_size;
+    char *p;
     flb_sds_t tmp;
     flb_sds_t metric_name = NULL;
     struct cmt_gauge *g;
@@ -189,6 +205,13 @@ static int meminfo_update(struct flb_ne *ctx)
         /* Metric name */
         entry = mk_list_entry_first(&split_list, struct flb_slist_entry, _head);
         metric_name = entry->str;
+
+        if ((p = strstr(entry->str, "(anon)")) ||
+            (p = strstr(entry->str, "(file)"))) {
+            *p = '_';
+            len = flb_sds_len(metric_name) - 1;
+            flb_sds_len_set(metric_name, len);
+        }
 
         /* Metric value */
         entry = mk_list_entry_next(&split_list, struct flb_slist_entry, _head,


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <edsiper@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
