### PR TITLE
tests: runtime: in_proc: modify absent process name(#4274)

### DIFF
--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -191,7 +191,7 @@ void flb_test_in_proc_absent_process(void)
     in_ffd = flb_input(ctx, (char *) "proc", NULL);
     TEST_CHECK(in_ffd >= 0);
     flb_input_set(ctx, in_ffd, "tag", "test",
-                  "interval_sec", "1", "proc_name", "",
+                  "interval_sec", "1", "proc_name", "-",
                   "alert", "true", "mem", "on", "fd", "on", NULL);
 
     out_ffd = flb_output(ctx, (char *) "lib", &cb);


### PR DESCRIPTION
This patch will fix one of #4274 issue.

I modified process name to collect metrics.
I believe the process `-` will not exist.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log output

```
$ bin/flb-rt-in_proc 
Test proc_flush...                              [2021/11/07 08:12:53] [ info] [engine] started (pid=5508)
[2021/11/07 08:12:53] [ info] [storage] version=1.1.5, initializing...
[2021/11/07 08:12:53] [ info] [storage] in-memory
[2021/11/07 08:12:53] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/07 08:12:53] [ info] [cmetrics] version=0.2.2
[2021/11/07 08:12:53] [ info] [sp] stream processor started
[2021/11/07 08:12:53] [ info] [test] flush triggered
[2021/11/07 08:12:54] [ info] [test] flush triggered
[2021/11/07 08:12:54] [ info] [test] flush triggered
[2021/11/07 08:12:55] [ info] [test] flush triggered
[2021/11/07 08:12:55] [ info] [test] check status 1
[2021/11/07 08:12:55] [ info] [test] flush triggered
[2021/11/07 08:12:56] [ info] [test] flush triggered
[2021/11/07 08:12:56] [ info] [test] flush triggered
[2021/11/07 08:12:57] [ info] [test] flush triggered
[2021/11/07 08:12:57] [ info] [test] check status 2
[2021/11/07 08:12:57] [ info] [test] flush triggered
[2021/11/07 08:12:57] [ warn] [engine] service will stop in 1 seconds
[2021/11/07 08:12:57] [ info] [engine] service stopped
[ OK ]
Test proc_absent_process...                     [2021/11/07 08:12:57] [ info] [engine] started (pid=5511)
[2021/11/07 08:12:57] [ info] [storage] version=1.1.5, initializing...
[2021/11/07 08:12:57] [ info] [storage] in-memory
[2021/11/07 08:12:57] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/07 08:12:57] [ info] [cmetrics] version=0.2.2
[2021/11/07 08:12:57] [ info] [sp] stream processor started
[2021/11/07 08:12:57] [ warn] [engine] service will stop in 1 seconds
[2021/11/07 08:12:58] [ info] [engine] service stopped
[ OK ]
SUCCESS: All unit tests have passed.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
