### PR TITLE
out_custom_calyptia: enable machine_id config property.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -35,6 +35,8 @@ struct calyptia {
     flb_sds_t store_path;
     flb_sds_t cloud_host;
     flb_sds_t cloud_port;
+    flb_sds_t machine_id;
+
     int cloud_tls;
     int cloud_tls_verify;
 
@@ -258,7 +260,6 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         flb_config_map_foreach(head, mv, ctx->add_labels) {
             k = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
             v = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
-
             kv = flb_sds_create_size(strlen(k->str) + strlen(v->str) + 1);
             if(!kv) {
                 flb_free(ctx);
@@ -275,6 +276,10 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     flb_output_set_property(ctx->o, "api_key", ctx->api_key);
     if (ctx->store_path) {
         flb_output_set_property(ctx->o, "store_path", ctx->store_path);
+    }
+
+    if (ctx->machine_id) {
+        flb_output_set_property(ctx->o, "machine_id", ctx->machine_id);
     }
 
     /* Override network details: development purposes only */
@@ -358,6 +363,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_SLIST_1, "add_label", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct calyptia, add_labels),
      "Label to append to the generated metric."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "machine_id", NULL,
+     0, FLB_TRUE, offsetof(struct calyptia, machine_id),
+     "Custom machine_id to be used when registering agent"
     },
 
     /* EOF */

--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -657,12 +657,16 @@ static struct flb_calyptia *config_init(struct flb_output_instance *ins,
         }
     }
 
-    /* machine id */
-    ret = get_machine_id(ctx, &machine_id, &size);
-    if (ret == -1) {
-        return NULL;
+    /* If no machine_id has been provided via a configuration option get it from the local machine-id. */
+    if (!ctx->machine_id) {
+        /* machine id */
+        ret = get_machine_id(ctx, &machine_id, &size);
+        if (ret == -1) {
+            return NULL;
+        }
+        ctx->machine_id = (flb_sds_t) machine_id;
     }
-    ctx->machine_id = (flb_sds_t) machine_id;
+
     flb_plg_debug(ctx->ins, "machine_id=%s", ctx->machine_id);
 
     /* Upstream */
@@ -871,6 +875,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "api_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_calyptia, api_key),
      "Calyptia Cloud API Key."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "machine_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_calyptia, machine_id),
+     "Custom machine_id to be used when registering agent"
     },
 
     {


### PR DESCRIPTION
if machine_id is set, that string value will be used
when registering the agent, if not given, a locally
generated one will be used.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change

[CUSTOM]
    name                calyptia
    api_key key-id
    machine_id 0xdeadbeef
    add_label           pipeline_id moguri
    add_label           pipeline_name testing
    log_level           debug
    calyptia_host       localhost
    calyptia_port       5000
    calyptia_tls        off
    calyptia_tls.verify off

- [X ] Debug log output from testing the change

without specifying machine_id

[2021/10/20 14:16:07] [debug] [stdout:stdout.0] created event channels: read=20 write=21
[2021/10/20 14:16:07] [debug] [calyptia:calyptia.1] created event channels: read=22 write=23
[2021/10/20 14:16:07] [debug] [output:calyptia:calyptia.1] machine_id=2bda59b7000f87707d080ffd7e60f838657fb3bf8c3f065464662deca2e07927
[2021/10/20 14:16:07] [debug] [http_client] not using http_proxy for header
[2021/10/20 14:16:07] [ info] [output:calyptia:calyptia.1] connected to Calyptia, agent_id='1a75a8ea-093e-42cf-9315-aa6c78fed24d'
[2021/10/20 14:16:07] [debug] [upstream] KA connection #24 to localhost:5000 is now available


with specyfing machine_id

[2021/10/20 14:16:43] [debug] [output:calyptia:calyptia.1] machine_id=0xdeadbeef
[2021/10/20 14:16:43] [debug] [http_client] not using http_proxy for header
[2021/10/20 14:16:43] [ info] [output:calyptia:calyptia.1] connected to Calyptia, agent_id='4ba69642-df23-4202-86ae-5bea7b1bdd86'
[2021/10/20 14:16:43] [debug] [upstream] KA connection #24 to localhost:5000 is now available

- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[2021/10/20 14:32:08] [ info] [engine] service stopped
==161677== 
==161677== HEAP SUMMARY:
==161677==     in use at exit: 0 bytes in 0 blocks
==161677==   total heap usage: 1,935 allocs, 1,936 frees, 572,620 bytes allocated
==161677== 
==161677== All heap blocks were freed -- no leaks are possible
==161677== 
==161677== For lists of detected and suppressed errors, rerun with: -s
==161677== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
