### PR TITLE
out_loki: Do not retry when loki returns 400.

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1242,7 +1242,17 @@ static void cb_loki_flush(const void *data, size_t bytes,
          * - 205: Reset content
          *
          */
-        if (c->resp.status < 200 || c->resp.status > 205) {
+        if (c->resp.status == 400) {
+            /*
+             * Loki will return 400 if incoming data is out of order.
+             * We should not retry such data.
+             */
+            flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i Not retrying.\n%s",
+                          ctx->tcp_host, ctx->tcp_port, c->resp.status,
+                          c->resp.payload);
+            out_ret = FLB_ERROR;
+        }
+        else if (c->resp.status < 200 || c->resp.status > 205) {
             if (c->resp.payload) {
                 flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i\n%s",
                               ctx->tcp_host, ctx->tcp_port, c->resp.status,


### PR DESCRIPTION
Loki returns 400 if incoming data is out of order.
Such data will never be accepted if we retry to send.
This patch is to drop data not to retry when Loki returns 400.
```
[2021/07/17 15:35:09] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400
entry with timestamp 2021-07-17 06:34:49.020024184 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:34:50.012992127 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:34:51.01254955 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:34:52.012880328 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:34:53.012515521 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 5 out of 5
```

See also below comments.
https://github.com/fluent/fluent-bit/issues/3082#issuecomment-785338654
https://github.com/fluent/fluent-bit/issues/3495#issuecomment-859934034

Similar issue: https://github.com/fluent/fluent-bit/issues/3495

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Testing command
`fluent-bit -i cpu -i mem -o loki -m '*'`

## Debug output
```
$ bin/fluent-bit -i cpu -i mem -o loki -m '*'
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/17 15:45:25] [ info] [engine] started (pid=59953)
[2021/07/17 15:45:25] [ info] [storage] version=1.1.1, initializing...
[2021/07/17 15:45:25] [ info] [storage] in-memory
[2021/07/17 15:45:25] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/17 15:45:25] [ info] [cmetrics] version=0.1.5
[2021/07/17 15:45:25] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/07/17 15:45:25] [ info] [sp] stream processor started
[2021/07/17 15:45:35] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:45:26.013052276 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:27.013071494 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:28.012604637 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:29.01294657 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 4 out of 4

^C[2021/07/17 15:45:37] [engine] caught signal (SIGINT)
[2021/07/17 15:45:37] [ info] [input] pausing cpu.0
[2021/07/17 15:45:37] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:45:30.014326521 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:31.013094772 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:32.013417886 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:33.013114459 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:34.012967137 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 5 out of 5

[2021/07/17 15:45:37] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:45:35.021963379 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:45:36.013005658 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 2 out of 3

[2021/07/17 15:45:37] [ warn] [engine] service will stop in 5 seconds
[2021/07/17 15:45:42] [ info] [engine] service stopped
```

## Valgrind Output 
```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -i mem -o loki -m '*'
==59948== Memcheck, a memory error detector
==59948== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==59948== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==59948== Command: bin/fluent-bit -i cpu -i mem -o loki -m *
==59948== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/17 15:44:24] [ info] [engine] started (pid=59948)
[2021/07/17 15:44:24] [ info] [storage] version=1.1.1, initializing...
[2021/07/17 15:44:24] [ info] [storage] in-memory
[2021/07/17 15:44:24] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/17 15:44:24] [ info] [cmetrics] version=0.1.5
[2021/07/17 15:44:24] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/07/17 15:44:24] [ info] [sp] stream processor started
==59948== Warning: client switching stacks?  SP change: 0x57e49f8 --> 0x4cdd680
==59948==          to suppress, use: --max-stackframe=11563896 or greater
==59948== Warning: client switching stacks?  SP change: 0x4cdd5f8 --> 0x57e49f8
==59948==          to suppress, use: --max-stackframe=11564032 or greater
==59948== Warning: client switching stacks?  SP change: 0x57e49f8 --> 0x4cdd5f8
==59948==          to suppress, use: --max-stackframe=11564032 or greater
==59948==          further instances of this message will not be shown.
[2021/07/17 15:44:34] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:44:25.059194106 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:26.017526604 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:27.01372012 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:28.013230891 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 4 out of 4

[2021/07/17 15:44:34] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:44:29.166555023 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:30.013449093 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:31.013818597 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:32.013235151 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 4 out of 5

[2021/07/17 15:44:39] [error] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=400 Not retrying.
entry with timestamp 2021-07-17 06:44:34.034211896 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:35.013360789 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:36.013665205 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
entry with timestamp 2021-07-17 06:44:37.013129793 +0000 UTC ignored, reason: 'entry out of order' for stream: {job="fluent-bit"},
total ignored: 4 out of 5

^C[2021/07/17 15:44:39] [engine] caught signal (SIGINT)
[2021/07/17 15:44:39] [ info] [input] pausing cpu.0
[2021/07/17 15:44:39] [ warn] [engine] service will stop in 5 seconds
[2021/07/17 15:44:44] [ info] [engine] service stopped
==59948== 
==59948== HEAP SUMMARY:
==59948==     in use at exit: 0 bytes in 0 blocks
==59948==   total heap usage: 1,452 allocs, 1,452 frees, 3,963,466 bytes allocated
==59948== 
==59948== All heap blocks were freed -- no leaks are possible
==59948== 
==59948== For lists of detected and suppressed errors, rerun with: -s
==59948== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
