### PR TITLE
aws: Fix AWS credential refresh to work as expected interval

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-#define FIVE_MINUTES   600
+#define FIVE_MINUTES   300
 #define TWELVE_HOURS   43200
 
 /* Credentials Environment Variables */


### PR DESCRIPTION
This PR fixes the constant value to have five-minute duration as labeled by its name "`FIVE_MINUTES`". The original change was in [this line](https://github.com/fluent/fluent-bit/pull/3041/files#diff-ed61be3e74ed702f8d8028b67314f060f112d1e474475d1a3e90c70d09f5db95R30) in #3041.

@PettitWesley, feel free to just close this PR if your change above was intentional.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
