### PR TITLE
config: add scheduler cap and base

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -232,6 +232,8 @@ struct flb_config {
     uint16_t in_table_id[512];
 
     void *sched;
+    unsigned int sched_cap;
+    unsigned int sched_base;
 
     struct flb_task_map tasks_map[2048];
 
@@ -299,5 +301,9 @@ enum conf_type {
 
 /* Coroutines */
 #define FLB_CONF_STR_CORO_STACK_SIZE "Coro_Stack_Size"
+
+/* Scheduler */
+#define FLB_CONF_STR_SCHED_CAP        "scheduler.cap"
+#define FLB_CONF_STR_SCHED_BASE       "scheduler.base"
 
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -136,6 +136,14 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, coro_stack_size)},
 
+    /* Scheduler */
+    {FLB_CONF_STR_SCHED_CAP,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, sched_cap)},
+    {FLB_CONF_STR_SCHED_BASE,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, sched_base)},
+
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     {FLB_CONF_STR_STREAMS_FILE,
      FLB_CONF_TYPE_STR,
@@ -201,6 +209,9 @@ struct flb_config *flb_config_init()
     config->cio          = NULL;
     config->storage_path = NULL;
     config->storage_input_plugin = NULL;
+
+    config->sched_cap  = FLB_SCHED_CAP;
+    config->sched_base = FLB_SCHED_BASE;
 
 #ifdef FLB_HAVE_SQLDB
     mk_list_init(&config->sqldb_list);

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -287,7 +287,7 @@ int flb_sched_request_create(struct flb_config *config, void *data, int tries)
     timer->event.mask = MK_EVENT_EMPTY;
 
     /* Get suggested wait_time for this request */
-    seconds = backoff_full_jitter(FLB_SCHED_BASE, FLB_SCHED_CAP, tries);
+    seconds = backoff_full_jitter((int)config->sched_base, (int)config->sched_cap, tries);
     seconds += 1;
 
     /* Populare request */


### PR DESCRIPTION
<!-- Provide summary of changes -->

See also #3597 

This is a patch to make configurable cap and base of backoff.

|key|description|default|
|----|------------|--------|
|scheduler.cap|Set a maximum retry time in second. |2000|
|scheduler.base|Set a base of exponential backoff.|5|

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration file

```
[SERVICE]
    scheduler.cap 5
    scheduler.base 1

[INPUT]
    Name dummy
    Dummy {"log": "message 1", "labels": {"color": "blue"}}
    Samples 1

[OUTPUT]
    Name forward
    Retry_limit 5
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/18 06:57:06] [ info] [engine] started (pid=8511)
[2021/09/18 06:57:06] [ info] [storage] version=1.1.1, initializing...
[2021/09/18 06:57:06] [ info] [storage] in-memory
[2021/09/18 06:57:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/18 06:57:06] [ info] [cmetrics] version=0.2.1
[2021/09/18 06:57:06] [ info] [sp] stream processor started
[2021/09/18 06:57:10] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:57:10] [ warn] [engine] failed to flush chunk '8511-1631915826.986880345.flb', retry in 3 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2021/09/18 06:57:13] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:57:13] [ warn] [engine] failed to flush chunk '8511-1631915826.986880345.flb', retry in 2 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2021/09/18 06:57:15] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:57:15] [ warn] [engine] failed to flush chunk '8511-1631915826.986880345.flb', retry in 3 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
^C[2021/09/18 06:57:16] [engine] caught signal (SIGINT)
[2021/09/18 06:57:16] [ warn] [engine] service will stop in 5 seconds
[2021/09/18 06:57:18] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:57:18] [ warn] [engine] failed to flush chunk '8511-1631915826.986880345.flb', retry in 3 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2021/09/18 06:57:20] [ info] [engine] service stopped
```

## Valgrind output
```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==8521== Memcheck, a memory error detector
==8521== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8521== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==8521== Command: bin/fluent-bit -c a.conf
==8521== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/18 06:58:43] [ info] [engine] started (pid=8521)
[2021/09/18 06:58:43] [ info] [storage] version=1.1.1, initializing...
[2021/09/18 06:58:43] [ info] [storage] in-memory
[2021/09/18 06:58:43] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/18 06:58:43] [ info] [cmetrics] version=0.2.1
[2021/09/18 06:58:43] [ info] [sp] stream processor started
^C[2021/09/18 06:58:46] [engine] caught signal (SIGINT)
==8521== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4c895d0
==8521==          to suppress, use: --max-stackframe=11912024 or greater
==8521== Warning: client switching stacks?  SP change: 0x4c89548 --> 0x57e5928
==8521==          to suppress, use: --max-stackframe=11912160 or greater
==8521== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4c89548
==8521==          to suppress, use: --max-stackframe=11912160 or greater
==8521==          further instances of this message will not be shown.
[2021/09/18 06:58:46] [ warn] [engine] service will stop in 5 seconds
[2021/09/18 06:58:46] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:58:46] [ warn] [engine] failed to flush chunk '8521-1631915924.21442218.flb', retry in 3 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2021/09/18 06:58:49] [error] [output:forward:forward.0] could not write forward header
[2021/09/18 06:58:49] [ warn] [engine] failed to flush chunk '8521-1631915924.21442218.flb', retry in 2 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2021/09/18 06:58:50] [ info] [engine] service stopped
==8521== 
==8521== HEAP SUMMARY:
==8521==     in use at exit: 0 bytes in 0 blocks
==8521==   total heap usage: 1,210 allocs, 1,210 frees, 886,911 bytes allocated
==8521== 
==8521== All heap blocks were freed -- no leaks are possible
==8521== 
==8521== For lists of detected and suppressed errors, rerun with: -s
==8521== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
