### PR TITLE
aws: Imdsv2 Support Added

### DIFF
--- a/include/fluent-bit/aws/flb_aws_imds.h
+++ b/include/fluent-bit/aws/flb_aws_imds.h
@@ -1,0 +1,114 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_AWS_IMDS
+#define FLB_AWS_IMDS
+
+#define FLB_AWS_IMDS_HOST "169.254.169.254"
+#define FLB_AWS_IMDS_HOST_LEN 15
+#define FLB_AWS_IMDS_PORT 80
+
+#define FLB_AWS_IMDS_VERSION_EVALUATE 0
+#define FLB_AWS_IMDS_VERSION_1 1
+#define FLB_AWS_IMDS_VERSION_2 2
+
+/* The following metadata paths can be evaluated with flb_aws_imds_request
+ * to retrieve specific metadata members */
+#define FLB_AWS_IMDS_INSTANCE_ID_PATH "/latest/meta-data/instance-id/"
+#define FLB_AWS_IMDS_AZ_PATH "/latest/meta-data/placement/availability-zone/"
+#define FLB_AWS_IMDS_INSTANCE_TYPE_PATH "/latest/meta-data/instance-type/"
+#define FLB_AWS_IMDS_PRIVATE_IP_PATH "/latest/meta-data/local-ipv4/"
+#define FLB_AWS_IMDS_VPC_ID_PATH_PREFIX "/latest/meta-data/network/interfaces/macs/"
+#define FLB_AWS_IMDS_AMI_ID_PATH "/latest/meta-data/ami-id/"
+#define FLB_AWS_IMDS_ACCOUNT_ID_PATH "/latest/dynamic/instance-identity/document/"
+#define FLB_AWS_IMDS_HOSTNAME_PATH "/latest/meta-data/hostname/"
+#define FLB_AWS_IMDS_MAC_PATH "/latest/meta-data/mac/"
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_sds.h>
+
+/* IMDS config values */
+struct flb_aws_imds_config {
+    int use_imds_version;  // FLB_AWS_IMDS_VERSION_EVALUATE for automatic detection
+};
+
+/* Default config values */
+const struct flb_aws_imds_config flb_aws_imds_config_default;
+
+/* Metadata service context struct */
+struct flb_aws_imds {
+    /* AWS Client to perform mockable requests to IMDS */
+    struct flb_aws_client *ec2_imds_client;
+
+    /* IMDSv2 requires a token which must be present in metadata requests */
+    flb_sds_t imds_v2_token;
+    size_t imds_v2_token_len;
+
+    /*
+     * Plugin can use EC2 metadata v1 or v2; default is FLB_AWS_IMDS_VERSION_EVALUATE
+     * which is evaluated to FLB_AWS_IMDS_VERSION_1 or FLB_AWS_IMDS_VERSION_2 when
+     * the IMDS is used.
+     */
+    int imds_version;
+};
+
+/*
+ * Create IMDS context
+ * Returns NULL on error
+ * Note: Setting the FLB_IO_ASYNC flag is the job of the client.
+ * Flag Set Example: flags &= ~(FLB_IO_ASYNC)
+ */
+struct flb_aws_imds *flb_aws_imds_create(const struct flb_aws_imds_config *imds_config,
+                                         struct flb_aws_client *ec2_imds_client);
+
+/*
+ * Destroy IMDS context
+ * The client is responsable for destroying
+ * the "ec2_imds_client" struct.
+ */
+void flb_aws_imds_destroy(struct flb_aws_imds *ctx);
+
+/*
+ * Get IMDS metadata.
+ * Sets flb_sds_t metadata string to the value found at IMDS' metadata_path.
+ * Returns -1 on error, 0 on success.
+ */
+int flb_aws_imds_request(struct flb_aws_imds *ctx, const char *metadata_path,
+                         flb_sds_t *metadata, size_t *metadata_len);
+
+/*
+ * Get IMDS metadata by key
+ * Expects metadata to be in a json object format.
+ * Sets flb_sds_t metadata string to the value associated with provided key.
+ * Sets flb_sds_t metadata string to "NULL" if key not found.
+ * Sets flb_sds_t metadata string to the full metadata value if key is NULL.
+ * Returns -1 on error, 0 on success.
+ */
+int flb_aws_imds_request_by_key(struct flb_aws_imds *ctx, const char *metadata_path,
+                                flb_sds_t *metadata, size_t *metadata_len, char *key);
+
+/*
+ * Get VPC id from EC2 IMDS. Requires multiple IMDS requests.
+ * Returns sds string encoding vpc_id.
+ * Note: Modified from AWS filter, not retested
+ */
+flb_sds_t flb_aws_imds_get_vpc_id(struct flb_aws_imds *ctx);
+
+#endif

--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -163,12 +163,6 @@ flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key);
 flb_sds_t flb_xml_get_val(char *response, size_t response_len, char *tag);
 
 /*
- * Request data from an IMDS path.
- */
-int flb_imds_request(struct flb_aws_client *client, char *metadata_path,
-                     flb_sds_t *metadata, size_t *metadata_len);
-
-/*
  * Checks if a response contains an AWS Auth error
  */
 int flb_aws_is_auth_error(char *payload, size_t payload_size);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ if(FLB_AWS)
     "aws/flb_aws_credentials.c"
     "aws/flb_aws_credentials_sts.c"
     "aws/flb_aws_credentials_ec2.c"
+    "aws/flb_aws_imds.c"
     "aws/flb_aws_credentials_http.c"
     "aws/flb_aws_credentials_profile.c"
     )

--- a/src/aws/flb_aws_imds.c
+++ b/src/aws/flb_aws_imds.c
@@ -1,0 +1,330 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/aws/flb_aws_imds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_jsmn.h>
+
+#define FLB_AWS_IMDS_ROOT "/"
+#define FLB_AWS_IMDS_V2_TOKEN_PATH "/latest/api/token"
+
+/* Request headers */
+static struct flb_aws_header imds_v2_token_ttl_header = {
+    .key = "X-aws-ec2-metadata-token-ttl-seconds",
+    .key_len = 36,
+    .val = "21600",  /* 6 hours (ie maximum ttl) */
+    .val_len = 5,
+};
+
+/* Request header templates */
+const static struct flb_aws_header imds_v2_token_token_header_template = {
+    .key = "X-aws-ec2-metadata-token",
+    .key_len = 24,
+    .val = "",     /* Replace with token value */
+    .val_len = 0,  /* Replace with token length */
+};
+
+/* Declarations */
+static int get_imds_version(struct flb_aws_imds *ctx);
+static int refresh_imds_v2_token(struct flb_aws_imds *ctx);
+
+/* Default config values */
+const struct flb_aws_imds_config flb_aws_imds_config_default = {
+    FLB_AWS_IMDS_VERSION_EVALUATE};
+
+/* Create IMDS context */
+struct flb_aws_imds *flb_aws_imds_create(const struct flb_aws_imds_config *imds_config,
+                                         struct flb_aws_client *ec2_imds_client)
+{
+    struct flb_aws_imds *ctx = NULL;
+
+    /* Create context */
+    ctx = flb_calloc(1, sizeof(struct flb_aws_imds));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+
+    /*
+     * Set IMDS version to whatever is specified in config
+     * Version may be evaluated later if set to FLB_AWS_IMDS_VERSION_EVALUATE
+     */
+    ctx->imds_version = imds_config->use_imds_version;
+    ctx->imds_v2_token = flb_sds_create_len("INVALID_TOKEN", 13);
+
+    /* Detect IMDS support */
+    if (!ec2_imds_client->upstream) {
+        flb_debug(
+            "[imds] unable to connect to EC2 IMDS. ec2_imds_client upstream is null");
+
+        flb_aws_imds_destroy(ctx);
+        return NULL;
+    }
+    if (0 != strncmp(ec2_imds_client->upstream->tcp_host, FLB_AWS_IMDS_HOST,
+                     FLB_AWS_IMDS_HOST_LEN)) {
+        flb_debug("[imds] ec2_imds_client tcp host must be set to %s", FLB_AWS_IMDS_HOST);
+        flb_aws_imds_destroy(ctx);
+        return NULL;
+    }
+    if (ec2_imds_client->upstream->tcp_port != FLB_AWS_IMDS_PORT) {
+        flb_debug("[imds] ec2_imds_client tcp port must be set to %i", FLB_AWS_IMDS_PORT);
+        flb_aws_imds_destroy(ctx);
+        return NULL;
+    }
+
+    /* Connect client */
+    ctx->ec2_imds_client = ec2_imds_client;
+    return ctx;
+}
+
+/* Destroy IMDS context */
+void flb_aws_imds_destroy(struct flb_aws_imds *ctx)
+{
+    if (ctx->imds_v2_token) {
+        flb_sds_destroy(ctx->imds_v2_token);
+    }
+
+    flb_free(ctx);
+}
+
+/* Get IMDS metadata */
+int flb_aws_imds_request(struct flb_aws_imds *ctx, const char *metadata_path,
+                         flb_sds_t *metadata, size_t *metadata_len)
+{
+    return flb_aws_imds_request_by_key(ctx, metadata_path, metadata, metadata_len, NULL);
+}
+
+/* Get IMDS metadata by key */
+int flb_aws_imds_request_by_key(struct flb_aws_imds *ctx, const char *metadata_path,
+                                flb_sds_t *metadata, size_t *metadata_len, char *key)
+{
+    int ret;
+    flb_sds_t tmp;
+
+    struct flb_http_client *c = NULL;
+
+    struct flb_aws_client *ec2_imds_client = ctx->ec2_imds_client;
+    struct flb_aws_header token_header = imds_v2_token_token_header_template;
+
+    /* Get IMDS version */
+    int imds_version = get_imds_version(ctx);
+
+    /* Abort on version detection failure */
+    if (imds_version == FLB_AWS_IMDS_VERSION_EVALUATE) {
+        /* Exit gracefully allowing for retrys */
+        flb_warn("[imds] unable to evaluate IMDS version");
+        return -1;
+    }
+
+    if (imds_version == FLB_AWS_IMDS_VERSION_2) {
+        token_header.val = ctx->imds_v2_token;
+        token_header.val_len = ctx->imds_v2_token_len;
+        flb_debug("[imds] using IMDSv2");
+    }
+    else {
+        flb_debug("[imds] using IMDSv1");
+    }
+
+    c = ec2_imds_client->client_vtable->request(
+        ec2_imds_client, FLB_HTTP_GET, metadata_path, NULL, 0, &token_header,
+        (imds_version == FLB_AWS_IMDS_VERSION_1) ? 0 : 1);
+    if (!c) {
+        /* Exit gracefully allowing for retrys */
+        flb_warn("[imds] failed to retrieve metadata");
+        return -1;
+    }
+
+    /* Detect invalid token */
+    if (imds_version == FLB_AWS_IMDS_VERSION_2 && c->resp.status == 401) {
+        /* Refresh token and retry request */
+        flb_http_client_destroy(c);
+        ret = refresh_imds_v2_token(ctx);
+        if (ret < 0) {
+            flb_debug("[imds] failed to refresh IMDSv2 token");
+            return -1;
+        }
+        token_header.val = ctx->imds_v2_token;
+        token_header.val_len = ctx->imds_v2_token_len;
+        flb_debug("[imds] refreshed IMDSv2 token");
+        c = ec2_imds_client->client_vtable->request(
+            ec2_imds_client, FLB_HTTP_GET, metadata_path, NULL, 0, &token_header, 1);
+    }
+
+    if (c->resp.status != 200) {
+        if (c->resp.payload_size > 0) {
+            flb_debug("[imds] metadata request failure response\n%s", c->resp.payload);
+        }
+        flb_http_client_destroy(c);
+        return -1;
+    }
+
+    if (key != NULL) {
+        /* get the value of the key from payload json string */
+        tmp = flb_json_get_val(c->resp.payload, c->resp.payload_size, key);
+        if (!tmp) {
+            tmp = flb_sds_create_len("NULL", 4);
+            flb_error("[imds] %s is undefined in EC2 instance", key);
+        }
+    }
+    else {
+        tmp = flb_sds_create_len(c->resp.payload, c->resp.payload_size);
+    }
+
+    if (!tmp) {
+        flb_errno();
+        flb_http_client_destroy(c);
+        return -1;
+    }
+
+    *metadata = tmp;
+    *metadata_len = key == NULL ? c->resp.payload_size : strlen(tmp);
+
+    flb_http_client_destroy(c);
+    return 0;
+}
+
+/* Get VPC Id */
+flb_sds_t flb_aws_imds_get_vpc_id(struct flb_aws_imds *ctx)
+{
+    int ret;
+    flb_sds_t mac_id = NULL;
+    size_t mac_len = 0;
+    flb_sds_t vpc_id = NULL;
+    size_t vpc_id_len = 0;
+
+    /* get EC2 instance Mac id first before getting VPC id */
+    ret = flb_aws_imds_request(ctx, FLB_AWS_IMDS_MAC_PATH, &mac_id, &mac_len);
+
+    if (ret < 0) {
+        flb_sds_destroy(mac_id);
+        return NULL;
+    }
+
+    /*
+     * the VPC full path should be like:
+     * latest/meta-data/network/interfaces/macs/{mac_id}/vpc-id/"
+     */
+    flb_sds_t vpc_path = flb_sds_create_size(70);
+    vpc_path =
+        flb_sds_printf(&vpc_path, "%s/%s/%s/",
+                       "/latest/meta-data/network/interfaces/macs", mac_id, "vpc-id");
+    ret = flb_aws_imds_request(ctx, vpc_path, &vpc_id, &vpc_id_len);
+
+    flb_sds_destroy(mac_id);
+    flb_sds_destroy(vpc_path);
+
+    return vpc_id;
+}
+
+/* Obtain the IMDS version */
+static int get_imds_version(struct flb_aws_imds *ctx)
+{
+    struct flb_aws_client *client = ctx->ec2_imds_client;
+    struct flb_aws_header invalid_token_header;
+    struct flb_http_client *c = NULL;
+
+    if (ctx->imds_version != FLB_AWS_IMDS_VERSION_EVALUATE) {
+        return ctx->imds_version;
+    }
+
+    /*
+     * Evaluate version
+     * To evaluate wether IMDSv2 is available, send an invalid token
+     * in IMDS request. If response status is 'Unauthorized', then IMDSv2
+     * is available.
+     */
+    invalid_token_header = imds_v2_token_token_header_template;
+    invalid_token_header.val = "INVALID";
+    invalid_token_header.val_len = 7;
+    c = client->client_vtable->request(client, FLB_HTTP_GET, FLB_AWS_IMDS_ROOT, NULL, 0,
+                                       &invalid_token_header, 1);
+
+    if (!c) {
+        return FLB_AWS_IMDS_VERSION_EVALUATE;
+    }
+
+    /* Unauthorized response means that IMDS version 2 is in use */
+    if (c->resp.status == 401) {
+        ctx->imds_version = FLB_AWS_IMDS_VERSION_2;
+        refresh_imds_v2_token(ctx);
+    }
+
+    /*
+     * Success means that IMDS version 1 is in use
+     * (Not Tested, TODO: Must test this on an instance without IMDSv2)
+     */
+    if (c->resp.status == 200) {
+        ctx->imds_version = FLB_AWS_IMDS_VERSION_1;
+    }
+
+    flb_http_client_destroy(c);
+    return ctx->imds_version;
+}
+
+/*
+ * Get an IMDSv2 token
+ * Token preserved in imds context
+ */
+static int refresh_imds_v2_token(struct flb_aws_imds *ctx)
+{
+    struct flb_http_client *c = NULL;
+    struct flb_aws_client *ec2_imds_client = ctx->ec2_imds_client;
+
+    c = ec2_imds_client->client_vtable->request(ec2_imds_client, FLB_HTTP_PUT,
+                                                FLB_AWS_IMDS_V2_TOKEN_PATH, NULL, 0,
+                                                &imds_v2_token_ttl_header, 1);
+
+    if (!c) {
+        return -1;
+    }
+
+    if (c->resp.status != 200) {
+        if (c->resp.payload_size > 0) {
+            flb_error("[imds] IMDSv2 token retrieval failure response\n%s",
+                      c->resp.payload);
+        }
+
+        flb_http_client_destroy(c);
+        return -1;
+    }
+
+    /* Preserve token information in ctx */
+    if (c->resp.payload_size > 0) {
+        if (ctx->imds_v2_token) {
+            flb_sds_destroy(ctx->imds_v2_token);
+        }
+        ctx->imds_v2_token = flb_sds_create_len(c->resp.payload, c->resp.payload_size);
+        if (!ctx->imds_v2_token) {
+            flb_errno();
+            flb_http_client_destroy(c);
+            return -1;
+        }
+        ctx->imds_v2_token_len = c->resp.payload_size;
+
+        flb_http_client_destroy(c);
+        return 0;
+    }
+
+    flb_debug("[imds] IMDS metadata response was empty");
+    flb_http_client_destroy(c);
+    return -1;
+}

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -598,53 +598,6 @@ flb_sds_t flb_json_get_val(char *response, size_t response_len, char *key)
     return error_type;
 }
 
-int flb_imds_request(struct flb_aws_client *client, char *metadata_path,
-                     flb_sds_t *metadata, size_t *metadata_len)
-{
-    struct flb_http_client *c = NULL;
-    flb_sds_t ec2_metadata;
-
-    flb_debug("[imds] Using instance metadata V1");
-    c = client->client_vtable->request(client, FLB_HTTP_GET,
-                                       metadata_path, NULL, 0,
-                                       NULL, 0);
-
-    if (!c) {
-        return -1;
-    }
-
-    if (c->resp.status != 200) {
-        if (c->resp.payload_size > 0) {
-            flb_debug("[ecs_imds] IMDS metadata response\n%s",
-                      c->resp.payload);
-        }
-
-        flb_http_client_destroy(c);
-        return -1;
-    }
-
-    if (c->resp.payload_size > 0) {
-        ec2_metadata = flb_sds_create_len(c->resp.payload,
-                                          c->resp.payload_size);
-
-        if (!ec2_metadata) {
-            flb_errno();
-            flb_http_client_destroy(c);
-            return -1;
-        }
-        *metadata = ec2_metadata;
-        *metadata_len = c->resp.payload_size;
-
-        flb_http_client_destroy(c);
-        return 0;
-    }
-
-    flb_debug("[ecs_imds] IMDS metadata response was empty");
-    flb_http_client_destroy(c);
-    return -1;
-
-}
-
 /* Generic replace function for strings. */
 static char* replace_uri_tokens(const char* original_string, const char* current_word,
                          const char* new_word)

--- a/tests/internal/aws_client_mock.c
+++ b/tests/internal/aws_client_mock.c
@@ -1,0 +1,256 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+#include "aws_client_mock.h"
+
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_http_client.h>
+
+/* Vtable mocked methods */
+static struct flb_http_client *flb_aws_client_mock_vtable_request(
+    struct flb_aws_client *aws_client, int method, const char *uri, const char *body,
+    size_t body_len, struct flb_aws_header *dynamic_headers, size_t dynamic_headers_len);
+
+/* Protected structs */
+
+/* flb_aws_client_mock pointer returned by mock_generator */
+static struct flb_aws_client_mock *flb_aws_client_mock_instance = NULL;
+
+/* Generator that returns clients with the test vtable */
+static struct flb_aws_client_generator mock_generator = {
+    .create = flb_aws_client_create_mock,
+};
+
+/* Test/mock flb_aws_client vtable */
+static struct flb_aws_client_vtable mock_client_vtable = {
+    .request = flb_aws_client_mock_vtable_request,
+};
+
+/*
+ * Configure generator
+ * Note: Automatically creates mock and wires to generator
+ *       Destroys any existing mock in generator
+ */
+void flb_aws_client_mock_configure_generator(
+    struct flb_aws_client_mock_request_chain *request_chain)
+{
+    if (flb_aws_client_mock_instance != NULL) {
+        flb_aws_client_mock_destroy(flb_aws_client_mock_instance);
+    }
+    flb_aws_client_mock_instance = flb_aws_client_mock_create(request_chain);
+}
+
+/*
+ * Clean up generator's memory
+ * Cleanup should be called on exiting generator
+ */
+void flb_aws_client_mock_destroy_generator()
+{
+    if (flb_aws_client_mock_instance != NULL) {
+        flb_aws_client_mock_destroy(flb_aws_client_mock_instance);
+    }
+}
+
+/* Create Mock of flb_aws_client */
+struct flb_aws_client_mock *flb_aws_client_mock_create(
+    struct flb_aws_client_mock_request_chain *request_chain)
+{
+    struct flb_aws_client_mock *mock = flb_calloc(1, sizeof(struct flb_aws_client_mock));
+
+    /* Create a surrogate aws_client and copy to mock client */
+    struct flb_aws_client *surrogate_aws_client = flb_aws_client_generator()->create();
+    mock->super = *surrogate_aws_client;
+    mock->surrogate = surrogate_aws_client;
+    memset(mock->surrogate, 0, sizeof(struct flb_aws_client));
+
+    /* Switch vtable to mock vtable */
+    mock->super.client_vtable = &mock_client_vtable;
+    mock->request_chain = request_chain;
+    mock->next_request_index = 0;
+    return mock;
+}
+
+/* Destroy flb_aws_client_mock */
+void flb_aws_client_mock_destroy(struct flb_aws_client_mock *mock)
+{
+    /* Remove from generator registry if stored */
+    if (flb_aws_client_mock_instance == mock) {
+        flb_aws_client_mock_instance = NULL;
+    }
+
+    /* Resurrect surrogate, and destroy flb_aws_client */
+    *mock->surrogate = mock->super;
+    flb_aws_client_destroy(mock->surrogate);
+
+    /* Destroy mock flb_aws_client */
+    flb_free(mock);
+}
+
+/* Return a Mocked flb_aws_client, ready for injection */
+struct flb_aws_client *flb_aws_client_mock_context(struct flb_aws_client_mock *mock)
+{
+    return (struct flb_aws_client *)mock;
+}
+
+/* Get the number of unused requests */
+int flb_aws_client_mock_count_unused_requests(struct flb_aws_client_mock *mock)
+{
+    return mock->request_chain->length - mock->next_request_index;
+}
+
+/* Set flb_aws_client_mock_instance used in mock generator */
+void flb_aws_client_mock_set_generator_instance(struct flb_aws_client_mock *mock)
+{
+    flb_aws_client_mock_instance = mock;
+}
+
+/* Set flb_aws_client_mock_instance used in mock generator */
+struct flb_aws_client_mock *flb_aws_client_mock_get_generator_instance(
+    struct flb_aws_client_mock *mock)
+{
+    return flb_aws_client_mock_instance = mock;
+}
+
+/* Get generator used in mock */
+struct flb_aws_client_generator *flb_aws_client_get_mock_generator()
+{
+    return &mock_generator;
+}
+
+/* Get the number of unused requests */
+int flb_aws_client_mock_generator_count_unused_requests()
+{
+    TEST_ASSERT(flb_aws_client_mock_instance != 0);
+    return flb_aws_client_mock_count_unused_requests(flb_aws_client_mock_instance);
+}
+
+/* Return the mock instance */
+struct flb_aws_client *flb_aws_client_create_mock()
+{
+    TEST_CHECK(flb_aws_client_mock_instance != NULL);
+    TEST_MSG(
+        "[aws_mock_client] Must initialize flb_aws_client_mock_instance before calling "
+        "flb_aws_client_create_mock()");
+    TEST_MSG(
+        "[aws_mock_client] This ouccurs when the generator is called, before tests are "
+        "initialized.");
+
+    return flb_aws_client_mock_context(flb_aws_client_mock_instance);
+}
+
+/* Mock request used by flb_aws_client mock */
+static struct flb_http_client *flb_aws_client_mock_vtable_request(
+    struct flb_aws_client *aws_client, int method, const char *uri, const char *body,
+    size_t body_len, struct flb_aws_header *dynamic_headers, size_t dynamic_headers_len)
+{
+    int ret;
+
+    /* Get access to mock */
+    struct flb_aws_client_mock *mock = (struct flb_aws_client_mock *)aws_client;
+
+    /* Check that a response is left in the chain */
+    ret = TEST_CHECK(mock->next_request_index < mock->request_chain->length);
+    if (!ret) {
+        TEST_MSG(
+            "[flb_aws_client_mock] %d mock responses provided. Attempting to call %d "
+            "times. Aborting.",
+            (int)mock->request_chain->length, (int)mock->next_request_index + 1);
+        return NULL;
+    }
+    struct flb_aws_client_mock_response *response =
+        &(mock->request_chain->responses[mock->next_request_index]);
+    struct flb_http_client *c = NULL;
+
+    /* create an http client so that we can set the response */
+    c = flb_calloc(1, sizeof(struct flb_http_client));
+    if (!c) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&c->headers);
+
+    /* Response configuration */
+    for (int i = 0; i < response->length; ++i) {
+        struct flb_aws_client_mock_response_config *response_config =
+            &(response->config_parameters[i]);
+        void *val1 = response_config->config_value;
+        void *val2 = response_config->config_value_2;
+
+        /* Expectations */
+        if (response_config->config_parameter == FLB_AWS_CLIENT_MOCK_EXPECT_HEADER) {
+            int header_found = FLB_FALSE;
+            /* Search for header in request */
+            for (int h = 0; h < dynamic_headers_len; ++h) {
+                ret = strncmp(dynamic_headers[h].key, (char *)val1,
+                              dynamic_headers[h].key_len);
+                if (ret == 0) {
+                    /* Check header value */
+                    ret = strncmp(dynamic_headers[h].val, (char *)val2,
+                                  dynamic_headers[h].val_len + 1);
+                    TEST_CHECK(ret == 0);
+                    TEST_MSG("[aws_mock_client] Expected Header: (%s: %s)", (char *)val1,
+                             (char *)val2);
+                    TEST_MSG("[aws_mock_client] Received Header: (%s: %s)", (char *)val1,
+                             dynamic_headers[h].val);
+
+                    header_found = FLB_TRUE;
+                }
+            }
+            TEST_CHECK(header_found);
+            TEST_MSG("[aws_mock_client] Expected Header: (%s: %s)", (char *)val1,
+                     (char *)val2);
+            TEST_MSG("[aws_mock_client] Header not received");
+        }
+        else if (response_config->config_parameter == FLB_AWS_CLIENT_MOCK_EXPECT_METHOD) {
+            char *flb_http_methods[] = {
+                "FLB_HTTP_GET",  "FLB_HTTP_POST",    "FLB_HTTP_PUT",
+                "FLB_HTTP_HEAD", "FLB_HTTP_CONNECT", "FLB_HTTP_PATCH",
+            };
+
+            /*
+             * Check method is what is expected
+             * Typecast config value from void * -> int
+             */
+            TEST_CHECK(method == (int)(uintptr_t)val1);
+            TEST_MSG("[aws_mock_client] Expected HTTP Method: %s",
+                     flb_http_methods[(int)(uintptr_t)val1]);
+            TEST_MSG("[aws_mock_client] Received HTTP Method: %s",
+                     flb_http_methods[method]);
+        }
+        else if (response_config->config_parameter ==
+                 FLB_AWS_CLIENT_MOCK_EXPECT_HEADER_COUNT) {
+            TEST_CHECK(dynamic_headers_len == (int)(uintptr_t)val1);
+            TEST_MSG("[aws_mock_client] Expected %d Headers", (int)(uintptr_t)val1);
+            TEST_MSG("[aws_mock_client] Received %d Headers",
+                     (int)(uintptr_t)dynamic_headers_len);
+        }
+        else if (response_config->config_parameter == FLB_AWS_CLIENT_MOCK_EXPECT_URI) {
+            ret = strncmp(uri, (char *)val1, strlen((char *)val1) + 1);
+            TEST_CHECK(ret == 0);
+            TEST_MSG("[aws_mock_client] Expected URI: %s", (char *)val1);
+            TEST_MSG("[aws_mock_client] Received URI: %s", uri);
+        }
+
+        /* Replace response client */
+        else if (response_config->config_parameter ==
+                 FLB_AWS_CLIENT_MOCK_CONFIG_REPLACE) {
+            flb_http_client_destroy(c);
+            c = (struct flb_http_client *)val1;
+        }
+
+        /*
+        * Response setters
+        * Set client fields using XMacro definitions
+        */
+#define EXPAND_CLIENT_RESPONSE_PARAMETER(lower, UPPER, type)                           \
+        else if (response_config->config_parameter == FLB_AWS_CLIENT_MOCK_SET_##UPPER) \
+        {                                                                              \
+            c->resp.lower = CONVERT_##type((char *)val1);                              \
+        }
+#include "aws_client_mock_client_resp.def"
+#undef EXPAND_CLIENT_RESPONSE_PARAMETER
+    }
+
+    /* Increment request */
+    ++mock->next_request_index;
+
+    return c;
+};

--- a/tests/internal/aws_client_mock.h
+++ b/tests/internal/aws_client_mock.h
@@ -1,0 +1,223 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ * AWS Client Mock
+ *
+ * Note: AWS Client Mock is not intended to be used with asynchronously
+ * running tests. A mock instance is stored and retrieved by
+ * the mock generator
+ */
+
+/*
+ * FLB_AWS_CLIENT_MOCK() definition
+ * The following macro FLB_AWS_CLIENT_MOCK() translates a request definition
+ * into a c compound literal, which constructs a mock request chain
+ * at the block scope.
+
+ * The following translation might ouccur:
+
+    FLB_AWS_CLIENT_MOCK(
+        response(
+            expect("token", "aws_token")
+            expect("time", "123456")
+            set(STATUS, 200),
+        ),
+        response(
+            set(STATUS, 200),
+        )
+    )
+
+ * ^^^^^^^^^^^^^^^^^^^^^^^^^
+ * *~~~> Translates to ~~~>*
+ * *vvvvvvvvvvvvvvvvvvvvvvv*
+
+    &(struct flb_aws_client_mock_request_chain){
+        2,
+        ((struct flb_aws_client_mock_response[]) { // Mock request chain
+            {
+                3,
+                (struct flb_aws_client_mock_response_config[]){
+                    ((struct flb_aws_client_mock_response_config) { // Response
+ configuration FLB_AWS_CLIENT_MOCK_EXPECT_HEADER, (void *) "token", (void *) "aws_token"
+                    }),
+                    ((struct flb_aws_client_mock_response_config)
+                        { FLB_AWS_CLIENT_MOCK_EXPECT_HEADER,
+                            (void *) "time",
+                            (void *) "123456"
+                        }
+                    )
+                    ((struct flb_aws_client_mock_response_config) { // Response
+ configuration FLB_AWS_CLIENT_MOCK_SET_STATUS, (void *) 200, (void *) 0
+                    }),
+                }
+            },
+            {
+                1,
+                &(struct flb_aws_client_mock_response_config) {
+                    FLB_AWS_CLIENT_MOCK_SET_STATUS,
+                    (void *) 200,
+                    (void *) 0
+                }
+            }
+        })
+    }
+*/
+
+#ifndef AWS_CLIENT_MOCK_H
+#define AWS_CLIENT_MOCK_H
+
+/* Variadic Argument Counter, Counts up to 64 variadic args */
+#define FLB_AWS_CLIENT_MOCK_COUNT64(...)                                                 \
+    _FLB_AWS_CLIENT_MOCK_COUNT64(dummy, ##__VA_ARGS__, 63, 62, 61, 60, 59, 58, 57, 56,   \
+                                 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, \
+                                 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, \
+                                 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, \
+                                 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define _FLB_AWS_CLIENT_MOCK_COUNT64(                                                    \
+    x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, \
+    x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31, x32, x33, x34, x35, \
+    x36, x37, x38, x39, x40, x41, x42, x43, x44, x45, x46, x47, x48, x49, x50, x51, x52, \
+    x53, x54, x55, x56, x57, x58, x59, x60, x61, x62, x63, count, ...)                   \
+    count
+
+#define FLB_AWS_CLIENT_MOCK_EVAL(...) __VA_ARGS__
+#define FLB_AWS_CLIENT_MOCK_EMPTY()
+#define FLB_AWS_CLIENT_MOCK_DIFER(...) \
+    FLB_AWS_CLIENT_MOCK_EVAL FLB_AWS_CLIENT_MOCK_EMPTY()(__VA_ARGS__)
+
+/* Make block-scope addressable compound-literal request chain */
+#define FLB_AWS_CLIENT_MOCK(...)                                          \
+    FLB_AWS_CLIENT_MOCK_EVAL(&(struct flb_aws_client_mock_request_chain){ \
+        FLB_AWS_CLIENT_MOCK_COUNT64(__VA_ARGS__),                         \
+        (struct flb_aws_client_mock_response[]){__VA_ARGS__}})
+
+#define FLB_AWS_CLIENT_MOCK_RESPONSE(...)                  \
+    {                                                      \
+        FLB_AWS_CLIENT_MOCK_COUNT64(__VA_ARGS__),          \
+            (struct flb_aws_client_mock_response_config[]) \
+        {                                                  \
+            __VA_ARGS__                                    \
+        }                                                  \
+    }
+
+#define FLB_AWS_CLIENT_MOCK_VFUNC___(name, n) name##n
+#define FLB_AWS_CLIENT_MOCK_VFUNC(name, n) FLB_AWS_CLIENT_MOCK_VFUNC___(name, n)
+
+#define FLB_AWS_CLIENT_MOCK_STAGE_CONFIG(mode, parameter, value, ...) \
+    ((struct flb_aws_client_mock_response_config){                    \
+        FLB_AWS_CLIENT_MOCK_##mode##parameter, (void *)value,         \
+        FLB_AWS_CLIENT_MOCK_VFUNC(                                    \
+            FLB_AWS_CLIENT_MOCK_STAGE_CONFIG_OPTIONAL_VALUES_,        \
+            FLB_AWS_CLIENT_MOCK_COUNT64(__VA_ARGS__))(__VA_ARGS__)})
+
+#define FLB_AWS_CLIENT_MOCK_STAGE_CONFIG_OPTIONAL_VALUES_1(value) (void *)value
+#define FLB_AWS_CLIENT_MOCK_STAGE_CONFIG_OPTIONAL_VALUES_0() (void *)0
+
+// DIFER() allows for correct arg count
+#define response(...) FLB_AWS_CLIENT_MOCK_DIFER(FLB_AWS_CLIENT_MOCK_RESPONSE(__VA_ARGS__))
+#define expect(...) \
+    FLB_AWS_CLIENT_MOCK_DIFER(FLB_AWS_CLIENT_MOCK_STAGE_CONFIG(EXPECT_, __VA_ARGS__))
+#define config(...) \
+    FLB_AWS_CLIENT_MOCK_DIFER(FLB_AWS_CLIENT_MOCK_STAGE_CONFIG(CONFIG_, __VA_ARGS__))
+#define set(...) \
+    FLB_AWS_CLIENT_MOCK_DIFER(FLB_AWS_CLIENT_MOCK_STAGE_CONFIG(SET_, __VA_ARGS__))
+
+/* Includes */
+#include <fluent-bit/flb_aws_util.h>
+
+#include "../lib/acutest/acutest.h"
+
+/* Enum */
+enum flb_aws_client_mock_response_config_parameter {
+    FLB_AWS_CLIENT_MOCK_EXPECT_METHOD,  // int: FLB_HTTP_<method> where method = { "GET",
+                                        // "POST", "PUT", "HEAD", "CONNECT", "PATCH" }
+    FLB_AWS_CLIENT_MOCK_EXPECT_HEADER,  // (string, string): (header key, header value)
+    FLB_AWS_CLIENT_MOCK_EXPECT_HEADER_COUNT,  // int: header count
+    FLB_AWS_CLIENT_MOCK_EXPECT_URI,           // string: uri
+    FLB_AWS_CLIENT_MOCK_CONFIG_REPLACE,  // flb_http_client ptr. Client can be null if
+                                         // needed
+// Define all client fields using XMacro definitions
+#define EXPAND_CLIENT_RESPONSE_PARAMETER(x, UPPER, y) FLB_AWS_CLIENT_MOCK_SET_##UPPER,
+#include "aws_client_mock_client_resp.def"
+#undef EXPAND_CLIENT_RESPONSE_PARAMETER
+};
+
+/* Structs */
+struct flb_aws_client_mock_response_config {
+    enum flb_aws_client_mock_response_config_parameter config_parameter;
+    void *config_value;  // Most configuration must be passed in string format.
+    void *config_value_2;
+};
+
+struct flb_aws_client_mock_response {
+    size_t length;
+    struct flb_aws_client_mock_response_config *config_parameters;
+};
+
+struct flb_aws_client_mock_request_chain {
+    size_t length;
+    struct flb_aws_client_mock_response *responses;
+};
+
+struct flb_aws_client_mock {
+    /* This member must come first in the struct's memory layout
+     * so that this struct can mock flb_aws_client context */
+    struct flb_aws_client super;
+    struct flb_aws_client *surrogate;
+
+    /* Additional data members added to mock */
+    struct flb_aws_client_mock_request_chain *request_chain;
+    size_t next_request_index;
+};
+
+/* Declarations */
+
+/*
+ * Configure mock generator to be returned by flb_aws_client_get_mock_generator()
+ * Generator is injected into credential providers and returns a mocked
+ * flb_aws_client instance.
+ *
+ * Note: Automatically creates mock and wires to generator
+ *       Destroys any existing mock in generator
+ */
+void flb_aws_client_mock_configure_generator(
+    struct flb_aws_client_mock_request_chain *request_chain);
+
+/*
+ * Clean up generator memory
+ * Note: Cleanup should be called at the end of each test
+ */
+void flb_aws_client_mock_destroy_generator();
+
+/* Create Mock of flb_aws_client */
+struct flb_aws_client_mock *flb_aws_client_mock_create(
+    struct flb_aws_client_mock_request_chain *request_chain);
+
+/*
+ * Destroy flb_aws_client_mock
+ * Note: flb_aws_client_destroy must not be used prior to flb_aws_client_mock_destroy.
+ */
+void flb_aws_client_mock_destroy(struct flb_aws_client_mock *mock);
+
+/* Get the number of unused requests */
+int flb_aws_client_mock_count_unused_requests(struct flb_aws_client_mock *mock);
+
+/* Return a Mocked flb_aws_client, ready for injection */
+struct flb_aws_client *flb_aws_client_mock_context(struct flb_aws_client_mock *mock);
+
+/* Generator Methods */
+/* Get/set flb_aws_client_mock_instance used by mock generator */
+void flb_aws_client_mock_set_generator_instance(struct flb_aws_client_mock *mock);
+struct flb_aws_client_mock *flb_aws_client_mock_get_generator_instance(
+    struct flb_aws_client_mock *mock);
+
+int flb_aws_client_mock_generator_count_unused_requests();
+
+/* Substitute Methods */
+/* Get generator used in mock */
+struct flb_aws_client_generator *flb_aws_client_get_mock_generator();
+
+/* Return the mock instance */
+struct flb_aws_client *flb_aws_client_create_mock();
+
+#endif /* AWS_CLIENT_MOCK_H */

--- a/tests/internal/aws_client_mock_client_resp.def
+++ b/tests/internal/aws_client_mock_client_resp.def
@@ -1,0 +1,34 @@
+/* XMacro Definition for Mock AWS Client http_client Response */
+
+/* Converters: CONVERT_<C_INT> */
+#define EVAL1(...) __VA_ARGS__
+#define CONVERT_T_INT(str)          (int) (uintptr_t) str
+#define CONVERT_T_SIZE_T(str)       (size_t) str
+#define CONVERT_T_LONG(str)         (long) str
+#define CONVERT_T_CHAR_STAR(str)    str
+
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(status,                STATUS,                 T_INT))          /* HTTP response status          */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(content_length,        CONTENT_LENGTH,         T_INT))          /* Content length set by headers */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(chunked_encoding,      CHUNKED_ENCODEING,      T_INT))          /* Chunked transfer encoding ?   */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(connection_close,      CONNECTION_CLOSE,       T_INT))          /* connection: close ?           */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(chunked_cur_size,      CHUNKED_CUR_SIZE,       T_LONG))
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(chunked_exp_size,      CHUNKED_EXP_SIZE,       T_LONG))         /* expected chunked size         */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(chunk_processed_end,   CHUNK_PROCESSED_END,    T_CHAR_STAR))    /* Position to mark last chunk   */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(headers_end,           HEADERS_END,            T_CHAR_STAR))    /* Headers end (\r\n\r\n)        */
+
+/* Payload: body response: reference to 'data' */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(payload,               PAYLOAD,                T_CHAR_STAR))
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(payload_size,          PAYLOAD_SIZE,           T_SIZE_T))
+
+/* Buffer to store server response */
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(data,                  DATA,                   T_CHAR_STAR))
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(data_len,              DATA_LEN,               T_SIZE_T))
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(data_size,             DATA_SIZE,              T_SIZE_T))
+EVAL1(EXPAND_CLIENT_RESPONSE_PARAMETER(data_size_max,         DATA_SIZE_MAX,          T_SIZE_T))
+
+#undef CONVERT_T_INT
+#undef CONVERT_T_SIZE
+#undef CONVERT_T_LONG
+#undef CONVERT_T_CHAR_STAR
+
+#undef EVAL1

--- a/tests/internal/aws_credentials_ec2.c
+++ b/tests/internal/aws_credentials_ec2.c
@@ -1,10 +1,17 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
+#include "aws_client_mock.h"
+#include "aws_client_mock.c"
+
+#include <fluent-bit.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/aws/flb_aws_imds.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_log.h>
 
 #include <monkey/mk_core.h>
 #include <string.h>
@@ -12,291 +19,153 @@
 
 #include "flb_tests_internal.h"
 
-#define ACCESS_KEY_EC2 "ec2_akid"
-#define SECRET_KEY_EC2 "ec2_skid"
-#define TOKEN_EC2      "ec2_token"
+/* Global variables for tests */
+struct flb_aws_provider *provider;
+struct flb_aws_credentials *creds;
+struct flb_config *config;
+struct flb_config *config_fluent;
+int ret;
 
-#define EC2_CREDENTIALS_RESPONSE "{\n\
-    \"AccessKeyId\": \"ec2_akid\",\n\
-    \"Expiration\": \"2025-10-24T23:00:23Z\",\n\
-    \"RoleArn\": \"EC2_ROLE_ARN\",\n\
-    \"SecretAccessKey\": \"ec2_skid\",\n\
-    \"Token\": \"ec2_token\"\n\
-}"
-
-/*
- * Unexpected/invalid response. The goal of this is not to test anything
- * that might happen in production, but rather to test the error handling
- * code for the providers. This helps ensure all code paths are tested and
- * the error handling code does not introduce memory leaks.
+/* 
+ * Hardcoding a copy of the ec2 credential provider struct from flb_aws_credentials_ec2.c
+ * Note: this will require a change if the other copy is changed.
+ * A provider that obtains credentials from EC2 IMDS.
  */
-#define MALFORMED_RESPONSE "some complete garbage that is not expected"
-
-#define EC2_TOKEN_RESPONSE     "AQAEAGB5i7Jq-RWC7OFZcjSs3Y5uxo06c5VB1vtYIOyVA=="
-#define EC2_ROLE_NAME_RESPONSE "my-role-Ec2InstanceRole-1CBV45ZZHA1E5"
-
-/*
- * Global variable to track number of http requests made.
- * This ensures credentials are being cached properly.
- */
-int g_request_count;
-
-struct flb_http_client * ec2_role_name_response(struct flb_aws_client *aws_client,
-                                                int method, const char *uri,
-                                                size_t dynamic_headers_len)
-{
-    struct flb_http_client *c = NULL;
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(dynamic_headers_len == 0);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = EC2_ROLE_NAME_RESPONSE;
-    c->resp.payload_size = strlen(EC2_ROLE_NAME_RESPONSE);
-
-    return c;
-}
-
-struct flb_http_client *ec2_credentials_response(struct flb_aws_client *aws_client,
-                                                 int method, const char *uri,
-                                                 size_t dynamic_headers_len)
-{
-    struct flb_http_client *c = NULL;
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(dynamic_headers_len == 0);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = EC2_CREDENTIALS_RESPONSE;
-    c->resp.payload_size = strlen(EC2_CREDENTIALS_RESPONSE);
-
-    return c;
-}
-
-/* test/mock version of the aws_http_client request function */
-struct flb_http_client *test_http_client_request(struct flb_aws_client *aws_client,
-                                                 int method, const char *uri,
-                                                 const char *body, size_t body_len,
-                                                 struct flb_aws_header *dynamic_headers,
-                                                 size_t dynamic_headers_len)
-{
-    g_request_count++;
-    /*
-     * route to the correct response fn using the uri
-     */
-     if (strstr(uri, "latest/meta-data/iam/security-credentials/"
-                            "my-role-Ec2InstanceRole-1CBV45ZZHA1E5") != NULL) {
-         return ec2_credentials_response(aws_client, method, uri,
-                                         dynamic_headers_len);
-     }
-     else if (strstr(uri, "latest/meta-data/iam/security-credentials") != NULL)
-     {
-         return ec2_role_name_response(aws_client, method, uri,
-                                       dynamic_headers_len);
-     }
-
-    /* uri should match one of the above conditions */
-    flb_errno();
-    return NULL;
-
-}
-
-/* Test/mock aws_http_client */
-static struct flb_aws_client_vtable test_vtable = {
-    .request = test_http_client_request,
-};
-
-struct flb_aws_client *test_http_client_create()
-{
-    struct flb_aws_client *client = flb_calloc(1,
-                                                sizeof(struct flb_aws_client));
-    if (!client) {
-        flb_errno();
-        return NULL;
-    }
-    client->client_vtable = &test_vtable;
-    return client;
-}
-
-/* Generator that returns clients with the test vtable */
-static struct flb_aws_client_generator test_generator = {
-    .create = test_http_client_create,
-};
-
-struct flb_aws_client_generator *generator_in_test()
-{
-    return &test_generator;
-}
-
-/* test/mock version of the aws_http_client request function */
-struct flb_http_client *malformed_http_client_request(struct flb_aws_client
-                                                      *aws_client,
-                                                      int method, const char *uri,
-                                                      const char *body,
-                                                      size_t body_len,
-                                                      struct flb_aws_header
-                                                      *dynamic_headers,
-                                                      size_t dynamic_headers_len)
-{
-    struct flb_http_client *c = NULL;
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = MALFORMED_RESPONSE;
-    c->resp.payload_size = strlen(MALFORMED_RESPONSE);
-
-    return c;
-
-}
-
-/* Test/mock aws_http_client */
-static struct flb_aws_client_vtable malformed_vtable = {
-    .request = malformed_http_client_request,
-};
-
-struct flb_aws_client *malformed_http_client_create()
-{
-    struct flb_aws_client *client = flb_calloc(1, sizeof(struct flb_aws_client));
-    if (!client) {
-        flb_errno();
-        return NULL;
-    }
-    client->client_vtable = &malformed_vtable;
-    return client;
-}
-
-/* Generator that returns clients with the test vtable */
-static struct flb_aws_client_generator malformed_generator = {
-    .create = malformed_http_client_create,
-};
-
-struct flb_aws_client_generator *generator_malformed()
-{
-    return &malformed_generator;
-}
-
-/* Error case mock - uses a different client and generator than happy case */
-struct flb_http_client *test_http_client_error_case(struct flb_aws_client
-                                                    *aws_client,
-                                                    int method, const char *uri,
-                                                    const char *body,
-                                                    size_t body_len,
-                                                    struct flb_aws_header
-                                                    *dynamic_headers,
-                                                    size_t dynamic_headers_len)
-{
-    /* create an http client so that we can set the response */
-    struct flb_http_client *c = NULL;
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 500;
-    c->resp.payload = "error";
-    c->resp.payload_size = 5;
-
-    return c;
-
-}
-
-/* Test/mock aws_http_client */
-static struct flb_aws_client_vtable error_case_vtable = {
-    .request = test_http_client_error_case,
-};
-
-struct flb_aws_client *test_http_client_create_error_case()
-{
-    struct flb_aws_client *client = flb_calloc(1,
-                                                sizeof(struct flb_aws_client));
-    if (!client) {
-        flb_errno();
-        return NULL;
-    }
-    client->client_vtable = &error_case_vtable;
-    return client;
-}
-
-/* Generator that returns clients with the test vtable */
-static struct flb_aws_client_generator error_case_generator = {
-    .create = test_http_client_create_error_case,
-};
-
-struct flb_aws_client_generator *generator_in_test_error_case()
-{
-    return &error_case_generator;
-}
-
-static void test_ec2_provider_v1()
-{
-    struct flb_aws_provider *provider;
+struct flb_aws_provider_ec2 {
     struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
+    time_t next_refresh;
 
-    g_request_count = 0;
+    /* upstream connection to IMDS */
+    struct flb_aws_client *client;
+    
+    /* IMDS interface */
+    struct flb_aws_imds *imds_interface;
+};
 
+/*
+ * Setup test & Initialize test environment
+ * Required for fluent bit debug logs
+ * Note: Log level definitions do not work.
+ * Example: config_fluent->verbose = FLB_LOG_OFF
+ */
+void setup_test(struct flb_aws_client_mock_request_chain *request_chain) {
+    /* Initialize test environment */
+    config_fluent = flb_config_init();
+    
+    flb_aws_client_mock_configure_generator(request_chain);
+
+    /* Init provider */
     config = flb_calloc(1, sizeof(struct flb_config));
-    if (!config) {
-        flb_errno();
-        return;
-    }
-
+    TEST_ASSERT(config != NULL);
     mk_list_init(&config->upstreams);
+    provider = flb_ec2_provider_create(config, flb_aws_client_get_mock_generator());
+    TEST_ASSERT(provider != NULL);
+}
 
-    provider = flb_ec2_provider_create(config, generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        return;
+/* Test clean up */
+void cleanup_test() {
+    flb_aws_client_mock_destroy_generator();
+    if (provider != NULL) {
+        ((struct flb_aws_provider_ec2 *) (provider->implementation))->client = NULL;
+        flb_aws_provider_destroy(provider);
+        provider = NULL;
     }
+    if (config != NULL) {
+        flb_free(config);
+    }
+    if (config_fluent != NULL) {
+        flb_config_exit(config_fluent);
+        config_fluent = NULL;
+    }
+}
 
-    /* repeated calls to get credentials should return the same set */
+/*
+ * IMDSv2 -- Test Summary
+ *  First call to get_credentials():
+ *  -> 2 requests are made to obtain IMDSv2 token
+ *  -> 2 requests are made to access credentials
+ *  Second call to get_credentials() hits cache:
+ *  -> 0 requests are made
+ *  refresh():
+ *  -> 2 requests are made to access credentials
+ */
+static void test_ec2_provider_v2()
+{
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        /* First call to get_credentials() */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 401)
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),  /* Expires Year 3021 */
+            set(PAYLOAD_SIZE, 257)
+        ),
+
+        /* Second call to get_credentials() hits cache */
+
+        /* Refresh credentials (No token refesh) */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name_New"),
+            set(PAYLOAD_SIZE, 20)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name_New"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"), // Expires Year 3021
+            set(PAYLOAD_SIZE, 257)
+        )
+    ));
+
+    /* Repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_EC2, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_EC2, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_EC2, creds->session_token) == 0);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
     flb_aws_credentials_destroy(creds);
 
+    /* Retrieve from cache */
     creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_EC2, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_EC2, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_EC2, creds->session_token) == 0);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
     flb_aws_credentials_destroy(creds);
 
@@ -304,96 +173,711 @@ static void test_ec2_provider_v1()
     ret = provider->provider_vtable->refresh(provider);
     TEST_CHECK(ret == 0);
 
-    /*
-     * 2 requests are made with v1 for the first call to get_credentials.
-     * The second call hits cache. The call to refresh leads to 2 more calls.
-     *
-     */
-    TEST_CHECK(g_request_count == 4);
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
-    flb_aws_provider_destroy(provider);
-    flb_free(config);
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test();
 }
 
-static void test_ec2_provider_error_case()
+/*
+ * IMDSv1 -- Fallback Test Summary
+ *  First call to get_credentials():
+ *  -> 1 requests is made to test for IMDSv2
+ *  -> 2 requests are made to access credentials
+ *  Second call to get_credentials() hits cache
+ *  -> 0 requests are made
+ *  refresh():
+ *  -> 2 requests are made to access credentials
+ */
+static void test_ec2_provider_v1()
 {
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        /* First call to get_credentials() */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(HEADER_COUNT, 1),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),  /* Expires Year 3021 */
+            set(PAYLOAD_SIZE, 257)
+        ),
 
-    config = flb_calloc(1, sizeof(struct flb_config));
-    if (!config) {
-        flb_errno();
-        return;
-    }
+        /* Second call to get_credentials() hits cache */
 
-    mk_list_init(&config->upstreams);
+        /* Refresh credentials (No token refesh) */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name_New"),
+            set(PAYLOAD_SIZE, 20)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name_New"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"), // Expires Year 3021
+            set(PAYLOAD_SIZE, 257)
+        )
+    ));
 
-    provider = flb_ec2_provider_create(config, generator_in_test_error_case());
-
-    if (!provider) {
-        flb_errno();
-        return;
-    }
-
-    /* get_credentials will fail */
+    /* Repeated calls to get credentials should return the same set */
     creds = provider->provider_vtable->get_credentials(provider);
-    TEST_CHECK(creds == NULL);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
     creds = provider->provider_vtable->get_credentials(provider);
-    TEST_CHECK(creds == NULL);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
-    /* refresh should return -1 (failure) */
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
     ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret < 0);
+    TEST_CHECK(ret == 0);
 
-    flb_aws_provider_destroy(provider);
-    flb_free(config);
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test();
 }
 
-/* unexpected output test- see description for MALFORMED_RESPONSE */
-static void test_ec2_provider_malformed_case()
+
+/*
+ * IMDS Version Detection Error -- Test Summary
+ *  First call to get_credentials():
+ *  -> 1 request made to test for IMDSv2 (Fails, 404)
+ *  Second call to get_credentials():
+ *  -> 1 request made to test for IMDSv2 (Fails, null http_client)
+ *  Third call to get_credentials():
+ *  -> 1 request made to test for IMDSv2 (Success)
+ *  -> 1 request made to get token (Failure)
+ *  Fourth call to get_credentials():
+ *  -> 2 requests made to obtain IMDSv2 token (Success)
+ *  -> 2 requests made to access credentials (Success)
+ */
+static void test_ec2_provider_version_detection_error()
 {
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        /* First call to get_credentials(): Version detection failure */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(HEADER_COUNT, 1),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 404) // IMDS not found (not likely to happen)
+        ),
 
-    config = flb_calloc(1, sizeof(struct flb_config));
-    if (!config) {
-        flb_errno();
-        return;
-    }
+        /* Second call to get_credentials(): Version detection failure */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(METHOD, FLB_HTTP_GET),
+            config(REPLACE, (struct flb_http_client *) NULL)
+        ),
 
-    mk_list_init(&config->upstreams);
+        /* Third call to get_credentials(): Version detection success */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 401)
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)            
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),  /* Expires Year 3021 */
+            set(PAYLOAD_SIZE, 257)
+        )
+    ));
 
-    provider = flb_ec2_provider_create(config, generator_malformed());
-
-    if (!provider) {
-        flb_errno();
-        return;
-    }
-
-    /* get_credentials will fail */
+    /* Version detection failure: Status 404 */
     creds = provider->provider_vtable->get_credentials(provider);
     TEST_CHECK(creds == NULL);
 
+    /* Version detection failure: NULL response */
     creds = provider->provider_vtable->get_credentials(provider);
     TEST_CHECK(creds == NULL);
 
-    /* refresh should return -1 (failure) */
-    ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret < 0);
+    /* Version detection success: IMDSv2 */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
 
-    flb_aws_provider_destroy(provider);
-    flb_free(config);
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test();
+}
+
+/*
+ * IMDS Aquire Token Error -- Test Summary
+ *  First call to get_credentials():
+ *  -> 1 request made to test for IMDSv2 (Success)
+ *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+ *  -> 1 requests are made to access credential (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+ *  Second call to get_credentials():
+ *  -> 1 request made to access instance name (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Success)
+ *  -> 1 request made to access instance name (Success)
+ *  -> 1 request made to access credentials (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+ *  Third call to get_credentials():
+ *  -> 1 request made to access instance name (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Success)
+ *  -> 1 request made to access instance name (Success)
+ *  -> 1 request made to access credentials (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Success)
+ *  -> 1 request made to access credentials (Success, but credentials are expired as of Year 2000)
+ *  Fourth call to get_credentials(): - hits expired cache
+ *  -> 1 request made to access credentials (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (http_client is null) <-* Aquire token error
+ *  Fifth call to get_credentials(): - hits expired cache
+ *  -> 1 request made to access credentials (Invalid token)
+ *  -> 1 request made to obtain IMDSv2 token (Success)
+ *  -> 2 requests are made to access credentials
+ */
+static void test_ec2_provider_acquire_token_error()
+{
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        
+        /*
+         *  First call to get_credentials():
+         *  -> 1 request made to test for IMDSv2 (Success)
+         *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+         *  -> 1 requests are made to access credential (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+         */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"), /* Why is this not invalid_token? */
+            expect(HEADER_COUNT, 1),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 401) /* IMDSv2 */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            config(REPLACE, NULL) /* HTTP Client is null */
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID_TOKEN"), /* Token failed to be set */
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200), /* Unauthorized, bad token */
+            set(PAYLOAD, ""),
+            set(PAYLOAD_SIZE, 0) /* Aquire token failure 2: no token in response */
+        ),
+
+        /*
+         *  Second call to get_credentials():
+         *  -> 1 request made to access instance name (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Success)
+         *  -> 1 request made to access instance name (Success)
+         *  -> 1 request made to access credentials (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Fails) <-* Aquire token error
+         */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID_TOKEN"), /* Token failed to be set */
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 404), /* This should never actually happen */
+            set(PAYLOAD, "Token not found"),
+            set(PAYLOAD_SIZE, 15)
+        ),
+
+        /*
+         *  Third call to get_credentials():
+         *  -> 1 request made to access instance name (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Success)
+         *  -> 1 request made to access instance name (Success)
+         *  -> 1 request made to access credentials (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Success)
+         *  -> 1 request made to access credentials (Success, but credentials are expired as of Year 2000)
+         */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="), /* Token failed to be set */
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"2000-09-17T00:41:00Z\"\n}"),  /* Expires Year 2000 */
+            set(PAYLOAD_SIZE, 257)
+        ),
+
+        /*
+         *  Fourth call to get_credentials(): - hits expired cache
+         *  -> 1 request made to access credentials (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (http_client is null) <-* Aquire token error
+         */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            config(REPLACE, NULL) /* HTTP Client is null */
+        ),
+
+        /*
+         *  Fifth call to get_credentials(): - hits expired cache
+         *  -> 1 request made to access credentials (Invalid token)
+         *  -> 1 request made to obtain IMDSv2 token (Success)
+         *  -> 2 requests are made to access credentials
+         */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 401) /* Unauthorized, bad token */
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),  /* Expires Year 3021 */
+            set(PAYLOAD_SIZE, 257)
+        )
+    ));
+
+    /* 1. Aquire token error */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* 2. Aquire token error */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* 3. Aquire token success */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* 4. Aquire token error */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds); /* Remains unchanged */
+
+    /* 5. Aquire token success */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test();
+}
+
+/*
+ * IMDS Metadata Request Failure -- Test Summary
+ *  First call to get_credentials():
+ *  -> 2 requests are made to obtain IMDSv2 token
+ *  -> 1 request is made to access instance name (fails, null client)
+ *  Second call to get_credentials(): -- token cached
+ *  -> 1 request is made to access instance name (success)
+ *  -> 1 request is made to access credentials (fails, 404)
+ *  Third call to get_credentials(): -- token cached
+ *  -> 1 request is made to access instance name
+ *  -> 1 request is made to access credentials (fails, garbage fuzz input)
+ *  Fourth call to get_credentials(): -- token cached
+ *  -> 1 request is made to access instance name
+ *  -> 1 request is made to access credentials (success)
+ */
+static void test_ec2_provider_metadata_request_error()
+{
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        /* First call to get_credentials() */
+        response(
+            expect(URI, "/"),
+            expect(HEADER, "X-aws-ec2-metadata-token", "INVALID"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 401)
+        ),
+        response(
+            expect(URI, "/latest/api/token"),
+            expect(HEADER, "X-aws-ec2-metadata-token-ttl-seconds", "21600"),  /* 6 hours */
+            expect(METHOD, FLB_HTTP_PUT),
+            set(STATUS, 200),
+            set(PAYLOAD, "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(PAYLOAD_SIZE, 56)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            config(REPLACE, NULL)
+        ),
+
+        /* Second call to get_credentials() */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 404),
+            set(PAYLOAD, "IMDS server not found"), /* This should never happen */
+            set(PAYLOAD_SIZE, 21)
+        ),
+
+        /* Third call to get_credentials() */
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, ("{tsJ@&K+Xo9?'a,uxb)=/iZg\"M4B\\&,qb"
+                        "Y\\%%niHubN^I[#arpu9|A':W!JZ@?frM|\""
+                        "?aVK<WS3ziAp:\"d=VD(Mu<Bl(e6I?G.3"
+                        "rI!f5OxfmkJ)ePc\\5@dGIA!q${iVCF3*"
+                        "#y6z<5Nal\\Wmp!0gpeoG!#iY[H&@350v"
+                        "$!)i4?6!&}uQ]3%%b25I._H{!.4{42T ,"
+                        "b{f\\jpAQ\"j>~<L%%<;k4uh5d+;\\%%soDl<F"
+                        "+\\j|WvhX+V)Xb)&tF&'Gj:2Q8@/m3Y46"
+                        "79HrM2^1sg11b94kP$)x-*A)ueiR=&L\""
+                        "-Hd&sN[M[#BS;ZVIn#j7Lj{E`7 c:%%bK")),  /* Random text fuzz */
+            set(PAYLOAD_SIZE, 328)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "My_Instance_Name"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/iam/security-credentials/My_Instance_Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "X-aws-ec2-metadata-token", "AQAAANjUxxxxxxXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_Q=="),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEC2XXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEC2XXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEC2XXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),  /* Expires Year 3021 */
+            set(PAYLOAD_SIZE, 257)
+        )
+    ));
+
+    /* First call to get_credentials() */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* Second call to get_credentials() */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* Third call to get_credentials() */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_CHECK(creds == NULL);
+
+    /* Fourth call to get_credentials() */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEC2XXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEC2XXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEC2XXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test();
+}
+
+/* IMDS specific testing */
+
+/*
+ * IMDS Creation and Destruction -- Test Summary
+ *  First call to flb_aws_imds_create (fail)
+ *  -> upstream not set
+ *  Second call to flb_aws_imds_create (fail)
+ *  -> upstream set
+ *  -> upstream tcp not equal to IMDS (random text)
+ *  Third call to flb_aws_imds_create (fail)
+ *  -> upstream set
+ *  -> upstream tcp not equal to IMDS (one fewer character)
+ *  Fourth call to flb_aws_imds_create (fail)
+ *  -> upstream set
+ *  -> upstream tcp not equal to IMDS (one extra character)
+ *  Fifth call to flb_aws_imds_create (fail)
+ *  -> upstream set
+ *  -> upstream tcp equal to IMDS address
+ *  -> upstream port not equal to IMDS port (number 0)
+ *  Sixth call to flb_aws_imds_create (success)
+ *  -> upstream set
+ *  -> upstream tcp equal to IMDS address
+ *  -> upstream port equal to IMDS port (80)
+ *  First call to flb_aws_imds_destroy (success)
+ */
+static void test_ec2_imds_create_and_destroy()
+{
+    /* Full test setup not needed */
+    /* Initialize test environment */
+    config_fluent = flb_config_init();
+
+    struct flb_aws_imds_config i_config = flb_aws_imds_config_default;
+    struct flb_aws_client a_client = { 0 };
+    struct flb_aws_imds* imds;
+
+    struct flb_upstream u_stream = { 0 };
+
+    /* First call to flb_aws_imds_create */
+    imds = flb_aws_imds_create(&i_config, &a_client);
+    TEST_CHECK(imds == NULL);
+
+    /* Second call to flb_aws_imds_create */
+    a_client.upstream = &u_stream;
+    u_stream.tcp_host = "Invalid host";
+    imds = flb_aws_imds_create(&i_config, &a_client);
+    TEST_CHECK(imds == NULL);
+
+    /* Third call to flb_aws_imds_create */
+    u_stream.tcp_host = "169.254.169.254ExtraInvalid";
+    imds = flb_aws_imds_create(&i_config, &a_client);
+    TEST_CHECK(imds == NULL);
+
+    /* Fourth call to flb_aws_imds_create */
+    u_stream.tcp_host = "169.254.169.254";
+    u_stream.tcp_port = 0xBAD;
+    imds = flb_aws_imds_create(&i_config, &a_client);
+    TEST_CHECK(imds == NULL);
+
+    /* Fifth call to flb_aws_imds_create */
+    u_stream.tcp_host = "169.254.169.254";
+    u_stream.tcp_port = 80;
+    imds = flb_aws_imds_create(&i_config, &a_client);
+    TEST_CHECK(imds != NULL);
+
+    /* Destruction */
+    flb_aws_imds_destroy(imds);
+
+    flb_config_exit(config_fluent);
 }
 
 TEST_LIST = {
+    { "test_ec2_provider_v2" , test_ec2_provider_v2},
     { "test_ec2_provider_v1" , test_ec2_provider_v1},
-    { "test_ec2_provider_error_case" , test_ec2_provider_error_case},
-    { "test_ec2_provider_malformed_response" ,
-    test_ec2_provider_malformed_case},
+    { "test_ec2_provider_version_detection_error" , test_ec2_provider_version_detection_error},
+    { "test_ec2_provider_acquire_token_error" , test_ec2_provider_acquire_token_error},
+    { "test_ec2_provider_metadata_request_error" , test_ec2_provider_metadata_request_error},
+    { "test_ec2_imds_create_and_destroy" , test_ec2_imds_create_and_destroy},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
## Add IMDSv2 Support to AWS Fluent Bit plugins
Instances with only IMDSv2 enabled should now have access to Fluent Bit.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

## Config File
```
[SERVICE]
     Grace 30
     Log_Level debug
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name cloudwatch_logs
     Match *
     log_stream_prefix test
     log_group_name fluent_group
     auto_create_group true
     region us-west-2
```

## Debug Log
```
@"\e[1mFluent Bit v1.9.0\e[0m\r\n"
@"* \e[1m\e[93mCopyright (C) 2019-2021 The Fluent Bit Authors\e[0m\r\n"
@"* \e[1m\e[93mCopyright (C) 2015-2018 Treasure Data\e[0m\r\n"
@"* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd\r\n"
@"* https://fluentbit.io\r\n"
@"\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] Configuration:\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  flush time     | 5.000000 seconds\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  grace          | 30 seconds\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  daemon         | 0\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] ___________\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  inputs:\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]      dummy\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] ___________\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  filters:\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] ___________\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  outputs:\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]      cloudwatch_logs.0\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] ___________\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m]  collectors:\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] [engine] started (pid=52932)\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [engine] coroutine stack size: 12288 bytes (12.0K)\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [storage] [cio stream] new stream registered: dummy.0\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] [storage] version=1.1.1, initializing...\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] [storage] in-memory\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[92m info\e[0m] [cmetrics] version=0.2.1\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [cloudwatch_logs:cloudwatch_logs.0] created event channels: read=19 write=20\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Initialized Env Provider in standard chain\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Initialized AWS Profile Provider in standard chain\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:51\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Not initializing ECS Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set\r\n"
Execute debugger commands using "-exec <command>", for example "-exec info registers" will list registers in use (when GDB is the debugger)
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Initialized EC2 Provider in standard chain\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Sync called on the EC2 provider\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Init called on the env provider\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Init called on the profile provider\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Reading shared config file.\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Reading shared credentials file.\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Shared credentials file /Users/falamatt/.aws/credentials does not exist\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Init called on the EC2 IMDS provider\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] requesting credentials from EC2 IMDS\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server 169.254.169.254:80 will close connection #21\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_client] (null): http_do=0, HTTP Status: 401\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:53\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:54\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server 169.254.169.254:80 will close connection #21\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:57\e[1m]\e[0m [\e[93mdebug\e[0m] **_[imds] using IMDSv2_**\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:57\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:58\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server 169.254.169.254:80 will close connection #21\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:58\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Requesting credentials for instance role Fluent_Bit_Test_Instance\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:59\e[1m]\e[0m [\e[93mdebug\e[0m] [imds] using IMDSv2\r\n"
@"\e[1m[\e[0m2021/09/13 13:04:59\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:00\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server 169.254.169.254:80 will close connection #21\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:01\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] upstream_set called on the EC2 provider\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:01\e[1m]\e[0m [\e[93mdebug\e[0m] [router] match rule dummy.0:cloudwatch_logs.0\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:01\e[1m]\e[0m [\e[92m info\e[0m] [sp] stream processor started\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:06\e[1m]\e[0m [\e[93mdebug\e[0m] [task] created task=0x1027040d0 id=0 OK\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:06\e[1m]\e[0m [\e[92m info\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log group fluent_group\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Requesting credentials from the EC2 provider..\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server logs.us-west-2.amazonaws.com:443 will close connection #28\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_client] logs.us-west-2.amazonaws.com: http_do=0, HTTP Status: 400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] CreateLogGroup http status=400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[92m info\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Log Group fluent_group already exists\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[92m info\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream testdummy in log group fluent_group\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Requesting credentials from the EC2 provider..\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server logs.us-west-2.amazonaws.com:443 will close connection #28\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_client] logs.us-west-2.amazonaws.com: http_do=0, HTTP Status: 400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] CreateLogStream http status=400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[92m info\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Log Stream testdummy already exists\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending 4 events\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream testdummy\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Requesting credentials from the EC2 provider..\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] server logs.us-west-2.amazonaws.com:443 will close connection #28\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_client] logs.us-west-2.amazonaws.com: http_do=0, HTTP Status: 400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=400\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sequence token was invalid, will retry\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending 4 events\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:07\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream testdummy\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_credentials] Requesting credentials from the EC2 provider..\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [upstream] KA connection #28 to logs.us-west-2.amazonaws.com:443 is now available\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sent events to testdummy\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sent 4 events to CloudWatch\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [out coro] cb_destroy coro_id=0\r\n"
@"\e[1m[\e[0m2021/09/13 13:05:08\e[1m]\e[0m [\e[93mdebug\e[0m] [task] destroy task=0x1027040d0 (task_id=0)\r\n"
```

## Disabled IMDS -> Enabled IMDS
1. `aws ec2 modify-instance-metadata-options --instance-id i-001234567 --http-endpoint disabled`
2. Run fluent bit on instance i-001234567
3. `aws ec2 modify-instance-metadata-options --instance-id i-004f8a124a6f1a9eb --http-endpoint enabled`
Result:
![Result](https://user-images.githubusercontent.com/34408404/134388764-7ed7f2fc-2556-47a4-a830-c0890b6245f5.png)


## Valgrind
### System Operation
![Screen Shot 2021-09-13 at 5 51 05 PM](https://user-images.githubusercontent.com/34408404/133175990-089b997f-1382-4cd5-9c47-e03b1b7d4ef2.png)

### Unit Tests
- test_ec2_provider_v2
![test_ec2_provider_v2](https://user-images.githubusercontent.com/34408404/134078518-82e02ff7-a593-48b3-a698-c02d1ef0a455.png)
- test_ec2_provider_v1
![test_ec2_provider_v1](https://user-images.githubusercontent.com/34408404/134078672-979117ab-e6d5-4cc3-a0b2-c8ea8edc4ec4.png)
- test_ec2_provider_version_detection_error
![test_ec2_provider_version_detection_error](https://user-images.githubusercontent.com/34408404/134078726-92d345a1-6c1a-40db-b46d-47360f928db2.png)
- test_ec2_provider_acquire_token_error
![test_ec2_provider_acquire_token_error](https://user-images.githubusercontent.com/34408404/134078788-d0a1be56-838c-4935-beb8-32ee1bf7604f.png)
- test_ec2_provider_metadata_request_error
![test_ec2_provider_metadata_request_error](https://user-images.githubusercontent.com/34408404/134078875-ac8a2b72-b663-42de-b995-57d06182b8d3.png)
- test_ec2_imds_create_and_destroy
![test_ec2_imds_create_and_destroy](https://user-images.githubusercontent.com/34408404/134078934-c494152d-04c8-47c6-a409-e30789e4a252.png)
- Unit test result
![Unit test result](https://user-images.githubusercontent.com/34408404/134079162-a242251f-38bf-4baf-b520-52780c07cd17.png)


# Design Motivation
## Motivation
Here is my motivation behind creating a new structure for IMDS. The plugins/filters_aws/aws.c file has essentially the same routines listed here, but it takes the specialized filter context for each routine. The previous version of IMDSv1 that was here, had some of the same code, copy pasted, but this code took a flb_aws_client as context. I could have continued the copy paste pattern, but though that code duplication would result in greater overhead in maintenance in the future.

## aws.c Compatability
The IMDS struct is designed to be fully compatible with plugins/aws_filters/aws.c with only about 5 lines of code changes. Moreover, much of aws.c's code can be deleted. Wiring the IMDS struct to the aws filter is out of the scope of this feature (since I am not going to retest the aws plugin), but also list the 5 code changes in aws.c that need to take place.

I expect that in the future, as changes are needed in aws.c and aws.c is being actively tested again, we can wire up the IMDS struct to aws.c and delete all the duplicated code.
