### PR TITLE
dns: backport change from 1.8.3.

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -743,7 +743,7 @@ int flb_net_getaddrinfo(const char *node, const char *service, struct addrinfo *
     struct flb_sched_timer        *timer;
     struct flb_sched              *sched;
 
-    dns_mode = FLB_DNS_USE_UDP;
+    dns_mode = FLB_DNS_USE_TCP;
 
     if (dns_mode_textual != NULL) {
         dns_mode = toupper(dns_mode_textual[0]);


### PR DESCRIPTION
Quick fix for DNS.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
