### PR TITLE
scheduler: added scheduler tracking to the timer

### DIFF
--- a/include/fluent-bit/flb_scheduler.h
+++ b/include/fluent-bit/flb_scheduler.h
@@ -37,6 +37,8 @@
 #define FLB_SCHED_TIMER_CB_ONESHOT  3  /* one-shot callback timer  */
 #define FLB_SCHED_TIMER_CB_PERM     4  /* permanent callback timer */
 
+struct flb_sched;
+
 /*
  * A sched timer struct belongs to an event triggered by the scheduler. This
  * is a generic type and keeps two fields as a reference for further
@@ -50,6 +52,7 @@ struct flb_sched_timer {
     int active;
     int type;
     void *data;
+    struct flb_sched *sched;
 
     /*
      * Custom timer specific data:


### PR DESCRIPTION
DISCLAIMER : This is part of the larger DNS fix PR group, 
it is self contained and should not break anything when merged but the
purpose of this is to fix underlying issues that the other PRs assist in correcting.

DISCLAIMER 2 : This PR will not pass any tests until PR 
https://github.com/monkey/monkey/pull/347 is merged.

When a timer is created in flb_sched_timer_cb_create it is
added to the event loop that's bound to the scheduler passed
as first argument. However, no reference to the scheduler or
its event loop is held by the timer structure and when time comes
to dispose of the timer, flb_sched_timer_invalidate removes the
timer from the active timer list where it is and adds it to the
timer drop list held by the scheduler referenced by the config
reference the timer holds which at least in the case of threaded
mode is not the same scheduler that is passed to flb_sched_timer_cb_create
when creating a DNS lookup UDP timeout manager timer.

This discrepancy causes the underlying calls to the lower level event
loop management functions to fail (ie. epoll_ctl) leaving the timer
active until the thread that's in charge of doing the cleanup of the
scheduler to whoses drop list this timer was added gets to the end
of the event list it's currently processing and calls flb_sched_timer_cleanup
which also introduces a synchronization issue because we might
invalidate a timer in a thread and expect it to stop emitting signals
yet get one and be handling that signal while another thread proceeds to
release the memory where the timer structure is located.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>
