### PR TITLE
out_nats: support config map

### DIFF
--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_config_map.h>
 
 #include <stdio.h>
 #include <msgpack.h>
@@ -32,6 +33,7 @@ static int cb_nats_init(struct flb_output_instance *ins, struct flb_config *conf
                         void *data)
 {
     int io_flags;
+    int ret;
     struct flb_upstream *upstream;
     struct flb_out_nats_config *ctx;
 
@@ -42,6 +44,14 @@ static int cb_nats_init(struct flb_output_instance *ins, struct flb_config *conf
     ctx = flb_malloc(sizeof(struct flb_out_nats_config));
     if (!ctx) {
         flb_errno();
+        return -1;
+    }
+
+    /* Set default values */
+    ret = flb_output_config_map_set(ins, ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "flb_output_config_map_set failed");
+        flb_free(ctx);
         return -1;
     }
 
@@ -224,6 +234,11 @@ int cb_nats_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    /* EOF */
+    {0}
+};
+
 struct flb_output_plugin out_nats_plugin = {
     .name         = "nats",
     .description  = "NATS Server",
@@ -231,4 +246,5 @@ struct flb_output_plugin out_nats_plugin = {
     .cb_flush     = cb_nats_flush,
     .cb_exit      = cb_nats_exit,
     .flags        = FLB_OUTPUT_NET,
+    .config_map   = config_map
 };


### PR DESCRIPTION
This patch is to support config map.

https://docs.fluentbit.io/manual/pipeline/outputs/nats
out_nats is supported only `host` and `port` properties and they are supported `flb_output_net_default` and `flb_output_set_property`.
So, the config map struct is blank.

This patch is for #3952 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug output

I added below diff to check timeout value.
```diff
diff --git a/src/flb_output.c b/src/flb_output.c
index 721a4029..b5283a46 100644
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1045,6 +1045,7 @@ int flb_output_init_all(struct flb_config *config)
                       flb_output_name(ins));
             return -1;
         }
+        flb_error("connect_timeout=%d", ins->net_setup.connect_timeout);
     }
 
     return 0;
```

1. `nc -l 12345`
2. `fluent-bit -i dummy -o nats -p port=12345`

```
$ bin/fluent-bit -i dummy -o nats -p port=12345
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/15 10:40:54] [ info] [engine] started (pid=44796)
[2021/08/15 10:40:54] [ info] [storage] version=1.1.1, initializing...
[2021/08/15 10:40:54] [ info] [storage] in-memory
[2021/08/15 10:40:54] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/15 10:40:54] [ info] [cmetrics] version=0.2.1
[2021/08/15 10:40:54] [error] connect_timeout=10
[2021/08/15 10:40:54] [ info] [sp] stream processor started
^C[2021/08/15 10:41:00] [engine] caught signal (SIGINT)
[2021/08/15 10:41:00] [ warn] [engine] service will stop in 5 seconds
```

```
$ nc -l 12345
CONNECT {"verbose":false,"pedantic":false,"ssl_required":false,"name":"fluent-bit","lang":"c","version":"1.9.0"}
PUB dummy.0 223
[[1628991655.24015,{"tag":"dummy.0","message":"dummy"}],[1628991656.239934,{"tag":"dummy.0","message":"dummy"}],[1628991657.23989,{"tag":"dummy.0","message":"dummy"}],[1628991658.239893,{"tag":"dummy.0","message":"dummy"}]]
CONNECT {"verbose":false,"pedantic":false,"ssl_required":false,"name":"fluent-bit","lang":"c","version":"1.9.0"}
PUB dummy.0 57
[[1628991659.241117,{"tag":"dummy.0","message":"dummy"}]]
```

## Valgrind output 

No error is reported. (except #3897)

```
$ valgrind --leak-check=full bin/fluent-bit -i dummy -o nats -p port=12345
==44801== Memcheck, a memory error detector
==44801== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==44801== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==44801== Command: bin/fluent-bit -i dummy -o nats -p port=12345
==44801== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/15 10:42:07] [ info] [engine] started (pid=44801)
[2021/08/15 10:42:07] [ info] [storage] version=1.1.1, initializing...
[2021/08/15 10:42:07] [ info] [storage] in-memory
[2021/08/15 10:42:07] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/15 10:42:07] [ info] [cmetrics] version=0.2.1
[2021/08/15 10:42:07] [error] connect_timeout=10
[2021/08/15 10:42:07] [ info] [sp] stream processor started
==44801== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c94a20
==44801==          to suppress, use: --max-stackframe=11861944 or greater
==44801== Warning: client switching stacks?  SP change: 0x4c94998 --> 0x57e49d8
==44801==          to suppress, use: --max-stackframe=11862080 or greater
==44801== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c94998
==44801==          to suppress, use: --max-stackframe=11862080 or greater
==44801==          further instances of this message will not be shown.
^C[2021/08/15 10:42:12] [engine] caught signal (SIGINT)
[2021/08/15 10:42:12] [ warn] [engine] service will stop in 5 seconds
[2021/08/15 10:42:17] [ info] [engine] service stopped
==44801== 
==44801== HEAP SUMMARY:
==44801==     in use at exit: 74,545 bytes in 6 blocks
==44801==   total heap usage: 1,150 allocs, 1,144 frees, 1,323,788 bytes allocated
==44801== 
==44801== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==44801==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==44801==    by 0x1B6501: flb_calloc (flb_mem.h:78)
==44801==    by 0x1B775C: flb_net_dns_lookup_context_create (flb_network.c:691)
==44801==    by 0x1B7937: flb_net_getaddrinfo (flb_network.c:755)
==44801==    by 0x1B7EEB: flb_net_tcp_connect (flb_network.c:916)
==44801==    by 0x1E0AD8: flb_io_net_connect (flb_io.c:89)
==44801==    by 0x1C44B7: create_conn (flb_upstream.c:523)
==44801==    by 0x1C498A: flb_upstream_conn_get (flb_upstream.c:666)
==44801==    by 0x259AD7: cb_nats_flush (nats.c:171)
==44801==    by 0x1AC786: output_pre_cb_flush (flb_output.h:509)
==44801==    by 0x6F888A: co_init (amd64.c:117)
==44801== 
==44801== LEAK SUMMARY:
==44801==    definitely lost: 128 bytes in 1 blocks
==44801==    indirectly lost: 74,417 bytes in 5 blocks
==44801==      possibly lost: 0 bytes in 0 blocks
==44801==    still reachable: 0 bytes in 0 blocks
==44801==         suppressed: 0 bytes in 0 blocks
==44801== 
==44801== For lists of detected and suppressed errors, rerun with: -s
==44801== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
