### PR TITLE
out_s3: fix use-after-free in destructor

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -307,12 +307,12 @@ static void s3_context_destroy(struct flb_s3 *ctx)
         flb_tls_destroy(ctx->sts_provider_tls);
     }
 
-    if (ctx->client_tls) {
-        flb_tls_destroy(ctx->client_tls);
-    }
-
     if (ctx->s3_client) {
         flb_aws_client_destroy(ctx->s3_client);
+    }
+
+    if (ctx->client_tls) {
+        flb_tls_destroy(ctx->client_tls);
     }
 
     if (ctx->free_endpoint == FLB_TRUE) {


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Fixes #3732.

cc @PettitWesley @DrewZhang13 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

[s3-fix-valgrind-results.txt](https://github.com/fluent/fluent-bit/files/6779857/s3-fix-valgrind-results.txt)

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
