### PR TITLE
out_prometheus_exporter: use ins host/port api(#4070)

### DIFF
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -66,6 +66,8 @@ static int cb_prom_init(struct flb_output_instance *ins,
     int ret;
     struct prom_exporter *ctx;
 
+    flb_output_net_default("0.0.0.0", 2021 , ins);
+
     ctx = flb_calloc(1, sizeof(struct prom_exporter));
     if (!ctx) {
         flb_errno();
@@ -89,7 +91,7 @@ static int cb_prom_init(struct flb_output_instance *ins,
 
     /* HTTP Server context */
     ctx->http = prom_http_server_create(ctx,
-                                        ctx->listen, ctx->tcp_port, config);
+                                        ins->host.name, ins->host.port, config);
     if (!ctx->http) {
         flb_plg_error(ctx->ins, "could not initialize HTTP server, aborting");
         return -1;
@@ -108,8 +110,8 @@ static int cb_prom_init(struct flb_output_instance *ins,
         return -1;
     }
 
-    flb_plg_info(ctx->ins, "listening iface=%s tcp_port=%s",
-                 ctx->listen, ctx->tcp_port, config);
+    flb_plg_info(ctx->ins, "listening iface=%s tcp_port=%d",
+                 ins->host.name, ins->host.port);
     return 0;
 }
 
@@ -257,18 +259,6 @@ static int cb_prom_exit(void *data, struct flb_config *config)
 
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
-    {
-     FLB_CONFIG_MAP_STR, "listen", "0.0.0.0",
-     0, FLB_TRUE, offsetof(struct prom_exporter, listen),
-     "Listener network interface."
-    },
-
-    {
-     FLB_CONFIG_MAP_STR, "port", "2021",
-     0, FLB_TRUE, offsetof(struct prom_exporter, tcp_port),
-     "TCP port for listening for HTTP connections."
-    },
-
     {
      FLB_CONFIG_MAP_SLIST_1, "add_label", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct prom_exporter, add_labels),

--- a/plugins/out_prometheus_exporter/prom.h
+++ b/plugins/out_prometheus_exporter/prom.h
@@ -28,10 +28,6 @@
 struct prom_exporter {
     void *http;
 
-    /* networking */
-    flb_sds_t listen;
-    flb_sds_t tcp_port;
-
     /* hash table for metrics reported */
     struct flb_hash *ht_metrics;
 

--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -192,7 +192,7 @@ static void cb_root(mk_request_t *request, void *data)
 
 struct prom_http *prom_http_server_create(struct prom_exporter *ctx,
                                           const char *listen,
-                                          const char *tcp_port,
+                                          int tcp_port,
                                           struct flb_config *config)
 {
     int ret;
@@ -215,7 +215,7 @@ struct prom_http *prom_http_server_create(struct prom_exporter *ctx,
     }
 
     /* Compose listen address */
-    snprintf(tmp, sizeof(tmp) -1, "%s:%s", listen, tcp_port);
+    snprintf(tmp, sizeof(tmp) -1, "%s:%d", listen, tcp_port);
     mk_config_set(ph->ctx,
                   "Listen", tmp,
                   "Workers", "1",

--- a/plugins/out_prometheus_exporter/prom_http.h
+++ b/plugins/out_prometheus_exporter/prom_http.h
@@ -44,7 +44,7 @@ struct prom_http {
 
 struct prom_http *prom_http_server_create(struct prom_exporter *ctx,
                                           const char *listen,
-                                          const char *tcp_port,
+                                          int tcp_port,
                                           struct flb_config *config);
 void prom_http_server_destroy(struct prom_http *ph);
 


### PR DESCRIPTION
Fixes #4070 

This patch is to use output instance host/port API to make configurable host/port.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name dummy

[OUTPUT]
    Name prometheus_exporter
    Host localhost
    Port 12345
```

## Debug output

```
$ bin/fluent-bit -c ~/fluentbit-conf/4070.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/11 08:55:06] [ info] [engine] started (pid=24400)
[2021/09/11 08:55:06] [ info] [storage] version=1.1.1, initializing...
[2021/09/11 08:55:06] [ info] [storage] in-memory
[2021/09/11 08:55:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/11 08:55:06] [ info] [cmetrics] version=0.2.1
[2021/09/11 08:55:06] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=localhost tcp_port=12345
[2021/09/11 08:55:06] [ warn] [router] NO match for prometheus_exporter.0 output instance
[2021/09/11 08:55:06] [ info] [sp] stream processor started
```

curl:
```
taka@locals:~$ curl localhost:12345
Fluent Bit Prometheus Exporter
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/fluentbit-conf/4070.conf 
==24411== Memcheck, a memory error detector
==24411== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24411== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==24411== Command: bin/fluent-bit -c /home/taka/fluentbit-conf/4070.conf
==24411== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/11 08:56:27] [ info] [engine] started (pid=24411)
[2021/09/11 08:56:27] [ info] [storage] version=1.1.1, initializing...
[2021/09/11 08:56:27] [ info] [storage] in-memory
[2021/09/11 08:56:27] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/11 08:56:27] [ info] [cmetrics] version=0.2.1
[2021/09/11 08:56:27] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=localhost tcp_port=12345
[2021/09/11 08:56:27] [ warn] [router] NO match for prometheus_exporter.0 output instance
[2021/09/11 08:56:27] [ info] [sp] stream processor started
==24411== Warning: client switching stacks?  SP change: 0x77e9578 --> 0x4ca9f40
==24411==          to suppress, use: --max-stackframe=45348408 or greater
==24411== Warning: client switching stacks?  SP change: 0x4ca9eb8 --> 0x77e9578
==24411==          to suppress, use: --max-stackframe=45348544 or greater
==24411== Warning: client switching stacks?  SP change: 0x77e9628 --> 0x4ca9eb8
==24411==          to suppress, use: --max-stackframe=45348720 or greater
==24411==          further instances of this message will not be shown.
^C[2021/09/11 08:56:31] [engine] caught signal (SIGINT)
[2021/09/11 08:56:31] [ warn] [engine] service will stop in 5 seconds
[2021/09/11 08:56:35] [ info] [engine] service stopped
==24411== 
==24411== HEAP SUMMARY:
==24411==     in use at exit: 0 bytes in 0 blocks
==24411==   total heap usage: 1,190 allocs, 1,190 frees, 895,034 bytes allocated
==24411== 
==24411== All heap blocks were freed -- no leaks are possible
==24411== 
==24411== For lists of detected and suppressed errors, rerun with: -s
==24411== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
