### PR TITLE
metrics: add cmetrics for chunks.

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -255,6 +255,9 @@ struct flb_input_instance {
     struct cmt *cmt;                     /* parent context              */
     struct cmt_counter *cmt_bytes;       /* metric: input_bytes_total   */
     struct cmt_counter *cmt_records;     /* metric: input_records_total */
+    struct cmt_gauge   *cmt_chunks_live; /* metric: current chunks      */
+    struct cmt_gauge   *cmt_chunks_up;   /* metric: current up chunks   */
+    struct cmt_counter *cmt_chunks_total;/* metric: total chunks        */
 
     /*
      * Indexes for generated chunks: simple hash tables that keeps the latest

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -505,15 +505,15 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                                           1, (char *[]) {"name"});
     /* Register chunk metrics */
     ins->cmt_chunks_live = cmt_gauge_create(ins->cmt,
-                                            "fluentbit", "chunks", "live",
+                                            "fluentbit", "input", "chunks_active",
                                             "Number of live chunks.",
                                             1, (char *[]) {"name"});
     ins->cmt_chunks_up = cmt_gauge_create(ins->cmt,
-                                          "fluentbit", "chunks", "up",
+                                          "fluentbit", "input", "chunks_up",
                                           "Number of up chunks.",
                                           1, (char *[]) {"name"});
     ins->cmt_chunks_total = cmt_counter_create(ins->cmt,
-                                               "fluentbit", "chunks", "total",
+                                               "fluentbit", "input", "chunks_total",
                                                "Number of total chunks.",
                                                1, (char *[]) {"name"});
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -500,9 +500,22 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                                         "Number of input bytes.",
                                         1, (char *[]) {"name"});
     ins->cmt_records = cmt_counter_create(ins->cmt,
-                                        "fluentbit", "input", "records_total",
-                                        "Number of input records.",
-                                        1, (char *[]) {"name"});
+                                          "fluentbit", "input", "records_total",
+                                          "Number of input records.",
+                                          1, (char *[]) {"name"});
+    /* Register chunk metrics */
+    ins->cmt_chunks_live = cmt_gauge_create(ins->cmt,
+                                            "fluentbit", "chunks", "live",
+                                            "Number of live chunks.",
+                                            1, (char *[]) {"name"});
+    ins->cmt_chunks_up = cmt_gauge_create(ins->cmt,
+                                          "fluentbit", "chunks", "up",
+                                          "Number of up chunks.",
+                                          1, (char *[]) {"name"});
+    ins->cmt_chunks_total = cmt_counter_create(ins->cmt,
+                                               "fluentbit", "chunks", "total",
+                                               "Number of total chunks.",
+                                               1, (char *[]) {"name"});
 
     /* OLD Metrics */
 #ifdef FLB_HAVE_METRICS


### PR DESCRIPTION
This change adds cmetrics for chunks, specifically the following metrics:

- fluentbit_input_chunks_live{name="plugin_name.N"}
- fluentbit_input_chunks_up{name="plugin_name.N"}
- fluentbit_input_chunks_total{name="plugin_name.N"}

An example of these metrics can be seen here:

```
$ fluent-bit -i fluentbit_metrics -o stdout -f 1
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/18 15:26:46] [ info] [engine] started (pid=2146841)
[2021/08/18 15:26:46] [ info] [storage] version=1.1.1, initializing...
[2021/08/18 15:26:46] [ info] [storage] in-memory
[2021/08/18 15:26:46] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/18 15:26:46] [ info] [cmetrics] version=0.2.1
[2021/08/18 15:26:46] [ info] [sp] stream processor started
2021-08-18T19:26:48.186838504Z fluentbit_uptime{hostname="hydra"} = 2
2021-08-18T19:26:48.186828875Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 1
2021-08-18T19:26:48.186838504Z fluentbit_process_start_time_seconds{hostname="hydra"} = 1629314806
2021-08-18T19:26:48.186838504Z fluentbit_build_info{hostname="hydra",version="1.9.0",os="linux"} = 1629314806
2021-08-18T19:26:50.186831026Z fluentbit_uptime{hostname="hydra"} = 4
2021-08-18T19:26:48.186914519Z fluentbit_input_bytes_total{name="fluentbit_metrics.0"} = 2775
2021-08-18T19:26:48.186914519Z fluentbit_input_records_total{name="fluentbit_metrics.0"} = 1
2021-08-18T19:26:48.186880824Z fluentbit_input_chunks_total{name="fluentbit_metrics.0"} = 1
2021-08-18T19:26:50.186826407Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 2
2021-08-18T19:26:48.187028476Z fluentbit_output_proc_records_total{name="stdout.0"} = 1
2021-08-18T19:26:48.187028476Z fluentbit_output_proc_bytes_total{name="stdout.0"} = 2775
2021-08-18T19:26:50.186831026Z fluentbit_process_start_time_seconds{hostname="hydra"} = 1629314806
2021-08-18T19:26:50.186831026Z fluentbit_build_info{hostname="hydra",version="1.9.0",os="linux"} = 1629314806
2021-08-18T19:26:48.187031361Z fluentbit_input_chunks_live{name="fluentbit_metrics.0"} = 0
2021-08-18T19:26:48.187031361Z fluentbit_input_chunks_up{name="fluentbit_metrics.0"} = 0
^C[2021/08/18 15:26:51] [engine] caught signal (SIGINT)
[2021/08/18 15:26:51] [ info] [input] pausing fluentbit_metrics.0
[2021/08/18 15:26:51] [ warn] [engine] service will stop in 5 seconds
[2021/08/18 15:26:56] [ info] [engine] service stopped
```

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [*] Debug log output from testing the change
- [*] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Debug log:
```
fluent-bit -vvvv -i dummy -t dummy -i fluentbit_metrics -t metrics -o stdout -p match='metrics' -o exit -p match='dummy' -f 1 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/18 15:35:56] [ info] Configuration:
[2021/08/18 15:35:56] [ info]  flush time     | 1.000000 seconds
[2021/08/18 15:35:56] [ info]  grace          | 5 seconds
[2021/08/18 15:35:56] [ info]  daemon         | 0
[2021/08/18 15:35:56] [ info] ___________
[2021/08/18 15:35:56] [ info]  inputs:
[2021/08/18 15:35:56] [ info]      dummy
[2021/08/18 15:35:56] [ info]      fluentbit_metrics
[2021/08/18 15:35:56] [ info] ___________
[2021/08/18 15:35:56] [ info]  filters:
[2021/08/18 15:35:56] [ info] ___________
[2021/08/18 15:35:56] [ info]  outputs:
[2021/08/18 15:35:56] [ info]      stdout.0
[2021/08/18 15:35:56] [ info]      exit.1
[2021/08/18 15:35:56] [ info] ___________
[2021/08/18 15:35:56] [ info]  collectors:
[2021/08/18 15:35:56] [ info] [engine] started (pid=2148008)
[2021/08/18 15:35:56] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/08/18 15:35:56] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/08/18 15:35:56] [debug] [storage] [cio stream] new stream registered: fluentbit_metrics.1
[2021/08/18 15:35:56] [ info] [storage] version=1.1.1, initializing...
[2021/08/18 15:35:56] [ info] [storage] in-memory
[2021/08/18 15:35:56] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/18 15:35:56] [ info] [cmetrics] version=0.2.1
[2021/08/18 15:35:56] [debug] [stdout:stdout.0] created event channels: read=19 write=20
[2021/08/18 15:35:56] [debug] [exit:exit.1] created event channels: read=21 write=22
[2021/08/18 15:35:56] [debug] [router] match rule dummy.0:exit.1
[2021/08/18 15:35:56] [debug] [router] match rule fluentbit_metrics.1:stdout.0
[2021/08/18 15:35:56] [ info] [sp] stream processor started
[2021/08/18 15:35:58] [debug] [task] created task=0x7ffff0011ee0 id=0 OK
[2021/08/18 15:35:58] [ info] [input] pausing fluentbit_metrics.1
[2021/08/18 15:35:58] [debug] [task] created task=0x7ffff000e9f0 id=1 OK
2021-08-18T19:35:58.186831812Z fluentbit_uptime{hostname="hydra"} = 2
2021-08-18T19:35:57.186866954Z fluentbit_input_bytes_total{name="dummy.0"} = 26
2021-08-18T19:35:57.186866954Z fluentbit_input_records_total{name="dummy.0"} = 1
2021-08-18T19:35:57.186843820Z fluentbit_input_chunks_total{name="dummy.0"} = 1
2021-08-18T19:35:58.186825570Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.1"} = 1
2021-08-18T19:35:58.186831812Z fluentbit_process_start_time_seconds{hostname="hydra"} = 1629315356
2021-08-18T19:35:58.186831812Z fluentbit_build_info{hostname="hydra",version="1.9.0",os="linux"} = 1629315356
2021-08-18T19:35:57.186843820Z fluentbit_input_chunks_live{name="dummy.0"} = 1
2021-08-18T19:35:57.186843820Z fluentbit_input_chunks_up{name="dummy.0"} = 1
[2021/08/18 15:35:58] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:35:58] [ warn] [engine] service will stop in 5 seconds
[2021/08/18 15:35:58] [debug] [out coro] cb_destroy coro_id=0
[2021/08/18 15:35:58] [debug] [task] destroy task=0x7ffff0011ee0 (task_id=0)
[2021/08/18 15:35:58] [debug] [out coro] cb_destroy coro_id=0
[2021/08/18 15:35:58] [debug] [task] destroy task=0x7ffff000e9f0 (task_id=1)
[2021/08/18 15:35:59] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:36:00] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:36:01] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:36:02] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:36:03] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/18 15:36:03] [ info] [engine] service stopped
```

Valgrind log:
```
valgrind fluent-bit -i dummy -t dummy -i fluentbit_metrics -t metrics -o stdout -p match='metrics' -o exit -p match='dummy' -f 1
==2147787== Memcheck, a memory error detector
==2147787== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2147787== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==2147787== Command: ./build/bin/fluent-bit -i dummy -t dummy -i fluentbit_metrics -t metrics -o stdout -p match=metrics -o exit -p match=dummy -f 1
==2147787== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/18 15:33:56] [ info] [engine] started (pid=2147787)
[2021/08/18 15:33:56] [ info] [storage] version=1.1.1, initializing...
[2021/08/18 15:33:56] [ info] [storage] in-memory
[2021/08/18 15:33:56] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/18 15:33:56] [ info] [cmetrics] version=0.2.1
[2021/08/18 15:33:56] [ info] [sp] stream processor started
[2021/08/18 15:33:58] [ info] [input] pausing fluentbit_metrics.1
2021-08-18T19:33:58.187450446Z fluentbit_uptime{hostname="hydra"} = 2
2021-08-18T19:33:57.210290992Z fluentbit_input_bytes_total{name="dummy.0"} = 26
2021-08-18T19:33:57.210290992Z fluentbit_input_records_total{name="dummy.0"} = 1
2021-08-18T19:33:57.196240189Z fluentbit_input_chunks_total{name="dummy.0"} = 1
2021-08-18T19:33:58.187010287Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.1"} = 1
2021-08-18T19:33:58.187450446Z fluentbit_process_start_time_seconds{hostname="hydra"} = 1629315236
2021-08-18T19:33:58.187450446Z fluentbit_build_info{hostname="hydra",version="1.9.0",os="linux"} = 1629315236
2021-08-18T19:33:57.196240189Z fluentbit_input_chunks_live{name="dummy.0"} = 1
2021-08-18T19:33:57.196240189Z fluentbit_input_chunks_up{name="dummy.0"} = 1
[2021/08/18 15:33:58] [ warn] [engine] service will stop in 5 seconds
[2021/08/18 15:34:03] [ info] [engine] service stopped
==2147787== 
==2147787== HEAP SUMMARY:
==2147787==     in use at exit: 320 bytes in 1 blocks
==2147787==   total heap usage: 5,021 allocs, 5,020 frees, 1,307,041 bytes allocated
==2147787== 
==2147787== LEAK SUMMARY:
==2147787==    definitely lost: 0 bytes in 0 blocks
==2147787==    indirectly lost: 0 bytes in 0 blocks
==2147787==      possibly lost: 320 bytes in 1 blocks
==2147787==    still reachable: 0 bytes in 0 blocks
==2147787==         suppressed: 0 bytes in 0 blocks
==2147787== Rerun with --leak-check=full to see details of leaked memory
==2147787== 
==2147787== For lists of detected and suppressed errors, rerun with: -s
==2147787== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
