### PR TITLE
proxy_plugin: Add worker support for proxy plugins

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -766,6 +766,21 @@ void flb_output_net_default(const char *host, const int port,
     }
 }
 
+/* Add thread pool for output plugin if configured with workers */
+int flb_output_enable_multi_threading(struct flb_output_instance *ins, struct flb_config *config)
+{
+    /* Multi-threading enabled ? (through 'workers' property) */
+    if (ins->tp_workers > 0) {
+        if(flb_output_thread_pool_create(config, ins) != 0) {
+            flb_output_instance_destroy(ins);
+            return -1;
+        }
+        flb_output_thread_pool_start(ins);
+    }
+
+    return 0;
+}
+
 /* Return an instance name or alias */
 const char *flb_output_name(struct flb_output_instance *ins)
 {
@@ -974,21 +989,6 @@ int flb_output_init_all(struct flb_config *config)
                       p->name);
             return -1;
         }
-    }
-
-    return 0;
-}
-
-/* Add thread pool for output plugin if configured with workers */
-int flb_output_enable_multi_threading(struct flb_output_instance *ins, struct flb_config *config)
-{
-    /* Multi-threading enabled ? (through 'workers' property) */
-    if (ins->tp_workers > 0) {
-        if(flb_output_thread_pool_create(config, ins) != 0) {
-            flb_output_instance_destroy(ins);
-            return -1;
-        }
-        flb_output_thread_pool_start(ins);
     }
 
     return 0;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -856,6 +856,15 @@ int flb_output_init_all(struct flb_config *config)
                 flb_output_instance_destroy(ins);
                 return -1;
             }
+
+            /* Multi-threading enabled if configured */
+            ret = flb_output_enable_multi_threading(ins, config);
+            if (ret == -1) {
+                flb_error("[output] could not start thread pool for '%s' plugin",
+                          p->name);
+                return -1;
+            }
+
             continue;
         }
 #endif
@@ -958,18 +967,28 @@ int flb_output_init_all(struct flb_config *config)
             return -1;
         }
 
-        /* Multi-threading enabled ? (through 'workers' property) */
-        if (ins->tp_workers > 0) {
-            ret = flb_output_thread_pool_create(config, ins);
-            if (ret == -1) {
-                flb_error("[output] could not start thread pool for '%s' plugin",
-                          p->name);
-                flb_output_instance_destroy(ins);
-                return -1;
-            }
-
-            flb_output_thread_pool_start(ins);
+        /* Multi-threading enabled if configured */
+        ret = flb_output_enable_multi_threading(ins, config);
+        if (ret == -1) {
+            flb_error("[output] could not start thread pool for '%s' plugin",
+                      p->name);
+            return -1;
         }
+    }
+
+    return 0;
+}
+
+/* Add thread pool for output plugin if configured with workers */
+int flb_output_enable_multi_threading(struct flb_output_instance *ins, struct flb_config *config)
+{
+    /* Multi-threading enabled ? (through 'workers' property) */
+    if (ins->tp_workers > 0) {
+        if(flb_output_thread_pool_create(config, ins) != 0) {
+            flb_output_instance_destroy(ins);
+            return -1;
+        }
+        flb_output_thread_pool_start(ins);
     }
 
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->
This applies the same code change brought in for making output plugins performant in v1.7.0 to the proxy plugins of Go. 
Without this change if the go output plugin gets slow/unresponsive, other input plugins and output plugins also were getting stuck because of single-threaded nature of invocation.
 
This addresses issue [fluent-bit-go#45](https://github.com/fluent/fluent-bit-go/issues/45)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
    Please note that, Valgrind with golang plugins show leaks without this change as well
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature (Documentation will be same as any output plugin with workers)

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
