### PR TITLE
filter_kubernetes: new option 'use_tag_for_meta' to use tag for metadata

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -87,7 +87,10 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
     /* Get Kubernetes API server */
     url = flb_filter_get_property("kube_url", ins);
 
-    if (ctx->use_kubelet) {
+    if (ctx->use_tag_for_meta) {
+        ctx->api_https = FLB_FALSE;
+    }
+    else if (ctx->use_kubelet) {
         ctx->api_host = flb_strdup(FLB_KUBELET_HOST);
         ctx->api_port = ctx->kubelet_port;
         ctx->api_https = FLB_TRUE;
@@ -184,8 +187,10 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
         }
     }
 
-    flb_plg_info(ctx->ins, "https=%i host=%s port=%i",
-                 ctx->api_https, ctx->api_host, ctx->api_port);
+    if (!ctx->use_tag_for_meta) {
+        flb_plg_info(ctx->ins, "https=%i host=%s port=%i",
+                     ctx->api_https, ctx->api_host, ctx->api_port);
+    }
     return ctx;
 }
 

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -154,6 +154,7 @@ struct flb_kube {
     int dns_retries;
     int dns_wait_time;
 
+    int use_tag_for_meta;
     int use_kubelet;
     int kubelet_port;
 

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -823,6 +823,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kube, cache_use_docker_id),
      "fetch K8s meta when docker_id is changed"
     },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "use_tag_for_meta", "false",
+     0, FLB_TRUE, offsetof(struct flb_kube, use_tag_for_meta),
+     "use tag associated to retrieve metadata instead of kube-server"
+    },
+
     /*
      * Enable the feature for using kubelet to get pods information
      */


### PR DESCRIPTION
The following patch adds a new option called 'use_tag_for_meta' which allows
to enrich the metadata only by using the information coming from the record
tags. This feature is useful only if you don't want to talk to API server or
Kubelet for metadata.

The data enrichment depends heavily on a right setup for Tail and the regular
expression to extract the proper components.

Usage example:

--- fluent-bit.conf ---
```
[INPUT]
    name       tail
    path       /var/log/containers/*.log
    tag        kube.<pod>.<namespace>.<container>
    tag_regex  ^/var/log/containers/(?:[^/]+/)?(?<pod>.+)_(?<namespace>.+)_(?<container>.+)\.log$

[FILTER]
    name             kubernetes
    match            kube.*
    kube_tag_prefix  kube.
    regex_parser     kube-name
    use_tag_for_meta on
```

In any of your parsers file, append the following entries:

--- parsers.conf ---
```
[PARSER]
    name    kube-name
    format  regex
    regex   (?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9]))\.(?<namespace_name>[^_]+)\.(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})$
```

Assuming that one of your log files has the proper common name it will be parsed and enriched as follows:

- file name

```
  /var/log/containers/traefik-97b44b794-f6sp6_kube-system_traefik-5ce550068d69ec7db2ba4cd9342bb04d79686da97cb802dd8e1eb19487ff727b.log
```

- record output

```
  tag   : kube.traefik-97b44b794-f6sp6.kube-system.traefik-987cea4dac49e14e64cd6caa4dfcc5610669e6838bd199fa396167a4adcbb4c0:
  record: [1630903216.378076554, {"log"=>"..."
                                  "time="2021-09-06T02:35:53Z"
                                  "kubernetes"=>{"pod_name"=>"traefik-97b44b794-f6sp6",
                                                 "namespace_name"=>"kube-system",
                                                 "container_name"=>"traefik",
                                                 "docker_id"=>"5ce550068d69ec7db2ba4cd9342bb04d79686da97cb802dd8e1eb19487ff727b"
                                                }
                                 }
          ]
```

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
