### PR TITLE
out_s3: don't complete uploads that were never created

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1727,6 +1727,10 @@ static void cb_s3_upload(struct flb_config *config, void *data)
             continue;
         }
 
+        if (m_upload->upload_state == MULTIPART_UPLOAD_STATE_NOT_CREATED) {
+            continue;
+        }
+
         if (m_upload->upload_state == MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS) {
             complete = FLB_TRUE;
         }
@@ -2121,6 +2125,10 @@ static int cb_s3_exit(void *data, struct flb_config *config)
     if (s3_store_has_uploads(ctx) == FLB_TRUE) {
         mk_list_foreach_safe(head, tmp, &ctx->uploads) {
             m_upload = mk_list_entry(head, struct multipart_upload, _head);
+
+            if (m_upload->upload_state == MULTIPART_UPLOAD_STATE_NOT_CREATED) {
+                continue;
+            }
 
             if (m_upload->bytes > 0) {
                 m_upload->upload_state = MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS;


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
