### PR TITLE
out_datadog: support config map

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_config_map.h>
 
 #include <msgpack.h>
 
@@ -422,6 +423,76 @@ static int cb_datadog_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "compress", "false",
+     0, FLB_FALSE, 0,
+     "compresses the payload in GZIP format, "
+     "Datadog supports and recommends setting this to 'gzip'."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "apikey", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, api_key),
+     "Datadog API key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "dd_service", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_service),
+     "The human readable name for your service generating the logs "
+     "- the name of your application or database."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "dd_source", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_source),
+     "A human readable name for the underlying technology of your service. "
+     "For example, 'postgres' or 'nginx'."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "dd_tags", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_tags),
+     "The tags you want to assign to your logs in Datadog."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "proxy", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, proxy),
+     "Specify an HTTP Proxy. The expected format of this value is http://host:port. "
+     "Note that https is not supported yet."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "include_tag_key", "false",
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, include_tag_key),
+     "If enabled, tag is appended to output. "
+     "The key name is used 'tag_key' property."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "tag_key", FLB_DATADOG_DEFAULT_TAG_KEY,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, tag_key),
+     "The key name of tag. If 'include_tag_key' is false, "
+     "This property is ignored"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "dd_message_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_message_key),
+     "By default, the plugin searches for the key 'log' "
+     "and remap the value to the key 'message'. "
+     "If the property is set, the plugin will search the property name key."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "provider", NULL,
+     0, FLB_FALSE, 0,
+     "To activate the remapping, specify configuration flag provider with value 'ecs'"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "json_date_key", FLB_DATADOG_DEFAULT_TIME_KEY,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, json_date_key),
+     "Date key name for output."
+    },
+
+    /* EOF */
+    {0}
+};
+
 struct flb_output_plugin out_datadog_plugin = {
     .name         = "datadog",
     .description  = "Send events to DataDog HTTP Event Collector",
@@ -431,6 +502,9 @@ struct flb_output_plugin out_datadog_plugin = {
 
     /* Test */
     .test_formatter.callback = datadog_format,
+
+    /* Config map */
+    .config_map   = config_map,
 
     /* Plugin flags */
     .flags        = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -43,7 +43,7 @@
 struct flb_out_datadog {
 
     /* Proxy */
-    const char *proxy;
+    flb_sds_t proxy;
     char *proxy_host;
     int proxy_port;
 

--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -21,6 +21,7 @@
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_config_map.h>
 
 #include "datadog.h"
 #include "datadog_conf.h"
@@ -49,6 +50,13 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     ctx->ins = ins;
     ctx->nb_additional_entries = 0;
 
+    ret = flb_output_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "flb_output_config_map_set failed");
+        flb_free(ctx);
+        return NULL;
+    }
+
     tmp = flb_output_get_property("proxy", ins);
     if (tmp) {
         ret = flb_utils_url_split(tmp, &protocol, &host, &port, &uri);
@@ -60,7 +68,6 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
 
         ctx->proxy_host = host;
         ctx->proxy_port = atoi(port);
-        ctx->proxy = tmp;
         flb_free(protocol);
         flb_free(port);
         flb_free(uri);
@@ -79,57 +86,30 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
 
     /* configure URI */
     api_key = flb_output_get_property("apikey", ins);
-    if (api_key) {
-        ctx->api_key = flb_sds_create(api_key);
-    }
-    else {
+    if (api_key == NULL) {
         flb_plg_error(ctx->ins, "no ApiKey configuration key defined");
         flb_datadog_conf_destroy(ctx);
         return NULL;
     }
 
-    /* Include Tag key */
-    tmp = flb_output_get_property("include_tag_key", ins);
-    if (tmp) {
-        ctx->include_tag_key = flb_utils_bool(tmp);
-    }
-    else {
-        ctx->include_tag_key = FLB_FALSE;
-    }
-
     /* Tag Key */
     if (ctx->include_tag_key == FLB_TRUE) {
         ctx->nb_additional_entries++;
-        tmp = flb_output_get_property("tag_key", ins);
-        if (tmp) {
-            ctx->tag_key = flb_sds_create(tmp);
-        }
-        else {
-            ctx->tag_key = flb_sds_create(FLB_DATADOG_DEFAULT_TAG_KEY);
-        }
     }
 
     tmp = flb_output_get_property("dd_source", ins);
     if (tmp) {
         ctx->nb_additional_entries++;
-        ctx->dd_source = flb_sds_create(tmp);
     }
 
     tmp = flb_output_get_property("dd_service", ins);
     if (tmp) {
         ctx->nb_additional_entries++;
-        ctx->dd_service = flb_sds_create(tmp);
     }
 
     tmp = flb_output_get_property("dd_tags", ins);
     if (tmp) {
         ctx->nb_additional_entries++;
-        ctx->dd_tags = flb_sds_create(tmp);
-    }
-
-    tmp = flb_output_get_property("dd_message_key", ins);
-    if (tmp) {
-        ctx->dd_message_key = flb_sds_create(tmp);
     }
 
     tmp = flb_output_get_property("provider", ins);
@@ -167,13 +147,6 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     flb_plg_debug(ctx->ins, "port: %i", ctx->port);
 
     /* Date tag for JSON output */
-    tmp = flb_output_get_property("json_date_key", ins);
-    if (tmp) {
-        ctx->json_date_key = flb_sds_create(tmp);
-    }
-    else {
-        ctx->json_date_key = flb_sds_create(FLB_DATADOG_DEFAULT_TIME_KEY);
-    }
     ctx->nb_additional_entries++;
     flb_plg_debug(ctx->ins, "json_date_key: %s", ctx->json_date_key);
 
@@ -229,27 +202,6 @@ int flb_datadog_conf_destroy(struct flb_out_datadog *ctx)
     }
     if (ctx->uri) {
         flb_sds_destroy(ctx->uri);
-    }
-    if (ctx->api_key) {
-        flb_sds_destroy(ctx->api_key);
-    }
-    if (ctx->tag_key) {
-        flb_sds_destroy(ctx->tag_key);
-    }
-    if (ctx->json_date_key) {
-        flb_sds_destroy(ctx->json_date_key);
-    }
-    if (ctx->dd_source) {
-        flb_sds_destroy(ctx->dd_source);
-    }
-    if (ctx->dd_service) {
-        flb_sds_destroy(ctx->dd_service);
-    }
-    if (ctx->dd_tags) {
-        flb_sds_destroy(ctx->dd_tags);
-    }
-    if (ctx->dd_message_key) {
-        flb_sds_destroy(ctx->dd_message_key);
     }
     if (ctx->upstream) {
         flb_upstream_destroy(ctx->upstream);


### PR DESCRIPTION
This patch is to support config map for out_datadog.
The patch is for #3952.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Configuration file

```
[SERVICE]
    Log_level debug

[INPUT]
    Name dummy
    Dummy {"dummy_mk":"log", "message":"dummy"}

[OUTPUT]
    Name datadog
    apikey hoge
    Host localhost
    Port 3100
#    Proxy http://proxy.hoge.com:12345
    dd_source hoge_source
    dd_service hoge_service
    dd_tags hoge_tag
    provider ecs
    json_date_key hoge_json_dk
#    compress gzip
    include_tag_key true
    tag_key hoge_tag
    dd_message_key dummy_mk
```

## Debug output

I added below diff to check timeout value.

```diff
diff --git a/src/flb_output.c b/src/flb_output.c
index 721a4029..b5283a46 100644
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1045,6 +1045,7 @@ int flb_output_init_all(struct flb_config *config)
                       flb_output_name(ins));
             return -1;
         }
+        flb_error("connect_timeout=%d", ins->net_setup.connect_timeout);
     }
 
     return 0;
```

1. `nc -l 3100`
2. `fluent-bit -c datadog.conf`

```
$ bin/fluent-bit -c ~/fluentbit-conf/datadog.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/22 10:44:02] [ info] Configuration:
[2021/08/22 10:44:02] [ info]  flush time     | 5.000000 seconds
[2021/08/22 10:44:02] [ info]  grace          | 5 seconds
[2021/08/22 10:44:02] [ info]  daemon         | 0
[2021/08/22 10:44:02] [ info] ___________
[2021/08/22 10:44:02] [ info]  inputs:
[2021/08/22 10:44:02] [ info]      dummy
[2021/08/22 10:44:02] [ info] ___________
[2021/08/22 10:44:02] [ info]  filters:
[2021/08/22 10:44:02] [ info] ___________
[2021/08/22 10:44:02] [ info]  outputs:
[2021/08/22 10:44:02] [ info]      datadog.0
[2021/08/22 10:44:02] [ info] ___________
[2021/08/22 10:44:02] [ info]  collectors:
[2021/08/22 10:44:02] [ info] [engine] started (pid=37681)
[2021/08/22 10:44:02] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/08/22 10:44:02] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/08/22 10:44:02] [ info] [storage] version=1.1.1, initializing...
[2021/08/22 10:44:02] [ info] [storage] in-memory
[2021/08/22 10:44:02] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/22 10:44:02] [ info] [cmetrics] version=0.2.1
[2021/08/22 10:44:02] [debug] [datadog:datadog.0] created event channels: read=19 write=20
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] scheme: http://
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] uri: /v1/input/hoge
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] host: localhost
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] port: 3100
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] json_date_key: hoge_json_dk
[2021/08/22 10:44:02] [debug] [output:datadog:datadog.0] compress_gzip: 0
[2021/08/22 10:44:02] [error] connect_timeout=10
[2021/08/22 10:44:02] [debug] [router] default match rule dummy.0:datadog.0
[2021/08/22 10:44:02] [ info] [sp] stream processor started
[2021/08/22 10:44:07] [debug] [task] created task=0x7f773000ab80 id=0 OK
[2021/08/22 10:44:07] [debug] [http_client] not using http_proxy for header
^C[2021/08/22 10:44:08] [engine] caught signal (SIGINT)
[2021/08/22 10:44:08] [debug] [task] created task=0x7f7730028450 id=1 OK
[2021/08/22 10:44:08] [ warn] [engine] service will stop in 5 seconds
[2021/08/22 10:44:08] [debug] [http_client] not using http_proxy for header
```

```
$ nc -l 3100
POST /v1/input/hoge HTTP/1.1
Host: localhost:3100
Content-Length: 561
User-Agent: Fluent-Bit
Content-Type: application/json

[{"hoge_json_dk":1629596643543,"hoge_tag":"dummy.0","ddsource":"hoge_source","service":"hoge_service","message":"dummy","ddtags":"hoge_tag"},{"hoge_json_dk":1629596644544,"hoge_tag":"dummy.0","ddsource":"hoge_source","service":"hoge_service","message":"dummy","ddtags":"hoge_tag"},{"hoge_json_dk":1629596645543,"hoge_tag":"dummy.0","ddsource":"hoge_source","service":"hoge_service","message":"dummy","ddtags":"hoge_tag"},{"hoge_json_dk":1629596646543,"hoge_tag":"dummy.0","ddsource":"hoge_source","service":"hoge_service","message":"dummy","ddtags":"hoge_tag"}]^C
```

## Valgrind output

No error is reported. (except #3897)

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/fluentbit-conf/datadog.conf 
==37684== Memcheck, a memory error detector
==37684== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==37684== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==37684== Command: bin/fluent-bit -c /home/taka/fluentbit-conf/datadog.conf
==37684== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/08/22 10:45:12] [ info] Configuration:
[2021/08/22 10:45:12] [ info]  flush time     | 5.000000 seconds
[2021/08/22 10:45:12] [ info]  grace          | 5 seconds
[2021/08/22 10:45:12] [ info]  daemon         | 0
[2021/08/22 10:45:12] [ info] ___________
[2021/08/22 10:45:12] [ info]  inputs:
[2021/08/22 10:45:12] [ info]      dummy
[2021/08/22 10:45:12] [ info] ___________
[2021/08/22 10:45:12] [ info]  filters:
[2021/08/22 10:45:12] [ info] ___________
[2021/08/22 10:45:12] [ info]  outputs:
[2021/08/22 10:45:12] [ info]      datadog.0
[2021/08/22 10:45:12] [ info] ___________
[2021/08/22 10:45:12] [ info]  collectors:
[2021/08/22 10:45:12] [ info] [engine] started (pid=37684)
[2021/08/22 10:45:12] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/08/22 10:45:12] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/08/22 10:45:12] [ info] [storage] version=1.1.1, initializing...
[2021/08/22 10:45:12] [ info] [storage] in-memory
[2021/08/22 10:45:12] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/08/22 10:45:12] [ info] [cmetrics] version=0.2.1
[2021/08/22 10:45:12] [debug] [datadog:datadog.0] created event channels: read=19 write=20
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] scheme: http://
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] uri: /v1/input/hoge
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] host: localhost
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] port: 3100
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] json_date_key: hoge_json_dk
[2021/08/22 10:45:12] [debug] [output:datadog:datadog.0] compress_gzip: 0
[2021/08/22 10:45:12] [error] connect_timeout=10
[2021/08/22 10:45:12] [debug] [router] default match rule dummy.0:datadog.0
[2021/08/22 10:45:12] [ info] [sp] stream processor started
[2021/08/22 10:45:17] [debug] [task] created task=0x4c95490 id=0 OK
==37684== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c9b8e0
==37684==          to suppress, use: --max-stackframe=11833592 or greater
==37684== Warning: client switching stacks?  SP change: 0x4c9b858 --> 0x57e49d8
==37684==          to suppress, use: --max-stackframe=11833728 or greater
==37684== Warning: client switching stacks?  SP change: 0x57e49d8 --> 0x4c9b858
==37684==          to suppress, use: --max-stackframe=11833728 or greater
==37684==          further instances of this message will not be shown.
[2021/08/22 10:45:17] [debug] [http_client] not using http_proxy for header
^C[2021/08/22 10:45:18] [engine] caught signal (SIGINT)
[2021/08/22 10:45:18] [debug] [task] created task=0x4d0e8c0 id=1 OK
[2021/08/22 10:45:18] [ warn] [engine] service will stop in 5 seconds
[2021/08/22 10:45:18] [debug] [http_client] not using http_proxy for header
[2021/08/22 10:45:18] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/22 10:45:19] [error] [http_client] broken connection to localhost:3100 ?
[2021/08/22 10:45:19] [error] [output:datadog:datadog.0] could not flush records to localhost:3100 (http_do=-1)
[2021/08/22 10:45:19] [debug] [upstream] KA connection #25 to localhost:3100 is now available
[2021/08/22 10:45:19] [error] [http_client] broken connection to localhost:3100 ?
[2021/08/22 10:45:19] [error] [output:datadog:datadog.0] could not flush records to localhost:3100 (http_do=-1)
[2021/08/22 10:45:19] [debug] [upstream] KA connection #26 to localhost:3100 is now available
[2021/08/22 10:45:19] [debug] [upstream] KA connection #25 to localhost:3100 has been disconnected by the remote service
[2021/08/22 10:45:19] [debug] [upstream] KA connection #26 to localhost:3100 has been disconnected by the remote service
[2021/08/22 10:45:19] [debug] [out coro] cb_destroy coro_id=0
[2021/08/22 10:45:19] [debug] [out coro] cb_destroy coro_id=1
[2021/08/22 10:45:19] [debug] [retry] new retry created for task_id=0 attempts=1
[2021/08/22 10:45:19] [ warn] [engine] failed to flush chunk '37684-1629596713.558220418.flb', retry in 6 seconds: task_id=0, input=dummy.0 > output=datadog.0 (out_id=0)
[2021/08/22 10:45:19] [debug] [retry] new retry created for task_id=1 attempts=1
[2021/08/22 10:45:19] [ warn] [engine] failed to flush chunk '37684-1629596717.691432175.flb', retry in 10 seconds: task_id=1, input=dummy.0 > output=datadog.0 (out_id=0)
[2021/08/22 10:45:19] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/22 10:45:20] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/22 10:45:21] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/08/22 10:45:22] [ info] [engine] service stopped
[2021/08/22 10:45:22] [debug] [task] destroy task=0x4c95490 (task_id=0)
[2021/08/22 10:45:22] [debug] [retry] task retry=0x4d3e950, invalidated from the scheduler
[2021/08/22 10:45:22] [debug] [task] destroy task=0x4d0e8c0 (task_id=1)
[2021/08/22 10:45:22] [debug] [retry] task retry=0x4d3ed70, invalidated from the scheduler
==37684== 
==37684== HEAP SUMMARY:
==37684==     in use at exit: 149,090 bytes in 12 blocks
==37684==   total heap usage: 1,378 allocs, 1,366 frees, 1,412,160 bytes allocated
==37684== 
==37684== 149,090 (256 direct, 148,834 indirect) bytes in 2 blocks are definitely lost in loss record 6 of 6
==37684==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==37684==    by 0x1B7590: flb_calloc (flb_mem.h:78)
==37684==    by 0x1B87EB: flb_net_dns_lookup_context_create (flb_network.c:691)
==37684==    by 0x1B89C6: flb_net_getaddrinfo (flb_network.c:755)
==37684==    by 0x1B8F7A: flb_net_tcp_connect (flb_network.c:916)
==37684==    by 0x1E1B67: flb_io_net_connect (flb_io.c:89)
==37684==    by 0x1C5546: create_conn (flb_upstream.c:523)
==37684==    by 0x1C5A19: flb_upstream_conn_get (flb_upstream.c:666)
==37684==    by 0x23B735: cb_datadog_flush (datadog.c:315)
==37684==    by 0x1AD7A3: output_pre_cb_flush (flb_output.h:509)
==37684==    by 0x6FC22A: co_init (amd64.c:117)
==37684== 
==37684== LEAK SUMMARY:
==37684==    definitely lost: 256 bytes in 2 blocks
==37684==    indirectly lost: 148,834 bytes in 10 blocks
==37684==      possibly lost: 0 bytes in 0 blocks
==37684==    still reachable: 0 bytes in 0 blocks
==37684==         suppressed: 0 bytes in 0 blocks
==37684== 
==37684== For lists of detected and suppressed errors, rerun with: -s
==37684== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build$ 
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
