### PR TITLE
flb_aws_util: set max response buffer size for the http client

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -311,7 +311,8 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
     }
 
     /* Increase the maximum HTTP response buffer size to fit large responses from AWS services */
-    if (flb_http_buffer_size(c, FLB_MAX_AWS_RESP_BUFFER_SIZE)) {
+    ret = flb_http_buffer_size(c, FLB_MAX_AWS_RESP_BUFFER_SIZE);
+    if (ret != 0) {
         flb_warn("[aws_http_client] failed to increase max response buffer size");
     } 
 

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -40,6 +40,7 @@
 #define S3_KEY_SIZE 1024
 #define RANDOM_STRING "$UUID"
 #define INDEX_STRING "$INDEX"
+#define FLB_MAX_AWS_RESP_BUFFER_SIZE 0 /* 0 means unlimited capacity as per requirement */
 
 struct flb_http_client *request_do(struct flb_aws_client *aws_client,
                                    int method, const char *uri,
@@ -308,6 +309,11 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
         }
         goto error;
     }
+
+    /* Increase the maximum HTTP response buffer size to fit large responses from AWS services */
+    if (flb_http_buffer_size(c, FLB_MAX_AWS_RESP_BUFFER_SIZE)) {
+        flb_warn("[aws_http_client] failed to increase max response buffer size");
+    } 
 
     /* Add AWS Fluent Bit user agent */
     if (aws_client->extra_user_agent == NULL) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
This change will enable unlimited response buffer for aws http client. In this way we can mitigate the following error for all AWS plugins including kinesis_firehose and s3.

`[ warn] [http_client] cannot increase buffer: current=4096 requested=36864 max=4096`




**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

**Debug log for this change**
```
[2021/09/02 23:50:55] [debug] [aws_http_client] max response buffer size was increased to 0
[2021/09/02 23:50:55] [debug] [upstream] KA connection #83 to firehose.us-west-2.amazonaws.com:443 is now available
[2021/09/02 23:50:55] [debug] [output:kinesis_firehose:kinesis_firehose.0] PutRecordBatch http status=200
[2021/09/02 23:50:55] [debug] [output:kinesis_firehose:kinesis_firehose.0] Sent events to fluent-bit-perf-test
[2021/09/02 23:50:55] [debug] [output:kinesis_firehose:kinesis_firehose.0] Sending 500 records
[2021/09/02 23:50:55] [debug] [output:kinesis_firehose:kinesis_firehose.0] Sending log records to delivery stream fluent-bit-perf-test
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
