### PR TITLE
network: add ctype.h header

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <ctype.h>
 
 #ifdef FLB_SYSTEM_WINDOWS
 #define poll WSAPoll


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <edsiper@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
