### PR TITLE
out_kafka_rest: Added avro config param to use avro header

### DIFF
--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -78,6 +78,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kafka_rest, tag_key),
      "Specify the key name of the record if include_tag_key is enabled. "
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "avro_http_header", "false",
+     0, FLB_TRUE, offsetof(struct flb_kafka_rest, avro_http_header),
+     "Specify if the format has avro header in http request"
+    },
 
     /* EOF */
     {0}
@@ -275,10 +280,17 @@ static void cb_kafka_flush(const void *data, size_t bytes,
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
                         js, js_size, NULL, 0, NULL, 0);
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
-    flb_http_add_header(c,
-                        "Content-Type", 12,
-                        "application/vnd.kafka.json.v2+json", 34);
-
+    if (ctx->avro_http_header == FLB_TRUE) {
+        flb_http_add_header(c,
+                            "Content-Type", 12,
+                            "application/vnd.kafka.avro.v2+json", 34);
+    }
+    else {
+        flb_http_add_header(c,
+                            "Content-Type", 12,
+                            "application/vnd.kafka.json.v2+json", 34);
+    }
+    
     if (ctx->http_user && ctx->http_passwd) {
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }

--- a/plugins/out_kafka_rest/kafka.h
+++ b/plugins/out_kafka_rest/kafka.h
@@ -58,6 +58,9 @@ struct flb_kafka_rest {
 
     /* Plugin instance */
     struct flb_output_instance *ins;
+
+    /* Avro http header*/
+    int avro_http_header;
 };
 
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Kafka Rest output plugin support for Avro header.
It will add the header for Avro converter on Kafka Rest API:
`"Content-Type": "application/vnd.kafka.json.v2+json"`
Usage:
```
[OUTPUT]
    name  kafka-rest
    Match *
    Host myhost
    Port 443
    Topic topic_name
    Message_Key message_key
    Time_Key timestamp
    **avro On** #default is off
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
