### PR TITLE
in_tail: add new option 'skip_empty_lines=false'

### DIFF
--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -174,6 +174,7 @@ static int cb_ml_filter(const void *data, size_t bytes,
     while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
         flb_time_pop_from_msgpack(&tm, &result, &obj);
         ret = flb_ml_append_object(ctx->m, ctx->stream_id, &tm, obj);
+
         if (ret != 0) {
             flb_plg_debug(ctx->ins, "could not append object");
         }

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -573,6 +573,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_tail_config, exit_on_eof),
      "exit Fluent Bit when reaching EOF on a monitored file."
     },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "skip_empty_lines", "false",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, skip_empty_lines),
+     "Allows to skip empty lines."
+    },
+
 #ifdef FLB_HAVE_INOTIFY
     {
      FLB_CONFIG_MAP_BOOL, "inotify_watcher", "true",

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -81,7 +81,9 @@ struct flb_tail_config {
     flb_sds_t path_key;        /* key name of file path        */
     flb_sds_t key;             /* key for unstructured record  */
     int   skip_long_lines;     /* skip long lines              */
+    int   skip_empty_lines;    /* skip empty lines (off)       */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+
 #ifdef FLB_HAVE_INOTIFY
     int   inotify_watcher;     /* enable/disable inotify monitor */
 #endif

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -249,10 +249,20 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         }
 
         /*
-         * Empty line (just \n): we skip empty lines only if we are NOT using
-         * multiline core mode.
+         * Empty line (just breakline)
+         * ---------------------------
+         * [NOTE] with the new Multiline core feature and Multiline Filter on
+         * Fluent Bit v1.8.2, there are a couple of cases where stack traces
+         * or multi line patterns expects an empty line (meaning only the
+         * breakline), skipping empty lines on this plugin will break that
+         * functionality.
+         *
+         * We are introducing 'skip_empty_lines=off' configuration
+         * property to revert this behavior if some user is affected by
+         * this change.
          */
-        if (len == 0 && !ctx->ml_ctx) {
+
+        if (len == 0 && ctx->skip_empty_lines) {
             data++;
             processed_bytes++;
             continue;


### PR DESCRIPTION
With the new Multiline core feature and Multiline Filter on Fluent Bit v1.8.2, there are a couple of cases where stack traces or multi line patterns expects an empty line (meaning only the breakline), skipping empty lines on this plugin will break that functionality.

We are introducing 'skip_empty_lines=off' configuration property to revert this behavior if some user is affected by this change.

Signed-off-by: Eduardo Silva <edsiper@gmail.com>
