### PR TITLE
input chunk: correctly calculate the difference when chunks grow in flb_input_chunk_append_raw for total size limit.

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -43,13 +43,14 @@
 #define FLB_INPUT_CHUNK_FS_MAX_SIZE   2048000  /* 2MB */
 
 struct flb_input_chunk {
-    int event_type;                 /* chunk type: logs or metrics */
-    int busy;                       /* buffer is being flushed  */
-    int fs_backlog;                 /* chunk originated from fs backlog */
-    int sp_done;                    /* sp already processed this chunk */
+    int  event_type;                 /* chunk type: logs or metrics */
+    bool fs_counted;
+    int  busy;                       /* buffer is being flushed  */
+    int  fs_backlog;                 /* chunk originated from fs backlog */
+    int  sp_done;                    /* sp already processed this chunk */
 #ifdef FLB_HAVE_METRICS
-    int total_records;              /* total records in the chunk */
-    int added_records;              /* recently added records */
+    int  total_records;              /* total records in the chunk */
+    int  added_records;              /* recently added records */
 #endif
     void *chunk;                    /* context of struct cio_chunk */
     off_t stream_off;               /* stream offset */

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1440,7 +1440,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     }
 
     real_size = flb_input_chunk_get_real_size(ic);
-    real_diff = llabs(real_size - pre_real_size);
+    real_diff = real_size - pre_real_size;
     if (real_diff != 0) {
         flb_debug("[input chunk] update output instances with new chunk size diff=%d",
                   real_diff);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1347,11 +1347,9 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 
     /* Get chunk size */
     size = cio_chunk_get_content_size(ic->chunk);
-    real_size = flb_input_chunk_get_real_size(ic);
 
     /* calculate the 'real' new bytes being added after the filtering phase */
     diff = llabs(size - pre_size);
-    real_diff = llabs(real_size - pre_real_size);
 
     /*
      * Update output instance bytes counters, note that bytes counter should
@@ -1377,12 +1375,6 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
      */
     if (flb_input_chunk_get_size(ic) == 0) {
         diff = 0;
-    }
-
-    if (real_diff != 0) {
-        flb_debug("[input chunk] update output instances with new chunk size diff=%d",
-                  real_diff);
-        flb_input_chunk_update_output_instances(ic, real_diff);
     }
 
     /* Lock buffers where size > 2MB */
@@ -1458,6 +1450,14 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
                 cio_chunk_down(ic->chunk);
             }
         }
+    }
+
+    real_size = flb_input_chunk_get_real_size(ic);
+    real_diff = llabs(real_size - pre_real_size);
+    if (real_diff != 0) {
+        flb_debug("[input chunk] update output instances with new chunk size diff=%d",
+                  real_diff);
+        flb_input_chunk_update_output_instances(ic, real_diff);
     }
 
     flb_input_chunk_protect(in);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1301,7 +1301,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
      * Keep the previous real size just to satisfy
      * flb_input_chunk_update_output_instances().
      */
-    pre_real_size = cio_chunk_get_real_size(ic->chunk);
+    pre_real_size = flb_input_chunk_get_real_size(ic);
 
     /* Write the new data */
     ret = flb_input_chunk_write(ic, buf, buf_size);
@@ -1341,7 +1341,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 
     /* Get chunk size */
     size = cio_chunk_get_content_size(ic->chunk);
-    real_size = cio_chunk_get_real_size(ic->chunk);
+    real_size = flb_input_chunk_get_real_size(ic);
 
     /* calculate the 'real' new bytes being added after the filtering phase */
     diff = llabs(size - pre_size);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1469,8 +1469,12 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
 {
     int ret;
+    size_t pre_size, post_size;
+    ssize_t diff_size;
     char *buf = NULL;
 
+
+    pre_size = flb_input_chunk_get_real_size(ic);
     if (cio_chunk_is_up(ic->chunk) == CIO_FALSE) {
         ret = cio_chunk_up(ic->chunk);
         if (ret == -1) {
@@ -1500,6 +1504,11 @@ const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
     /* Lock the internal chunk */
     cio_chunk_lock(ic->chunk);
 
+    post_size = flb_input_chunk_get_real_size(ic);
+    if (post_size != pre_size) {
+        diff_size = post_size - pre_size;
+        flb_input_chunk_update_output_instances(ic, diff_size);
+    }
     return buf;
 }
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1298,10 +1298,16 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
      */
     pre_size = cio_chunk_get_content_size(ic->chunk);
     /*
-     * Keep the previous real size just to satisfy
-     * flb_input_chunk_update_output_instances().
+     * Keep the previous real size to calculate the real size
+     * difference for flb_input_chunk_update_output_instances(),
+     * use 0 when the chunk is new since it's size will never
+     * have been calculated before.
      */
-    pre_real_size = new_chunk == FLB_TRUE ? 0 : flb_input_chunk_get_real_size(ic);
+    if (new_chunk == FLB_TRUE) {
+        pre_real_size = 0;
+    } else {
+        pre_real_size = flb_input_chunk_get_real_size(ic);
+    }
 
     /* Write the new data */
     ret = flb_input_chunk_write(ic, buf, buf_size);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1452,7 +1452,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
 {
     int ret;
-    size_t pre_size
+    size_t pre_size;
     size_t post_size;
     ssize_t diff_size;
     char *buf = NULL;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1301,7 +1301,7 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
      * Keep the previous real size just to satisfy
      * flb_input_chunk_update_output_instances().
      */
-    pre_real_size = flb_input_chunk_get_real_size(ic);
+    pre_real_size = new_chunk == FLB_TRUE ? 0 : flb_input_chunk_get_real_size(ic);
 
     /* Write the new data */
     ret = flb_input_chunk_write(ic, buf, buf_size);
@@ -1373,7 +1373,9 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
         diff = 0;
     }
 
-    if (diff != 0) {
+    if (real_diff != 0) {
+        flb_debug("[input chunk] update output instances with new chunk size diff=%d",
+                  real_diff);
         flb_input_chunk_update_output_instances(ic, real_diff);
     }
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -18,8 +18,11 @@
  *  limitations under the License.
  */
 
-#define FS_CHUNK_SIZE_DEBUG(op)  {flb_debug("[%d] %s -> fs_chunks_size = %zu", __LINE__, op->name, op->fs_chunks_size);}
-#define FS_CHUNK_SIZE_DEBUG_MOD(op, chunk, mod)  {flb_debug("[%d] %s -> fs_chunks_size = %zu mod=%zd chunk=%s", __LINE__, op->name, op->fs_chunks_size, mod, flb_input_chunk_get_name(chunk));}
+#define FS_CHUNK_SIZE_DEBUG(op)  {flb_trace("[%d] %s -> fs_chunks_size = %zu", \
+	__LINE__, op->name, op->fs_chunks_size);}
+#define FS_CHUNK_SIZE_DEBUG_MOD(op, chunk, mod)  {flb_trace( \
+	"[%d] %s -> fs_chunks_size = %zu mod=%zd chunk=%s", __LINE__, \
+	op->name, op->fs_chunks_size, mod, flb_input_chunk_get_name(chunk));}
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -6,8 +6,10 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_storage.h>
+#include <fluent-bit/flb_router.h>
 #include "flb_tests_internal.h"
-
+#include "chunkio/chunkio.h"
 #include "data/input_chunk/log/test_buffer_drop_chunks.h"
 
 #define DPATH FLB_TESTS_DATA_PATH "data/input_chunk/"
@@ -316,10 +318,165 @@ void flb_test_input_chunk_dropping_chunks()
     flb_destroy(ctx);
 }
 
+/*
+ * When chunk is set to DOWN from memory, data_size is set to 0 and
+ * cio_chunk_get_content_size(1) returns the data_size. fs_chunks_size
+ * is used to track the size of chunks in filesystem so we need to call
+ * cio_chunk_get_real_size to return the original size in the file system
+ */
+static ssize_t flb_input_chunk_get_real_size(struct flb_input_chunk *ic)
+{
+    ssize_t meta_size;
+    ssize_t size;
+
+    size = cio_chunk_get_real_size(ic->chunk);
+
+    if (size != 0) {
+        return size;
+    }
+
+    // Real size is not synced to chunk yet
+    size = flb_input_chunk_get_size(ic);
+    if (size == 0) {
+        flb_debug("[input chunk] no data in the chunk %s",
+                  flb_input_chunk_get_name(ic));
+        return -1;
+    }
+
+    meta_size = cio_meta_size(ic->chunk);
+    size += meta_size
+        /* See https://github.com/edsiper/chunkio#file-layout for more details */
+         + 2    /* HEADER BYTES */
+         + 4    /* CRC32 */
+         + 16   /* PADDING */
+         + 2;   /* METADATA LENGTH BYTES */
+
+    return size;
+}
+
+static int gen_buf(msgpack_sbuffer *mp_sbuf, char *buf, size_t buf_size)
+{
+    msgpack_unpacked result;
+    msgpack_packer mp_pck;
+
+    msgpack_unpacked_init(&result);
+
+    /* Initialize local msgpack buffer */
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_str_body(&mp_pck, buf, buf_size);
+    msgpack_unpacked_destroy(&result);
+
+    return 0;
+}
+
+static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
+                  char *str)
+{
+    if (level == CIO_LOG_ERROR) {
+        flb_error("[fstore] %s", str);
+    }
+    else if (level == CIO_LOG_WARN) {
+        flb_warn("[fstore] %s", str);
+    }
+    else if (level == CIO_LOG_INFO) {
+        flb_info("[fstore] %s", str);
+    }
+    else if (level == CIO_LOG_DEBUG) {
+        flb_debug("[fstore] %s", str);
+    }
+
+    return 0;
+}
+
+void flb_test_input_chunk_fs_chunks_size_real()
+{
+    bool have_size_discrepancy = FLB_FALSE;
+    bool has_checked_size = FLB_FALSE;
+    struct flb_input_instance *i_ins;
+    struct flb_output_instance *o_ins;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_input_chunk *ic;
+    struct flb_task *task;
+    size_t chunk_size = 0;
+    struct flb_config *cfg;
+    struct cio_ctx *cio;
+    msgpack_sbuffer mp_sbuf;
+    char buf[262144];
+
+    cfg = flb_config_init();
+    flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, NULL);
+
+    i_ins = flb_input_new(cfg, "dummy", NULL, FLB_TRUE);
+    i_ins->storage_type = CIO_STORE_FS;
+    cio = cio_create("/tmp/input-chunk-fs_chunks-size_real", log_cb, CIO_LOG_DEBUG, CIO_OPEN);
+    flb_storage_input_create(cio, i_ins);
+    flb_input_init_all(cfg);
+
+    o_ins = flb_output_new(cfg, "http", NULL, FLB_TRUE);
+    // not the right way to do this
+    o_ins->id = 1;
+    TEST_CHECK_(o_ins != NULL, "unable to instance output");
+    flb_output_set_property(o_ins, "match", "*");
+    flb_output_set_property(o_ins, "storage.total_limit_size", "1M");
+
+    TEST_CHECK_((flb_router_io_set(cfg) != -1), "unable to router");
+
+    /* fill up the chunk ... */
+    memset((void *)buf, 0x41, sizeof(buf));
+    msgpack_sbuffer_init(&mp_sbuf);
+    gen_buf(&mp_sbuf, buf, sizeof(buf));
+    flb_input_chunk_append_raw(i_ins, "dummy", 4, (void *)buf, sizeof(buf));
+
+    /* then force a realloc? */
+    memset((void *)buf, 0x42, 256);
+    msgpack_sbuffer_init(&mp_sbuf);
+    gen_buf(&mp_sbuf, buf, 256);
+    flb_input_chunk_append_raw(i_ins, "dummy", 4, (void *)buf, 256);
+
+    /* clean up test chunks */
+    mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
+        ic = mk_list_entry(head, struct flb_input_chunk, _head);
+        if (cio_chunk_get_real_size(ic->chunk) != cio_chunk_get_content_size(ic->chunk)) {
+            have_size_discrepancy = FLB_TRUE;
+        }
+        chunk_size += flb_input_chunk_get_real_size(ic);
+    }
+
+    TEST_CHECK_(have_size_discrepancy == FLB_TRUE, "need a size discrepancy");
+
+    /* check fs_chunks_size for output plugins against logical and
+     *  physical size
+     */
+    mk_list_foreach_safe(head, tmp, &ic->in->config->outputs) {
+        o_ins = mk_list_entry(head, struct flb_output_instance, _head);
+        flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
+                 o_ins->fs_chunks_size);
+        has_checked_size = FLB_TRUE;
+        TEST_CHECK_(chunk_size == o_ins->fs_chunks_size, "fs_chunks_size must match total real size");
+    }
+    TEST_CHECK_(has_checked_size == FLB_TRUE, "need to check size discrepancy");
+
+    /* FORCE clean up test tasks*/
+    mk_list_foreach_safe(head, tmp, &i_ins->tasks) {
+        task = mk_list_entry(head, struct flb_task, _head);
+        flb_info("[task] cleanup test task");
+        flb_task_destroy(task, FLB_TRUE);
+    }
+
+    /* clean up test chunks */
+    mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
+        ic = mk_list_entry(head, struct flb_input_chunk, _head);
+        flb_input_chunk_destroy(ic, FLB_TRUE);
+    }
+}
+
 /* Test list */
 TEST_LIST = {
     {"input_chunk_exceed_limit",       flb_test_input_chunk_exceed_limit},
     {"input_chunk_buffer_valid",       flb_test_input_chunk_buffer_valid},
     {"input_chunk_dropping_chunks",    flb_test_input_chunk_dropping_chunks},
+    {"input_chunk_fs_chunk_size_real", flb_test_input_chunk_fs_chunks_size_real},
     {NULL, NULL}
 };


### PR DESCRIPTION
This pull request fixes 2 bugs related to the calculation of fs_chunks_size, both of which result in chunks not being able to be created over time:

- fs_chunks_size becomes negative
- fs_chunks_size does not return to zero

**fs_chunks_size becomes negative**

This first change, applied in flb_input_chunk_append_raw, is to calculate the chunk_size argument for flb_input_update_output_instance using the chunk's real size instead of it's content size since that is the same value that is used to subtract from fs_chunks_size when destroying a chunk.

When using the content size to calculate the value for flb_input_update_output_instance we will inevitably cause fs_chunks_size to become negative when destroying the chunk since the content size is at best equal to the real size but is usually larger since it is aligned to an allocation size based on the system's page size.

The real size is used over the content size for fs_chunks_size because the important metric is how much space on disk is being used.

**fs_chunks_size does not return to zero**

The second change, applied in flb_input_chunk_flush, is to calculate if there is a difference in chunk size caused by cio_chunk_lock and if so apply it as well to fs_chunks_size by invoking flb_input_chunk_update_output_instances.

This change is necessary since in some cases cio_chunk_lock can change the meta data or size of the chunk.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change (N/A)
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
