### PR TITLE
out_azure: new plugin parameter "resource_id" - adds support for x-ms…

### DIFF
--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -232,6 +232,12 @@ static int build_headers(struct flb_http_client *c,
         flb_http_add_header(c, "time-generated-field", 20, ctx->time_key, flb_sds_len(ctx->time_key));
     }
 
+    /* Header resource_id is optional */
+    if (ctx->resource_id) {
+        flb_http_add_header(c, "x-ms-AzureResourceId", 20, ctx->resource_id ,flb_sds_len(ctx->resource_id));
+        flb_plg_debug(ctx->ins, "resource_id=%s", ctx->resource_id);
+    }
+
     size = 32 + flb_sds_len(ctx->customer_id) + olen;
     auth = flb_malloc(size);
     if (!auth) {

--- a/plugins/out_azure/azure.h
+++ b/plugins/out_azure/azure.h
@@ -36,6 +36,7 @@ struct flb_azure {
     /* account setup */
     flb_sds_t customer_id;
     flb_sds_t log_type;
+    flb_sds_t resource_id;
     flb_sds_t shared_key;
     flb_sds_t dec_shared_key;
 

--- a/plugins/out_azure/azure_conf.c
+++ b/plugins/out_azure/azure_conf.c
@@ -129,6 +129,12 @@ struct flb_azure *flb_azure_conf_create(struct flb_output_instance *ins,
         ctx->time_generated = FLB_FALSE;
     }
 
+    /* config: 'resource_id' */
+    tmp = flb_output_get_property("resource_id", ins);
+    if (tmp) {
+        ctx->resource_id = flb_sds_create(tmp);
+    }
+
     /* Validate hostname given by command line or 'Host' property */
     if (!ins->host.name && !cid) {
         flb_plg_error(ctx->ins, "property 'customer_id' is not defined");
@@ -237,6 +243,9 @@ int flb_azure_conf_destroy(struct flb_azure *ctx)
     }
     if (ctx->log_type) {
         flb_sds_destroy(ctx->log_type);
+    }
+    if (ctx->resource_id) {
+        flb_sds_destroy(ctx->resource_id);
     }
     if (ctx->time_key) {
         flb_sds_destroy(ctx->time_key);


### PR DESCRIPTION
…-AzureResourceId header

When AzureResourceId is defined, it will be hand over to Azure data-collector-api using
"x-ms-AzureResourceId" http header - as specified in azure documentation:

>> The resource ID of the Azure resource that the data should be associated with.
>> It populates the _ResourceId property and allows the data to be included in resource-context queries.

The documentation is available at:
https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api

_ResourceId is something like:
/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/example-rg/providers/Microsoft.Insights/components/insights-test-01
or just id of some ResourceGroup:
/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/example-rg

Log records with any _RessourceId (and also records without _RessourceId) are still visible
at the Log Analytics Workspace level. But only log records with corresponding _ResourceId
are visible at the ResourceGroup level - so it is easier to find required records later.
Also access policies can be implemented to allow user to access log records relevant
to some project but disallow access to log records from other projects.

initially suggested by Florian Koch <flo@ctrl.wtf>:
  https://github.com/fluent/fluent-bit/issues/2184

Signed-off-by: Evgeny Nifontov <nifontov@nifsa.de>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
