### PR TITLE
build: avoid conflicting command options on Visual Studio 2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,9 @@ if(FLB_COVERAGE)
 endif()
 
 # Enable Debug symbols if specified
-if(FLB_DEBUG)
+if(MSVC)
+  set(CMAKE_BUILD_TYPE None)  # Avoid flag conflicts (See CMakeList.txt:L18)
+elseif(FLB_DEBUG)
   set(CMAKE_BUILD_TYPE "Debug")
 elseif(FLB_RELEASE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")


### PR DESCRIPTION
Currently, Visual Studio emits tons of the following warnings
while compilation:

    cl : command line warning D9025 : '/Od' is preferred to '/O2'
    cl : command line warning D9025 : '/MT' is preferred to '/MDd'

This happens, because CMake is adding bogus flags which are
interferring with our Windows build configuration. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
-[N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
