### PR TITLE
tests: internal: fuzzers: fix issue in utils fuzzer

### DIFF
--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -142,7 +142,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         for(int i = 0; i < 20; i++) {
             char *hash_out_buf;
             size_t hash_out_size;
-            flb_hash_get_by_id(ht, (int)data[i], (char*)&data[i+1],
+            flb_hash_get_by_id(ht, (int)data[i], null_terminated,
                                (const char **)&hash_out_buf, &hash_out_size);
         }
 


### PR DESCRIPTION
Fixes bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36718

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
