### PR TITLE
out_s3: add back flb_sds_destroy() lost in 8cd50f8 (fluent#4038).

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1569,6 +1569,7 @@ static int send_upload_request(void *out_context, flb_sds_t chunk,
 
     /* Create buffer to upload to S3 */
     ret = construct_request_buffer(ctx, chunk, upload_file, &buffer, &buffer_size);
+    flb_sds_destroy(chunk);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Could not construct request buffer for %s",
                       upload_file->file_path);


### PR DESCRIPTION
**Testing**
Tested under same test load used to evidence issue with no increase in memory usage.

Verified that without this commit the issue exists still in HEAD.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
