### PR TITLE
in_node_exporter_metrics: fix a typo

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_filefd_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_filefd_linux.c
@@ -80,7 +80,7 @@ static int filefd_update(struct flb_ne *ctx)
             continue;
         }
         else if (parts != 3) {
-            flb_plg_warn(ctx->ins, "/sts/fs/file-nr: invalid number of fields");
+            flb_plg_warn(ctx->ins, "/sys/fs/file-nr: invalid number of fields");
             flb_slist_destroy(&split_list);
             break;
         }


### PR DESCRIPTION
plugins/in_node_exporter_metrics/ne_filefd_linux.c  contains a typo in warning message.

/sts/fs/file-nr =>
/sys/fs/file-nr


This typo exists since ne_filefd_linux was implemented.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
