### PR TITLE
network : assorted improvements

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -174,6 +174,9 @@ struct flb_config {
      */
     char *no_proxy;
 
+    /* DNS */
+    char *dns_mode;
+
     /* Chunk I/O Buffering */
     void *cio;
     char *storage_path;
@@ -272,6 +275,9 @@ enum conf_type {
 #define FLB_CONF_STR_HC_RETRIES_FAILURE_COUNT               "HC_Retry_Failure_Count"
 #define FLB_CONF_STR_HC_PERIOD                              "HC_Period"
 #endif /* !FLB_HAVE_HTTP_SERVER */
+
+/* DNS */
+#define FLB_CONF_DNS_MODE              "dns.mode"
 
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"

--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -36,6 +36,7 @@
 #define FLB_ENGINE_EV_SCHED_FRAME   (FLB_ENGINE_EV_SCHED + 4096)
 #define FLB_ENGINE_EV_OUTPUT        8192
 #define FLB_ENGINE_EV_THREAD_OUTPUT 16384
+#define FLB_ENGINE_EV_DNS           32768
 
 /* Engine events: all engine events set the left 32 bits to '1' */
 #define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -44,7 +44,7 @@ struct flb_net_setup {
     /* maximum of times a keepalive connection can be used */
     int keepalive_max_recycle;
 
-    /* dns mode : FLB_DNS_USE_TCP, FLB_DNS_USE_UDP */
+    /* dns mode : TCP or UDP */
     char *dns_mode;
 };
 
@@ -60,10 +60,10 @@ struct flb_net_host {
 
 /* Defines an async DNS lookup context */
 struct flb_dns_lookup_context {
+    struct mk_event       response_event;                  /* c-ares socket event */
     int                  *udp_timeout_detected;
     int                   ares_socket_created;
     int                   ares_socket_type;
-    struct mk_event       response_event;                  /* c-ares socket event */
     void                 *ares_channel;
     int                  *result_code;
     struct mk_event_loop *event_loop;

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -71,12 +71,13 @@ struct flb_dns_lookup_context {
     struct mk_event response_event;                  /* c-ares socket event */
     int ares_socket_created;
     void *ares_channel;
-    int result_code;
+    int *result_code;
     int finished;
     struct mk_event_loop *event_loop;
     struct flb_coro *coroutine;
-    struct addrinfo *result;
+    struct addrinfo **result;
     /* result is a synthetized result, don't call freeaddrinfo on it */
+    struct mk_list _head;
 };
 
 #define FLB_DNS_USE_TCP 'T'
@@ -91,6 +92,9 @@ void flb_net_init();
 /* Generic functions */
 void flb_net_setup_init(struct flb_net_setup *net);
 int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address);
+
+/* DNS handling */
+void flb_net_dns_lookup_context_cleanup(struct mk_list *cleanup_queue);
 
 /* TCP options */
 int flb_net_socket_reset(flb_sockfd_t fd);

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -58,15 +58,7 @@ struct flb_net_host {
     struct flb_uri *uri;   /* Extra URI parameters */
 };
 
-/* Defines an async DNS lookup context and its result event */
-struct flb_dns_lookup_context;
-
-struct flb_dns_lookup_result_event {
-    struct mk_event event;
-    flb_pipefd_t ch_events[2];
-    struct flb_dns_lookup_context *parent;
-};
-
+/* Defines an async DNS lookup context */
 struct flb_dns_lookup_context {
     int                  *udp_timeout_detected;
     int                   ares_socket_created;
@@ -79,8 +71,12 @@ struct flb_dns_lookup_context {
     int                   finished;
     struct addrinfo     **result;
     /* result is a synthetized result, don't call freeaddrinfo on it */
-    struct mk_list _head;
+    struct mk_list        _head;
 };
+
+#define FLB_DNS_LOOKUP_CONTEXT_FOR_EVENT(event) \
+    ((struct flb_dns_lookup_context *) \
+        &((uint8_t *) event)[-offsetof(struct flb_dns_lookup_context, response_event)])
 
 #define FLB_DNS_USE_TCP 'T'
 #define FLB_DNS_USE_UDP 'U'

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -43,6 +43,9 @@ struct flb_net_setup {
 
     /* maximum of times a keepalive connection can be used */
     int keepalive_max_recycle;
+
+    /* dns mode : FLB_DNS_USE_TCP, FLB_DNS_USE_UDP */
+    char *dns_mode;
 };
 
 /* Defines a host service and it properties */
@@ -75,6 +78,9 @@ struct flb_dns_lookup_context {
     struct addrinfo *result;
     /* result is a synthetized result, don't call freeaddrinfo on it */
 };
+
+#define FLB_DNS_USE_TCP 'T'
+#define FLB_DNS_USE_UDP 'U'
 
 #ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN  23

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -68,20 +68,25 @@ struct flb_dns_lookup_result_event {
 };
 
 struct flb_dns_lookup_context {
-    struct mk_event response_event;                  /* c-ares socket event */
-    int ares_socket_created;
-    void *ares_channel;
-    int *result_code;
-    int finished;
+    int                  *udp_timeout_detected;
+    int                   ares_socket_created;
+    int                   ares_socket_type;
+    struct mk_event       response_event;                  /* c-ares socket event */
+    void                 *ares_channel;
+    int                  *result_code;
     struct mk_event_loop *event_loop;
-    struct flb_coro *coroutine;
-    struct addrinfo **result;
+    struct flb_coro      *coroutine;
+    int                   finished;
+    struct addrinfo     **result;
     /* result is a synthetized result, don't call freeaddrinfo on it */
     struct mk_list _head;
 };
 
 #define FLB_DNS_USE_TCP 'T'
 #define FLB_DNS_USE_UDP 'U'
+
+#define FLB_ARES_SOCKET_TYPE_TCP 1
+#define FLB_ARES_SOCKET_TYPE_UDP 2
 
 #ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN  23

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -106,6 +106,10 @@ struct flb_service_config service_configs[] = {
      offsetof(struct flb_config, health_check_period)},
 
 #endif
+    /* DNS*/
+    {FLB_CONF_DNS_MODE,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, dns_mode)},
 
     /* Storage */
     {FLB_CONF_STORAGE_PATH,

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -693,7 +693,7 @@ int flb_engine_start(struct flb_config *config)
             }
             else if (event->type == FLB_ENGINE_EV_DNS) {
                 struct flb_dns_lookup_context *lookup_context;
-                lookup_context = (struct flb_dns_lookup_context *) event;
+                lookup_context = FLB_DNS_LOOKUP_CONTEXT_FOR_EVENT(event);
 
                 if (!lookup_context->finished) {
                     event->handler(event);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -695,10 +695,10 @@ int flb_engine_start(struct flb_config *config)
                 struct flb_dns_lookup_context *lookup_context;
                 lookup_context = (struct flb_dns_lookup_context *) event;
 
-                if (0 == lookup_context->finished) {
+                if (!lookup_context->finished) {
                     event->handler(event);
 
-                    if (1 == lookup_context->finished) {
+                    if (lookup_context->finished) {
                         mk_list_add(&lookup_context->_head, &lookup_context_cleanup_queue);
                     }
                 }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -35,6 +35,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_engine_dispatch.h>
+#include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_task.h>
 #include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_http_server.h>
@@ -469,6 +470,7 @@ int flb_engine_start(struct flb_config *config)
     struct mk_event *event;
     struct mk_event_loop *evl;
     struct flb_sched *sched;
+    struct mk_list lookup_context_cleanup_queue;
 
     /* Initialize the networking layer */
     flb_net_init();
@@ -629,6 +631,8 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
 
+    mk_list_init(&lookup_context_cleanup_queue);
+
     /* Signal that we have started */
     flb_engine_started(config);
 
@@ -687,6 +691,18 @@ int flb_engine_start(struct flb_config *config)
             else if (event->type == FLB_ENGINE_EV_CUSTOM) {
                 event->handler(event);
             }
+            else if (event->type == FLB_ENGINE_EV_DNS) {
+                struct flb_dns_lookup_context *lookup_context;
+                lookup_context = (struct flb_dns_lookup_context *) event;
+
+                if (0 == lookup_context->finished) {
+                    event->handler(event);
+
+                    if (1 == lookup_context->finished) {
+                        mk_list_add(&lookup_context->_head, &lookup_context_cleanup_queue);
+                    }
+                }
+            }
             else if (event->type == FLB_ENGINE_EV_THREAD) {
                 struct flb_upstream_conn *u_conn;
                 struct flb_coro *co;
@@ -715,6 +731,7 @@ int flb_engine_start(struct flb_config *config)
         if (config->is_running == FLB_TRUE) {
             flb_sched_timer_cleanup(config->sched);
             flb_upstream_conn_pending_destroy_list(&config->upstreams);
+            flb_net_dns_lookup_context_cleanup(&lookup_context_cleanup_queue);
 
             /*
             * depend on main thread to clean up expired message

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -575,7 +575,7 @@ static int flb_net_getaddrinfo_event_handler(void *arg)
 {
     struct flb_dns_lookup_context *context;
 
-    context = (struct flb_dns_lookup_context *) arg;
+    context = FLB_DNS_LOOKUP_CONTEXT_FOR_EVENT(arg);
 
     ares_process_fd(context->ares_channel,
                     context->response_event.fd,

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -534,7 +534,7 @@ static struct addrinfo *flb_net_translate_ares_addrinfo(struct ares_addrinfo *in
         }
     }
 
-    if (1 == failure_detected) {
+    if (failure_detected) {
         if (NULL != output) {
             flb_net_free_translated_addrinfo(output);
             output = NULL;
@@ -586,7 +586,7 @@ static int flb_net_getaddrinfo_event_handler(void *arg)
      * close but we will need to figure this out if there is a chance for c-ares
      * to open multiple simultaneous connections as suspected.
      */
-    if (context->finished == 1) {
+    if (context->finished) {
         mk_event_del(context->event_loop, &context->response_event);
     }
 
@@ -604,7 +604,7 @@ static void flb_net_getaddrinfo_timeout_handler(struct flb_config *config, void 
 
     ares_cancel(lookup_context->ares_channel);
 
-    if (lookup_context->ares_socket_created == 1) {
+    if (lookup_context->ares_socket_created) {
         mk_event_del(lookup_context->event_loop, &lookup_context->response_event);
     }
 
@@ -623,7 +623,7 @@ static int flb_net_ares_sock_create_callback(ares_socket_t socket_fd,
 
     context = (struct flb_dns_lookup_context *) userdata;
 
-    if (context->ares_socket_created == 1) {
+    if (context->ares_socket_created) {
         /* This context already had a connection established and the code is not ready
          * to handle multiple connections so we abort the process.
          */
@@ -657,7 +657,7 @@ static int flb_net_ares_sock_create_callback(ares_socket_t socket_fd,
 
     ret = mk_event_add(context->event_loop, socket_fd, FLB_ENGINE_EV_CUSTOM,
                        event_mask, &context->response_event);
-    if (ret != 0) {
+    if (ret) {
         return -1;
     }
 
@@ -781,7 +781,7 @@ int flb_net_getaddrinfo(const char *node, const char *service, struct addrinfo *
                      flb_net_getaddrinfo_callback, lookup_context);
 
 
-    if (1 == lookup_context->ares_socket_created) {
+    if (lookup_context->ares_socket_created) {
         if (lookup_context->ares_socket_type == FLB_ARES_SOCKET_TYPE_UDP) {
             /* If the socket type created by c-ares is UDP then we need to create our
              * own timeout mechanism before yielding and cancel it if things go as
@@ -812,7 +812,7 @@ int flb_net_getaddrinfo(const char *node, const char *service, struct addrinfo *
         }
     }
 
-    if (0 == result_code) {
+    if (!result_code) {
         *res = result_data;
     }
 
@@ -911,7 +911,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         ret = getaddrinfo(host, _port, &hints, &res);
     }
 
-    if (ret != 0) {
+    if (ret) {
         if (is_async) {
             flb_warn("[net] getaddrinfo(host='%s', err=%d): %s", host, ret, ares_strerror(ret));
         }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -744,9 +744,8 @@ int flb_net_getaddrinfo(const char *node, const char *service, struct addrinfo *
 
     dns_mode = FLB_DNS_USE_UDP;
 
-    if (dns_mode_textual != NULL &&
-        strncasecmp(dns_mode_textual, "TCP", 3) == 0) {
-        dns_mode = FLB_DNS_USE_TCP;
+    if (dns_mode_textual != NULL) {
+        dns_mode = toupper(dns_mode_textual[0]);
     }
 
     event_loop = flb_engine_evl_get();

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -301,10 +301,10 @@ static void output_thread(void *data)
                 struct flb_dns_lookup_context *lookup_context;
                 lookup_context = (struct flb_dns_lookup_context *) event;
 
-                if (0 == lookup_context->finished) {
+                if (!lookup_context->finished) {
                     event->handler(event);
 
-                    if (1 == lookup_context->finished) {
+                    if (lookup_context->finished) {
                         mk_list_add(&lookup_context->_head, &lookup_context_cleanup_queue);
                     }
                 }

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -299,7 +299,7 @@ static void output_thread(void *data)
             }
             else if (event->type == FLB_ENGINE_EV_DNS) {
                 struct flb_dns_lookup_context *lookup_context;
-                lookup_context = (struct flb_dns_lookup_context *) event;
+                lookup_context = FLB_DNS_LOOKUP_CONTEXT_FOR_EVENT(event);
 
                 if (!lookup_context->finished) {
                     event->handler(event);

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -35,7 +35,7 @@ FLB_TLS_DEFINE(struct mk_list, flb_upstream_list_key);
 /* Config map for Upstream networking setup */
 struct flb_config_map upstream_net[] = {
     {
-     FLB_CONFIG_MAP_STR, "net.dns_mode", NULL,
+     FLB_CONFIG_MAP_STR, "net.dns.mode", NULL,
      0, FLB_TRUE, offsetof(struct flb_net_setup, dns_mode),
      "Select the primary DNS connection type (TCP or UDP)"
     },
@@ -109,7 +109,7 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
     if (config->dns_mode != NULL) {
 
         for (config_index = 0 ; upstream_net[config_index].name != NULL ; config_index++) {
-            if(strcmp(upstream_net[config_index].name, "net.dns_mode") == 0)
+            if(strcmp(upstream_net[config_index].name, "net.dns.mode") == 0)
             {
                 upstream_net[config_index].def_value = config->dns_mode;
             }

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -35,6 +35,12 @@ FLB_TLS_DEFINE(struct mk_list, flb_upstream_list_key);
 /* Config map for Upstream networking setup */
 struct flb_config_map upstream_net[] = {
     {
+     FLB_CONFIG_MAP_STR, "net.dns_mode", NULL,
+     0, FLB_TRUE, offsetof(struct flb_net_setup, dns_mode),
+     "Select the primary DNS connection type (TCP or UDP)"
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
      "Enable or disable Keepalive support"
@@ -90,9 +96,28 @@ void flb_upstream_thread_safe(struct flb_upstream *u)
 
 struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
 {
+    size_t          config_index;
     struct mk_list *config_map;
 
+    /* If a global dns mode was provided in the SERVICE category then we set it as
+     * the default value for net.dns_mode, that way the user can set a global value and
+     * override it on a per plugin basis, however, it's not because of this flexibility
+     * that it was done but because in order to be able to save the value in the
+     * flb_net_setup structure (and not lose it when flb_output_upstream_set overwrites
+     * the structure) we need to do it this way (or at least that's what I think)
+     */
+    if (config->dns_mode != NULL) {
+
+        for (config_index = 0 ; upstream_net[config_index].name != NULL ; config_index++) {
+            if(strcmp(upstream_net[config_index].name, "net.dns_mode") == 0)
+            {
+                upstream_net[config_index].def_value = config->dns_mode;
+            }
+        }
+    }
+
     config_map = flb_config_map_create(config, upstream_net);
+
     return config_map;
 }
 
@@ -238,6 +263,7 @@ struct flb_upstream *flb_upstream_create(struct flb_config *config,
 #endif
 
     mk_list_add(&u->_head, &config->upstreams);
+
     return u;
 }
 


### PR DESCRIPTION
network : The primary async  DNS mode can now be selected globally and overriden on a per plugin basis

network : Refactored the async DNS event loop interaction to prevent a corner case where a use after free would happen if there was more than one event for a DNS lookup socket where one of the events satisfied the lookup request and triggered context cleanup.

network : Re-added UDP support with a new artificial timeout mechanism.