### PR TITLE
filter_rewrite_tag: add NULL check(#4246)

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -181,8 +181,13 @@ static int process_config(struct flb_rewrite_tag *ctx)
 
 static int is_wildcard(char* match)
 {
-    size_t len = strlen(match);
+    size_t len;
     size_t i;
+
+    if (match == NULL) {
+        return 0;
+    }
+    len = strlen(match);
 
     /* '***' should be ignored. So we check every char. */
     for (i=0; i<len; i++) {


### PR DESCRIPTION
Fixes #4246

I added missing NULL checking.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[INPUT]
    Name dummy
    Tag  aaa
    Dummy {"msg":"hello"}

[FILTER]
    Name rewrite_tag
    Match_Regex a.a
#    Match  *
    Rule $msg .*  new false

[OUTPUT]
    Name stdout
    Match new
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/30 08:15:18] [ info] [engine] started (pid=13407)
[2021/10/30 08:15:18] [ info] [storage] version=1.1.5, initializing...
[2021/10/30 08:15:18] [ info] [storage] in-memory
[2021/10/30 08:15:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/30 08:15:18] [ info] [cmetrics] version=0.2.2
[2021/10/30 08:15:18] [ info] [sp] stream processor started
[0] new: [1635549319.705854689, {"msg"=>"hello"}]
[1] new: [1635549320.706214662, {"msg"=>"hello"}]
[2] new: [1635549321.705911782, {"msg"=>"hello"}]
[3] new: [1635549322.705876423, {"msg"=>"hello"}]
^C[2021/10/30 08:15:24] [engine] caught signal (SIGINT)
[0] new: [1635549323.706051590, {"msg"=>"hello"}]
[2021/10/30 08:15:24] [ warn] [engine] service will stop in 5 seconds
[2021/10/30 08:15:28] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==13410== Memcheck, a memory error detector
==13410== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13410== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==13410== Command: ../bin/fluent-bit -c a.conf
==13410== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/30 08:15:52] [ info] [engine] started (pid=13410)
[2021/10/30 08:15:52] [ info] [storage] version=1.1.5, initializing...
[2021/10/30 08:15:52] [ info] [storage] in-memory
[2021/10/30 08:15:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/30 08:15:52] [ info] [cmetrics] version=0.2.2
[2021/10/30 08:15:52] [ info] [sp] stream processor started
==13410== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc78f0
==13410==          to suppress, use: --max-stackframe=10608856 or greater
==13410== Warning: client switching stacks?  SP change: 0x4dc7868 --> 0x57e59c8
==13410==          to suppress, use: --max-stackframe=10608992 or greater
==13410== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc7868
==13410==          to suppress, use: --max-stackframe=10608992 or greater
==13410==          further instances of this message will not be shown.
[0] new: [1635549353.717455243, {"msg"=>"hello"}]
[1] new: [1635549354.705944056, {"msg"=>"hello"}]
[2] new: [1635549355.706149844, {"msg"=>"hello"}]
[3] new: [1635549356.705992153, {"msg"=>"hello"}]
^C[2021/10/30 08:15:58] [engine] caught signal (SIGINT)
[0] new: [1635549357.731680817, {"msg"=>"hello"}]
[2021/10/30 08:15:58] [ warn] [engine] service will stop in 5 seconds
[2021/10/30 08:16:02] [ info] [engine] service stopped
==13410== 
==13410== HEAP SUMMARY:
==13410==     in use at exit: 0 bytes in 0 blocks
==13410==   total heap usage: 1,414 allocs, 1,414 frees, 2,743,871 bytes allocated
==13410== 
==13410== All heap blocks were freed -- no leaks are possible
==13410== 
==13410== For lists of detected and suppressed errors, rerun with: -s
==13410== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
