### PR TITLE
openssl: Fix the usage of SSL_CTX_check_private_key

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -262,8 +262,10 @@ static void *tls_context_create(int verify, int debug,
 
         /* Make sure the key and certificate file match */
         if (SSL_CTX_check_private_key(ssl_ctx) != 1) {
-            flb_error("[tls] private_key '%s' and password don't match",
-                      key_file);
+            flb_error("[tls] private_key '%s' %lu: %s",
+                      key_file,
+                      ERR_get_error(),
+                      ERR_error_string(ERR_get_error(), NULL));
             goto error;
         }
     }


### PR DESCRIPTION
Fixed `SSL_CTX_check_private_key` usage in tls/openssl.c to forward the actual OpenSSL error messages to the user.

Fixes #4289.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
