### PR TITLE
upstream: async connection timeout coroutine resume fix

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -224,6 +224,11 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
              */
             flb_coro_yield(co, FLB_FALSE);
 
+            /* We want this field to hold NULL at all times unless we are explicitly
+             * waiting to be resumed.
+             */
+            u_conn->coro = NULL;
+
             /* Save events mask since mk_event_del() will reset it */
             mask = u_conn->event.mask;
 
@@ -277,7 +282,14 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
                 return -1;
             }
         }
+
         flb_coro_yield(co, MK_FALSE);
+
+        /* We want this field to hold NULL at all times unless we are explicitly
+         * waiting to be resumed.
+         */
+        u_conn->coro = NULL;
+
         goto retry;
     }
 
@@ -326,7 +338,14 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
                  */
                 return -1;
             }
+
             flb_coro_yield(co, MK_FALSE);
+
+            /* We want this field to hold NULL at all times unless we are explicitly
+             * waiting to be resumed.
+             */
+            u_conn->coro = NULL;
+
             goto retry_read;
         }
         return -1;

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -420,6 +420,11 @@ static int net_connect_async(int fd,
      */
     flb_coro_yield(async_ctx, FLB_FALSE);
 
+    /* We want this field to hold NULL at all times unless we are explicitly
+     * waiting to be resumed.
+     */
+    u_conn->coro = NULL;
+
     /* Save the mask before the event handler do a reset */
     mask = u_conn->event.mask;
 


### PR DESCRIPTION
This PR aims to fix an issue where coroutines hang indefinitely waiting to be resumed after yielding in `net_connect_async` if there is a timeout.

This is an uncommon scenario that's easily reproducible by adding a firewall rule to DROP packets from / to a host or net.
