### PR TITLE
output: coroutine creation error handling fix

### DIFF
--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -84,7 +84,10 @@ static FLB_INLINE void flb_coro_destroy(struct flb_coro *coro)
     VALGRIND_STACK_DEREGISTER(coro->valgrind_stack_id);
 #endif
 
-    co_delete(coro->callee);
+    if (coro->callee != NULL) {
+        co_delete(coro->callee);
+    }
+
     flb_free(coro);
 }
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -554,6 +554,13 @@ struct flb_output_coro *flb_output_coro_create(struct flb_task *task,
     coro->callee = co_create(config->coro_stack_size,
                              output_pre_cb_flush, &stack_size);
 
+    if(coro->callee == NULL) {
+        flb_coro_destroy(coro);
+        flb_free(out_coro);
+
+        return NULL;
+    }
+
 #ifdef FLB_HAVE_VALGRIND
     coro->valgrind_stack_id = \
         VALGRIND_STACK_REGISTER(coro->callee, ((char *) coro->callee) + stack_size);


### PR DESCRIPTION
When flb_output_coro_create tries to create a new coroutine (ie. output plugins flush task) but the system is out of memory (soft or hard limits, not system wide OOM) co_create will return NULL, it will not fail itself because it verifies what malloc returns and when it's null it doesn't write any of the context and just forwards the result. However, when that happens flb_output_coro_create ends up calling output_params_set which calls co_switch to switch context to the "newly created" coroutine using the NULL context which causes fluent-bit to crash.