### PR TITLE
tests: use more portable variable initialization for 1.8 branch

### DIFF
--- a/tests/internal/aws_client_mock.c
+++ b/tests/internal/aws_client_mock.c
@@ -141,6 +141,8 @@ static struct flb_http_client *flb_aws_client_mock_vtable_request(
     struct flb_aws_client *aws_client, int method, const char *uri, const char *body,
     size_t body_len, struct flb_aws_header *dynamic_headers, size_t dynamic_headers_len)
 {
+    int h;
+    int i;
     int ret;
 
     /* Get access to mock */
@@ -168,7 +170,7 @@ static struct flb_http_client *flb_aws_client_mock_vtable_request(
     mk_list_init(&c->headers);
 
     /* Response configuration */
-    for (int i = 0; i < response->length; ++i) {
+    for (i = 0; i < response->length; ++i) {
         struct flb_aws_client_mock_response_config *response_config =
             &(response->config_parameters[i]);
         void *val1 = response_config->config_value;
@@ -178,7 +180,7 @@ static struct flb_http_client *flb_aws_client_mock_vtable_request(
         if (response_config->config_parameter == FLB_AWS_CLIENT_MOCK_EXPECT_HEADER) {
             int header_found = FLB_FALSE;
             /* Search for header in request */
-            for (int h = 0; h < dynamic_headers_len; ++h) {
+            for (h = 0; h < dynamic_headers_len; ++h) {
                 ret = strncmp(dynamic_headers[h].key, (char *)val1,
                               dynamic_headers[h].key_len);
                 if (ret == 0) {


### PR DESCRIPTION
This PR is for v1.8 branch.
Original patch is https://github.com/fluent/fluent-bit/pull/4196 and I cherry-picked.

Fixes #4255

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
