### PR TITLE
in_tail: close inotify fd on exit

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -410,6 +410,7 @@ static int in_tail_exit(void *data, struct flb_config *config)
     struct flb_tail_config *ctx = data;
 
     flb_tail_file_remove_all(ctx);
+    flb_tail_fs_exit(ctx);
     flb_tail_config_destroy(ctx);
 
     return 0;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -363,6 +363,5 @@ int flb_tail_fs_inotify_remove(struct flb_tail_file *file)
 
 int flb_tail_fs_inotify_exit(struct flb_tail_config *ctx)
 {
-    (void) ctx;
-    return 0;
+    return close(ctx->fd_notify);
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch fixes a problem where the fd returned by inotify_init1(2) was
not closed.

Tested with the unit test and valgrind.

Signed-off-by: Emma Haruka Iwao <yuryu@google.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
valgrind ./bin/flb-rt-in_tail          
==2445744== Memcheck, a memory error detector
==2445744== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2445744== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==2445744== Command: ./bin/flb-rt-in_tail
==2445744== 
Test issue_3943...                              ==2445745== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x4fd1da0
==2445745==          to suppress, use: --max-stackframe=12011960 or greater
==2445745== Warning: client switching stacks?  SP change: 0x4fd1d18 --> 0x5b46758
==2445745==          to suppress, use: --max-stackframe=12012096 or greater
==2445745== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x4fd1d18
==2445745==          to suppress, use: --max-stackframe=12012096 or greater
==2445745==          further instances of this message will not be shown.
[2021/10/29 19:18:46] [ info] [input] pausing tail.0
[ OK ]
==2445745== 
==2445745== HEAP SUMMARY:
==2445745==     in use at exit: 112 bytes in 1 blocks
==2445745==   total heap usage: 1,144 allocs, 1,143 frees, 596,599 bytes allocated
==2445745== 
==2445745== LEAK SUMMARY:
==2445745==    definitely lost: 0 bytes in 0 blocks
==2445745==    indirectly lost: 0 bytes in 0 blocks
==2445745==      possibly lost: 0 bytes in 0 blocks
==2445745==    still reachable: 112 bytes in 1 blocks
==2445745==         suppressed: 0 bytes in 0 blocks
==2445745== Rerun with --leak-check=full to see details of leaked memory
==2445745== 
==2445745== For lists of detected and suppressed errors, rerun with: -s
==2445745== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test skip_long_lines...                         ==2445774== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x4fda020
==2445774==          to suppress, use: --max-stackframe=11978552 or greater
==2445774== Warning: client switching stacks?  SP change: 0x4fd9f98 --> 0x5b46758
==2445774==          to suppress, use: --max-stackframe=11978688 or greater
==2445774== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x4fd9f98
==2445774==          to suppress, use: --max-stackframe=11978688 or greater
==2445774==          further instances of this message will not be shown.
[2021/10/29 19:18:50] [ info] [input] pausing tail.0
[ OK ]
==2445774== 
==2445774== HEAP SUMMARY:
==2445774==     in use at exit: 112 bytes in 1 blocks
==2445774==   total heap usage: 1,149 allocs, 1,148 frees, 605,078 bytes allocated
==2445774== 
==2445774== LEAK SUMMARY:
==2445774==    definitely lost: 0 bytes in 0 blocks
==2445774==    indirectly lost: 0 bytes in 0 blocks
==2445774==      possibly lost: 0 bytes in 0 blocks
==2445774==    still reachable: 112 bytes in 1 blocks
==2445774==         suppressed: 0 bytes in 0 blocks
==2445774== Rerun with --leak-check=full to see details of leaked memory
==2445774== 
==2445774== For lists of detected and suppressed errors, rerun with: -s
==2445774== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test in_tail_dockermode...                      ==2445801== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5016810
==2445801==          to suppress, use: --max-stackframe=11730760 or greater
==2445801== Warning: client switching stacks?  SP change: 0x5016788 --> 0x5b46758
==2445801==          to suppress, use: --max-stackframe=11730896 or greater
==2445801== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5016788
==2445801==          to suppress, use: --max-stackframe=11730896 or greater
==2445801==          further instances of this message will not be shown.
[2021/10/29 19:18:51] [ info] [input] pausing tail.0
[ OK ]
==2445801== 
==2445801== HEAP SUMMARY:
==2445801==     in use at exit: 112 bytes in 1 blocks
==2445801==   total heap usage: 1,318 allocs, 1,317 frees, 805,366 bytes allocated
==2445801== 
==2445801== LEAK SUMMARY:
==2445801==    definitely lost: 0 bytes in 0 blocks
==2445801==    indirectly lost: 0 bytes in 0 blocks
==2445801==      possibly lost: 0 bytes in 0 blocks
==2445801==    still reachable: 112 bytes in 1 blocks
==2445801==         suppressed: 0 bytes in 0 blocks
==2445801== Rerun with --leak-check=full to see details of leaked memory
==2445801== 
==2445801== For lists of detected and suppressed errors, rerun with: -s
==2445801== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test in_tail_dockermode_splitted_line...        ==2445850== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5015230
==2445850==          to suppress, use: --max-stackframe=11736360 or greater
==2445850== Warning: client switching stacks?  SP change: 0x50151a8 --> 0x5b46758
==2445850==          to suppress, use: --max-stackframe=11736496 or greater
==2445850== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x50151a8
==2445850==          to suppress, use: --max-stackframe=11736496 or greater
==2445850==          further instances of this message will not be shown.
[2021/10/29 19:18:53] [ info] [input] pausing tail.0
[ OK ]
==2445850== 
==2445850== HEAP SUMMARY:
==2445850==     in use at exit: 112 bytes in 1 blocks
==2445850==   total heap usage: 1,317 allocs, 1,316 frees, 810,752 bytes allocated
==2445850== 
==2445850== LEAK SUMMARY:
==2445850==    definitely lost: 0 bytes in 0 blocks
==2445850==    indirectly lost: 0 bytes in 0 blocks
==2445850==      possibly lost: 0 bytes in 0 blocks
==2445850==    still reachable: 112 bytes in 1 blocks
==2445850==         suppressed: 0 bytes in 0 blocks
==2445850== Rerun with --leak-check=full to see details of leaked memory
==2445850== 
==2445850== For lists of detected and suppressed errors, rerun with: -s
==2445850== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test in_tail_dockermode_multiple_lines...       ==2445877== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5010e40
==2445877==          to suppress, use: --max-stackframe=11753752 or greater
==2445877== Warning: client switching stacks?  SP change: 0x5010db8 --> 0x5b46758
==2445877==          to suppress, use: --max-stackframe=11753888 or greater
==2445877== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5010db8
==2445877==          to suppress, use: --max-stackframe=11753888 or greater
==2445877==          further instances of this message will not be shown.
[2021/10/29 19:18:58] [ info] [input] pausing tail.0
[ OK ]
==2445877== 
==2445877== HEAP SUMMARY:
==2445877==     in use at exit: 112 bytes in 1 blocks
==2445877==   total heap usage: 1,369 allocs, 1,368 frees, 1,199,315 bytes allocated
==2445877== 
==2445877== LEAK SUMMARY:
==2445877==    definitely lost: 0 bytes in 0 blocks
==2445877==    indirectly lost: 0 bytes in 0 blocks
==2445877==      possibly lost: 0 bytes in 0 blocks
==2445877==    still reachable: 112 bytes in 1 blocks
==2445877==         suppressed: 0 bytes in 0 blocks
==2445877== Rerun with --leak-check=full to see details of leaked memory
==2445877== 
==2445877== For lists of detected and suppressed errors, rerun with: -s
==2445877== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test in_tail_dockermode_splitted_multiple_lines... ==2445902== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x50162f0
==2445902==          to suppress, use: --max-stackframe=11732072 or greater
==2445902== Warning: client switching stacks?  SP change: 0x5016268 --> 0x5b46758
==2445902==          to suppress, use: --max-stackframe=11732208 or greater
==2445902== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5016268
==2445902==          to suppress, use: --max-stackframe=11732208 or greater
==2445902==          further instances of this message will not be shown.
[2021/10/29 19:19:03] [ info] [input] pausing tail.0
[ OK ]
==2445902== 
==2445902== HEAP SUMMARY:
==2445902==     in use at exit: 112 bytes in 1 blocks
==2445902==   total heap usage: 1,378 allocs, 1,377 frees, 1,195,677 bytes allocated
==2445902== 
==2445902== LEAK SUMMARY:
==2445902==    definitely lost: 0 bytes in 0 blocks
==2445902==    indirectly lost: 0 bytes in 0 blocks
==2445902==      possibly lost: 0 bytes in 0 blocks
==2445902==    still reachable: 112 bytes in 1 blocks
==2445902==         suppressed: 0 bytes in 0 blocks
==2445902== Rerun with --leak-check=full to see details of leaked memory
==2445902== 
==2445902== For lists of detected and suppressed errors, rerun with: -s
==2445902== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test in_tail_dockermode_firstline_detection...  ==2445926== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5034590
==2445926==          to suppress, use: --max-stackframe=11608520 or greater
==2445926== Warning: client switching stacks?  SP change: 0x5034508 --> 0x5b46758
==2445926==          to suppress, use: --max-stackframe=11608656 or greater
==2445926== Warning: client switching stacks?  SP change: 0x5b46758 --> 0x5034508
==2445926==          to suppress, use: --max-stackframe=11608656 or greater
==2445926==          further instances of this message will not be shown.
[2021/10/29 19:19:08] [ info] [input] pausing tail.0
[ OK ]
==2445926== 
==2445926== HEAP SUMMARY:
==2445926==     in use at exit: 112 bytes in 1 blocks
==2445926==   total heap usage: 1,438 allocs, 1,437 frees, 1,382,279 bytes allocated
==2445926== 
==2445926== LEAK SUMMARY:
==2445926==    definitely lost: 0 bytes in 0 blocks
==2445926==    indirectly lost: 0 bytes in 0 blocks
==2445926==      possibly lost: 0 bytes in 0 blocks
==2445926==    still reachable: 112 bytes in 1 blocks
==2445926==         suppressed: 0 bytes in 0 blocks
==2445926== Rerun with --leak-check=full to see details of leaked memory
==2445926== 
==2445926== For lists of detected and suppressed errors, rerun with: -s
==2445926== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==2445744== 
==2445744== HEAP SUMMARY:
==2445744==     in use at exit: 0 bytes in 0 blocks
==2445744==   total heap usage: 2 allocs, 2 frees, 1,136 bytes allocated
==2445744== 
==2445744== All heap blocks were freed -- no leaks are possible
==2445744== 
==2445744== For lists of detected and suppressed errors, rerun with: -s
==2445744== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
