### PR TITLE
out_splunk: set channel len on init

### DIFF
--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -244,6 +244,11 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* channel */
+    if (ctx->channel != NULL) {
+        ctx->channel_len = flb_sds_len(ctx->channel);
+    }
+
     /* Set instance flags into upstream */
     flb_output_upstream_set(ctx->u, ins);
 


### PR DESCRIPTION
This patch is to fix below comment issue.
'channel' of out_splunk doesn't work correctly since channel length is not initialized.
Then it is failed to append header.
https://github.com/fluent/fluent-bit/commit/23aaf15d844f5d73a6d58c25ae347f8167595a3d#commitcomment-53317894


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[INPUT]
    Name dummy
    Samples 1

[OUTPUT]
    Name splunk
    Http_User nanashi
    Channel bd3b4270-3c26-4127-a677-8643d44f3984
```

## Valgrind output

1. exec `nc -l 8088`
1. exec `fluent-bit -c splunk.conf`

```
$ nc -l 8088
POST /services/collector/event HTTP/1.1
Host: 127.0.0.1:8088
Content-Length: 54
User-Agent: Fluent-Bit
Authorization: Basic bmFuYXNoaTo=
X-Splunk-Request-Channel: bd3b4270-3c26-4127-a677-8643d44f3984

{"time":1625987478.772393,"event":{"message":"dummy"}}^C
```

```
$ valgrind bin/fluent-bit -c ~/git/WORKTREE/v1.8.1/build/splunk.conf 
==114819== Memcheck, a memory error detector
==114819== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==114819== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==114819== Command: bin/fluent-bit -c /home/taka/git/WORKTREE/v1.8.1/build/splunk.conf
==114819== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/11 16:11:17] [ info] [engine] started (pid=114819)
[2021/07/11 16:11:17] [ info] [storage] version=1.1.1, initializing...
[2021/07/11 16:11:17] [ info] [storage] in-memory
[2021/07/11 16:11:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/11 16:11:17] [ info] [cmetrics] version=0.1.3
[2021/07/11 16:11:17] [ info] [sp] stream processor started
==114819== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c81e00
==114819==          to suppress, use: --max-stackframe=11938488 or greater
==114819== Warning: client switching stacks?  SP change: 0x4c81d78 --> 0x57e48b8
==114819==          to suppress, use: --max-stackframe=11938624 or greater
==114819== Warning: client switching stacks?  SP change: 0x57e48b8 --> 0x4c81d78
==114819==          to suppress, use: --max-stackframe=11938624 or greater
==114819==          further instances of this message will not be shown.
^C[2021/07/11 16:11:24] [engine] caught signal (SIGINT)
[2021/07/11 16:11:24] [ warn] [engine] service will stop in 5 seconds
[2021/07/11 16:11:25] [error] [http_client] broken connection to 127.0.0.1:8088 ?
[2021/07/11 16:11:25] [ warn] [output:splunk:splunk.0] http_do=-1
[2021/07/11 16:11:25] [ warn] [engine] failed to flush chunk '114819-1625987478.782892611.flb', retry in 8 seconds: task_id=0, input=dummy.0 > output=splunk.0 (out_id=0)
[2021/07/11 16:11:28] [ info] [engine] service stopped
==114819== 
==114819== HEAP SUMMARY:
==114819==     in use at exit: 0 bytes in 0 blocks
==114819==   total heap usage: 1,062 allocs, 1,062 frees, 853,462 bytes allocated
==114819== 
==114819== All heap blocks were freed -- no leaks are possible
==114819== 
==114819== For lists of detected and suppressed errors, rerun with: -s
==114819== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
