### PR TITLE
flb_str: use flb_strndup to implement flb_strdup

### DIFF
--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -28,22 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static inline char *flb_strdup(const char *s)
-{
-    int len;
-    char *str;
-
-    len = strlen(s);
-    str = (char *) flb_malloc(len + 1);
-    if (!str) {
-        return NULL;
-    }
-    memcpy(str, s, len);
-    str[len] = '\0';
-
-    return str;
-}
-
 static inline char *flb_strndup(const char *s, size_t n)
 {
     char *str;
@@ -56,6 +40,11 @@ static inline char *flb_strndup(const char *s, size_t n)
     str[n] = '\0';
 
     return str;
+}
+
+static inline char *flb_strdup(const char *s)
+{
+    return flb_strndup(s, strlen(s));
 }
 
 /* emptyval checks whether a string has a non-null value "". */


### PR DESCRIPTION
This patch changes flb_strdup to use flb_strndup as
flb_strdup is an alias of flb_strndup(s, strlen(s)).

Signed-off-by: Emma Haruka Iwao <yuryu@google.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Using `flb-it-pack` here because it uses `flb_strdup` internally.

```
valgrind bin/flb-it-pack
==4175023== Memcheck, a memory error detector
==4175023== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4175023== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==4175023== Command: bin/flb-it-pack
==4175023== 
Test json_pack...                               [ OK ]
Test json_pack_iter...                          [ OK ]
Test json_pack_mult...                          [ OK ]
Test json_pack_mult_iter...                     [ OK ]
Test json_dup_keys...                           [ OK ]
Test json_pack_bug342...                        [ OK ]
Test json_pack_bug1278...                       
test 0 out => "one\u0007two"
test 1 out => "one\btwo"
test 2 out => "one\ttwo"
test 3 out => "one\ntwo"
test 4 out => "one\u000btwo"
test 5 out => "one\ftwo"
test 6 out => "one\rtwo"
test 7 out => "\\n"
[ OK ]
Test utf8_to_json...                            [ OK ]
SUCCESS: All unit tests have passed.
==4175023== 
==4175023== HEAP SUMMARY:
==4175023==     in use at exit: 0 bytes in 0 blocks
==4175023==   total heap usage: 758 allocs, 758 frees, 3,045,132 bytes allocated
==4175023== 
==4175023== All heap blocks were freed -- no leaks are possible
==4175023== 
==4175023== For lists of detected and suppressed errors, rerun with: -s
==4175023== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
