### PR TITLE
out_es: estimate bulk size to less reallocation(#3775)

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -252,6 +252,7 @@ static int elasticsearch_format(struct flb_config *config,
     int index_len = 0;
     size_t s = 0;
     size_t off = 0;
+    size_t off_prev = 0;
     char *p;
     char *es_index;
     char logstash_index[256];
@@ -300,7 +301,7 @@ static int elasticsearch_format(struct flb_config *config,
     }
 
     /* Create the bulk composer */
-    bulk = es_bulk_create();
+    bulk = es_bulk_create(bytes);
     if (!bulk) {
         return -1;
     }
@@ -534,8 +535,10 @@ static int elasticsearch_format(struct flb_config *config,
         }
 
         ret = es_bulk_append(bulk, j_index, index_len,
-                             out_buf, flb_sds_len(out_buf));
+                             out_buf, flb_sds_len(out_buf),
+                             bytes, off_prev);
         flb_sds_destroy(out_buf);
+        off_prev = off;
         if (ret == -1) {
             /* We likely ran out of memory, abort here */
             msgpack_unpacked_destroy(&result);

--- a/plugins/out_es/es_bulk.c
+++ b/plugins/out_es/es_bulk.c
@@ -25,24 +25,27 @@
 #include <fluent-bit.h>
 #include "es_bulk.h"
 
-struct es_bulk *es_bulk_create()
+struct es_bulk *es_bulk_create(size_t estimated_size)
 {
     struct es_bulk *b;
+
+    if (estimated_size < ES_BULK_CHUNK) {
+        estimated_size = ES_BULK_CHUNK;
+    }
 
     b = flb_malloc(sizeof(struct es_bulk));
     if (!b) {
         perror("calloc");
         return NULL;
     }
-
-    b->ptr = flb_malloc(ES_BULK_CHUNK);
-    if (!b->ptr) {
+    b->ptr = flb_malloc(estimated_size);
+    if (b->ptr == NULL) {
         perror("malloc");
         flb_free(b);
         return NULL;
     }
 
-    b->size = ES_BULK_CHUNK;
+    b->size = estimated_size;
     b->len  = 0;
 
     return b;
@@ -57,10 +60,11 @@ void es_bulk_destroy(struct es_bulk *bulk)
 }
 
 int es_bulk_append(struct es_bulk *bulk, char *index, int i_len,
-                   char *json, size_t j_len)
+                   char *json, size_t j_len,
+                   size_t whole_size, size_t converted_size)
 {
     int available;
-    int new_size;
+    int append_size;
     int required;
     char *ptr;
 
@@ -68,14 +72,25 @@ int es_bulk_append(struct es_bulk *bulk, char *index, int i_len,
     available = (bulk->size - bulk->len);
 
     if (available < required) {
-        new_size = bulk->size + available + required + ES_BULK_CHUNK;
-        ptr = flb_realloc(bulk->ptr, new_size);
+        /*
+         *  estimate a converted size of json
+         *  calculate
+         *    1. rest of msgpack data size
+         *    2. ratio from bulk json size and processed msgpack size.
+         */
+        append_size = (whole_size - converted_size) /* rest of size to convert */
+                    * (bulk->size / converted_size); /* = json size / msgpack size */
+        if (append_size < ES_BULK_CHUNK) {
+            /* append at least ES_BULK_CHUNK size */
+            append_size = ES_BULK_CHUNK;
+        }
+        ptr = flb_realloc(bulk->ptr, bulk->size + append_size);
         if (!ptr) {
             flb_errno();
             return -1;
         }
         bulk->ptr  = ptr;
-        bulk->size = new_size;
+        bulk->size += append_size;
     }
 
     memcpy(bulk->ptr + bulk->len, index, i_len);

--- a/plugins/out_es/es_bulk.h
+++ b/plugins/out_es/es_bulk.h
@@ -36,9 +36,10 @@ struct es_bulk {
     uint32_t size;
 };
 
-struct es_bulk *es_bulk_create();
+struct es_bulk *es_bulk_create(size_t estimated_size);
 int es_bulk_append(struct es_bulk *bulk, char *index, int i_len,
-                   char *json, size_t j_len);
+                   char *json, size_t j_len,
+                   size_t whole_size, size_t curr_size);
 void es_bulk_destroy(struct es_bulk *bulk);
 
 #endif


### PR DESCRIPTION
Fixes #3775 
This patch is to reduce realloc in es_bulk_append.

1. Initial bulk size is a size of messagepack
2. Estimate appending size from current convert ratio (json->messagepack ) and left messagepack size.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[INPUT]
    Name dummy
    Rate 100000

[OUTPUT]
    Name es
    Match *
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c 3775/a.conf 
==27669== Memcheck, a memory error detector
==27669== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27669== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==27669== Command: bin/fluent-bit -c 3775/a.conf
==27669== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/18 22:02:55] [ info] [engine] started (pid=27669)
[2021/07/18 22:02:55] [ info] [storage] version=1.1.1, initializing...
[2021/07/18 22:02:55] [ info] [storage] in-memory
[2021/07/18 22:02:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/18 22:02:55] [ info] [cmetrics] version=0.1.5
[2021/07/18 22:02:55] [ info] [sp] stream processor started
^C[2021/07/18 22:02:57] [engine] caught signal (SIGINT)
==27669== Warning: client switching stacks?  SP change: 0x57e4958 --> 0x6618cb0
==27669==          to suppress, use: --max-stackframe=14893912 or greater
==27669== Warning: client switching stacks?  SP change: 0x6618c28 --> 0x57e4958
==27669==          to suppress, use: --max-stackframe=14893776 or greater
==27669== Warning: client switching stacks?  SP change: 0x57e4958 --> 0x6618c28
==27669==          to suppress, use: --max-stackframe=14893776 or greater
==27669==          further instances of this message will not be shown.
[2021/07/18 22:02:57] [ warn] [engine] service will stop in 5 seconds
[2021/07/18 22:02:59] [error] [src/flb_http_client.c:1159 errno=32] Broken pipe
[2021/07/18 22:02:59] [ warn] [output:es:es.0] http_do=-1 URI=/_bulk
[2021/07/18 22:02:59] [ warn] [engine] failed to flush chunk '27669-1626613375.626651597.flb', retry in 11 seconds: task_id=0, input=dummy.0 > output=es.0 (out_id=0)
[2021/07/18 22:03:01] [ info] [engine] service stopped
==27669== Warning: invalid file descriptor -1 in syscall close()
==27669== 
==27669== HEAP SUMMARY:
==27669==     in use at exit: 0 bytes in 0 blocks
==27669==   total heap usage: 257,155 allocs, 257,155 frees, 1,199,009,254 bytes allocated
==27669== 
==27669== All heap blocks were freed -- no leaks are possible
==27669== 
==27669== For lists of detected and suppressed errors, rerun with: -s
==27669== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
