### PR TITLE
output: don't return uninitialized variable

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -680,8 +680,12 @@ static inline int flb_output_config_map_set(struct flb_output_instance *ins,
     if (ins->net_config_map) {
         ret = flb_config_map_set(&ins->net_properties, ins->net_config_map,
                                  &ins->net_setup);
+        if (ret == -1) {
+            return -1;
+        }
     }
-    return ret;
+
+    return 0;
 }
 
 int flb_output_help(struct flb_output_instance *ins, void **out_buf, size_t *out_size);


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Fixes #3770.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
