### PR TITLE
plugin_proxy: destroy used buffer on exit 

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -44,10 +44,7 @@ struct flb_plugin_proxy_def {
 /* Proxy context */
 struct flb_plugin_proxy {
     /* Fields populated once remote flb_cb_register() is called */
-    int type;                 /* defined by FLB_PROXY_[INPUT|OUTPUT]_PLUGIN  */
-    int proxy;                /* proxy type                                  */
-    char *name;               /* plugin short name                           */
-    char *description;        /* plugin description                          */
+    struct flb_plugin_proxy_def *def;
 
     /* Internal */
     struct flb_api *api;      /* API context to export functions             */

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -104,8 +104,8 @@ static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
     out->type  = FLB_OUTPUT_PLUGIN_PROXY;
     out->proxy = proxy;
     out->flags = def->flags;
-    out->name  = flb_strdup(def->name);
-    out->description = flb_strdup(def->description);
+    out->name  = def->name;
+    out->description = def->description;
     mk_list_add(&out->_head, &config->out_plugins);
 
     /*

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -253,6 +253,7 @@ struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
 void flb_plugin_proxy_destroy(struct flb_plugin_proxy *proxy)
 {
     /* cleanup */
+    flb_api_destroy(proxy->api);
     dlclose(proxy->dso_handler);
     mk_list_del(&proxy->_head);
     flb_free(proxy);

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -70,21 +70,10 @@ static int flb_proxy_cb_exit(void *data, struct flb_config *config)
 {
     struct flb_output_plugin *instance = data;
     struct flb_plugin_proxy *proxy = (instance->proxy);
-    struct flbgo_output_plugin *plugin;
-    void *inst;
 
-    inst = proxy->data;
-
-    plugin = (struct flbgo_output_plugin *) inst;
-    flb_debug("[GO] running exit callback");
-
-    if (plugin->cb_exit_ctx) {
-        return plugin->cb_exit_ctx(plugin->context->remote_context);
+    if (proxy->def->proxy == FLB_PROXY_GOLANG) {
+        proxy_go_destroy(proxy->data);
     }
-    else if (plugin->cb_exit) {
-        return plugin->cb_exit();
-    }
-
     return 0;
 }
 

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -145,3 +145,22 @@ int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
     flb_free(buf);
     return ret;
 }
+
+int proxy_go_destroy(void *data)
+{
+    int ret = 0;
+    struct flbgo_output_plugin *plugin;
+
+    plugin = (struct flbgo_output_plugin *) data;
+    flb_debug("[GO] running exit callback");
+
+    if (plugin->cb_exit_ctx) {
+        ret = plugin->cb_exit_ctx(plugin->context->remote_context);
+    }
+    else if (plugin->cb_exit) {
+        ret = plugin->cb_exit();
+    }
+    flb_free(plugin->name);
+    flb_free(plugin);
+    return ret;
+}

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -45,5 +45,5 @@ int proxy_go_init(struct flb_plugin_proxy *proxy);
 int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
                    const void *data, size_t size,
                    const char *tag, int tag_len);
-
+int proxy_go_destroy(void *data);
 #endif


### PR DESCRIPTION
plugin_proxy leaks several times. I fixed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration file
It is same as https://github.com/fluent/fluent-bit/pull/3863#issuecomment-888928614



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
