### PR TITLE
filter_modify: change log level to suppress(#4210)

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1231,7 +1231,7 @@ static inline int apply_modifying_rules(msgpack_packer *packer,
         // * * Record array item 1/2
         msgpack_pack_object(packer, ts);
 
-        flb_plg_debug(ctx->ins, "Input map size %d elements, output map size "
+        flb_plg_trace(ctx->ins, "Input map size %d elements, output map size "
                       "%d elements", records_in, map.via.map.size);
 
         // * * Record array item 2/2


### PR DESCRIPTION
Fixes #4210 


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[SERVICE]
    Log_Level trace

[INPUT]
    Name dummy

[FILTER]
    Name modify
    Match *
    Set aa bb

[OUTPUT]
    Name stdout
```

## Debug output

```
$ bin/fluent-bit -c 4210/a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/23 07:39:34] [ info] Configuration:
[2021/10/23 07:39:34] [ info]  flush time     | 5.000000 seconds
[2021/10/23 07:39:34] [ info]  grace          | 5 seconds
[2021/10/23 07:39:34] [ info]  daemon         | 0
[2021/10/23 07:39:34] [ info] ___________
[2021/10/23 07:39:34] [ info]  inputs:
[2021/10/23 07:39:34] [ info]      dummy
[2021/10/23 07:39:34] [ info] ___________
[2021/10/23 07:39:34] [ info]  filters:
[2021/10/23 07:39:34] [ info]      modify.0
[2021/10/23 07:39:34] [ info] ___________
[2021/10/23 07:39:34] [ info]  outputs:
[2021/10/23 07:39:34] [ info]      stdout.0
[2021/10/23 07:39:34] [ info] ___________
[2021/10/23 07:39:34] [ info]  collectors:
[2021/10/23 07:39:34] [ info] [engine] started (pid=5419)
[2021/10/23 07:39:34] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/10/23 07:39:34] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/10/23 07:39:34] [ info] [storage] version=1.1.4, initializing...
[2021/10/23 07:39:34] [ info] [storage] in-memory
[2021/10/23 07:39:34] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/23 07:39:34] [ info] [cmetrics] version=0.2.2
[2021/10/23 07:39:34] [debug] [filter:modify:modify.0] Initialized modify filter with 0 conditions and 1 rules
[2021/10/23 07:39:34] [debug] [stdout:stdout.0] created event channels: read=19 write=20
[2021/10/23 07:39:34] [debug] [router] default match rule dummy.0:stdout.0
[2021/10/23 07:39:34] [ info] [sp] stream processor started
[2021/10/23 07:39:34] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[2021/10/23 07:39:35] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[2021/10/23 07:39:36] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[2021/10/23 07:39:37] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[0] dummy.0: [1634942374.674470291, {"message"=>"dummy", "aa"=>"bb"}]
[2021/10/23 07:39:38] [debug] [task] created task=0x7f9c5800b070 id=0 OK
[1] dummy.0: [1634942375.674434673, {"message"=>"dummy", "aa"=>"bb"}]
[2] dummy.0: [1634942376.673816075, {"message"=>"dummy", "aa"=>"bb"}]
[3] dummy.0: [1634942377.674536730, {"message"=>"dummy", "aa"=>"bb"}]
[2021/10/23 07:39:38] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[2021/10/23 07:39:38] [debug] [out coro] cb_destroy coro_id=0
[2021/10/23 07:39:38] [debug] [task] destroy task=0x7f9c5800b070 (task_id=0)
^C[2021/10/23 07:39:39] [engine] caught signal (SIGINT)
[0] dummy.0: [1634942378.674027304, {"message"=>"dummy", "aa"=>"bb"}]
[2021/10/23 07:39:39] [debug] [task] created task=0x7f9c5800b7f0 id=0 OK
[2021/10/23 07:39:39] [ warn] [engine] service will stop in 5 seconds
[2021/10/23 07:39:39] [debug] [out coro] cb_destroy coro_id=1
[2021/10/23 07:39:39] [debug] [task] destroy task=0x7f9c5800b7f0 (task_id=0)
[2021/10/23 07:39:39] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:39:40] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:39:41] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:39:42] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:39:43] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c 4210/a.conf 
==5525== Memcheck, a memory error detector
==5525== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5525== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5525== Command: bin/fluent-bit -c 4210/a.conf
==5525== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/23 07:43:24] [ info] Configuration:
[2021/10/23 07:43:24] [ info]  flush time     | 5.000000 seconds
[2021/10/23 07:43:24] [ info]  grace          | 5 seconds
[2021/10/23 07:43:24] [ info]  daemon         | 0
[2021/10/23 07:43:24] [ info] ___________
[2021/10/23 07:43:24] [ info]  inputs:
[2021/10/23 07:43:24] [ info]      dummy
[2021/10/23 07:43:24] [ info] ___________
[2021/10/23 07:43:24] [ info]  filters:
[2021/10/23 07:43:24] [ info]      modify.0
[2021/10/23 07:43:24] [ info] ___________
[2021/10/23 07:43:24] [ info]  outputs:
[2021/10/23 07:43:24] [ info]      stdout.0
[2021/10/23 07:43:24] [ info] ___________
[2021/10/23 07:43:24] [ info]  collectors:
[2021/10/23 07:43:24] [ info] [engine] started (pid=5525)
[2021/10/23 07:43:24] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/10/23 07:43:24] [debug] [storage] [cio stream] new stream registered: dummy.0
[2021/10/23 07:43:24] [ info] [storage] version=1.1.4, initializing...
[2021/10/23 07:43:24] [ info] [storage] in-memory
[2021/10/23 07:43:24] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/23 07:43:24] [ info] [cmetrics] version=0.2.2
[2021/10/23 07:43:24] [debug] [filter:modify:modify.0] Initialized modify filter with 0 conditions and 1 rules
[2021/10/23 07:43:24] [debug] [stdout:stdout.0] created event channels: read=19 write=20
[2021/10/23 07:43:24] [debug] [router] default match rule dummy.0:stdout.0
[2021/10/23 07:43:24] [ info] [sp] stream processor started
[2021/10/23 07:43:25] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
[2021/10/23 07:43:26] [trace] [filter:modify:modify.0 at plugins/filter_modify/modify.c:1234] Input map size 1 elements, output map size 2 elements
^C[2021/10/23 07:43:27] [engine] caught signal (SIGINT)
[2021/10/23 07:43:27] [debug] [task] created task=0x4c9af90 id=0 OK
==5525== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4ca13e0
==5525==          to suppress, use: --max-stackframe=11814216 or greater
==5525== Warning: client switching stacks?  SP change: 0x4ca1358 --> 0x57e5928
==5525==          to suppress, use: --max-stackframe=11814352 or greater
==5525== Warning: client switching stacks?  SP change: 0x57e5928 --> 0x4ca1358
==5525==          to suppress, use: --max-stackframe=11814352 or greater
==5525==          further instances of this message will not be shown.
[0] dummy.0: [1634942605.691172713, {"message"=>"dummy", "aa"=>"bb"}]
[1] dummy.0: [1634942606.674275639, {"message"=>"dummy", "aa"=>"bb"}]
[2021/10/23 07:43:27] [ warn] [engine] service will stop in 5 seconds
[2021/10/23 07:43:27] [debug] [out coro] cb_destroy coro_id=0
[2021/10/23 07:43:27] [debug] [task] destroy task=0x4c9af90 (task_id=0)
[2021/10/23 07:43:27] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:43:28] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:43:29] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:43:30] [debug] [input chunk] dummy.0 is paused, cannot append records
[2021/10/23 07:43:31] [ info] [engine] service stopped
==5525== 
==5525== HEAP SUMMARY:
==5525==     in use at exit: 0 bytes in 0 blocks
==5525==   total heap usage: 1,172 allocs, 1,172 frees, 869,435 bytes allocated
==5525== 
==5525== All heap blocks were freed -- no leaks are possible
==5525== 
==5525== For lists of detected and suppressed errors, rerun with: -s
==5525== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
