### PR TITLE
bin: add SIGFPE handler

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -546,10 +546,12 @@ static void flb_signal_handler(int signal)
 #endif
         flb_print_signal(SIGTERM);
         flb_print_signal(SIGSEGV);
+        flb_print_signal(SIGFPE);
     };
 
     switch(signal) {
     case SIGSEGV:
+    case SIGFPE:
 #ifdef FLB_HAVE_LIBBACKTRACE
         /* To preserve stacktrace */
         flb_stacktrace_print(&flb_st);
@@ -572,6 +574,7 @@ static void flb_signal_init()
 #endif
     signal(SIGTERM, &flb_signal_handler_break_loop);
     signal(SIGSEGV, &flb_signal_handler);
+    signal(SIGFPE,  &flb_signal_handler);
 }
 
 static int input_set_property(struct flb_input_instance *in, char *kv)


### PR DESCRIPTION
Refer to #3905, if SIGFPE occurred, there is no stack trace.
It is hard to debug/trouble shooting. 

This patch is to support SIGFPE to dump stacktrace.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

https://github.com/fluent/fluent-bit/pull/3931#issue-706205400

## Debug output
It reports stacktrace.
```
[2021/08/09 14:53:31] [engine] caught signal (SIGFPE)
#0  0x555957f8a63f      in  es_bulk_append() at plugins/out_es/es_bulk.c:82
#1  0x555957f87e64      in  elasticsearch_format() at plugins/out_es/es.c:537
#2  0x555957f88d3c      in  cb_es_flush() at plugins/out_es/es.c:772
#3  0x555957ef959c      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:490
#4  0x55595843af6a      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
#5  0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)
```

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/09 14:53:26] [ info] [engine] started (pid=51687)
[2021/08/09 14:53:26] [ info] [storage] version=1.1.1, initializing...
[2021/08/09 14:53:26] [ info] [storage] in-memory
[2021/08/09 14:53:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/09 14:53:26] [ info] [cmetrics] version=0.1.6
[2021/08/09 14:53:26] [ info] [sp] stream processor started
[2021/08/09 14:53:26] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1452803 watch_fd=1 name=a.log
[2021/08/09 14:53:31] [engine] caught signal (SIGFPE)
#0  0x555957f8a63f      in  es_bulk_append() at plugins/out_es/es_bulk.c:82
#1  0x555957f87e64      in  elasticsearch_format() at plugins/out_es/es.c:537
#2  0x555957f88d3c      in  cb_es_flush() at plugins/out_es/es.c:772
#3  0x555957ef959c      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:490
#4  0x55595843af6a      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
#5  0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
