### PR TITLE
upstream: fix mutex lock on pending destroy connections

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -842,7 +842,7 @@ int flb_upstream_conn_pending_destroy(struct flb_upstream *u)
     }
 
     if (u->thread_safe == FLB_TRUE) {
-        pthread_mutex_lock(&u->mutex_lists);
+        pthread_mutex_unlock(&u->mutex_lists);
     }
 
     return 0;


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

--
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
