### PR TITLE
openssl: Fix return value from tls_net_read.

### DIFF
--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -180,6 +180,9 @@ int flb_tls_net_read(struct flb_upstream_conn *u_conn, void *buf, size_t len)
     if (ret == FLB_TLS_WANT_READ) {
         goto retry_read;
     }
+    else if (ret == FLB_TLS_WANT_WRITE) {
+        goto retry_read;
+    }
     else if (ret < 0) {
         return -1;
     }
@@ -204,6 +207,14 @@ int flb_tls_net_read_async(struct flb_coro *co, struct flb_upstream_conn *u_conn
         io_tls_event_switch(u_conn, MK_EVENT_READ);
         flb_coro_yield(co, FLB_FALSE);
 
+        goto retry_read;
+    }
+    else if (ret == FLB_TLS_WANT_WRITE) {
+        u_conn->coro = co;
+
+        io_tls_event_switch(u_conn, MK_EVENT_WRITE);
+        flb_coro_yield(co, FLB_FALSE);
+        
         goto retry_read;
     }
     else


### PR DESCRIPTION
<!-- Provide summary of changes -->
Error codes returned from SSL_get_error() are positive values: https://github.com/openssl/openssl/blob/master/include/openssl/ssl.h.in#L1181
Without this fix, if the read fails and SSL_get_error() returned SSL_ERROR_SSL or any other similar error, tls_net_read returns 1 to the caller which thinks it read 1 byte.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses 
----
Addresses #4098

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
