### PR TITLE
strptime: typecast to avoid signed overflow

### DIFF
--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -636,7 +636,7 @@ literal:
 
 	/* Compute some missing values when possible. */
 	if (fields & FIELD_TM_YEAR) {
-		const int year = tm->tm_year + TM_YEAR_BASE;
+		const int year = (unsigned int)tm->tm_year + (unsigned int)TM_YEAR_BASE;
 		const int *mon_lens = mon_lengths[isleap(year)];
 		if (!(fields & FIELD_TM_YDAY) &&
 		    (fields & FIELD_TM_MON) && (fields & FIELD_TM_MDAY)) {


### PR DESCRIPTION
Fixes bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31770

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
