### PR TITLE
upstream: flb_upstream_conn busy flag addition

### DIFF
--- a/include/fluent-bit/flb_upstream_conn.h
+++ b/include/fluent-bit/flb_upstream_conn.h
@@ -55,6 +55,15 @@ struct flb_upstream_conn {
      */
     int net_error;
 
+    /* If this flag is set, then destroy_conn will ignore this connection, this
+     * helps mitigate issues caused by flb_upstream_conn_timeouts marking a connection
+     * to be dropped and the event loop manager function destroying that connection
+     * at the end of the cycle while the connection coroutine is still suspended which
+     * causes the outer functions to access invalid memory when handling the error amongst
+     * other things.
+     */
+    int busy_flag;
+
     /* Timestamps */
     time_t ts_assigned;
     time_t ts_created;

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -446,6 +446,11 @@ static inline int prepare_destroy_conn_safe(struct flb_upstream_conn *u_conn)
 
 static int destroy_conn(struct flb_upstream_conn *u_conn)
 {
+    /* Delay the destruction of busy connections */
+    if (u_conn->busy_flag) {
+        return 0;
+    }
+
 #ifdef FLB_HAVE_TLS
     if (u_conn->tls_session) {
         flb_tls_session_destroy(u_conn->tls, u_conn);
@@ -476,6 +481,7 @@ static struct flb_upstream_conn *create_conn(struct flb_upstream *u)
     conn->u             = u;
     conn->fd            = -1;
     conn->net_error     = -1;
+    conn->busy_flag     = FLB_FALSE;
 
     /* retrieve the event loop */
     evl = flb_engine_evl_get();


### PR DESCRIPTION
This PR addresses what was discussed in PR #4107 as a simple way to delay the disposal of flb_upstream_conn instances before the coroutine is done using it.

