### PR TITLE
out_s3: fix NULL dereference when upload_id is unset

### DIFF
--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -431,6 +431,12 @@ int complete_multipart_upload(struct flb_s3 *ctx,
     struct flb_http_client *c = NULL;
     struct flb_aws_client *s3_client;
 
+    if (!m_upload->upload_id) {
+        flb_plg_error(ctx->ins, "Cannot complete multipart upload for key %s: "
+                      "upload ID is unset ", m_upload->s3_key);
+        return -1;
+    }
+
     uri = flb_sds_create_size(flb_sds_len(m_upload->s3_key) + 11 +
                               flb_sds_len(m_upload->upload_id));
     if (!uri) {


### PR DESCRIPTION
When upload_id is not set in `create_multipart_upload()` (which can occur in some failure modes seen in #3838), subsequent retries will segfault when checking this ID in `complete_multipart_upload()`.

This PR simply checks that the upload ID has been set and returns the usual error code instead of crashing if not. I don't have a way to reproduce the errors that could lead to this state, unfortunately.

Discussed in #3838.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.