### PR TITLE
signv4: allow url query parameter has no value to 1.8

### DIFF
--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -357,7 +357,7 @@ static flb_sds_t url_params_format(char *params)
          * results in issues since kv->val will be equal to NULL.
          * Thus, check here whether key length is satisfied
          */
-        if (flb_sds_len(key) == 0 || flb_sds_len(val) == 0) {
+        if (flb_sds_len(key) == 0) {
             flb_sds_destroy(key);
             flb_sds_destroy(val);
             flb_slist_destroy(&split);
@@ -414,24 +414,27 @@ static flb_sds_t url_params_format(char *params)
     for (i = 0; i < items; i++) {
         kv = (struct flb_kv *) arr[i];
         if (i + 1 < items) {
-            tmp = flb_sds_printf(&buf, "%s=%s&",
-                                 kv->key, kv->val);
-        }
-        else if (kv->val == NULL) {
-            /*
-             * special/edge case- last query param has a null value
-             * This happens in the S3 CreateMultipartUpload request
-             */
-            tmp = flb_sds_printf(&buf, "%s=",
-                                 kv->key);
-        }
+            if (kv->val == NULL) {
+                tmp = flb_sds_printf(&buf, "%s=&",
+                                     kv->key);
+            }
+            else {
+                tmp = flb_sds_printf(&buf, "%s=%s&",
+                                     kv->key, kv->val);
+            }
+        } 
         else {
-            tmp = flb_sds_printf(&buf, "%s=%s",
-                                 kv->key, kv->val);
+            if (kv->val == NULL) {
+                tmp = flb_sds_printf(&buf, "%s=",
+                                     kv->key);
+            }
+            else {
+                tmp = flb_sds_printf(&buf, "%s=%s",
+                                     kv->key, kv->val);
+            }
         }
         if (!tmp) {
             flb_error("[signv4] error allocating value");
-
         }
         buf = tmp;
     }


### PR DESCRIPTION
Signed-off-by: Zhonghui Hu <zh0512xx@gmail.com>

<!-- Provide summary of changes -->
Right now we might have s3 signv4 issue when we do multipart upload as we don't allow url query parameter has no value. But it should be valid.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes https://github.com/fluent/fluent-bit/issues/3838
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
