### PR TITLE
out_loki: remove kv only if remove_keys enabled(#3867)

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -577,14 +577,13 @@ static int prepare_remove_keys(struct flb_loki *ctx)
                 return -1;
             }
         }
-    }
-
-    size = mk_list_size(patterns);
-    flb_plg_debug(ctx->ins, "remove_mpa size: %d", size);
-    if (size > 0) {
-        ctx->remove_mpa = flb_mp_accessor_create(patterns);
-        if (ctx->remove_mpa == NULL) {
-            return -1;
+        size = mk_list_size(patterns);
+        flb_plg_debug(ctx->ins, "remove_mpa size: %d", size);
+        if (size > 0) {
+            ctx->remove_mpa = flb_mp_accessor_create(patterns);
+            if (ctx->remove_mpa == NULL) {
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3867

Current loki plugin removes key/value even if `remove_keys` is not set.
1. `remove_keys_derived` is updated at `flb_loki_kv_append` if record accessor is used.
2. `remove_keys_derived` is used to create `remove_mpa` even if `remove_keys` is not set at `prepare_remove_keys`.
3. Remove key/value when `remove_mpa` is created.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[INPUT]
    Name dummy
    Dummy {"TraceId":"","SeverityText":"INFO","SessionId":null,"DocumentId":null,"Name":"__main__","UserMessage":"Temporal worker started.","Body":null,"Resource":{"service.name":"xtr-worker"}}
    Samples 1

[OUTPUT]
    Name  loki
    Match *
    Auto_kubernetes_labels  off
    Retry_Limit 5
    labels job=fluent-bit, level=$SeverityText, service=$Resource['service.name']
```

## Debug output

1. `nc -l 3100`
2. `fluent-bit -c a.conf`
```
taka@locals:~$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 332
User-Agent: Fluent-Bit
Content-Type: application/json

{"streams":[{"stream":{"job":"fluent-bit","level":"INFO","service":"xtr-worker"},"values":[["1628056230920059373","{\"TraceId\":\"\",\"SeverityText\":\"INFO\",\"SessionId\":null,\"DocumentId\":null,\"Name\":\"__main__\",\"UserMessage\":\"Temporal worker started.\",\"Body\":null,\"Resource\":{\"service.name\":\"xtr-worker\"}}"]]}]}
```

## Valgrind output

There is no leak. (Reported error is #3897 )
```
 valgrind --leak-check=full bin/fluent-bit -c 3867.conf 
==59360== Memcheck, a memory error detector
==59360== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==59360== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==59360== Command: bin/fluent-bit -c 3867.conf
==59360== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/04 14:51:33] [ info] [engine] started (pid=59360)
[2021/08/04 14:51:33] [ info] [storage] version=1.1.1, initializing...
[2021/08/04 14:51:33] [ info] [storage] in-memory
[2021/08/04 14:51:33] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/04 14:51:33] [ info] [cmetrics] version=0.1.6
[2021/08/04 14:51:34] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2021/08/04 14:51:34] [ info] [sp] stream processor started
^C[2021/08/04 14:51:41] [engine] caught signal (SIGINT)
[2021/08/04 14:51:41] [ warn] [engine] service will stop in 5 seconds
[2021/08/04 14:51:45] [ info] [engine] service stopped
==59360== 
==59360== HEAP SUMMARY:
==59360==     in use at exit: 74,545 bytes in 6 blocks
==59360==   total heap usage: 1,144 allocs, 1,138 frees, 885,635 bytes allocated
==59360== 
==59360== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==59360==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==59360==    by 0x1889FC: flb_calloc (flb_mem.h:78)
==59360==    by 0x189ED4: flb_net_dns_lookup_context_create (flb_network.c:690)
==59360==    by 0x18A0AF: flb_net_getaddrinfo (flb_network.c:754)
==59360==    by 0x18A665: flb_net_tcp_connect (flb_network.c:915)
==59360==    by 0x1B67DB: flb_io_net_connect (flb_io.c:89)
==59360==    by 0x197782: create_conn (flb_upstream.c:523)
==59360==    by 0x197C55: flb_upstream_conn_get (flb_upstream.c:666)
==59360==    by 0x23C26B: cb_loki_flush (loki.c:1177)
==59360==    by 0x17EB7A: output_pre_cb_flush (flb_output.h:490)
==59360==    by 0x51794A: co_init (amd64.c:117)
==59360== 
==59360== LEAK SUMMARY:
==59360==    definitely lost: 128 bytes in 1 blocks
==59360==    indirectly lost: 74,417 bytes in 5 blocks
==59360==      possibly lost: 0 bytes in 0 blocks
==59360==    still reachable: 0 bytes in 0 blocks
==59360==         suppressed: 0 bytes in 0 blocks
==59360== 
==59360== For lists of detected and suppressed errors, rerun with: -s
==59360== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
