### PR TITLE
out_loki: fix invalid memory reference on pack_label_key (#3279)

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -254,6 +254,7 @@ static int pack_label_key(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     int i;
     int k_len = key_len;
     int is_digit = FLB_FALSE;
+    size_t sbuf_size;
     char *p;
 
     /* Normalize key name using the packed value */
@@ -268,14 +269,13 @@ static int pack_label_key(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         msgpack_pack_str_body(mp_pck, "_", 1);
     }
 
-    /*
-     * 'p' will point to the next memory area where the key will be
-     * written.
-     */
-    p = (char *) (mp_sbuf->data + mp_sbuf->size);
+    sbuf_size = mp_sbuf->size;
 
     /* Pack the key name */
     msgpack_pack_str_body(mp_pck, key, key_len);
+
+    /* 'p' will point to the beginning memory area where the key written. */
+    p = (char *) (mp_sbuf->data + sbuf_size);
 
     for (i = 0; i < key_len; i++) {
         if (!isalnum(p[i]) && p[i] != '_') {


### PR DESCRIPTION
If the internal buffer in mp_sbuf is not enough for the key,
msgpack_pack_str_body allocates new memory area, therefore mp_sbuf->data
will be invalidated.
This postpone setting a pointer after calling the function to
prevent invalid memory reference.

Signed-off-by: toshipp <toshiq2@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fix #3279

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
