### PR TITLE
scheduler: fix back off full jitter calculation

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -256,7 +256,7 @@ static int backoff_full_jitter(int base, int cap, int n)
 {
     int temp;
 
-    temp = xmin(cap, ipow(base * 2, n));
+    temp = xmin(cap, base * ipow(2, n));
     return random_uniform(base, temp);
 }
 


### PR DESCRIPTION
Addresses #3597 and fixes a potential bug caused as a side effect of https://github.com/fluent/fluent-bit/commit/16968ccd77e3e9e72af4c247f3305a021d20b185

The current implementation of calculating the back off jitter does not follow the paper https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ 

It generates retries like
```
retry  0 -    4 backoff
retry  1 -    8 backoff
retry  2 -   25 backoff
retry  3 -  566 backoff
retry  4 - 1280 backoff
retry  5 - 1826 backoff
retry  6 - 1332 backoff
retry  7 -  933 backoff
retry  8 - 1598 backoff
retry  9 -  694 backoff
```

This is not desired. We are roughly doing a 10x backoff with every retry upto a maximum configured value. The correct implementation should do a backoff based on the exponent of multiplier.

With the change made in the PR, the retries look correct:
```
retry  0 -    6 backoff
retry  1 -    9 backoff
retry  2 -   14 backoff
retry  3 -    7 backoff
retry  4 -   54 backoff
retry  5 -   93 backoff
retry  6 -  162 backoff
retry  7 -  472 backoff
retry  8 -  222 backoff
retry  9 -  627 backoff
```
----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature
- [Reference](https://www.baeldung.com/resilience4j-backoff-jitter) for correct calculation

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
