### PR TITLE
out_cloudwatch_logs: support auto_retry_requests for failed connections

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -89,6 +89,9 @@ struct flb_aws_client {
      struct flb_aws_header *static_headers;
      size_t static_headers_len;
 
+    /* Are requests to AWS services retried? */
+    int retry_requests;
+
     /*
      * If an API responds with auth error, we refresh creds and retry.
      * For safety, credential refresh can only happen once per

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -162,6 +162,13 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->create_group = FLB_TRUE;
     }
 
+    ctx->retry_requests = FLB_FALSE;
+    tmp = flb_output_get_property("auto_retry_requests", ins);
+    /* native plugins use On/Off as bool, the old Go plugin used true/false */
+    if (tmp && (strcasecmp(tmp, "On") == 0 || strcasecmp(tmp, "true") == 0)) {
+        ctx->retry_requests = FLB_TRUE;
+    }
+
     ctx->log_retention_days = 0;
     tmp = flb_output_get_property("log_retention_days", ins);
     if (tmp) {
@@ -302,6 +309,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     ctx->cw_client->static_headers = &content_type_header;
     ctx->cw_client->static_headers_len = 1;
     ctx->cw_client->extra_user_agent = (char *) ctx->extra_user_agent;
+    ctx->cw_client->retry_requests = ctx->retry_requests;
 
     struct flb_upstream *upstream = flb_upstream_create(config, ctx->endpoint,
                                                         443, FLB_IO_TLS,
@@ -550,6 +558,16 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Automatically create the log group (log streams will always automatically"
      " be created)"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "auto_retry_requests", "false",
+     0, FLB_FALSE, 0,
+     "Immediately retry failed requests to AWS services once. This option "
+     "does not affect the normal Fluent Bit retry mechanism with backoff. "
+     "Instead, it enables an immediate retry with no delay for networking "
+     "errors, which may help improve throughput when there are transient/random "
+     "networking issues."
     },
 
     {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -122,6 +122,9 @@ struct flb_cloudwatch {
     /* Should the plugin create the log group */
     int create_group;
 
+    /* Should requests to AWS services be retried */
+    int retry_requests;
+
     /* If set to a number greater than zero, and newly create log group's retention policy is set to this many days. */
     int log_retention_days;
 

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -243,6 +243,7 @@ static int cb_firehose_init(struct flb_output_instance *ins,
     ctx->firehose_client->has_auth = FLB_TRUE;
     ctx->firehose_client->provider = ctx->aws_provider;
     ctx->firehose_client->region = (char *) ctx->region;
+    ctx->firehose_client->retry_requests = ctx->retry_requests;
     ctx->firehose_client->service = "firehose";
     ctx->firehose_client->port = 443;
     ctx->firehose_client->flags = 0;
@@ -434,6 +435,16 @@ static struct flb_config_map config_map[] = {
      "that key will be sent to Firehose. For example, if you are using "
      "the Fluentd Docker log driver, you can specify `log_key log` and only "
      "the log message will be sent to Firehose."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "auto_retry_requests", "false",
+     0, FLB_TRUE, offsetof(struct flb_firehose, retry_requests),
+     "Immediately retry failed requests to AWS services once. This option "
+     "does not affect the normal Fluent Bit retry mechanism with backoff. "
+     "Instead, it enables an immediate retry with no delay for networking "
+     "errors, which may help improve throughput when there are transient/random "
+     "networking issues."
     },
 
     /* EOF */

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -88,6 +88,7 @@ struct flb_firehose {
     const char *log_key;
     char *sts_endpoint;
     int custom_endpoint;
+    int retry_requests;
 
     /* must be freed on shutdown if custom_endpoint is not set */
     char *endpoint;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -250,6 +250,7 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
     ctx->kinesis_client->has_auth = FLB_TRUE;
     ctx->kinesis_client->provider = ctx->aws_provider;
     ctx->kinesis_client->region = (char *) ctx->region;
+    ctx->kinesis_client->retry_requests = ctx->retry_requests;
     ctx->kinesis_client->service = "kinesis";
     ctx->kinesis_client->port = 443;
     ctx->kinesis_client->flags = 0;
@@ -448,6 +449,16 @@ static struct flb_config_map config_map[] = {
      "that key will be sent to Kinesis. For example, if you are using "
      "the Fluentd Docker log driver, you can specify `log_key log` and only "
      "the log message will be sent to Kinesis."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "auto_retry_requests", "false",
+     0, FLB_TRUE, offsetof(struct flb_kinesis, retry_requests),
+     "Immediately retry failed requests to AWS services once. This option "
+     "does not affect the normal Fluent Bit retry mechanism with backoff. "
+     "Instead, it enables an immediate retry with no delay for networking "
+     "errors, which may help improve throughput when there are transient/random "
+     "networking issues."
     },
 
     /* EOF */

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -89,6 +89,7 @@ struct flb_kinesis {
     const char *region;
     const char *role_arn;
     const char *log_key;
+    int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;
 

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -823,6 +823,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
     ctx->s3_client->flags = 0;
     ctx->s3_client->proxy = NULL;
     ctx->s3_client->s3_mode = S3_MODE_SIGNED_PAYLOAD;
+    ctx->s3_client->retry_requests = ctx->retry_requests;
 
     ctx->s3_client->upstream = flb_upstream_create(config, ctx->endpoint, 443,
                                                    FLB_IO_TLS, ctx->client_tls);
@@ -2276,6 +2277,16 @@ static struct flb_config_map config_map[] = {
     "A series of characters which will be used to split the tag into “parts” for "
     "use with the s3_key_format option. See the in depth examples and tutorial in "
     "the documentation."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "auto_retry_requests", "false",
+     0, FLB_TRUE, offsetof(struct flb_s3, retry_requests),
+     "Immediately retry failed requests to AWS services once. This option "
+     "does not affect the normal Fluent Bit retry mechanism with backoff. "
+     "Instead, it enables an immediate retry with no delay for networking "
+     "errors, which may help improve throughput when there are transient/random "
+     "networking issues."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -114,6 +114,7 @@ struct flb_s3 {
     char *content_type;
     char *log_key;
     int free_endpoint;
+    int retry_requests;
     int use_put_object;
     int send_content_md5;
     int static_file_path;

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -156,10 +156,15 @@ struct flb_http_client *flb_aws_client_request(struct flb_aws_client *aws_client
 {
     struct flb_http_client *c = NULL;
 
-    //TODO: Need to think more about the retry strategy.
-
     c = request_do(aws_client, method, uri, body, body_len,
                    dynamic_headers, dynamic_headers_len);
+
+    // Auto retry if request fails
+    if (c == NULL && aws_client->retry_requests) {
+        flb_debug("[aws_client] auto-retrying");
+        c = request_do(aws_client, method, uri, body, body_len,
+                       dynamic_headers, dynamic_headers_len);
+    }
 
     /*
      * 400 or 403 could indicate an issue with credentials- so we check for auth
@@ -196,6 +201,7 @@ struct flb_aws_client *flb_aws_client_create()
         return NULL;
     }
     client->client_vtable = &client_vtable;
+    client->retry_requests = FLB_FALSE;
     client->debug_only = FLB_FALSE;
     return client;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
# Auto Retry Config Option Added for AWS Plugins
> ## Config option info
> - Option name: auto_retry_requests
> - Description: "Automatically retry requests to AWS services upon request failure. (If true, requests will be retried at most once per each failed request.)
> - Plugins: out_kinesis_streams, out_kinesis_firehose, out_cloudwatch_logs, out_s3

# Function
Automatically retry requests to AWS services upon request failure. Requests will be retried at most once per each failed request.

# Tests

## Cloudwatch
> Default and auto_retry_requests to false 
> ![cw1](https://user-images.githubusercontent.com/34408404/131747020-e7b29af8-dc3c-4e18-8c31-489ffd1a5463.png)
> Set auto_retry_requests to true (see auto retrying after connection error)
> ![cw2](https://user-images.githubusercontent.com/34408404/131747060-f0dd7ef2-5907-4e87-9f60-aa70192e84ab.png)

## S3
> Default and auto_retry_requests to false (do not see auto retrying after connection error)
> ![s31](https://user-images.githubusercontent.com/34408404/131747105-464b7872-f0c5-4b02-bc65-57ac8127775e.png)
> Set auto_retry_requests to true (see auto retrying after connection error)
> ![s32](https://user-images.githubusercontent.com/34408404/131747125-1cbfc69b-f561-40f5-b5b9-7a9c022d4979.png)

## Kinesis Streams
> Default and auto_retry_requests to false (do not see auto retrying after connection error)
> ![kin1](https://user-images.githubusercontent.com/34408404/131747150-a1260211-fa7a-4f25-b315-cfacd7faa674.png)
> auto_retry_requsts set to true
> ![kin2](https://user-images.githubusercontent.com/34408404/131747167-2cb3b894-8a42-4403-830f-1376cead77d1.png)

## Firehose
> Default and auto_retry_requests_set to false
> ![fir1](https://user-images.githubusercontent.com/34408404/131747196-8d7250fd-d5b8-4486-bebb-95c850cbde19.png)
> auto_retry_requsts set to true
> ![fir2](https://user-images.githubusercontent.com/34408404/131747486-6e46d134-9e08-4e10-ad5d-c5e3d98ede5c.png)

> Note: Successful requests only tested for cloudwatch plugin, not for s3, kinesis streams, and kinesis firehose, because the code is introduced after the cloudwatch plugin commit can be fully tested with the request failures.

# Config files
## Cloudwatch
```
[SERVICE]
     Grace 30
     Log_Level debug
[INPUT]
     Name        forward
     Listen      0.0.0.0
     Port        24224
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name cloudwatch_logs
     Match *
     log_stream_prefix test
     log_group_name fluent_onboarding
     auto_create_group true
     region us-west-2
     auto_retry_requests false
```

## S3
```
[SERVICE]
     Grace 30
     Log_Level debug
[INPUT]
     Name        forward
     Listen      0.0.0.0
     Port        24224
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name cloudwatch_logs
     Match *
     log_stream_prefix test
     log_group_name fluent_onboarding
     auto_create_group true
     region us-west-2
     auto_retry_requests false
```

## Kinesis Streams
```
[SERVICE]
     Grace 30
     Log_Level debug
[INPUT]
     Name        forward
     Listen      0.0.0.0
     Port        24224
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name  kinesis_streams
     Match *
     region us-west-2
     stream fluentbit-test
     auto_retry_requests false
```

## Kinesis Firehose
```
[SERVICE]
     Grace 30
     Log_Level debug
[INPUT]
     Name        forward
     Listen      0.0.0.0
     Port        24224
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name  kinesis_firehose
     Match *
     region us-west-2
     delivery_stream fluentbit-test
     auto_retry_requests false
```
#  Valgrind
![Screen Shot 2021-09-02 at 12 00 03 PM](https://user-images.githubusercontent.com/34408404/131901365-3f3339d2-23b6-4267-b60d-67763f9e26eb.png)
> Note: only cloudwatch is tested here.
> I ran the test for about 5 minutes. The retry request code may not have run.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
