### PR TITLE
ra: fix bison warnings

### DIFF
--- a/src/record_accessor/ra.l
+++ b/src/record_accessor/ra.l
@@ -61,7 +61,6 @@ static inline char *remove_dup_quotes(const char *s, size_t n)
 "."                     |
 ","                     |
 ";"                     { return yytext[0]; }
-\'                      return QUOTE;
 \n
 [ \t]+			/* ignore whitespace */;
 

--- a/src/record_accessor/ra.y
+++ b/src/record_accessor/ra.y
@@ -1,5 +1,5 @@
 %define api.pure full
-%name-prefix="flb_ra_"
+%name-prefix "flb_ra_"
 
 %parse-param { struct flb_ra_parser *rp };
 %parse-param { const char *str };
@@ -33,8 +33,7 @@ void flb_ra_error(struct flb_ra_parser *rp, const char *query, void *scanner,
 /* Known Tokens (refer to sql.l) */
 
 /* Keywords */
-%token IDENTIFIER QUOTE QUOTED
-%token STRING INTEGER
+%token IDENTIFIER STRING INTEGER
 
 %define parse.error verbose
 
@@ -85,7 +84,8 @@ record_accessor: record_key
                     }
                     flb_free($2);
                   }
-      record_subkey:
+      record_subkey: record_subkey record_subkey_index | record_subkey_index
+      record_subkey_index:
                   '[' STRING ']'
                   {
                     flb_ra_parser_subentry_add_string(rp, $2);
@@ -96,6 +96,4 @@ record_accessor: record_key
                   {
                     flb_ra_parser_subentry_add_array_id(rp, $2);
                   }
-                  |
-                  record_subkey record_subkey
                   ;


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Fixed warnings from bison pertaining to the record accessor.

1. Switched from deprecated `%name-prefix="..."` directive to `%name-prefix "..."` directive (no equal sign).
2. Removed unneeded/unused token types `QUOTE` and `QUOTED`.
3. Resolved a shift/reduce conflict re: `record_subkey` (see below).

The original `record_subkey: record_subkey record_subkey` rule had a [shift/reduce conflict](https://www.gnu.org/software/bison/manual/html_node/Shift_002fReduce.html). I believe the underlying issue was an ambiguity over left- vs. right-recursion. Consider an input such as `$foo[0][1][2]`. The subkey could be parsed as either of the following:

Interpretation A (right-recursion)
```
    / \
  /     \
[0]   /  \
     [1] [2]
```

Interpretation B (left-recursion)
```
      / \
    /     \
  /  \   [2]
[0] [1]
```

I don't think the distinction ultimately mattered in this case, but I've rewritten the rule to unambiguously force interpretation B, since bison is more efficient with left-recursion. https://www.gnu.org/software/bison/manual/html_node/Recursion.html

> Any kind of sequence can be defined using either left recursion or right recursion, but you should always use left recursion, because it can parse a sequence of any number of elements with bounded stack space.

cc @edsiper 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
