### PR TITLE
lib: fix race between flb_start and flb_destroy

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -668,6 +668,8 @@ int flb_start(flb_ctx_t *ctx)
         fd = event->fd;
         bytes = flb_pipe_r(fd, &val, sizeof(uint64_t));
         if (bytes <= 0) {
+            pthread_cancel(tid);
+            pthread_join(tid, NULL);
             ctx->status = FLB_LIB_ERROR;
             return -1;
         }
@@ -679,6 +681,7 @@ int flb_start(flb_ctx_t *ctx)
         }
         else if (val == FLB_ENGINE_FAILED) {
             flb_error("[lib] backend failed");
+            pthread_join(tid, NULL);
             ctx->status = FLB_LIB_ERROR;
             return -1;
         }


### PR DESCRIPTION
Signed-off-by: Jesse Rittner <rittneje@gmail.com>

Fixes a race condition between `flb_start` and `flb_destroy` that was caused by `flb_start` leaking the worker thread in the failure case.

Fixes #3852.

@nokute78 Can you test this branch with the thread sanitizer? I am not able to run it on my end.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

There was no more output from Valgrind with this fix.

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
