### PR TITLE
out_custom: enable add_label property.

### DIFF
--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -774,6 +774,7 @@ static void cb_calyptia_flush(const void *data, size_t bytes,
             flb_upstream_conn_release(u_conn);
             FLB_OUTPUT_RETURN(FLB_ERROR);
         }
+        cmt_destroy(cmt);
     }
     else {
         out_buf = (char *) data;
@@ -845,6 +846,8 @@ static int cb_calyptia_exit(void *data, struct flb_config *config)
     if (ctx->fs) {
         flb_fstore_destroy(ctx->fs);
     }
+
+    flb_kv_release(&ctx->kv_labels);
     flb_free(ctx);
 
     return 0;
@@ -874,6 +877,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "store_path", NULL,
      0, FLB_TRUE, offsetof(struct flb_calyptia, store_path),
      ""
+    },
+
+    {
+     FLB_CONFIG_MAP_SLIST_1, "add_label", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_calyptia, add_labels),
+     "Label to append to the generated metric."
     },
 
     /* EOF */

--- a/plugins/out_calyptia/calyptia.h
+++ b/plugins/out_calyptia/calyptia.h
@@ -57,6 +57,8 @@ struct flb_calyptia {
     flb_sds_t api_key;
     flb_sds_t cloud_host;
     flb_sds_t store_path;
+
+    /* config reader for 'add_label' */
     struct mk_list *add_labels;
 
     /* internal */


### PR DESCRIPTION
This patch enables the add_label property in the custom and output calyptia plugin configuration.

With this change the following configuration will result on metrics output being appended with the
given labels tag1 and tag2.

```yaml
[INPUT]
    Name tcp
    Port        5170
    Chunk_Size  32
    Buffer_Size 64
    Format      json

[OUTPUT]
    Name        stdout
    Match       *
[CUSTOM]
    name                calyptia
    api_key xxxx
    add_label           tag1 test
    add_label           tag2 test1
    log_level           debug
    calyptia_host       localhost
    calyptia_port       5000
    calyptia_tls        off
    calyptia_tls.verify off
```

Valgrind output

```bash
$ valgrind ./bin/fluent-bit -c test.conf 
==566180== Memcheck, a memory error detector
==566180== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==566180== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==566180== Command: ./bin/fluent-bit -c test.conf
==566180== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/08 20:39:42] [ info] [engine] started (pid=566180)
[2021/10/08 20:39:42] [ info] [custom:calyptia:calyptia.0] custom initialized!
[2021/10/08 20:39:42] [ info] [storage] version=1.1.4, initializing...
[2021/10/08 20:39:42] [ info] [storage] in-memory
[2021/10/08 20:39:42] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/08 20:39:42] [ info] [cmetrics] version=0.2.2
[2021/10/08 20:39:42] [ info] [input:tcp:tcp.0] listening on 0.0.0.0:5170
[2021/10/08 20:39:43] [ info] [output:calyptia:calyptia.1] connected to Calyptia, agent_id='3236e80d-2c76-43de-95a4-f931185e3dcd'
[2021/10/08 20:39:43] [ info] [sp] stream processor started
2021-10-08T18:39:47.577271013Z fluentbit_uptime{hostname="alicorn"} = 5
2021-10-08T18:39:47.562052933Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.1"} = 1
2021-10-08T18:39:47.577271013Z fluentbit_process_start_time_seconds{hostname="alicorn"} = 1633718382
2021-10-08T18:39:47.577271013Z fluentbit_build_info{hostname="alicorn",version="1.9.0",os="linux"} = 1633718382
^C[2021/10/08 20:39:55] [engine] caught signal (SIGINT)
[2021/10/08 20:39:55] [ info] [input] pausing fluentbit_metrics.1
[2021/10/08 20:39:55] [ warn] [engine] service will stop in 5 seconds
[2021/10/08 20:39:59] [ info] [engine] service stopped
==566180== 
==566180== HEAP SUMMARY:
==566180==     in use at exit: 0 bytes in 0 blocks
==566180==   total heap usage: 3,462 allocs, 3,462 frees, 1,460,174 bytes allocated
==566180== 
==566180== All heap blocks were freed -- no leaks are possible
==566180== 
==566180== For lists of detected and suppressed errors, rerun with: -s
==566180== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```


----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
N/A
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
