### PR TITLE
config: fix inconsistent parsing of configuration keys

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -187,10 +187,10 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     else if (strcasecmp(format, "json") == 0) {
         p->type = FLB_PARSER_JSON;
     }
-    else if (strcmp(format, "ltsv") == 0) {
+    else if (strcasecmp(format, "ltsv") == 0) {
         p->type = FLB_PARSER_LTSV;
     }
-    else if (strcmp(format, "logfmt") == 0) {
+    else if (strcasecmp(format, "logfmt") == 0) {
         p->type = FLB_PARSER_LOGFMT;
     }
     else {

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -371,7 +371,7 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
 
         mk_list_foreach(head_e, &section->entries) {
             entry = mk_list_entry(head_e, struct mk_rconf_entry, _head);
-            if (strcmp(entry->key, "Path") != 0) {
+            if (strcasecmp(entry->key, "Path") != 0) {
                 continue;
             }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This patch fixes issues with inconsistent parsing of configuration
keys. It changes a couple of key comparisons to be case-insensitive
like most of them already are.

Signed-off-by: Janne K <0x022b@gmail.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ NA ] Example configuration file for the change
- [ NA ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ NA ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ NA ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
