### PR TITLE
network: async dns corrections

### DIFF
--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -36,7 +36,6 @@
 #define FLB_ENGINE_EV_SCHED_FRAME   (FLB_ENGINE_EV_SCHED + 4096)
 #define FLB_ENGINE_EV_OUTPUT        8192
 #define FLB_ENGINE_EV_THREAD_OUTPUT 16384
-#define FLB_ENGINE_EV_DNS           32768
 
 /* Engine events: all engine events set the left 32 bits to '1' */
 #define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */

--- a/include/fluent-bit/flb_net_dns.h
+++ b/include/fluent-bit/flb_net_dns.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_NET_DNS_H
+#define FLB_NET_DNS_H
+
+struct flb_net_dns {
+    struct mk_list lookups;
+    struct mk_list lookups_drop;
+};
+
+#endif
+

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -181,7 +181,7 @@ static void output_thread(void *data)
     struct flb_output_coro *out_coro;
     struct flb_out_thread_instance *th_ins = data;
     struct flb_out_coro_params *params;
-    struct mk_list lookup_context_cleanup_queue;
+    struct flb_net_dns dns_ctx;
 
     /* Register thread instance */
     flb_output_thread_instance_set(th_ins);
@@ -190,6 +190,10 @@ static void output_thread(void *data)
     thread_id = th_ins->th->id;
 
     flb_coro_thread_init();
+
+    flb_net_ctx_init(&dns_ctx);
+    flb_net_dns_ctx_init();
+    flb_net_dns_ctx_set(&dns_ctx);
 
     /*
      * Expose the event loop to the I/O interfaces: since we are in a separate
@@ -237,8 +241,6 @@ static void output_thread(void *data)
         return;
     }
     event_local.type = FLB_ENGINE_EV_OUTPUT;
-
-    mk_list_init(&lookup_context_cleanup_queue);
 
     flb_plg_info(th_ins->ins, "worker #%i started", thread_id);
 
@@ -298,18 +300,6 @@ static void output_thread(void *data)
             else if (event->type == FLB_ENGINE_EV_CUSTOM) {
                 event->handler(event);
             }
-            else if (event->type == FLB_ENGINE_EV_DNS) {
-                struct flb_dns_lookup_context *lookup_context;
-                lookup_context = FLB_DNS_LOOKUP_CONTEXT_FOR_EVENT(event);
-
-                if (!lookup_context->finished) {
-                    event->handler(event);
-
-                    if (lookup_context->finished) {
-                        mk_list_add(&lookup_context->_head, &lookup_context_cleanup_queue);
-                    }
-                }
-            }
             else if (event->type == FLB_ENGINE_EV_THREAD) {
                 /*
                  * Check if we have some co-routine associated to this event,
@@ -336,9 +326,11 @@ static void output_thread(void *data)
             }
         }
 
+        flb_net_dns_lookup_context_cleanup(&dns_ctx);
+
         /* Destroy upstream connections from the 'pending destroy list' */
         flb_upstream_conn_pending_destroy_list(&th_ins->upstreams);
-        flb_net_dns_lookup_context_cleanup(&lookup_context_cleanup_queue);
+        flb_sched_timer_cleanup(sched);
 
         /* Check if we should stop the event loop */
         if (stopping == FLB_TRUE && mk_list_size(&th_ins->coros) == 0) {


### PR DESCRIPTION
This PR slightly refactors the async dns related code back to using a "generic" custom event instead of a specific event type thus removing the necessity to handle that in both engine and output_thread. 

It also effectively separates the active and drop lookup context lists in a per thread context which is cleaned up after each batch of events is processed in both engine and output_thread. 

DISCLAIMER : Do NOT merge this until we have thoroughly verified it. I have extensively tested it but we are still in the last stage of testing so please double check with me before merging it.