### PR TITLE
filter_modify: check if key exists for not conditions (#4319)

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -681,6 +681,9 @@ bool evaluate_condition_KEY_VALUE_DOES_NOT_EQUAL(struct filter_modify_ctx *ctx,
                                                  modify_condition
                                                  *condition)
 {
+    if (!evaluate_condition_KEY_EXISTS(map, condition)) {
+        return false;
+    }
     return !evaluate_condition_KEY_VALUE_EQUALS(ctx, map, condition);
 }
 
@@ -715,6 +718,9 @@ bool evaluate_condition_KEY_VALUE_DOES_NOT_MATCH(struct filter_modify_ctx *ctx,
                                                  modify_condition
                                                  *condition)
 {
+    if (!evaluate_condition_KEY_EXISTS(map, condition)) {
+        return false;
+    }
     return !evaluate_condition_KEY_VALUE_MATCHES(ctx, map, condition);
 }
 


### PR DESCRIPTION
Fixes #4319 

`evaluate_condition_KEY_VALUE_MATCHES` checks if key exists and returns false when key doesn't exist.
On the other hand `evaluate_condition_KEY_VALUE_DOES_NOT_MATCH` returns `!evaluate_condition_KEY_VALUE_MATCHES`.
So, `evaluate_condition_KEY_VALUE_DOES_NOT_MATCH`  will return true when key doesn't exist.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

## Configuration

```
[INPUT]
    Name Dummy

[FILTER]
    Condition Key_value_does_not_equal foo test
    Match     *
    Name      modify
    Add       a b

[OUTPUT]
    Name stdout
```

## Debug output
```
$ bin/fluent-bit -c 4319/a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/13 09:54:41] [ info] [engine] started (pid=62975)
[2021/11/13 09:54:41] [ info] [storage] version=1.1.5, initializing...
[2021/11/13 09:54:41] [ info] [storage] in-memory
[2021/11/13 09:54:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/13 09:54:41] [ info] [cmetrics] version=0.2.2
[2021/11/13 09:54:41] [ info] [sp] stream processor started
[0] dummy.0: [1636764881.538278675, {"message"=>"dummy"}]
[1] dummy.0: [1636764882.537914869, {"message"=>"dummy"}]
[2] dummy.0: [1636764883.538638917, {"message"=>"dummy"}]
[3] dummy.0: [1636764884.538371678, {"message"=>"dummy"}]
^C[2021/11/13 09:54:46] [engine] caught signal (SIGINT)
[0] dummy.0: [1636764885.538158686, {"message"=>"dummy"}]
[2021/11/13 09:54:46] [ warn] [engine] service will stop in 5 seconds
[2021/11/13 09:54:50] [ info] [engine] service stopped
taka@locals:~/git/fluent-bit/build$ 
```

## Valgrind output
```
$ valgrind --leak-check=full bin/fluent-bit -c 4319/a.conf 
==62980== Memcheck, a memory error detector
==62980== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==62980== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==62980== Command: bin/fluent-bit -c 4319/a.conf
==62980== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/13 09:55:26] [ info] [engine] started (pid=62980)
[2021/11/13 09:55:26] [ info] [storage] version=1.1.5, initializing...
[2021/11/13 09:55:26] [ info] [storage] in-memory
[2021/11/13 09:55:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/13 09:55:26] [ info] [cmetrics] version=0.2.2
[2021/11/13 09:55:26] [ info] [sp] stream processor started
==62980== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4cb4db0
==62980==          to suppress, use: --max-stackframe=11734040 or greater
==62980== Warning: client switching stacks?  SP change: 0x4cb4d28 --> 0x57e59c8
==62980==          to suppress, use: --max-stackframe=11734176 or greater
==62980== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4cb4d28
==62980==          to suppress, use: --max-stackframe=11734176 or greater
==62980==          further instances of this message will not be shown.
[0] dummy.0: [1636764926.562840705, {"message"=>"dummy"}]
[1] dummy.0: [1636764927.538354847, {"message"=>"dummy"}]
[2] dummy.0: [1636764928.538110773, {"message"=>"dummy"}]
[3] dummy.0: [1636764929.538405136, {"message"=>"dummy"}]
^C[2021/11/13 09:55:31] [engine] caught signal (SIGINT)
[0] dummy.0: [1636764930.580573809, {"message"=>"dummy"}]
[2021/11/13 09:55:31] [ warn] [engine] service will stop in 5 seconds
[2021/11/13 09:55:35] [ info] [engine] service stopped
==62980== 
==62980== HEAP SUMMARY:
==62980==     in use at exit: 0 bytes in 0 blocks
==62980==   total heap usage: 1,231 allocs, 1,231 frees, 1,326,062 bytes allocated
==62980== 
==62980== All heap blocks were freed -- no leaks are possible
==62980== 
==62980== For lists of detected and suppressed errors, rerun with: -s
==62980== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
\
```


<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
