### PR TITLE
increase supported custom http headers count

### DIFF
--- a/lib/monkey/include/monkey/mk_http_parser.h
+++ b/lib/monkey/include/monkey/mk_http_parser.h
@@ -45,7 +45,7 @@
 #define MK_HTTP_PARSER_UPGRADE_H2    1
 #define MK_HTTP_PARSER_UPGRADE_H2C   2
 
-#define MK_HEADER_EXTRA_SIZE         8
+#define MK_HEADER_EXTRA_SIZE        50
 
 /* Request levels
  * ==============


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR increase custom http headers to reasonable count. For example, cloudflare adds to requests another 5 custom CF-* headers. It partially fixes [#3645 ](https://github.com/fluent/fluent-bit/issues/3645), still gives SIGSEGV (instead of reporting entity too large) but hopefully 50 custom headers would be enough. Fixing only root cause of SIGSEGV [#3645 ](https://github.com/fluent/fluent-bit/issues/3645) will still limit to 8 custom headers. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
