### PR TITLE
filter_rewrite_tag: fix Match aborting issue (#4276)

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -210,9 +210,7 @@ static int cb_rewrite_tag_init(struct flb_filter_instance *ins,
         return -1;
     }
     if (is_wildcard(ins->match)) {
-        flb_plg_error(ins, "'Match' causes infinite loop. abort.");
-        flb_free(ctx);
-        return -1;
+        flb_plg_warn(ins, "'Match' may cause infinite loop.");
     }
     ctx->ins = ins;
     ctx->config = config;


### PR DESCRIPTION
Fixes #4276.

We should take care `Match` and `Rule` to determine if it causes infinite loop.
`Rule` is depended on incoming record and we can't determine on init.
So I modified Fluent-bit only reports warning if `Match` may cause infinite loop.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature


## Example Configuration

```
[INPUT]
    Name Dummy
    Dummy {"msg":"hoge", "_forward":"true"}

# if _forward is not set, set to false
[FILTER]
    Name       modify
    Match      *
    Add        _forward false

# set _forward key to false, if tag is prefixed with _forward. If not we get an endless rewrite_tag filter loop.
[FILTER]
    Name       modify
    Match      _forward.*
    Set        _forward false

# prefix tag with _forward, where _forward key is true
[FILTER]
    Name          rewrite_tag
    Match         *
    Rule          $_forward ^true$  _forward.$TAG true
    Emitter_Name  re_emitted

# delete _forward key from tags prefixed with _forward
[FILTER]
    Name       modify
    Match      _forward.*
    Remove     _forward

[OUTPUT]
    Name stdout
    Match *
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/07 08:28:59] [ info] [engine] started (pid=17180)
[2021/11/07 08:28:59] [ info] [storage] version=1.1.5, initializing...
[2021/11/07 08:28:59] [ info] [storage] in-memory
[2021/11/07 08:28:59] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/07 08:28:59] [ info] [cmetrics] version=0.2.2
[2021/11/07 08:28:59] [ warn] [filter:rewrite_tag:rewrite_tag.2] 'Match' may cause infinite loop.
[2021/11/07 08:28:59] [ info] [sp] stream processor started
[0] dummy.0: [1636241339.737420689, {"msg"=>"hoge", "_forward"=>"true"}]
[1] dummy.0: [1636241340.739238505, {"msg"=>"hoge", "_forward"=>"true"}]
[2] dummy.0: [1636241341.736227922, {"msg"=>"hoge", "_forward"=>"true"}]
[3] dummy.0: [1636241342.736501887, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1636241339.737420689, {"msg"=>"hoge"}]
[1] _forward.dummy.0: [1636241340.739238505, {"msg"=>"hoge"}]
[2] _forward.dummy.0: [1636241341.736227922, {"msg"=>"hoge"}]
[3] _forward.dummy.0: [1636241342.736501887, {"msg"=>"hoge"}]
^C[2021/11/07 08:29:04] [engine] caught signal (SIGINT)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==17234== Memcheck, a memory error detector
==17234== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17234== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==17234== Command: bin/fluent-bit -c a.conf
==17234== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/07 08:37:00] [ info] [engine] started (pid=17234)
[2021/11/07 08:37:00] [ info] [storage] version=1.1.5, initializing...
[2021/11/07 08:37:00] [ info] [storage] in-memory
[2021/11/07 08:37:00] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/07 08:37:00] [ info] [cmetrics] version=0.2.2
[2021/11/07 08:37:00] [ warn] [filter:rewrite_tag:rewrite_tag.2] 'Match' may cause infinite loop.
[2021/11/07 08:37:00] [ info] [sp] stream processor started
==17234== Thread 2 flb-pipeline:
==17234== Conditional jump or move depends on uninitialised value(s)
==17234==    at 0x2AABE2: cb_rewrite_tag_filter (rewrite_tag.c:418)
==17234==    by 0x180CE9: flb_filter_do (flb_filter.c:124)
==17234==    by 0x1BB9C7: flb_input_chunk_append_raw (flb_input_chunk.c:1329)
==17234==    by 0x1E7A2F: in_emitter_add_record (emitter.c:117)
==17234==    by 0x2AA9E4: process_record (rewrite_tag.c:347)
==17234==    by 0x2AABBE: cb_rewrite_tag_filter (rewrite_tag.c:406)
==17234==    by 0x180CE9: flb_filter_do (flb_filter.c:124)
==17234==    by 0x1BB9C7: flb_input_chunk_append_raw (flb_input_chunk.c:1329)
==17234==    by 0x1F8A13: in_dummy_collect (in_dummy.c:108)
==17234==    by 0x1804E9: flb_input_collector_fd (flb_input.c:1107)
==17234==    by 0x194A35: flb_engine_handle_event (flb_engine.c:411)
==17234==    by 0x194A35: flb_engine_start (flb_engine.c:696)
==17234==    by 0x173888: flb_lib_worker (flb_lib.c:627)
==17234== 
[0] dummy.0: [1636241820.751297068, {"msg"=>"hoge", "_forward"=>"true"}]
[1] dummy.0: [1636241821.736362875, {"msg"=>"hoge", "_forward"=>"true"}]
[2] dummy.0: [1636241822.736327953, {"msg"=>"hoge", "_forward"=>"true"}]
[3] dummy.0: [1636241823.737019691, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1636241820.751297068, {"msg"=>"hoge"}]
[1] _forward.dummy.0: [1636241821.736362875, {"msg"=>"hoge"}]
[2] _forward.dummy.0: [1636241822.736327953, {"msg"=>"hoge"}]
[3] _forward.dummy.0: [1636241823.737019691, {"msg"=>"hoge"}]
^C[2021/11/07 08:37:05] [engine] caught signal (SIGINT)
[0] dummy.0: [1636241824.763908988, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1636241824.763908988, {"msg"=>"hoge"}]
[2021/11/07 08:37:05] [ warn] [engine] service will stop in 5 seconds
[2021/11/07 08:37:09] [ info] [engine] service stopped
==17234== 
==17234== HEAP SUMMARY:
==17234==     in use at exit: 0 bytes in 0 blocks
==17234==   total heap usage: 1,838 allocs, 1,838 frees, 3,062,090 bytes allocated
==17234== 
==17234== All heap blocks were freed -- no leaks are possible
==17234== 
==17234== Use --track-origins=yes to see where uninitialised values come from
==17234== For lists of detected and suppressed errors, rerun with: -s
==17234== ERROR SUMMARY: 5 errors from 1 contexts (suppressed: 0 from 0)
```
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
