### PR TITLE
scheduler: fix race condition of double closing of oneshot timers 

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -491,11 +491,9 @@ int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
 /* Disable notifications, used before to destroy the context */
 int flb_sched_timer_cb_disable(struct flb_sched_timer *timer)
 {
-    int ret;
-
-    ret = mk_event_closesocket(timer->timer_fd);
+    mk_event_timeout_disable(timer->sched->evl, &timer->event);
     timer->timer_fd = -1;
-    return ret;
+    return 0;
 }
 
 int flb_sched_timer_cb_destroy(struct flb_sched_timer *timer)


### PR DESCRIPTION
Fixes #3766

Kafka output plugin does oneshot timer of 1 second via flb_time_sleep(1000)
when the queue is full and will retry up to 10 times.
Before flb_time_sleep(1000) calls the callback to resume coroutine,
it closes the timer fd (timer->timer_fd) via flb_sched_timer_cb_disable(timer).
After the callback, it again closes the timer fd (timer->event.fd) via
flb_sched_timer_cb_destroy(timer). The issue is with the second close of the timer fd
as that fd got recycled and is now associated with another timer initiated
by flb_time_sleep(1000). Since the fd got closed for another flb_time_sleep(1000),
the kafka output plugin gets stuck and never recovers until the process is
restarted.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
