### PR TITLE
network: fix error logging

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -506,9 +506,9 @@ static int net_connect_async(int fd,
             }
 
             /* Connection is broken, not much to do here */
-            str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
-            flb_error("[net] TCP connection failed: %s:%i (%s)",
-                      u->tcp_host, u->tcp_port, str);
+            strerror_r(error, so_error_buf, sizeof(so_error_buf) - 1);
+            flb_error("[net] TCP connection failed: %s:%i errno=%i (%s)",
+                      u->tcp_host, u->tcp_port, error, so_error_buf);
             return -1;
         }
     }


### PR DESCRIPTION
Before:
`[2021/09/23 12:43:46] [error] [net] TCP connection failed: logs.example.com:80 ((null))`

After:
`[2021/09/23 13:31:38] [error] [net] TCP connection failed: logs.example.com:80 errno=61 (Connection refused)`