### PR TITLE
out_es: prevent div0

### DIFF
--- a/plugins/out_es/es_bulk.c
+++ b/plugins/out_es/es_bulk.c
@@ -78,11 +78,17 @@ int es_bulk_append(struct es_bulk *bulk, char *index, int i_len,
          *    1. rest of msgpack data size
          *    2. ratio from bulk json size and processed msgpack size.
          */
-        append_size = (whole_size - converted_size) /* rest of size to convert */
-                    * (bulk->size / converted_size); /* = json size / msgpack size */
-        if (append_size < ES_BULK_CHUNK) {
-            /* append at least ES_BULK_CHUNK size */
+        if (converted_size == 0) {
+            /* converted_size = 0 causes div/0 */
+            flb_debug("[out_es] converted_size is 0");
             append_size = ES_BULK_CHUNK;
+        } else {
+            append_size = (whole_size - converted_size) /* rest of size to convert */
+                        * (bulk->size / converted_size); /* = json size / msgpack size */
+            if (append_size < ES_BULK_CHUNK) {
+                /* append at least ES_BULK_CHUNK size */
+                append_size = ES_BULK_CHUNK;
+            }
         }
         ptr = flb_realloc(bulk->ptr, bulk->size + append_size);
         if (!ptr) {


### PR DESCRIPTION
Fixes #3905 

I modified re-allocation logic #3788 
The patch tries to divide by `converted_size`.
If `converted_size` is 0, it causes SIGFPE and fluent-bit exits code 136.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration
a.log:
```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

a.conf:
```
[INPUT]
    Name tail
    Path a.log
    Read_From_Head true

[OUTPUT]
    Name es
    Match *
```

## Debug output
`[2021/08/09 13:22:18] [debug] [out_es] converted_size is 0` is the log to prevent div0.


```
$ ../bin/fluent-bit -c a.conf -vvv
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/09 13:22:13] [ info] Configuration:
[2021/08/09 13:22:13] [ info]  flush time     | 5.000000 seconds
[2021/08/09 13:22:13] [ info]  grace          | 5 seconds
[2021/08/09 13:22:13] [ info]  daemon         | 0
[2021/08/09 13:22:13] [ info] ___________
[2021/08/09 13:22:13] [ info]  inputs:
[2021/08/09 13:22:13] [ info]      tail
[2021/08/09 13:22:13] [ info] ___________
[2021/08/09 13:22:13] [ info]  filters:
[2021/08/09 13:22:13] [ info] ___________
[2021/08/09 13:22:13] [ info]  outputs:
[2021/08/09 13:22:13] [ info]      es.0
[2021/08/09 13:22:13] [ info] ___________
[2021/08/09 13:22:13] [ info]  collectors:
[2021/08/09 13:22:13] [ info] [engine] started (pid=48541)
[2021/08/09 13:22:13] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/08/09 13:22:13] [debug] [storage] [cio stream] new stream registered: tail.0
[2021/08/09 13:22:13] [ info] [storage] version=1.1.1, initializing...
[2021/08/09 13:22:13] [ info] [storage] in-memory
[2021/08/09 13:22:13] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/09 13:22:13] [ info] [cmetrics] version=0.1.6
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] inotify watch fd=23
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] scanning path a.log
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] inode=1452803 with offset=0 appended as a.log
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] scan_glob add(): a.log, inode 1452803
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] 1 new files found on path 'a.log'
[2021/08/09 13:22:13] [debug] [es:es.0] created event channels: read=25 write=26
[2021/08/09 13:22:13] [debug] [output:es:es.0] host=127.0.0.1 port=9200 uri=/_bulk index=fluent-bit type=_doc
[2021/08/09 13:22:13] [debug] [router] match rule tail.0:es.0
[2021/08/09 13:22:13] [ info] [sp] stream processor started
[2021/08/09 13:22:13] [debug] [input:tail:tail.0] inode=1452803 file=a.log promote to TAIL_EVENT
[2021/08/09 13:22:13] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1452803 watch_fd=1 name=a.log
[2021/08/09 13:22:18] [debug] [task] created task=0x7f2e98013d60 id=0 OK
[2021/08/09 13:22:18] [debug] [out_es] converted_size is 0
[2021/08/09 13:22:18] [debug] [http_client] not using http_proxy for header
[2021/08/09 13:22:18] [debug] [http_client] header=POST /_bulk HTTP/1.1
Host: 127.0.0.1:9200
Content-Length: 7283
Content-Type: application/x-ndjson
User-Agent: Fluent-Bit
```

## Valgrind output

No error is reported. (except #3897)
```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf
==48548== Memcheck, a memory error detector
==48548== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==48548== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==48548== Command: ../bin/fluent-bit -c a.conf
==48548== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/09 13:23:43] [ info] [engine] started (pid=48548)
[2021/08/09 13:23:43] [ info] [storage] version=1.1.1, initializing...
[2021/08/09 13:23:43] [ info] [storage] in-memory
[2021/08/09 13:23:43] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/09 13:23:43] [ info] [cmetrics] version=0.1.6
[2021/08/09 13:23:44] [ info] [sp] stream processor started
[2021/08/09 13:23:44] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1452803 watch_fd=1 name=a.log
==48548== Warning: client switching stacks?  SP change: 0x57e49e8 --> 0x4c92c60
==48548==          to suppress, use: --max-stackframe=11869576 or greater
==48548== Warning: client switching stacks?  SP change: 0x4c92bd8 --> 0x57e49e8
==48548==          to suppress, use: --max-stackframe=11869712 or greater
==48548== Warning: client switching stacks?  SP change: 0x57e49e8 --> 0x4c92bd8
==48548==          to suppress, use: --max-stackframe=11869712 or greater
==48548==          further instances of this message will not be shown.
[2021/08/09 13:23:48] [error] [src/flb_http_client.c:1160 errno=32] Broken pipe
[2021/08/09 13:23:48] [ warn] [output:es:es.0] http_do=-1 URI=/_bulk
[2021/08/09 13:23:48] [ warn] [engine] failed to flush chunk '48548-1628483024.83432657.flb', retry in 9 seconds: task_id=0, input=tail.0 > output=es.0 (out_id=0)
^C[2021/08/09 13:23:50] [engine] caught signal (SIGINT)
[2021/08/09 13:23:50] [ info] [input] pausing tail.0
[2021/08/09 13:23:50] [ warn] [engine] service will stop in 5 seconds
[2021/08/09 13:23:55] [ info] [engine] service stopped
[2021/08/09 13:23:55] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1452803 watch_fd=1
==48548== 
==48548== HEAP SUMMARY:
==48548==     in use at exit: 74,545 bytes in 6 blocks
==48548==   total heap usage: 1,204 allocs, 1,198 frees, 942,033 bytes allocated
==48548== 
==48548== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==48548==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==48548==    by 0x1B4D6B: flb_calloc (flb_mem.h:78)
==48548==    by 0x1B5FC6: flb_net_dns_lookup_context_create (flb_network.c:691)
==48548==    by 0x1B61A1: flb_net_getaddrinfo (flb_network.c:755)
==48548==    by 0x1B6755: flb_net_tcp_connect (flb_network.c:916)
==48548==    by 0x1DE528: flb_io_net_connect (flb_io.c:89)
==48548==    by 0x1C2669: create_conn (flb_upstream.c:523)
==48548==    by 0x1C2B3C: flb_upstream_conn_get (flb_upstream.c:666)
==48548==    by 0x23ACA9: cb_es_flush (es.c:766)
==48548==    by 0x1AB56C: output_pre_cb_flush (flb_output.h:490)
==48548==    by 0x6ECFCA: co_init (amd64.c:117)
==48548== 
==48548== LEAK SUMMARY:
==48548==    definitely lost: 128 bytes in 1 blocks
==48548==    indirectly lost: 74,417 bytes in 5 blocks
==48548==      possibly lost: 0 bytes in 0 blocks
==48548==    still reachable: 0 bytes in 0 blocks
==48548==         suppressed: 0 bytes in 0 blocks
==48548== 
==48548== For lists of detected and suppressed errors, rerun with: -s
==48548== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
