### PR TITLE
lib: monkey: cherry-pick added rudimentary initialization check on mk_http_error

### DIFF
--- a/lib/monkey/mk_server/mk_http.c
+++ b/lib/monkey/mk_server/mk_http.c
@@ -1213,6 +1213,14 @@ int mk_http_error(int http_status, struct mk_http_session *cs,
     struct file_info finfo;
     struct mk_iov *iov;
 
+    /* This function requires monkey to be properly initialized which is not the case
+     * when it's just used to parse http requests in fluent-bit so we want it to ignore
+     * that case and let fluent-bit handle it.
+    */
+    if (server->workers == 0) {
+        return MK_EXIT_OK;
+    }
+
     mk_header_set_http_status(sr, http_status);
     mk_ptr_reset(&page);
 


### PR DESCRIPTION
Fluent-bit in_http plugin faces a problem that when posting invalid content the program exits.

Here is how to reproduce. With the config:
```
[INPUT]
    name http
    port 18080
    host 0.0.0.0
    successful_response_code 200
[OUTPUT]
    name stdout
```

do a 
```
curl -XPUT http://127.0.0.1:18080
curl -XPOST http://127.0.0.1:18080
```
Any of them will cause fluent-bit to exit. This is due to not passing any data on POST/PUT and then no Content-Length header been sent.

This apparently is due to the lack of some initialization.

After digging a lot (sorry, I'm not a C developer!!) I've found that this was actually fixed in upstream monkey lib, so I'm proposing here to get the fix already made in upstream lib by @leonardo-albertovich to fluent-bit lib directory.

So I cherry-picked https://github.com/monkey/monkey/commit/0a0dbb2dd3107f74182ce2d0b72994c9be9b83c0 into here

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
