### PR TITLE
random: Use getentropy(3) if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,20 @@ if(FLB_INOTIFY)
   endif()
 endif()
 
+include(CheckSymbolExists)
+
+# Check for getentropy(3)
+check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)
+if(HAVE_GETENTROPY)
+  FLB_DEFINITION(FLB_HAVE_GETENTROPY)
+endif()
+
+# getentropy(3) is in sys/random.h on mac
+check_symbol_exists(getentropy "sys/random.h" HAVE_GETENTROPY_SYS_RANDOM)
+if(HAVE_GETENTROPY_SYS_RANDOM)
+  FLB_DEFINITION(FLB_HAVE_GETENTROPY_SYS_RANDOM)
+endif()
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h.in"
   "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h"

--- a/src/flb_random.c
+++ b/src/flb_random.c
@@ -21,6 +21,15 @@
 #include <fluent-bit/flb_compat.h>
 #include <fcntl.h>
 
+#ifdef FLB_HAVE_GETENTROPY
+#include <unistd.h>
+#endif
+#ifdef FLB_HAVE_GETENTROPY_SYS_RANDOM
+#include <sys/random.h>
+#endif
+
+#define MAX_GETENTROPY_LEN 256
+
 /*
  * This module provides a random number generator for common use cases.
  *
@@ -28,7 +37,8 @@
  * is available since Windows Vista, and should be compliant to the
  * official recommendation.
  *
- * On Unix, we use /dev/urandom as a secure random source.
+ * On other platforms, we use getentropy(3) if available, otherwise
+ * /dev/urandom as a secure random source.
  */
 
 int flb_random_bytes(unsigned char *buf, int len)
@@ -41,9 +51,33 @@ int flb_random_bytes(unsigned char *buf, int len)
     }
     return 0;
 #else
-    int fd;
-    int bytes;
+    int     fd;
+    ssize_t bytes;
 
+#if defined(FLB_HAVE_GETENTROPY) || defined(FLB_HAVE_GETENTROPY_SYS_RANDOM)
+    while (len > 0) {
+        if (len > MAX_GETENTROPY_LEN) {
+            bytes = MAX_GETENTROPY_LEN;
+        }
+        else {
+            bytes = len;
+        }
+        if (getentropy(buf, bytes) < 0) {
+#ifdef ENOSYS
+            /* Fall back to urandom if the syscall is not available (Linux only) */
+            if (errno == ENOSYS) {                
+                goto try_urandom;
+            }
+#endif
+            return -1;
+        }
+        len -= bytes;
+        buf += bytes;
+    }
+    return 0;
+
+try_urandom:
+#endif /* FLB_HAVE_GETENTROPY || FLB_HAVE_GETENTROPY_SYS_RANDOM */
     fd = open("/dev/urandom", O_RDONLY);
     if (fd == -1) {
         return -1;
@@ -60,5 +94,5 @@ int flb_random_bytes(unsigned char *buf, int len)
     }
     close(fd);
     return 0;
-#endif
+#endif /* FLB_SYSTEM_WINDOWS */
 }


### PR DESCRIPTION
getentropy(3) is the preferred method of obtaining entropy from the
system on recent Linux (3.17 and later) and many BSD-like platforms.
getentropy(3) works even when there's no available file descriptor
to open(2) or under chroot.
    
Signed-off-by: Emma Haruka Iwao <yuryu@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
See the unit test results attached below.
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
✗ valgrind bin/flb-it-random 
==516641== Memcheck, a memory error detector
==516641== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==516641== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==516641== Command: bin/flb-it-random
==516641== 
Test random_bytes...                            [ OK ]
SUCCESS: All unit tests have passed.
==516641== 
==516641== HEAP SUMMARY:
==516641==     in use at exit: 0 bytes in 0 blocks
==516641==   total heap usage: 2 allocs, 2 frees, 1,040 bytes allocated
==516641== 
==516641== All heap blocks were freed -- no leaks are possible
==516641== 
==516641== For lists of detected and suppressed errors, rerun with: -s
==516641== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
