### PR TITLE
multiline: rule state fixes and others

### DIFF
--- a/include/fluent-bit/multiline/flb_ml.h
+++ b/include/fluent-bit/multiline/flb_ml.h
@@ -279,6 +279,8 @@ int flb_ml_append_object(struct flb_ml *ml, uint64_t stream_id,
 
 int flb_ml_parsers_init(struct flb_config *ctx);
 
+void flb_ml_flush_pending_now(struct flb_ml *ml);
+
 void flb_ml_flush_parser_instance(struct flb_ml *ml,
                                   struct flb_ml_parser_ins *parser_i,
                                   uint64_t stream_id);
@@ -316,6 +318,10 @@ int flb_ml_init(struct flb_config *config);
 int flb_ml_exit(struct flb_config *config);
 
 int flb_ml_type_lookup(char *str);
+
+int flb_ml_flush_stdout(struct flb_ml_parser *parser,
+                        struct flb_ml_stream *mst,
+                        void *data, char *buf_data, size_t buf_size);
 
 #include "flb_ml_mode.h"
 

--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_filter_plugin.h>
 
 struct ml_ctx {
+    int debug_flush;
     flb_sds_t key_content;
 
     /* packaging buffers */

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -50,6 +50,91 @@ static inline void consume_bytes(char *buf, int bytes, int length)
     memmove(buf, buf + bytes, length - bytes);
 }
 
+static int record_append_custom_keys(struct flb_tail_file *file,
+                                     size_t processed_bytes,
+                                     char *in_data, size_t in_size,
+                                     char **out_data, size_t *out_size)
+{
+    int i;
+    int ok = MSGPACK_UNPACK_SUCCESS;
+    int len;
+    size_t off = 0;
+    size_t total;
+    msgpack_unpacked result;
+    msgpack_object time;
+    msgpack_object map;
+    msgpack_object k;
+    msgpack_object v;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    struct flb_mp_map_header mh;
+
+    /* init new buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* Some extra content will be added... */
+    msgpack_unpacked_init(&result);
+    while ((msgpack_unpack_next(&result, in_data, in_size, &off) == ok)) {
+        time = result.data.via.array.ptr[0];
+        map = result.data.via.array.ptr[1];
+
+        msgpack_pack_array(&mp_pck, 2);
+        msgpack_pack_object(&mp_pck, time);
+
+        /* pack map */
+        flb_mp_map_header_init(&mh, &mp_pck);
+
+        /* append previous map keys */
+        for (i = 0; i < map.via.map.size; i++) {
+            k = map.via.map.ptr[i].key;
+            v = map.via.map.ptr[i].val;
+
+            flb_mp_map_header_append(&mh);
+            msgpack_pack_object(&mp_pck, k);
+            msgpack_pack_object(&mp_pck, v);
+        }
+
+        /* path_key */
+        if (file->config->path_key) {
+            len = flb_sds_len(file->config->path_key);
+
+            flb_mp_map_header_append(&mh);
+
+            /* key */
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, file->config->path_key, len);
+
+            /* val */
+            msgpack_pack_str(&mp_pck, file->name_len);
+            msgpack_pack_str_body(&mp_pck, file->name, file->name_len);
+        }
+
+        /* offset_key */
+        if (file->config->offset_key) {
+            len = flb_sds_len(file->config->offset_key);
+
+            flb_mp_map_header_append(&mh);
+
+            /* key */
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, file->config->offset_key, len);
+
+            /* val */
+            total = file->offset + processed_bytes;
+            msgpack_pack_uint64(&mp_pck, total);
+        }
+
+        /* finalize map */
+        flb_mp_map_header_end(&mh);
+    }
+
+    *out_data = mp_sbuf.data;
+    *out_size = mp_sbuf.size;
+
+    return 0;
+}
+
 static int unpack_and_pack(msgpack_packer *pck, msgpack_object *root,
                            const char *key, size_t key_len,
                            const char *val, size_t val_len, size_t val_uint64)
@@ -385,11 +470,45 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
     if (lines > 0) {
         /* Append buffer content to a chunk */
         *bytes = processed_bytes;
-        flb_input_chunk_append_raw(ctx->ins,
-                                   file->tag_buf,
-                                   file->tag_len,
-                                   out_sbuf->data,
-                                   out_sbuf->size);
+
+        if (out_sbuf->size > 0) {
+            flb_input_chunk_append_raw(ctx->ins,
+                                       file->tag_buf,
+                                       file->tag_len,
+                                       out_sbuf->data,
+                                       out_sbuf->size);
+        }
+        else if (ctx->ml_ctx && file->mult_sbuf.size > 0) {
+            /* If no extra keys are needed, just enqueue the buffer */
+            if (file->config->path_key == NULL &&
+                file->config->offset_key == NULL) {
+                flb_input_chunk_append_raw(ctx->ins,
+                                           file->tag_buf,
+                                           file->tag_len,
+                                           file->mult_sbuf.data,
+                                           file->mult_sbuf.size);
+
+            }
+            else {
+                char *mult_buf = NULL;
+                size_t mult_size = 0;
+
+                /* adjust the records in a new buffer */
+                record_append_custom_keys(file,
+                                          processed_bytes,
+                                          file->mult_sbuf.data,
+                                          file->mult_sbuf.size,
+                                          &mult_buf, &mult_size);
+
+                flb_input_chunk_append_raw(ctx->ins,
+                                           file->tag_buf,
+                                           file->tag_len,
+                                           mult_buf,
+                                           mult_size);
+                flb_free(mult_buf);
+            }
+            file->mult_sbuf.size = 0;
+        }
     }
     else if (file->skip_next) {
         *bytes = file->buf_len;
@@ -649,17 +768,16 @@ static int set_file_position(struct flb_tail_config *ctx,
     return 0;
 }
 
+
+/* Multiline flush callback: invoked every time some content is complete */
 static int ml_flush_callback(struct flb_ml_parser *parser,
                              struct flb_ml_stream *mst,
                              void *data, char *buf_data, size_t buf_size)
 {
     struct flb_tail_file *file = data;
 
-    flb_input_chunk_append_raw(file->config->ins,
-                               file->tag_buf,
-                               file->tag_len,
-                               buf_data,
-                               buf_size);
+    /* Enqueue the records in our file->multiline buffer */
+    msgpack_sbuffer_write(&file->mult_sbuf, buf_data, buf_size);
     return 0;
 }
 
@@ -741,7 +859,13 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->mult_keys = 0;
     file->mult_flush_timeout = 0;
     file->mult_skipping = FLB_FALSE;
+
+    /* multiline msgpack buffers */
     msgpack_sbuffer_init(&file->mult_sbuf);
+    msgpack_packer_init(&file->mult_pck, &file->mult_sbuf,
+                        msgpack_sbuffer_write);
+
+    /* docker mode */
     file->dmode_flush_timeout = 0;
     file->dmode_complete = true;
     file->dmode_buf = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 65536 : 0);
@@ -886,6 +1010,8 @@ void flb_tail_file_remove(struct flb_tail_file *file)
 #endif
         mk_list_del(&file->_rotate_head);
     }
+
+    msgpack_sbuffer_destroy(&file->mult_sbuf);
 
     flb_sds_destroy(file->dmode_buf);
     flb_sds_destroy(file->dmode_lastline);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -60,8 +60,8 @@ struct flb_tail_file {
     int mult_firstline_append;  /* bool: mult firstline appendable ?     */
     int mult_skipping;          /* skipping because ignode_older than ?  */
     int mult_keys;              /* total number of buffered keys         */
-    msgpack_sbuffer mult_sbuf;  /* temporary msgpack buffer               */
-    msgpack_packer mult_pck;    /* temporary msgpack packer               */
+    msgpack_sbuffer mult_sbuf;  /* temporary msgpack buffer              */
+    msgpack_packer mult_pck;    /* temporary msgpack packer              */
     struct flb_time mult_time;  /* multiline time parsed from first line */
 
     /* docker mode */

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -63,6 +63,22 @@ static uint64_t time_ms_now()
     return ms;
 }
 
+
+int flb_ml_flush_stdout(struct flb_ml_parser *parser,
+                        struct flb_ml_stream *mst,
+                        void *data, char *buf_data, size_t buf_size)
+{
+    fprintf(stdout, "\n%s----- MULTILINE FLUSH (stream_id=%" PRIu64 ") -----%s\n",
+            ANSI_GREEN, mst->id, ANSI_RESET);
+
+    /* Print incoming flush buffer */
+    flb_pack_print(buf_data, buf_size);
+
+    fprintf(stdout, "%s----------- EOF -----------%s\n",
+            ANSI_GREEN, ANSI_RESET);
+    return 0;
+}
+
 int flb_ml_type_lookup(char *str)
 {
     int type = -1;
@@ -120,6 +136,14 @@ void flb_ml_flush_pending(struct flb_ml *ml, uint64_t now)
         parser_i = mk_list_entry(head, struct flb_ml_parser_ins, _head);
         flb_ml_flush_parser_instance(ml, parser_i, 0);
     }
+}
+
+void flb_ml_flush_pending_now(struct flb_ml *ml)
+{
+    uint64_t now;
+
+    now = time_ms_now();
+    flb_ml_flush_pending(ml, now);
 }
 
 static void cb_ml_flush_timer(struct flb_config *ctx, void *data)
@@ -416,8 +440,8 @@ static int process_append(struct flb_ml_parser_ins *parser_i,
     else if (type == FLB_ML_TYPE_MAP) {
         full_map = obj;
         if (!full_map) {
-            msgpack_unpacked_init(&result);
             off = 0;
+            msgpack_unpacked_init(&result);
             ret = msgpack_unpack_next(&result, buf, size, &off);
             if (ret != MSGPACK_UNPACK_SUCCESS) {
                 return -1;
@@ -500,10 +524,12 @@ static int ml_append_try_parser(struct flb_ml_parser_ins *parser,
         /* Parse incoming content */
         ret = flb_parser_do(parser->ml_parser->parser, (char *) buf, size,
                             &out_buf, &out_size, &out_time);
+
+        if (flb_time_to_double(&out_time) == 0.0) {
+            flb_time_copy(&out_time, tm);
+        }
+
         if (ret >= 0) {
-            if (flb_time_to_double(&out_time) == 0.0) {
-                flb_time_copy(&out_time, tm);
-            }
             release = FLB_TRUE;
             type = FLB_ML_TYPE_MAP;
         }
@@ -751,6 +777,7 @@ int flb_ml_append_object(struct flb_ml *ml, uint64_t stream_id,
 
         /* Append record content to group msgpack buffer */
         msgpack_pack_array(&st_group->mp_pck, 2);
+
         flb_time_append_to_msgpack(tm, &st_group->mp_pck, 0);
         msgpack_pack_object(&st_group->mp_pck, *obj);
 
@@ -897,6 +924,11 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
     /* init msgpack buffer */
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* if the group don't have a time set, use current time */
+    if (flb_time_to_double(&group->mp_time) == 0.0) {
+        flb_time_get(&group->mp_time);
+    }
 
     /* compose final record if we have a first line context */
     if (group->mp_sbuf.size > 0) {

--- a/src/multiline/flb_ml_parser_java.c
+++ b/src/multiline/flb_ml_parser_java.c
@@ -53,7 +53,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
                                NULL);                /* parser name */
 
     if (!mlp) {
-        flb_error("[multiline] could not create 'python mode'");
+        flb_error("[multiline] could not create 'java mode'");
         return NULL;
     }
 
@@ -86,7 +86,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
 
     ret = rule(mlp,
                "java_after_exception, java",
-               "/^[\t ]+(?:eval )?at /",
+               "/^[\\t ]+(?:eval )?at /",
                "java", NULL);
     if (ret != 0) {
         rule_error(mlp);
@@ -116,7 +116,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
 
     ret = rule(mlp,
                "java_after_exception, java",
-               "/^[\t ]*(?:Caused by|Suppressed):/",
+               "/^[\\t ]*(?:Caused by|Suppressed):/",
                "java_after_exception", NULL);
     if (ret != 0) {
         rule_error(mlp);
@@ -125,7 +125,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
 
     ret = rule(mlp,
                "java_after_exception, java",
-               "/^[\t ]*... \\d+ (?:more|common frames omitted)/",
+               "/^[\\t ]*... \\d+ (?:more|common frames omitted)/",
                "java", NULL);
     if (ret != 0) {
         rule_error(mlp);


### PR DESCRIPTION
- multiline: fix rule states
- filter_multiline: force flush of pending data before return and new 'debug_flush' option
- in_tail: multiline now supports custom keys (offset_key, path_key)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
