### PR TITLE
http_server: storage: add destructor to prevent leak

### DIFF
--- a/src/http_server/api/v1/storage.c
+++ b/src/http_server/api/v1/storage.c
@@ -157,10 +157,40 @@ static void cb_storage(mk_request_t *request, void *data)
     buf->users--;
 }
 
+static void hs_storage_metrics_key_destroy(void *data)
+{
+    struct mk_list *metrics_list = (struct mk_list*)data;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_hs_buf *entry;
+
+    if (metrics_list == NULL) {
+        return;
+    }
+
+    mk_list_foreach_safe(head, tmp, metrics_list) {
+        entry = mk_list_entry(head, struct flb_hs_buf, _head);
+        if (entry != NULL) {
+            if (entry->raw_data != NULL) {
+                flb_free(entry->raw_data);
+                entry->raw_data = NULL;
+            }
+            if (entry->data) {
+                flb_sds_destroy(entry->data);
+                entry->data = NULL;
+            }
+            mk_list_del(&entry->_head);
+            flb_free(entry);
+        }
+    }
+
+    flb_free(metrics_list);
+}
+
 /* Perform registration */
 int api_v1_storage_metrics(struct flb_hs *hs)
 {
-    pthread_key_create(&hs_storage_metrics_key, NULL);
+    pthread_key_create(&hs_storage_metrics_key, hs_storage_metrics_key_destroy);
 
     /* Create a message queue */
     hs->qid_storage = mk_mq_create(hs->ctx, "/storage",


### PR DESCRIPTION
Similar PR: #4058

I added destructor function`hs_storage_metrics_key_destroy` to release allocated buffer.
```
==29495== 586 (16 direct, 570 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
==29495==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==29495==    by 0x2C5190: flb_malloc (flb_mem.h:62)
==29495==    by 0x2C53D8: cb_mq_storage_metrics (storage.c:99)
==29495==    by 0x70CC47: mk_fifo_worker_read (mk_fifo.c:438)
==29495==    by 0x71C80D: mk_server_worker_loop (mk_server.c:569)
==29495==    by 0x7131ED: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==29495==    by 0x4865608: start_thread (pthread_create.c:477)
==29495==    by 0x4B11292: clone (clone.S:95)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[SERVICE]
    HTTP_Server on
    storage.metrics on
[INPUT]
    Name dummy

[OUTPUT]
    Name null
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c 4240/a.conf 
==27637== Memcheck, a memory error detector
==27637== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27637== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==27637== Command: bin/fluent-bit -c 4240/a.conf
==27637== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/10/31 15:04:23] [ info] [engine] started (pid=27637)
[2021/10/31 15:04:23] [ info] [storage] version=1.1.5, initializing...
[2021/10/31 15:04:23] [ info] [storage] in-memory
[2021/10/31 15:04:23] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/10/31 15:04:23] [ info] [cmetrics] version=0.2.2
[2021/10/31 15:04:23] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/10/31 15:04:23] [ info] [sp] stream processor started
==27637== Warning: client switching stacks?  SP change: 0x77e9568 --> 0x4ccd770
==27637==          to suppress, use: --max-stackframe=45202936 or greater
==27637== Warning: client switching stacks?  SP change: 0x4ccd6d8 --> 0x77e9568
==27637==          to suppress, use: --max-stackframe=45203088 or greater
==27637== Warning: client switching stacks?  SP change: 0x77e9628 --> 0x4ccd6d8
==27637==          to suppress, use: --max-stackframe=45203280 or greater
==27637==          further instances of this message will not be shown.
^C[2021/10/31 15:04:28] [engine] caught signal (SIGINT)
[2021/10/31 15:04:28] [ warn] [engine] service will stop in 5 seconds
[2021/10/31 15:04:32] [ info] [engine] service stopped
==27637== 
==27637== HEAP SUMMARY:
==27637==     in use at exit: 56 bytes in 1 blocks
==27637==   total heap usage: 1,342 allocs, 1,341 frees, 1,469,769 bytes allocated
==27637== 
==27637== 56 bytes in 1 blocks are definitely lost in loss record 1 of 1
==27637==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==27637==    by 0x71980F: mk_mem_alloc_z (mk_memory.h:70)
==27637==    by 0x719986: thread_get_libco_params (mk_http_thread.c:60)
==27637==    by 0x719B6E: thread_params_set (mk_http_thread.c:168)
==27637==    by 0x719D61: mk_http_thread_create (mk_http_thread.c:226)
==27637==    by 0x715F4B: mk_http_init (mk_http.c:748)
==27637==    by 0x714D94: mk_http_request_prepare (mk_http.c:232)
==27637==    by 0x717D76: mk_http_sched_read (mk_http.c:1568)
==27637==    by 0x713992: mk_sched_event_read (mk_scheduler.c:693)
==27637==    by 0x71C713: mk_server_worker_loop (mk_server.c:487)
==27637==    by 0x7132ED: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==27637==    by 0x4865608: start_thread (pthread_create.c:477)
==27637== 
==27637== LEAK SUMMARY:
==27637==    definitely lost: 56 bytes in 1 blocks
==27637==    indirectly lost: 0 bytes in 0 blocks
==27637==      possibly lost: 0 bytes in 0 blocks
==27637==    still reachable: 0 bytes in 0 blocks
==27637==         suppressed: 0 bytes in 0 blocks
==27637== 
==27637== For lists of detected and suppressed errors, rerun with: -s
==27637== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
