### PR TITLE
pack: add 'epoch_ms' format

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -39,6 +39,7 @@
 #define FLB_PACK_JSON_DATE_ISO8601               1
 #define FLB_PACK_JSON_DATE_EPOCH                 2
 #define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP    3
+#define FLB_PACK_JSON_DATE_EPOCH_MS              4
 
 /* Specific ISO8601 format */
 #define FLB_PACK_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -817,6 +817,11 @@ int flb_pack_to_json_date_type(const char *str)
     else if (strcasecmp(str, "epoch") == 0) {
         return FLB_PACK_JSON_DATE_EPOCH;
     }
+    else if (strcasecmp(str, "epoch_ms") == 0 ||
+             strcasecmp(str, "epoch_millis") == 0 ||
+             strcasecmp(str, "epoch_milliseconds") == 0) {
+        return FLB_PACK_JSON_DATE_EPOCH_MS;
+    }
 
     return -1;
 }
@@ -950,6 +955,11 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
                 break;
             case FLB_PACK_JSON_DATE_EPOCH:
                 msgpack_pack_uint64(&tmp_pck, (long long unsigned)(tms.tm.tv_sec));
+                break;
+            case FLB_PACK_JSON_DATE_EPOCH_MS:
+                msgpack_pack_uint64(&tmp_pck,
+                                    (long long unsigned)(tms.tm.tv_sec) * 1000 +
+                                    tms.tm.tv_nsec / 1000000);
                 break;
             }
         }


### PR DESCRIPTION
This PR adds `epoch_ms` format which represents UNIX epoch in milliseconds.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration snippet
```
[OUTPUT]
    Name  stdout
    Match *
    Format json
    json_date_key timestamp
    json_date_format epoch_millis
    # ...
```

## Debug log output
```
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/28 11:54:06] [ info] Configuration:
[2021/09/28 11:54:06] [ info]  flush time     | 0.100000 seconds
[2021/09/28 11:54:06] [ info]  grace          | 5 seconds
[2021/09/28 11:54:06] [ info]  daemon         | 0
[2021/09/28 11:54:06] [ info] ___________
[2021/09/28 11:54:06] [ info]  inputs:
[2021/09/28 11:54:06] [ info]      tail
[2021/09/28 11:54:06] [ info] ___________
[2021/09/28 11:54:06] [ info]  filters:
[2021/09/28 11:54:06] [ info] ___________
[2021/09/28 11:54:06] [ info]  outputs:
[2021/09/28 11:54:06] [ info]      stdout.0
[2021/09/28 11:54:06] [ info] ___________
[2021/09/28 11:54:06] [ info]  collectors:
[2021/09/28 11:54:06] [ info] [engine] started (pid=30920)
[2021/09/28 11:54:06] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/09/28 11:54:06] [debug] [storage] [cio stream] new stream registered: tail.0
[2021/09/28 11:54:06] [ info] [storage] version=1.1.1, initializing...
[2021/09/28 11:54:06] [ info] [storage] in-memory
[2021/09/28 11:54:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/28 11:54:06] [ info] [cmetrics] version=0.2.1
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] inotify watch fd=25
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] scanning path test.log
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] inode=11797143 with offset=1665152 appended as test.log
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] scan_glob add(): test.log, inode 11797143
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] 1 new files found on path 'test.log'
[2021/09/28 11:54:06] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2021/09/28 11:54:06] [debug] [router] match rule tail.0:stdout.0
[2021/09/28 11:54:06] [ info] [sp] stream processor started
[2021/09/28 11:54:06] [debug] [input:tail:tail.0] inode=11797143 file=test.log promote to TAIL_EVENT
[2021/09/28 11:54:06] [ info] [input:tail:tail.0] inotify_fs_add(): inode=11797143 watch_fd=1 name=test.log
[2021/09/28 11:54:09] [debug] [input:tail:tail.0] inode=11797143 events: IN_MODIFY 
[2021/09/28 11:54:09] [debug] [task] created task=0x7f70d8013410 id=0 OK
[{"logTime":1632797649178,"log":"testlog"}]
[2021/09/28 11:54:09] [debug] [out coro] cb_destroy coro_id=0
[2021/09/28 11:54:09] [debug] [task] destroy task=0x7f70d8013410 (task_id=0)
[2021/09/28 11:54:09] [debug] [input:tail:tail.0] inode=11797143 events: IN_MODIFY 
[{"logTime":1632797649778,"log":"testlog"}][2021/09/28 11:54:09] [debug] [task] created task=0x7f70d8013c10 id=0 OK

[2021/09/28 11:54:09] [debug] [out coro] cb_destroy coro_id=1
[2021/09/28 11:54:09] [debug] [task] destroy task=0x7f70d8013c10 (task_id=0)
[2021/09/28 11:54:10] [debug] [input:tail:tail.0] inode=11797143 events: IN_MODIFY 
[{"logTime":1632797650393,"log":"testlog"}]
[2021/09/28 11:54:10] [debug] [task] created task=0x7f70d8013e40 id=0 OK
[2021/09/28 11:54:10] [debug] [out coro] cb_destroy coro_id=2
[2021/09/28 11:54:10] [debug] [task] destroy task=0x7f70d8013e40 (task_id=0)
^C[2021/09/28 11:54:22] [engine] caught signal (SIGINT)
[2021/09/28 11:54:22] [ info] [input] pausing tail.0
[2021/09/28 11:54:22] [ warn] [engine] service will stop in 5 seconds
[2021/09/28 11:54:27] [ info] [engine] service stopped
[2021/09/28 11:54:27] [debug] [input:tail:tail.0] inode=11797143 removing file name test.log
[2021/09/28 11:54:27] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=11797143 watch_fd=1
```
## Valgrind output
```
$ valgrind --leak-check=full --error-limit=no bin/fluent-bit -c test.conf
...
^C[2021/09/28 11:49:14] [engine] caught signal (SIGINT)
[2021/09/28 11:49:14] [ info] [input] pausing tail.0
[2021/09/28 11:49:14] [ warn] [engine] service will stop in 5 seconds
==28047== 
==28047== HEAP SUMMARY:
==28047==     in use at exit: 95,888 bytes in 3,216 blocks
==28047==   total heap usage: 65,968 allocs, 62,752 frees, 262,848,238 bytes allocated
==28047== 
==28047== LEAK SUMMARY:
==28047==    definitely lost: 0 bytes in 0 blocks
==28047==    indirectly lost: 0 bytes in 0 blocks
==28047==      possibly lost: 0 bytes in 0 blocks
==28047==    still reachable: 95,888 bytes in 3,216 blocks
==28047==         suppressed: 0 bytes in 0 blocks
==28047== Reachable blocks (those to which a pointer was found) are not shown.
==28047== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==28047== 
==28047== For counts of detected and suppressed errors, rerun with: -v
==28047== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
