### PR TITLE
network: fixed error detection and handling

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -137,6 +137,8 @@ int flb_net_bind(flb_sockfd_t fd, const struct sockaddr *addr,
 int flb_net_bind_udp(flb_sockfd_t fd, const struct sockaddr *addr,
                  socklen_t addrlen);
 flb_sockfd_t flb_net_accept(flb_sockfd_t server_fd);
+int flb_net_address_to_str(int family, const struct sockaddr *addr,
+                           char *output_buffer, size_t output_buffer_size);
 int flb_net_socket_ip_str(flb_sockfd_t fd, char **buf, int size, unsigned long *len);
 
 #endif

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -407,9 +407,6 @@ static int net_connect_async(int fd,
      */
 
     if (!FLB_EINPROGRESS(socket_errno) || err != 0) {
-        flb_info("[net] connection #%i failed to: %s:%i",
-                  fd, host, port);
-
         return -1;
     }
 

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -315,7 +315,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
         /*
          * Prepare a timeout using poll(2): we could use our own
          * event loop mechanism for this, but it will require an
-         * extra file descriptor, the poll(2) call is straightforward
+         * extra file descriptor,   the poll(2) call is straightforward
          * for this use case.
          */
 
@@ -1185,7 +1185,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
                                          address, sizeof(address));
 
             /* If the connection failed, just abort and report the problem */
-            flb_error("[net] socket #%i could not connect to %s:%s",
+            flb_debug("[net] socket #%i could not connect to %s:%s",
                       fd, address, _port);
             if (u_conn) {
                 u_conn->fd = -1;

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -281,6 +281,7 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
                             char *host, int port, int connect_timeout)
 {
     int ret;
+    int err;
     int socket_errno;
     struct pollfd pfd_read;
 
@@ -297,10 +298,13 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
          */
 #ifdef FLB_SYSTEM_WINDOWS
         socket_errno = flb_socket_error(fd);
+        err = 0;
 #else
         socket_errno = errno;
+        err = flb_socket_error(fd);
 #endif
-        if (!FLB_EINPROGRESS(socket_errno)) {
+
+        if (!FLB_EINPROGRESS(socket_errno) || err != 0) {
             goto exit_error;
         }
 
@@ -358,6 +362,7 @@ static int net_connect_async(int fd,
                              void *async_ctx, struct flb_upstream_conn *u_conn)
 {
     int ret;
+    int err;
     int error = 0;
     int socket_errno;
     uint32_t mask;
@@ -378,15 +383,33 @@ static int net_connect_async(int fd,
      */
 #ifdef FLB_SYSTEM_WINDOWS
     socket_errno = flb_socket_error(fd);
+    err = 0;
 #else
     socket_errno = errno;
+    err = flb_socket_error(fd);
 #endif
-    /* The  '&& flb_socket_error != 0' comparison was removed because when
-     * there is no route to the destination host getopt doesn't return
-     * anything when we query SO_ERROR and this causes a false negative
-     * which is the origin of issue 4262
+    /* The logic behind this check is that when establishing a connection
+     * errno should be EINPROGRESS with no additional information in order
+     * for it to be a healthy attempt. However, when errno is EINPROGRESS
+     * and an error occurs it could be saved in the so_error socket field
+     * which has to be accessed through getsockopt(... SO_ERROR ...) so
+     * in order to preserve that behavior while also properly detecting
+     * other errno values as error conditions the comparison was changed.
+     *
+     * Windows note : flb_socket_error returns either the value returned
+     * by WSAGetLastError or the value returned by getsockopt(... SO_ERROR ...)
+     * if WSAGetLastError returns WSAEWOULDBLOCK as per libevents code.
+     *
+     * General note : according to the connect syscall man page (not libc)
+     * there could be a timing issue with checking SO_ERROR here because
+     * the suggested use involves checking it after a select or poll call
+     * returns the socket as writable which is not the case here.
      */
-    if (!FLB_EINPROGRESS(socket_errno)) {
+
+    if (!FLB_EINPROGRESS(socket_errno) || err != 0) {
+        flb_info("[net] connection #%i failed to: %s:%i",
+                  fd, host, port);
+
         return -1;
     }
 
@@ -1165,7 +1188,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
                                          address, sizeof(address));
 
             /* If the connection failed, just abort and report the problem */
-            flb_debug("[net] socket #%i could not connect to %s:%s",
+            flb_error("[net] socket #%i could not connect to %s:%s",
                       fd, address, _port);
             if (u_conn) {
                 u_conn->fd = -1;


### PR DESCRIPTION
NOTE : This PR is a backport of #4294

This PR addresses issue 4262 which intermitent reports flush errors
in certain platforms. The origin of the error is that with the introduction
of c-ares the order in which DNS results arrive is not changed and because
of that, in certain platforms in which IPv6 is set up but not operational
fluent-bit still tries to connect to the first result which may or may not be
an IPv6 address.

Additionaly there were three issues:

    the underlying connection functions did not properly detect connection issues
    the public tcp connect function would construct the socket using the arguments for the first results only caused a problem when the family was different between them
    the public tcp connect function would abort if the underlying connect function failed and would not verify the connection object error level.

network: fixed error in flb_net_tcp_connect where it
used the wrong result for socket construction

network: changed flb_net_tcp_connect so when a connection
attempt fails it logs the IP address that was used
and continues trying to connect to the

network: removed the FLB_EINPROGRESS error messages in both
net_connect_sync and net_connect_async because
those overlap with the error flb_net_tcp_connect
prints which now prints the actual address used
and was demoted to DEBUG level to keep it from
being a red herring. A new flb_net_tcp_connect level
error message is produced only when none of the
results were usable to establish a connection
or when a timeout happens in between attempts.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>