### PR TITLE
in_node_exporter_metrics: Ensure zero with epsilon on double type factor

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
@@ -26,6 +26,7 @@
 #include "ne_utils.h"
 
 #include <unistd.h>
+#include <float.h>
 
 /*
  * Diskstats interface references
@@ -119,7 +120,7 @@ static void metric_cache_update(struct flb_ne *ctx, int id, flb_sds_t device,
 
     ts = cmt_time_now();
 
-    if (m->factor != 0) {
+    if (m->factor > DBL_EPSILON) {
         val *= m->factor;
     }
 


### PR DESCRIPTION
Floating point number is not point zero precisely event if it is initialized with `0`.
Floating point number contains always error and this error can be
removed by `epsilon`.

C language defines epsilon for floating number in `<float.h>`.
For safe comparison, we must use epsilon even if factor value is zero.

`m->factor-> != 0` should be evaluated as `true`.
`(m->factor - 0) > DBL_EPSILON` or its equivalent
`m->factor > DBL_EPSILON` clause must be used for confirming whether zero or
not.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```console
$ bin/fluent-bit \
    -i node_exporter_metrics \
    -o forward -p host=<TOUR_HOST> -p port=24224 -p "tag=test.tag.awesome" \
    -f 1
```

- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Not memory related bug fix.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
