### PR TITLE
out_s3: added static file path configuration option

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1055,7 +1055,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
     }
 
     len = strlen(s3_key);
-    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid) {
+    if ((len + 16) <= 1024 && !ctx->key_fmt_has_uuid && !ctx->static_file_path) {
         append_random = FLB_TRUE;
         len += 16;
     }
@@ -1649,6 +1649,14 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "send_content_md5", "false",
      0, FLB_TRUE, offsetof(struct flb_s3, send_content_md5),
      "Send the Content-MD5 header with object uploads, as is required when Object Lock is enabled"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "static_file_path", "false",
+     0, FLB_TRUE, offsetof(struct flb_s3, static_file_path),
+     "Disables behavior where UUID string is automatically appended to end of S3 key name when "
+     "$UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic "
+     "key formatters all work as expected while this feature is set to true."
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -100,6 +100,7 @@ struct flb_s3 {
     int free_endpoint;
     int use_put_object;
     int send_content_md5;
+    int static_file_path;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;


### PR DESCRIPTION
By default, when a dynamic key formatter like $UUID is not specified in s3_key_format,
a UUID is automatically appended to the end of the key.

If static_file_path is set to true, this behavior is disabled.

This patch has been tested using test configuration files using various input plugins
(exec, random, etc) as well as valgrind.

Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
