### PR TITLE
ra_key: check subkeys length

### DIFF
--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -225,7 +225,7 @@ struct flb_ra_value *flb_ra_key_to_value(flb_sds_t ckey,
     result->o = val;
 
     if ((val.type == MSGPACK_OBJECT_MAP || val.type == MSGPACK_OBJECT_ARRAY)
-        && subkeys != NULL) {
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
 
         ret = subkey_to_object(&val, subkeys, &out_key, &out_val);
         if (ret == 0) {
@@ -275,7 +275,7 @@ int flb_ra_key_value_get(flb_sds_t ckey, msgpack_object map,
     val = map.via.map.ptr[i].val;
 
     if ((val.type == MSGPACK_OBJECT_MAP || val.type == MSGPACK_OBJECT_ARRAY)
-        && subkeys != NULL) {
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
         ret = subkey_to_object(&val, subkeys, &o_key, &o_val);
         if (ret == 0) {
             *out_key = o_key;
@@ -311,7 +311,7 @@ int flb_ra_key_strcmp(flb_sds_t ckey, msgpack_object map,
     val = map.via.map.ptr[i].val;
 
     if ((val.type == MSGPACK_OBJECT_MAP || val.type == MSGPACK_OBJECT_ARRAY)
-        && subkeys != NULL) {
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
         ret = subkey_to_object(&val, subkeys, &out_key, &out_val);
         if (ret == 0) {
             return msgpack_object_strcmp(*out_val, str, len);
@@ -344,7 +344,7 @@ int flb_ra_key_regex_match(flb_sds_t ckey, msgpack_object map,
     val = map.via.map.ptr[i].val;
 
     if ((val.type == MSGPACK_OBJECT_MAP || val.type == MSGPACK_OBJECT_ARRAY)
-        && subkeys != NULL) {
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
         ret = subkey_to_object(&val, subkeys, &out_key, &out_val);
         if (ret == 0) {
             if (out_val->type != MSGPACK_OBJECT_STR) {

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -73,7 +73,8 @@ void flb_test_basic()
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
-    flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
 
     sleep(2);
     flb_stop(ctx);
@@ -131,7 +132,8 @@ void flb_test_labels()
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
-    flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
 
     sleep(2);
     flb_stop(ctx);
@@ -190,7 +192,8 @@ void flb_test_label_keys()
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
-    flb_lib_push(ctx, in_ffd, (char *) JSON_LABEL_KEYS, size);
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_LABEL_KEYS, size);
+    TEST_CHECK(ret >= 0);
 
     sleep(2);
     flb_stop(ctx);
@@ -248,7 +251,112 @@ void flb_test_line_format()
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
-    flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
+static void cb_check_line_format_remove_keys(void *ctx, int ffd,
+                                             int res_ret, void *res_data,
+                                             size_t res_size, void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "value_nested";
+
+    /* p == NULL is expected since it should be removed.*/
+    p = strstr(out_js, index_line);
+    if (!TEST_CHECK(p == NULL)) {
+      TEST_MSG("Given:%s", out_js);
+    }
+
+    flb_sds_destroy(out_js);
+}
+#define JSON_BASIC_NEST "[12345678, {\"key\": {\"nest\":\"value_nested\"}} ]"
+void flb_test_remove_keys()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC_NEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "remove_keys", "$key['nest']",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_line_format_remove_keys,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC_NEST, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+/* https://github.com/fluent/fluent-bit/issues/3875 */
+void flb_test_remove_map()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC_NEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "remove_keys", "key",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_line_format_remove_keys,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC_NEST, size);
+    TEST_CHECK(ret >= 0);
 
     sleep(2);
     flb_stop(ctx);
@@ -257,9 +365,11 @@ void flb_test_line_format()
 
 /* Test list */
 TEST_LIST = {
-    {"basic"            , flb_test_basic },
-    {"labels"           , flb_test_labels },
-    {"label_keys"       , flb_test_label_keys },
-    {"line_format"      , flb_test_line_format },
+    {"remove_keys_remove_map" , flb_test_remove_map},
+    {"remove_keys"            , flb_test_remove_keys },
+    {"basic"                  , flb_test_basic },
+    {"labels"                 , flb_test_labels },
+    {"label_keys"             , flb_test_label_keys },
+    {"line_format"            , flb_test_line_format },
     {NULL, NULL}
 };

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -277,48 +277,6 @@ static void cb_check_line_format_remove_keys(void *ctx, int ffd,
     flb_sds_destroy(out_js);
 }
 #define JSON_BASIC_NEST "[12345678, {\"key\": {\"nest\":\"value_nested\"}} ]"
-void flb_test_remove_keys()
-{
-    int ret;
-    int size = sizeof(JSON_BASIC_NEST) - 1;
-    flb_ctx_t *ctx;
-    int in_ffd;
-    int out_ffd;
-
-    /* Create context, flush every second (some checks omitted here) */
-    ctx = flb_create();
-    flb_service_set(ctx, "flush", "1", "grace", "1",
-                    "log_level", "error",
-                    NULL);
-
-    /* Lib input mode */
-    in_ffd = flb_input(ctx, (char *) "lib", NULL);
-    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
-
-    /* Elasticsearch output */
-    out_ffd = flb_output(ctx, (char *) "loki", NULL);
-    flb_output_set(ctx, out_ffd,
-                   "match", "test",
-                   "remove_keys", "$key['nest']",
-                   NULL);
-
-    /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_line_format_remove_keys,
-                              NULL, NULL);
-
-    /* Start */
-    ret = flb_start(ctx);
-    TEST_CHECK(ret == 0);
-
-    /* Ingest data sample */
-    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC_NEST, size);
-    TEST_CHECK(ret >= 0);
-
-    sleep(2);
-    flb_stop(ctx);
-    flb_destroy(ctx);
-}
 /* https://github.com/fluent/fluent-bit/issues/3875 */
 void flb_test_remove_map()
 {


### PR DESCRIPTION
Fixes #3875 

The issue is caused by `subkey_to_object`.
The API expects a length of subkeys > 0.
However some APIs invokes `subkey_to_object` even if the length is 0.
e.g. Only the root key of record accessor `$key`



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration

```
[INPUT]
    Name dummy
    Dummy {"kubernetes":{"namespace_name":"hoge", "pod_id":"05b0a58a-9ed6-42ab-9742-b1e685a3f636"}, "anotations":"hogehoge"}
    Samples 1

[OUTPUT]
    Name loki
    remove_keys kubernetes
    auto_kubernetes_labels off
    line_format json
```

## Debug output
1. `nc -l 3100`
2. `fluent-bit -c a.conf`

The `"kubernetes":{"namespace_name":"hoge", "pod_id":"05b0a58a-9ed6-42ab-9742-b1e685a3f636"},` is removed.
```
$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 112
User-Agent: Fluent-Bit
Content-Type: application/json

{"streams":[{"stream":{"job":"fluent-bit"},"values":[["1627789209244215794","{\"anotations\":\"hogehoge\"}"]]}]}^C
```

## Valgrind output

Valgrind reports a leak which is not related this PR..

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/fluent-bit-conf/3875.conf 
==90979== Memcheck, a memory error detector
==90979== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==90979== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==90979== Command: bin/fluent-bit -c /home/taka/fluent-bit-conf/3875.conf
==90979== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/01 12:42:32] [ info] [engine] started (pid=90979)
[2021/08/01 12:42:32] [ info] [storage] version=1.1.1, initializing...
[2021/08/01 12:42:32] [ info] [storage] in-memory
[2021/08/01 12:42:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/01 12:42:32] [ info] [cmetrics] version=0.1.6
[2021/08/01 12:42:33] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/08/01 12:42:33] [ info] [sp] stream processor started
^C[2021/08/01 12:42:33] [engine] caught signal (SIGINT)
==90979== Warning: client switching stacks?  SP change: 0x57e4948 --> 0x4c79230
==90979==          to suppress, use: --max-stackframe=11974424 or greater
==90979== Warning: client switching stacks?  SP change: 0x4c791a8 --> 0x57e4948
==90979==          to suppress, use: --max-stackframe=11974560 or greater
==90979== Warning: client switching stacks?  SP change: 0x57e4948 --> 0x4c791a8
==90979==          to suppress, use: --max-stackframe=11974560 or greater
==90979==          further instances of this message will not be shown.
[2021/08/01 12:42:33] [ warn] [engine] service will stop in 5 seconds
[2021/08/01 12:42:38] [ info] [engine] service stopped
==90979== 
==90979== HEAP SUMMARY:
==90979==     in use at exit: 74,545 bytes in 6 blocks
==90979==   total heap usage: 1,081 allocs, 1,075 frees, 750,653 bytes allocated
==90979== 
==90979== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==90979==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==90979==    by 0x1B4CD1: flb_calloc (flb_mem.h:78)
==90979==    by 0x1B5F2C: flb_net_dns_lookup_context_create (flb_network.c:690)
==90979==    by 0x1B6107: flb_net_getaddrinfo (flb_network.c:754)
==90979==    by 0x1B66BB: flb_net_tcp_connect (flb_network.c:915)
==90979==    by 0x1DE4D6: flb_io_net_connect (flb_io.c:89)
==90979==    by 0x1C25CF: create_conn (flb_upstream.c:523)
==90979==    by 0x1C2AA2: flb_upstream_conn_get (flb_upstream.c:666)
==90979==    by 0x24FAE2: cb_loki_flush (loki.c:1178)
==90979==    by 0x1AB56C: output_pre_cb_flush (flb_output.h:490)
==90979==    by 0x6ECB6A: co_init (amd64.c:117)
==90979== 
==90979== LEAK SUMMARY:
==90979==    definitely lost: 128 bytes in 1 blocks
==90979==    indirectly lost: 74,417 bytes in 5 blocks
==90979==      possibly lost: 0 bytes in 0 blocks
==90979==    still reachable: 0 bytes in 0 blocks
==90979==         suppressed: 0 bytes in 0 blocks
==90979== 
==90979== For lists of detected and suppressed errors, rerun with: -s
==90979== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
