### PR TITLE
build: append extra control file when ldconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,7 +879,7 @@ ldconfig
 rm -f -- /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
     ")
-    set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
+    set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA};${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
   endif(FLB_RUN_LDCONFIG)
 
 endif()


### PR DESCRIPTION
Append CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA to the existing pre/postrm control files.

Related to issue #3742

**Testing**

niedbalski@alicorn:~/fluent-bit/build$ ar vx /home/niedbalski/fluent-bit/build/td-agent-bit_1.9.0_amd64.deb
x - debian-binary
x - control.tar.gz
x - data.tar.gz
niedbalski@alicorn:~/fluent-bit/build$ tar -xvf control.tar.gz 
./md5sums
./control
./conffiles
niedbalski@alicorn:~/fluent-bit/build$ more conffiles 
/etc/td-agent-bit/parsers.conf
/etc/td-agent-bit/plugins.conf
/etc/td-agent-bit/td-agent-bit.conf
