### PR TITLE
in_node_exporter_metrics: add 'uname' collector

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -2,6 +2,7 @@ set(src
   ne_cpu.c
   ne_meminfo.c
   ne_diskstats.c
+  ne_uname.c
   ne_utils.c
   ne_config.c
   ne.c

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -32,6 +32,7 @@
 #include "ne_cpufreq.h"
 #include "ne_meminfo.h"
 #include "ne_diskstats.h"
+#include "ne_uname.h"
 
 static void update_metrics(struct flb_input_instance *ins, struct flb_ne *ctx)
 {
@@ -42,6 +43,7 @@ static void update_metrics(struct flb_input_instance *ins, struct flb_ne *ctx)
     ne_cpufreq_update(ctx);
     ne_meminfo_update(ctx);
     ne_diskstats_update(ctx);
+    ne_uname_update(ctx);
 
     /* Append the updated metrics */
     ret = flb_input_metrics_append(ins, NULL, 0, ctx->cmt);
@@ -96,6 +98,7 @@ static int in_ne_init(struct flb_input_instance *in,
     ne_cpufreq_init(ctx);
     ne_meminfo_init(ctx);
     ne_diskstats_init(ctx);
+    ne_uname_init(ctx);
 
     update_metrics(in, ctx);
     return 0;

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -76,6 +76,9 @@ struct flb_ne {
     void *dt_metrics;
     struct flb_regex *dt_regex_skip_devices;
 
+    /* uname */
+    struct cmt_gauge *uname;
+
     /* filesystem: abbreviation 'fs' */
     struct flb_regex *fs_regex_skip_mount;
     struct flb_regex *fs_regex_skip_fs_types;

--- a/plugins/in_node_exporter_metrics/ne_uname.c
+++ b/plugins/in_node_exporter_metrics/ne_uname.c
@@ -1,0 +1,23 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_uname_linux.c"
+#endif

--- a/plugins/in_node_exporter_metrics/ne_uname.h
+++ b/plugins/in_node_exporter_metrics/ne_uname.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_UNAME_H
+#define FLB_IN_NE_UNAME_H
+
+#include "ne.h"
+
+int ne_uname_init(struct flb_ne *ctx);
+int ne_uname_update(struct flb_ne *ctx);
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_uname_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_uname_linux.c
@@ -1,0 +1,85 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+#include <unistd.h>
+#include <sys/utsname.h>
+
+static int uname_configure(struct flb_ne *ctx)
+{
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(ctx->cmt, "node", "uname", "info",
+                         "Labeled system information as provided by the uname system call.",
+                         6, (char *[])
+                         {
+                             "sysname",
+                             "release",
+                             "version",
+                             "machine",
+                             "nodename",
+                             "domainname"
+                         });
+    if (!g) {
+        return -1;
+    }
+    ctx->uname = g;
+    return 0;
+}
+
+static int uname_update(struct flb_ne *ctx)
+{
+    int ret;
+    uint64_t ts;
+    struct utsname u = {0};
+
+
+    uname(&u);
+
+    ts = cmt_time_now();
+    ret = cmt_gauge_set(ctx->uname, ts, 1, 6,
+                        (char *[]) {
+                            u.sysname,
+                            u.release,
+                            u.version,
+                            u.machine,
+                            u.nodename,
+                            u.domainname});
+    return ret;
+}
+
+int ne_uname_init(struct flb_ne *ctx)
+{
+    uname_configure(ctx);
+    return 0;
+}
+
+int ne_uname_update(struct flb_ne *ctx)
+{
+    uname_update(ctx);
+    return 0;
+}


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <edsiper@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
