### PR TITLE
Dockerfile: use the binary as the entrypoint so we can pass arguments to docker run.

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -86,4 +86,5 @@ RUN rm /usr/bin/qemu-arm-static
 EXPOSE 2020
 
 # Entry point
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]
+CMD ["-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -109,4 +109,5 @@ COPY conf/fluent-bit.conf \
 EXPOSE 2020
 
 # Entry point
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT["/fluent-bit/bin/fluent-bit"]
+CMD ["-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -108,4 +108,5 @@ COPY --from=builder /fluent-bit /fluent-bit
 EXPOSE 2020
 
 # Entry point
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT ["/fluent-bit/bin/fluent-bit"]
+CMD ["-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/dockerfiles/Dockerfile.x86_64-1_7
+++ b/dockerfiles/Dockerfile.x86_64-1_7
@@ -100,4 +100,5 @@ COPY --from=builder /fluent-bit /fluent-bit
 COPY ci/scripts/run_log_generator.py /run_log_generator.py
 
 EXPOSE 2020
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT["/fluent-bit/bin/fluent-bit"]
+CMD ["-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/dockerfiles/Dockerfile.x86_64-master
+++ b/dockerfiles/Dockerfile.x86_64-master
@@ -93,4 +93,5 @@ COPY --from=builder /lib/x86_64-linux-gnu/libkeyutils* /lib/x86_64-linux-gnu/
 COPY --from=builder /fluent-bit /fluent-bit
 
 EXPOSE 2020
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT [ "/fluent-bit/bin/fluent-bit" ]
+CMD [ "-c", "/fluent-bit/etc/fluent-bit.conf" ]

--- a/dockerfiles/Dockerfile.x86_64-master_debug
+++ b/dockerfiles/Dockerfile.x86_64-master_debug
@@ -105,4 +105,5 @@ COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /bin/busybox /bin/
 
 # Entry point
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+ENTRYPOINT["/fluent-bit/bin/fluent-bit"]
+CMD ["-c", "/fluent-bit/etc/fluent-bit.conf"]


### PR DESCRIPTION
This is a relatively small change but a huge QoL gain. With this small change it makes several things extremely easy and intuitive:

- run the docker container to see the help
- pass in a volume with a configuration and parse it
- run ephemeral instances quickly to just push metrics from one place to another.

In essence this just removes the requirement to pass the full binary name to docker run if you want to run it with different arguments, ie you could quickly invoke fluent-bit to just log what events docker is generating:

```
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock fluent/fluent-bit:master -i docker_events -o stdout -f 1
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/22 18:27:35] [ info] [engine] started (pid=1)
[2021/10/22 18:27:35] [ info] [storage] version=1.1.4, initializing...
[2021/10/22 18:27:35] [ info] [storage] in-memory
[2021/10/22 18:27:35] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/22 18:27:35] [ info] [cmetrics] version=0.2.2
[2021/10/22 18:27:35] [ info] [input:docker_events:docker_events.0] listening for events on /var/run/docker.sock
[2021/10/22 18:27:35] [ info] [sp] stream processor started
[0] docker_events.0: [1634927255.260770919, {"message"=>"{"status":"start","id":"aedd25fbdcb015e1a2ad322fcadb119fbff0a19c793b1fdbfd83856557c3e589","from":"pwhelan/fluent-bit:master","Type":"container","Action":"start","Actor":{"ID":"aedd25fbdcb015e1a2ad322fcadb119fbff0a19c793b1fdbfd83856557c3e589","Attributes":{"Description":"Fluent Bit docker image","Vendor":"Fluent Organization","Version":"1.1","image":"pwhelan/fluent-bit:master","name":"bold_johnson"}},"scope":"local","time":1634927255,"timeNano":1634927255260648616}
"}]
^C[2021/10/22 18:27:42] [engine] caught signal (SIGINT)
[2021/10/22 18:27:42] [ warn] [engine] service will stop in 5 seconds
[2021/10/22 18:27:46] [ info] [engine] service stopped
```
