### PR TITLE
filter_nest: change log level (#4005)

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -496,7 +496,7 @@ static inline int apply_nesting_rules(msgpack_packer *packer,
 
     size_t toplevel_items = (map.via.map.size - items_to_nest + 1);
 
-    flb_plg_debug(ctx->ins, "outer map size is %d, will be %lu, nested "
+    flb_plg_trace(ctx->ins, "outer map size is %d, will be %lu, nested "
                   "map size will be %lu",
                   map.via.map.size, toplevel_items, items_to_nest);
 


### PR DESCRIPTION
Fixes #4005 

I changed the log level debug -> trace.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Configuration

```
[SERVICE]
    Log_level debug

[INPUT]
    Name mem
    Tag  mem.local

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard Mem.*
    Nest_under Memstats
    Remove_prefix Mem.
```

## Debug output

```
$ bin/fluent-bit -c 4005/a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/04 12:17:36] [ info] Configuration:
[2021/09/04 12:17:36] [ info]  flush time     | 5.000000 seconds
[2021/09/04 12:17:36] [ info]  grace          | 5 seconds
[2021/09/04 12:17:36] [ info]  daemon         | 0
[2021/09/04 12:17:36] [ info] ___________
[2021/09/04 12:17:36] [ info]  inputs:
[2021/09/04 12:17:36] [ info]      mem
[2021/09/04 12:17:36] [ info] ___________
[2021/09/04 12:17:36] [ info]  filters:
[2021/09/04 12:17:36] [ info]      nest.0
[2021/09/04 12:17:36] [ info] ___________
[2021/09/04 12:17:36] [ info]  outputs:
[2021/09/04 12:17:36] [ info]      stdout.0
[2021/09/04 12:17:36] [ info] ___________
[2021/09/04 12:17:36] [ info]  collectors:
[2021/09/04 12:17:36] [ info] [engine] started (pid=28348)
[2021/09/04 12:17:36] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/09/04 12:17:36] [debug] [storage] [cio stream] new stream registered: mem.0
[2021/09/04 12:17:36] [ info] [storage] version=1.1.1, initializing...
[2021/09/04 12:17:36] [ info] [storage] in-memory
[2021/09/04 12:17:36] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/04 12:17:36] [ info] [cmetrics] version=0.2.1
[2021/09/04 12:17:36] [debug] [stdout:stdout.0] created event channels: read=19 write=20
[2021/09/04 12:17:36] [debug] [router] match rule mem.0:stdout.0
[2021/09/04 12:17:36] [ info] [sp] stream processor started
[0] mem.local: [1630725456.256965751, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3461512, "free"=>4689428}}]
[2021/09/04 12:17:40] [debug] [task] created task=0x7fb5b0008340 id=0 OK
[1] mem.local: [1630725457.256857449, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3461512, "free"=>4689428}}]
[2] mem.local: [1630725458.256867256, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3461512, "free"=>4689428}}]
[3] mem.local: [1630725459.256869518, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3461512, "free"=>4689428}}]
[2021/09/04 12:17:40] [debug] [out coro] cb_destroy coro_id=0
[2021/09/04 12:17:40] [debug] [task] destroy task=0x7fb5b0008340 (task_id=0)
^C[2021/09/04 12:17:40] [engine] caught signal (SIGINT)
[0] mem.local: [1630725460.257496147, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3461512, "free"=>4689428}}]
[2021/09/04 12:17:40] [debug] [task] created task=0x7fb5b0008b00 id=0 OK
[2021/09/04 12:17:40] [ warn] [engine] service will stop in 5 seconds
[2021/09/04 12:17:40] [debug] [out coro] cb_destroy coro_id=1
[2021/09/04 12:17:40] [debug] [task] destroy task=0x7fb5b0008b00 (task_id=0)
[2021/09/04 12:17:41] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:17:42] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:17:43] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:17:44] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:17:45] [ info] [engine] service stopped
```

## Valgrind output 
```
$ valgrind --leak-check=full bin/fluent-bit -c 4005/a.conf 
==28335== Memcheck, a memory error detector
==28335== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28335== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==28335== Command: bin/fluent-bit -c 4005/a.conf
==28335== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/04 12:15:17] [ info] Configuration:
[2021/09/04 12:15:17] [ info]  flush time     | 5.000000 seconds
[2021/09/04 12:15:17] [ info]  grace          | 5 seconds
[2021/09/04 12:15:17] [ info]  daemon         | 0
[2021/09/04 12:15:17] [ info] ___________
[2021/09/04 12:15:17] [ info]  inputs:
[2021/09/04 12:15:17] [ info]      mem
[2021/09/04 12:15:17] [ info] ___________
[2021/09/04 12:15:17] [ info]  filters:
[2021/09/04 12:15:17] [ info]      nest.0
[2021/09/04 12:15:17] [ info] ___________
[2021/09/04 12:15:17] [ info]  outputs:
[2021/09/04 12:15:17] [ info]      stdout.0
[2021/09/04 12:15:17] [ info] ___________
[2021/09/04 12:15:17] [ info]  collectors:
[2021/09/04 12:15:17] [ info] [engine] started (pid=28335)
[2021/09/04 12:15:17] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/09/04 12:15:17] [debug] [storage] [cio stream] new stream registered: mem.0
[2021/09/04 12:15:17] [ info] [storage] version=1.1.1, initializing...
[2021/09/04 12:15:17] [ info] [storage] in-memory
[2021/09/04 12:15:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/04 12:15:17] [ info] [cmetrics] version=0.2.1
[2021/09/04 12:15:17] [debug] [stdout:stdout.0] created event channels: read=19 write=20
[2021/09/04 12:15:17] [debug] [router] match rule mem.0:stdout.0
[2021/09/04 12:15:17] [ info] [sp] stream processor started
[2021/09/04 12:15:22] [debug] [task] created task=0x4c9fdf0 id=0 OK
==28335== Warning: client switching stacks?  SP change: 0x57e49c8 --> 0x4ca6240
==28335==          to suppress, use: --max-stackframe=11790216 or greater
==28335== Warning: client switching stacks?  SP change: 0x4ca61b8 --> 0x57e49c8
==28335==          to suppress, use: --max-stackframe=11790352 or greater
==28335== Warning: client switching stacks?  SP change: 0x57e49c8 --> 0x4ca61b8
==28335==          to suppress, use: --max-stackframe=11790352 or greater
==28335==          further instances of this message will not be shown.
[0] mem.local: [1630725318.268557830, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3520244, "free"=>4630696}}]
[1] mem.local: [1630725319.256984787, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3520748, "free"=>4630192}}]
[2] mem.local: [1630725320.256986862, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3520748, "free"=>4630192}}]
[3] mem.local: [1630725321.257103049, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3520748, "free"=>4630192}}]
[2021/09/04 12:15:22] [debug] [out coro] cb_destroy coro_id=0
[2021/09/04 12:15:22] [debug] [task] destroy task=0x4c9fdf0 (task_id=0)
^C[2021/09/04 12:15:22] [engine] caught signal (SIGINT)
[2021/09/04 12:15:22] [debug] [task] created task=0x4cfd330 id=0 OK
[0] mem.local: [1630725322.345509322, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8150940, "used"=>3521000, "free"=>4629940}}]
[2021/09/04 12:15:22] [ warn] [engine] service will stop in 5 seconds
[2021/09/04 12:15:22] [debug] [out coro] cb_destroy coro_id=1
[2021/09/04 12:15:22] [debug] [task] destroy task=0x4cfd330 (task_id=0)
[2021/09/04 12:15:23] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:15:24] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:15:25] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:15:26] [debug] [input chunk] mem.0 is paused, cannot append records
[2021/09/04 12:15:27] [ info] [engine] service stopped
==28335== 
==28335== HEAP SUMMARY:
==28335==     in use at exit: 0 bytes in 0 blocks
==28335==   total heap usage: 1,188 allocs, 1,188 frees, 1,231,019 bytes allocated
==28335== 
==28335== All heap blocks were freed -- no leaks are possible
==28335== 
==28335== For lists of detected and suppressed errors, rerun with: -s
==28335== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
