### PR TITLE
net: Fix handling of upstream connection timeout events. #4040

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -794,11 +794,17 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
                  * Shutdown the connection, this is the safest way to indicate
                  * that the socket cannot longer work and any co-routine on
                  * waiting for I/O will receive the notification and trigger
-                 * the error to it caller.
+                 * the error to it caller. This only works if the connection
+                 * has a valid fd, which is assigned after the DNS lookup
+                 * succeeds.
+                 * Do not call prepare_destroy_conn here since the connection
+                 * is still pending. It will be handled when the function for
+                 * creating a new connection returns.
                  */
-                shutdown(u_conn->fd, SHUT_RDWR);
+                if (u_conn->fd > -1) {
+                    shutdown(u_conn->fd, SHUT_RDWR);
+                }
                 u_conn->net_error = ETIMEDOUT;
-                prepare_destroy_conn(u_conn);
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Ramya <89954993+krispraws@users.noreply.github.com>

Fluent Bit crashes with SIGSEGV consistently for my AWS workflow that creates a burst of TLS connections under high load.
The workflow uses the tail input plugin and the kinesis.firehose output plugin. The bug happens when DNS lookups are slow and the event loop processing is slow, so the DNS timeout doesn't get invoked on time. The upstream timeout handler gets invoked and moves the connection to the destroy queue. The scheduled event that removes the connection from the destroy queue and frees the memory also gets invoked. When the DNS call finally returns, the connection pointer is invalid. This causes segmentation faults with a variety of stack traces. I will post some of them in the comments.

I verified my initial hypothesis in https://github.com/fluent/fluent-bit/issues/4040#issuecomment-911117687 by adding a lot of logs. This is one stack trace, with corresponding logs:

```
Thread 3 (Thread 0x7f639fa85700 (LWP 18786)):
#0  0x00007f63a07893dc in epoll_wait (epfd=9, events=0x7f6398004870, maxevents=32, timeout=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
#1  0x000000000077800f in _mk_event_wait (loop=0x7f6398004a00) at /home/ec2-user/fluent-bit/lib/monkey/mk_core/mk_event_epoll.c:366
#2  0x0000000000778324 in mk_event_wait (loop=0x7f6398004a00) at /home/ec2-user/fluent-bit/lib/monkey/mk_core/mk_event.c:169
#3  0x0000000000444bbc in log_worker_collector (data=0x7f6398004780) at /home/ec2-user/fluent-bit/src/flb_log.c:132
#4  0x000000000046b3c1 in step_callback (data=0x7f63980050d0) at /home/ec2-user/fluent-bit/src/flb_worker.c:44
#5  0x00007f63a1b1240b in start_thread (arg=0x7f639fa85700) at pthread_create.c:465
#6  0x00007f63a07890bf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 2 (Thread 0x7f63a1f3f340 (LWP 18784)):
#0  0x00007f63a075977b in __GI___nanosleep (requested_time=requested_time@entry=0x7ffd5112f7b0, remaining=remaining@entry=0x7ffd5112f7b0)
    at ../sysdeps/unix/sysv/linux/nanosleep.c:27
#1  0x00007f63a075969a in __sleep (seconds=0) at ../sysdeps/posix/sleep.c:55
#2  0x0000000000439bf6 in flb_main (argc=5, argv=0x7ffd5112f958) at /home/ec2-user/fluent-bit/src/fluent-bit.c:1286
#3  0x0000000000439c6d in main (argc=5, argv=0x7ffd5112f958) at /home/ec2-user/fluent-bit/src/fluent-bit.c:1303

Thread 1 (Thread 0x7f63a0486700 (LWP 18785)):
#0  x86_64_fallback_frame_state (context=0x7f6399997670, context=0x7f6399997670, fs=0x7f6399997760) at ./md-unwind-support.h:58
#1  uw_frame_state_for (context=context@entry=0x7f6399997670, fs=fs@entry=0x7f6399997760) at ../../../libgcc/unwind-dw2.c:1257
#2  0x00007f63a0a56e52 in _Unwind_Backtrace (trace=trace@entry=0x43a540 <unwind>, trace_argument=trace_argument@entry=0x7f6399997920)
    at ../../../libgcc/unwind.inc:290
#3  0x000000000043a637 in backtrace_full (state=0x7f63a1f4b000, skip=<optimized out>, callback=<optimized out>, 
    error_callback=<optimized out>, data=<optimized out>) at /home/ec2-user/fluent-bit/lib/libbacktrace-ca0de05/backtrace.c:127
#4  0x0000000000436ebb in flb_stacktrace_print (st=0xad4df0 <flb_st>) at /home/ec2-user/fluent-bit/include/fluent-bit/flb_stacktrace.h:71
#5  0x000000000043850c in flb_signal_handler (signal=11) at /home/ec2-user/fluent-bit/src/fluent-bit.c:559
#6  <signal handler called>
#7  0x000000000046894c in __mk_list_del (prev=0x0, next=0x0) at /home/ec2-user/fluent-bit/lib/monkey/include/monkey/mk_core/mk_list.h:87
#8  0x0000000000468984 in mk_list_del (entry=0x7f6398d725f0) at /home/ec2-user/fluent-bit/lib/monkey/include/monkey/mk_core/mk_list.h:93
#9  0x0000000000469548 in prepare_destroy_conn (u_conn=0x7f6398d72570) at /home/ec2-user/fluent-bit/src/flb_upstream.c:416
#10 0x00000000004695aa in prepare_destroy_conn_safe (u_conn=0x7f6398d72570) at /home/ec2-user/fluent-bit/src/flb_upstream.c:438
#11 0x0000000000469935 in create_conn (u=0x7f63982b36e0) at /home/ec2-user/fluent-bit/src/flb_upstream.c:534
#12 0x0000000000469e5e in flb_upstream_conn_get (u=0x7f63982b36e0) at /home/ec2-user/fluent-bit/src/flb_upstream.c:677
#13 0x000000000055b27a in request_do (aws_client=0x7f63982b3650, method=1, uri=0x7a2a1d "/", 
    body=0x7f639b139b10 "{\"DeliveryStreamName\":\"PUT-S3-4vsGw\",\"Records\":[{\"Data\":\"eyJpbnB1dF9maWxlIjoiL2hvbWUvZWMyLXVzZXIvZmxiLWRhdGEvaW5wdXRfZGF0YS9pbnB1dF8xNjMyMDk0OTk2LmxvZyIsImlucHV0X29mZnNldCI6MjcwNTg3NTIsImxvZyI6InsgXCJ"..., body_len=831653, 
    dynamic_headers=0xac9e60 <put_record_batch_header>, dynamic_headers_len=1) at /home/ec2-user/fluent-bit/src/aws/flb_aws_util.c:292
#14 0x000000000055ae0b in flb_aws_client_request (aws_client=0x7f63982b3650, method=1, uri=0x7a2a1d "/", 
    body=0x7f639b139b10 "{\"DeliveryStreamName\":\"PUT-S3-4vsGw\",\"Records\":[{\"Data\":\"eyJpbnB1dF9maWxlIjoiL2hvbWUvZWMyLXVzZXIvZmxiLWRhdGEvaW5wdXRfZGF0YS9pbnB1dF8xNjMyMDk0OTk2LmxvZyIsImlucHV0X29mZnNldCI6MjcwNTg3NTIsImxvZyI6InsgXCJ"..., body_len=831653, 
    dynamic_headers=0xac9e60 <put_record_batch_header>, dynamic_headers_len=1) at /home/ec2-user/fluent-bit/src/aws/flb_aws_util.c:160
#15 0x0000000000519e17 in put_record_batch (ctx=0x7f6398041770, buf=0x7f6398435dc0, payload_size=831653, num_records=500)
    at /home/ec2-user/fluent-bit/plugins/out_kinesis_firehose/firehose_api.c:828
#16 0x00000000005187e4 in send_log_events (ctx=0x7f6398041770, buf=0x7f6398435dc0)
```

Logs from my branch with trace statements that print connection pointer:
```
[2021/09/19 23:44:18] [trace] [upstream][conn=0x7f6398d72570][fd=-1][coro=0x7f6398d70a00] create_conn set connect_timeout=10
[2021/09/19 23:44:18] [trace] [io][conn=0x7f6398d72570][coro=0x7f6398d70a00] flb_io_net_connect called
[2021/09/19 23:44:30] [debug] [upstream][conn=0x7f6398d72570][fd=-1] flb_upstream_conn_timeouts connection #-1 to firehose.us-east-1.amazonaws.com:443 timed out after 10 seconds
[2021/09/19 23:44:30] [debug] [upstream][conn=0x7f6398d72570][fd=-1] flb_upstream_conn_timeouts cleaning up connection #-1 due to connect timeout
[2021/09/19 23:44:30] [trace] [upstream][conn=0x7f6398d72570][fd=-1] prepare_destroy_conn #-1 to firehose.us-east-1.amazonaws.com:443
[2021/09/19 23:44:32] [trace] [upstream][conn=0x7f6398d72570][fd=-1] flb_upstream_conn_pending_destroy connection #-1 net_error=110
[2021/09/19 23:44:32] [trace] [upstream][conn=0x7f6398d72570][fd=-1] destroy_conn connection #-1 tls_session=(nil). Memory for connection freed.
[2021/09/19 23:44:34] [ warn] [net][conn=0x7f6398d72570] flb_net_tcp_connect async getaddrinfo(host='firehose.us-east-1.amazonaws.com', err=12): Timeout while contacting DNS servers
[2021/09/19 23:44:34] [debug] [io][conn=0x7f6398d72570][coro=0x7f6398d70a00] flb_io_net_connect tcp connection failed
[2021/09/19 23:44:34] [debug] [upstream][conn=0x7f6398d72570][fd=-1][coro=0x7f6398d70a00] create_conn connection #-1 to firehose.us-east-1.amazonaws.com:443 failed, cleaning up
[2021/09/19 23:44:34] [trace] [upstream][conn=0x7f6398d72570][fd=-1] prepare_destroy_conn #-1 to firehose.us-east-1.amazonaws.com:443
```

The fix in this PR is not perfect because I haven't fully figured out how to make the upstream timeout handler cancel a pending DNS call. I have a couple of ideas around it but haven't tested them. It does prevent the invalid memory reference.

I will attach valgrind output and debug logs with and without the fix. Running the task with valgrind makes every connection timeout, however with the fix, the crashes don't happen.

There is also some performance regression in versions after 1.7.5 that make DNS lookups or TCP connections slow because I can run the same load on 1.7.5 with no issues.

----
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #4040 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [Y] Example configuration file for the change
- [Y] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [Y] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
