### PR TITLE
aws: fix constant definition in header, set it as extern

### DIFF
--- a/include/fluent-bit/aws/flb_aws_imds.h
+++ b/include/fluent-bit/aws/flb_aws_imds.h
@@ -50,7 +50,7 @@ struct flb_aws_imds_config {
 };
 
 /* Default config values */
-const struct flb_aws_imds_config flb_aws_imds_config_default;
+extern const struct flb_aws_imds_config flb_aws_imds_config_default;
 
 /* Metadata service context struct */
 struct flb_aws_imds {


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>
