### PR TITLE
lib: monkey: sync library changes

### DIFF
--- a/lib/monkey/api/test.c
+++ b/lib/monkey/api/test.c
@@ -21,7 +21,6 @@ void cb_worker(void *data)
 
 void cb_sp_test_task_detail(mk_request_t *request, void *data)
 {
-    int i;
     (void) data;
 
     mk_http_status(request, 200);
@@ -31,7 +30,6 @@ void cb_sp_test_task_detail(mk_request_t *request, void *data)
 
 void cb_sp_test_task_main(mk_request_t *request, void *data)
 {
-    int i;
     (void) data;
 
     mk_http_status(request, 200);

--- a/lib/monkey/include/monkey/mk_http_parser.h
+++ b/lib/monkey/include/monkey/mk_http_parser.h
@@ -45,7 +45,7 @@
 #define MK_HTTP_PARSER_UPGRADE_H2    1
 #define MK_HTTP_PARSER_UPGRADE_H2C   2
 
-#define MK_HEADER_EXTRA_SIZE         8
+#define MK_HEADER_EXTRA_SIZE        50
 
 /* Request levels
  * ==============

--- a/lib/monkey/mk_core/mk_iov.c
+++ b/lib/monkey/mk_core/mk_iov.c
@@ -57,7 +57,7 @@ struct mk_iov *mk_iov_create(int n, int offset)
 
     /* Set pointer address */
     iov     = p;
-    iov->io = (struct mk_iov *)((uint8_t *)p + sizeof(struct mk_iov));
+    iov->io = (struct mk_iovec *)((uint8_t *)p + sizeof(struct mk_iov));
     iov->buf_to_free = (void *) ((uint8_t*)p + sizeof(struct mk_iov) + s_iovec);
 
     mk_iov_init(iov, n, offset);

--- a/lib/monkey/mk_server/mk_http.c
+++ b/lib/monkey/mk_server/mk_http.c
@@ -1213,6 +1213,14 @@ int mk_http_error(int http_status, struct mk_http_session *cs,
     struct file_info finfo;
     struct mk_iov *iov;
 
+    /* This function requires monkey to be properly initialized which is not the case
+     * when it's just used to parse http requests in fluent-bit so we want it to ignore
+     * that case and let fluent-bit handle it.
+    */
+    if (server->workers == 0) {
+        return MK_EXIT_OK;
+    }
+
     mk_header_set_http_status(sr, http_status);
     mk_ptr_reset(&page);
 

--- a/lib/monkey/plugins/cgi/cgi.c
+++ b/lib/monkey/plugins/cgi/cgi.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <monkey/mk_stream.h>
 #include "cgi.h"
 
 #include <sys/types.h>
@@ -78,7 +79,7 @@ int channel_write(struct cgi_request *r, void *buf, size_t count)
     }
 
     MK_TRACE("channel write: %d bytes", count);
-    mk_stream_in_cbuf(&r->sr->stream,
+    mk_stream_in_raw(&r->sr->stream,
                       NULL,
                       buf, count,
                       NULL, NULL);

--- a/lib/monkey/plugins/dirlisting/dirlisting.c
+++ b/lib/monkey/plugins/dirlisting/dirlisting.c
@@ -27,6 +27,7 @@
  */
 
 #include <monkey/mk_api.h>
+#include <monkey/mk_stream.h>
 #include "dirlisting.h"
 
 #include <time.h>
@@ -664,7 +665,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
         if (req->chunked) {
             len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                            (int) req->iov_footer->total_len);
-            mk_stream_in_cbuf(req->stream,
+            mk_stream_in_raw(req->stream,
                               NULL,
                               tmp, len,
                               NULL, NULL);
@@ -679,7 +680,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
                          req->iov_footer,
                          NULL, NULL);
         if (req->chunked) {
-            mk_stream_in_cbuf(req->stream,
+            mk_stream_in_raw(req->stream,
                               NULL,
                               "\r\n0\r\n\r\n", 7,
                               NULL, mk_dirhtml_cb_complete);
@@ -692,7 +693,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
     if (req->chunked) {
         len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                        (int) req->iov_entry->total_len);
-        mk_stream_in_cbuf(req->stream,
+        mk_stream_in_raw(req->stream,
                           NULL,
                           tmp, len,
                           NULL, NULL);
@@ -708,7 +709,7 @@ void mk_dirhtml_cb_body_rows(struct mk_stream_input *in)
                      NULL, cb_ok);
 
     if (req->chunked) {
-        mk_stream_in_cbuf(req->stream,
+        mk_stream_in_raw(req->stream,
                           NULL,
                           "\r\n", 2,
                           mk_dirhtml_cb_chunk_body_rows, NULL);
@@ -839,7 +840,7 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
     if (request->chunked) {
         len = snprintf(tmp, sizeof(tmp), "%x\r\n",
                        (int) request->iov_header->total_len);
-        mk_stream_in_cbuf(request->stream,
+        mk_stream_in_raw(request->stream,
                           NULL,
                           tmp, len,
                           NULL, mk_dirhtml_cb_complete);
@@ -851,7 +852,7 @@ static int mk_dirhtml_init(struct mk_plugin *plugin,
                      NULL, cb_header_finish);
 
     if (request->chunked) {
-        mk_stream_in_cbuf(request->stream,
+        mk_stream_in_raw(request->stream,
                           NULL,
                           "\r\n", 2,
                           NULL, NULL);

--- a/lib/monkey/plugins/fastcgi/fcgi_handler.c
+++ b/lib/monkey/plugins/fastcgi/fcgi_handler.c
@@ -19,6 +19,7 @@
 
 #include <monkey/mk_api.h>
 #include <monkey/mk_net.h>
+#include <monkey/mk_stream.h>
 
 #include "fastcgi.h"
 #include "fcgi_handler.h"
@@ -525,13 +526,13 @@ static char *getearliestbreak(const char buf[], const unsigned bufsize,
 
 static int fcgi_write(struct fcgi_handler *handler, char *buf, size_t len)
 {
-    mk_stream_in_cbuf(handler->stream,
+    mk_stream_in_raw(handler->stream,
                       NULL,
                       buf, len,
                       NULL, NULL);
 
     if (handler->headers_set == MK_TRUE) {
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           "\r\n", 2,
                           NULL, NULL);
@@ -622,7 +623,7 @@ static int fcgi_response(struct fcgi_handler *handler, char *buf, size_t len)
 
     if (len == 0 && handler->chunked && handler->headers_set == MK_TRUE) {
         MK_TRACE("[fastcgi=%i] sending EOF", handler->server_fd);
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           "0\r\n\r\n", 5,
                           NULL, NULL);
@@ -672,7 +673,7 @@ static int fcgi_response(struct fcgi_handler *handler, char *buf, size_t len)
 
     if (p_len > 0) {
         xlen = snprintf(tmp, 16, "%x\r\n", (unsigned int) p_len);
-        mk_stream_in_cbuf(handler->stream,
+        mk_stream_in_raw(handler->stream,
                           NULL,
                           tmp, xlen,
                           NULL, NULL);

--- a/lib/monkey/plugins/liana/liana.c
+++ b/lib/monkey/plugins/liana/liana.c
@@ -86,9 +86,6 @@ int mk_liana_close(int socket_fd)
 int mk_liana_send_file(int socket_fd, int file_fd, off_t *file_offset,
                        size_t file_count)
 {
-    ssize_t bytes_written = 0;
-    ssize_t to_be_sent = -1;
-    ssize_t send_ret = -1;
     ssize_t ret = -1;
 
 #if defined (__linux__)
@@ -129,6 +126,9 @@ int mk_liana_send_file(int socket_fd, int file_fd, off_t *file_offset,
 #else
     #pragma message ("This is a terrible sendfile \"implementation\" and just a crutch")
 
+    ssize_t bytes_written = 0;
+    ssize_t to_be_sent = -1;
+    ssize_t send_ret = -1;
     uint8_t temporary_buffer[1024];
 
     if (NULL != file_offset) {


### PR DESCRIPTION
**Summary**

This PR syncs changes in library monkey/monkey.

* modify indentation error log
  *  https://github.com/monkey/monkey/pull/348
* increase custom http headers count
  * https://github.com/monkey/monkey/pull/350 
  * fixes: https://github.com/fluent/fluent-bit/issues/3645
* add initialization check on mk_http_error
  * https://github.com/monkey/monkey/pull/351
* fix compiler warnings
  * https://github.com/monkey/monkey/pull/345
* fix @INCLUDE with absolute path and glob
  * https://github.com/monkey/monkey/pull/353
  * fixes: https://github.com/fluent/fluent-bit/issues/1294

Signed-off-by: Yohta Kimura <kitakita7617@gmail.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----

These changes are tested and reviewed in monkey/monkey.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
