### PR TITLE
output: initialize network defaults for output instances (#4050)

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -989,6 +989,9 @@ int flb_output_init_all(struct flb_config *config)
             }
         }
 
+        /* Init network defaults */
+        flb_net_setup_init(&ins->net_setup);
+
         /* Get Upstream net_setup configmap */
         ins->net_config_map = flb_upstream_get_config_map(config);
         if (!ins->net_config_map) {


### PR DESCRIPTION
For plugins that do not implement a config map interface, the networking
setup was missing, leading to connect_timeout=0, no keep alive, plus
others.

In this patch we always initialize the plugin instance network defaults,
but this becomes a fixed value that cannot be changed through the
configuration.

The long term solution is to migrate plugins to use config maps.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
