### PR TITLE
out_file plugin : add option create output directory if does not exist.

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -31,10 +31,16 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#ifdef FLB_SYSTEM_WINDOWS
+#include <Shlobj.h>
+#include <Shlwapi.h>
+#endif
+
 #include "file.h"
 
 #ifdef FLB_SYSTEM_WINDOWS
 #define NEWLINE "\r\n"
+#define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
 #else
 #define NEWLINE "\n"
 #endif
@@ -47,6 +53,7 @@ struct flb_file_conf {
     const char *template;
     int format;
     int csv_column_names;
+    int mkdir;
     struct flb_output_instance *ins;
 };
 
@@ -354,6 +361,57 @@ static void print_metrics_text(struct flb_output_instance *ins,
     cmt_encode_text_destroy(text);
 }
 
+static int mkpath(struct flb_output_instance *ins, const char *dir)
+{
+    struct stat st;
+    char *dup_dir = NULL;
+    int ret;
+
+    if (!dir) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (strlen(dir) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (stat(dir, &st) == 0) {
+        if (S_ISDIR (st.st_mode)) {
+            return 0;
+        }
+        flb_plg_error(ins, "%s is not a directory", dir);
+        errno = ENOTDIR;
+        return -1;
+    }
+
+#ifdef FLB_SYSTEM_WINDOWS
+    char path[MAX_PATH];
+
+    if (_fullpath(path, dir, MAX_PATH) == NULL) {
+        return -1;
+    }
+
+    if (SHCreateDirectoryExA(NULL, path, NULL) != ERROR_SUCCESS) {
+        return -1;
+    }
+    return 0;
+#else
+    dup_dir = strdup(dir);
+    if (!dup_dir) {
+        return -1;
+    }
+    ret = mkpath(ins, dirname(dup_dir));
+    free(dup_dir);
+    if (ret != 0) {
+        return ret;
+    }
+    flb_plg_debug(ins, "creating directory %s", dir);
+    return mkdir(dir, 0755);
+#endif
+}
+
 static void cb_file_flush(struct flb_event_chunk *event_chunk,
                           struct flb_output_flush *out_flush,
                           struct flb_input_instance *ins,
@@ -375,6 +433,7 @@ static void cb_file_flush(struct flb_event_chunk *event_chunk,
     struct flb_file_conf *ctx = out_context;
     struct flb_time tm;
     (void) config;
+    char* out_file_copy;
 
     /* Set the right output file */
     if (ctx->out_path) {
@@ -398,6 +457,21 @@ static void cb_file_flush(struct flb_event_chunk *event_chunk,
 
     /* Open output file with default name as the Tag */
     fp = fopen(out_file, "ab+");
+    if (ctx->mkdir == FLB_TRUE && fp == NULL && errno == ENOENT) {
+        out_file_copy = strdup(out_file);
+        if (out_file_copy) {
+#ifdef FLB_SYSTEM_WINDOWS
+            PathRemoveFileSpecA(out_file_copy);
+            ret = mkpath(ctx->ins, out_file_copy);
+#else
+            ret = mkpath(ctx->ins, dirname(out_file_copy));
+#endif
+            free(out_file_copy);
+            if (ret == 0) {
+                fp = fopen(out_file, "ab+");
+            }
+        }
+    }
     if (fp == NULL) {
         flb_errno();
         flb_plg_error(ctx->ins, "error opening: %s", out_file);
@@ -555,6 +629,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "csv_column_names", "false",
      0, FLB_TRUE, offsetof(struct flb_file_conf, csv_column_names),
      "Add column names (keys) in the first line of the target file"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "mkdir", "false",
+     0, FLB_TRUE, offsetof(struct flb_file_conf, mkdir),
+     "Recursively create output directory if it does not exist. Permissions set to 0755"
     },
 
     /* EOF */


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add an `Mkdir` option to tell the output file plugin to recursively create output path if missing.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Adresses #604,#2253

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [X] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/635

I'm not familiar with C code, so please comment on any code issue. I've tested the current code on linux (Ubuntu).
This PR enables creating dynamically directories in some cases where the rewrite tag is used and adds `/`.
A use case is creating a log directory per pod that sends its data.

**Exemple configuration**
```
[OUTPUT]
    Name file
    Path logs
    Mkdir true
```

**Valgrind output**
```
valgrind --leak-check=yes  /fluent-bit/bin/fluent-bit -c fluent-bit.conf
==28== Memcheck, a memory error detector
==28== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==28== Command: /fluent-bit/bin/fluent-bit -c fluent-bit.conf
==28==
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/19 08:45:28] [ info] [engine] started (pid=28)
[2021/11/19 08:45:28] [ info] [storage] version=1.1.5, initializing...
[2021/11/19 08:45:28] [ info] [storage] in-memory
[2021/11/19 08:45:28] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/19 08:45:28] [ info] [cmetrics] version=0.2.2
[2021/11/19 08:45:28] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2021/11/19 08:45:28] [ info] [sp] stream processor started
==28== Warning: client switching stacks?  SP change: 0x71f5678 --> 0x5fc8eb0
==28==          to suppress, use: --max-stackframe=19056584 or greater
==28== Warning: client switching stacks?  SP change: 0x5fc8e58 --> 0x71f5678
==28==          to suppress, use: --max-stackframe=19056672 or greater
==28== Warning: client switching stacks?  SP change: 0x71f5678 --> 0x5fc8e58
==28==          to suppress, use: --max-stackframe=19056672 or greater
==28==          further instances of this message will not be shown.
^C[2021/11/19 08:45:37] [engine] caught signal (SIGINT)
[2021/11/19 08:45:37] [ info] [input] pausing forward.0
[2021/11/19 08:45:37] [ warn] [engine] service will stop in 0 seconds
[2021/11/19 08:45:37] [ info] [engine] service stopped
==28== Invalid free() / delete / delete[] / realloc()
==28==    at 0x48369AB: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==28==    by 0x509BAB9: free_key_mem (dlerror.c:223)
==28==    by 0x509BAB9: __dlerror_main_freeres (dlerror.c:239)
==28==    by 0x5223B71: __libc_freeres (in /lib/x86_64-linux-gnu/libc-2.28.so)
==28==    by 0x482B19E: _vgnU_freeres (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_core-amd64-linux.so)
==28==    by 0x1968F2: flb_signal_exit (fluent-bit.c:515)
==28==    by 0x1981E8: flb_main (fluent-bit.c:1289)
==28==    by 0x198230: main (fluent-bit.c:1303)
==28==  Address 0x5d9b0e0 is in a rw- anonymous segment
==28==
==28==
==28== HEAP SUMMARY:
==28==     in use at exit: 88,641 bytes in 656 blocks
==28==   total heap usage: 5,388 allocs, 4,733 frees, 32,643,423 bytes allocated
==28==
==28== LEAK SUMMARY:
==28==    definitely lost: 0 bytes in 0 blocks
==28==    indirectly lost: 0 bytes in 0 blocks
==28==      possibly lost: 0 bytes in 0 blocks
==28==    still reachable: 88,641 bytes in 656 blocks
==28==         suppressed: 0 bytes in 0 blocks
==28== Reachable blocks (those to which a pointer was found) are not shown.
==28== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==28==
==28== For counts of detected and suppressed errors, rerun with: -v
==28== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```