### PR TITLE
out_prometheus_exporter: remove unused variable

### DIFF
--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -80,7 +80,6 @@ static int cleanup_metrics()
 /* destructor callback */
 static void destruct_metrics(void *data)
 {
-    int c = 0;
     struct mk_list *tmp;
     struct mk_list *head;
     struct mk_list *metrics_list = (struct mk_list*)data;


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Removes an unused variable flagged by the compiler.

cc @nokute78 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
