### PR TITLE
winlog: Support use_ansi config property

### DIFF
--- a/plugins/in_winlog/in_winlog.c
+++ b/plugins/in_winlog/in_winlog.c
@@ -244,6 +244,12 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct winlog_config, string_inserts),
       "Whether to include StringInserts in output records"
     },
+    {
+      FLB_CONFIG_MAP_BOOL, "use_ansi", "false",
+      0, FLB_TRUE, offsetof(struct winlog_config, use_ansi),
+      "Use ANSI encoding on eventlog messages"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/in_winlog/winlog.h
+++ b/plugins/in_winlog/winlog.h
@@ -26,6 +26,7 @@ struct winlog_config {
     unsigned int interval_nsec;
     unsigned int bufsize;
     int string_inserts;
+    int use_ansi;
     char *buf;
     struct mk_list *active_channel;
     struct flb_sqldb *db;


### PR DESCRIPTION
In Japanese edition of Windows 10, UTF-8(CP_UTF8) causes garbage characters
on Windows Terminal due to character encoding issue.

This option is aimed for debugging data pipeline with stdout plugin.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush           5
    Daemon          yes
    Log_Level       debug

[INPUT]
    Name            winlog
    Channels        Application
    Interval_Sec    1
    Use_ANSI        yes # or no. Default no.

[OUTPUT]
    Name            stdout
```

- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->

Before:

![image](https://user-images.githubusercontent.com/700876/134865880-2fbc3614-fe5c-4b76-be8f-9cf9e42c0dbb.png)

After:
![image](https://user-images.githubusercontent.com/700876/134866379-14052f76-88d1-4ef4-968a-fbe0fe20bf8b.png)

- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
