### PR TITLE
out_prometheus_exporter: add destructor callback

### DIFF
--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -77,6 +77,29 @@ static int cleanup_metrics()
     return c;
 }
 
+/* destructor callback */
+static void destruct_metrics(void *data)
+{
+    int c = 0;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct mk_list *metrics_list = (struct mk_list*)data;
+    struct prom_http_buf *entry;
+
+    if (!metrics_list) {
+        return;
+    }
+
+    mk_list_foreach_safe(head, tmp, metrics_list) {
+        entry = mk_list_entry(head, struct prom_http_buf, _head);
+        mk_list_del(&entry->_head);
+        flb_free(entry->buf_data);
+        flb_free(entry);
+    }
+
+    flb_free(metrics_list);
+}
+
 /*
  * Callback invoked every time a new payload of Metrics is received from
  * Fluent Bit engine through Message Queue channel.
@@ -126,7 +149,7 @@ static int http_server_mq_create(struct prom_http *ph)
 {
     int ret;
 
-    pthread_key_create(&ph_metrics_key, NULL);
+    pthread_key_create(&ph_metrics_key, destruct_metrics);
 
     ret = mk_mq_create(ph->ctx, "/metrics", cb_mq_metrics, NULL);
     if (ret == -1) {


### PR DESCRIPTION
This patch is to destruct pthread specific data.

Valgrind reports `struct prom_http_buf` is not released.
This PR is to fix it.
```
==14380== 16,980 (40 direct, 16,940 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 4
==14380==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==14380==    by 0x249AA8: flb_malloc (flb_mem.h:62)
==14380==    by 0x249D62: cb_mq_metrics (prom_http.c:105)
==14380==    by 0x4B842E: mk_fifo_worker_read (mk_fifo.c:431)
==14380==    by 0x4C7EB7: mk_server_worker_loop (mk_server.c:569)
==14380==    by 0x4BE9AC: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==14380==    by 0x4864608: start_thread (pthread_create.c:477)
==14380==    by 0x4B10292: clone (clone.S:95)

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Configuration file

https://github.com/fluent/fluent-bit/blob/34cbedb70f91bf9744ec2ca87add9b8ef79baefc/conf/fluent-bit-metrics.conf
```
#
# After starting the service try it with:
#
# $ curl http://127.0.0.1:2021/metrics
#
[SERVICE]
    flush           1
    log_level       info

[INPUT]
    name            node_exporter_metrics
    tag             node_metrics
    scrape_interval 2

[OUTPUT]
    name            prometheus_exporter
    match           node_metrics
    listen          0.0.0.0
    port            2021
    # Add user-defined labels
    # -----------------------
    # add_label       app fluent-bit
    # add_label       color blue
```

## Valgrind output

A reported error is not related this PR.
```
$ valgrind --leak-check=full bin/fluent-bit -c ../conf/fluent-bit-metrics.conf 
==11357== Memcheck, a memory error detector
==11357== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11357== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==11357== Command: bin/fluent-bit -c ../conf/fluent-bit-metrics.conf
==11357== 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/07 19:15:18] [ info] [engine] started (pid=11357)
[2021/07/07 19:15:18] [ info] [storage] version=1.1.1, initializing...
[2021/07/07 19:15:18] [ info] [storage] in-memory
[2021/07/07 19:15:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/07 19:15:18] [ info] [cmetrics] version=0.1.0
[2021/07/07 19:15:18] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2021/07/07 19:15:18] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2021/07/07 19:15:19] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2021/07/07 19:15:19] [ info] [sp] stream processor started
==11357== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4cf2b10
==11357==          to suppress, use: --max-stackframe=11476392 or greater
==11357== Warning: client switching stacks?  SP change: 0x4cf2a88 --> 0x57e48b8
==11357==          to suppress, use: --max-stackframe=11476528 or greater
==11357== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4cf2a88
==11357==          to suppress, use: --max-stackframe=11476528 or greater
==11357==          further instances of this message will not be shown.
^C[2021/07/07 19:15:30] [engine] caught signal (SIGINT)
[2021/07/07 19:15:30] [ info] [input] pausing node_exporter_metrics.0
[2021/07/07 19:15:30] [ warn] [engine] service will stop in 5 seconds
[2021/07/07 19:15:34] [ info] [engine] service stopped
==11357== 
==11357== HEAP SUMMARY:
==11357==     in use at exit: 8,056 bytes in 1 blocks
==11357==   total heap usage: 36,619 allocs, 36,618 frees, 64,911,017 bytes allocated
==11357== 
==11357== 8,056 bytes in 1 blocks are possibly lost in loss record 1 of 1
==11357==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11357==    by 0x4BDF0D: mk_mem_alloc_z (mk_memory.h:70)
==11357==    by 0x4BE52C: mk_sched_add_connection (mk_scheduler.c:204)
==11357==    by 0x4C7347: mk_server_listen_handler (mk_server.c:108)
==11357==    by 0x4C7E01: mk_server_worker_loop (mk_server.c:509)
==11357==    by 0x4BEA6C: mk_sched_launch_worker_loop (mk_scheduler.c:418)
==11357==    by 0x4864608: start_thread (pthread_create.c:477)
==11357==    by 0x4B10292: clone (clone.S:95)
==11357== 
==11357== LEAK SUMMARY:
==11357==    definitely lost: 0 bytes in 0 blocks
==11357==    indirectly lost: 0 bytes in 0 blocks
==11357==      possibly lost: 8,056 bytes in 1 blocks
==11357==    still reachable: 0 bytes in 0 blocks
==11357==         suppressed: 0 bytes in 0 blocks
==11357== 
==11357== For lists of detected and suppressed errors, rerun with: -s
==11357== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
