### PR TITLE
core: add support for buffering in metrics and enhance output flush callbacks

### DIFF
--- a/CHUNKS.md
+++ b/CHUNKS.md
@@ -1,0 +1,109 @@
+# Fluent Bit Chunks (internals)
+
+When using Fluent Bit you might read about `chunks`. A Chunk is a unit of
+data that groups multiple records of the same type under the same Tag.
+
+As part of the data ingestion workflow in the pipeline, input plugins who are in
+charge to collect information from different sources, encode the data as `records`
+in a MessagePack buffer and associate them with a Tag (a tag is used for routing).
+
+Internally, Fluent Bit offer two APIs to _ingest_ the records into the pipeline
+depending of the message type to ingest.
+
+- flb_input_chunk_append_raw(): logs ingestion, defined in flb_input_chunk.c
+- flb_input_metrics_append(): metrics ingestion, defined in flb_input_metric.c
+
+When invoking any of the functions mentioned above, the API will make sure to
+find a pre-existing Chunk of the same type that contains the exact same Tag specified
+by the caller, if no available Chunk exists, a new one is created.
+
+For reliability and flexibility reasons, an input plugin might specify that all
+Chunks associated to it will be only located in memory, others might enable
+```storage.type filesystem``` so the Chunk will be located also in filesystem.
+
+## Chunk I/O: Low level
+
+In the low level side, all the Chunks management magic happens on a thin library called
+[Chunk I/O](https://github.com/edsiper/chunkio). This library helps to provide
+different backend types such as memory and filesystem, checksums and care of file system
+data synchronization.
+
+The Chunks at the file system level has it own format, but it's totally agnostic from the
+content that Fluent Bit stores on it.
+
+The following is the layout of a Chunk in the file system:
+
+```
++--------------+----------------+
+|     0xC1     |     0x00       +--> Header 2 bytes
++--------------+----------------+
+|    4 BYTES CRC32 + 16 BYTES   +--> CRC32(Content) + Padding
++-------------------------------+
+|            Content            |
+|  +-------------------------+  |
+|  |         2 BYTES         +-----> Metadata Length
+|  +-------------------------+  |
+|  +-------------------------+  |
+|  |                         |  |
+|  |        Metadata         +-----> Optional Metadata (up to 65535 bytes)
+|  |                         |  |
+|  +-------------------------+  |
+|  +-------------------------+  |
+|  |                         |  |
+|  |       Content Data      +-----> User Data
+|  |                         |  |
+|  +-------------------------+  |
++-------------------------------+
+```
+
+For Fluent Bit, the important areas of information are _Metadata_ and _Content Data_.
+
+## Metadata and Content Data
+
+On Fluent Bit the metadata and content handling has changed a bit, specifically from the
+original version implemented as of v1.8 and the changes on the new v1.9 series:
+
+### Fluent Bit >= v1.9
+
+Metadata on this version introduces 4 bytes at the beginning that identifies the
+format version by setting bytes 0xF1 and 0x77. The third byte called ```type```
+specifies the type of records the Chunk is storing, for Logs this value is ```0x0``` and for Metrics is ```0x1```. The four byte is unused for now.
+
+The following diagrams shows the data format:
+
+
+```
+                --   +---------+-------+
+               /     |  0xF1   | 0x77  |  <- Magic Bytes
+              /      +---------+-------+
+Metadata     <       |  Type   | 0x00  |  <- Chunk type and unused byte
+              \      +---------+-------+
+               \     |      Tag        |  <- Tag associated to records in the content
+                --   +-----------------+
+               /     |  +-----------+  |
+              /      |  |           |  |
+Content Data <       |  |  records  |  |
+              \      |  |           |  |
+               \     |  +-----------+  |
+                --   +-----------------+
+```
+
+Fluent Bit API provides backward compatibility with the previous metadata and content
+format found on series v1.8.
+
+### Fluent Bit <= v1.8
+
+Up to Fluent Bit <= 1.8.x, the metadata and content data is simple, where metadata
+only stores the Tag and content data the msgpack records.
+
+```
+                     +-----------------+
+Metadata     <       |      Tag        |  <- Tag associated to records in the content
+                --   +-----------------+
+               /     |  +-----------+  |
+              /      |  |           |  |
+Content Data <       |  |  records  |  |
+              \      |  |           |  |
+               \     |  +-----------+  |
+                --   +-----------------+
+```

--- a/include/fluent-bit/flb_event.h
+++ b/include/fluent-bit/flb_event.h
@@ -23,6 +23,11 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_input_chunk.h>
+
+/* Event types */
+#define FLB_EVENT_TYPE_LOG     FLB_INPUT_CHUNK_TYPE_LOG
+#define FLB_EVENT_TYPE_METRIC  FLB_INPUT_CHUNK_TYPE_METRIC
 
 /*
  * The flb_event_chunk structure is a full context used in the output plugins

--- a/include/fluent-bit/flb_event.h
+++ b/include/fluent-bit/flb_event.h
@@ -1,0 +1,50 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_EVENT_H
+#define FLB_EVENT_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+
+/*
+ * The flb_event_chunk structure is a full context used in the output plugins
+ * flush callback. It contains the type of records (logs, metrics), the tag,
+ * msgpack buffer, it size and a hint of the serialized msgpack events.
+ */
+struct flb_event_chunk {
+    int type;               /* event type */
+    flb_sds_t tag;          /* tag associated */
+    const void *data;       /* event content */
+    size_t size;            /* size of event */
+    size_t total_events;    /* total number of serialized events */
+};
+
+struct flb_event_chunk *flb_event_chunk_create(int type,
+                                               int total_events,
+                                               char *tag_buf, int tag_len,
+                                               char *buf_data, size_t buf_size);
+
+int flb_event_chunk_update(struct flb_event_chunk *evc,
+                           char *buf_data, size_t buf_size);
+
+void flb_event_chunk_destroy(struct flb_event_chunk *evc);
+
+#endif

--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -27,9 +27,6 @@
 #include <monkey/mk_core.h>
 #include <msgpack.h>
 
-#define FLB_INPUT_CHUNK_LOG            0
-#define FLB_INPUT_CHUNK_METRIC         1
-
 /*
  * This variable defines a 'hint' size for new Chunks created, this
  * value is passed to Chunk I/O.
@@ -41,6 +38,17 @@
  * this is considered a limit, a Chunk size might get greater than this.
  */
 #define FLB_INPUT_CHUNK_FS_MAX_SIZE   2048000  /* 2MB */
+
+/* Number of bytes reserved for Metadata Header on Chunks */
+#define FLB_INPUT_CHUNK_META_HEADER   4
+
+/* Chunks magic bytes (starting from Fluent Bit v1.8.10) */
+#define FLB_INPUT_CHUNK_MAGIC_BYTE_0  (unsigned char) 0xF1
+#define FLB_INPUT_CHUNK_MAGIC_BYTE_1  (unsigned char) 0x77
+
+/* Chunk types: Log and Metrics are supported */
+#define FLB_INPUT_CHUNK_TYPE_LOG      0
+#define FLB_INPUT_CHUNK_TYPE_METRIC   1
 
 struct flb_input_chunk {
     int event_type;                 /* chunk type: logs or metrics */
@@ -77,12 +85,15 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size);
 int flb_input_chunk_release_lock(struct flb_input_chunk *ic);
 flb_sds_t flb_input_chunk_get_name(struct flb_input_chunk *ic);
+int flb_input_chunk_get_event_type(struct flb_input_chunk *ic);
+
 int flb_input_chunk_get_tag(struct flb_input_chunk *ic,
                             const char **tag_buf, int *tag_len);
 ssize_t flb_input_chunk_get_size(struct flb_input_chunk *ic);
 size_t flb_input_chunk_set_limits(struct flb_input_instance *in);
 size_t flb_input_chunk_total_size(struct flb_input_instance *in);
 struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
+                                            int event_type,
                                             void *chunk);
 int flb_input_chunk_set_up_down(struct flb_input_chunk *ic);
 int flb_input_chunk_set_up(struct flb_input_chunk *ic);

--- a/include/fluent-bit/flb_mp.h
+++ b/include/fluent-bit/flb_mp.h
@@ -27,8 +27,11 @@
 #define FLB_MP_ARRAY      MSGPACK_OBJECT_ARRAY
 
 int flb_mp_count(const void *data, size_t bytes);
-int flb_mp_validate_chunk(const void *data, size_t bytes,
-                          int *out_records, size_t *processed_bytes);
+int flb_mp_validate_log_chunk(const void *data, size_t bytes,
+                              int *out_records, size_t *processed_bytes);
+int flb_mp_validate_metric_chunk(const void *data, size_t bytes,
+                                 int *out_series, size_t *processed_bytes);
+
 void flb_mp_set_map_header_size(char *buf, int arr_size);
 
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -47,6 +47,7 @@
 #include <fluent-bit/flb_output_thread.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_upstream_ha.h>
+#include <fluent-bit/flb_event.h>
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
@@ -66,6 +67,14 @@
 /* Event type handlers */
 #define FLB_OUTPUT_LOGS        1
 #define FLB_OUTPUT_METRICS     2
+
+#define FLB_OUTPUT_FLUSH_COMPAT_OLD_18()                 \
+    const void *data   = event_chunk->data;              \
+    size_t     bytes   = event_chunk->size;              \
+    int        tag_len = flb_sds_len(event_chunk->tag);  \
+    const char *tag    = event_chunk->tag;
+
+struct flb_output_flush;
 
 /*
  * Tests callbacks
@@ -125,14 +134,14 @@ struct flb_test_out_formatter {
                      struct flb_config *,
                      /* plugin that ingested the records */
                      struct flb_input_instance *,
-                     void *,       /* plugin instance context */
-                     void *,       /* optional flush context */
-                     const char *, /* tag        */
-                     int,          /* tag length */
-                     const void *, /* incoming msgpack data */
-                     size_t,       /* incoming msgpack size */
-                     void **,      /* output buffer      */
-                     size_t *);    /* output buffer size */
+                     void *,         /* plugin instance context */
+                     void *,         /* optional flush context */
+                     const char *,   /* tag        */
+                     int,            /* tag length */
+                     const void *,   /* incoming msgpack data */
+                     size_t,         /* incoming msgpack size */
+                     void **,        /* output buffer      */
+                     size_t *);      /* output buffer size */
 };
 
 struct flb_output_plugin {
@@ -185,8 +194,8 @@ struct flb_output_plugin {
     int (*cb_pre_run) (void *, struct flb_config *);
 
     /* Flush callback */
-    void (*cb_flush) (const void *, size_t,
-                      const char *, int,
+    void (*cb_flush) (struct flb_event_chunk *,
+                      struct flb_output_flush *,
                       struct flb_input_instance *,
                       void *,
                       struct flb_config *);
@@ -367,35 +376,42 @@ struct flb_output_instance {
     struct mk_list upstreams;
 
     /*
-     * co-routines
-     * -----------
-     * Every output flush() runs under a co-routine, upon creation the
-     * co-routine context is linked in the 'coros' linked list.
+     * flush context and co-routines
+     * -----------------------------
+     * Every invocation of flush() output callback runs under a co-routine, this
+     * co-routine context (struct flb_coro) is wrapped inside the structure
+     * 'flb_output_flush' which is added to the 'flush_list' linked list.
      *
      * In order to assign the coro 'id', we use the 'coro_id' incremental
      * counter to generate the next id. co-routine id's aims to be held
      * in 14 bits so the range goes from 0 to 16383.
      *
-     * When a coroutine needs to be destroyed, it moved out from 'coros'
-     * list and placed into 'coros_destroy', a cleanup function will
-     * run later to cleanup the coroutine context.
+     * When the 'flush context' needs to be destroyed, it's moved out from the
+     * 'flush_list' and placed into 'flush_list_destroy', a cleanup function will
+     * destroy the remaining resources.
      *
      * note on multi-threading mode
      * ----------------------------
-     * Every output instance in threaded mode has it own context which
-     * has similar fields like 'coro_id', 'coros', 'coros_destroy'.
+     * Every output instance in threaded mode has it own flush context which
+     * has similar fields like 'coro_id', 'flush_list' and 'flush_list_destroy'.
      *
      * On that mode, field fields are not used.
      */
-    int coro_id;
-    struct mk_list coros;
-    struct mk_list coros_destroy;
+    int flush_id;
+    struct mk_list flush_list;
+    struct mk_list flush_list_destroy;
 
     /* Keep a reference to the original context this instance belongs to */
     struct flb_config *config;
 };
 
-struct flb_output_coro {
+/*
+ * [note] this has been renamed from flb_output_coro to flb_output_flush.
+ *
+ * This structure represents the context of a flush invocation with internal
+ * information about the output instance being called plus other internal details.
+ */
+struct flb_output_flush {
     int id;                            /* out-thread ID      */
     const void *buffer;                /* output buffer      */
     struct flb_task *task;             /* Parent flb_task    */
@@ -411,13 +427,13 @@ static FLB_INLINE int flb_output_is_threaded(struct flb_output_instance *ins)
 }
 
 /* When an output_thread is going to be destroyed, this callback is triggered */
-static FLB_INLINE void flb_output_coro_destroy(struct flb_output_coro *out_coro)
+static FLB_INLINE void flb_output_flush_destroy(struct flb_output_flush *out_flush)
 {
-    flb_debug("[out coro] cb_destroy coro_id=%i", out_coro->id);
+    flb_debug("[out flush] cb_destroy coro_id=%i", out_flush->id);
 
-    mk_list_del(&out_coro->_head);
-    flb_coro_destroy(out_coro->coro);
-    flb_free(out_coro);
+    mk_list_del(&out_flush->_head);
+    flb_coro_destroy(out_flush->coro);
+    flb_free(out_flush);
 }
 
 /*
@@ -426,33 +442,31 @@ static FLB_INLINE void flb_output_coro_destroy(struct flb_output_coro *out_coro)
  * it provide a workaround using a global structure as a middle entry-point
  * that achieve the same stuff.
  */
-struct flb_out_coro_params {
-    const void  *data;
-    size_t bytes;
-    const char *tag;
-    int tag_len;
-    struct flb_input_instance *i_ins;
-    void *out_context;
-    struct flb_config *config;
-    struct flb_output_plugin *out_plugin;
-    struct flb_coro *coro;
+struct flb_out_flush_params {
+    struct flb_event_chunk *event_chunk;        /* event chunk           */
+    struct flb_output_flush *out_flush;         /* output flush          */
+    struct flb_input_instance *i_ins;           /* input instance        */
+    struct flb_output_plugin *out_plugin;       /* output plugin context */
+    void *out_context;                          /* custom plugin context */
+    struct flb_config *config;                  /* Fluent Bit context    */
+    struct flb_coro *coro;                      /* coroutine context     */
 };
 
-extern FLB_TLS_DEFINE(struct flb_out_coro_params, out_coro_params);
+extern FLB_TLS_DEFINE(struct flb_out_flush_params, out_flush_params);
 
-static FLB_INLINE void output_params_set(struct flb_coro *coro,
-                                         const void *data, size_t bytes,
-                                         const char *tag, int tag_len,
-                                         struct flb_input_instance *i_ins,
+static FLB_INLINE void output_params_set(struct flb_output_flush *out_flush,
+                                         struct flb_coro *coro,
+                                         struct flb_task *task,
                                          struct flb_output_plugin *out_plugin,
-                                         void *out_context, struct flb_config *config)
+                                         void *out_context,
+                                         struct flb_config *config)
 {
-    int s = sizeof(struct flb_out_coro_params);
-    struct flb_out_coro_params *params;
+    int s = sizeof(struct flb_out_flush_params);
+    struct flb_out_flush_params *params;
 
-    params = (struct flb_out_coro_params *) FLB_TLS_GET(out_coro_params);
+    params = (struct flb_out_flush_params *) FLB_TLS_GET(out_flush_params);
     if (!params) {
-        params = (struct flb_out_coro_params *) flb_malloc(s);
+        params = (struct flb_out_flush_params *) flb_malloc(s);
         if (!params) {
             flb_errno();
             return;
@@ -460,87 +474,72 @@ static FLB_INLINE void output_params_set(struct flb_coro *coro,
     }
 
     /* Callback parameters in order */
-    params->data        = data;
-    params->bytes       = bytes;
-    params->tag         = tag;
-    params->tag_len     = tag_len;
-    params->i_ins       = i_ins;
+    params->event_chunk = task->event_chunk;
+    params->out_flush   = out_flush;
+    params->i_ins       = task->i_ins;
     params->out_context = out_context;
     params->config      = config;
     params->out_plugin  = out_plugin;
     params->coro        = coro;
 
-    FLB_TLS_SET(out_coro_params, params);
+    FLB_TLS_SET(out_flush_params, params);
     co_switch(coro->callee);
 }
 
 static FLB_INLINE void output_pre_cb_flush(void)
 {
-    const void *data;
-    size_t bytes;
-    const char *tag;
-    int tag_len;
-    struct flb_input_instance *i_ins;
-    struct flb_output_plugin *out_p;
-    void *out_context;
-    struct flb_config *config;
     struct flb_coro *coro;
-    struct flb_out_coro_params *params;
+    struct flb_output_plugin *out_p;
+    struct flb_out_flush_params *params;
 
-    params = (struct flb_out_coro_params *) FLB_TLS_GET(out_coro_params);
+    params = (struct flb_out_flush_params *) FLB_TLS_GET(out_flush_params);
     if (!params) {
         flb_error("[output] no co-routines params defined, unexpected");
         return;
     }
-
-    data        = params->data;
-    bytes       = params->bytes;
-    tag         = params->tag;
-    tag_len     = params->tag_len;
-    i_ins       = params->i_ins;
-    out_p       = params->out_plugin;
-    out_context = params->out_context;
-    config      = params->config;
-    coro        = params->coro;
 
     /*
      * Until this point the th->callee already set the variables, so we
      * wait until the core wanted to resume so we really trigger the
      * output callback.
      */
+    coro = params->coro;
     co_switch(coro->caller);
 
     /* Continue, we will resume later */
-    out_p->cb_flush(data, bytes, tag, tag_len, i_ins, out_context, config);
+    out_p = params->out_plugin;
+    out_p->cb_flush(params->event_chunk,
+                    params->out_flush,
+                    params->i_ins,
+                    params->out_context,
+                    params->config);
 }
 
-void flb_output_coro_prepare_destroy(struct flb_output_coro *coro);
-int flb_output_coro_id_get(struct flb_output_instance *ins);
+void flb_output_flush_prepare_destroy(struct flb_output_flush *out_flush);
+int flb_output_flush_id_get(struct flb_output_instance *ins);
 
 static FLB_INLINE
-struct flb_output_coro *flb_output_coro_create(struct flb_task *task,
-                                               struct flb_input_instance *i_ins,
-                                               struct flb_output_instance *o_ins,
-                                               struct flb_config *config,
-                                               const void *buf, size_t size,
-                                               const char *tag, int tag_len)
+struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
+                                                 struct flb_input_instance *i_ins,
+                                                 struct flb_output_instance *o_ins,
+                                                 struct flb_config *config)
 {
     size_t stack_size;
     struct flb_coro *coro;
-    struct flb_output_coro *out_coro;
+    struct flb_output_flush *out_flush;
     struct flb_out_thread_instance *th_ins;
 
-    /* Custom output-thread info */
-    out_coro = (struct flb_output_coro *) flb_malloc(sizeof(struct flb_output_coro));
-    if (!out_coro) {
+    /* Custom output coroutine info */
+    out_flush = (struct flb_output_flush *) flb_calloc(1, sizeof(struct flb_output_flush));
+    if (!out_flush) {
         flb_errno();
         return NULL;
     }
 
     /* Create a new co-routine */
-    coro = flb_coro_create(out_coro);
+    coro = flb_coro_create(out_flush);
     if (!coro) {
-        flb_free(out_coro);
+        flb_free(out_flush);
         return NULL;
     }
 
@@ -548,21 +547,20 @@ struct flb_output_coro *flb_output_coro_create(struct flb_task *task,
      * Each co-routine receives an 'id', the value is always incremental up to
      * 16383.
      */
-    out_coro->id     = flb_output_coro_id_get(o_ins);
-    out_coro->o_ins  = o_ins;
-    out_coro->task   = task;
-    out_coro->buffer = buf;
-    out_coro->config = config;
-    out_coro->coro   = coro;
+    out_flush->id     = flb_output_flush_id_get(o_ins);
+    out_flush->o_ins  = o_ins;
+    out_flush->task   = task;
+    out_flush->buffer = task->event_chunk->data;
+    out_flush->config = config;
+    out_flush->coro   = coro;
 
     coro->caller = co_active();
     coro->callee = co_create(config->coro_stack_size,
                              output_pre_cb_flush, &stack_size);
 
-    if(coro->callee == NULL) {
+    if (coro->callee == NULL) {
         flb_coro_destroy(coro);
-        flb_free(out_coro);
-
+        flb_free(out_flush);
         return NULL;
     }
 
@@ -574,25 +572,17 @@ struct flb_output_coro *flb_output_coro_create(struct flb_task *task,
     if (o_ins->is_threaded == FLB_TRUE) {
         th_ins = flb_output_thread_instance_get();
 
-        pthread_mutex_lock(&th_ins->coro_mutex);
-        mk_list_add(&out_coro->_head, &th_ins->coros);
-        pthread_mutex_unlock(&th_ins->coro_mutex);
+        pthread_mutex_lock(&th_ins->flush_mutex);
+        mk_list_add(&out_flush->_head, &th_ins->flush_list);
+        pthread_mutex_unlock(&th_ins->flush_mutex);
     }
     else {
-        mk_list_add(&out_coro->_head, &o_ins->coros);
+        mk_list_add(&out_flush->_head, &o_ins->flush_list);
     }
 
     /* Workaround for makecontext() */
-    output_params_set(coro,
-                      buf,
-                      size,
-                      tag,
-                      tag_len,
-                      i_ins,
-                      o_ins->p,
-                      o_ins->context,
-                      config);
-    return out_coro;
+    output_params_set(out_flush, coro, task, o_ins->p, o_ins->context, config);
+    return out_flush;
 }
 
 /*
@@ -609,13 +599,13 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
     uint32_t set;
     uint64_t val;
     struct flb_task *task;
-    struct flb_output_coro *out_coro;
+    struct flb_output_flush *out_flush;
     struct flb_output_instance *o_ins;
     struct flb_out_thread_instance *th_ins = NULL;
 
-    out_coro = (struct flb_output_coro *) co->data;
-    o_ins = out_coro->o_ins;
-    task = out_coro->task;
+    out_flush = (struct flb_output_flush *) co->data;
+    o_ins = out_flush->o_ins;
+    task = out_flush->task;
 
     /*
      * To compose the signal event the relevant info is:
@@ -642,7 +632,7 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
         pipe_fd = th_ins->ch_thread_events[1];
     }
     else {
-        pipe_fd = out_coro->o_ins->ch_events[1];
+        pipe_fd = out_flush->o_ins->ch_events[1];
     }
 
     /* Notify the event loop about our return status */
@@ -655,7 +645,7 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
      * Prepare the co-routine to be destroyed: real-destroy happens in the
      * event loop cleanup functions.
      */
-    flb_output_coro_prepare_destroy(out_coro);
+    flb_output_flush_prepare_destroy(out_flush);
 }
 
 /* return the number of co-routines running in the instance */
@@ -671,7 +661,7 @@ static inline int flb_output_coros_size(struct flb_output_instance *ins)
         size = flb_output_thread_pool_coros_size(ins);
     }
     else {
-        size = mk_list_size(&ins->coros);
+        size = mk_list_size(&ins->flush_list);
     }
 
     return size;

--- a/include/fluent-bit/flb_output_thread.h
+++ b/include/fluent-bit/flb_output_thread.h
@@ -77,16 +77,16 @@ struct flb_out_thread_instance {
      *
      * note: in single-thread mode, the same fields are in 'struct flb_output_instance'.
      */
-    int coro_id;                         /* coroutine id counter */
-    struct mk_list coros;                /* list of co-routines */
-    struct mk_list coros_destroy;        /* list of co-routines */
+    int flush_id;                             /* coroutine id counter */
+    struct mk_list flush_list;                /* flush context list */
+    struct mk_list flush_list_destroy;        /* flust context destroy list */
 
     /*
      * If the main engine (parent thread) needs to query the number of active
-     * coroutines being used by a threaded instance, the access to the 'coros'
-     * list must be protected: we use 'coro_mutex for that purpose.
+     * 'flushes' running by a threaded instance, then the access to the 'flush_list'
+     * must be protected: we use 'flush_mutex for that purpose.
      */
-     pthread_mutex_t coro_mutex;         /* mutex for 'coros' list */
+     pthread_mutex_t flush_mutex;         /* mutex for 'flush_list' */
 
     /* List of mapped 'upstream' contexts */
     struct mk_list upstreams;

--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -73,23 +73,20 @@ struct flb_task_retry {
 
 /* A task takes a buffer and sync input and output instances to handle it */
 struct flb_task {
-    int id;                             /* task id                   */
-    uint64_t ref_id;                    /* external reference id     */
-    uint8_t status;                     /* new task or running ?     */
-    int users;                          /* number of users (threads) */
-    char *tag;                          /* record tag                */
-    int tag_len;                        /* tag length                */
-    const char *buf;                    /* buffer                    */
-    size_t size;                        /* buffer data size          */
-    void *ic;                           /* input chunk */
+    int id;                              /* task id                   */
+    uint64_t ref_id;                     /* external reference id     */
+    uint8_t status;                      /* new task or running ?     */
+    int users;                           /* number of users (threads) */
+    struct flb_event_chunk *event_chunk; /* event chunk context       */
+    void *ic;                            /* input chunk context       */
 #ifdef FLB_HAVE_METRICS
-    int records;                        /* numbers of records in 'buf'   */
+    int records;                         /* numbers of records in 'buf'   */
 #endif
-    struct mk_list routes;              /* routes to dispatch data       */
-    struct mk_list retries;             /* queued in-memory retries      */
-    struct mk_list _head;               /* link to input_instance        */
-    struct flb_input_instance *i_ins;   /* input instance                */
-    struct flb_config *config;          /* parent flb config             */
+    struct mk_list routes;               /* routes to dispatch data       */
+    struct mk_list retries;              /* queued in-memory retries      */
+    struct mk_list _head;                /* link to input_instance        */
+    struct flb_input_instance *i_ins;    /* input instance                */
+    struct flb_config *config;           /* parent flb config             */
 };
 
 int flb_task_running_count(struct flb_config *config);

--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -18,7 +18,7 @@
  *  limitations under the License.
  */
 
-#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_storage.h>
@@ -468,10 +468,12 @@ static int cb_queue_chunks(struct flb_input_instance *in,
     struct sb_out_chunk    *chunk_instance;
     struct flb_sb          *ctx;
     struct flb_input_chunk *ic;
+    struct flb_input_chunk  tmp_ic;
     void                   *ch;
     size_t                  total = 0;
     ssize_t                 size;
     int                     ret;
+    int                     event_type;
 
     /* Get context */
     ctx = (struct flb_sb *) data;
@@ -526,6 +528,27 @@ static int cb_queue_chunks(struct flb_input_instance *in,
                     }
                 }
 
+                /*
+                 * Map the chunk file context into a temporary buffer since the
+                 * flb_input_chunk_get_event_type() interface needs an
+                 * struct fb_input_chunk argument.
+                 */
+                tmp_ic.chunk = chunk_instance->chunk;
+
+                /* Retrieve the event type: FLB_INPUT_LOGS or FLB_INPUT_METRICS */
+                ret = flb_input_chunk_get_event_type(&tmp_ic);
+                if (ret == -1) {
+                    flb_plg_error(ctx->ins, "removing chunk with wrong metadata "
+                                  "from the queue %s:%s",
+                                  chunk_instance->stream->name,
+                                  chunk_instance->chunk->name);
+                    cio_chunk_close(chunk_instance->chunk, FLB_TRUE);
+                    sb_remove_chunk_from_segregated_backlogs(chunk_instance->chunk,
+                                                             ctx);
+                    continue;
+                }
+                event_type = ret;
+
                 /* get the number of bytes being used by the chunk */
                 size = cio_chunk_get_content_size(chunk_instance->chunk);
                 if (size <= 0) {
@@ -543,7 +566,7 @@ static int cb_queue_chunks(struct flb_input_instance *in,
                 ch = chunk_instance->chunk;
 
                 /* Associate this backlog chunk to this instance into the engine */
-                ic = flb_input_chunk_map(in, ch);
+                ic = flb_input_chunk_map(in, event_type, ch);
                 if (!ic) {
                     flb_plg_error(ctx->ins, "removing chunk %s:%s from the queue",
                                   chunk_instance->stream->name, chunk_instance->chunk->name);

--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -254,8 +254,8 @@ static int build_headers(struct flb_http_client *c,
     return 0;
 }
 
-static void cb_azure_flush(const void *data, size_t bytes,
-                           const char *tag, int tag_len,
+static void cb_azure_flush(struct flb_event_chunk *event_chunk,
+                           struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)
@@ -278,7 +278,8 @@ static void cb_azure_flush(const void *data, size_t bytes,
     }
 
     /* Convert binary logs into a JSON payload */
-    ret = azure_format(data, bytes, &buf_data, &buf_size, ctx);
+    ret = azure_format(event_chunk->data, event_chunk->size,
+                       &buf_data, &buf_size, ctx);
     if (ret == -1) {
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -446,8 +446,8 @@ static int bigquery_format(const void *data, size_t bytes,
     return 0;
 }
 
-static void cb_bigquery_flush(const void *data, size_t bytes,
-                              const char *tag, int tag_len,
+static void cb_bigquery_flush(struct flb_event_chunk *event_chunk,
+                              struct flb_output_flush *out_flush,
                               struct flb_input_instance *i_ins,
                               void *out_context,
                               struct flb_config *config)
@@ -464,7 +464,7 @@ static void cb_bigquery_flush(const void *data, size_t bytes,
     struct flb_upstream_conn *u_conn;
     struct flb_http_client *c;
 
-    flb_plg_trace(ctx->ins, "flushing bytes %zu", bytes);
+    flb_plg_trace(ctx->ins, "flushing bytes %zu", event_chunk->size);
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -481,7 +481,8 @@ static void cb_bigquery_flush(const void *data, size_t bytes,
     }
 
     /* Reformat msgpack to bigquery JSON payload */
-    ret = bigquery_format(data, bytes, tag, tag_len,
+    ret = bigquery_format(event_chunk->data, event_chunk->size,
+                          event_chunk->tag, flb_sds_len(event_chunk->tag),
                           &payload_buf, &payload_size, ctx);
     if (ret != 0) {
         flb_upstream_conn_release(u_conn);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -376,8 +376,8 @@ error:
     return -1;
 }
 
-static void cb_cloudwatch_flush(const void *data, size_t bytes,
-                                const char *tag, int tag_len,
+static void cb_cloudwatch_flush(struct flb_event_chunk *event_chunk,
+                                struct flb_output_flush *out_flush,
                                 struct flb_input_instance *i_ins,
                                 void *out_context,
                                 struct flb_config *config)
@@ -398,12 +398,14 @@ static void cb_cloudwatch_flush(const void *data, size_t bytes,
         }
     }
 
-    stream = get_log_stream(ctx, tag, tag_len);
+    stream = get_log_stream(ctx,
+                            event_chunk->tag, flb_sds_len(event_chunk->tag));
     if (!stream) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    event_count = process_and_send(ctx, i_ins->p->name, ctx->buf, stream, data, bytes);
+    event_count = process_and_send(ctx, i_ins->p->name, ctx->buf, stream,
+                                   event_chunk->data, event_chunk->size);
     if (event_count < 0) {
         flb_plg_error(ctx->ins, "Failed to send events");
         FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/plugins/out_counter/counter.c
+++ b/plugins/out_counter/counter.c
@@ -50,16 +50,12 @@ static int cb_counter_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_counter_flush(const void *data, size_t bytes,
-                             const char *tag, int tag_len,
+static void cb_counter_flush(struct flb_event_chunk *event_chunk,
+                             struct flb_output_flush *out_flush,
                              struct flb_input_instance *i_ins,
                              void *out_context,
                              struct flb_config *config)
 {
-    (void) data;
-    (void) bytes;
-    (void) tag;
-    (void) tag_len;
     (void) i_ins;
     (void) out_context;
     (void) config;
@@ -68,7 +64,7 @@ static void cb_counter_flush(const void *data, size_t bytes,
     struct flb_time tm;
 
     /* Count number of parent items */
-    cnt = flb_mp_count(data, bytes);
+    cnt = flb_mp_count(event_chunk->data, event_chunk->size);
     ctx->total += cnt;
 
     flb_time_get(&tm);

--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -291,8 +291,8 @@ static int datadog_format(struct flb_config *config,
     return 0;
 }
 
-static void cb_datadog_flush(const void *data, size_t bytes,
-                             const char *tag, int tag_len,
+static void cb_datadog_flush(struct flb_event_chunk *event_chunk,
+                             struct flb_output_flush *out_flush,
                              struct flb_input_instance *i_ins,
                              void *out_context,
                              struct flb_config *config)
@@ -319,8 +319,8 @@ static void cb_datadog_flush(const void *data, size_t bytes,
     /* Convert input data into a Datadog JSON payload */
     ret = datadog_format(config, i_ins,
                          ctx, NULL,
-                         tag, tag_len,
-                         data, bytes,
+                         event_chunk->tag, flb_sds_len(event_chunk->tag),
+                         event_chunk->data, event_chunk->size,
                          &out_buf, &out_size);
     if (ret == -1) {
         flb_upstream_conn_release(upstream_conn);

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -746,8 +746,8 @@ static int elasticsearch_error_check(struct flb_elasticsearch *ctx,
     return check;
 }
 
-static void cb_es_flush(const void *data, size_t bytes,
-                        const char *tag, int tag_len,
+static void cb_es_flush(struct flb_event_chunk *event_chunk,
+                        struct flb_output_flush *out_flush,
                         struct flb_input_instance *ins, void *out_context,
                         struct flb_config *config)
 {
@@ -771,8 +771,8 @@ static void cb_es_flush(const void *data, size_t bytes,
     /* Convert format */
     ret = elasticsearch_format(config, ins,
                                ctx, NULL,
-                               tag, tag_len,
-                               data, bytes,
+                               event_chunk->tag, flb_sds_len(event_chunk->tag),
+                               event_chunk->data, event_chunk->size,
                                &out_buf, &out_size);
     if (ret != 0) {
         flb_upstream_conn_release(u_conn);

--- a/plugins/out_exit/exit.c
+++ b/plugins/out_exit/exit.c
@@ -58,8 +58,8 @@ static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *conf
     return 0;
 }
 
-static void cb_exit_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_exit_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -350,8 +350,8 @@ static void print_metrics_text(struct flb_output_instance *ins,
     cmt_encode_text_destroy(text);
 }
 
-static void cb_file_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_file_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *ins,
                           void *out_context,
                           struct flb_config *config)
@@ -366,7 +366,6 @@ static void cb_file_flush(const void *data, size_t bytes,
     size_t total;
     char out_file[PATH_MAX];
     char *buf;
-    char *tag_buf;
     long file_pos;
     msgpack_object *obj;
     struct flb_file_conf *ctx = out_context;
@@ -381,7 +380,7 @@ static void cb_file_flush(const void *data, size_t bytes,
         }
         else {
             snprintf(out_file, PATH_MAX - 1, "%s/%s",
-                     ctx->out_path, tag);
+                     ctx->out_path, event_chunk->tag);
         }
     }
     else {
@@ -389,7 +388,7 @@ static void cb_file_flush(const void *data, size_t bytes,
             snprintf(out_file, PATH_MAX - 1, "%s", ctx->out_file);
         }
         else {
-            snprintf(out_file, PATH_MAX - 1, "%s", tag);
+            snprintf(out_file, PATH_MAX - 1, "%s", event_chunk->tag);
         }
     }
 
@@ -408,21 +407,12 @@ static void cb_file_flush(const void *data, size_t bytes,
     file_pos = ftell(fp);
 
     /* Check if the event type is metrics, handle the payload differently */
-    if (flb_input_event_type_is_metric(ins)) {
-        print_metrics_text(ctx->ins, fp, (char *) data, bytes);
+    if (event_chunk->type == FLB_INPUT_METRICS) {
+        print_metrics_text(ctx->ins, fp,
+                           event_chunk->data, event_chunk->size);
         fclose(fp);
         FLB_OUTPUT_RETURN(FLB_OK);
     }
-
-    tag_buf = flb_malloc(tag_len + 1);
-    if (!tag_buf) {
-        flb_errno();
-        fclose(fp);
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-    memcpy(tag_buf, tag, tag_len);
-    tag_buf[tag_len] = '\0';
-
 
     /*
      * Msgpack output format used to create unit tests files, useful for
@@ -433,18 +423,17 @@ static void cb_file_flush(const void *data, size_t bytes,
         total = 0;
 
         do {
-            ret = fwrite((char *)data + off, 1, bytes - off, fp);
+            ret = fwrite((char *) event_chunk->data + off, 1,
+                         event_chunk->size - off, fp);
             if (ret < 0) {
                 flb_errno();
                 fclose(fp);
-                flb_free(tag_buf);
                 FLB_OUTPUT_RETURN(FLB_RETRY);
             }
             total += ret;
-        } while (total < bytes);
+        } while (total < event_chunk->size);
 
         fclose(fp);
-        flb_free(tag_buf);
         FLB_OUTPUT_RETURN(FLB_OK);
     }
 
@@ -453,7 +442,9 @@ static void cb_file_flush(const void *data, size_t bytes,
      * of the map to use as a data point.
      */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         alloc_size = (off - last_off) + 128; /* JSON is larger than msgpack */
         last_off = off;
 
@@ -464,7 +455,7 @@ static void cb_file_flush(const void *data, size_t bytes,
             buf = flb_msgpack_to_json_str(alloc_size, obj);
             if (buf) {
                 fprintf(fp, "%s: [%"PRIu64".%09lu, %s]" NEWLINE,
-                        tag_buf,
+                        event_chunk->tag,
                         tm.tm.tv_sec, tm.tm.tv_nsec,
                         buf);
                 flb_free(buf);
@@ -472,7 +463,6 @@ static void cb_file_flush(const void *data, size_t bytes,
             else {
                 msgpack_unpacked_destroy(&result);
                 fclose(fp);
-                flb_free(tag_buf);
                 FLB_OUTPUT_RETURN(FLB_RETRY);
             }
             break;
@@ -498,7 +488,6 @@ static void cb_file_flush(const void *data, size_t bytes,
         }
     }
 
-    flb_free(tag_buf);
     msgpack_unpacked_destroy(&result);
     fclose(fp);
 

--- a/plugins/out_flowcounter/out_flowcounter.c
+++ b/plugins/out_flowcounter/out_flowcounter.c
@@ -182,14 +182,12 @@ static struct flb_out_fcount_buffer* seek_buffer(time_t t,
 
 
 
-static void out_fcount_flush(const void *data, size_t bytes,
-                             const char *tag, int tag_len,
+static void out_fcount_flush(struct flb_event_chunk *event_chunk,
+                             struct flb_output_flush *out_flush,
                              struct flb_input_instance *i_ins,
                              void *out_context,
                              struct flb_config *config)
 {
-    msgpack_unpacked result;
-    msgpack_object *obj;
     struct flb_flowcounter *ctx = out_context;
     struct flb_out_fcount_buffer *buf = NULL;
     size_t off = 0;
@@ -197,11 +195,15 @@ static void out_fcount_flush(const void *data, size_t bytes,
     uint64_t last_off   = 0;
     uint64_t byte_data  = 0;
     struct flb_time tm;
+    msgpack_unpacked result;
+    msgpack_object *obj;
     (void) i_ins;
     (void) config;
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&tm, &result, &obj);
 
         if (ctx->event_based == FLB_FALSE) {
@@ -236,7 +238,6 @@ static void out_fcount_flush(const void *data, size_t bytes,
         }
     }
     msgpack_unpacked_destroy(&result);
-
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1126,8 +1126,8 @@ static int flush_forward_compat_mode(struct flb_forward *ctx,
     return FLB_OK;
 }
 
-static void cb_forward_flush(const void *data, size_t bytes,
-                             const char *tag, int tag_len,
+static void cb_forward_flush(struct flb_event_chunk *event_chunk,
+                             struct flb_output_flush *out_flush,
                              struct flb_input_instance *i_ins,
                              void *out_context,
                              struct flb_config *config)
@@ -1152,7 +1152,8 @@ static void cb_forward_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    flb_plg_debug(ctx->ins, "request %lu bytes to flush", bytes);
+    flb_plg_debug(ctx->ins, "request %lu bytes to flush",
+                  event_chunk->size);
 
     /* Initialize packager */
     msgpack_sbuffer_init(&mp_sbuf);
@@ -1172,8 +1173,9 @@ static void cb_forward_flush(const void *data, size_t bytes,
 
     /* Format the right payload and retrieve the 'forward mode' used */
     mode = flb_forward_format(config, i_ins, ctx, flush_ctx,
-                              tag, tag_len,
-                              data, bytes, &out_buf, &out_size);
+                              event_chunk->tag, flb_sds_len(event_chunk->tag),
+                              event_chunk->data, event_chunk->size,
+                              &out_buf, &out_size);
 
     /* Get a TCP connection instance */
     if (ctx->ha_mode == FLB_TRUE) {
@@ -1215,13 +1217,16 @@ static void cb_forward_flush(const void *data, size_t bytes,
         flb_free(out_buf);
     }
     else if (mode == MODE_FORWARD) {
-        ret = flush_forward_mode(ctx, fc, u_conn, tag, tag_len,
-                                 data, bytes,
+        ret = flush_forward_mode(ctx, fc, u_conn,
+                                 event_chunk->tag, flb_sds_len(event_chunk->tag),
+                                 event_chunk->data, event_chunk->size,
                                  out_buf, out_size);
         flb_free(out_buf);
     }
     else if (mode == MODE_FORWARD_COMPAT) {
-        ret = flush_forward_compat_mode(ctx, fc, u_conn, tag, tag_len,
+        ret = flush_forward_compat_mode(ctx, fc, u_conn,
+                                        event_chunk->tag,
+                                        flb_sds_len(event_chunk->tag),
                                         out_buf, out_size);
         flb_free(out_buf);
     }

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -226,8 +226,8 @@ static int gelf_send_udp(struct flb_out_gelf_config *ctx, char *msg,
     return 0;
 }
 
-static void cb_gelf_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)
@@ -257,7 +257,9 @@ static void cb_gelf_flush(const void *data, size_t bytes,
 
     msgpack_unpacked_init(&result);
 
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data, event_chunk->size,
+                               &off) == MSGPACK_UNPACK_SUCCESS) {
         size = off - prev_off;
         prev_off = off;
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -475,6 +475,7 @@ static void cb_influxdb_flush(const void *data, size_t bytes,
                               struct flb_config *config)
 {
     int ret;
+    int out_ret = FLB_OK;
     int is_metric = FLB_FALSE;
     size_t b_sent;
     size_t bytes_out;
@@ -559,7 +560,8 @@ static void cb_influxdb_flush(const void *data, size_t bytes,
         flb_plg_debug(ctx->ins, "http_do=%i OK", ret);
     }
     else {
-        flb_plg_warn(ctx->ins, "http_do=%i", ret);
+        flb_plg_error(ctx->ins, "http_do=%i", ret);
+        out_ret = FLB_RETRY;
     }
 
     flb_http_client_destroy(c);
@@ -574,7 +576,7 @@ static void cb_influxdb_flush(const void *data, size_t bytes,
     /* Release the connection */
     flb_upstream_conn_release(u_conn);
 
-    FLB_OUTPUT_RETURN(FLB_OK);
+    FLB_OUTPUT_RETURN(out_ret);
 }
 
 static int cb_influxdb_exit(void *data, struct flb_config *config)

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -451,8 +451,8 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     return FLB_OK;
 }
 
-static void cb_kafka_flush(const void *data, size_t bytes,
-                           const char *tag, int tag_len,
+static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
+                           struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)
@@ -476,7 +476,9 @@ static void cb_kafka_flush(const void *data, size_t bytes,
 
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 
         ret = produce_message(&tms, obj, ctx, config);

--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -246,8 +246,8 @@ static int cb_kafka_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_kafka_flush(const void *data, size_t bytes,
-                           const char *tag, int tag_len,
+static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
+                           struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)
@@ -260,8 +260,6 @@ static void cb_kafka_flush(const void *data, size_t bytes,
     struct flb_upstream_conn *u_conn;
     struct flb_kafka_rest *ctx = out_context;
     (void) i_ins;
-    (void) tag;
-    (void) tag_len;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -270,7 +268,9 @@ static void cb_kafka_flush(const void *data, size_t bytes,
     }
 
     /* Convert format */
-    js = kafka_rest_format(data, bytes, tag, tag_len, &js_size, ctx);
+    js = kafka_rest_format(event_chunk->data, event_chunk->size,
+                           event_chunk->tag, flb_sds_len(event_chunk->tag),
+                           &js_size, ctx);
     if (!js) {
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -306,11 +306,11 @@ struct flush *new_flush_buffer()
     return buf;
 }
 
-static void cb_firehose_flush(const void *data, size_t bytes,
-                                const char *tag, int tag_len,
-                                struct flb_input_instance *i_ins,
-                                void *out_context,
-                                struct flb_config *config)
+static void cb_firehose_flush(struct flb_event_chunk *event_chunk,
+                              struct flb_output_flush *out_flush,
+                              struct flb_input_instance *i_ins,
+                              void *out_context,
+                              struct flb_config *config)
 {
     struct flb_firehose *ctx = out_context;
     int ret;
@@ -324,7 +324,8 @@ static void cb_firehose_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    ret = process_and_send_records(ctx, buf, data, bytes);
+    ret = process_and_send_records(ctx, buf,
+                                   event_chunk->data, event_chunk->size);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send records");
         flush_destroy(buf);

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -316,11 +316,11 @@ static struct flush *new_flush_buffer(const char *tag, int tag_len)
     return buf;
 }
 
-static void cb_kinesis_flush(const void *data, size_t bytes,
-                                const char *tag, int tag_len,
-                                struct flb_input_instance *i_ins,
-                                void *out_context,
-                                struct flb_config *config)
+static void cb_kinesis_flush(struct flb_event_chunk *event_chunk,
+                             struct flb_output_flush *out_flush,
+                             struct flb_input_instance *i_ins,
+                             void *out_context,
+                             struct flb_config *config)
 {
     struct flb_kinesis *ctx = out_context;
     int ret;
@@ -328,13 +328,15 @@ static void cb_kinesis_flush(const void *data, size_t bytes,
     (void) i_ins;
     (void) config;
 
-    buf = new_flush_buffer(tag, tag_len);
+    buf = new_flush_buffer(event_chunk->tag, flb_sds_len(event_chunk->tag));
     if (!buf) {
         flb_plg_error(ctx->ins, "Failed to construct flush buffer");
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    ret = process_and_send_to_kinesis(ctx, buf, data, bytes);
+    ret = process_and_send_to_kinesis(ctx, buf,
+                                      event_chunk->data,
+                                      event_chunk->size);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send records to kinesis");
         kinesis_flush_destroy(buf);

--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -354,8 +354,8 @@ static int cb_logdna_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_logdna_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
+static void cb_logdna_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)
@@ -371,7 +371,11 @@ static void cb_logdna_flush(const void *data, size_t bytes,
     struct flb_http_client *c;
 
     /* Format the data to the expected LogDNA Payload */
-    payload = logdna_compose_payload(ctx, data, bytes, tag, tag_len);
+    payload = logdna_compose_payload(ctx,
+                                     event_chunk->data,
+                                     event_chunk->size,
+                                     event_chunk->tag,
+                                     flb_sds_len(event_chunk->tag));
     if (!payload) {
         flb_plg_error(ctx->ins, "cannot compose request payload");
         FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1152,8 +1152,8 @@ static flb_sds_t loki_compose_payload(struct flb_loki *ctx,
     return json;
 }
 
-static void cb_loki_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_loki_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)
@@ -1167,7 +1167,10 @@ static void cb_loki_flush(const void *data, size_t bytes,
     struct flb_http_client *c;
 
     /* Format the data to the expected Newrelic Payload */
-    payload = loki_compose_payload(ctx, (char *) tag, tag_len, data, bytes);
+    payload = loki_compose_payload(ctx,
+                                   (char *) event_chunk->tag,
+                                   flb_sds_len(event_chunk->tag),
+                                   event_chunk->data, event_chunk->size);
     if (!payload) {
         flb_plg_error(ctx->ins, "cannot compose request payload");
         FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/plugins/out_nrlogs/newrelic.c
+++ b/plugins/out_nrlogs/newrelic.c
@@ -343,8 +343,8 @@ static int cb_newrelic_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_newrelic_flush(const void *data, size_t bytes,
-                              const char *tag, int tag_len,
+static void cb_newrelic_flush(struct flb_event_chunk *event_chunk,
+                              struct flb_output_flush *out_flush,
                               struct flb_input_instance *i_ins,
                               void *out_context,
                               struct flb_config *config)
@@ -361,7 +361,8 @@ static void cb_newrelic_flush(const void *data, size_t bytes,
     struct flb_http_client *c;
 
     /* Format the data to the expected Newrelic Payload */
-    payload = newrelic_compose_payload(ctx, data, bytes);
+    payload = newrelic_compose_payload(ctx,
+                                       event_chunk->data, event_chunk->size);
     if (!payload) {
         flb_plg_error(ctx->ins, "cannot compose request payload");
         FLB_OUTPUT_RETURN(FLB_RETRY);

--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -32,21 +32,17 @@ int cb_null_init(struct flb_output_instance *ins,
     return 0;
 }
 
-void cb_null_flush(const void *data, size_t bytes,
-                   const char *tag, int tag_len,
-                   struct flb_input_instance *i_ins,
-                   void *out_context,
-                   struct flb_config *config)
+static void cb_null_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
+                          struct flb_input_instance *i_ins,
+                          void *out_context,
+                          struct flb_config *config)
 {
-    (void) data;
-    (void) bytes;
-    (void) tag;
-    (void) tag_len;
     (void) out_context;
     (void) config;
     struct flb_output_instance *ins = out_context;
 
-    flb_plg_debug(ins, "discarding %lu bytes", bytes);
+    flb_plg_debug(ins, "discarding %lu bytes", event_chunk->size);
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 

--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -68,8 +68,8 @@ static int cb_plot_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_plot_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_plot_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
                           void *out_context,
                           struct flb_config *config)
@@ -90,7 +90,7 @@ static void cb_plot_flush(const void *data, size_t bytes,
 
     /* Set the right output */
     if (!ctx->out_file) {
-        out_file = tag;
+        out_file = event_chunk->tag;
     }
     else {
         out_file = ctx->out_file;
@@ -110,7 +110,9 @@ static void cb_plot_flush(const void *data, size_t bytes,
      * of the map to use as a data point.
      */
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&atime, &result, &map);
 
         /*

--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -167,8 +167,8 @@ static flb_sds_t hash_format_metrics(struct prom_exporter *ctx)
     return buf;
 }
 
-static void cb_prom_flush(const void *data, size_t bytes,
-                          const char *tag, int tag_len,
+static void cb_prom_flush(struct flb_event_chunk *event_chunk,
+                          struct flb_output_flush *out_flush,
                           struct flb_input_instance *ins, void *out_context,
                           struct flb_config *config)
 {
@@ -184,7 +184,9 @@ static void cb_prom_flush(const void *data, size_t bytes,
      * convert to Prometheus text format and store the output in the
      * hash table for metrics.
      */
-    ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
+    ret = cmt_decode_msgpack_create(&cmt,
+                                    (char *) event_chunk->data,
+                                    event_chunk->size, &off);
     if (ret != 0) {
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }

--- a/plugins/out_retry/retry.c
+++ b/plugins/out_retry/retry.c
@@ -62,16 +62,12 @@ static int cb_retry_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_retry_flush(const void *data, size_t bytes,
-                           const char *tag, int tag_len,
+static void cb_retry_flush(struct flb_event_chunk *event_chunk,
+                           struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)
 {
-    (void) data;
-    (void) bytes;
-    (void) tag;
-    (void) tag_len;
     (void) i_ins;
     (void) out_context;
     (void) config;
@@ -89,7 +85,7 @@ static void cb_retry_flush(const void *data, size_t bytes,
         ctx->count = 0;
     }
 
-    flb_pack_print(data, bytes);
+    flb_pack_print(event_chunk->data, event_chunk->size);
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -2009,11 +2009,11 @@ static void flush_init(void *out_context)
     }
 }
 
-static void cb_s3_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
-                            struct flb_input_instance *i_ins,
-                            void *out_context,
-                            struct flb_config *config)
+static void cb_s3_flush(struct flb_event_chunk *event_chunk,
+                        struct flb_output_flush *out_flush,
+                        struct flb_input_instance *i_ins,
+                        void *out_context,
+                        struct flb_config *config)
 {
     int ret;
     int chunk_size;
@@ -2029,10 +2029,13 @@ static void cb_s3_flush(const void *data, size_t bytes,
 
     /* Process chunk */
     if (ctx->log_key) {
-        chunk = flb_pack_msgpack_extract_log_key(ctx, data, bytes);
+        chunk = flb_pack_msgpack_extract_log_key(ctx,
+                                                 event_chunk->data,
+                                                 event_chunk->size);
     }
     else {
-        chunk = flb_pack_msgpack_to_json_format(data, bytes,
+        chunk = flb_pack_msgpack_to_json_format(event_chunk->data,
+                                                event_chunk->size,
                                                 FLB_PACK_JSON_FORMAT_LINES,
                                                 ctx->json_date_format,
                                                 ctx->date_key);
@@ -2044,17 +2047,21 @@ static void cb_s3_flush(const void *data, size_t bytes,
     chunk_size = flb_sds_len(chunk);
 
     /* Get a file candidate matching the given 'tag' */
-    upload_file = s3_store_file_get(ctx, tag, tag_len);
+    upload_file = s3_store_file_get(ctx,
+                                    event_chunk->tag,
+                                    flb_sds_len(event_chunk->tag));
 
     /* Specific to unit tests, will not get called normally */
     if (s3_plugin_under_test() == FLB_TRUE) {
-        unit_test_flush(ctx, upload_file, tag, tag_len, chunk, chunk_size, m_upload_file);
+        unit_test_flush(ctx, upload_file,
+                        event_chunk->tag, flb_sds_len(event_chunk->tag),
+                        chunk, chunk_size, m_upload_file);
     }
 
     /* Discard upload_file if it has failed to upload MAX_UPLOAD_ERRORS times */
     if (upload_file != NULL && upload_file->failures >= MAX_UPLOAD_ERRORS) {
         flb_plg_warn(ctx->ins, "File with tag %s failed to send %d times, will not "
-                     "retry", tag, MAX_UPLOAD_ERRORS);
+                     "retry", event_chunk->tag, MAX_UPLOAD_ERRORS);
         s3_store_file_inactive(ctx, upload_file);
         upload_file = NULL;
     }
@@ -2063,15 +2070,17 @@ static void cb_s3_flush(const void *data, size_t bytes,
     if (upload_file != NULL && time(NULL) >
         (upload_file->create_time + ctx->upload_timeout)) {
         upload_timeout_check = FLB_TRUE;
-        flb_plg_info(ctx->ins, "upload_timeout reached for %s", tag);
+        flb_plg_info(ctx->ins, "upload_timeout reached for %s",
+                     event_chunk->tag);
     }
 
-    m_upload_file = get_upload(ctx, tag, tag_len);
+    m_upload_file = get_upload(ctx,
+                               event_chunk->tag, flb_sds_len(event_chunk->tag));
 
     if (m_upload_file != NULL && time(NULL) >
         (m_upload_file->init_time + ctx->upload_timeout)) {
         upload_timeout_check = FLB_TRUE;
-        flb_plg_info(ctx->ins, "upload_timeout reached for %s", tag);
+        flb_plg_info(ctx->ins, "upload_timeout reached for %s", event_chunk->tag);
     }
 
     /* If total_file_size has been reached, upload file */
@@ -2084,14 +2093,16 @@ static void cb_s3_flush(const void *data, size_t bytes,
     if (upload_timeout_check == FLB_TRUE || total_file_size_check == FLB_TRUE) {
         if (ctx->preserve_data_ordering == FLB_TRUE) {
             /* Buffer last chunk in file and lock file to prevent further changes */
-            ret = buffer_chunk(ctx, upload_file, chunk, chunk_size, tag, tag_len);
+            ret = buffer_chunk(ctx, upload_file, chunk, chunk_size,
+                               event_chunk->tag, flb_sds_len(event_chunk->tag));
             if (ret < 0) {
                 FLB_OUTPUT_RETURN(FLB_RETRY);
             }
             s3_store_file_lock(upload_file);
 
             /* Add chunk file to upload queue */
-            ret = add_to_queue(ctx, upload_file, m_upload_file, tag, tag_len);
+            ret = add_to_queue(ctx, upload_file, m_upload_file,
+                               event_chunk->tag, flb_sds_len(event_chunk->tag));
             if (ret < 0) {
                 FLB_OUTPUT_RETURN(FLB_ERROR);
             }
@@ -2106,7 +2117,9 @@ static void cb_s3_flush(const void *data, size_t bytes,
         }
         else {
             /* Send upload directly without upload queue */
-            ret = send_upload_request(ctx, chunk, upload_file, m_upload_file, tag, tag_len);
+            ret = send_upload_request(ctx, chunk, upload_file, m_upload_file,
+                                      event_chunk->tag,
+                                      flb_sds_len(event_chunk->tag));
             if (ret < 0) {
                 FLB_OUTPUT_RETURN(FLB_ERROR);
             }
@@ -2115,7 +2128,8 @@ static void cb_s3_flush(const void *data, size_t bytes,
     }
 
     /* Buffer current chunk in filesystem and wait for next chunk from engine */
-    ret = buffer_chunk(ctx, upload_file, chunk, chunk_size, tag, tag_len);
+    ret = buffer_chunk(ctx, upload_file, chunk, chunk_size,
+                       event_chunk->tag, flb_sds_len(event_chunk->tag));
     if (ret < 0) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }

--- a/plugins/out_slack/slack.c
+++ b/plugins/out_slack/slack.c
@@ -143,8 +143,8 @@ error:
     return -1;
 }
 
-static void cb_slack_flush(const void *data, size_t bytes,
-                           const char *tag, int tag_len,
+static void cb_slack_flush(struct flb_event_chunk *event_chunk,
+                           struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
                            void *out_context,
                            struct flb_config *config)
@@ -167,7 +167,7 @@ static void cb_slack_flush(const void *data, size_t bytes,
     struct flb_upstream_conn *u_conn;
     struct flb_slack *ctx = out_context;
 
-    size = bytes * 4;
+    size = event_chunk->size * 4;
     json = flb_sds_create_size(size);
     if (!json) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -175,7 +175,9 @@ static void cb_slack_flush(const void *data, size_t bytes,
     memset(json, '\0', size);
 
     msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         flb_time_pop_from_msgpack(&tmp, &result, &p);
 
         ret = snprintf(json + printed, size - printed,

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -426,8 +426,8 @@ static inline int splunk_format(const void *in_buf, size_t in_bytes,
     return 0;
 }
 
-static void cb_splunk_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
+static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
                             struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)
@@ -453,7 +453,11 @@ static void cb_splunk_flush(const void *data, size_t bytes,
     }
 
     /* Convert binary logs into a JSON payload */
-    ret = splunk_format(data, bytes, (char *) tag, tag_len, &buf_data, &buf_size, ctx);
+    ret = splunk_format(event_chunk->data,
+                        event_chunk->size,
+                        (char *) event_chunk->tag,
+                        flb_sds_len(event_chunk->tag),
+                        &buf_data, &buf_size, ctx);
     if (ret == -1) {
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2072,8 +2072,8 @@ static int stackdriver_format(struct flb_config *config,
     return 0;
 }
 
-static void cb_stackdriver_flush(const void *data, size_t bytes,
-                                 const char *tag, int tag_len,
+static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
+                                 struct flb_output_flush *out_flush,
                                  struct flb_input_instance *i_ins,
                                  void *out_context,
                                  struct flb_config *config)
@@ -2112,8 +2112,8 @@ static void cb_stackdriver_flush(const void *data, size_t bytes,
     /* Reformat msgpack to stackdriver JSON payload */
     ret = stackdriver_format(config, i_ins,
                              ctx, NULL,
-                             tag, tag_len,
-                             data, bytes,
+                             event_chunk->tag, flb_sds_len(event_chunk->tag),
+                             event_chunk->data, event_chunk->size,
                              &out_buf, &out_size);
     if (ret != 0) {
 #ifdef FLB_HAVE_METRICS

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -125,9 +125,9 @@ static void print_metrics_text(struct flb_output_instance *ins,
 }
 #endif
 
-static void cb_stdout_flush(const void *data, size_t bytes,
-                            const char *tag, int tag_len,
-                            struct flb_input_instance *ins,
+static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
+                            struct flb_input_instance *i_ins,
                             void *out_context,
                             struct flb_config *config)
 {
@@ -142,15 +142,18 @@ static void cb_stdout_flush(const void *data, size_t bytes,
 
 #ifdef FLB_HAVE_METRICS
     /* Check if the event type is metrics, handle the payload differently */
-    if (flb_input_event_type_is_metric(ins)) {
-        print_metrics_text(ctx->ins, (char *) data, bytes);
+    if (event_chunk->type == FLB_EVENT_TYPE_METRIC) {
+        print_metrics_text(ctx->ins, (char *)
+                           event_chunk->data,
+                           event_chunk->size);
         FLB_OUTPUT_RETURN(FLB_OK);
     }
 #endif
 
     /* Assuming data is a log entry...*/
     if (ctx->out_format != FLB_PACK_JSON_FORMAT_NONE) {
-        json = flb_pack_msgpack_to_json_format(data, bytes,
+        json = flb_pack_msgpack_to_json_format(event_chunk->data,
+                                               event_chunk->size,
                                                ctx->out_format,
                                                ctx->json_date_format,
                                                ctx->date_key);
@@ -167,17 +170,11 @@ static void cb_stdout_flush(const void *data, size_t bytes,
         fflush(stdout);
     }
     else {
-        /* A tag might not contain a NULL byte */
-        buf = flb_malloc(tag_len + 1);
-        if (!buf) {
-            flb_errno();
-            FLB_OUTPUT_RETURN(FLB_RETRY);
-        }
-        memcpy(buf, tag, tag_len);
-        buf[tag_len] = '\0';
         msgpack_unpacked_init(&result);
-        while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
-            printf("[%zd] %s: [", cnt++, buf);
+        while (msgpack_unpack_next(&result,
+                                   event_chunk->data,
+                                   event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
+            printf("[%zd] %s: [", cnt++, event_chunk->tag);
             flb_time_pop_from_msgpack(&tmp, &result, &p);
             printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
             msgpack_object_print(stdout, *p);

--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -745,11 +745,11 @@ clean:
     return ret_sds;
 }
 
-static void cb_syslog_flush(const void *data, size_t bytes,
-                   const char *tag, int tag_len,
-                   struct flb_input_instance *i_ins,
-                   void *out_context,
-                   struct flb_config *config)
+static void cb_syslog_flush(struct flb_event_chunk *event_chunk,
+                            struct flb_output_flush *out_flush,
+                            struct flb_input_instance *i_ins,
+                            void *out_context,
+                            struct flb_config *config)
 {
     struct flb_syslog *ctx = out_context;
     flb_sds_t s;
@@ -780,7 +780,9 @@ static void cb_syslog_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
 
-    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+    while (msgpack_unpack_next(&result,
+                               event_chunk->data,
+                               event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type != MSGPACK_OBJECT_ARRAY) {
             continue;
         }

--- a/plugins/out_tcp/tcp.c
+++ b/plugins/out_tcp/tcp.c
@@ -52,8 +52,8 @@ static int cb_tcp_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static void cb_tcp_flush(const void *data, size_t bytes,
-                         const char *tag, int tag_len,
+static void cb_tcp_flush(struct flb_event_chunk *event_chunk,
+                         struct flb_output_flush *out_flush,
                          struct flb_input_instance *i_ins,
                          void *out_context,
                          struct flb_config *config)
@@ -76,10 +76,13 @@ static void cb_tcp_flush(const void *data, size_t bytes,
     }
 
     if (ctx->out_format == FLB_PACK_JSON_FORMAT_NONE) {
-        ret = flb_io_net_write(u_conn, data, bytes, &bytes_sent);
+        ret = flb_io_net_write(u_conn,
+                               event_chunk->data, event_chunk->size,
+                               &bytes_sent);
     }
     else {
-        json = flb_pack_msgpack_to_json_format(data, bytes,
+        json = flb_pack_msgpack_to_json_format(event_chunk->data,
+                                               event_chunk->size,
                                                ctx->out_format,
                                                ctx->json_date_format,
                                                ctx->date_key);

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -180,8 +180,8 @@ static int cb_td_init(struct flb_output_instance *ins, struct flb_config *config
     return 0;
 }
 
-static void cb_td_flush(const void *data, size_t bytes,
-                        const char *tag, int tag_len,
+static void cb_td_flush(struct flb_event_chunk *event_chunk,
+                        struct flb_output_flush *out_flush,
                         struct flb_input_instance *i_ins,
                         void *out_context,
                         struct flb_config *config)
@@ -195,11 +195,9 @@ static void cb_td_flush(const void *data, size_t bytes,
     struct flb_upstream_conn *u_conn;
     struct flb_http_client *c;
     (void) i_ins;
-    (void) tag;
-    (void) tag_len;
 
     /* Convert format */
-    pack = td_format(data, bytes, &bytes_out);
+    pack = td_format(event_chunk->data, event_chunk->size, &bytes_out);
     if (!pack) {
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(src
   flb_fstore.c
   flb_thread_pool.c
   flb_routes_mask.c
+  flb_event.c
   )
 
 # Multiline subsystem

--- a/src/flb_dump.c
+++ b/src/flb_dump.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_event.h>
 
 #ifdef FLB_DUMP_STACKTRACE
 #include <fluent-bit/flb_stacktrace.h>
@@ -118,7 +119,7 @@ static void dump_input_chunks(struct flb_config *ctx)
         /* Iterate tasks and print a summary */
         mk_list_foreach(h_task, &i->tasks) {
             task = mk_list_entry(h_task, struct flb_task, _head);
-            size += task->size;
+            size += task->event_chunk->size;
             if (task->status == FLB_TASK_NEW) {
                 task_new++;
             }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -196,17 +196,19 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
     /* A task has finished, delete it */
     if (ret == FLB_OK) {
         /* cmetrics */
-        cmt_counter_add(ins->cmt_proc_records, ts, task->records,
+        cmt_counter_add(ins->cmt_proc_records, ts, task->event_chunk->total_events,
                         1, (char *[]) {name});
 
-        cmt_counter_add(ins->cmt_proc_bytes, ts, task->size,
+        cmt_counter_add(ins->cmt_proc_bytes, ts, task->event_chunk->size,
                         1, (char *[]) {name});
 
         /* [OLD API] Update metrics */
 #ifdef FLB_HAVE_METRICS
         if (ins->metrics) {
-            flb_metrics_sum(FLB_METRIC_OUT_OK_RECORDS, task->records, ins->metrics);
-            flb_metrics_sum(FLB_METRIC_OUT_OK_BYTES, task->size, ins->metrics);
+            flb_metrics_sum(FLB_METRIC_OUT_OK_RECORDS,
+                            task->event_chunk->total_events, ins->metrics);
+            flb_metrics_sum(FLB_METRIC_OUT_OK_BYTES,
+                            task->event_chunk->size, ins->metrics);
         }
 #endif
         /* Inform the user if a 'retry' succedeed */

--- a/src/flb_event.c
+++ b/src/flb_event.c
@@ -1,0 +1,77 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
+
+#include <fluent-bit/flb_event.h>
+#include <fluent-bit/flb_sds.h>
+
+struct flb_event_chunk *flb_event_chunk_create(int type,
+                                               int total_events,
+                                               char *tag_buf, int tag_len,
+                                               char *buf_data, size_t buf_size)
+{
+    struct flb_event_chunk *evc;
+
+    /* event chunk context */
+    evc = flb_malloc(sizeof(struct flb_event_chunk));
+    if (!evc) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* create a copy of the tag */
+    evc->tag = flb_sds_create_len(tag_buf, tag_len);
+    if (!evc->tag) {
+        flb_free(evc);
+        return NULL;
+    }
+
+    evc->type = type;
+    evc->data = buf_data;
+    evc->size = buf_size;
+    evc->total_events = total_events;
+
+    return evc;
+}
+
+/* Update the buffer reference */
+int flb_event_chunk_update(struct flb_event_chunk *evc,
+                           char *buf_data, size_t buf_size)
+{
+    evc->data = buf_data;
+    evc->size = buf_size;
+
+    return 0;
+}
+
+void flb_event_chunk_destroy(struct flb_event_chunk *evc)
+{
+    if (!evc) {
+        return;
+    }
+
+    if (evc->tag) {
+        flb_sds_destroy(evc->tag);
+    }
+    flb_free(evc);
+}

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -350,22 +350,16 @@ int flb_input_set_property(struct flb_input_instance *ins,
         flb_sds_destroy(tmp);
     }
     else if (prop_key_check("storage.type", k, len) == 0 && tmp) {
-        /* If the input generate metrics, always use memory storage (for now) */
-        if (flb_input_event_type_is_metric(ins)) {
+        /* Set the storage type */
+        if (strcasecmp(tmp, "filesystem") == 0) {
+            ins->storage_type = CIO_STORE_FS;
+        }
+        else if (strcasecmp(tmp, "memory") == 0) {
             ins->storage_type = CIO_STORE_MEM;
         }
         else {
-            /* Set the storage type */
-            if (strcasecmp(tmp, "filesystem") == 0) {
-                ins->storage_type = CIO_STORE_FS;
-            }
-            else if (strcasecmp(tmp, "memory") == 0) {
-                ins->storage_type = CIO_STORE_MEM;
-            }
-            else {
-                flb_sds_destroy(tmp);
-                return -1;
-            }
+            flb_sds_destroy(tmp);
+            return -1;
         }
         flb_sds_destroy(tmp);
     }

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -178,9 +178,9 @@ static void output_thread(void *data)
     struct flb_task *task;
     struct flb_upstream_conn *u_conn;
     struct flb_output_instance *ins;
-    struct flb_output_coro *out_coro;
+    struct flb_output_flush *out_flush;
     struct flb_out_thread_instance *th_ins = data;
-    struct flb_out_coro_params *params;
+    struct flb_out_flush_params *params;
     struct flb_net_dns dns_ctx;
 
     /* Register thread instance */
@@ -284,17 +284,14 @@ static void output_thread(void *data)
                 }
 
                 /* Start the co-routine with the flush callback */
-                out_coro = flb_output_coro_create(task,
-                                                  task->i_ins,
-                                                  th_ins->ins,
-                                                  th_ins->config,
-                                                  task->buf, task->size,
-                                                  task->tag,
-                                                  task->tag_len);
-                if (!out_coro) {
+                out_flush = flb_output_flush_create(task,
+                                                    task->i_ins,
+                                                    th_ins->ins,
+                                                    th_ins->config);
+                if (!out_flush) {
                     continue;
                 }
-                flb_coro_resume(out_coro->coro);
+                flb_coro_resume(out_flush->coro);
             }
             else if (event->type == FLB_ENGINE_EV_CUSTOM) {
                 event->handler(event);
@@ -332,7 +329,7 @@ static void output_thread(void *data)
         flb_sched_timer_cleanup(sched);
 
         /* Check if we should stop the event loop */
-        if (stopping == FLB_TRUE && mk_list_size(&th_ins->coros) == 0) {
+        if (stopping == FLB_TRUE && mk_list_size(&th_ins->flush_list) == 0) {
             /*
              * If there are no busy network connections (and no coroutines) its
              * safe to stop it.
@@ -359,7 +356,7 @@ static void output_thread(void *data)
     mk_event_loop_destroy(th_ins->evl);
 
     flb_sched_destroy(sched);
-    params = FLB_TLS_GET(out_coro_params);
+    params = FLB_TLS_GET(out_flush_params);
     if (params) {
         flb_free(params);
     }
@@ -431,10 +428,10 @@ int flb_output_thread_pool_create(struct flb_config *config,
 
         th_ins->config = config;
         th_ins->ins = ins;
-        th_ins->coro_id = 0;
-        mk_list_init(&th_ins->coros);
-        mk_list_init(&th_ins->coros_destroy);
-        pthread_mutex_init(&th_ins->coro_mutex, NULL);
+        th_ins->flush_id = 0;
+        mk_list_init(&th_ins->flush_list);
+        mk_list_init(&th_ins->flush_list_destroy);
+        pthread_mutex_init(&th_ins->flush_mutex, NULL);
         mk_list_init(&th_ins->upstreams);
 
         upstream_thread_create(th_ins, ins);
@@ -500,9 +497,9 @@ int flb_output_thread_pool_coros_size(struct flb_output_instance *ins)
 
         th_ins = th->params.data;
 
-        pthread_mutex_lock(&th_ins->coro_mutex);
-        n = mk_list_size(&th_ins->coros);
-        pthread_mutex_unlock(&th_ins->coro_mutex);
+        pthread_mutex_lock(&th_ins->flush_mutex);
+        n = mk_list_size(&th_ins->flush_list);
+        pthread_mutex_unlock(&th_ins->flush_mutex);
 
         size += n;
     }

--- a/src/stream_processor/parser/flb_sp_parser.c
+++ b/src/stream_processor/parser/flb_sp_parser.c
@@ -320,7 +320,7 @@ int flb_sp_cmd_key_add(struct flb_sp_cmd *cmd, int func, const char *key_name)
 
 void flb_sp_cmd_alias_add(struct flb_sp_cmd *cmd, const char *key_alias)
 {
-    cmd->alias = key_alias;
+    cmd->alias = (char *) key_alias;
 }
 
 int flb_sp_cmd_source(struct flb_sp_cmd *cmd, int type, const char *source)


### PR DESCRIPTION
The following PR contains several changes:

- Enable metrics buffering: this is done by extending how the Chunk metadata is used, now in addition to the Tag we add some prefix bytes as magic bytes and chunk type (log or metric for now). This is documented on CHUNKS.md

- Output flush callbacks: as of Fluent Bit v1.8 the flush output callbacks received a couple of parameters to identify contexts of the source of msgpack information, tag, input instance, output context, and Fluent Bit context. In order to avoid changing the prototype in the future now, we added two main structures to represent the incoming buffer (struct flb_event_chunk) and the context of the execution of the plugin (struct flb_output_flush). 

- All the output plugins function prototypes have been adapted to support the new API interface described above.

Note there are no breaking changes for Go plugins interface (proxy), but external plugins developed by third-parties will need to adjust to the new API.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
