### PR TITLE
parser: remove unused list and check its size(#4132)

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -195,6 +195,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
     else {
         flb_error("[parser:%s] Invalid format %s", name, format);
+        mk_list_del(&p->_head);
         flb_free(p);
         return NULL;
     }
@@ -202,6 +203,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     if (p->type == FLB_PARSER_REGEX) {
         if (!p_regex) {
             flb_error("[parser:%s] Invalid regex pattern", name);
+            mk_list_del(&p->_head);
             flb_free(p);
             return NULL;
         }
@@ -209,6 +211,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
         regex = flb_regex_create(p_regex);
         if (!regex) {
             flb_error("[parser:%s] Invalid regex pattern %s", name, p_regex);
+            mk_list_del(&p->_head);
             flb_free(p);
             return NULL;
         }
@@ -317,6 +320,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
 void flb_parser_destroy(struct flb_parser *parser)
 {
     int i = 0;
+
     if (parser->type == FLB_PARSER_REGEX) {
         flb_regex_destroy(parser->regex);
         flb_free(parser->p_regex);
@@ -867,8 +871,15 @@ struct flb_parser *flb_parser_get(const char *name, struct flb_config *config)
     struct mk_list *head;
     struct flb_parser *parser;
 
+    if (config == NULL || mk_list_size(&config->parsers) <= 0) {
+        return NULL;
+    }
+
     mk_list_foreach(head, &config->parsers) {
         parser = mk_list_entry(head, struct flb_parser, _head);
+        if (parser == NULL || parser->name == NULL) {
+            continue;
+        }
         if (strcmp(parser->name, name) == 0) {
             return parser;
         }


### PR DESCRIPTION
Fixes #4132.

I fixed these point.
- remove unused element from list
- check the list size and its pointer before touching it.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

parsers.conf:
```
[PARSER]
    Name broken
    Format regex
    Regex ^[^\]+
```

a.conf:
```
[SERVICE]
    Parsers_File parsers.conf

[INPUT]
    Name tail
    Path parsers.conf
    parser broken

[OUTPUT]
    Name stdout
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/02 10:49:58] [error] [parser:broken] Invalid regex pattern ^[^\]+
[2021/10/02 10:49:58] [ info] [engine] started (pid=27441)
[2021/10/02 10:49:58] [ info] [storage] version=1.1.3, initializing...
[2021/10/02 10:49:58] [ info] [storage] in-memory
[2021/10/02 10:49:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/02 10:49:58] [ info] [cmetrics] version=0.2.1
[2021/10/02 10:49:58] [error] [input:tail:tail.0] parser 'broken' is not registered
[2021/10/02 10:49:58] [ info] [sp] stream processor started
[2021/10/02 10:49:58] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1453668 watch_fd=1 name=parsers.conf
^C[2021/10/02 10:50:00] [engine] caught signal (SIGINT)
[2021/10/02 10:50:00] [ info] [input] pausing tail.0
[2021/10/02 10:50:00] [ warn] [engine] service will stop in 5 seconds
[2021/10/02 10:50:05] [ info] [engine] service stopped
[2021/10/02 10:50:05] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1453668 watch_fd=1
```

## Valgrind output

```
$ valgrind ../bin/fluent-bit -c a.conf 
==27435== Memcheck, a memory error detector
==27435== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27435== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==27435== Command: ../bin/fluent-bit -c a.conf
==27435== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/02 10:49:18] [error] [parser:broken] Invalid regex pattern ^[^\]+
[2021/10/02 10:49:19] [ info] [engine] started (pid=27435)
[2021/10/02 10:49:19] [ info] [storage] version=1.1.3, initializing...
[2021/10/02 10:49:19] [ info] [storage] in-memory
[2021/10/02 10:49:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/02 10:49:19] [ info] [cmetrics] version=0.2.1
[2021/10/02 10:49:19] [error] [input:tail:tail.0] parser 'broken' is not registered
[2021/10/02 10:49:19] [ info] [sp] stream processor started
[2021/10/02 10:49:19] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1453668 watch_fd=1 name=parsers.conf
^C[2021/10/02 10:49:21] [engine] caught signal (SIGINT)
[2021/10/02 10:49:21] [ info] [input] pausing tail.0
[2021/10/02 10:49:21] [ warn] [engine] service will stop in 5 seconds
[2021/10/02 10:49:25] [ info] [engine] service stopped
[2021/10/02 10:49:25] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1453668 watch_fd=1
==27435== 
==27435== HEAP SUMMARY:
==27435==     in use at exit: 0 bytes in 0 blocks
==27435==   total heap usage: 1,201 allocs, 1,201 frees, 345,097 bytes allocated
==27435== 
==27435== All heap blocks were freed -- no leaks are possible
==27435== 
==27435== For lists of detected and suppressed errors, rerun with: -s
==27435== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
