### PR TITLE
out_gelf: support config map

### DIFF
--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_random.h>
+#include <fluent-bit/flb_config_map.h>
 #include <msgpack.h>
 
 #include <stdio.h>
@@ -322,6 +323,7 @@ static void cb_gelf_flush(const void *data, size_t bytes,
 static int cb_gelf_init(struct flb_output_instance *ins, struct flb_config *config,
                         void *data)
 {
+    int ret;
     const char *tmp;
     struct flb_out_gelf_config *ctx = NULL;
 
@@ -335,6 +337,13 @@ static int cb_gelf_init(struct flb_output_instance *ins, struct flb_config *conf
         return -1;
     }
     ctx->ins = ins;
+
+    ret = flb_output_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "flb_output_config_map_set failed");
+        flb_free(ctx);
+        return -1;
+    }
 
     /* Config Mode */
     tmp = flb_output_get_property("mode", ins);
@@ -386,24 +395,6 @@ static int cb_gelf_init(struct flb_output_instance *ins, struct flb_config *conf
     tmp = flb_output_get_property("gelf_level_key", ins);
     if (tmp) {
         ctx->fields.level_key = flb_sds_create(tmp);
-    }
-
-    /* Config UDP Packet_Size */
-    tmp = flb_output_get_property("packet_size", ins);
-    if (tmp != NULL && atoi(tmp) >= 0) {
-        ctx->pckt_size = atoi(tmp);
-    }
-    else {
-        ctx->pckt_size = 1420;
-    }
-
-    /* Config UDP Compress */
-    tmp = flb_output_get_property("compress", ins);
-    if (tmp) {
-        ctx->compress = flb_utils_bool(tmp);
-    }
-    else {
-        ctx->compress = FLB_TRUE;
     }
 
     /* init random seed */
@@ -477,6 +468,58 @@ static int cb_gelf_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "mode", "udp",
+     0, FLB_FALSE, 0,
+     "The protocol to use. 'tls', 'tcp' or 'udp'"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_short_message_key", NULL,
+     0, FLB_FALSE, 0,
+     "A short descriptive message (MUST be set in GELF)"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_timestamp_key", NULL,
+     0, FLB_FALSE, 0,
+     "Timestamp key name (SHOULD be set in GELF)"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_host_key", NULL,
+     0, FLB_FALSE, 0,
+     "Key which its value is used as the name of the host,"
+     "source or application that sent this message. (MUST be set in GELF) "
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_full_message_key", NULL,
+     0, FLB_FALSE, 0,
+     "Key to use as the long message that can i.e. contain a backtrace. "
+     "(Optional in GELF)"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_level_key", NULL,
+     0, FLB_FALSE, 0,
+     "Key to be used as the log level. "
+     "Its value must be in standard syslog levels (between 0 and 7). "
+     "(Optional in GELF)"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "packet_size", "1420",
+     0, FLB_TRUE, offsetof(struct flb_out_gelf_config, pckt_size),
+     "If transport protocol is udp, you can set the size of packets to be sent."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "compress", "true",
+     0, FLB_TRUE, offsetof(struct flb_out_gelf_config, compress),
+     "If transport protocol is udp, "
+     "you can set this if you want your UDP packets to be compressed."
+    },
+
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_output_plugin out_gelf_plugin = {
     .name           = "gelf",
@@ -486,4 +529,5 @@ struct flb_output_plugin out_gelf_plugin = {
     .cb_flush       = cb_gelf_flush,
     .cb_exit        = cb_gelf_exit,
     .flags          = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
+    .config_map     = config_map
 };


### PR DESCRIPTION
This patch is to support config map for out_gelf.
The patch is for #3952.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug output

I added below diff to check timeout value.

```diff
diff --git a/src/flb_output.c b/src/flb_output.c
index 721a4029..b5283a46 100644
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1045,6 +1045,7 @@ int flb_output_init_all(struct flb_config *config)
                       flb_output_name(ins));
             return -1;
         }
+        flb_error("connect_timeout=%d", ins->net_setup.connect_timeout);
     }
 
     return 0;
```

1. `nc -l 12345`
2. `fluent-bit -c gelf.conf`

```
$ bin/fluent-bit -c gelf.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/15 16:59:51] [ info] [engine] started (pid=53650)
[2021/08/15 16:59:51] [ info] [storage] version=1.1.1, initializing...
[2021/08/15 16:59:51] [ info] [storage] in-memory
[2021/08/15 16:59:51] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/15 16:59:51] [ info] [cmetrics] version=0.2.1
[2021/08/15 16:59:51] [error] connect_timeout=10
[2021/08/15 16:59:51] [ info] [sp] stream processor started
^C[2021/08/15 16:59:57] [engine] caught signal (SIGINT)
```

```
taka@locals:~$ nc -l 12345
{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}{"version":"1.1", "_msg":"message", "short_message":"HOGE", "timestamp":1629013222.288000, "host":"local", "full_message":"fullmessage", "level":3}taka@locals:~$ 
```

## Valgrind output

No error is reported. (except #3897)

```
$ valgrind --leak-check=full bin/fluent-bit -c gelf.conf 
==53654== Memcheck, a memory error detector
==53654== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==53654== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==53654== Command: bin/fluent-bit -c gelf.conf
==53654== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/15 17:01:12] [ info] [engine] started (pid=53654)
[2021/08/15 17:01:12] [ info] [storage] version=1.1.1, initializing...
[2021/08/15 17:01:12] [ info] [storage] in-memory
[2021/08/15 17:01:12] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/15 17:01:12] [ info] [cmetrics] version=0.2.1
[2021/08/15 17:01:12] [error] connect_timeout=10
[2021/08/15 17:01:12] [ info] [sp] stream processor started
==53654== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c9aba0
==53654==          to suppress, use: --max-stackframe=11836984 or greater
==53654== Warning: client switching stacks?  SP change: 0x4c9ab18 --> 0x57e49d8
==53654==          to suppress, use: --max-stackframe=11837120 or greater
==53654== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c9ab18
==53654==          to suppress, use: --max-stackframe=11837120 or greater
==53654==          further instances of this message will not be shown.
^C[2021/08/15 17:01:17] [engine] caught signal (SIGINT)
[2021/08/15 17:01:17] [ warn] [engine] service will stop in 5 seconds
[2021/08/15 17:01:22] [ info] [engine] service stopped
==53654== 
==53654== HEAP SUMMARY:
==53654==     in use at exit: 74,545 bytes in 6 blocks
==53654==   total heap usage: 1,282 allocs, 1,276 frees, 1,268,828 bytes allocated
==53654== 
==53654== 74,545 (128 direct, 74,417 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==53654==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==53654==    by 0x1B6501: flb_calloc (flb_mem.h:78)
==53654==    by 0x1B775C: flb_net_dns_lookup_context_create (flb_network.c:691)
==53654==    by 0x1B7937: flb_net_getaddrinfo (flb_network.c:755)
==53654==    by 0x1B7EEB: flb_net_tcp_connect (flb_network.c:916)
==53654==    by 0x1E0AD8: flb_io_net_connect (flb_io.c:89)
==53654==    by 0x1C44B7: create_conn (flb_upstream.c:523)
==53654==    by 0x1C498A: flb_upstream_conn_get (flb_upstream.c:666)
==53654==    by 0x27520A: cb_gelf_flush (gelf.c:252)
==53654==    by 0x1AC786: output_pre_cb_flush (flb_output.h:509)
==53654==    by 0x6F880A: co_init (amd64.c:117)
==53654== 
==53654== LEAK SUMMARY:
==53654==    definitely lost: 128 bytes in 1 blocks
==53654==    indirectly lost: 74,417 bytes in 5 blocks
==53654==      possibly lost: 0 bytes in 0 blocks
==53654==    still reachable: 0 bytes in 0 blocks
==53654==         suppressed: 0 bytes in 0 blocks
==53654== 
==53654== For lists of detected and suppressed errors, rerun with: -s
==53654== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)