### PR TITLE
out_loki: Add support for bearer token auth

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -155,6 +155,8 @@ int flb_http_basic_auth(struct flb_http_client *c,
                         const char *user, const char *passwd);
 int flb_http_proxy_auth(struct flb_http_client *c,
                         const char *user, const char *passwd);
+int flb_http_bearer_auth(struct flb_http_client *c,
+                        const char *token);
 int flb_http_set_keepalive(struct flb_http_client *c);
 int flb_http_set_content_encoding_gzip(struct flb_http_client *c);
 int flb_http_set_callback_context(struct flb_http_client *c,

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1442,9 +1442,11 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     /* User Agent */
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
 
-    /* Basic Auth headers */
-    if (ctx->http_user && ctx->http_passwd) {
+    /* Auth headers */
+    if (ctx->http_user && ctx->http_passwd) { /* Basic */
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    } else if (ctx->bearer_token) { /* Bearer token */
+        flb_http_bearer_auth(c, ctx->bearer_token);
     }
 
     /* Add Content-Type header */
@@ -1615,6 +1617,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "http_passwd", "",
      0, FLB_TRUE, offsetof(struct flb_loki, http_passwd),
      "Set HTTP auth password"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "bearer_token", NULL,
+     0, FLB_TRUE, offsetof(struct flb_loki, bearer_token),
+     "Set bearer token auth"
     },
 
     /* EOF */

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -61,6 +61,9 @@ struct flb_loki {
     flb_sds_t http_user;
     flb_sds_t http_passwd;
 
+    /* Bearer Token Auth */
+    flb_sds_t bearer_token;
+
     /* Labels */
     struct mk_list *labels;
     struct mk_list *label_keys;

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1136,6 +1136,43 @@ int flb_http_proxy_auth(struct flb_http_client *c,
     return flb_http_add_auth_header(c, user, passwd, FLB_HTTP_HEADER_PROXY_AUTH);
 }
 
+int flb_http_bearer_auth(struct flb_http_client *c, const char *token)
+{
+    int ret;
+    int len_t;
+    int len_h = 8; /* length of "Bearer " plus null terminator */
+    char *h;
+
+    if (token) {
+        len_t = strlen(token);
+    }
+    else {
+        len_t = 0;
+    }
+
+    len_h += len_t;
+
+    h = flb_malloc(len_h);
+    if (!h) {
+        flb_errno();
+        return -1;
+    }
+
+    memcpy(h, "Bearer ", 7);
+    if(len_t && token) {
+        memcpy(h + 7, token, len_t);
+    }
+    h[len_h - 1] = '\0';
+    
+    ret = flb_http_add_header(c,
+                              FLB_HTTP_HEADER_AUTH, strlen(FLB_HTTP_HEADER_AUTH),
+                              h, len_h);
+
+    flb_free(h);
+
+    return ret;
+}
+
 
 int flb_http_do(struct flb_http_client *c, size_t *bytes)
 {


### PR DESCRIPTION
Add bearer token authentication support to the general http client. Then use the added bearer token support in the Loki output plugin. This allows fluent-bit to be used for opstrace and other non basic auth loki configurations.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

----

### Config File
```
[SERVICE]
     Log_Level debug
[INPUT]
     Name dummy
     Tag dummy
[OUTPUT]
     Name loki
     Match *
     labels job=fluentbit
     host https://loki.example
     port 443
     bearer_token insertbigtokenhere
```

### Debug Log
```
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/19 21:51:16] [ info] Configuration:
[2021/09/19 21:51:16] [ info]  flush time     | 5.000000 seconds
[2021/09/19 21:51:16] [ info]  grace          | 30 seconds
[2021/09/19 21:51:16] [ info]  daemon         | 0
[2021/09/19 21:51:16] [ info] ___________
[2021/09/19 21:51:16] [ info]  inputs:
[2021/09/19 21:51:16] [ info]      dummy
[2021/09/19 21:51:16] [ info] ___________
[2021/09/19 21:51:16] [ info]  filters:
[2021/09/19 21:51:16] [ info] ___________
[2021/09/19 21:51:16] [ info]  outputs:
[2021/09/19 21:51:16] [ info]      loki.0
[2021/09/19 21:51:16] [ info] ___________
[2021/09/19 21:51:16] [ info]  collectors:
[2021/09/19 21:51:16] [ info] [engine] started (pid=60907)
[2021/09/19 21:51:16] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/09/19 21:51:16] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/09/19 21:51:16] [ info] [storage] version=1.1.1, initializing...
[2021/09/19 21:51:16] [ info] [storage] in-memory
[2021/09/19 21:51:16] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/19 21:51:16] [ info] [cmetrics] version=0.2.1
[2021/09/19 21:51:16] [debug] [loki:loki.0] created event channels: read=19 write=20
[2021/09/19 21:51:16] [ info] [output:loki:loki.0] configured, hostname=loki.example:443
[2021/09/19 21:51:16] [debug] [router] match rule dummy.0:loki.0
[2021/09/19 21:51:16] [ info] [sp] stream processor started
[2021/09/19 21:51:20] [debug] [task] created task=0x7f6da002f530 id=0 OK
[2021/09/19 21:51:20] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:21] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:21] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:21] [debug] [out coro] cb_destroy coro_id=0
[2021/09/19 21:51:21] [debug] [task] destroy task=0x7f6da002f530 (task_id=0)
[2021/09/19 21:51:25] [debug] [task] created task=0x7f6da0048840 id=0 OK
[2021/09/19 21:51:25] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:25] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:25] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:25] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:25] [debug] [out coro] cb_destroy coro_id=1
[2021/09/19 21:51:25] [debug] [task] destroy task=0x7f6da0048840 (task_id=0)
[2021/09/19 21:51:30] [debug] [task] created task=0x7f6da0048a60 id=0 OK
[2021/09/19 21:51:30] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:30] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:30] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:30] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:30] [debug] [out coro] cb_destroy coro_id=2
[2021/09/19 21:51:30] [debug] [task] destroy task=0x7f6da0048a60 (task_id=0)
[2021/09/19 21:51:35] [debug] [task] created task=0x7f6da0047000 id=0 OK
[2021/09/19 21:51:35] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:35] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:35] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:35] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:35] [debug] [out coro] cb_destroy coro_id=3
[2021/09/19 21:51:35] [debug] [task] destroy task=0x7f6da0047000 (task_id=0)
[2021/09/19 21:51:40] [debug] [task] created task=0x7f6da0047170 id=0 OK
[2021/09/19 21:51:40] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:40] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:40] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:40] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:40] [debug] [out coro] cb_destroy coro_id=4
[2021/09/19 21:51:40] [debug] [task] destroy task=0x7f6da0047170 (task_id=0)
[2021/09/19 21:51:45] [debug] [task] created task=0x7f6da0047c10 id=0 OK
[2021/09/19 21:51:45] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:45] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:45] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:45] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:45] [debug] [out coro] cb_destroy coro_id=5
[2021/09/19 21:51:45] [debug] [task] destroy task=0x7f6da0047c10 (task_id=0)
[2021/09/19 21:51:50] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:51:50] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:50] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:50] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:50] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:50] [debug] [out coro] cb_destroy coro_id=6
[2021/09/19 21:51:50] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:51:55] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:51:55] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:51:55] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:51:55] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:51:55] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:51:55] [debug] [out coro] cb_destroy coro_id=7
[2021/09/19 21:51:55] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:00] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:00] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:00] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:00] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:00] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:00] [debug] [out coro] cb_destroy coro_id=8
[2021/09/19 21:52:00] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:05] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:05] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:05] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:05] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:05] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:05] [debug] [out coro] cb_destroy coro_id=9
[2021/09/19 21:52:05] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:10] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:10] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:10] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:10] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:10] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:10] [debug] [out coro] cb_destroy coro_id=10
[2021/09/19 21:52:10] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:15] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:15] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:15] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:15] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:15] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:15] [debug] [out coro] cb_destroy coro_id=11
[2021/09/19 21:52:15] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:20] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:20] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:20] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:20] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:20] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:20] [debug] [out coro] cb_destroy coro_id=12
[2021/09/19 21:52:20] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:25] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:25] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:25] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:25] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:25] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:25] [debug] [out coro] cb_destroy coro_id=13
[2021/09/19 21:52:25] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
^C[2021/09/19 21:52:28] [engine] caught signal (SIGINT)
[2021/09/19 21:52:28] [debug] [task] created task=0x7f6da0047d80 id=0 OK
[2021/09/19 21:52:28] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:52:28] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:52:28] [ warn] [engine] service will stop in 30 seconds
[2021/09/19 21:52:28] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:52:28] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:52:28] [debug] [out coro] cb_destroy coro_id=14
[2021/09/19 21:52:28] [debug] [task] destroy task=0x7f6da0047d80 (task_id=0)
[2021/09/19 21:52:29] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:30] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:31] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:32] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:33] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:34] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:35] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:36] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:37] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:38] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:39] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:40] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:41] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:42] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:43] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:44] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:45] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:46] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:47] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:48] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:49] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:50] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:51] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:52] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:53] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:54] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:55] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:56] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:57] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:52:58] [ info] [engine] service stopped
[2021/09/19 21:52:58] [debug] [socket] could not validate socket status for #25 (don't worry)
```

### Valgrind Results
```
==61956== Memcheck, a memory error detector
==61956== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==61956== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==61956== Command: ./bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
==61956==
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/19 21:53:46] [ info] Configuration:
[2021/09/19 21:53:46] [ info]  flush time     | 5.000000 seconds
[2021/09/19 21:53:46] [ info]  grace          | 30 seconds
[2021/09/19 21:53:46] [ info]  daemon         | 0
[2021/09/19 21:53:46] [ info] ___________
[2021/09/19 21:53:46] [ info]  inputs:
[2021/09/19 21:53:46] [ info]      dummy
[2021/09/19 21:53:46] [ info] ___________
[2021/09/19 21:53:46] [ info]  filters:
[2021/09/19 21:53:46] [ info] ___________
[2021/09/19 21:53:46] [ info]  outputs:
[2021/09/19 21:53:46] [ info]      loki.0
[2021/09/19 21:53:46] [ info] ___________
[2021/09/19 21:53:46] [ info]  collectors:
[2021/09/19 21:53:46] [ info] [engine] started (pid=61956)
[2021/09/19 21:53:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/09/19 21:53:46] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/09/19 21:53:46] [ info] [storage] version=1.1.1, initializing...
[2021/09/19 21:53:46] [ info] [storage] in-memory
[2021/09/19 21:53:46] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/19 21:53:46] [ info] [cmetrics] version=0.2.1
[2021/09/19 21:53:46] [debug] [loki:loki.0] created event channels: read=19 write=20
[2021/09/19 21:53:46] [ info] [output:loki:loki.0] configured, hostname=loki.example:443
[2021/09/19 21:53:46] [debug] [router] match rule dummy.0:loki.0
[2021/09/19 21:53:46] [ info] [sp] stream processor started
[2021/09/19 21:53:51] [debug] [task] created task=0x506f6b0 id=0 OK
[2021/09/19 21:53:52] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:53:52] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:53:52] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:53:52] [debug] [out coro] cb_destroy coro_id=0
[2021/09/19 21:53:52] [debug] [task] destroy task=0x506f6b0 (task_id=0)
[2021/09/19 21:53:56] [debug] [task] created task=0x516dd40 id=0 OK
[2021/09/19 21:53:56] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:53:56] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:53:56] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:53:56] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:53:56] [debug] [out coro] cb_destroy coro_id=1
[2021/09/19 21:53:56] [debug] [task] destroy task=0x516dd40 (task_id=0)
[2021/09/19 21:54:01] [debug] [task] created task=0x51f9440 id=0 OK
[2021/09/19 21:54:01] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:54:01] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:54:01] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:54:01] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:54:01] [debug] [out coro] cb_destroy coro_id=2
[2021/09/19 21:54:01] [debug] [task] destroy task=0x51f9440 (task_id=0)
^C[2021/09/19 21:54:02] [engine] caught signal (SIGINT)
[2021/09/19 21:54:02] [debug] [task] created task=0x525c310 id=0 OK
[2021/09/19 21:54:02] [debug] [upstream] KA connection #25 to loki.example:443 has been assigned (recycled)
[2021/09/19 21:54:02] [debug] [http_client] not using http_proxy for header
[2021/09/19 21:54:02] [ warn] [engine] service will stop in 30 seconds
[2021/09/19 21:54:02] [debug] [output:loki:loki.0] loki.example:443, HTTP status=204
[2021/09/19 21:54:02] [debug] [upstream] KA connection #25 to loki.example:443 is now available
[2021/09/19 21:54:02] [debug] [out coro] cb_destroy coro_id=3
[2021/09/19 21:54:02] [debug] [task] destroy task=0x525c310 (task_id=0)
[2021/09/19 21:54:02] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:03] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:04] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:05] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:06] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:07] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:08] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:09] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:10] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:11] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:12] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:13] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:14] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:15] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:16] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:17] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:18] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:19] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:20] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:21] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:22] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:23] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:24] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:25] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:26] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:27] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:28] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:29] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:30] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/09/19 21:54:31] [ info] [engine] service stopped
[2021/09/19 21:54:31] [debug] [socket] could not validate socket status for #25 (don't worry)
==61956==
==61956== HEAP SUMMARY:
==61956==     in use at exit: 107,350 bytes in 3,660 blocks
==61956==   total heap usage: 7,621 allocs, 3,961 frees, 3,942,513 bytes allocated
==61956==
==61956== LEAK SUMMARY:
==61956==    definitely lost: 0 bytes in 0 blocks
==61956==    indirectly lost: 0 bytes in 0 blocks
==61956==      possibly lost: 0 bytes in 0 blocks
==61956==    still reachable: 107,350 bytes in 3,660 blocks
==61956==         suppressed: 0 bytes in 0 blocks
==61956== Rerun with --leak-check=full to see details of leaked memory
==61956==
==61956== For lists of detected and suppressed errors, rerun with: -s
==61956== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### Documentation PR
https://github.com/fluent/fluent-bit-docs/pull/607