### PR TITLE
Debian: adding bullseye build

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -14,8 +14,9 @@ jobs:
       matrix:
         distro: [ amazonlinux/2, amazonlinux/2.arm64v8, centos/7, centos/7.arm64v8, debian/jessie,
                   debian/jessie.arm64v8, debian/stretch, debian/stretch.arm64v8, debian/buster,
-                  debian/buster.arm64v8, ubuntu/16.04, ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8,
-                  ubuntu/20.04.arm64v8, raspbian/jessie, raspbian/stretch, raspbian/buster ]
+                  debian/buster.arm64v8, debian/bullseye, debian/bullseye.arm64v8, ubuntu/16.04,
+                  ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8, ubuntu/20.04.arm64v8,
+                  raspbian/jessie, raspbian/stretch, raspbian/buster, raspbian/bullseye ]
 
     runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]
     steps:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -156,8 +156,9 @@ jobs:
       matrix:
         distro: [ amazonlinux/2, amazonlinux/2.arm64v8, centos/7, centos/7.arm64v8, debian/jessie,
                   debian/jessie.arm64v8, debian/stretch, debian/stretch.arm64v8, debian/buster,
-                  debian/buster.arm64v8, ubuntu/16.04, ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8,
-                  ubuntu/20.04.arm64v8, raspbian/jessie, raspbian/stretch, raspbian/buster ]
+                  debian/buster.arm64v8, debian/bullseye, debian/bullseye.arm64v8, ubuntu/16.04,
+                  ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8, ubuntu/20.04.arm64v8,
+                  raspbian/jessie, raspbian/stretch, raspbian/buster, raspbian/bullseye ]
         include:
           - distro: amazonlinux/2
             target: amazonlinux/2/
@@ -199,6 +200,14 @@ jobs:
             target: debian/buster/
             format: deb
 
+          - distro: debian/bullseye
+            target: debian/bullseye/
+            format: deb
+
+          - distro: debian/bullseye.arm64v8
+            target: debian/bullseye/
+            format: deb
+
           - distro: ubuntu/16.04
             target: ubuntu/xenial/
             format: deb
@@ -229,6 +238,10 @@ jobs:
 
           - distro: raspbian/buster
             target: raspbian/buster/
+            format: deb
+
+          - distro: raspbian/bullseye
+            target: raspbian/bullseye/
             format: deb
 
     runs-on: [ ubuntu-latest ] #self-hosted, Linux, X64, packet-builder]


### PR DESCRIPTION
This is the build parameters for bullseye.

Fixes fluent/fluent-bit#4298

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
