### PR TITLE
out_kafka: upgrade librdkafka path v1.7.0

### DIFF
--- a/plugins/out_kafka/CMakeLists.txt
+++ b/plugins/out_kafka/CMakeLists.txt
@@ -4,10 +4,10 @@ FLB_OPTION(RDKAFKA_BUILD_EXAMPLES Off)
 FLB_OPTION(RDKAFKA_BUILD_TESTS    Off)
 FLB_OPTION(ENABLE_LZ4_EXT         Off)
 
-add_subdirectory(librdkafka-1.6.0 EXCLUDE_FROM_ALL)
+add_subdirectory(librdkafka-1.7.0 EXCLUDE_FROM_ALL)
 
 # librdkafka headers
-include_directories(librdkafka-1.6.0/src/)
+include_directories(librdkafka-1.7.0/src/)
 
 # Fluent Bit Kafka Output plugin
 set(src


### PR DESCRIPTION
To fix current CI error. https://github.com/fluent/fluent-bit/runs/3090379547
CMakeLists.txt points to older librdkafka version.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Build
No error to build using below command.
```
cmake .. -DFLB_OUT_KAFKA=yes && make
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
