### PR TITLE
out_gelf: check NULL context on exit

### DIFF
--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -458,6 +458,10 @@ static int cb_gelf_exit(void *data, struct flb_config *config)
 {
     struct flb_out_gelf_config *ctx = data;
 
+    if (ctx == NULL) {
+        return 0;
+    }
+
     if (ctx->u) {
         flb_upstream_destroy(ctx->u);
     }


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/3818#issuecomment-884268501

It reports NULL access occurred.
We can reproduce by `fluent-bit -i dummy -p hoge=hoge -o gelf`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration 

```
[INPUT]
    Name dummy
    Hoge hoge

[OUTPUT]
    Name gelf
```

## Valgrind output

Sigsegv is not occurred.
Valgrind reports error, but it is not related this patch.
```
$ valgrind --leak-check=full bin/fluent-bit -i dummy -p hoge=hoge -o gelf 
==65211== Memcheck, a memory error detector
==65211== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==65211== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==65211== Command: bin/fluent-bit -i dummy -p hoge=hoge -o gelf
==65211== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/07/22 09:38:06] [ info] [engine] started (pid=65211)
[2021/07/22 09:38:06] [ info] [storage] version=1.1.1, initializing...
[2021/07/22 09:38:06] [ info] [storage] in-memory
[2021/07/22 09:38:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/07/22 09:38:06] [ info] [cmetrics] version=0.1.5
[2021/07/22 09:38:06] [error] [config] dummy: unknown configuration property 'hoge'. The following properties are allowed: samples, dummy, rate, start_time_sec, and start_time_nsec.
[2021/07/22 09:38:06] [ help] try the command: bin/fluent-bit -i dummy -h

[2021/07/22 09:38:06] [error] [lib] backend failed
==65211== 
==65211== HEAP SUMMARY:
==65211==     in use at exit: 288 bytes in 1 blocks
==65211==   total heap usage: 765 allocs, 764 frees, 137,091 bytes allocated
==65211== 
==65211== 288 bytes in 1 blocks are possibly lost in loss record 1 of 1
==65211==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==65211==    by 0x4014B1A: allocate_dtv (dl-tls.c:343)
==65211==    by 0x4014B1A: _dl_allocate_tls (dl-tls.c:589)
==65211==    by 0x4865322: allocate_stack (allocatestack.c:622)
==65211==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==65211==    by 0x6E583A: mk_utils_worker_spawn (mk_utils.c:284)
==65211==    by 0x19DF08: flb_start (flb_lib.c:659)
==65211==    by 0x1924A1: flb_main (fluent-bit.c:1198)
==65211==    by 0x192533: main (fluent-bit.c:1221)
==65211== 
==65211== LEAK SUMMARY:
==65211==    definitely lost: 0 bytes in 0 blocks
==65211==    indirectly lost: 0 bytes in 0 blocks
==65211==      possibly lost: 288 bytes in 1 blocks
==65211==    still reachable: 0 bytes in 0 blocks
==65211==         suppressed: 0 bytes in 0 blocks
==65211== 
==65211== For lists of detected and suppressed errors, rerun with: -s
==65211== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
