### PR TITLE
mem: fix alloc_size attribute and remove extra ifs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,21 @@ if(FLB_HAVE_UNIX_SOCKET)
   FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
 endif()
 
+# check attribute alloc_size
+check_c_source_compiles("
+#include <stdlib.h>
+__attribute__ ((alloc_size(1, 2))) static void* f(size_t a, size_t b) {
+    return calloc(a, b);
+}
+int main() {
+    f(1, 2);
+    return 0;
+}
+" FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
+if(FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
+  FLB_DEFINITION(FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
+endif()
+
 # Build tools/xxd-c
 add_subdirectory(tools/xxd-c)
 

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -41,62 +41,37 @@
  * Here there is no error logging in case of failures, we defer that task to the
  * caller.
  */
-#ifdef __GNUC__
-  #if ((__GNUC__ * 100 + __GNUC__MINOR__) > 430)  /* gcc version > 4.3 */
-    #define ALLOCSZ_ATTR(x,...) __attribute__ ((alloc_size(x, ##__VA_ARGS__)))
-  #else
-    #define ALLOCSZ_ATTR(x,...)
-  #endif
+#ifdef FLB_HAVE_ATTRIBUTE_ALLOC_SIZE
+    #define FLB_ALLOCSZ_ATTR(x,...) __attribute__ ((alloc_size(x, ##__VA_ARGS__)))
 #else
-    #define ALLOCSZ_ATTR(x,...)
+    #define FLB_ALLOCSZ_ATTR(x,...)
 #endif
 
-static inline ALLOCSZ_ATTR(1)
+static inline FLB_ALLOCSZ_ATTR(1)
 void *flb_malloc(const size_t size) {
-    void *aux;
-
     if (size == 0) {
         return NULL;
     }
 
-    aux = malloc(size);
-    if (flb_unlikely(!aux && size)) {
-        return NULL;
-    }
-
-    return aux;
+    return malloc(size);
 }
 
-static inline ALLOCSZ_ATTR(1)
+static inline FLB_ALLOCSZ_ATTR(1, 2)
 void *flb_calloc(size_t n, const size_t size) {
-    void *buf;
-
     if (size == 0) {
         return NULL;
     }
 
-    buf = calloc(n, size);
-    if (flb_unlikely(!buf)) {
-        return NULL;
-    }
-
-    return buf;
+    return calloc(n, size);
 }
 
-static inline ALLOCSZ_ATTR(2)
+static inline FLB_ALLOCSZ_ATTR(2)
 void *flb_realloc(void *ptr, const size_t size)
 {
-    void *aux;
-
-    aux = realloc(ptr, size);
-    if (flb_unlikely(!aux && size)) {
-        return NULL;
-    }
-
-    return aux;
+    return realloc(ptr, size);
 }
 
-static inline ALLOCSZ_ATTR(2, 3)
+static inline FLB_ALLOCSZ_ATTR(3)
 void *flb_realloc_z(void *ptr, const size_t old_size, const size_t new_size)
 {
     void *tmp;
@@ -121,5 +96,7 @@ void *flb_realloc_z(void *ptr, const size_t old_size, const size_t new_size)
 static inline void flb_free(void *ptr) {
     free(ptr);
 }
+
+#undef FLB_ALLOCSZ_ATTR
 
 #endif


### PR DESCRIPTION
This patch fixes the alloc_size attributes for flb_mem functions where
they passed the wrong argument numbers to indicate the allocation size.
This also
 - removes extra if statements that check return values against NULL and
 return NULL.
 - Rename ALLOCSZ_ATTR to FLB_ALLOCSZ_ATTR because it conflicts with
   monkey.
 - Use FLB_HAVE_ATTRIBUTE_ALLOC_SIZE instead of checking gcc version.


Signed-off-by: Emma Haruka Iwao <yuryu@google.com>

<!-- Provide summary of changes -->

According to the [gcc manual](https://gcc.gnu.org/onlinedocs/gcc-11.2.0/gcc/Common-Function-Attributes.html#Common-Function-Attributes), alloc_size takes one or two arguments and when it takes two, it assumes the size of the allocation is a product of both. `flb_calloc` had only the first argument in alloc_size, and `flb_realloc_z` had both arguments when the actual allocation size was the third argument (`new_size`).

This information is used only for `__builtin_object_size` and fluent-bit doesn't use it for now. So this patch doesn't change the actual behavior.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
valgrind bin/fluent-bit -v
==179892== Memcheck, a memory error detector
==179892== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==179892== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==179892== Command: bin/fluent-bit -v
==179892== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/10 02:00:10] [ info] Configuration:
[2021/11/10 02:00:10] [ info]  flush time     | 5.000000 seconds
[2021/11/10 02:00:10] [ info]  grace          | 5 seconds
[2021/11/10 02:00:10] [ info]  daemon         | 0
[2021/11/10 02:00:10] [ info] ___________
[2021/11/10 02:00:10] [ info]  inputs:
[2021/11/10 02:00:10] [ info] ___________
[2021/11/10 02:00:10] [ info]  filters:
[2021/11/10 02:00:10] [ info] ___________
[2021/11/10 02:00:10] [ info]  outputs:
[2021/11/10 02:00:10] [ info] ___________
[2021/11/10 02:00:10] [ info]  collectors:
[2021/11/10 02:00:11] [ info] [engine] started (pid=179892)
[2021/11/10 02:00:11] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/11/10 02:00:11] [ info] [storage] version=1.1.5, initializing...
[2021/11/10 02:00:11] [ info] [storage] in-memory
[2021/11/10 02:00:11] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/10 02:00:11] [ info] [cmetrics] version=0.2.2
[2021/11/10 02:00:11] [ info] [sp] stream processor started
^C[2021/11/10 02:00:12] [engine] caught signal (SIGINT)
[2021/11/10 02:00:12] [ warn] [engine] service will stop in 5 seconds
[2021/11/10 02:00:16] [ info] [engine] service stopped
==179892== 
==179892== HEAP SUMMARY:
==179892==     in use at exit: 0 bytes in 0 blocks
==179892==   total heap usage: 740 allocs, 740 frees, 151,038 bytes allocated
==179892== 
==179892== All heap blocks were freed -- no leaks are possible
==179892== 
==179892== For lists of detected and suppressed errors, rerun with: -s
==179892== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
