### PR TITLE
network: added default timeout for corner cases

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -922,6 +922,11 @@ int flb_net_getaddrinfo(const char *node, const char *service, struct addrinfo *
     result_data = NULL;
     udp_timeout_detected = 0;
 
+    /* If there is no timeout configured then let the lookup take at most 1 minute */
+    if (timeout <= 0) {
+        timeout = 60;
+    }
+
     /* The timeout we get is expressed in seconds so we need to convert it to
      * milliseconds
      */


### PR DESCRIPTION
This pull request implements a default timeout for those output plugins
that do not implement the config_map configuration interface. It's meant
to emulate the create_conn behavior in order alleviate the issue while these
plugins are updated.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>