### PR TITLE
1.7

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1655,8 +1655,8 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "static_file_path", "false",
      0, FLB_TRUE, offsetof(struct flb_s3, static_file_path),
      "Disables behavior where UUID string is automatically appended to end of S3 key name when "
-     "$UUID is not provided in s3_key_format. If this is enabled without a dynamic key format, "
-     "the previous file will be overwritten."
+     "$UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic "
+     "key formatters all work as expected while this feature is set to true."
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1055,7 +1055,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
     }
 
     len = strlen(s3_key);
-    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid) {
+    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid && !ctx->static_file_path) {
         append_random = FLB_TRUE;
         len += 16;
     }
@@ -1649,6 +1649,14 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "send_content_md5", "false",
      0, FLB_TRUE, offsetof(struct flb_s3, send_content_md5),
      "Send the Content-MD5 header with object uploads, as is required when Object Lock is enabled"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "static_file_path", "false",
+     0, FLB_TRUE, offsetof(struct flb_s3, static_file_path),
+     "Disables behavior where UUID string is automatically appended to end of S3 key name when "
+     "$UUID is not provided in s3_key_format. If this is enabled without a dynamic key format, "
+     "the previous file will be overwritten."
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -100,6 +100,7 @@ struct flb_s3 {
     int free_endpoint;
     int use_put_object;
     int send_content_md5;
+    int static_file_path;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;


### PR DESCRIPTION
Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/556

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

By default, when a dynamic key formatter like `$UUID` is not specified in `s3_key_format`,
a UUID is automatically appended to the end of the key. 

If `static_file_path` is set to true, this behavior is disabled. If this is enabled without a dynamic key format,
the previous file will be overwritten.

This patch has been tested using test configuration files using various input plugins
(exec, random, etc) as well as valgrind.

### Example Configuration File
```
[INPUT]
    name exec
    command date +"%Y-%m-%d %H:%M:%S,%3N"

[OUTPUT]
    name s3
    match *
    region us-west-2
    bucket bucket-name
    s3_key_format /test/static-file-path.gz
    use_put_object true
    total_file_size 2M
    upload_timeout 10s
    compression gzip
    store_dir /tmp/fluent-bit/s3-output-buffer
    retry_limit 5
    log_key exec
```

### File names when `static_file_path` is set to `false`
```
...
static-file-path.gz-objectBeSuDZGS
static-file-path.gz-objectbWZtP76c
```

### File names when `static_file_path` is set to `true`
```
static-file-path.gz
```

## Valgrind
#### Example Configuration File Valgrind Logs
```
[2021/06/25 17:58:32] [ info] [output:s3:s3.0] Successfully uploaded object /test/static-file-path-test.gz
^C[2021/06/25 17:59:58] [engine] caught signal (SIGINT)
[2021/06/25 17:59:58] [ warn] [engine] service will stop in 5 seconds
[2021/06/25 18:00:03] [ info] [engine] service stopped
==19548==
==19548== HEAP SUMMARY:
==19548==     in use at exit: 701,635 bytes in 5,374 blocks
==19548==   total heap usage: 120,094 allocs, 114,720 frees, 16,539,171 bytes allocated
==19548==
==19548== LEAK SUMMARY:
==19548==    definitely lost: 0 bytes in 0 blocks
==19548==    indirectly lost: 0 bytes in 0 blocks
==19548==      possibly lost: 0 bytes in 0 blocks
==19548==    still reachable: 701,635 bytes in 5,374 blocks
==19548==         suppressed: 0 bytes in 0 blocks
==19548== Reachable blocks (those to which a pointer was found) are not shown.
==19548== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==19548==
==19548== For counts of detected and suppressed errors, rerun with: -v
==19548== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```