### PR TITLE
in_tail: avoid double free for multiline msgpack buffer

### DIFF
--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -489,6 +489,7 @@ int flb_tail_mult_flush(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
     file->mult_keys = 0;
     file->mult_flush_timeout = 0;
     msgpack_sbuffer_destroy(&file->mult_sbuf);
+    file->mult_sbuf.data = NULL;
     flb_time_zero(&file->mult_time);
 
     return 0;


### PR DESCRIPTION
Signed-off-by: Rayhan Hossain <hossain.rayhan@outlook.com>

We are double freeing &file->mult_sbuf for multiline flush and Fluent Bit is crasing. This happens when we use multiline parser and rotate the file.

The first free is happening at tail_multiline.c:491 and the next free is happening at tail_file.c:1024.

From my investigation, I think we can avoid it in two different ways.

- Assign NULL after freeing the memory at tail_multiline.c:491 which I am doing in this PR. This way we won't have an issue if tail_file.c tries again to free that NULL assigned memory. I tested and it works.
- Rmove the double fee from line tail_file.c:1024. I am not sure if it has any other use case. But this will also work and I have tested it.

Fixes #4177 
Copy: https://github.com/aws/aws-for-fluent-bit/issues/255

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
