### PR TITLE
out_s3: added sequential indexing feature

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -176,7 +176,8 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size);
 int flb_read_file(const char *path, char **out_buf, size_t *out_size);
 
 //* Constructs S3 object key as per the format. */
-flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag, char *tag_delimiter);
+flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
+                         char *tag_delimiter, uint64_t seq_index);
 
 #endif
 #endif /* FLB_HAVE_AWS */

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -29,6 +29,7 @@
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_gzip.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <mbedtls/base64.h>
 #include <mbedtls/md5.h>
 #include <msgpack.h>
@@ -252,6 +253,128 @@ static flb_sds_t concat_path(char *p1, char *p2)
     return dir;
 }
 
+/* Reads in index value from metadata file and sets seq_index to value */
+static int read_seq_index(char *seq_index_file, uint64_t *seq_index)
+{
+    FILE *fp;
+    int ret;
+
+    fp = fopen(seq_index_file, "r");
+    if (fp == NULL) {
+        return -1;
+    }
+
+    ret = fscanf(fp, "%"PRIu64, seq_index);
+    if (ret != 1) {
+        return -1;
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+/* Writes index value to metadata file */
+static int write_seq_index(char *seq_index_file, uint64_t seq_index)
+{
+    FILE *fp;
+    int ret;
+
+    fp = fopen(seq_index_file, "w+");
+    if (fp == NULL) {
+        return -1;
+    }
+
+    ret = fprintf(fp, "%"PRIu64, seq_index);
+    if (ret < 0) {
+        return -1;
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+static int init_seq_index(void *context) {
+    int ret;
+    const char *tmp;
+    char tmp_buf[1024];
+    struct flb_s3 *ctx = context;
+
+    ctx->key_fmt_has_seq_index = FLB_TRUE;
+
+    ctx->stream_metadata = flb_fstore_stream_create(ctx->fs, "sequence");
+    if (!ctx->stream_metadata) {
+        flb_plg_error(ctx->ins, "could not initialize metadata stream");
+        flb_fstore_destroy(ctx->fs);
+        ctx->fs = NULL;
+        return -1;
+    }
+
+    /* Construct directories and file path names */
+    ctx->metadata_dir = flb_sds_create(ctx->stream_metadata->path);
+    if (ctx->metadata_dir == NULL) {
+        flb_plg_error(ctx->ins, "Failed to create metadata path");
+        flb_errno();
+        return -1;
+    }
+    tmp = "/index_metadata";
+    ret = flb_sds_cat_safe(&ctx->metadata_dir, tmp, strlen(tmp));
+    if (ret < 0) {
+        flb_plg_error(ctx->ins, "Failed to create metadata path");
+        flb_errno();
+        return -1;
+    }
+
+    ctx->seq_index_file = flb_sds_create(ctx->metadata_dir);
+    if (ctx->seq_index_file == NULL) {
+        flb_plg_error(ctx->ins, "Failed to create sequential index file path");
+        flb_errno();
+        return -1;
+    }
+    tmp = "/seq_index_";
+    ret = flb_sds_cat_safe(&ctx->seq_index_file, tmp, strlen(tmp));
+    if (ret < 0) {
+        flb_plg_error(ctx->ins, "Failed to create sequential index file path");
+        flb_errno();
+        return -1;
+    }
+
+    sprintf(tmp_buf, "%d", ctx->ins->id);
+    ret = flb_sds_cat_safe(&ctx->seq_index_file, tmp_buf, strlen(tmp_buf));
+    if (ret < 0) {
+        flb_plg_error(ctx->ins, "Failed to create sequential index file path");
+        flb_errno();
+        return -1;
+    }
+
+    /* Create directory path if it doesn't exist */
+    ret = mkdir(ctx->metadata_dir, 0755);
+    if (ret < 0 && errno != EEXIST) {
+        flb_plg_error(ctx->ins, "Failed to create metadata directory");
+        return -1;
+    }
+
+    /* Check if index file doesn't exist and set index value */
+    if (access(ctx->seq_index_file, F_OK) != 0) {
+        ctx->seq_index = 0;
+        ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to write to sequential index metadata file");
+            return -1;
+        }
+    } 
+    else {
+        ret = read_seq_index(ctx->seq_index_file, &ctx->seq_index);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to read from sequential index "
+                          "metadata file");
+            return -1;
+        }
+        flb_plg_info(ctx->ins, "Successfully recovered index. "
+                     "Continuing at index=%d", ctx->seq_index);
+    }
+    return 0;
+}
+
 void multipart_upload_destroy(struct multipart_upload *m_upload)
 {
     int i;
@@ -321,6 +444,14 @@ static void s3_context_destroy(struct flb_s3 *ctx)
 
     if (ctx->buffer_dir) {
         flb_sds_destroy(ctx->buffer_dir);
+    }
+
+    if (ctx->metadata_dir) {
+        flb_sds_destroy(ctx->metadata_dir);
+    }
+
+    if (ctx->seq_index_file) {
+        flb_sds_destroy(ctx->seq_index_file);
     }
 
     /* Remove uploads */
@@ -417,11 +548,25 @@ static int cb_s3_init(struct flb_output_instance *ins,
     }
     ctx->buffer_dir = tmp_sds;
 
+    /* Initialize local storage */
+    ret = s3_store_init(ctx);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "Failed to initialize S3 storage: %s",
+                      ctx->store_dir);
+        return -1;
+    }
+
     tmp = flb_output_get_property("s3_key_format", ins);
     if (tmp) {
         if (tmp[0] != '/') {
             flb_plg_error(ctx->ins, "'s3_key_format' must start with a '/'");
             return -1;
+        }
+        if (strstr((char *) tmp, "$INDEX")) {
+            ret = init_seq_index(ctx);
+            if (ret < 0) {
+                return -1;
+            }
         }
         if (strstr((char *) tmp, "$UUID")) {
             ctx->key_fmt_has_uuid = FLB_TRUE;
@@ -622,14 +767,6 @@ static int cb_s3_init(struct flb_output_instance *ins,
             return -1;
         }
 
-    }
-
-    /* Initialize local storage */
-    ret = s3_store_init(ctx);
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "Failed to initialize S3 storage: %s",
-                      ctx->store_dir);
-        return -1;
     }
 
     /* read any remaining buffers from previous (failed) executions */
@@ -857,6 +994,15 @@ multipart:
             s3_store_file_unlock(chunk);
             chunk->failures += 1;
         }
+        if (ctx->key_fmt_has_seq_index) {
+            ctx->seq_index--;
+
+            ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "Failed to decrement index after request error");
+                return -1;
+            }
+        }
         return FLB_RETRY;
     }
     m_upload->part_number += 1;
@@ -916,6 +1062,10 @@ static int put_all_chunks(struct flb_s3 *ctx)
         /* skip multi upload stream */
         fs_stream = mk_list_entry(head, struct flb_fstore_stream, _head);
         if (fs_stream == ctx->stream_upload) {
+            continue;
+        }
+        /* skip metadata stream */
+        if (fs_stream == ctx->stream_metadata) {
             continue;
         }
 
@@ -1048,14 +1198,16 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
     size_t final_body_size;
     char final_body_md5[25];
 
-    s3_key = flb_get_s3_key(ctx->s3_key_format, create_time, tag, ctx->tag_delimiters);
+    s3_key = flb_get_s3_key(ctx->s3_key_format, create_time, tag, ctx->tag_delimiters,
+                            ctx->seq_index);
     if (!s3_key) {
         flb_plg_error(ctx->ins, "Failed to construct S3 Object Key for %s", tag);
         return -1;
     }
 
     len = strlen(s3_key);
-    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid && !ctx->static_file_path) {
+    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid &&
+        !ctx->key_fmt_has_seq_index) {
         append_random = FLB_TRUE;
         len += 16;
     }
@@ -1113,6 +1265,19 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
             return -1;
         }
     }
+
+    /* Update file and increment index value right before request */
+    if (ctx->key_fmt_has_seq_index) {
+        ctx->seq_index++;
+
+        ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
+        if (ret < 0 && access(ctx->seq_index_file, F_OK) == 0) {
+            ctx->seq_index--;
+            flb_sds_destroy(s3_key);
+            flb_plg_error(ctx->ins, "Failed to update sequential index metadata file");
+            return -1;
+        }
+    }
     
     s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
@@ -1123,7 +1288,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to create headers");
             flb_sds_destroy(uri);
-            return -1;
+            goto decrement_index;
         }
         c = s3_client->client_vtable->request(s3_client, FLB_HTTP_PUT,
                                               uri, final_body, final_body_size,
@@ -1144,6 +1309,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
             flb_plg_info(ctx->ins, "Successfully uploaded object %s", final_key);
             flb_sds_destroy(uri);
             flb_http_client_destroy(c);
+
             return 0;
         }
         flb_aws_print_xml_error(c->resp.payload, c->resp.payload_size,
@@ -1156,6 +1322,18 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
 
     flb_plg_error(ctx->ins, "PutObject request failed");
     flb_sds_destroy(uri);
+    goto decrement_index;
+
+decrement_index:
+    if (ctx->key_fmt_has_seq_index) {
+        ctx->seq_index--;
+
+        ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to decrement index after request error");
+            return -1;
+        }
+    }
     return -1;
 }
 
@@ -1211,6 +1389,7 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
 static struct multipart_upload *create_upload(struct flb_s3 *ctx,
                                               const char *tag, int tag_len)
 {
+    int ret;
     struct multipart_upload *m_upload = NULL;
     flb_sds_t s3_key = NULL;
     flb_sds_t tmp_sds = NULL;
@@ -1221,7 +1400,8 @@ static struct multipart_upload *create_upload(struct flb_s3 *ctx,
         flb_errno();
         return NULL;
     }
-    s3_key = flb_get_s3_key(ctx->s3_key_format, time(NULL), tag, ctx->tag_delimiters);
+    s3_key = flb_get_s3_key(ctx->s3_key_format, time(NULL), tag, ctx->tag_delimiters,
+                            ctx->seq_index);
     if (!s3_key) {
         flb_plg_error(ctx->ins, "Failed to construct S3 Object Key for %s", tag);
         flb_free(m_upload);
@@ -1239,6 +1419,19 @@ static struct multipart_upload *create_upload(struct flb_s3 *ctx,
     m_upload->part_number = 1;
     m_upload->init_time = time(NULL);
     mk_list_add(&m_upload->_head, &ctx->uploads);
+
+    /* Update file and increment index value right before request */
+    if (ctx->key_fmt_has_seq_index) {
+        ctx->seq_index++;
+
+        ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
+        if (ret < 0) {
+            ctx->seq_index--;
+            flb_sds_destroy(s3_key);
+            flb_plg_error(ctx->ins, "Failed to write to sequential index metadata file");
+            return NULL;
+        }
+    }
 
     return m_upload;
 }
@@ -1628,8 +1821,10 @@ static struct flb_config_map config_map[] = {
     "by the rewrite_tag filter. Add $TAG in the format string to insert the full "
     "log tag; add $TAG[0] to insert the first part of the tag in the s3 key. "
     "The tag is split into “parts” using the characters specified with the "
-    "s3_key_format_tag_delimiters option. See the in depth examples and tutorial"
-    " in the documentation."
+    "s3_key_format_tag_delimiters option. Add $INDEX to enable sequential indexing "
+    "for file names. Adding $INDEX will prevent random string being added to end of key"
+    "when $UUID is not provided. See the in depth examples and tutorial in the "
+    "documentation."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -121,6 +121,7 @@ struct flb_s3 {
     struct flb_fstore *fs;
     struct flb_fstore_stream *stream_active;  /* default active stream */
     struct flb_fstore_stream *stream_upload;  /* multipart upload stream */
+    struct flb_fstore_stream *stream_metadata; /* s3 metadata stream */
 
     /*
      * used to track that unset buffers were found on startup that have not
@@ -139,6 +140,11 @@ struct flb_s3 {
     int timer_created;
     int timer_ms;
     int key_fmt_has_uuid;
+
+    uint64_t seq_index;
+    int key_fmt_has_seq_index;
+    flb_sds_t metadata_dir;
+    flb_sds_t seq_index_file;
 
     struct flb_output_instance *ins;
 };


### PR DESCRIPTION
Specify $INDEX in s3_key_format to add an index that increments every time it uploads a
file. Sequential indexing is compatible with all other s3_key_format features, so $UUID
and $TAG can be specified at the same time as $INDEX. When $INDEX is specified but $UUID
is not, a random string will not be appended to the end of the key name.

If FluentBit crashes or fails to upload, the index will be preserved in the filesystem
in a metadata file located in ${store_dir}/index_metadata and reused on startup. This
configuration option uses native C functions so is incompatible with multi-threading.

Tested through unit testing and various input plugins (exec, random, etc).

Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
