### PR TITLE
in_forward: fix handling of TCP connections on SIGTERM (#2610)

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -186,6 +186,8 @@ static void in_fw_pause(void *data, struct flb_config *config)
      */
     if (config->is_ingestion_active == FLB_FALSE) {
         mk_event_closesocket(ctx->server_fd);
+        fw_conn_del_all(ctx);
+
     }
 }
 
@@ -197,11 +199,11 @@ static int in_fw_exit(void *data, struct flb_config *config)
     struct flb_in_fw_config *ctx = data;
     struct fw_conn *conn;
 
-    mk_list_foreach_safe(head, tmp, &ctx->connections) {
-        conn = mk_list_entry(head, struct fw_conn, _head);
-        fw_conn_del(conn);
+    if (!ctx) {
+        return 0;
     }
 
+    fw_conn_del_all(ctx);
     fw_config_destroy(ctx);
     return 0;
 }

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -161,3 +161,17 @@ int fw_conn_del(struct fw_conn *conn)
 
     return 0;
 }
+
+int fw_conn_del_all(struct flb_in_fw_config *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct fw_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct fw_conn, _head);
+        fw_conn_del(conn);
+    }
+
+    return 0;
+}

--- a/plugins/in_forward/fw_conn.h
+++ b/plugins/in_forward/fw_conn.h
@@ -54,5 +54,6 @@ struct fw_conn {
 
 struct fw_conn *fw_conn_add(int fd, struct flb_in_fw_config *ctx);
 int fw_conn_del(struct fw_conn *conn);
+int fw_conn_del_all(struct flb_in_fw_config *ctx);
 
 #endif


### PR DESCRIPTION
When Fluent Bit receives a SIGTERM, internally it was only taking
care of the server socket leaving the active connections in an
open state.

This patch changes that behavior and if the plugin is paused or
if the engine receives SIGTERM (which will trigger a pause), now
the agent will drop the active TCP connections.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>
