### PR TITLE
sp: fix sql grammar precedence and warnings

### DIFF
--- a/include/fluent-bit/stream_processor/flb_sp_parser.h
+++ b/include/fluent-bit/stream_processor/flb_sp_parser.h
@@ -248,7 +248,7 @@ const char *flb_sp_cmd_stream_prop_get(struct flb_sp_cmd *cmd, const char *key);
 /* Selection keys */
 int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func, const char *key_name);
 void flb_sp_cmd_key_del(struct flb_sp_cmd_key *key);
-void flb_sp_cmd_alias_add(struct flb_sp_cmd *cmd, const char *key_alias);
+void flb_sp_cmd_alias_add(struct flb_sp_cmd *cmd, char *key_alias);
 int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, const char *source);
 void flb_sp_cmd_dump(struct flb_sp_cmd *cmd);
 

--- a/src/stream_processor/parser/flb_sp_parser.c
+++ b/src/stream_processor/parser/flb_sp_parser.c
@@ -317,7 +317,7 @@ int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func, const char *key_name)
     return 0;
 }
 
-void flb_sp_cmd_alias_add(struct flb_sp_cmd *cmd, const char *key_alias)
+void flb_sp_cmd_alias_add(struct flb_sp_cmd *cmd, char *key_alias)
 {
     cmd->alias = (char *) key_alias;
 }

--- a/src/stream_processor/parser/sql.l
+++ b/src/stream_processor/parser/sql.l
@@ -181,7 +181,6 @@ RECORD_TIME             {yylval->integer = func_to_code(yytext, yyleng); return 
 ">"                     return GT;
 ">="                    return GTE;
 
-\'                      return QUOTE;
 \n
 [ \t]+			/* ignore whitespace */;
 

--- a/tests/internal/include/sp_cb_functions.h
+++ b/tests/internal/include/sp_cb_functions.h
@@ -206,6 +206,26 @@ static void cb_record_not_contains(int id, struct task_check *check,
     TEST_CHECK(ret == 0);
 }
 
+static void cb_select_and_or_precedence(int id, struct task_check *check,
+                                        char *buf, size_t size)
+{
+    int ret;
+
+    /* Expect all 11 rows */
+    ret = mp_count_rows(buf, size);
+    TEST_CHECK_(ret == 11, "expected 11 rows but got %d", ret);
+}
+
+static void cb_select_not_precedence(int id, struct task_check *check,
+                                     char *buf, size_t size)
+{
+    int ret;
+
+    /* Expect all 11 rows */
+    ret = mp_count_rows(buf, size);
+    TEST_CHECK_(ret == 11, "expected 11 rows but got %d", ret);
+}
+
 /* Callback functions to perform checks over results */
 static void cb_select_sub_blue(int id, struct task_check *check,
                                char *buf, size_t size)

--- a/tests/internal/include/sp_select_keys.h
+++ b/tests/internal/include/sp_select_keys.h
@@ -126,6 +126,18 @@ struct task_check select_keys_checks[] = {
         "SELECT id FROM TAG:'samples' WHERE @record.contains(x);",
         cb_record_not_contains,
     },
+    {
+        18, 0, 0, 0,
+        "and_or_precedence",
+        "SELECT id FROM STREAM:FLB WHERE false AND true OR true;",
+        cb_select_and_or_precedence,
+    },
+    {
+        19, 0, 0, 0,
+        "not_precedence",
+        "SELECT id FROM STREAM:FLB WHERE NOT true OR true;",
+        cb_select_not_precedence,
+    },
 };
 
 #endif


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Fixed the ambiguously defined SQL grammar for the stream processor, which caused `AND`, `OR`, and `NOT` to have non-standard precedence. Also fixed a few compiler warnings.

Fixes #3763.

cc @edsiper @koleini 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**

- [x] Documentation required for this feature

TODO (note: this is a **breaking change**)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
