### PR TITLE
http_server: add content type(#4240)

### DIFF
--- a/include/fluent-bit/http_server/flb_hs_utils.h
+++ b/include/fluent-bit/http_server/flb_hs_utils.h
@@ -2,7 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
  *  Copyright (C) 2015-2018 Treasure Data Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +18,26 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_info.h>
-#ifdef FLB_HAVE_HTTP_SERVER
+#ifndef FLB_HS_UTIL_H
+#define FLB_HS_UTIL_H
 
-#ifndef FLB_HTTP_SERVER_H
-#define FLB_HTTP_SERVER_H
-#include "http_server/flb_hs.h"
-#include "http_server/flb_hs_utils.h"
-#include "http_server/flb_hs_endpoints.h"
+#include <monkey/mk_lib.h>
+
+int flb_hs_add_content_type_to_req(mk_request_t *request, int type);
+
+/* Content-type */
+enum content_type {
+    FLB_HS_CONTENT_TYPE_JSON,
+    FLB_HS_CONTENT_TYPE_PROMETHEUS,
+    FLB_HS_CONTENT_TYPE_OTHER
+};
+
+#define FLB_HS_CONTENT_TYPE_KEY_STR "Content-Type"
+#define FLB_HS_CONTENT_TYPE_KEY_LEN 12
+
+#define FLB_HS_CONTENT_TYPE_JSON_STR  "application/json"
+#define FLB_HS_CONTENT_TYPE_JSON_LEN  16
+#define FLB_HS_CONTENT_TYPE_PROMETHEUS_STR "text/plain; version=0.0.4"
+#define FLB_HS_CONTENT_TYPE_PROMETHEUS_LEN 25
 
 #endif
-
-#endif /* !FLB_HAVE_HTTP_SERVER */

--- a/src/http_server/CMakeLists.txt
+++ b/src/http_server/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 set(src
   flb_hs.c
   flb_hs_endpoints.c
+  flb_hs_utils.c
   )
 
 # api/v1

--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -31,8 +31,6 @@
 #include <fluent-bit/flb_http_server.h>
 #include <msgpack.h>
 
-#define PROMETHEUS_HEADER "text/plain; version=0.0.4"
-
 #define null_check(x) do { if (!x) { goto error; } else {sds = x;} } while (0)
 
 pthread_key_t hs_metrics_key;
@@ -515,9 +513,7 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
     buf->users--;
 
     mk_http_status(request, 200);
-    mk_http_header(request,
-                   "Content-Type", 12,
-                   PROMETHEUS_HEADER, sizeof(PROMETHEUS_HEADER) - 1);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_PROMETHEUS);
     mk_http_send(request, sds, flb_sds_len(sds), NULL);
     for (i = 0; i < num_metrics; i++) {
       flb_sds_destroy(metrics_arr[i]);
@@ -558,6 +554,7 @@ static void cb_metrics(mk_request_t *request, void *data)
     buf->users++;
 
     mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_JSON);
     mk_http_send(request, buf->data, flb_sds_len(buf->data), NULL);
     mk_http_done(request);
 

--- a/src/http_server/api/v1/storage.c
+++ b/src/http_server/api/v1/storage.c
@@ -151,6 +151,7 @@ static void cb_storage(mk_request_t *request, void *data)
     buf->users++;
 
     mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_JSON);
     mk_http_send(request, buf->data, flb_sds_len(buf->data), NULL);
     mk_http_done(request);
 

--- a/src/http_server/api/v1/uptime.c
+++ b/src/http_server/api/v1/uptime.c
@@ -97,6 +97,7 @@ static void cb_uptime(mk_request_t *request, void *data)
     out_size = flb_sds_len(out_buf);
 
     mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_JSON);
     mk_http_send(request, out_buf, out_size, NULL);
     mk_http_done(request);
 

--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -33,6 +33,7 @@ static void cb_root(mk_request_t *request, void *data)
     struct flb_hs *hs = data;
 
     mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_JSON);
     mk_http_send(request, hs->ep_root_buf, hs->ep_root_size, NULL);
     mk_http_done(request);
 }

--- a/src/http_server/flb_hs_utils.c
+++ b/src/http_server/flb_hs_utils.c
@@ -1,0 +1,49 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_http_server.h>
+#include <monkey/mk_lib.h>
+
+int flb_hs_add_content_type_to_req(mk_request_t *request, int type)
+{
+    if (request == NULL) {
+        return -1;
+    }
+
+    switch (type) {
+    case FLB_HS_CONTENT_TYPE_JSON:
+        mk_http_header(request,
+                       FLB_HS_CONTENT_TYPE_KEY_STR, FLB_HS_CONTENT_TYPE_KEY_LEN,
+                       FLB_HS_CONTENT_TYPE_JSON_STR, FLB_HS_CONTENT_TYPE_JSON_LEN);
+        break;
+    case FLB_HS_CONTENT_TYPE_PROMETHEUS:
+        mk_http_header(request,
+                       FLB_HS_CONTENT_TYPE_KEY_STR, FLB_HS_CONTENT_TYPE_KEY_LEN,
+                       FLB_HS_CONTENT_TYPE_PROMETHEUS_STR, FLB_HS_CONTENT_TYPE_PROMETHEUS_LEN);
+        break;
+    default:
+        flb_error("[%s] unknown type=%d", type);
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #4240 

This patch is to add 
* flb_fs_utils: to support `flb_hs_add_content_type_to_req`
* http_server/uptime/metrics/storage: add content-type using `flb_hs_add_content_type_to_req`

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[SERVICE]
    HTTP_Server on
    storage.metrics on
    Health_Check on
[INPUT]
    Name dummy

[OUTPUT]
    Name null
```

## Valgrind output

Leak is reported, but I think it is not related this PR.

Accessing `/api/v1/metrics/prometheus` causes a lot of leaks.
It doesn't contain below result.

```
 valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==18498== Memcheck, a memory error detector
==18498== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18498== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18498== Command: ../bin/fluent-bit -c a.conf
==18498== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/31 11:06:58] [ info] [engine] started (pid=18498)
[2021/10/31 11:06:58] [ info] [storage] version=1.1.5, initializing...
[2021/10/31 11:06:58] [ info] [storage] in-memory
[2021/10/31 11:06:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/31 11:06:58] [ info] [cmetrics] version=0.2.2
[2021/10/31 11:06:59] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/10/31 11:06:59] [ info] [sp] stream processor started
==18498== Warning: client switching stacks?  SP change: 0x77e9568 --> 0x4cb2560
==18498==          to suppress, use: --max-stackframe=45314056 or greater
==18498== Warning: client switching stacks?  SP change: 0x4cb24c8 --> 0x77e9568
==18498==          to suppress, use: --max-stackframe=45314208 or greater
==18498== Warning: client switching stacks?  SP change: 0x77e9628 --> 0x4cb24c8
==18498==          to suppress, use: --max-stackframe=45314400 or greater
==18498==          further instances of this message will not be shown.
^C[2021/10/31 11:07:16] [engine] caught signal (SIGINT)
[2021/10/31 11:07:16] [ warn] [engine] service will stop in 5 seconds
[2021/10/31 11:07:20] [ info] [engine] service stopped
==18498== 
==18498== HEAP SUMMARY:
==18498==     in use at exit: 642 bytes in 5 blocks
==18498==   total heap usage: 1,603 allocs, 1,598 frees, 2,935,427 bytes allocated
==18498== 
==18498== 56 bytes in 1 blocks are definitely lost in loss record 2 of 5
==18498==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==18498==    by 0x71985F: mk_mem_alloc_z (mk_memory.h:70)
==18498==    by 0x7199D6: thread_get_libco_params (mk_http_thread.c:60)
==18498==    by 0x719BBE: thread_params_set (mk_http_thread.c:168)
==18498==    by 0x719DB1: mk_http_thread_create (mk_http_thread.c:226)
==18498==    by 0x715F9B: mk_http_init (mk_http.c:748)
==18498==    by 0x714DE4: mk_http_request_prepare (mk_http.c:232)
==18498==    by 0x717DC6: mk_http_sched_read (mk_http.c:1568)
==18498==    by 0x7139E2: mk_sched_event_read (mk_scheduler.c:693)
==18498==    by 0x71C763: mk_server_worker_loop (mk_server.c:487)
==18498==    by 0x71333D: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==18498==    by 0x4865608: start_thread (pthread_create.c:477)
==18498== 
==18498== 586 (16 direct, 570 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
==18498==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==18498==    by 0x2C52CD: flb_malloc (flb_mem.h:62)
==18498==    by 0x2C5515: cb_mq_storage_metrics (storage.c:99)
==18498==    by 0x70CD97: mk_fifo_worker_read (mk_fifo.c:438)
==18498==    by 0x71C95D: mk_server_worker_loop (mk_server.c:569)
==18498==    by 0x71333D: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==18498==    by 0x4865608: start_thread (pthread_create.c:477)
==18498==    by 0x4B11292: clone (clone.S:95)
==18498== 
==18498== LEAK SUMMARY:
==18498==    definitely lost: 72 bytes in 2 blocks
==18498==    indirectly lost: 570 bytes in 3 blocks
==18498==      possibly lost: 0 bytes in 0 blocks
==18498==    still reachable: 0 bytes in 0 blocks
==18498==         suppressed: 0 bytes in 0 blocks
==18498== 
==18498== For lists of detected and suppressed errors, rerun with: -s
==18498== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```


## Output of nc

### /
```
$ curl -I localhost:2020
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 01:57:17 GMT
Transfer-Encoding: chunked
Content-Type: application/json


$ curl  localhost:2020
{"fluent-bit":{"version":"1.9.0","edition":"Community","flags":["FLB_HAVE_PARSER","FLB_HAVE_RECORD_ACCESSOR","FLB_HAVE_STREAM_PROCESSOR","FLB_HAVE_TLS","FLB_HAVE_METRICS","FLB_HAVE_AWS","FLB_HAVE_AWS_CREDENTIAL_PROCESS","FLB_HAVE_SIGNV4","FLB_HAVE_SQLDB","FLB_HAVE_METRICS","FLB_HAVE_HTTP_SERVER","FLB_HAVE_SYSTEMD","FLB_HAVE_FORK","FLB_HAVE_MTRACE","FLB_HAVE_TIMESPEC_GET","FLB_HAVE_GMTOFF","FLB_HAVE_UNIX_SOCKET","FLB_HAVE_PROXY_GO","FLB_HAVE_LIBBACKTRACE","FLB_HAVE_REGEX","FLB_HAVE_UTF8_ENCODER","FLB_HAVE_AVRO_ENCODER","FLB_HAVE_LUAJIT","FLB_HAVE_C_TLS","FLB_HAVE_ACCEPT4","FLB_HAVE_INOTIFY"]}}t
```

### /api/v1/uptime

```
$ curl -I localhost:2020/api/v1/uptime
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 01:58:13 GMT
Transfer-Encoding: chunked
Content-Type: application/json

$ curl  localhost:2020/api/v1/uptime
{"uptime_sec":77,"uptime_hr":"Fluent Bit has been running:  0 day, 0 hour, 1 minute and 17 seconds"}
```

### /api/v1/metrics

```
$ curl -I localhost:2020/api/v1/metrics
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 01:59:01 GMT
Transfer-Encoding: chunked
Content-Type: application/json

$ curl  localhost:2020/api/v1/metrics
{"input":{"dummy.0":{"records":125,"bytes":3250}},"filter":{},"output":{"null.0":{"proc_records":119,"proc_bytes":3094,"errors":0,"retries":0,"retries_failed":0,"dropped_records":0,"retried_records":0}}}
```

### /api/v1/metrics/prometheus

```
$ curl -I localhost:2020/api/v1/metrics/prometheus
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 02:00:14 GMT
Transfer-Encoding: chunked
Content-Type: text/plain; version=0.0.4

$ curl  localhost:2020/api/v1/metrics/prometheus
# HELP fluentbit_input_bytes_total Number of input bytes.
# TYPE fluentbit_input_bytes_total counter
fluentbit_input_bytes_total{name="dummy.0"} 5200 1635645619242
# HELP fluentbit_input_records_total Number of input records.
# TYPE fluentbit_input_records_total counter
fluentbit_input_records_total{name="dummy.0"} 200 1635645619242
# HELP fluentbit_output_dropped_records_total Number of dropped records.
# TYPE fluentbit_output_dropped_records_total counter
fluentbit_output_dropped_records_total{name="null.0"} 0 1635645619242
# HELP fluentbit_output_errors_total Number of output errors.
# TYPE fluentbit_output_errors_total counter
fluentbit_output_errors_total{name="null.0"} 0 1635645619242
# HELP fluentbit_output_proc_bytes_total Number of processed output bytes.
# TYPE fluentbit_output_proc_bytes_total counter
fluentbit_output_proc_bytes_total{name="null.0"} 5044 1635645619242
# HELP fluentbit_output_proc_records_total Number of processed output records.
# TYPE fluentbit_output_proc_records_total counter
fluentbit_output_proc_records_total{name="null.0"} 194 1635645619242
# HELP fluentbit_output_retried_records_total Number of retried records.
# TYPE fluentbit_output_retried_records_total counter
fluentbit_output_retried_records_total{name="null.0"} 0 1635645619242
# HELP fluentbit_output_retries_failed_total Number of abandoned batches because the maximum number of re-tries was reached.
# TYPE fluentbit_output_retries_failed_total counter
fluentbit_output_retries_failed_total{name="null.0"} 0 1635645619242
# HELP fluentbit_output_retries_total Number of output retries.
# TYPE fluentbit_output_retries_total counter
fluentbit_output_retries_total{name="null.0"} 0 1635645619242
# HELP fluentbit_uptime Number of seconds that Fluent Bit has been running.
# TYPE fluentbit_uptime counter
fluentbit_uptime 200
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1635645419
# HELP fluentbit_build_info Build version information.
# TYPE fluentbit_build_info gauge
fluentbit_build_info{version="1.9.0",edition="Community"} 1
```

### /api/v1/storage

```
$ curl -I localhost:2020/api/v1/storage
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 02:00:56 GMT
Transfer-Encoding: chunked
Content-Type: application/json

$ curl  localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"130b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":1,"busy_size":"130b"}}}}
```

### /api/v1/health (not changed)

```
$ curl -I localhost:2020/api/v1/health
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Sun, 31 Oct 2021 02:01:35 GMT
Transfer-Encoding: chunked

$ curl  localhost:2020/api/v1/health
ok

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
