### PR TITLE
input_chunk: clarify space limit error.

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -522,8 +522,8 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
              * old chunks for the incoming chunk. We need to adjust the routes_mask
              * of the incoming chunk to not flush to that output instance.
              */
-            flb_error("[input chunk] no enough space in filesystem to buffer "
-                      "chunk %s in plugin %s", flb_input_chunk_get_name(ic), o_ins->name);
+            flb_error("[input chunk] chunk %s would exceed total limit size in plugin %s",
+                      flb_input_chunk_get_name(ic), o_ins->name);
 
             flb_routes_mask_clear_bit(ic->routes_mask, o_ins->id);
             if (flb_routes_mask_is_empty(ic->routes_mask)) {


### PR DESCRIPTION
This PR attempts to clarify the error that is triggered when chunks in storage.type=filesystem attempts to exceed the storage.total_limit_size. This particular message log has led to ambiguities since the gut reaction to it is to see if the actual underlying disk space has been exceeded.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
