### PR TITLE
in_tail: fix cmetrics label name

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -388,19 +388,19 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
                                                "fluentbit", "input",
                                                "files_opened_total",
                                                "Total number of opened files",
-                                               1, (char *[]) {name});
+                                               1, (char *[]) {"name"});
 
     ctx->cmt_files_closed = cmt_counter_create(ins->cmt,
                                                "fluentbit", "input",
                                                "files_closed_total",
                                                "Total number of closed files",
-                                               1, (char *[]) {name});
+                                               1, (char *[]) {"name"});
 
     ctx->cmt_files_rotated = cmt_counter_create(ins->cmt,
                                                 "fluentbit", "input",
                                                 "files_rotated_total",
                                                 "Total number of rotated files",
-                                                1, (char *[]) {name});
+                                                1, (char *[]) {"name"});
 
     /* OLD metrics */
     flb_metrics_add(FLB_TAIL_METRIC_F_OPENED,

--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -55,5 +55,6 @@ struct flb_output_plugin out_null_plugin = {
     .description  = "Throws away events",
     .cb_init      = cb_null_init,
     .cb_flush     = cb_null_flush,
+    .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
     .flags        = 0,
 };


### PR DESCRIPTION
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
