### PR TITLE
out_kafka: Skip if msgpack object is not an array

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -479,6 +479,10 @@ static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
     while (msgpack_unpack_next(&result,
                                event_chunk->data,
                                event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 
         ret = produce_message(&tms, obj, ctx, config);


### PR DESCRIPTION
Do similar check as seen in different output plugins.
```
        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
            continue;
        }
```


Fixes SIGSERV when using kafka with file storage buffering.
```
[2021/11/08 18:21:36] [engine] caught signal (SIGSEGV)
#0  0x578236            in  produce_message() at plugins/out_kafka/kafka.c:151
#1  0x579002            in  cb_kafka_flush() at plugins/out_kafka/kafka.c:482
#2  0x4d55ac            in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:514
#3  0x9d0406            in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
```

Partially fixes #4271 but I believe the issue seen in #4271 is probably caused by #2661.
I ran into #2661 while trying to replicating the issue after fixing the SIGSERV issue.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
