### PR TITLE
out_stackdriver: Add http_request_key config

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1373,8 +1373,8 @@ static int pack_json_payload(int insert_id_extracted,
             continue;
         }
 
-        if (validate_key(kv->key, HTTPREQUEST_FIELD_IN_JSON,
-                         HTTP_REQUEST_KEY_SIZE)
+        if (validate_key(kv->key, ctx->http_request_key,
+                         ctx->http_request_key_size)
             && kv->val.type == MSGPACK_OBJECT_MAP) {
 
             if(http_request_extra_size > 0) {

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -131,6 +131,8 @@ struct flb_stackdriver {
     flb_sds_t severity_key;
     flb_sds_t trace_key;
     flb_sds_t log_name_key;
+    flb_sds_t http_request_key;
+    int http_request_key_size;
     bool autoformat_stackdriver_trace;
 
     flb_sds_t stackdriver_agent;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -523,6 +523,7 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->severity_key);
     flb_sds_destroy(ctx->trace_key);
     flb_sds_destroy(ctx->log_name_key);
+    flb_sds_destroy(ctx->http_request_key);
     flb_sds_destroy(ctx->labels_key);
     flb_sds_destroy(ctx->tag_prefix);
     flb_sds_destroy(ctx->custom_k8s_regex);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -328,8 +328,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             ctx->http_request_key = http_request_key;
             ctx->http_request_key_size = (int)http_request_key_size;
         } else {
-            ctx->http_request_key = flb_sds_create(HTTPREQUEST_FIELD_IN_JSON);
-            ctx->http_request_key_size = HTTP_REQUEST_KEY_SIZE;
+            flb_plg_error(ctx->ins, "http_request_key is too long");
         }
     }
     else {

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -174,6 +174,8 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     int ret;
     const char *tmp;
     struct flb_stackdriver *ctx;
+    flb_sds_t http_request_key;
+    size_t http_request_key_size;
 
     /* Allocate config context */
     ctx = flb_calloc(1, sizeof(struct flb_stackdriver));
@@ -322,8 +324,8 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
 
     tmp = flb_output_get_property("http_request_key", ins);
     if (tmp) {
-        flb_sds_t http_request_key = flb_sds_create(tmp);
-        size_t http_request_key_size = flb_sds_len(http_request_key);
+        http_request_key = flb_sds_create(tmp);
+        http_request_key_size = flb_sds_len(http_request_key);
         if (http_request_key_size < INT_MAX) {
             ctx->http_request_key = http_request_key;
             ctx->http_request_key_size = (int)http_request_key_size;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_unescape.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_sds.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -317,6 +318,23 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     }
     else {
         ctx->log_name_key = flb_sds_create(DEFAULT_LOG_NAME_KEY);
+    }
+
+    tmp = flb_output_get_property("http_request_key", ins);
+    if (tmp) {
+        flb_sds_t http_request_key = flb_sds_create(tmp);
+        size_t http_request_key_size = flb_sds_len(http_request_key);
+        if (http_request_key_size < INT_MAX) {
+            ctx->http_request_key = http_request_key;
+            ctx->http_request_key_size = (int)http_request_key_size;
+        } else {
+            ctx->http_request_key = flb_sds_create(HTTPREQUEST_FIELD_IN_JSON);
+            ctx->http_request_key_size = HTTP_REQUEST_KEY_SIZE;
+        }
+    }
+    else {
+        ctx->http_request_key = flb_sds_create(HTTPREQUEST_FIELD_IN_JSON);
+        ctx->http_request_key_size = HTTP_REQUEST_KEY_SIZE;
     }
 
     if (flb_sds_cmp(ctx->resource, "k8s_container",

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -327,7 +327,8 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         if (http_request_key_size < INT_MAX) {
             ctx->http_request_key = http_request_key;
             ctx->http_request_key_size = (int)http_request_key_size;
-        } else {
+        } 
+        else {
             flb_plg_error(ctx->ins, "http_request_key is too long");
         }
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
As an interim non-breaking fix while #4200 is open, this PR will add an `http_request_key` configuration field to the `out_stackdriver` plugin. If specified, the value in this field of the config will be used instead of the value in the `HTTPREQUEST_FIELD_IN_JSON` macro.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
https://gist.github.com/braydonk/b8cbe93bd183075e0a53703de162fa15

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
