### PR TITLE
oauth2: release upstream connection on exit

### DIFF
--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -398,6 +398,7 @@ char *flb_oauth2_token_get(struct flb_oauth2 *ctx)
             flb_info("[oauth2] access token from '%s:%s' retrieved",
                      ctx->host, ctx->port);
             flb_http_client_destroy(c);
+            flb_upstream_conn_release(u_conn);
             ctx->issued = time(NULL);
             ctx->expires = ctx->issued + ctx->expires_in;
             return ctx->access_token;
@@ -405,6 +406,8 @@ char *flb_oauth2_token_get(struct flb_oauth2 *ctx)
     }
 
     flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+
     return NULL;
 }
 


### PR DESCRIPTION
When retrieving an oauth2 token, upon authentication failure, we were
not releasing the upstream connection, only releasing the HTTP client
context.

This patch makes sure to release the upstream context on exception and
on return, this fix a little memory leak:

```
------ before ------

    MB
33.32^                                                                       #
     |                                                                   @@@:#
     |                                                              @@@@@@@@:#
     |                                                         @@@@@@@@@@@@@:#
     |                                                   @@@@@@@@@@@@@@@@@@@:#
     |                                              ::@@@@@@@@@@@@@@@@@@@@@@:#
     |                                         ::@@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |                                    @@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |                               @::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |                          :::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |                    ::::@@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |               ::::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |          @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |    ::::::@::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
     |:@::::::: @::::: ::@::: @@:::::@::::@@::@: @@@::@@@@@@@@@@@@@@@@@@@@@@:#
   0 +----------------------------------------------------------------------->Gi
     0                                                                   29.22

------ after ------

    MB
10.56^                                                                      #
     | :::::::::::::::::@:::::@::@::::::::::::::::::::::@:::::::::@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
     | :: ::: ::::::: : @: : :@: @:: :: : :::: ::: :::::@::::::: :@::::::@::#:
   0 +----------------------------------------------------------------------->Gi
     0                                                                   211.1
```

Signed-off-by: Phillip Whelan <phil@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
