### PR TITLE
ra: allow dash as an IDENTIFIER(#4236)

### DIFF
--- a/src/record_accessor/ra.l
+++ b/src/record_accessor/ra.l
@@ -53,7 +53,7 @@ static inline char *remove_dup_quotes(const char *s, size_t n)
 
 [1-9][0-9]*|0            { yylval->integer = atoi(yytext);  return INTEGER; }
 \'([^']|'{2})*\'           { yylval->string = remove_dup_quotes(yytext + 1, yyleng - 2); return STRING; }
-[_A-Za-z][A-Za-z0-9_.]*	   { yylval->string = flb_strdup(yytext); return IDENTIFIER; }
+[_A-Za-z][A-Za-z0-9_.-]*	   { yylval->string = flb_strdup(yytext); return IDENTIFIER; }
 
 "$"                     |
 "["                     |


### PR DESCRIPTION
Fixes #4236 

This patch is to allow a key name which contains '-'.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Example Configuration

```
[INPUT]
    Name dummy
    Tag aaa
    Dummy {"talos-service":"hoge", "msg":"sample"}

[FILTER]
    Name rewrite_tag
    Match aaa
    Rule msg .+ $talos-service false

[OUTPUT]
    Name stdout
    Match hoge
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/30 20:50:35] [ info] [engine] started (pid=51299)
[2021/10/30 20:50:35] [ info] [storage] version=1.1.5, initializing...
[2021/10/30 20:50:35] [ info] [storage] in-memory
[2021/10/30 20:50:35] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/30 20:50:35] [ info] [cmetrics] version=0.2.2
[2021/10/30 20:50:35] [ info] [sp] stream processor started
[0] hoge: [1635594635.960586178, {"talos-service"=>"hoge", "msg"=>"sample"}]
[1] hoge: [1635594636.961582417, {"talos-service"=>"hoge", "msg"=>"sample"}]
[2] hoge: [1635594637.960907764, {"talos-service"=>"hoge", "msg"=>"sample"}]
[3] hoge: [1635594638.961098704, {"talos-service"=>"hoge", "msg"=>"sample"}]
^C[2021/10/30 20:50:42] [engine] caught signal (SIGINT)
[0] hoge: [1635594639.961209245, {"talos-service"=>"hoge", "msg"=>"sample"}]
[1] hoge: [1635594640.961166884, {"talos-service"=>"hoge", "msg"=>"sample"}]
[2] hoge: [1635594641.960747081, {"talos-service"=>"hoge", "msg"=>"sample"}]
[2021/10/30 20:50:42] [ warn] [engine] service will stop in 5 seconds
[2021/10/30 20:50:46] [ info] [engine] service stopped
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==51302== Memcheck, a memory error detector
==51302== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==51302== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==51302== Command: ../bin/fluent-bit -c a.conf
==51302== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/30 20:51:18] [ info] [engine] started (pid=51302)
[2021/10/30 20:51:18] [ info] [storage] version=1.1.5, initializing...
[2021/10/30 20:51:18] [ info] [storage] in-memory
[2021/10/30 20:51:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/30 20:51:18] [ info] [cmetrics] version=0.2.2
[2021/10/30 20:51:18] [ info] [sp] stream processor started
==51302== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc76c0
==51302==          to suppress, use: --max-stackframe=10609416 or greater
==51302== Warning: client switching stacks?  SP change: 0x4dc7638 --> 0x57e59c8
==51302==          to suppress, use: --max-stackframe=10609552 or greater
==51302== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc7638
==51302==          to suppress, use: --max-stackframe=10609552 or greater
==51302==          further instances of this message will not be shown.
[0] hoge: [1635594678.973094050, {"talos-service"=>"hoge", "msg"=>"sample"}]
[1] hoge: [1635594679.960630096, {"talos-service"=>"hoge", "msg"=>"sample"}]
[2] hoge: [1635594680.961598370, {"talos-service"=>"hoge", "msg"=>"sample"}]
[3] hoge: [1635594681.961331490, {"talos-service"=>"hoge", "msg"=>"sample"}]
^C[2021/10/30 20:51:23] [engine] caught signal (SIGINT)
[0] hoge: [1635594682.989695801, {"talos-service"=>"hoge", "msg"=>"sample"}]
[2021/10/30 20:51:23] [ warn] [engine] service will stop in 5 seconds
[2021/10/30 20:51:27] [ info] [engine] service stopped
==51302== 
==51302== HEAP SUMMARY:
==51302==     in use at exit: 0 bytes in 0 blocks
==51302==   total heap usage: 1,414 allocs, 1,414 frees, 2,743,620 bytes allocated
==51302== 
==51302== All heap blocks were freed -- no leaks are possible
==51302== 
==51302== For lists of detected and suppressed errors, rerun with: -s
==51302== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Internal test

```
$ bin/flb-it-record_accessor 
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a

type       : STRING
string     : ' extra '

type       : KEYMAP
key name   : bbb
 - subkey  : b

type       : STRING
string     : ' final access'

=== test ===
type       : KEYMAP
key name   : b
 - subkey  : x
 - subkey  : y

=== test ===
type       : KEYMAP
key name   : z

=== test ===
type       : STRING
string     : 'abc'
[2021/10/30 20:51:53] [error] [record accessor] syntax error, unexpected $end, expecting ']' at '$abc['a''
[ OK ]
Test dash_key...                                == input ==
something
== output ==
something
[ OK ]
Test translate...                               == input ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
== output ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
[ OK ]
Test translate_tag...                           [ OK ]
Test dots_subkeys...                            == input ==
thetag
== output ==
thetag
[ OK ]
Test array_id...                                == input ==
thetag
== output ==
thetag
[ OK ]
Test get_kv_pair...                             [ OK ]
SUCCESS: All unit tests have passed.
```
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
