### PR TITLE
Output the banner and success messages to stdout

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -95,15 +95,15 @@ static void flb_version()
 
 static void flb_banner()
 {
-    fprintf(stderr, "%sFluent Bit v%s%s\n", ANSI_BOLD, FLB_VERSION_STR,
+    fprintf(stdout, "%sFluent Bit v%s%s\n", ANSI_BOLD, FLB_VERSION_STR,
             ANSI_RESET);
-    fprintf(stderr, "* %sCopyright (C) 2019-2021 The Fluent Bit Authors%s\n",
+    fprintf(stdout, "* %sCopyright (C) 2019-2021 The Fluent Bit Authors%s\n",
             ANSI_BOLD ANSI_YELLOW, ANSI_RESET);
-    fprintf(stderr, "* %sCopyright (C) 2015-2018 Treasure Data%s\n",
+    fprintf(stdout, "* %sCopyright (C) 2015-2018 Treasure Data%s\n",
             ANSI_BOLD ANSI_YELLOW, ANSI_RESET);
-    fprintf(stderr, "* Fluent Bit is a CNCF sub-project under the "
+    fprintf(stdout, "* Fluent Bit is a CNCF sub-project under the "
             "umbrella of Fluentd\n");
-    fprintf(stderr, "* https://fluentbit.io\n\n");
+    fprintf(stdout, "* https://fluentbit.io\n\n");
 }
 
 static void flb_help(int rc, struct flb_config *config)
@@ -1272,7 +1272,7 @@ int flb_main(int argc, char **argv)
 #endif
 
     if (config->dry_run == FLB_TRUE) {
-        fprintf(stderr, "configuration test is successful\n");
+        fprintf(stdout, "configuration test is successful\n");
         exit(EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
This changes the banner output and "configuration test is successful" log messages to go to stdout instead of stderr, since they are not errors.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature
  - I could not find any documentation on this
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.