### PR TITLE
in_tail: release event loop between files (#3947)

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -209,12 +209,16 @@ static int in_tail_collect_static(struct flb_input_instance *ins,
             }
             break;
         }
-        /* 
-        * if we processed at least one file it is better to break here to give 
-        * control back to the event loop. This will be called again anyway. 
-        */
-        if (processed > 0) {
-            break;
+
+        if (ctx->process_files_batch_size > 0) {
+           /* 
+            * For performance when there are lots of files users can opt to break  
+            * here to give control back to the event loop. 
+            * This will be called again anyway. 
+            */
+            if (processed > ctx->process_files_batch_size) {
+                break;
+            }
         }
     }
 
@@ -672,6 +676,14 @@ static struct flb_config_map config_map[] = {
      "specify one or multiple multiline parsers: docker, cri, go, java, etc."
     },
 #endif
+
+    {
+     FLB_CONFIG_MAP_INT, "process_files_batch_size", "0",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, process_files_batch_size),
+     "Number of files to process in a single invocation of the plugin by the event loop. "
+     "Default is 0 which means unlimited/all watched files."
+
+    },
 
     /* EOF */
     {0}

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -104,6 +104,8 @@ struct flb_tail_config {
     sqlite3_stmt *stmt_offset;
 #endif
 
+    int process_files_batch_size;
+
     /* Parser / Format */
     struct flb_parser *parser;
 


### PR DESCRIPTION
This patch fixes a problem where in_tail will block the event loop until all files have been processed. This problem becomes more obvious when the number of files that the plugin is monitoring is large (>100)

Signed-off-by: Pablo E. Colazurdo pabcol@amazon.com

<!-- Provide summary of changes -->
This helps with issue #3947. The goal is to release the function after each file is processed, which will be invoked again by the event loop. Without this fix the function won't release until all files has been processed which, in situations where there are many files (>200) or the files are too long, causes stuck files and the output plugins aren't invoked until the function finishes.

This has been tested using tools/cio with different 100, 1000, 2000 files and 1000 and 10000 records.

```
tools/cio -p "tests/data/1.5kb.txt" -v -e 1000 -w 1000
tools/cio -p "tests/data/1.5kb.txt" -v -e 1000 -w 10000
tools/cio -p "tests/data/1.5kb.txt" -v -e 2000 -w 10000
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
