### PR TITLE
build: Link to libatomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 endif()
 
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
+  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")
+  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
+endif()
+
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)


### PR DESCRIPTION
This fixes build errors like `undefined reference to __atomic_store_8` on armv7l:

```
[ 87%] Linking C executable ../bin/fluent-bit
/usr/bin/ld: ../library/libcmetrics.a(cmt_atomic_gcc.c.o): in function `cmt_atomic_compare_exchange':
/home/pi/fluent-bit-1.8.3/lib/cmetrics/src/cmt_atomic_gcc.c:30: undefined reference to `__atomic_compare_exchange_8'
/usr/bin/ld: ../library/libcmetrics.a(cmt_atomic_gcc.c.o): in function `cmt_atomic_store':
/home/pi/fluent-bit-1.8.3/lib/cmetrics/src/cmt_atomic_gcc.c:36: undefined reference to `__atomic_store_8'
/usr/bin/ld: ../library/libcmetrics.a(cmt_atomic_gcc.c.o): in function `cmt_atomic_load':
/home/pi/fluent-bit-1.8.3/lib/cmetrics/src/cmt_atomic_gcc.c:41: undefined reference to `__atomic_load_8'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/fluent-bit-bin.dir/build.make:298: bin/fluent-bit] Error 1
make[1]: *** [CMakeFiles/Makefile2:6206: src/CMakeFiles/fluent-bit-bin.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

<!-- Provide summary of changes -->

This PR adds a C link flag to libatomic.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
