### PR TITLE
out_forward: Initialize uninitialized variables. This resolves a compiler issue with building the out_forward plugin with Clang.

### DIFF
--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -44,6 +44,8 @@ int flb_forward_format_append_tag(struct flb_forward *ctx,
 #ifdef FLB_HAVE_RECORD_ACCESSOR
     flb_sds_t tmp;
     msgpack_object m;
+    
+    memset(&m, 0, sizeof(m));
 
     if (!fc->ra_tag) {
         msgpack_pack_str(mp_pck, tag_len);
@@ -422,7 +424,7 @@ int flb_forward_format(struct flb_config *config,
                        const void *data, size_t bytes,
                        void **out_buf, size_t *out_size)
 {
-    int ret;
+    int ret = 0;
     int mode = MODE_FORWARD;
     struct flb_upstream_node *node = NULL;
     struct flb_forward_config *fc;


### PR DESCRIPTION
This passes clang builds with flag -Wsometimes-unitialized enabled.

Signed-off-by: Aaron Epstein <a.epstein7ae@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
