### PR TITLE
network: fixed error detection and handling

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -137,6 +137,8 @@ int flb_net_bind(flb_sockfd_t fd, const struct sockaddr *addr,
 int flb_net_bind_udp(flb_sockfd_t fd, const struct sockaddr *addr,
                  socklen_t addrlen);
 flb_sockfd_t flb_net_accept(flb_sockfd_t server_fd);
+int flb_net_address_to_str(int family, const struct sockaddr *addr,
+                           char *output_buffer, size_t output_buffer_size);
 int flb_net_socket_ip_str(flb_sockfd_t fd, char **buf, int size, unsigned long *len);
 
 #endif

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -281,7 +281,6 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
                             char *host, int port, int connect_timeout)
 {
     int ret;
-    int err;
     int socket_errno;
     struct pollfd pfd_read;
 
@@ -298,14 +297,10 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          */
 #ifdef FLB_SYSTEM_WINDOWS
         socket_errno = flb_socket_error(fd);
-        err = -1;
 #else
         socket_errno = errno;
-        err = flb_socket_error(fd);
 #endif
-        if (!FLB_EINPROGRESS(socket_errno) && err != 0) {
-            flb_error("[net] connection #%i failed to: %s:%i",
-                      fd, host, port);
+        if (!FLB_EINPROGRESS(socket_errno)) {
             goto exit_error;
         }
 
@@ -363,7 +358,6 @@ static int net_connect_async(int fd,
                              void *async_ctx, struct flb_upstream_conn *u_conn)
 {
     int ret;
-    int err;
     int error = 0;
     int socket_errno;
     uint32_t mask;
@@ -384,14 +378,15 @@ static int net_connect_async(int fd,
      */
 #ifdef FLB_SYSTEM_WINDOWS
     socket_errno = flb_socket_error(fd);
-    err = -1;
 #else
     socket_errno = errno;
-    err = flb_socket_error(fd);
 #endif
-    if (!FLB_EINPROGRESS(socket_errno) && err != 0) {
-        flb_error("[net] connection #%i failed to: %s:%i",
-                  fd, host, port);
+    /* The  '&& flb_socket_error != 0' comparison was removed because when
+     * there is no route to the destination host getopt doesn't return
+     * anything when we query SO_ERROR and this causes a false negative
+     * which is the origin of issue 4262
+     */
+    if (!FLB_EINPROGRESS(socket_errno)) {
         return -1;
     }
 
@@ -1061,6 +1056,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
     int ret;
     flb_sockfd_t fd = -1;
     char _port[6];
+    char address[41];
     struct addrinfo hints;
     struct addrinfo *res, *rp;
 
@@ -1119,8 +1115,14 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
      * available address.
      */
     for (rp = res; rp != NULL; rp = rp->ai_next) {
+        if (u_conn->net_error > 0) {
+            if (u_conn->net_error == ETIMEDOUT) {
+                flb_warn("[net] timeout detected between connection attempts");
+            }
+        }
+
         /* create socket */
-        fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
         if (fd == -1) {
             flb_error("[net] coult not create client socket, retrying");
             continue;
@@ -1163,18 +1165,31 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         }
 
         if (ret == -1) {
+            address[0] = '\0';
+
+            ret = flb_net_address_to_str(rp->ai_family, rp->ai_addr,
+                                         address, sizeof(address));
+
             /* If the connection failed, just abort and report the problem */
-            flb_error("[net] socket #%i could not connect to %s:%s",
-                      fd, host, _port);
+            flb_debug("[net] socket #%i could not connect to %s:%s",
+                      fd, address, _port);
             if (u_conn) {
                 u_conn->fd = -1;
                 u_conn->event.fd = -1;
             }
+
             flb_socket_close(fd);
             fd = -1;
-            break;
+
+            continue;
         }
+
         break;
+    }
+
+    if (fd == -1) {
+        flb_error("[net] could not connect to %s:%s",
+                  host, _port);
     }
 
     if (is_async) {
@@ -1434,6 +1449,39 @@ flb_sockfd_t flb_net_accept(flb_sockfd_t server_fd)
     }
 
     return remote_fd;
+}
+
+int flb_net_address_to_str(int family, const struct sockaddr *addr,
+                           char *output_buffer, size_t output_buffer_size)
+{
+    struct sockaddr *proper_addr;
+    const char      *result;
+
+    if (family == AF_INET) {
+        proper_addr = (struct sockaddr *) &((struct sockaddr_in *) addr)->sin_addr;
+    }
+    else if (family == AF_INET6) {
+        proper_addr = (struct sockaddr *) &((struct sockaddr_in6 *) addr)->sin6_addr;
+    }
+    else {
+        strncpy(output_buffer,
+                "CONVERSION ERROR 1",
+                output_buffer_size);
+
+        return -1;
+    }
+
+    result = inet_ntop(family, proper_addr, output_buffer, output_buffer_size);
+
+    if (result == NULL) {
+        strncpy(output_buffer,
+                "CONVERSION ERROR 2",
+                output_buffer_size);
+
+        return -2;
+    }
+
+    return 0;
 }
 
 int flb_net_socket_ip_str(flb_sockfd_t fd, char **buf, int size, unsigned long *len)


### PR DESCRIPTION
This PR addresses issue 4262 which intermitent reports flush errors 
in certain platforms. The origin of the error is that with the introduction
of c-ares the order in which DNS results arrive is not changed and because
of that, in certain platforms in which IPv6 is set up but not operational 
fluent-bit still tries to connect to the first result which may or may not be
an IPv6 address.

Additionaly there were three issues:

1. the underlying connection functions did not properly detect connection issues
2. the public tcp connect function would construct the socket using the arguments for the first results only caused a problem when the family was different between them
3. the public tcp connect function would abort if the underlying connect function failed and would not verify the connection object error level.



network: fixed error in flb_net_tcp_connect where it
         used the wrong result for socket construction

network: changed flb_net_tcp_connect so when a connection
         attempt fails it logs the IP address that was used
         and continues trying to connect to the

network: removed the FLB_EINPROGRESS error messages in both
         net_connect_sync and net_connect_async because
         those overlap with the error flb_net_tcp_connect
         prints which now prints the actual address used
         and was demoted to DEBUG level to keep it from
         being a red herring. A new flb_net_tcp_connect level
         error message is produced only when none of the
         results were usable to establish a connection
         or when a timeout happens in between attempts.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>