### PR TITLE
out_azure: add missing flb_utils.h

### DIFF
--- a/plugins/out_azure/azure_conf.c
+++ b/plugins/out_azure/azure_conf.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_utils.h>
 #include <mbedtls/base64.h>
 
 #include "azure.h"


### PR DESCRIPTION
I added missing flb_utils.h to remove warning.
```
Scanning dependencies of target flb-plugin-out_azure
[ 69%] Building C object plugins/out_azure/CMakeFiles/flb-plugin-out_azure.dir/azure_conf.c.o
/home/taka/git/fluent-bit/plugins/out_azure/azure_conf.c: In function ‘flb_azure_conf_create’:
/home/taka/git/fluent-bit/plugins/out_azure/azure_conf.c:126:31: warning: implicit declaration of function ‘flb_utils_bool’ [-Wimplicit-function-declaration]
  126 |         ctx->time_generated = flb_utils_bool(tmp);
      |                               ^~~~~~~~~~~~~~

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
