### PR TITLE
in_node_exporter_metrics: drop needless assignment

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
@@ -154,7 +154,6 @@ static int vmstat_update(struct flb_ne *ctx)
         if (ret == -1) {
             continue;
         }
-        parts = ret;
 
         parts = ret;
         if (parts == 0) {


### PR DESCRIPTION
plugins/in_node_exporter_metrics/ne_vmstat_linux.c contains a redundant assginment.

parts = ret; is assigned twice.

This code exists since ne_vmstat_linux was implemented.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
