### PR TITLE
out_s3: fix compiler warnings

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1165,12 +1165,13 @@ int get_md5_base64(char *buf, size_t buf_size, char *md5_str, size_t md5_str_siz
     size_t olen;
     int ret;
 
-    ret = mbedtls_md5_ret(buf, buf_size, md5_bin);
+    ret = mbedtls_md5_ret((unsigned char*) buf, buf_size, md5_bin);
     if (ret != 0) {
         return ret;
     }
 
-    ret = mbedtls_base64_encode(md5_str, md5_str_size, &olen, md5_bin, sizeof(md5_bin));
+    ret = mbedtls_base64_encode((unsigned char*) md5_str, md5_str_size, &olen, md5_bin,
+                                sizeof(md5_bin));
     if (ret != 0) {
         return ret;
     }


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Add explicit casts to fix compiler warnings.

cc @PettitWesley 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
