### PR TITLE
fcntl: set FD_CLOEXEC on file descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,6 +846,19 @@ if(FLB_INOTIFY)
   endif()
 endif()
 
+# pipe2
+check_c_source_compiles("
+    #define _GNU_SOURCE
+    #include <unistd.h>
+    int main() {
+        int pipefd[2];
+        pipe2(pipefd, 0);
+        return 0;
+    }" FLB_HAVE_PIPE2)
+if(FLB_HAVE_PIPE2)
+  FLB_DEFINITION(FLB_HAVE_PIPE2)
+endif()
+
 include(CheckSymbolExists)
 
 # Check for getentropy(3)

--- a/include/fluent-bit/flb_fcntl.h
+++ b/include/fluent-bit/flb_fcntl.h
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2021 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FCNTL_H
+#define FLB_FCNTL_H
+
+#include <fcntl.h>
+
+#ifdef _WIN32
+typedef int mode_t;
+#endif
+
+int flb_fcntl_cloexec(int fd);
+
+int flb_open(const char *pathname, int flags, mode_t mode);
+
+#endif

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -17,16 +17,17 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_filter_plugin.h>
 #include <fluent-bit/flb_compat.h>
-#include <fluent-bit/flb_hash.h>
-#include <fluent-bit/flb_regex.h>
-#include <fluent-bit/flb_io.h>
-#include <fluent-bit/flb_upstream.h>
-#include <fluent-bit/flb_http_client.h>
-#include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_filter_plugin.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_io.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/tls/flb_tls.h>
 
 #include <sys/types.h>
@@ -316,7 +317,7 @@ static int get_meta_file_info(struct flb_kube *ctx, const char *namespace,
         ret = snprintf(uri, sizeof(uri) - 1, "%s/%s_%s.meta",
                        ctx->meta_preload_cache_dir, namespace, podname);
         if (ret > 0) {
-            fd = open(uri, O_RDONLY, 0);
+            fd = flb_open(uri, O_RDONLY, 0);
             if (fd != -1) {
                 if (fstat(fd, &sb) == 0) {
                     payload = flb_malloc(sb.st_size);

--- a/plugins/in_collectd/typesdb.c
+++ b/plugins/in_collectd/typesdb.c
@@ -17,8 +17,9 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_str.h>
@@ -36,7 +37,7 @@
 static int typesdb_load(struct flb_in_collectd_config *ctx,
                         struct mk_list *tdb, const char *path)
 {
-    int fd = open(path, O_RDONLY);
+    int fd = flb_open(path, O_RDONLY, 0);
     if (fd < 0) {
         flb_errno();
         flb_plg_error(ctx->ins, "failed to open '%s'", path);

--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -17,13 +17,14 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_plugin.h>
-#include <fluent-bit/flb_config.h>
-#include <fluent-bit/flb_error.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_utils.h>
 #include <msgpack.h>
 
 #include <stdio.h>
@@ -88,7 +89,7 @@ static int read_bytes(struct flb_in_head_config *ctx)
 {
     int fd = -1;
     /* open at every collect callback */
-    fd = open(ctx->filepath, O_RDONLY);
+    fd = flb_open(ctx->filepath, O_RDONLY, 0);
     if (fd < 0) {
         flb_errno();
         return -1;

--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -17,10 +17,11 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_plugin.h>
-#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_time.h>
 
 #include <msgpack.h>
@@ -57,7 +58,7 @@ static int boot_time(struct timeval *boot_time)
     char buf[256];
     struct timeval curr_time;
 
-    fd = open("/proc/uptime", O_RDONLY);
+    fd = flb_open("/proc/uptime", O_RDONLY, 0);
     if (fd == -1) {
         return -1;
     }
@@ -292,7 +293,7 @@ static int in_kmsg_init(struct flb_input_instance *ins,
     flb_input_set_context(ins, ctx);
 
     /* open device */
-    fd = open(FLB_KMSG_DEV, O_RDONLY);
+    fd = flb_open(FLB_KMSG_DEV, O_RDONLY, 0);
     if (fd == -1) {
         flb_errno();
         flb_free(ctx);

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_sds.h>
@@ -99,7 +100,7 @@ int ne_utils_file_read_uint64(const char *mount,
         flb_sds_cat_safe(&p, join_b, len);
     }
 
-    fd = open(p, O_RDONLY);
+    fd = flb_open(p, O_RDONLY, 0);
     if (fd == -1) {
         flb_sds_destroy(p);
         return -1;

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -17,8 +17,9 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
@@ -131,7 +132,7 @@ static pid_t get_pid_from_procname_linux(struct flb_in_proc_config *ctx,
     }
 
     for (i = 0; i < glb.gl_pathc; i++) {
-        fd = open(glb.gl_pathv[i], O_RDONLY);
+        fd = flb_open(glb.gl_pathv[i], O_RDONLY, 0);
         if (fd < 0) {
             continue;
         }

--- a/plugins/in_serial/in_serial.c
+++ b/plugins/in_serial/in_serial.c
@@ -18,12 +18,13 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_utils.h>
-#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_pack.h>
-#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_utils.h>
 #include <msgpack.h>
 
 
@@ -285,7 +286,7 @@ static int cb_serial_init(struct flb_input_instance *in,
     flb_input_set_context(in, ctx);
 
     /* open device */
-    fd = open(ctx->file, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    fd = flb_open(ctx->file, O_RDWR | O_NOCTTY | O_NONBLOCK, 0);
     if (fd == -1) {
         perror("open");
         flb_error("[in_serial] Could not open serial port device");

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -17,13 +17,14 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_config.h>
-#include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_engine.h>
-#include <fluent-bit/flb_time.h>
-#include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_utils.h>
 
 #include <msgpack.h>
@@ -302,6 +303,9 @@ static int in_stdin_init(struct flb_input_instance *in,
         flb_plg_error(ctx->ins, "Could not open standard input!");
         goto init_error;
     }
+
+    flb_fcntl_cloexec(fd);
+
     ctx->fd = fd;
 
     /* Always initialize built-in JSON pack state */

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -17,11 +17,12 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_plugin.h>
-#include <fluent-bit/flb_config.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_utils.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -67,7 +68,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     }
 
     /* Create the channel manager */
-    ret = pipe(ctx->ch_manager);
+    ret = flb_pipe_create(ctx->ch_manager);
     if (ret == -1) {
         flb_errno();
         flb_free(ctx);
@@ -258,8 +259,7 @@ int flb_systemd_config_destroy(struct flb_systemd_config *ctx)
     }
 #endif
 
-    close(ctx->ch_manager[0]);
-    close(ctx->ch_manager[1]);
+    flb_pipe_destroy(ctx->ch_manager);
 
     flb_free(ctx);
     return 0;

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -20,9 +20,10 @@
 #ifndef FLB_SYSTEMD_CONFIG_H
 #define FLB_SYSTEMD_CONFIG_H
 
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
-#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_pipe.h>
 #include <fluent-bit/flb_sqldb.h>
 
 #include <systemd/sd-journal.h>
@@ -54,10 +55,10 @@ struct flb_systemd_config {
     int strip_underscores;
 
     /* Internal */
-    int ch_manager[2];         /* pipe: channel manager    */
-    int coll_fd_archive;       /* archive collector        */
-    int coll_fd_journal;       /* journal, events mode     */
-    int coll_fd_pending;       /* pending records          */
+    flb_pipefd_t ch_manager[2]; /* pipe: channel manager    */
+    int coll_fd_archive;        /* archive collector        */
+    int coll_fd_journal;        /* journal, events mode     */
+    int coll_fd_pending;        /* pending records          */
     int dynamic_tag;
     int max_fields;            /* max number of fields per record */
     int max_entries;           /* max number of records per iteration */

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -23,6 +23,7 @@
 #include <time.h>
 
 #include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_parser.h>
@@ -883,7 +884,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         return -1;
     }
 
-    fd = open(path, O_RDONLY);
+    fd = flb_open(path, O_RDONLY, 0);
     if (fd == -1) {
         flb_errno();
         flb_plg_error(ctx->ins, "cannot open %s", path);

--- a/plugins/in_tail/win32.h
+++ b/plugins/in_tail/win32.h
@@ -45,7 +45,7 @@
 #undef S_ISREG
 #undef S_ISLNK
 
-#define open win32_open
+#define flb_open win32_open
 #define stat win32_stat
 #define lstat win32_lstat
 #define fstat win32_fstat

--- a/plugins/in_tail/win32/interface.h
+++ b/plugins/in_tail/win32/interface.h
@@ -32,7 +32,7 @@ int win32_stat(const char *path, struct win32_stat *wst);
 int win32_lstat(const char *path, struct win32_stat *wst);
 int win32_fstat(int fd, struct win32_stat *wst);
 
-int win32_open(const char *path, int flags);
+int win32_open(const char *path, int flags, int mode);
 
 #define WIN32_S_IFDIR 0x1000
 #define WIN32_S_IFCHR 0x2000

--- a/plugins/in_tail/win32/io.c
+++ b/plugins/in_tail/win32/io.c
@@ -30,7 +30,7 @@
  * open(2) that does not acquire an exclusive lock.
  */
 
-int win32_open(const char *path, int flags)
+int win32_open(const char *path, int flags, int mode)
 {
     HANDLE h;
     h = CreateFileA(path,

--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -17,9 +17,10 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_fcntl.h>
 #include <fluent-bit/flb_output_plugin.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_utils.h>
 #include <msgpack.h>
 
 #include <stdio.h>
@@ -90,7 +91,7 @@ static void cb_plot_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Open output file with default name as the Tag */
-    fd = open(out_file, O_WRONLY | O_CREAT | O_APPEND, 0666);
+    fd = flb_open(out_file, O_WRONLY | O_CREAT | O_APPEND, 0666);
     if (fd == -1) {
         flb_errno();
         flb_plg_warn(ctx->ins, "could not open %s, switching to STDOUT",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ set(src
   flb_typecast.c
   flb_event.c
   flb_base64.c
+  flb_fcntl.c
   )
 
 # Config format

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -17,14 +17,15 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_sds.h>
-#include <fluent-bit/flb_http_client.h>
-#include <fluent-bit/flb_signv4.h>
-#include <fluent-bit/flb_aws_util.h>
 #include <fluent-bit/flb_aws_credentials.h>
-#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_signv4.h>
 
 #include <stdlib.h>
 #include <sys/types.h>
@@ -103,7 +104,7 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size)
     struct stat st;
     int fd;
 
-    fd = open(path, O_RDONLY);
+    fd = flb_open(path, O_RDONLY, 0);
     if (fd < 0) {
         return -1;
     }

--- a/src/flb_fcntl.c
+++ b/src/flb_fcntl.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2021 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_log.h>
+
+int flb_fcntl_cloexec(int fd)
+{
+#ifdef FD_CLOEXEC
+    int flags = fcntl(fd, F_GETFD);
+    if (flags == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
+        flb_errno();
+        return -1;
+    }
+#endif
+    return 0;
+}
+
+int flb_open(const char *pathname, int flags, mode_t mode)
+{
+#ifdef O_CLOEXEC
+    return open(pathname, flags | O_CLOEXEC, mode);
+#else
+    int fd = open(pathname, flags, mode);
+    if (fd == -1) {
+        return -1;
+    }
+    flb_fcntl_cloexec(fd);
+    return fd;
+#endif
+}

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -27,11 +27,12 @@
 #include <fcntl.h>
 
 #include <monkey/mk_core.h>
-#include <fluent-bit/flb_log.h>
-#include <fluent-bit/flb_pipe.h>
 #include <fluent-bit/flb_config.h>
-#include <fluent-bit/flb_worker.h>
+#include <fluent-bit/flb_fcntl.h>
+#include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_worker.h>
 
 #ifdef FLB_HAVE_AWS_ERROR_REPORTER
 #include <fluent-bit/aws/flb_aws_error_reporter.h>
@@ -71,7 +72,7 @@ static inline int log_push(struct log_message *msg, struct flb_log *log)
         return write(STDERR_FILENO, msg->msg, msg->size);
     }
     else if (log->type == FLB_LOG_FILE) {
-        fd = open(log->out, O_CREAT | O_WRONLY | O_APPEND, 0666);
+        fd = flb_open(log->out, O_CREAT | O_WRONLY | O_APPEND, 0666);
         if (fd == -1) {
             fprintf(stderr, "[log] error opening log file %s. Using stderr.\n",
                     log->out);

--- a/src/flb_random.c
+++ b/src/flb_random.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_fcntl.h>
 #include <fcntl.h>
 
 #ifdef FLB_HAVE_GETENTROPY
@@ -77,7 +78,7 @@ int flb_random_bytes(unsigned char *buf, int len)
 
 try_urandom:
 #endif /* FLB_HAVE_GETENTROPY || FLB_HAVE_GETENTROPY_SYS_RANDOM */
-    fd = open("/dev/urandom", O_RDONLY);
+    fd = flb_open("/dev/urandom", O_RDONLY, 0);
     if (fd == -1) {
         return -1;
     }


### PR DESCRIPTION
Set `FD_CLOEXEC` on file descriptors. This prevents child processes from inheriting them, which is almost always the intended behavior.

Partial fix for #3671. For simplicity it only fixes usages of direct file descriptors. It does not fix usages of `popen` or `fopen`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
