### PR TITLE
out_cloudwatch_logs: resolve unpaired trailing backslash sanitization failure

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -353,6 +353,33 @@ static void set_stream_time_span(struct log_stream *stream, struct cw_event *eve
     }
 }
 
+/*
+ * Truncate log if needed. If truncated, only `written` is modified
+ * returns FLB_TRUE if truncated
+ */
+static int truncate_log(const struct flb_cloudwatch *ctx, const char *log_buffer,
+                         size_t *written) {
+    size_t trailing_backslash_count = 0;
+
+    if (*written > MAX_EVENT_LEN) {
+        flb_plg_warn(ctx->ins, "[size=%zu] Truncating event which is larger than "
+                        "max size allowed by CloudWatch", *written);
+        *written = MAX_EVENT_LEN;
+
+        /* remove trailing unescaped backslash if inadvertently synthesized */
+        while (trailing_backslash_count < *written &&
+                log_buffer[(*written - 1) - trailing_backslash_count] == '\\') {
+            trailing_backslash_count++;
+        }
+        if (trailing_backslash_count % 2 == 1) {
+            /* odd number of trailing backslashes, remove unpaired backslash */
+            (*written)--;
+        }
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
 
 /*
  * Processes the msgpack object
@@ -422,24 +449,13 @@ int process_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
             return 1;
         }
 
-        if (written > MAX_EVENT_LEN) {
-            flb_plg_warn(ctx->ins, "[size=%zu] Truncating event which is larger than "
-                         "max size allowed by CloudWatch", written);
-            written = MAX_EVENT_LEN;
-        }
+        /* truncate log, if needed */
+        truncate_log(ctx, buf->event_buf, &written);
 
         /* copy serialized json to tmp_buf */
         if (!strncpy(tmp_buf_ptr, buf->event_buf, written)) {
             return -1;
         }
-
-        buf->tmp_buf_offset += written;
-        event = &buf->events[buf->event_index];
-        event->json = tmp_buf_ptr;
-        event->len = written;
-        event->timestamp = (unsigned long long) (tms->tm.tv_sec * 1000 +
-                                                 tms->tm.tv_nsec/1000000);
-
     }
     else {
         /*
@@ -448,21 +464,20 @@ int process_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
          * and last character
          */
         written -= 2;
-
-        if (written > MAX_EVENT_LEN) {
-            flb_plg_warn(ctx->ins, "[size=%zu] Truncating event which is larger than "
-                         "max size allowed by CloudWatch", written);
-            written = MAX_EVENT_LEN;
-        }
-
         tmp_buf_ptr++; /* pass over the opening quote */
-        buf->tmp_buf_offset += (written + 1);
-        event = &buf->events[buf->event_index];
-        event->json = tmp_buf_ptr;
-        event->len = written;
-        event->timestamp = (unsigned long long) (tms->tm.tv_sec * 1000 +
-                                                 tms->tm.tv_nsec/1000000);
+        buf->tmp_buf_offset++; /* advance tmp_buf past opening quote */
+
+        /* truncate log, if needed */
+        truncate_log(ctx, tmp_buf_ptr, &written);
     }
+
+    /* add log to events list */
+    buf->tmp_buf_offset += written;
+    event = &buf->events[buf->event_index];
+    event->json = tmp_buf_ptr;
+    event->len = written;
+    event->timestamp = (unsigned long long) (tms->tm.tv_sec * 1000ull +
+                                                tms->tm.tv_nsec/1000000);
 
     return 0;
 }


### PR DESCRIPTION
When logs are truncated to 262118 bytes, an escaped backslash may be
truncated into an unescaped backslash.

This trailing unescaped backslash escapes the preceding character in
the cloudwatch PUT payload invalidating the JSON's well-formed
structure and triggering AWS cloudwatch api to throw a
'SerializationException'

Signed-off-by: Matthew Fala <falamatt@amazon.com>

<!-- Provide summary of changes -->
### Impact
Fluent Bit customers who are sending logs in JSON format which require string sanitation and are sending logs frequently beyond 262118 characters requiring truncation.

### Issue
There is a possibility for an invalid cloudwatch PUT payload to be generated currently when the above two conditions are met.

### Digging in
I attached the log payload which will generate a serialization exception. Note that the payload is ~262118 characters in length, which is the longest log our cloudwatch plugin allows, with the last character being an escaped backslash. ( + 1 for the escaped backslash )

The cloudwatch plugin does some some string sanitization followed by log truncation.

At the sanitization step, the cloudwatch plugin expands the ~262118 character payload to 262121 characters with the backslash expanded to \\ to escape the backslash allowing for well-formed JSON.
At the truncation step, the cloudwatch plugin chops off the end of the 263121 character sanitized log back to 262118 characters.

> Summary: "xxxxx\" ->(sanitize)-> "xxxxx\\" ->(truncate)-> "xxxxx\"

That's a major problem because the plugin undoes the effects of sanitizing the backslash and permits escaping the next character in the JSON payload. The cloudwatch PUT request JSON may be invalid and when sent to cloudwatch, AWS cloudwatch api correctly returns "SerializationException"

### Solution
To solve, the cloudwatch plugin's truncation feature must be edited to delete an inadvertently synthesized trailing unescaped backslash.
```
 /* remove trailing unescaped backslash if inadvertently synthesized */
while (trailing_backslash_count < written &&
       buf->event_buf[(written - 1) - trailing_backslash_count] == '\\') {
    trailing_backslash_count++;
}
if (trailing_backslash_count % 2 == 1) {
    /* odd number of trailing backslashes, remove unpaired backslash */
    written--;
}
```
Please note the following:
- If a backslash proceeds the trailing backslash escaping it, the removal must be omitted.
- Trailing backslash pairs are counted and only if odd, the final backslash does not have a pair to escape it.


### Configuration
[SERVICE]
     Grace 30
     Log_Level debug

[INPUT]
     Name http
     host 0.0.0.0
     port 8888

[OUTPUT]
     Name cloudwatch_logs
     Match *
     log_stream_prefix test
     log_group_name test_group
     auto_create_group true
     region us-west-2

### Failure Output - Before Commit
- The following logs occur when payload described above is sent to Fluent Bit and directed to out_cloudwatch_logs
```
@"\e[1m[\e[0m2021/09/29 10:13:25\e[1m]\e[0m [\e[93mdebug\e[0m] [aws_client] logs.us-west-2.amazonaws.com: http_do=0, HTTP Status: 400\r\n"
@"\e[1m[\e[0m2021/09/29 10:13:25\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=400\r\n"
@"\e[1m[\e[0m2021/09/29 10:13:25\e[1m]\e[0m [\e[91merror\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents API responded with error='SerializationException'\r\n"
```

### Success Output - After Commit
- The following logs occur when payload described above is sent to Fluent Bit and directed to out_cloudwatch_logs
```
@"\e[1m[\e[0m2021/09/29 15:47:17\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending 1 events\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:17\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream testapp.log\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:17\e[1m]\e[0m [\e[93mdebug\e[0m] [http_client] not using http_proxy for header\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:19\e[1m]\e[0m [\e[93mdebug\e[0m] [upstream] KA connection #31 to logs.us-west-2.amazonaws.com:443 is now available\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:19\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:19\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sent events to testapp.log\r\n"
@"\e[1m[\e[0m2021/09/29 15:47:19\e[1m]\e[0m [\e[93mdebug\e[0m] [output:cloudwatch_logs:cloudwatch_logs.0] Sent 1 events to CloudWatch\r\n"
```


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
