### PR TITLE
core: new 'Calyptia Cloud' output and custom plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,10 @@ option(FLB_METRICS            "Enable metrics support"       Yes)
 # Proxy Plugins
 option(FLB_PROXY_GO           "Enable Go plugins support"   Yes)
 
-# Build-in Plugins
+# Built-in Custom Plugins
+option(FLB_CUSTOM_CALYPTIA    "Enable Calyptia Support"      Yes)
+
+# Built-in Plugins
 option(FLB_IN_CPU             "Enable CPU input plugin"             Yes)
 option(FLB_IN_THERMAL         "Enable Thermal plugin"               Yes)
 option(FLB_IN_DISK            "Enable Disk input plugin"            Yes)
@@ -143,6 +146,7 @@ option(FLB_IN_NODE_EXPORTER_METRICS "Enable node exporter metrics input plugin" 
 option(FLB_OUT_AZURE          "Enable Azure output plugin"          Yes)
 option(FLB_OUT_AZURE_BLOB     "Enable Azure output plugin"          Yes)
 option(FLB_OUT_BIGQUERY       "Enable BigQuery output plugin"       Yes)
+option(FLB_OUT_CALYPTIA       "Enable Calyptia monitoring plugin"   Yes)
 option(FLB_OUT_COUNTER        "Enable Counter output plugin"        Yes)
 option(FLB_OUT_DATADOG        "Enable DataDog output plugin"        Yes)
 option(FLB_OUT_ES             "Enable Elasticsearch output plugin"  Yes)

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -86,10 +86,14 @@ struct flb_config {
     void *dso_plugins;
 
     /* Plugins references */
+    struct mk_list custom_plugins;
     struct mk_list in_plugins;
     struct mk_list parser_plugins;      /* not yet implemented */
     struct mk_list filter_plugins;
     struct mk_list out_plugins;
+
+    /* Custom instances */
+    struct mk_list customs;
 
     /* Inputs instances */
     struct mk_list inputs;

--- a/include/fluent-bit/flb_custom.h
+++ b/include/fluent-bit/flb_custom.h
@@ -1,0 +1,93 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CUSTOM_H
+#define FLB_CUSTOM_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#ifdef FLB_HAVE_METRICS
+#include <fluent-bit/flb_metrics.h>
+#endif
+
+struct flb_custom_instance;
+
+struct flb_custom_plugin {
+    int flags;             /* Flags (not available at the moment */
+    char *name;            /* Custom plugin short name           */
+    char *description;     /* Description                        */
+
+    /* Config map */
+    struct flb_config_map *config_map;
+
+    /* Callbacks */
+    int (*cb_init) (struct flb_custom_instance *, struct flb_config *, void *);
+    int (*cb_run) (const void *, size_t, const char *, int,
+                   void **, size_t *,
+                   struct flb_custom_instance *,
+                   void *, struct flb_config *);
+    int (*cb_exit) (void *, struct flb_config *);
+
+    struct mk_list _head;  /* Link to parent list (config->custom) */
+};
+
+struct flb_custom_instance {
+    int id;                        /* instance id              */
+    int log_level;                 /* instance log level       */
+    char name[32];                 /* numbered name            */
+    char *alias;                   /* alias name               */
+    void *context;                 /* instance local context   */
+    void *data;
+    struct flb_custom_plugin *p;   /* original plugin          */
+    struct mk_list properties;     /* config properties        */
+    struct mk_list *config_map;    /* configuration map        */
+    struct mk_list _head;          /* link to config->customs  */
+
+    /*
+     * CMetrics
+     * --------
+     */
+    struct cmt *cmt;                      /* parent context               */
+
+    /* Keep a reference to the original context this instance belongs to */
+    struct flb_config *config;
+};
+
+static inline int flb_custom_config_map_set(struct flb_custom_instance *ins,
+                                            void *context)
+{
+    return flb_config_map_set(&ins->properties, ins->config_map, context);
+}
+
+int flb_custom_set_property(struct flb_custom_instance *ins,
+                            const char *k, const char *v);
+const char *flb_custom_get_property(const char *key,
+                                    struct flb_custom_instance *ins);
+
+struct flb_custom_instance *flb_custom_new(struct flb_config *config,
+                                           const char *custom, void *data);
+void flb_custom_exit(struct flb_config *config);
+const char *flb_custom_name(struct flb_custom_instance *ins);
+int flb_custom_init_all(struct flb_config *config);
+void flb_custom_set_context(struct flb_custom_instance *ins, void *context);
+void flb_custom_instance_destroy(struct flb_custom_instance *ins);
+
+#endif

--- a/include/fluent-bit/flb_custom_plugin.h
+++ b/include/fluent-bit/flb_custom_plugin.h
@@ -1,0 +1,54 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CUSTOM_PLUGIN_H
+#define FLB_CUSTOM_PLUGIN_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_custom.h>
+#include <fluent-bit/flb_log.h>
+
+#define flb_plg_error(ctx, fmt, ...)                                    \
+    if (flb_log_check_level(ctx->log_level, FLB_LOG_ERROR))             \
+        flb_log_print(FLB_LOG_ERROR, NULL, 0, "[custom:%s:%s] " fmt,    \
+                      ctx->p->name, flb_custom_name(ctx), ##__VA_ARGS__)
+
+#define flb_plg_warn(ctx, fmt, ...)                                     \
+    if (flb_log_check_level(ctx->log_level, FLB_LOG_WARN))              \
+        flb_log_print(FLB_LOG_WARN, NULL, 0, "[custom:%s:%s] " fmt,     \
+                      ctx->p->name, flb_custom_name(ctx), ##__VA_ARGS__)
+
+#define flb_plg_info(ctx, fmt, ...)                                     \
+    if (flb_log_check_level(ctx->log_level, FLB_LOG_INFO))              \
+        flb_log_print(FLB_LOG_INFO, NULL, 0, "[custom:%s:%s] " fmt,     \
+                      ctx->p->name, flb_custom_name(ctx), ##__VA_ARGS__)
+
+#define flb_plg_debug(ctx, fmt, ...)                                    \
+    if (flb_log_check_level(ctx->log_level, FLB_LOG_DEBUG))             \
+        flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[custom:%s:%s] " fmt,    \
+                      ctx->p->name, flb_custom_name(ctx), ##__VA_ARGS__)
+
+#define flb_plg_trace(ctx, fmt, ...)                                    \
+    if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
+        flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
+                      "[custom:%s:%s at %s:%i] " fmt,                   \
+                      ctx->p->name, flb_custom_name(ctx), __FILENAME__, \
+                      __LINE__, ##__VA_ARGS__)
+#endif

--- a/include/fluent-bit/flb_error.h
+++ b/include/fluent-bit/flb_error.h
@@ -27,6 +27,7 @@
 #define FLB_ERR_CFG_FLUSH             20
 #define FLB_ERR_CFG_FLUSH_CREATE      21
 #define FLB_ERR_CFG_FLUSH_REGISTER    22
+#define FLB_ERR_CUSTOM_INVALID        49
 #define FLB_ERR_INPUT_INVALID         50
 #define FLB_ERR_INPUT_UNDEF           51
 #define FLB_ERR_INPUT_UNSUP           52

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -56,10 +56,12 @@
 #endif
 
 /* Output plugin masks */
-#define FLB_OUTPUT_NET           32  /* output address may set host and port */
-#define FLB_OUTPUT_PLUGIN_CORE    0
-#define FLB_OUTPUT_PLUGIN_PROXY   1
-#define FLB_OUTPUT_NO_MULTIPLEX 512
+#define FLB_OUTPUT_NET            32  /* output address may set host and port */
+#define FLB_OUTPUT_PLUGIN_CORE     0
+#define FLB_OUTPUT_PLUGIN_PROXY    1
+#define FLB_OUTPUT_NO_MULTIPLEX  512
+#define FLB_OUTPUT_PRIVATE      1024
+
 
 /* Event type handlers */
 #define FLB_OUTPUT_LOGS        1
@@ -712,7 +714,8 @@ struct flb_output_instance *flb_output_get_instance(struct flb_config *config,
 int flb_output_flush_finished(struct flb_config *config, int out_id);
 
 struct flb_output_instance *flb_output_new(struct flb_config *config,
-                                           const char *output, void *data);
+                                           const char *output, void *data,
+                                           int public_only);
 const char *flb_output_name(struct flb_output_instance *in);
 int flb_output_set_property(struct flb_output_instance *out,
                             const char *k, const char *v);

--- a/include/fluent-bit/flb_plugins.h.in
+++ b/include/fluent-bit/flb_plugins.h.in
@@ -21,6 +21,7 @@
 #define FLB_PLUGINS_H
 
 #include <monkey/mk_core.h>
+#include <fluent-bit/flb_custom.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_filter.h>
@@ -33,10 +34,12 @@
 
 int flb_plugins_register(struct flb_config *config)
 {
+    struct flb_custom_plugin *custom;
     struct flb_input_plugin *in;
     struct flb_output_plugin *out;
     struct flb_filter_plugin *filter;
 
+@FLB_CUSTOM_PLUGINS_ADD@
 @FLB_IN_PLUGINS_ADD@
 @FLB_OUT_PLUGINS_ADD@
 @FLB_FILTER_PLUGINS_ADD@
@@ -48,9 +51,16 @@ void flb_plugins_unregister(struct flb_config *config)
 {
     struct mk_list *tmp;
     struct mk_list *head;
+    struct flb_custom_plugin *custom;
     struct flb_input_plugin *in;
     struct flb_output_plugin *out;
     struct flb_filter_plugin *filter;
+
+    mk_list_foreach_safe(head, tmp, &config->custom_plugins) {
+        custom = mk_list_entry(head, struct flb_custom_plugin, _head);
+        mk_list_del(&custom->_head);
+        flb_free(custom);
+    }
 
     mk_list_foreach_safe(head, tmp, &config->in_plugins) {
         in = mk_list_entry(head, struct flb_input_plugin, _head);

--- a/include/fluent-bit/flb_router.h
+++ b/include/fluent-bit/flb_router.h
@@ -45,6 +45,9 @@ static inline int flb_router_match_type(int in_event_type,
     return FLB_TRUE;
 }
 
+int flb_router_connect(struct flb_input_instance *in,
+                       struct flb_output_instance *out);
+
 int flb_router_match(const char *tag, int tag_len,
                      const char *match, void *match_regex);
 int flb_router_io_set(struct flb_config *config);

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,41 @@
 set(flb_plugins "" CACHE INTERNAL "flb_plugins")
 
+# REGISTER_CUSTOM_PLUGIN
+macro(REGISTER_CUSTOM_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL CUSTOM PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
+
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_IN_PLUGINS_DECL "${FLB_CUSTOM_PLUGINS_DECL}extern struct flb_custom_plugin ${p_name}_plugin;\n")
+
+    # C code
+    set(C_CODE          "    custom = flb_malloc(sizeof(struct flb_custom_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!custom) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(custom, &${p_name}_plugin, sizeof(struct flb_custom_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&custom->_head, &config->custom_plugins);\n\n")
+
+    set(FLB_IN_PLUGINS_ADD "${FLB_CUSTOM_PLUGINS_ADD}${C_CODE}")
+
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
 # REGISTER_IN_PLUGIN
 macro(REGISTER_IN_PLUGIN name)
   string(FIND ${name} "=" pos)
@@ -118,6 +154,9 @@ endmacro()
 #  Plugins Registration
 # ======================
 
+# Custom Plugins
+REGISTER_CUSTOM_PLUGIN("custom_calyptia")
+
 # These plugins works only on Linux
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   REGISTER_IN_PLUGIN("in_cpu")
@@ -173,6 +212,7 @@ REGISTER_IN_PLUGIN("in_random")
 REGISTER_OUT_PLUGIN("out_azure")
 REGISTER_OUT_PLUGIN("out_azure_blob")
 REGISTER_OUT_PLUGIN("out_bigquery")
+REGISTER_OUT_PLUGIN("out_calyptia")
 REGISTER_OUT_PLUGIN("out_counter")
 REGISTER_OUT_PLUGIN("out_datadog")
 REGISTER_OUT_PLUGIN("out_es")

--- a/plugins/custom_calyptia/CMakeLists.txt
+++ b/plugins/custom_calyptia/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  calyptia.c)
+
+FLB_PLUGIN(custom_calyptia "${src}" "")

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -1,0 +1,329 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_custom_plugin.h>
+#include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_router.h>
+
+/* pipeline plugins */
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_output.h>
+
+struct calyptia {
+    /* config map options */
+    flb_sds_t api_key;
+    flb_sds_t cloud_host;
+    flb_sds_t cloud_port;
+    int cloud_tls;
+    int cloud_tls_verify;
+
+    /* instances */
+    struct flb_input_instance *i;
+    struct flb_output_instance *o;
+    struct flb_custom_instance *ins;
+};
+
+/*
+ * Check if the key belongs to a sensitive data field, if so report it. We never
+ * share any sensitive data.
+ */
+static int is_sensitive_property(char *key)
+{
+
+    if (strcasecmp(key, "password") == 0 ||
+        strcasecmp(key, "passwd") == 0   ||
+        strcasecmp(key, "user") == 0 ||
+        strcasecmp(key, "http_user") == 0 ||
+        strcasecmp(key, "http_passwd") == 0 ||
+        strcasecmp(key, "shared_key") == 0 ||
+        strcasecmp(key, "endpoint") == 0 ||
+        strcasecmp(key, "apikey") == 0 ||
+        strcasecmp(key, "private_key") == 0 ||
+        strcasecmp(key, "service_account_secret") == 0 ||
+        strcasecmp(key, "splunk_token") == 0 ||
+        strcasecmp(key, "logdna_host") == 0 ||
+        strcasecmp(key, "api_key") == 0 ||
+        strcasecmp(key, "hostname") == 0 ||
+        strcasecmp(key, "license_key") == 0 ||
+        strcasecmp(key, "base_uri") == 0 ||
+        strcasecmp(key, "api") == 0) {
+
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static char *get_str(char *p)
+{
+    if (p) {
+        return p;
+    }
+
+    return "(not set)";
+}
+
+static void pipeline_config_add_properties(flb_sds_t *buf, struct mk_list *props)
+{
+    struct mk_list *head;
+    struct flb_kv *kv;
+
+    mk_list_foreach(head, props) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+
+        flb_sds_printf(buf, "    %s ", kv->key);
+
+        if (is_sensitive_property(kv->key)) {
+            flb_sds_printf(buf, "--redacted--");
+        }
+        else {
+            flb_sds_printf(buf, kv->val);
+        }
+
+        flb_sds_printf(buf, "\n");
+    }
+}
+
+flb_sds_t custom_calyptia_pipeline_config_get(struct flb_config *ctx)
+{
+    char tmp[32];
+    flb_sds_t buf;
+    struct mk_list *head;
+    struct flb_input_instance *i_ins;
+    struct flb_filter_instance *f_ins;
+    struct flb_output_instance *o_ins;
+
+    buf = flb_sds_create_size(2048);
+    if (!buf) {
+        return NULL;
+    }
+
+    /* [INPUT] */
+    mk_list_foreach(head, &ctx->inputs) {
+        i_ins = mk_list_entry(head, struct flb_input_instance, _head);
+        flb_sds_printf(&buf, "[INPUT]\n");
+        flb_sds_printf(&buf, "    name %s\n", i_ins->name);
+        if (i_ins->alias) {
+            flb_sds_printf(&buf, "    alias %s\n", i_ins->alias);
+        }
+        if (i_ins->tag) {
+            flb_sds_printf(&buf, "    tag %s\n", i_ins->tag);
+        }
+
+        if (i_ins->mem_buf_limit > 0) {
+            flb_utils_bytes_to_human_readable_size(i_ins->mem_buf_limit,
+                                                   tmp, sizeof(tmp) - 1);
+            flb_sds_printf(&buf, "    mem_buf_limit %s\n", tmp);
+        }
+
+        pipeline_config_add_properties(&buf, &i_ins->properties);
+    }
+    flb_sds_printf(&buf, "\n");
+
+    /* Config: [FILTER] */
+    mk_list_foreach(head, &ctx->filters) {
+        f_ins = mk_list_entry(head, struct flb_filter_instance, _head);
+        flb_sds_printf(&buf, "[FILTER]\n");
+        flb_sds_printf(&buf, "    name  %s\n", f_ins->name);
+        flb_sds_printf(&buf, "    match %s\n", f_ins->match);
+
+        pipeline_config_add_properties(&buf, &f_ins->properties);
+    }
+    flb_sds_printf(&buf, "\n");
+
+    /* Config: [OUTPUT] */
+    mk_list_foreach(head, &ctx->outputs) {
+        o_ins = mk_list_entry(head, struct flb_output_instance, _head);
+        flb_sds_printf(&buf, "[OUTPUT]\n");
+        flb_sds_printf(&buf, "    name  %s\n", o_ins->name);
+        if (o_ins->match) {
+            flb_sds_printf(&buf, "    match %s\n", o_ins->match);
+        }
+        else {
+            flb_sds_printf(&buf, "    match *\n");
+        }
+
+#ifdef FLB_HAVE_TLS
+        if (o_ins->use_tls == FLB_TRUE) {
+            flb_sds_printf(&buf, "    tls   %s\n", o_ins->use_tls ? "on" : "off");
+            flb_sds_printf(&buf, "    tls.verify     %s\n",
+                             o_ins->tls_verify ? "on": "off");
+            flb_sds_printf(&buf, "    tls.ca_file    %s\n",
+                             get_str(o_ins->tls_ca_file));
+            flb_sds_printf(&buf, "    tls.crt_file   %s\n",
+                             get_str(o_ins->tls_crt_file));
+            flb_sds_printf(&buf, "    tls.key_file   %s\n",
+                             get_str(o_ins->tls_key_file));
+            flb_sds_printf(&buf, "    tls.key_passwd %s\n",
+                              o_ins->tls_key_passwd ? "--redacted--" : "(not set)");
+        }
+#endif
+        if (o_ins->retry_limit == FLB_OUT_RETRY_UNLIMITED) {
+            flb_sds_printf(&buf, "    retry_limit no_limits\n");
+        }
+        else if (o_ins->retry_limit == FLB_OUT_RETRY_NONE) {
+            flb_sds_printf(&buf, "    retry_limit no_retries\n");
+        }
+        else {
+            flb_sds_printf(&buf, "    retry_limit %i\n", o_ins->retry_limit);
+        }
+
+        if (o_ins->host.name) {
+            flb_sds_printf(&buf, "    host  --redacted--\n");
+        }
+
+        pipeline_config_add_properties(&buf, &o_ins->properties);
+        flb_sds_printf(&buf, "\n");
+    }
+
+    return buf;
+}
+
+static int cb_calyptia_init(struct flb_custom_instance *ins,
+                            struct flb_config *config,
+                            void *data)
+{
+    int ret;
+    struct calyptia *ctx;
+    (void) data;
+
+    ctx = flb_calloc(1, sizeof(struct calyptia));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+    ctx->ins = ins;
+
+    /* Load the config map */
+    ret = flb_custom_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
+    /* map instance and local context */
+    flb_custom_set_context(ins, ctx);
+
+    /* input collector */
+    ctx->i = flb_input_new(config, "fluentbit_metrics", NULL, FLB_TRUE);
+    if (!ctx->i) {
+        flb_plg_error(ctx->ins, "could not load metrics collector");
+        return -1;
+    }
+    flb_input_set_property(ctx->i, "tag", "_calyptia_cloud");
+    flb_input_set_property(ctx->i, "scrape_on_start", "true");
+    flb_input_set_property(ctx->i, "scrape_interval", "30");
+
+    /* output cloud connector */
+    ctx->o = flb_output_new(config, "calyptia", ctx, FLB_FALSE);
+    if (!ctx->o) {
+        flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
+        flb_free(ctx);
+        return -1;
+    }
+    flb_output_set_property(ctx->o, "match", "_calyptia_cloud");
+    flb_output_set_property(ctx->o, "api_key", ctx->api_key);
+
+    /* Override network details: development purposes only */
+    if (ctx->cloud_host) {
+        flb_output_set_property(ctx->o, "cloud_host", ctx->cloud_host);
+    }
+
+    if (ctx->cloud_port) {
+        flb_output_set_property(ctx->o, "cloud_port", ctx->cloud_port);
+    }
+
+    if (ctx->cloud_tls) {
+        flb_output_set_property(ctx->o, "tls", "true");
+    }
+    else {
+        flb_output_set_property(ctx->o, "tls", "false");
+    }
+
+    if (ctx->cloud_tls_verify) {
+        flb_output_set_property(ctx->o, "tls.verify", "true");
+    }
+    else {
+        flb_output_set_property(ctx->o, "tls.verify", "false");
+    }
+
+    flb_router_connect(ctx->i, ctx->o);
+    flb_plg_info(ins, "custom initialized!");
+    return 0;
+}
+
+static int cb_calyptia_exit(void *data, struct flb_config *config)
+{
+    struct calyptia *ctx = data;
+
+    if (!ctx) {
+        return 0;
+    }
+
+    flb_free(ctx);
+    return 0;
+}
+
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "api_key", NULL,
+     0, FLB_TRUE, offsetof(struct calyptia, api_key),
+     "Calyptia Cloud API Key."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "calyptia_host", NULL,
+     0, FLB_TRUE, offsetof(struct calyptia, cloud_host),
+     ""
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "calyptia_port", NULL,
+     0, FLB_TRUE, offsetof(struct calyptia, cloud_port),
+     ""
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "calyptia_tls", "true",
+     0, FLB_TRUE, offsetof(struct calyptia, cloud_tls),
+     ""
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "calyptia_tls.verify", "true",
+     0, FLB_TRUE, offsetof(struct calyptia, cloud_tls_verify),
+     ""
+    },
+
+    /* EOF */
+    {0}
+};
+
+struct flb_custom_plugin custom_calyptia_plugin = {
+    .name         = "calyptia",
+    .description  = "Calyptia Cloud",
+    .config_map   = config_map,
+    .cb_init      = cb_calyptia_init,
+    .cb_exit      = cb_calyptia_exit,
+};

--- a/plugins/in_fluentbit_metrics/metrics.c
+++ b/plugins/in_fluentbit_metrics/metrics.c
@@ -24,36 +24,65 @@
 #include <fluent-bit/flb_metrics_exporter.h>
 
 struct flb_in_metrics {
-    int coll_fd;
+    /* config map options */
+    int scrape_on_start;
     int scrape_interval;
+
+    /* internal */
+    int coll_fd_start;
+    int coll_fd_runtime;
+    struct cmt_counter *c;
     struct flb_input_instance *ins;
 };
 
-/*
- * Update the metrics, this function is invoked every time 'scrape_interval'
- * expires.
- */
-static int cb_metrics_collect(struct flb_input_instance *ins,
-                              struct flb_config *config, void *in_context)
+static int scrape_metrics(struct flb_config *config, struct flb_in_metrics *ctx)
 {
     int ret;
+    size_t ts;
+    char *name;
     struct cmt *cmt;
-    struct flb_in_metrics *ctx = in_context;
+
+    /* Update internal metric */
+    ts = cmt_time_now();
+    name = (char *) flb_input_name(ctx->ins);
+    cmt_counter_inc(ctx->c, ts, 1, (char *[]) {name});
+
 
     cmt = flb_me_get_cmetrics(config);
     if (!cmt) {
-        flb_plg_error(ins, "could not scrape metrics");
+        flb_plg_error(ctx->ins, "could not scrape metrics");
         return 0;
     }
 
     /* Append the updated metrics */
     ret = flb_input_metrics_append(ctx->ins, NULL, 0, cmt);
     if (ret != 0) {
-        flb_plg_error(ins, "could not append metrics");
+        flb_plg_error(ctx->ins, "could not append metrics");
     }
     cmt_destroy(cmt);
 
     return 0;
+}
+
+/*
+ * Update the metrics, this function is invoked every time 'scrape_interval'
+ * expires.
+ */
+static int cb_metrics_collect_runtime(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    return scrape_metrics(config, in_context);
+}
+
+static int cb_metrics_collect_start(struct flb_input_instance *ins,
+                                    struct flb_config *config, void *in_context)
+{
+    struct flb_in_metrics *ctx = in_context;
+
+    /* pause collector */
+    flb_input_collector_pause(ctx->coll_fd_start, ctx->ins);
+
+    return scrape_metrics(config, ctx);
 }
 
 static int in_metrics_init(struct flb_input_instance *in,
@@ -80,9 +109,24 @@ static int in_metrics_init(struct flb_input_instance *in,
     /* Associate context with the instance */
     flb_input_set_context(in, ctx);
 
-    /* Create the collector */
+    /* Scrape metrics on start / collector */
+    if (ctx->scrape_interval > 2 && ctx->scrape_on_start) {
+        ret = flb_input_set_collector_time(in,
+                                           cb_metrics_collect_start,
+                                           5, 0,
+                                           config);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins,
+                          "could not set collector on start for Fluent Bit "
+                          "metrics plugin");
+            return -1;
+        }
+        ctx->coll_fd_start = ret;
+    }
+
+    /* Create the runtime collector */
     ret = flb_input_set_collector_time(in,
-                                       cb_metrics_collect,
+                                       cb_metrics_collect_runtime,
                                        ctx->scrape_interval, 0,
                                        config);
     if (ret == -1) {
@@ -90,7 +134,13 @@ static int in_metrics_init(struct flb_input_instance *in,
                       "could not set collector for Fluent Bit metrics plugin");
         return -1;
     }
-    ctx->coll_fd = ret;
+    ctx->coll_fd_runtime = ret;
+
+    /* Internal metrics */
+    ctx->c = cmt_counter_create(ctx->ins->cmt,
+                                "fluentbit", "input_metrics", "scrapes_total",
+                                "Number of total metrics scrapes",
+                                1, (char *[]) {"name"});
     return 0;
 }
 
@@ -110,14 +160,14 @@ static void in_metrics_pause(void *data, struct flb_config *config)
 {
     struct flb_in_metrics *ctx = data;
 
-    flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+    flb_input_collector_pause(ctx->coll_fd_runtime, ctx->ins);
 }
 
 static void in_metrics_resume(void *data, struct flb_config *config)
 {
     struct flb_in_metrics *ctx = data;
 
-    flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+    flb_input_collector_resume(ctx->coll_fd_runtime, ctx->ins);
 }
 
 /* Configuration properties map */
@@ -126,6 +176,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "scrape_interval", "2",
      0, FLB_TRUE, offsetof(struct flb_in_metrics, scrape_interval),
      "scrape interval to collect the internal metrics of Fluent Bit."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "scrape_on_start", "false",
+     0, FLB_TRUE, offsetof(struct flb_in_metrics, scrape_on_start),
+     "scrape metrics upon start, useful to avoid waiting for 'scrape_interval' "
+     "for the first round of metrics."
     },
 
     /* EOF */
@@ -137,7 +194,6 @@ struct flb_input_plugin in_fluentbit_metrics_plugin = {
     .description  = "Fluent Bit internal metrics",
     .cb_init      = in_metrics_init,
     .cb_pre_run   = NULL,
-    .cb_collect   = cb_metrics_collect,
     .cb_flush_buf = NULL,
     .config_map   = config_map,
     .cb_pause     = in_metrics_pause,

--- a/plugins/out_calyptia/CMakeLists.txt
+++ b/plugins/out_calyptia/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  calyptia.c)
+
+FLB_PLUGIN(out_calyptia "${src}" "")

--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -1,0 +1,699 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_upstream.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_version.h>
+#include <fluent-bit/flb_metrics.h>
+
+#include "calyptia.h"
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_encode_influx.h>
+
+flb_sds_t custom_calyptia_pipeline_config_get(struct flb_config *ctx);
+
+static int get_io_flags(struct flb_output_instance *ins)
+{
+    int flags = 0;
+
+    if (ins->use_tls) {
+        flags = FLB_IO_TLS;
+    }
+    else {
+        flags = FLB_IO_TCP;
+    }
+
+    return flags;
+}
+
+static int config_add_labels(struct flb_output_instance *ins,
+                             struct flb_calyptia *ctx)
+{
+    struct mk_list *head;
+    struct flb_config_map_val *mv;
+    struct flb_slist_entry *k = NULL;
+    struct flb_slist_entry *v = NULL;
+    struct flb_kv *kv;
+
+    if (!ctx->add_labels || mk_list_size(ctx->add_labels) == 0) {
+        return 0;
+    }
+
+    /* iterate all 'add_label' definitions */
+    flb_config_map_foreach(head, mv, ctx->add_labels) {
+        if (mk_list_size(mv->val.list) != 2) {
+            flb_plg_error(ins, "'add_label' expects a key and a value, "
+                          "e.g: 'add_label version 1.8.x'");
+            return -1;
+        }
+
+        k = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+        v = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+
+        kv = flb_kv_item_create(&ctx->kv_labels, k->str, v->str);
+        if (!kv) {
+            flb_plg_error(ins, "could not append label %s=%s\n", k->str, v->str);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static void append_labels(struct flb_calyptia *ctx, struct cmt *cmt)
+{
+    struct flb_kv *kv;
+    struct mk_list *head;
+
+    mk_list_foreach(head, &ctx->kv_labels) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+        cmt_label_add(cmt, kv->key, kv->val);
+    }
+}
+
+static flb_sds_t sha256_to_hex(unsigned char *sha256)
+{
+    int i;
+    flb_sds_t hex;
+    flb_sds_t tmp;
+
+    hex = flb_sds_create_size(64);
+    if (!hex) {
+        return NULL;
+    }
+
+    for (i = 0; i < 32; i++) {
+        tmp = flb_sds_printf(&hex, "%02x", sha256[i]);
+        if (!tmp) {
+            flb_sds_destroy(hex);
+            return NULL;
+        }
+        hex = tmp;
+    }
+
+    flb_sds_len_set(hex, 64);
+    return hex;
+}
+
+static int get_machine_id(struct flb_calyptia *ctx, char **out_buf, size_t *out_size)
+{
+    int ret;
+    char *buf;
+    flb_sds_t s_buf;
+    size_t s;
+    unsigned char sha256_buf[64] = {0};
+    mbedtls_sha256_context sha256_ctx;
+
+    /* retrieve raw machine id */
+    ret = flb_utils_get_machine_id(&buf, &s);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not obtain machine id");
+        return -1;
+    }
+
+    /* perform sha256 */
+    mbedtls_sha256_init(&sha256_ctx);
+    mbedtls_sha256_starts(&sha256_ctx, 0);
+    mbedtls_sha256_update(&sha256_ctx, (const unsigned char *) buf, s);
+    mbedtls_sha256_finish(&sha256_ctx, sha256_buf);
+    flb_free(buf);
+
+    /* convert to hex */
+    s_buf = sha256_to_hex(sha256_buf);
+    if (!s_buf) {
+        return -1;
+    }
+
+    *out_buf = s_buf;
+    *out_size = flb_sds_len(s_buf);
+
+    return 0;
+}
+
+static flb_sds_t get_agent_metadata(struct flb_calyptia *ctx)
+{
+    int len;
+    char *host;
+    flb_sds_t conf;
+    flb_sds_t meta;
+    struct flb_mp_map_header mh;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+
+    /* init msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* pack map */
+    flb_mp_map_header_init(&mh, &mp_pck);
+
+    host = (char *) flb_env_get(ctx->env, "HOSTNAME");
+    if (!host) {
+        host = "unknown";
+    }
+    len = strlen(host);
+
+    /* name */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "name", 4);
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, host, len);
+
+    /* type */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "type", 4);
+    msgpack_pack_str(&mp_pck, 9);
+    msgpack_pack_str_body(&mp_pck, "fluentbit", 9);
+
+    /* rawConfig */
+    conf = custom_calyptia_pipeline_config_get(ctx->config);
+    if (conf) {
+        flb_mp_map_header_append(&mh);
+        len = flb_sds_len(conf);
+        msgpack_pack_str(&mp_pck, 9);
+        msgpack_pack_str_body(&mp_pck, "rawConfig", 9);
+        msgpack_pack_str(&mp_pck, len);
+        msgpack_pack_str_body(&mp_pck, conf, len);
+    }
+    flb_sds_destroy(conf);
+
+    /* version */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 7);
+    msgpack_pack_str_body(&mp_pck, "version", 7);
+    len = strlen(FLB_VERSION_STR);
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, FLB_VERSION_STR, len);
+
+    /* edition */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 7);
+    msgpack_pack_str_body(&mp_pck, "edition", 7);
+    msgpack_pack_str(&mp_pck, 9);
+    msgpack_pack_str_body(&mp_pck, "community", 9);
+
+    /* machineID */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 9);
+    msgpack_pack_str_body(&mp_pck, "machineID", 9);
+    len = flb_sds_len(ctx->machine_id);
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, ctx->machine_id, len);
+
+    /* finalize */
+    flb_mp_map_header_end(&mh);
+
+    /* convert to json */
+    meta = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    return meta;
+}
+
+static int calyptia_http_do(struct flb_calyptia *ctx, struct flb_http_client *c,
+                            int type)
+{
+    int ret;
+    size_t b_sent;
+
+    /* append headers */
+    if (type == CALYPTIA_ACTION_REGISTER) {
+        flb_http_add_header(c,
+                            CALYPTIA_H_CTYPE, sizeof(CALYPTIA_H_CTYPE) - 1,
+                            CALYPTIA_H_CTYPE_JSON, sizeof(CALYPTIA_H_CTYPE_JSON) - 1);
+
+        flb_http_add_header(c,
+                            CALYPTIA_H_PROJECT, sizeof(CALYPTIA_H_PROJECT) - 1,
+                            ctx->api_key, flb_sds_len(ctx->api_key));
+    }
+    else if (type == CALYPTIA_ACTION_METRICS) {
+        flb_http_add_header(c,
+                            CALYPTIA_H_CTYPE, sizeof(CALYPTIA_H_CTYPE) - 1,
+                            CALYPTIA_H_CTYPE_MSGPACK,
+                            sizeof(CALYPTIA_H_CTYPE_MSGPACK) - 1);
+
+        flb_http_add_header(c,
+                            CALYPTIA_H_AGENT_TOKEN,
+                            sizeof(CALYPTIA_H_AGENT_TOKEN) - 1,
+                            ctx->agent_token, flb_sds_len(ctx->agent_token));
+    }
+
+    /* Map debug callbacks */
+    flb_http_client_debug(c, ctx->ins->callback);
+
+    /* Perform HTTP request */
+    ret = flb_http_do(c, &b_sent);
+    if (ret != 0) {
+        flb_plg_warn(ctx->ins, "http_do=%i", ret);
+        return FLB_RETRY;
+    }
+
+    if (c->resp.status != 200 && c->resp.status != 201) {
+        if (c->resp.payload_size > 0) {
+            flb_plg_warn(ctx->ins, "http_status=%i:\n%s",
+                         c->resp.status, c->resp.payload);
+        }
+        else {
+            flb_plg_warn(ctx->ins, "http_status=%i", c->resp.status);
+        }
+
+        /* invalid metrics */
+        if (c->resp.status == 422) {
+            return FLB_ERROR;
+        }
+        return FLB_RETRY;;
+    }
+
+    return FLB_OK;
+}
+
+static flb_sds_t get_agent_info(char *buf, size_t size, char *k)
+{
+    int i;
+    int ret;
+    int type;
+    int len;
+    char *out_buf;
+    flb_sds_t v = NULL;
+    size_t off = 0;
+    size_t out_size;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object key;
+    msgpack_object val;
+
+    len = strlen(k);
+
+    ret = flb_pack_json(buf, size, &out_buf, &out_size, &type);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, out_buf, out_size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        flb_free(out_buf);
+        msgpack_unpacked_destroy(&result);
+        return NULL;
+    }
+
+    root = result.data;
+    if (root.type != MSGPACK_OBJECT_MAP) {
+        flb_free(out_buf);
+        msgpack_unpacked_destroy(&result);
+        return NULL;
+    }
+
+    for (i = 0; i < root.via.map.size; i++) {
+        key = root.via.map.ptr[i].key;
+        val = root.via.map.ptr[i].val;
+
+        if (key.type != MSGPACK_OBJECT_STR || val.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (key.via.str.size != len) {
+            continue;
+        }
+
+        if (strncmp(key.via.str.ptr, k, len) == 0) {
+            v = flb_sds_create_len(val.via.str.ptr, val.via.str.size);
+            break;
+        }
+    }
+
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+    return v;
+}
+
+/* Agent creation is perform on initialization using a sync upstream connection */
+static int api_agent_create(struct flb_config *config, struct flb_calyptia *ctx)
+{
+    int ret;
+    int flags;
+    flb_sds_t meta;
+    struct flb_upstream *u;
+    struct flb_upstream_conn *u_conn;
+    struct flb_http_client *c;
+
+    /* Meta */
+    meta = get_agent_metadata(ctx);
+    if (!meta) {
+        flb_plg_error(ctx->ins, "could not retrieve metadata");
+        return -1;
+    }
+
+    /* Upstream */
+    flags = get_io_flags(ctx->ins);
+    u = flb_upstream_create(ctx->config,
+                            ctx->cloud_host, ctx->cloud_port,
+                            flags, ctx->ins->tls);
+    if (!u) {
+        flb_plg_error(ctx->ins,
+                      "could not create upstream connection on 'agent create'");
+        flb_sds_destroy(meta);
+        return -1;
+    }
+
+    /* Make it synchronous */
+    u->flags &= ~(FLB_IO_ASYNC);
+
+    /* Get upstream connection */
+    u_conn = flb_upstream_conn_get(u);
+    if (!u_conn) {
+        flb_upstream_destroy(u);
+        flb_sds_destroy(meta);
+        return -1;
+    }
+
+    /* Compose HTTP Client request */
+    c = flb_http_client(u_conn, FLB_HTTP_POST, CALYPTIA_ENDPOINT_CREATE,
+                        meta, flb_sds_len(meta), NULL, 0, NULL, 0);
+    if (!c) {
+        flb_upstream_conn_release(u_conn);
+        flb_upstream_destroy(u);
+        return -1;
+    }
+
+    /* perform requst */
+    ret = calyptia_http_do(ctx, c, CALYPTIA_ACTION_REGISTER);
+    if (ret == FLB_OK && (c->resp.status == 200 || c->resp.status == 201)) {
+        if (c->resp.payload_size > 0) {
+            /* agent id */
+            ctx->agent_id = get_agent_info(c->resp.payload,
+                                           c->resp.payload_size,
+                                           "id");
+
+            /* agent token */
+            ctx->agent_token = get_agent_info(c->resp.payload,
+                                              c->resp.payload_size,
+                                              "token");
+
+            flb_plg_info(ctx->ins, "connected to Calyptia, agent_id='%s'",
+                         ctx->agent_id);
+        }
+    }
+
+    /* release resources */
+    flb_sds_destroy(meta);
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+    flb_upstream_destroy(u);
+
+    return ret;
+}
+
+static struct flb_calyptia *config_init(struct flb_output_instance *ins,
+                                        struct flb_config *config)
+{
+    int ret;
+    int flags;
+    size_t size;
+    char *machine_id;
+    struct flb_calyptia *ctx;
+
+    /* Calyptia plugin context */
+    ctx = flb_calloc(1, sizeof(struct flb_calyptia));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->ins = ins;
+    ctx->config = config;
+    flb_kv_init(&ctx->kv_labels);
+
+    /* Load the config map */
+    ret = flb_output_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return NULL;
+    }
+
+    /* api_key */
+    if (!ctx->api_key) {
+        flb_plg_error(ctx->ins, "configuration 'api_key' is missing");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    /* parse 'add_label' */
+    ret = config_add_labels(ins, ctx);
+    if (ret == -1) {
+        return NULL;
+    }
+
+    /* env reader */
+    ctx->env = flb_env_create();
+
+    /* Set context */
+    flb_output_set_context(ins, ctx);
+
+    /* machine id */
+    ret = get_machine_id(ctx, &machine_id, &size);
+    if (ret == -1) {
+        return NULL;
+    }
+    ctx->machine_id = (flb_sds_t) machine_id;
+    flb_plg_debug(ctx->ins, "machine_id=%s", ctx->machine_id);
+
+    /* Upstream */
+    flags = get_io_flags(ctx->ins);
+    ctx->u = flb_upstream_create(ctx->config,
+                                 ctx->cloud_host, ctx->cloud_port,
+                                 flags, ctx->ins->tls);
+    if (!ctx->u) {
+        return NULL;
+    }
+
+    /* Set instance flags into upstream */
+    flb_output_upstream_set(ctx->u, ins);
+
+    return ctx;
+}
+
+static int cb_calyptia_init(struct flb_output_instance *ins,
+                            struct flb_config *config, void *data)
+{
+    int ret;
+    struct flb_calyptia *ctx;
+    (void) data;
+
+    /* create config context */
+    ctx = config_init(ins, config);
+    if (!ctx) {
+        flb_plg_error(ins, "could not initialize configuration");
+        return -1;
+    }
+
+    /*
+     * This plugin instance uses the HTTP client interface, let's register
+     * it debugging callbacks.
+     */
+    flb_output_set_http_debug_callbacks(ins);
+
+    /* register/update agent */
+    ret = api_agent_create(config, ctx);
+    if (ret != FLB_OK) {
+        flb_plg_error(ctx->ins, "agent registration failed");
+        return -1;
+    }
+
+    /* metrics endpoint */
+    ctx->metrics_endpoint = flb_sds_create_size(256);
+    flb_sds_printf(&ctx->metrics_endpoint, CALYPTIA_ENDPOINT_METRICS,
+                   ctx->agent_id);
+    return 0;
+}
+
+static void debug_payload(struct flb_calyptia *ctx, void *data, size_t bytes)
+{
+    int ret;
+    size_t off = 0;
+    struct cmt *cmt;
+    cmt_sds_t out;
+
+    ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
+    if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
+        flb_plg_warn(ctx->ins, "could not unpack debug payload");
+        return;
+    }
+
+    out = cmt_encode_text_create(cmt);
+    flb_plg_info(ctx->ins, "debug payload:\n%s", out);
+    cmt_encode_text_destroy(out);
+    cmt_destroy(cmt);
+}
+
+static void cb_calyptia_flush(const void *data, size_t bytes,
+                              const char *tag, int tag_len,
+                              struct flb_input_instance *i_ins,
+                              void *out_context,
+                              struct flb_config *config)
+{
+    int ret;
+    size_t off = 0;
+    size_t out_size = 0;
+    char *out_buf = NULL;
+    struct flb_upstream_conn *u_conn;
+    struct flb_http_client *c;
+    struct flb_calyptia *ctx = out_context;
+    struct cmt *cmt;
+    (void) i_ins;
+    (void) config;
+
+    /* Get upstream connection */
+    u_conn = flb_upstream_conn_get(ctx->u);
+    if (!u_conn) {
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /* if we have labels append them */
+    if (ctx->add_labels && mk_list_size(ctx->add_labels) > 0) {
+        ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
+        if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
+            flb_upstream_conn_release(u_conn);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+
+        /* append labels set by config */
+        append_labels(ctx, cmt);
+
+        /* encode back to msgpack */
+        ret = cmt_encode_msgpack_create(cmt, &out_buf, &out_size);
+        if (ret != 0) {
+            cmt_destroy(cmt);
+            flb_upstream_conn_release(u_conn);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+    }
+    else {
+        out_buf = (char *) data;
+        out_size = bytes;
+    }
+
+    /* Compose HTTP Client request */
+    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->metrics_endpoint,
+                        out_buf, out_size, NULL, 0, NULL, 0);
+    if (!c) {
+        if (out_buf != data) {
+            cmt_encode_msgpack_destroy(out_buf);
+        }
+        flb_upstream_conn_release(u_conn);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /* perform request: 'ret' might be FLB_OK, FLB_ERROR or FLB_RETRY */
+    ret = calyptia_http_do(ctx, c, CALYPTIA_ACTION_METRICS);
+    if (ret == FLB_OK) {
+        flb_plg_debug(ctx->ins, "metrics delivered OK");
+    }
+    else if (ret == FLB_ERROR) {
+        flb_plg_error(ctx->ins, "could not deliver metrics");
+        debug_payload(ctx, out_buf, out_size);
+    }
+
+    if (out_buf != data) {
+        cmt_encode_msgpack_destroy(out_buf);
+    }
+
+    flb_upstream_conn_release(u_conn);
+    flb_http_client_destroy(c);
+    FLB_OUTPUT_RETURN(ret);
+}
+
+static int cb_calyptia_exit(void *data, struct flb_config *config)
+{
+    struct flb_calyptia *ctx = data;
+
+    if (!ctx) {
+        return 0;
+    }
+
+    if (ctx->u) {
+        flb_upstream_destroy(ctx->u);
+    }
+
+    if (ctx->agent_id) {
+        flb_sds_destroy(ctx->agent_id);
+    }
+
+    if (ctx->agent_token) {
+        flb_sds_destroy(ctx->agent_token);
+    }
+
+    if (ctx->machine_id) {
+        flb_sds_destroy(ctx->machine_id);
+    }
+
+    if (ctx->env) {
+        flb_env_destroy(ctx->env);
+    }
+
+    if (ctx->metrics_endpoint) {
+        flb_sds_destroy(ctx->metrics_endpoint);
+    }
+
+    flb_free(ctx);
+
+    return 0;
+}
+
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "cloud_host", CALYPTIA_HOST,
+     0, FLB_TRUE, offsetof(struct flb_calyptia, cloud_host),
+     "",
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "cloud_port", CALYPTIA_PORT,
+     0, FLB_TRUE, offsetof(struct flb_calyptia, cloud_port),
+     "",
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "api_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_calyptia, api_key),
+     "Calyptia Cloud API Key."
+    },
+
+    /* EOF */
+    {0}
+};
+
+struct flb_output_plugin out_calyptia_plugin = {
+    .name         = "calyptia",
+    .description  = "Calyptia Cloud",
+    .cb_init      = cb_calyptia_init,
+    .cb_flush     = cb_calyptia_flush,
+    .cb_exit      = cb_calyptia_exit,
+    .config_map   = config_map,
+    .flags        = FLB_OUTPUT_NET | FLB_OUTPUT_PRIVATE | FLB_IO_OPT_TLS,
+    .event_type   = FLB_OUTPUT_METRICS
+};

--- a/plugins/out_calyptia/calyptia.h
+++ b/plugins/out_calyptia/calyptia.h
@@ -1,0 +1,67 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_OUT_CALYPTIA_H
+#define FLB_OUT_CALYPTIA_H
+
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_upstream.h>
+#include <fluent-bit/flb_env.h>
+#include <mbedtls/sha256.h>
+
+/* End point */
+#define CALYPTIA_HOST            "cloud-api-dev.calyptia.com"
+#define CALYPTIA_PORT            "443"
+
+/* HTTP action types */
+#define CALYPTIA_ACTION_REGISTER  0
+#define CALYPTIA_ACTION_METRICS   1
+
+/* Endpoints */
+#define CALYPTIA_ENDPOINT_CREATE  "/v1/agents"
+#define CALYPTIA_ENDPOINT_METRICS "/v1/agents/%s/metrics"
+
+/* Headers */
+#define CALYPTIA_H_PROJECT       "X-Project-Token"
+#define CALYPTIA_H_AGENT_TOKEN   "X-Agent-Token"
+#define CALYPTIA_H_CTYPE         "Content-Type"
+#define CALYPTIA_H_CTYPE_JSON    "application/json"
+#define CALYPTIA_H_CTYPE_MSGPACK "application/x-msgpack"
+
+struct flb_calyptia {
+    /* config map */
+    int cloud_port;
+    flb_sds_t cloud_host;
+    flb_sds_t api_key;
+    struct mk_list *add_labels;
+
+    /* internal */
+    flb_sds_t agent_id;
+    flb_sds_t agent_token;
+    flb_sds_t machine_id;              /* machine-id  */
+    flb_sds_t metrics_endpoint;        /* metrics endpoint */
+    struct flb_env *env;               /* environment */
+    struct flb_upstream *u;            /* upstream connection */
+    struct mk_list kv_labels;          /* parsed add_labels */
+    struct flb_output_instance *ins;   /* plugin instance */
+    struct flb_config *config;         /* Fluent Bit context */
+};
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(src
   flb_pipe.c
   flb_meta.c
   flb_kernel.c
+  flb_custom.c
   flb_input.c
   flb_input_chunk.c
   flb_input_metric.c

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -219,10 +219,13 @@ struct flb_config *flb_config_init()
 
     /* Initialize linked lists */
     mk_list_init(&config->collectors);
+    mk_list_init(&config->custom_plugins);
+    mk_list_init(&config->custom_plugins);
     mk_list_init(&config->in_plugins);
     mk_list_init(&config->parser_plugins);
     mk_list_init(&config->filter_plugins);
     mk_list_init(&config->out_plugins);
+    mk_list_init(&config->customs);
     mk_list_init(&config->inputs);
     mk_list_init(&config->parsers);
     mk_list_init(&config->filters);

--- a/src/flb_custom.c
+++ b/src/flb_custom.c
@@ -1,0 +1,301 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_custom.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_router.h>
+#include <fluent-bit/flb_mp.h>
+#include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_metrics.h>
+#include <chunkio/chunkio.h>
+
+static inline int instance_id(struct flb_config *config)
+{
+    struct flb_custom_instance *entry;
+
+    if (mk_list_size(&config->customs) == 0) {
+        return 0;
+    }
+
+    entry = mk_list_entry_last(&config->customs, struct flb_custom_instance,
+                               _head);
+    return (entry->id + 1);
+}
+
+static inline int prop_key_check(const char *key, const char *kv, int k_len)
+{
+    int len;
+
+    len = strlen(key);
+    if (strncasecmp(key, kv, k_len) == 0 && len == k_len) {
+        return 0;
+    }
+
+    return -1;
+}
+
+int flb_custom_set_property(struct flb_custom_instance *ins,
+                            const char *k, const char *v)
+{
+    int len;
+    int ret;
+    flb_sds_t tmp;
+    struct flb_kv *kv;
+
+    len = strlen(k);
+    tmp = flb_env_var_translate(ins->config->env, v);
+    if (!tmp) {
+        return -1;
+    }
+
+    if (prop_key_check("alias", k, len) == 0 && tmp) {
+        ins->alias = tmp;
+    }
+    else if (prop_key_check("log_level", k, len) == 0 && tmp) {
+        ret = flb_log_get_level_str(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
+        }
+        ins->log_level = ret;
+    }
+    else {
+        /*
+         * Create the property, we don't pass the value since we will
+         * map it directly to avoid an extra memory allocation.
+         */
+        kv = flb_kv_item_create(&ins->properties, (char *) k, NULL);
+        if (!kv) {
+            if (tmp) {
+                flb_sds_destroy(tmp);
+            }
+            return -1;
+        }
+        kv->val = tmp;
+    }
+
+    return 0;
+}
+
+const char *flb_custom_get_property(const char *key,
+                                    struct flb_custom_instance *ins)
+{
+    return flb_kv_get_key_value(key, &ins->properties);
+}
+
+void flb_custom_instance_exit(struct flb_custom_instance *ins,
+                              struct flb_config *config)
+{
+    struct flb_custom_plugin *p;
+
+    p = ins->p;
+    if (p->cb_exit && ins->context) {
+        p->cb_exit(ins->context, config);
+    }
+}
+
+/* Invoke exit call for the custom plugin */
+void flb_custom_exit(struct flb_config *config)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_custom_instance *ins;
+    struct flb_custom_plugin *p;
+
+    mk_list_foreach_safe(head, tmp, &config->customs) {
+        ins = mk_list_entry(head, struct flb_custom_instance, _head);
+        p = ins->p;
+        if (!p) {
+            continue;
+        }
+        flb_custom_instance_exit(ins, config);
+        flb_custom_instance_destroy(ins);
+    }
+}
+
+struct flb_custom_instance *flb_custom_new(struct flb_config *config,
+                                           const char *custom, void *data)
+{
+    int id;
+    struct mk_list *head;
+    struct flb_custom_plugin *plugin;
+    struct flb_custom_instance *instance = NULL;
+
+    if (!custom) {
+        return NULL;
+    }
+
+    mk_list_foreach(head, &config->custom_plugins) {
+        plugin = mk_list_entry(head, struct flb_custom_plugin, _head);
+        if (strcmp(plugin->name, custom) == 0) {
+            break;
+        }
+        plugin = NULL;
+    }
+
+    if (!plugin) {
+        return NULL;
+    }
+
+    instance = flb_calloc(1, sizeof(struct flb_custom_instance));
+    if (!instance) {
+        flb_errno();
+        return NULL;
+    }
+    instance->config = config;
+
+    /* Get an ID */
+    id =  instance_id(config);
+
+    /* format name (with instance id) */
+    snprintf(instance->name, sizeof(instance->name) - 1,
+             "%s.%i", plugin->name, id);
+
+    instance->id    = id;
+    instance->alias = NULL;
+    instance->p     = plugin;
+    instance->data  = data;
+    instance->log_level = -1;
+
+    mk_list_init(&instance->properties);
+    mk_list_add(&instance->_head, &config->customs);
+
+    return instance;
+}
+
+/* Return an instance name or alias */
+const char *flb_custom_name(struct flb_custom_instance *ins)
+{
+    if (ins->alias) {
+        return ins->alias;
+    }
+
+    return ins->name;
+}
+
+/* Initialize all custom plugins */
+int flb_custom_init_all(struct flb_config *config)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct mk_list *config_map;
+    struct flb_custom_plugin *p;
+    struct flb_custom_instance *ins;
+
+    /* Iterate all active custom instance plugins */
+    mk_list_foreach_safe(head, tmp, &config->customs) {
+        ins = mk_list_entry(head, struct flb_custom_instance, _head);
+
+        if (ins->log_level == -1) {
+            ins->log_level = config->log->level;
+        }
+
+        p = ins->p;
+
+#ifdef FLB_HAVE_METRICS
+        /* CMetrics */
+        ins->cmt = cmt_create();
+        if (!ins->cmt) {
+            flb_error("[custom] could not create cmetrics context: %s",
+                      flb_custom_name(ins));
+            return -1;
+        }
+#endif
+
+        /*
+         * Before to call the initialization callback, make sure that the received
+         * configuration parameters are valid if the plugin is registering a config map.
+         */
+        if (p->config_map) {
+            /*
+             * Create a dynamic version of the configmap that will be used by the specific
+             * instance in question.
+             */
+            config_map = flb_config_map_create(config, p->config_map);
+            if (!config_map) {
+                flb_error("[custom] error loading config map for '%s' plugin",
+                          p->name);
+                return -1;
+            }
+            ins->config_map = config_map;
+
+            /* Validate incoming properties against config map */
+            ret = flb_config_map_properties_check(ins->p->name,
+                                                  &ins->properties, ins->config_map);
+            if (ret == -1) {
+                if (config->program_name) {
+                    flb_helper("try the command: %s -F %s -h\n",
+                               config->program_name, ins->p->name);
+                }
+                flb_custom_instance_destroy(ins);
+                return -1;
+            }
+        }
+
+        /* Initialize the input */
+        if (p->cb_init) {
+            ret = p->cb_init(ins, config, ins->data);
+            if (ret != 0) {
+                flb_error("Failed initialize custom %s", ins->name);
+                flb_custom_instance_destroy(ins);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+void flb_custom_instance_destroy(struct flb_custom_instance *ins)
+{
+    if (!ins) {
+        return;
+    }
+
+    /* destroy config map */
+    if (ins->config_map) {
+        flb_config_map_destroy(ins->config_map);
+    }
+
+    /* release properties */
+    flb_kv_release(&ins->properties);
+
+    if (ins->alias) {
+        flb_sds_destroy(ins->alias);
+    }
+
+#ifdef FLB_HAVE_METRICS
+    if (ins->cmt) {
+        cmt_destroy(ins->cmt);
+    }
+#endif
+
+    mk_list_del(&ins->_head);
+    flb_free(ins);
+}
+
+void flb_custom_set_context(struct flb_custom_instance *ins, void *context)
+{
+    ins->context = context;
+}

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -28,6 +28,7 @@
 
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_custom.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_error.h>
@@ -547,6 +548,12 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
 
+    /* Initialize custom plugins */
+    ret = flb_custom_init_all(config);
+    if (ret == -1) {
+        return -1;
+    }
+
     /* Start the Storage engine */
     ret = flb_storage_create(config);
     if (ret == -1) {
@@ -568,6 +575,7 @@ int flb_engine_start(struct flb_config *config)
     /* Register the scheduler context */
     flb_sched_ctx_init();
     flb_sched_ctx_set(sched);
+
 
     /* Initialize input plugins */
     ret = flb_input_init_all(config);
@@ -801,6 +809,7 @@ int flb_engine_shutdown(struct flb_config *config)
     flb_filter_exit(config);
     flb_input_exit_all(config);
     flb_output_exit(config);
+    flb_custom_exit(config);
 
     /* Destroy the storage context */
     flb_storage_destroy(config);

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -264,7 +264,7 @@ int flb_output(flb_ctx_t *ctx, const char *output, struct flb_lib_out_cb *cb)
 {
     struct flb_output_instance *o_ins;
 
-    o_ins = flb_output_new(ctx->config, output, cb);
+    o_ins = flb_output_new(ctx->config, output, cb, FLB_TRUE);
     if (!o_ins) {
         return -1;
     }

--- a/src/flb_router.c
+++ b/src/flb_router.c
@@ -126,8 +126,8 @@ int flb_router_match(const char *tag, int tag_len, const char *match,
 }
 
 /* Associate and input and output instances due to a previous match */
-static int flb_router_connect(struct flb_input_instance *in,
-                              struct flb_output_instance *out)
+int flb_router_connect(struct flb_input_instance *in,
+                       struct flb_output_instance *out)
 {
     struct flb_router_path *p;
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -40,6 +40,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_version.h>
 #include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_custom.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_filter.h>
@@ -73,9 +74,10 @@ struct flb_stacktrace flb_st;
 #define FLB_HELP_TEXT   0
 #define FLB_HELP_JSON   1
 
-#define PLUGIN_INPUT    0
-#define PLUGIN_OUTPUT   1
-#define PLUGIN_FILTER   2
+#define PLUGIN_CUSTOM   0
+#define PLUGIN_INPUT    1
+#define PLUGIN_OUTPUT   2
+#define PLUGIN_FILTER   3
 
 #define print_opt(a, b)      printf("  %-24s%s\n", a, b)
 #define print_opt_i(a, b, c) printf("  %-24s%s (default: %i)\n", a, b, c)
@@ -173,7 +175,7 @@ static void flb_help(int rc, struct flb_config *config)
     printf("\n%sOutputs%s\n", ANSI_BOLD, ANSI_RESET);
     mk_list_foreach(head, &config->out_plugins) {
         out = mk_list_entry(head, struct flb_output_plugin, _head);
-        if (strcmp(out->name, "lib") == 0) {
+        if (strcmp(out->name, "lib") == 0 || (out->flags & FLB_OUTPUT_PRIVATE)) {
             /* useless..., just skip it. */
             continue;
         }
@@ -574,6 +576,37 @@ static void flb_signal_init()
     signal(SIGSEGV, &flb_signal_handler);
 }
 
+static int custom_set_property(struct flb_custom_instance *in, char *kv)
+{
+    int ret;
+    int len;
+    int sep;
+    char *key;
+    char *value;
+
+    len = strlen(kv);
+    sep = mk_string_char_search(kv, '=', len);
+    if (sep == -1) {
+        return -1;
+    }
+
+    key = mk_string_copy_substr(kv, 0, sep);
+    value = kv + sep + 1;
+
+    if (!key) {
+        return -1;
+    }
+
+    ret = flb_custom_set_property(in, key, value);
+    if (ret == -1) {
+        fprintf(stderr, "[error] setting up '%s' plugin property '%s'\n",
+                in->p->name, key);
+    }
+
+    mk_mem_free(key);
+    return ret;
+}
+
 static int input_set_property(struct flb_input_instance *in, char *kv)
 {
     int ret;
@@ -697,6 +730,7 @@ static int flb_service_conf(struct flb_config *config, char *file)
     struct mk_rconf *fconf = NULL;
     struct mk_rconf_entry *entry;
     struct mk_rconf_section *section;
+    struct flb_custom_instance *custom;
     struct flb_input_instance *in;
     struct flb_output_instance *out;
     struct flb_filter_instance *filter;
@@ -725,6 +759,7 @@ static int flb_service_conf(struct flb_config *config, char *file)
         section = mk_list_entry(head, struct mk_rconf_section, _head);
 
         if (strcasecmp(section->name, "SERVICE") == 0 ||
+            strcasecmp(section->name, "CUSTOM") == 0 ||
             strcasecmp(section->name, "INPUT") == 0 ||
             strcasecmp(section->name, "FILTER") == 0 ||
             strcasecmp(section->name, "OUTPUT") == 0) {
@@ -760,6 +795,49 @@ static int flb_service_conf(struct flb_config *config, char *file)
         }
     }
 
+    /* Read all [CUSTOM] sections */
+    mk_list_foreach(head, &fconf->sections) {
+        section = mk_list_entry(head, struct mk_rconf_section, _head);
+        if (strcasecmp(section->name, "CUSTOM") != 0) {
+            continue;
+        }
+
+        /* Get the input plugin name */
+        name = s_get_key(section, "name", MK_RCONF_STR);
+        if (!name) {
+            flb_service_conf_err(section, "name");
+            goto flb_service_conf_end;
+        }
+
+        flb_debug("[service] loading custom plugin: %s", name);
+
+        /* Create an instace of the plugin */
+        tmp = flb_env_var_translate(config->env, name);
+        custom = flb_custom_new(config, tmp, NULL);
+        mk_mem_free(name);
+        if (!custom) {
+            fprintf(stderr, "Custom plugin '%s' cannot be loaded\n", tmp);
+            flb_sds_destroy(tmp);
+            goto flb_service_conf_end;
+        }
+        flb_sds_destroy(tmp);
+
+        /* Iterate other properties */
+        mk_list_foreach(h_prop, &section->entries) {
+            entry = mk_list_entry(h_prop, struct mk_rconf_entry, _head);
+            if (strcasecmp(entry->key, "name") == 0) {
+                continue;
+            }
+
+            /* Set the property */
+            ret = flb_custom_set_property(custom, entry->key, entry->val);
+            if (ret == -1) {
+                fprintf(stderr, "Error setting up %s plugin property '%s'\n",
+                        custom->name, entry->key);
+                goto flb_service_conf_end;
+            }
+        }
+    }
 
     /* Read all [INPUT] sections */
     mk_list_foreach(head, &fconf->sections) {
@@ -821,7 +899,7 @@ static int flb_service_conf(struct flb_config *config, char *file)
 
         /* Create an instace of the plugin */
         tmp = flb_env_var_translate(config->env, name);
-        out = flb_output_new(config, tmp, NULL);
+        out = flb_output_new(config, tmp, NULL, FLB_TRUE);
         mk_mem_free(name);
         if (!out) {
             fprintf(stderr, "Output plugin '%s' cannot be loaded\n", tmp);
@@ -895,6 +973,7 @@ int flb_main(int argc, char **argv)
 
     /* local variables to handle config options */
     char *cfg_file = NULL;
+    struct flb_custom_instance *custom = NULL;
     struct flb_input_instance *in = NULL;
     struct flb_output_instance *out = NULL;
     struct flb_filter_instance *filter = NULL;
@@ -915,6 +994,7 @@ int flb_main(int argc, char **argv)
         { "http",            no_argument      , NULL, 'H' },
         { "log_file",        required_argument, NULL, 'l' },
         { "port",            required_argument, NULL, 'P' },
+        { "custom",          required_argument, NULL, 'C' },
         { "input",           required_argument, NULL, 'i' },
         { "match",           required_argument, NULL, 'm' },
         { "output",          required_argument, NULL, 'o' },
@@ -961,7 +1041,7 @@ int flb_main(int argc, char **argv)
 
     /* Parse the command line options */
     while ((opt = getopt_long(argc, argv,
-                              "b:c:dDf:i:m:o:R:F:p:e:"
+                              "b:c:dDf:C:i:m:o:R:F:p:e:"
                               "t:T:l:vw:qVhJL:HP:s:S",
                               long_opts, NULL)) != -1) {
 
@@ -989,6 +1069,13 @@ int flb_main(int argc, char **argv)
         case 'f':
             config->flush = atof(optarg);
             break;
+        case 'C':
+            custom = flb_custom_new(config, optarg, NULL);
+            if (!custom) {
+                flb_utils_error(FLB_ERR_CUSTOM_INVALID);
+            }
+            last_plugin = PLUGIN_CUSTOM;
+            break;
         case 'i':
             in = flb_input_new(config, optarg, NULL, FLB_TRUE);
             if (!in) {
@@ -1005,7 +1092,7 @@ int flb_main(int argc, char **argv)
             }
             break;
         case 'o':
-            out = flb_output_new(config, optarg, NULL);
+            out = flb_output_new(config, optarg, NULL, FLB_TRUE);
             if (!out) {
                 flb_utils_error(FLB_ERR_OUTPUT_INVALID);
             }
@@ -1041,6 +1128,9 @@ int flb_main(int argc, char **argv)
             }
             else if (last_plugin == PLUGIN_FILTER) {
                 filter_set_property(filter, optarg);
+            }
+            else if (last_plugin == PLUGIN_CUSTOM) {
+                custom_set_property(custom, optarg);
             }
             break;
         case 't':
@@ -1160,18 +1250,6 @@ int flb_main(int argc, char **argv)
     /* Validate flush time (seconds) */
     if (config->flush <= (double) 0.0) {
         flb_utils_error(FLB_ERR_CFG_FLUSH);
-    }
-
-    /* Inputs */
-    ret = flb_input_check(config);
-    if (ret == -1 && config->support_mode == FLB_FALSE) {
-        flb_utils_error(FLB_ERR_INPUT_UNDEF);
-    }
-
-    /* Outputs */
-    ret = flb_output_check(config);
-    if (ret == -1 && config->support_mode == FLB_FALSE) {
-        flb_utils_error(FLB_ERR_OUTPUT_UNDEF);
     }
 
     /* debug or trace */


### PR DESCRIPTION
This PR add supports for:

- [Calyptia Cloud](https://cloud.calyptia.com) (custom and output plugins)
- new `custom` plugin types
- allow `private` output plugins

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
