### PR TITLE
config_map: Support deprecated config

### DIFF
--- a/include/fluent-bit/flb_config_map.h
+++ b/include/fluent-bit/flb_config_map.h
@@ -34,6 +34,7 @@
 #define FLB_CONFIG_MAP_DOUBLE      4    /* double */
 #define FLB_CONFIG_MAP_SIZE        5    /* string size to integer (e.g: 2M) */
 #define FLB_CONFIG_MAP_TIME        6    /* string time to integer seconds (e.g: 2H) */
+#define FLB_CONFIG_MAP_DEPRECATED  7    /* for deprecated parameter */
 
 #define FLB_CONFIG_MAP_CLIST    30   /* comma separated list of strings */
 #define FLB_CONFIG_MAP_CLIST_1  31   /* split up to 1 node  + remaining data */

--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -477,6 +477,10 @@ int flb_config_map_properties_check(char *context_name,
                         break;
                     }
                 }
+                else if(m->type == FLB_CONFIG_MAP_DEPRECATED) {
+                    flb_warn("[config] %s: '%s' is deprecated",
+                             context_name, kv->key);
+                }
                 found = FLB_TRUE;
                 break;
             }

--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -80,6 +80,9 @@ int pack_config_map_entry(msgpack_packer *mp_pck, struct flb_config_map *m)
     if (m->type == FLB_CONFIG_MAP_STR) {
         pack_str(mp_pck, "string");
     }
+    else if (m->type == FLB_CONFIG_MAP_DEPRECATED) {
+        pack_str(mp_pck, "deprecated");
+    }
     else if (m->type == FLB_CONFIG_MAP_INT) {
         pack_str(mp_pck, "integer");
     }


### PR DESCRIPTION
In some cases, a property of plugin is deprecated.
https://github.com/fluent/fluent-bit/pull/4081#issuecomment-922118401

This patch is to support deprecated option for config_map.
The patch adds `FLB_CONFIG_MAP_DEPRECATED` to notify the property is deprecated.

If user sets the deprecated parameter, fluent-bit outputs warning.
`[2021/09/19 08:14:24] [ warn] [config] prometheus_exporter: 'listen' is deprecated`

Below is an example to support deprecated parameter `listen`.
```diff
diff --git a/plugins/out_prometheus_exporter/prom.c b/plugins/out_prometheus_exporter/prom.c
index 083a12b9..6e0a5472 100644
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -264,6 +264,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct prom_exporter, add_labels),
      "TCP port for listening for HTTP connections."
     },
+    {
+     FLB_CONFIG_MAP_DEPRECATED, "listen", "",
+     0, FLB_FALSE, 0,
+     "Deprecated. Please use `host`"
+    },
 
     /* EOF */
     {0}
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example config

```
[INPUT]
    Name dummy

[OUTPUT]
    Name prometheus_exporter
    listen localhost
```

## Debug ouptut

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/19 08:17:29] [ info] [engine] started (pid=15273)
[2021/09/19 08:17:29] [ info] [storage] version=1.1.1, initializing...
[2021/09/19 08:17:29] [ info] [storage] in-memory
[2021/09/19 08:17:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/19 08:17:29] [ info] [cmetrics] version=0.2.1
[2021/09/19 08:17:29] [ warn] [config] prometheus_exporter: 'listen' is deprecated
[2021/09/19 08:17:29] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2021/09/19 08:17:29] [ warn] [router] NO match for prometheus_exporter.0 output instance
[2021/09/19 08:17:29] [ info] [sp] stream processor started
^C[2021/09/19 08:17:30] [engine] caught signal (SIGINT)
[2021/09/19 08:17:30] [ warn] [engine] service will stop in 5 seconds
[2021/09/19 08:17:35] [ info] [engine] service stopped
```

Help text will be 
```
$ bin/fluent-bit -o prometheus_exporter -h
(snip)

OPTIONS
add_label                   TCP port for listening for HTTP connections.
                            > default: default, type: space delimited strings (minimum 1)

listen                      Deprecated. Please use `host`
                            > default: , type: deprecated
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==16276== Memcheck, a memory error detector
==16276== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16276== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==16276== Command: bin/fluent-bit -c a.conf
==16276== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/19 08:19:44] [ info] [engine] started (pid=16276)
[2021/09/19 08:19:44] [ info] [storage] version=1.1.1, initializing...
[2021/09/19 08:19:44] [ info] [storage] in-memory
[2021/09/19 08:19:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/19 08:19:44] [ info] [cmetrics] version=0.2.1
[2021/09/19 08:19:44] [ warn] [config] prometheus_exporter: 'listen' is deprecated
[2021/09/19 08:19:44] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2021/09/19 08:19:44] [ warn] [router] NO match for prometheus_exporter.0 output instance
[2021/09/19 08:19:44] [ info] [sp] stream processor started
^C[2021/09/19 08:19:45] [engine] caught signal (SIGINT)
[2021/09/19 08:19:45] [ warn] [engine] service will stop in 5 seconds
[2021/09/19 08:19:49] [ info] [engine] service stopped
==16276== 
==16276== HEAP SUMMARY:
==16276==     in use at exit: 0 bytes in 0 blocks
==16276==   total heap usage: 1,108 allocs, 1,108 frees, 716,888 bytes allocated
==16276== 
==16276== All heap blocks were freed -- no leaks are possible
==16276== 
==16276== For lists of detected and suppressed errors, rerun with: -s
==16276== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
