### PR TITLE
in_storage_backlog: Delete corrupted chunks from the filesystem

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -84,7 +84,7 @@ static int cb_queue_chunks(struct flb_input_instance *in,
                 flb_plg_error(ctx->ins, "removing corrupted chunk from the "
                               "queue %s:%s",
                               sbc->stream->name, sbc->chunk->name);
-                cio_chunk_close(sbc->chunk, FLB_FALSE);
+                cio_chunk_close(sbc->chunk, FLB_TRUE);
                 mk_list_del(&sbc->_head);
                 flb_free(sbc);
                 continue;


### PR DESCRIPTION
Signed-off-by: James Elias Sigurdarson <jamiees2@gmail.com>

<!-- Provide summary of changes -->
It looks like we mean to delete corrupted chunks out of the filesystem once we detect they are corrupted. This fixes a single case where they are not removed, but are corrupted.

Some discussion on Slack: https://fluent-all.slack.com/archives/C0CTQGHKJ/p1629489446426900

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
