### PR TITLE
out_file: add explicit default format case(#4152)

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -123,6 +123,10 @@ static int cb_file_init(struct flb_output_instance *ins,
         else if (!strcasecmp(tmp, "template")) {
             ctx->format    = FLB_OUT_FILE_FMT_TEMPLATE;
         }
+        else if (!strcasecmp(tmp, "out_file")) {
+            /* for explicit setting */
+            ctx->format = FLB_OUT_FILE_FMT_JSON;
+        }
         else {
             flb_plg_error(ctx->ins, "unknown format %s. abort.", tmp);
             flb_free(ctx);

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -15,6 +15,7 @@ void flb_test_file_json_small(void);
 void flb_test_file_format_csv(void);
 void flb_test_file_format_ltsv(void);
 void flb_test_file_format_invalid(void);
+void flb_test_file_format_out_file(void);
 
 /* Test list */
 TEST_LIST = {
@@ -24,6 +25,7 @@ TEST_LIST = {
     {"format_csv",      flb_test_file_format_csv     },
     {"format_ltsv",     flb_test_file_format_ltsv    },
     {"format_invalid",  flb_test_file_format_invalid },
+    {"format_out_file", flb_test_file_format_out_file},
     {NULL, NULL}
 };
 
@@ -242,6 +244,54 @@ void flb_test_file_format_ltsv(void)
     flb_output_set(ctx, out_ffd, "format", "ltsv", NULL);
     flb_output_set(ctx, out_ffd, "delimiter", "tab", NULL);
     flb_output_set(ctx, out_ffd, "label_delimiter", "comma", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < (int) sizeof(JSON_SMALL) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        TEST_CHECK(bytes == 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+/* https://github.com/fluent/fluent-bit/issues/4152 */
+void flb_test_file_format_out_file(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_SMALL;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "format", "out_file", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);


### PR DESCRIPTION
Fixes #4152 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name dummy

[OUTPUT]
    Name file
    Format out_file
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/03 08:14:30] [ info] [engine] started (pid=10483)
[2021/10/03 08:14:30] [ info] [storage] version=1.1.3, initializing...
[2021/10/03 08:14:30] [ info] [storage] in-memory
[2021/10/03 08:14:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/03 08:14:30] [ info] [cmetrics] version=0.2.1
[2021/10/03 08:14:30] [ info] [sp] stream processor started
^C[2021/10/03 08:14:34] [engine] caught signal (SIGINT)
[2021/10/03 08:14:34] [ warn] [engine] service will stop in 5 seconds
[2021/10/03 08:14:38] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==10487== Memcheck, a memory error detector
==10487== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10487== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==10487== Command: ../bin/fluent-bit -c a.conf
==10487== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/03 08:15:15] [ info] [engine] started (pid=10487)
[2021/10/03 08:15:15] [ info] [storage] version=1.1.3, initializing...
[2021/10/03 08:15:15] [ info] [storage] in-memory
[2021/10/03 08:15:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/03 08:15:15] [ info] [cmetrics] version=0.2.1
[2021/10/03 08:15:15] [ info] [sp] stream processor started
^C[2021/10/03 08:15:17] [engine] caught signal (SIGINT)
==10487== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4c8fff0
==10487==          to suppress, use: --max-stackframe=11884856 or greater
==10487== Warning: client switching stacks?  SP change: 0x4c8ff68 --> 0x57e5928
==10487==          to suppress, use: --max-stackframe=11884992 or greater
==10487== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4c8ff68
==10487==          to suppress, use: --max-stackframe=11884992 or greater
==10487==          further instances of this message will not be shown.
[2021/10/03 08:15:17] [ warn] [engine] service will stop in 5 seconds
[2021/10/03 08:15:22] [ info] [engine] service stopped
==10487== 
==10487== HEAP SUMMARY:
==10487==     in use at exit: 0 bytes in 0 blocks
==10487==   total heap usage: 1,091 allocs, 1,091 frees, 784,221 bytes allocated
==10487== 
==10487== All heap blocks were freed -- no leaks are possible
==10487== 
==10487== For lists of detected and suppressed errors, rerun with: -s
==10487== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
