### PR TITLE
regex: log allocation failures in Onigmo

### DIFF
--- a/src/flb_regex.c
+++ b/src/flb_regex.c
@@ -125,6 +125,7 @@ ssize_t flb_regex_do(struct flb_regex *r, const char *str, size_t slen,
 
     region = onig_region_new();
     if (!region) {
+        flb_errno();
         result->region = NULL;
         return -1;
     }


### PR DESCRIPTION
Calls to `flb_malloc()` and friends normally log allocation failures with `flb_errno()`. This PR adds the same logging for allocation failures in the Onigmo library.

This should help disambiguate errors in `flb_regex_do()` that are due to memory issues as opposed to actual regular expression match failures.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.