### PR TITLE
pack_gelf: make time precision explicit(#3727)

### DIFF
--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -762,7 +762,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
         }
         *s = tmp;
 
-        tmp = flb_sds_printf(s, "%" PRIu32".%lu",
+        /* gelf supports milliseconds */
+        tmp = flb_sds_printf(s, "%" PRIu32".%03lu",
                              tm->tm.tv_sec, tm->tm.tv_nsec / 1000000);
         if (tmp == NULL) {
             return NULL;

--- a/tests/internal/gelf.c
+++ b/tests/internal/gelf.c
@@ -50,7 +50,52 @@ void test_gelf_pack()
     msgpack_sbuffer_destroy(&mp_sbuf);
 }
 
+#define EXPECTED_OUT_MSEC \
+    "{\"version\":\"1.1\", \"short_message\":\"true, 2019, str\", \"_t2\":\"false\", \"timestamp\":337647600.012}"
+
+/* https://github.com/fluent/fluent-bit/issues/3727 */
+void test_gelf_pack_msec()
+{
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    struct flb_time ts;
+    struct flb_gelf_fields fields = {0};
+    flb_sds_t out;
+
+    /* Pack sample msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+
+    ts.tm.tv_sec =  337647600;
+    ts.tm.tv_nsec =  12341111; /* 12.34msec */
+
+    msgpack_pack_map(&mp_pck, 2);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "t1", 2);
+    msgpack_pack_array(&mp_pck, 3);
+    msgpack_pack_true(&mp_pck);
+    msgpack_pack_uint64(&mp_pck, 2019);
+    msgpack_pack_str(&mp_pck, 3);
+    msgpack_pack_str_body(&mp_pck, "str", 3);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "t2", 2);
+    msgpack_pack_false(&mp_pck);
+
+    fields.short_message_key = flb_sds_create("t1");
+    out = flb_msgpack_raw_to_gelf(mp_sbuf.data, mp_sbuf.size, &ts, &fields);
+    TEST_CHECK(out != NULL);
+
+    if(!TEST_CHECK(strcmp(out, EXPECTED_OUT_MSEC) == 0)) {
+        TEST_MSG("out=%s", out);
+    }
+    flb_sds_destroy(out);
+    flb_sds_destroy(fields.short_message_key);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
 TEST_LIST = {
-    {"gelf_pack", test_gelf_pack},
+    {"gelf_pack",      test_gelf_pack},
+    {"gelf_pack_msec", test_gelf_pack_msec},
     { 0 }
 };


### PR DESCRIPTION
Fixes #3727 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name dummy
    Samples 1
# 10msec
    Start_time_nsec 10000000
    Dummy {"hoge":"short", "msg":"test"}

[OUTPUT]
    Name http
    Format gelf
    Port 10080
    gelf_short_message_key hoge
```

## Debug output

1. `nc -l 10080`
2. `fluent-bit -c a.conf`

```
$ nc -l 10080
POST / HTTP/1.1
Host: 127.0.0.1:10080
Content-Length: 77
Content-Type: application/json
User-Agent: Fluent-Bit

{"version":"1.1", "short_message":"short", "_msg":"test", "timestamp":0.010}
^C
```

## Valgrind output

There is no leak except #3897 
```
$ valgrind --leak-check=full bin/fluent-bit -c ~/fluent-bit-conf/3727.conf 
==27873== Memcheck, a memory error detector
==27873== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27873== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==27873== Command: bin/fluent-bit -c /home/taka/fluent-bit-conf/3727.conf
==27873== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/02 10:04:07] [ info] [engine] started (pid=27873)
[2021/08/02 10:04:07] [ info] [storage] version=1.1.1, initializing...
[2021/08/02 10:04:07] [ info] [storage] in-memory
[2021/08/02 10:04:07] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/02 10:04:07] [ info] [cmetrics] version=0.1.6
[2021/08/02 10:04:07] [ info] [sp] stream processor started
==27873== Warning: client switching stacks?  SP change: 0x57e49e8 --> 0x4c8acb0
==27873==          to suppress, use: --max-stackframe=11902264 or greater
==27873== Warning: client switching stacks?  SP change: 0x4c8ac28 --> 0x57e49e8
==27873==          to suppress, use: --max-stackframe=11902400 or greater
==27873== Warning: client switching stacks?  SP change: 0x57e49e8 --> 0x4c8ac28
==27873==          to suppress, use: --max-stackframe=11902400 or greater
==27873==          further instances of this message will not be shown.
^C[2021/08/02 10:04:12] [engine] caught signal (SIGINT)
[2021/08/02 10:04:12] [ warn] [engine] service will stop in 5 seconds
[2021/08/02 10:04:16] [ info] [engine] service stopped
[2021/08/02 10:04:16] [ warn] [engine] shutdown delayed, grace period has finished but some tasks are still running.
[2021/08/02 10:04:16] [ info] [task] dummy/dummy.0 has 1 pending task(s):
[2021/08/02 10:04:16] [ info] [task]   task_id=0 still running on route(s): http/http.0 
[2021/08/02 10:04:16] [ warn] [engine] service will stop in 5 seconds
[2021/08/02 10:04:21] [error] [http_client] broken connection to 127.0.0.1:10080 ?
[2021/08/02 10:04:21] [error] [output:http:http.0] could not flush records to 127.0.0.1:10080 (http_do=-1)
[2021/08/02 10:04:21] [ warn] [engine] failed to flush chunk '27873-1627866247.699055264.flb', retry in 9 seconds: task_id=0, input=dummy.0 > output=http.0 (out_id=0)
[2021/08/02 10:04:21] [ info] [engine] service stopped
==27873== 
==27873== HEAP SUMMARY:
==27873==     in use at exit: 74,545 bytes in 6 blocks
==27873==   total heap usage: 1,108 allocs, 1,102 frees, 937,117 bytes allocated
==27873== 
==27873== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==27873==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==27873==    by 0x1B4CD1: flb_calloc (flb_mem.h:78)
==27873==    by 0x1B5F2C: flb_net_dns_lookup_context_create (flb_network.c:690)
==27873==    by 0x1B6107: flb_net_getaddrinfo (flb_network.c:754)
==27873==    by 0x1B66BB: flb_net_tcp_connect (flb_network.c:915)
==27873==    by 0x1DE48E: flb_io_net_connect (flb_io.c:89)
==27873==    by 0x1C25CF: create_conn (flb_upstream.c:523)
==27873==    by 0x1C2AA2: flb_upstream_conn_get (flb_upstream.c:666)
==27873==    by 0x245A26: http_post (http.c:86)
==27873==    by 0x246754: http_gelf (http.c:299)
==27873==    by 0x246889: cb_http_flush (http.c:331)
==27873==    by 0x1AB56C: output_pre_cb_flush (flb_output.h:490)
==27873== 
==27873== LEAK SUMMARY:
==27873==    definitely lost: 128 bytes in 1 blocks
==27873==    indirectly lost: 74,417 bytes in 5 blocks
==27873==      possibly lost: 0 bytes in 0 blocks
==27873==    still reachable: 0 bytes in 0 blocks
==27873==         suppressed: 0 bytes in 0 blocks
==27873== 
==27873== For lists of detected and suppressed errors, rerun with: -s
==27873== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
