### PR TITLE
pack_gelf: ensure proper cleanup in case of failure.

### DIFF
--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -801,6 +801,7 @@ flb_sds_t flb_msgpack_raw_to_gelf(char *buf, size_t buf_size,
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, buf_size, &off);
     if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
         return NULL;
     }
 


### PR DESCRIPTION
Memory leaks can happen if msgpack_unpack_next fails.
Bug tracker: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35460

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
