### PR TITLE
in_tail: avoid double free for multiline msgpack buffer

### DIFF
--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -489,6 +489,7 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     file->mult_keys = 0;
     file->mult_flush_timeout = 0;
     msgpack_sbuffer_destroy(&file->mult_sbuf);
+    file->mult_sbuf.data = NULL;
     flb_time_zero(&file->mult_time);
 
     return 0;


### PR DESCRIPTION
Signed-off-by: Rayhan Hossain <hossain.rayhan@outlook.com>

<!-- Provide summary of changes -->
We are double freeing `&file->mult_sbuf` for multiline flush and Fluent Bit is crasing. This happens when we use multiline parser and rotate the file.

The first free is happening at `tail_multiline.c:491` and the next free is happening at `tail_file.c:1024`. 

From my investigation, I think we can avoid it in two different ways.
1. Assign NULL after freeing the memory at `tail_multiline.c:491` which I am doing in this PR. This way we won't have an issue if tail_file.c tries again to free that NULL assigned memory. I tested and it works.
2. Rmove the double fee from line [`tail_file.c:1024`](https://github.com/fluent/fluent-bit/blob/master/plugins/in_tail/tail_file.c#L1024). I am not sure if it has any other use case. But this will also work and I have tested it. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #4177 
Copy: https://github.com/aws/aws-for-fluent-bit/issues/255

**Valgrind Output:**
```
==22561== HEAP SUMMARY:
==22561==     in use at exit: 99,848 bytes in 3,381 blocks
==22561==   total heap usage: 7,559 allocs, 4,178 frees, 7,455,312 bytes allocated
==22561== 
==22561== LEAK SUMMARY:
==22561==    definitely lost: 0 bytes in 0 blocks
==22561==    indirectly lost: 0 bytes in 0 blocks
==22561==      possibly lost: 0 bytes in 0 blocks
==22561==    still reachable: 99,848 bytes in 3,381 blocks
==22561==         suppressed: 0 bytes in 0 blocks
==22561== Rerun with --leak-check=full to see details of leaked memory
==22561== 
==22561== For counts of detected and suppressed errors, rerun with: -v
==22561== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [`N/A`] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
