### PR TITLE
signv4: fix NULL dereference

### DIFF
--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -357,7 +357,7 @@ static flb_sds_t url_params_format(char *params)
          * results in issues since kv->val will be equal to NULL.
          * Thus, check here whether key length is satisfied
          */
-        if (flb_sds_len(key) == 0) {
+        if (flb_sds_len(key) == 0 || flb_sds_len(val) == 0) {
             flb_sds_destroy(key);
             flb_sds_destroy(val);
             flb_slist_destroy(&split);


### PR DESCRIPTION
Fixes bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31801

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
