### PR TITLE
http_client default size and chunk doesn't allow for buffer increase

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -25,9 +25,10 @@
 #include <fluent-bit/flb_upstream.h>
 
 /* Buffer size */
-#define FLB_HTTP_BUF_SIZE        2048
-#define FLB_HTTP_DATA_SIZE_MAX   4096
-#define FLB_HTTP_DATA_CHUNK     32768
+#define FLB_HTTP_BUF_SIZE           2048
+#define FLB_HTTP_DATA_SIZE_INITIAL  4096
+#define FLB_HTTP_DATA_SIZE_MAX      36864
+#define FLB_HTTP_DATA_CHUNK         32768
 
 /* HTTP Methods */
 #define FLB_HTTP_GET         0

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -762,7 +762,7 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
     }
 
     /* 'Read' buffer size */
-    c->resp.data = flb_malloc(FLB_HTTP_DATA_SIZE_MAX);
+    c->resp.data = flb_malloc(FLB_HTTP_DATA_SIZE_INITIAL);
     if (!c->resp.data) {
         flb_errno();
         flb_http_client_destroy(c);
@@ -770,7 +770,7 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
     }
     c->resp.data[0] = '\0';
     c->resp.data_len  = 0;
-    c->resp.data_size = FLB_HTTP_DATA_SIZE_MAX;
+    c->resp.data_size = FLB_HTTP_DATA_SIZE_INITIAL;
     c->resp.data_size_max = FLB_HTTP_DATA_SIZE_MAX;
 
     return c;


### PR DESCRIPTION
This commit adds another FLB_HTTP_DATA_SIZE_INITIAL, set to 4096, and changes FLB_HTTP_DATA_SIZE_MAX to the initial + the FLB_HTTP_DATA_CHUNK, to allow one increase of the response buffer by default.

fixes #4044.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
