### PR TITLE
upstream: made a few shutdown calls conditional

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -796,7 +796,10 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
                  * waiting for I/O will receive the notification and trigger
                  * the error to it caller.
                  */
-                shutdown(u_conn->fd, SHUT_RDWR);
+                if (u_conn->fd != -1) {
+                    shutdown(u_conn->fd, SHUT_RDWR);
+                }
+
                 u_conn->net_error = ETIMEDOUT;
                 prepare_destroy_conn(u_conn);
             }
@@ -806,7 +809,10 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
         mk_list_foreach_safe(u_head, tmp, &uq->av_queue) {
             u_conn = mk_list_entry(u_head, struct flb_upstream_conn, _head);
             if ((now - u_conn->ts_available) >= u->net.keepalive_idle_timeout) {
-                shutdown(u_conn->fd, SHUT_RDWR);
+                if (u_conn->fd != -1) {
+                    shutdown(u_conn->fd, SHUT_RDWR);
+                }
+
                 prepare_destroy_conn(u_conn);
                 flb_debug("[upstream] drop keepalive connection #%i to %s:%i "
                           "(keepalive idle timeout)",


### PR DESCRIPTION
This PR wraps the shutdown calls in flb_upstream_conn_timeouts so we don't make useless syscalls when a connection timeout happens while making a DNS lookup.

This is part of what's fixed in #4107 which I think will have to be made into a new PR just for the logs once the next PR with the connection busy flag is made.

So just to be clear, this is krispraws work and credit should be attributed to her (I just don't know how to do that)

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>