### PR TITLE
scheduler: backport of PR 3997 to 1.8

### DIFF
--- a/include/fluent-bit/flb_scheduler.h
+++ b/include/fluent-bit/flb_scheduler.h
@@ -37,6 +37,8 @@
 #define FLB_SCHED_TIMER_CB_ONESHOT  3  /* one-shot callback timer  */
 #define FLB_SCHED_TIMER_CB_PERM     4  /* permanent callback timer */
 
+struct flb_sched;
+
 /*
  * A sched timer struct belongs to an event triggered by the scheduler. This
  * is a generic type and keeps two fields as a reference for further
@@ -50,6 +52,7 @@ struct flb_sched_timer {
     int active;
     int type;
     void *data;
+    struct flb_sched *sched;
 
     /*
      * Custom timer specific data:
@@ -134,7 +137,7 @@ int flb_sched_request_invalidate(struct flb_config *config, void *data);
 
 int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
                               void (*cb)(struct flb_config *, void *),
-                              void *data);
+                              void *data, struct flb_sched_timer **out_timer);
 int flb_sched_timer_cb_disable(struct flb_sched_timer *timer);
 int flb_sched_timer_cb_destroy(struct flb_sched_timer *timer);
 void flb_sched_timer_invalidate(struct flb_sched_timer *timer);

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -434,7 +434,7 @@ int flb_sched_event_handler(struct flb_config *config, struct mk_event *event)
  */
 int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
                               void (*cb)(struct flb_config *, void *),
-                              void *data)
+                              void *data, struct flb_sched_timer **out_timer)
 {
     int fd;
     time_t sec;
@@ -480,6 +480,10 @@ int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
      */
     event->type = FLB_ENGINE_EV_SCHED;
     timer->timer_fd = fd;
+
+    if (out_timer != NULL) {
+        *out_timer = timer;
+    }
 
     return 0;
 }
@@ -621,6 +625,7 @@ struct flb_sched_timer *flb_sched_timer_create(struct flb_sched *sched)
 
     timer->timer_fd = -1;
     timer->config = sched->config;
+    timer->sched = sched;
     timer->data = NULL;
 
     /* Active timer (not invalidated) */
@@ -632,25 +637,26 @@ struct flb_sched_timer *flb_sched_timer_create(struct flb_sched *sched)
 
 void flb_sched_timer_invalidate(struct flb_sched_timer *timer)
 {
-    struct flb_sched *sched;
-
-    sched  = timer->config->sched;
+    mk_event_timeout_disable(timer->sched->evl, &timer->event);
 
     timer->active = FLB_FALSE;
+
     mk_list_del(&timer->_head);
-    mk_list_add(&timer->_head, &sched->timers_drop);
+    mk_list_add(&timer->_head, &timer->sched->timers_drop);
 }
 
 /* Destroy a timer context */
 int flb_sched_timer_destroy(struct flb_sched_timer *timer)
 {
-    mk_event_timeout_destroy(timer->config->evl, &timer->event);
+    mk_event_timeout_destroy(timer->sched->evl, &timer->event);
+
     if (timer->timer_fd > 0) {
         flb_sched_timer_cb_disable(timer);
     }
 
     mk_list_del(&timer->_head);
     flb_free(timer);
+
     return 0;
 }
 


### PR DESCRIPTION
The merge order should be as follows : 

4020 - scheduler improvement
4015 - scheduler fixes (merged with 1.8 after 4020)
4016 - coroutine creation fixes
4017 - header fix needed for 4018 to build properly 
4018 - async DNS fixes (merged with 1.8 after 4017)

This way we can ensure that all of these PRs pass the required checks.