### PR TITLE
in_docker: use 64bit api to prevent overflow(#4083)

### DIFF
--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -708,7 +708,7 @@ static void flush_snapshot(struct flb_input_instance *i_ins,
     /* Memory limit [bytes] */
     msgpack_pack_str(&mp_pck, 9);
     msgpack_pack_str_body(&mp_pck, "mem_limit", 9);
-    msgpack_pack_unsigned_int(&mp_pck, snapshot->mem->limit);
+    msgpack_pack_uint64(&mp_pck, snapshot->mem->limit);
 
     flb_trace("[in_docker] ID %s CPU %lu MEMORY %ld", snapshot->id,
               snapshot->cpu->used, snapshot->mem->used);


### PR DESCRIPTION
Fixes #4083.

The type of mem_limit is uint64_t. However fluent-bit uses unsigned int (32bit) API.
It causes overflow.

https://github.com/fluent/fluent-bit/blob/v1.8.7/plugins/in_docker/docker.h#L56


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
sudo fluent-bit -i docker -o stdout
```

## Debug output

mem_limit is not overflow.
```
"mem_limit"=>9223372036854771712
```

```
$ sudo bin/fluent-bit -i docker -o stdout
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/03 20:43:28] [ info] [engine] started (pid=35385)
[2021/10/03 20:43:28] [ info] [storage] version=1.1.3, initializing...
[2021/10/03 20:43:28] [ info] [storage] in-memory
[2021/10/03 20:43:28] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/03 20:43:28] [ info] [cmetrics] version=0.2.1
[2021/10/03 20:43:28] [ info] [sp] stream processor started
[0] docker.0: [1633261409.428055762, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1633261410.427740347, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
```

## Valgrind output

```
$ sudo valgrind bin/fluent-bit -i docker -o stdout
==35389== Memcheck, a memory error detector
==35389== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==35389== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==35389== Command: bin/fluent-bit -i docker -o stdout
==35389== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/03 20:44:25] [ info] [engine] started (pid=35389)
[2021/10/03 20:44:25] [ info] [storage] version=1.1.3, initializing...
[2021/10/03 20:44:25] [ info] [storage] in-memory
[2021/10/03 20:44:25] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/03 20:44:25] [ info] [cmetrics] version=0.2.1
[2021/10/03 20:44:25] [ info] [sp] stream processor started
==35389== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4cc51f0
==35389==          to suppress, use: --max-stackframe=11667416 or greater
==35389== Warning: client switching stacks?  SP change: 0x4cc5168 --> 0x57e59c8
==35389==          to suppress, use: --max-stackframe=11667552 or greater
==35389== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4cc5168
==35389==          to suppress, use: --max-stackframe=11667552 or greater
==35389==          further instances of this message will not be shown.
[0] docker.0: [1633261465.456095955, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1633261466.429983931, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
[2] docker.0: [1633261467.428888942, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
[3] docker.0: [1633261468.429298184, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
^C[2021/10/03 20:44:29] [engine] caught signal (SIGINT)
[2021/10/03 20:44:29] [ info] [input] pausing docker.0
[0] docker.0: [1633261469.469511274, {"id"=>"daf48712ba71", "name"=>"quizzical_beaver", "cpu_used"=>24710821, "mem_used"=>823296, "mem_limit"=>9223372036854771712}]
[2021/10/03 20:44:29] [ warn] [engine] service will stop in 5 seconds
[2021/10/03 20:44:34] [ info] [engine] service stopped
==35389== 
==35389== HEAP SUMMARY:
==35389==     in use at exit: 0 bytes in 0 blocks
==35389==   total heap usage: 1,149 allocs, 1,149 frees, 1,327,803 bytes allocated
==35389== 
==35389== All heap blocks were freed -- no leaks are possible
==35389== 
==35389== For lists of detected and suppressed errors, rerun with: -s
==35389== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
