### PR TITLE
workflows: depend on run-unit-tests-amd64

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,5 +86,5 @@ jobs:
     needs: run-unit-tests-amd64
     steps:
       - name: Check build matrix status
-        if: ${{ needs.build.result != 'success' }}
+        if: ${{ needs.run-unit-tests-amd64.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
* Depends on run-unit-tests-amd64 job.