### PR TITLE
filter_lua: calculate table size using table.maxn(#3433)

### DIFF
--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -436,11 +436,87 @@ void flb_test_type_array_key(void)
     flb_destroy(ctx);
 }
 
+/* https://github.com/fluent/fluent-bit/issues/3433 */
+void flb_test_array_contains_null(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *output = NULL;
+    char *input = "[0, {\"hello\": [1, null, \"world\"]}]";
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    new_record = record\n"
+      "    new_record[\"modify\"] = \"yes\"\n"
+      "    return 1, timestamp, new_record\n"
+      "end\n";
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret==0);
+
+    flb_lib_push(ctx, in_ffd, input, strlen(input));
+    sleep(1);
+    output = get_output();
+    result = strstr(output, "[1,null,\"world\"]");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+    result = strstr(output, "\"modify\":\"yes\"");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* clean up */
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
     {"type_int_key_multi", flb_test_type_int_key_multi},
     {"type_array_key", flb_test_type_array_key},
+    {"array_contains_null", flb_test_array_contains_null},
     {NULL, NULL}
 };


### PR DESCRIPTION
Fixes #3433.

Lua5.1 can't get the size of table which contains null using operator '#'.
We can get the size using table.maxn.

Note: table.maxn is deprecated from Lua5.2.
https://www.lua.org/manual/5.2/manual.html#8.2
```
Function table.maxn is deprecated. Write it in Lua if you really need it.
```

```lua
array = {};
array[1] = 1;
array[2] = nil;
array[3] = "world";
print (#array)
print (table.maxn(array))
```

Lua5.1:
```
$ lua5.1 lua.script 
1
3
```
Lua5.2:
```
$ lua5.2 lua.script 
1
3
```
lua5.3:
```
$ lua5.3 lua.script 
1
lua5.3: lua.script:6: attempt to call a nil value (field 'maxn')
stack traceback:
	lua.script:6: in main chunk
	[C]: in ?
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration

functions.lua:
```lua
function lua_noop(tag, timestamp, record)
    return 1, timestamp, record
end
```

a.conf:
```
[INPUT]
    Name dummy
    Dummy {"hello": [1, null, "world"]}
    Samples 1

[FILTER]
    Name lua
    Match *
    Script functions.lua
    Call lua_noop

[OUTPUT]
    Name stdout
    Format json_stream
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/05 16:29:00] [ info] [engine] started (pid=46718)
[2021/09/05 16:29:00] [ info] [storage] version=1.1.1, initializing...
[2021/09/05 16:29:00] [ info] [storage] in-memory
[2021/09/05 16:29:00] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/05 16:29:00] [ info] [cmetrics] version=0.2.1
[2021/09/05 16:29:00] [ info] [sp] stream processor started
{"date":1630826940.898431,"hello":[1,null,"world"]}
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==46721== Memcheck, a memory error detector
==46721== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==46721== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==46721== Command: ../bin/fluent-bit -c a.conf
==46721== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/05 16:29:29] [ info] [engine] started (pid=46721)
[2021/09/05 16:29:29] [ info] [storage] version=1.1.1, initializing...
[2021/09/05 16:29:29] [ info] [storage] in-memory
[2021/09/05 16:29:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/05 16:29:29] [ info] [cmetrics] version=0.2.1
[2021/09/05 16:29:29] [ info] [sp] stream processor started
==46721== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4ca35b0
==46721==          to suppress, use: --max-stackframe=11805720 or greater
==46721== Warning: client switching stacks?  SP change: 0x4ca3528 --> 0x57e59c8
==46721==          to suppress, use: --max-stackframe=11805856 or greater
==46721== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4ca3528
==46721==          to suppress, use: --max-stackframe=11805856 or greater
==46721==          further instances of this message will not be shown.
{"date":1630826969.934302,"hello":[1,null,"world"]}
^C[2021/09/05 16:29:34] [engine] caught signal (SIGINT)
[2021/09/05 16:29:34] [ warn] [engine] service will stop in 5 seconds
[2021/09/05 16:29:38] [ info] [engine] service stopped
==46721== 
==46721== HEAP SUMMARY:
==46721==     in use at exit: 0 bytes in 0 blocks
==46721==   total heap usage: 1,179 allocs, 1,179 frees, 853,228 bytes allocated
==46721== 
==46721== All heap blocks were freed -- no leaks are possible
==46721== 
==46721== For lists of detected and suppressed errors, rerun with: -s
==46721== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
