### PR TITLE
out_s3: fixed potential segfault on file discard

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1633,6 +1633,7 @@ static void s3_upload_queue(struct flb_config *config, void *out_context)
                 s3_store_file_inactive(ctx, upload_contents->upload_file);
                 multipart_upload_destroy(upload_contents->m_upload_file);
                 remove_from_queue(upload_contents);
+                continue;
             }
 
             /* Retry in N seconds */


### PR DESCRIPTION
In the upload queue logic, if we exceed the acceptable number of upload errors in a row,
we remove the entry from the upload queue. However, instead of immediately moving onto
the next entry, we try to set upload_time. This will cause a segfault. Adding a continue
after removing entry will fix this issue.

Signed-off-by: Stephen Lee <sleemamz@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
