### PR TITLE
scheduler : added an output parameter

### DIFF
--- a/include/fluent-bit/flb_scheduler.h
+++ b/include/fluent-bit/flb_scheduler.h
@@ -134,7 +134,7 @@ int flb_sched_request_invalidate(struct flb_config *config, void *data);
 
 int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
                               void (*cb)(struct flb_config *, void *),
-                              void *data);
+                              void *data, struct flb_sched_timer **out_timer);
 int flb_sched_timer_cb_disable(struct flb_sched_timer *timer);
 int flb_sched_timer_cb_destroy(struct flb_sched_timer *timer);
 void flb_sched_timer_invalidate(struct flb_sched_timer *timer);

--- a/include/fluent-bit/flb_time_utils.h
+++ b/include/fluent-bit/flb_time_utils.h
@@ -61,7 +61,7 @@ static FLB_INLINE void flb_time_sleep(int ms)
     assert(sched != NULL);
 
     ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_ONESHOT,
-                                    ms, flb_time_thread_wakeup, coro);
+                                    ms, flb_time_thread_wakeup, coro, NULL);
     if (ret == -1) {
         return;
     }

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1397,7 +1397,7 @@ static void cb_s3_flush(const void *data, size_t bytes,
         ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
                                         ctx->timer_ms,
                                         cb_s3_upload,
-                                        ctx);
+                                        ctx, NULL);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to create upload timer");
             FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -623,7 +623,7 @@ int flb_engine_start(struct flb_config *config)
      */
     ret = flb_sched_timer_cb_create(config->sched,
                                     FLB_SCHED_TIMER_CB_PERM,
-                                    1500, cb_engine_sched_timer, config);
+                                    1500, cb_engine_sched_timer, config, NULL);
     if (ret == -1) {
         flb_error("[engine] could not schedule permanent callback");
         return -1;

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -214,7 +214,7 @@ static void output_thread(void *data)
      */
     ret = flb_sched_timer_cb_create(sched,
                                     FLB_SCHED_TIMER_CB_PERM,
-                                    1500, cb_thread_sched_timer, ins);
+                                    1500, cb_thread_sched_timer, ins, NULL);
     if (ret == -1) {
         flb_plg_error(ins, "could not schedule permanent callback");
         return;

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -434,7 +434,7 @@ int flb_sched_event_handler(struct flb_config *config, struct mk_event *event)
  */
 int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
                               void (*cb)(struct flb_config *, void *),
-                              void *data)
+                              void *data, struct flb_sched_timer **out_timer)
 {
     int fd;
     time_t sec;
@@ -480,6 +480,10 @@ int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
      */
     event->type = FLB_ENGINE_EV_SCHED;
     timer->timer_fd = fd;
+
+    if (out_timer != NULL) {
+        *out_timer = timer;
+    }
 
     return 0;
 }

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -267,7 +267,7 @@ struct flb_storage_metrics *flb_storage_metrics_create(struct flb_config *ctx)
 
     ret = flb_sched_timer_cb_create(ctx->sched, FLB_SCHED_TIMER_CB_PERM, 5000,
                                     cb_storage_metrics_collect,
-                                    ctx->storage_metrics_ctx);
+                                    ctx->storage_metrics_ctx, NULL);
     if (ret == -1) {
         flb_error("[storage metrics] cannot create timer to collect metrics");
         flb_free(sm);

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -846,7 +846,7 @@ int flb_ml_auto_flush_init(struct flb_ml *ml)
                                     FLB_SCHED_TIMER_CB_PERM,
                                     ml->flush_ms,
                                     cb_ml_flush_timer,
-                                    ml);
+                                    ml, NULL);
     return ret;
 }
 


### PR DESCRIPTION
scheduler : added an optional output parameter where the timer reference
is returned as needed by the UDP timeout detection mechanism I am
working on.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>