### PR TITLE
in_emitter: support async mode(#4325)

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.h
+++ b/plugins/filter_rewrite_tag/rewrite_tag.h
@@ -44,6 +44,7 @@ struct flb_rewrite_tag {
     flb_sds_t emitter_name;                 /* emitter input plugin name */
     flb_sds_t emitter_storage_type;         /* emitter storage type */
     size_t emitter_mem_buf_limit;           /* Emitter buffer limit */
+    flb_sds_t  emitter_async_emit;          /* Emit by timer */
     struct mk_list rules;                   /* processed rules */
     struct mk_list *cm_rules;               /* config_map rules (only strings) */
     struct flb_input_instance *ins_emitter; /* emitter input plugin instance */

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -36,6 +36,13 @@ struct em_chunk {
 };
 
 struct flb_emitter {
+    int coll_fd;                        /* collector id */
+    int async_emit;                     /* queueing by time */
+
+    /* function pointer to add record. It is invoked by other plugin */
+    int (*add_record_func) (const char *tag, int tag_len,
+                            const char *buf_data, size_t buf_size,
+                            struct flb_input_instance *in);
     struct mk_list chunks;              /* list of all pending chunks */
     struct flb_input_instance *ins;     /* input instance */
 };
@@ -79,9 +86,44 @@ static void em_chunk_destroy(struct em_chunk *ec)
  * Function used by filters to ingest custom records with custom tags, at the
  * moment it's only used by rewrite_tag filter.
  */
-int in_emitter_add_record(const char *tag, int tag_len,
-                          const char *buf_data, size_t buf_size,
-                          struct flb_input_instance *in)
+static int in_emitter_add_record_async(const char *tag, int tag_len,
+                                       const char *buf_data, size_t buf_size,
+                                       struct flb_input_instance *in)
+{
+    struct mk_list *head;
+    struct em_chunk *ec = NULL;
+    struct flb_emitter *ctx;
+
+    ctx = (struct flb_emitter *) in->context;
+
+    /* Check if any target chunk already exists */
+    mk_list_foreach(head, &ctx->chunks) {
+        ec = mk_list_entry(head, struct em_chunk, _head);
+        if (flb_sds_cmp(ec->tag, tag, tag_len) != 0) {
+            ec = NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* No candidate chunk found, so create a new one */
+    if (!ec) {
+        ec = em_chunk_create(tag, tag_len, ctx);
+        if (!ec) {
+            flb_plg_error(ctx->ins, "cannot create new chunk for tag: %s",
+                      tag);
+            return -1;
+        }
+    }
+
+    /* Append raw msgpack data */
+    msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
+    return 0;
+}
+
+static int in_emitter_add_record_sync(const char *tag, int tag_len,
+                                      const char *buf_data, size_t buf_size,
+                                      struct flb_input_instance *in)
 {
     struct mk_list *head;
     struct em_chunk *ec = NULL;
@@ -130,10 +172,65 @@ int in_emitter_add_record(const char *tag, int tag_len,
     return 0;
 }
 
+int in_emitter_add_record(const char *tag, int tag_len,
+                          const char *buf_data, size_t buf_size,
+                          struct flb_input_instance *in)
+{
+    struct flb_emitter *ctx;
+    ctx = (struct flb_emitter *) in->context;
+    return ctx->add_record_func(tag, tag_len, buf_data, buf_size, in);
+}
+
+int in_emitter_get_collector_id(struct flb_input_instance *in)
+{
+    struct flb_emitter *ctx = (struct flb_emitter *) in->context;
+    if (ctx->async_emit == FLB_FALSE) {
+        return -1;
+    }
+    return ctx->coll_fd;
+}
+
+/* queueing callback for async mode */
+static int cb_queue_chunks(struct flb_input_instance *in,
+                           struct flb_config *config, void *data)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct em_chunk *echunk;
+    struct flb_emitter *ctx;
+
+    /* Get context */
+    ctx = (struct flb_emitter *) data;
+
+    /* Try to enqueue chunks under our limits */
+    mk_list_foreach_safe(head, tmp, &ctx->chunks) {
+        echunk = mk_list_entry(head, struct em_chunk, _head);
+
+        /* Associate this backlog chunk to this instance into the engine */
+        ret = flb_input_chunk_append_raw(in,
+                                         echunk->tag, flb_sds_len(echunk->tag),
+                                         echunk->mp_sbuf.data,
+                                         echunk->mp_sbuf.size);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "error registering chunk with tag: %s",
+                          echunk->tag);
+            continue;
+        }
+
+        /* Release the echunk */
+        em_chunk_destroy(echunk);
+    }
+
+    return 0;
+}
+
 /* Initialize plugin */
 static int cb_emitter_init(struct flb_input_instance *in,
                            struct flb_config *config, void *data)
 {
+    int ret;
+    flb_sds_t tmp;
     struct flb_emitter *ctx;
 
     ctx = flb_malloc(sizeof(struct flb_emitter));
@@ -142,12 +239,54 @@ static int cb_emitter_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->ins = in;
+    ctx->async_emit = FLB_FALSE;
     mk_list_init(&ctx->chunks);
 
     /* export plugin context */
     flb_input_set_context(in, ctx);
 
+    tmp = (char *)flb_input_get_property("async_emit", in);
+    if (tmp) {
+        ctx->async_emit = flb_utils_bool(tmp);
+    }
+
+    if (ctx->async_emit) {
+        /* Async mode setting */
+        flb_plg_debug(ctx->ins, "async mode");
+        ctx->add_record_func = in_emitter_add_record_async;
+
+        /* Set a collector to trigger the callback to queue data every 0.5 second */
+        ret = flb_input_set_collector_time(in, cb_queue_chunks, 0, 50000000, config);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "could not create collector");
+            flb_free(ctx);
+            return -1;
+        }
+        ctx->coll_fd = ret;
+    }
+    else {
+        /* Sync mode setting */
+        flb_plg_debug(ctx->ins, "sync mode");
+        ctx->add_record_func = in_emitter_add_record_sync;
+        ctx->coll_fd = -1;
+    }
     return 0;
+}
+
+static void cb_emitter_pause(void *data, struct flb_config *config)
+{
+    struct flb_emitter *ctx = data;
+    if (ctx->async_emit) {
+        flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+    }
+}
+
+static void cb_emitter_resume(void *data, struct flb_config *config)
+{
+    struct flb_emitter *ctx = data;
+    if (ctx->async_emit) {
+        flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+    }
 }
 
 static int cb_emitter_exit(void *data, struct flb_config *config)
@@ -156,6 +295,9 @@ static int cb_emitter_exit(void *data, struct flb_config *config)
     struct mk_list *head;
     struct flb_emitter *ctx = data;
     struct em_chunk *echunk;
+    if (ctx->async_emit) {
+        flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+    }
 
     mk_list_foreach_safe(head, tmp, &ctx->chunks) {
         echunk = mk_list_entry(head, struct em_chunk, _head);
@@ -176,8 +318,8 @@ struct flb_input_plugin in_emitter_plugin = {
     .cb_collect   = NULL,
     .cb_ingest    = NULL,
     .cb_flush_buf = NULL,
-    .cb_pause     = NULL,
-    .cb_resume    = NULL,
+    .cb_pause     = cb_emitter_pause,
+    .cb_resume    = cb_emitter_resume,
     .cb_exit      = cb_emitter_exit,
 
     /* This plugin can only be configured and invoked by the Engine only */


### PR DESCRIPTION
Fixes #4325 

in_emitter writes records to msgpack buffer directly from v1.8.9 to fix https://github.com/fluent/fluent-bit/issues/4049.

However, that synchronous behavior  causes new issue when using multiline filter. https://github.com/fluent/fluent-bit/issues/4325.
So, this patch is to make be selectable sync(v1.8.9+)/async(~v1.8.8) mode.

- in_emitter
  - support `async_emit` property. (default is false)
  - If `async_emit` is true, in_emitter creates timer collector to queue chunk.
  - If `async_emit` is true, in_emitter supports `cb_pause`/`cb_resume`.
- filter_rewrite_tag
  - support `emitter_async_emit` to pass `async_emit` for in_emitter. (default is false)
  - If true, filter_rewrite_tag initializes plugin collector.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature


## Configuration

```
[SERVICE]
    Daemon Off
    Flush 1
    Log_Level debug
    Parsers_File custom_parsers-repro.conf
    HTTP_Server Off
    HTTP_Listen 0.0.0.0
    HTTP_Port 2020
    Health_Check Off

[INPUT]
    Name tail
    Path ./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log
    multiline.parser docker, cri
    Tag kube.*
    Mem_Buf_Limit 5MB
    Skip_Long_Lines On
    Refresh_Interval 5
    Read_from_Head true

[FILTER]
    Name record_modifier
    Match kube.*
    Record kubernetes staging

[FILTER]
    Name          rewrite_tag
    Match         kube.*
    Rule          kubernetes ^(staging|production)$ apps false
    Emitter_Name  apps_tag_rewriter
    Emitter_async_emit true

[FILTER]
    name                  multiline
    match                 apps
    multiline.key_content log
    multiline.parser      multiline_dotnet_console

[OUTPUT]
    Name stdout
    Match *
```
- [custom_parsers-repro.conf](https://gist.github.com/starteleport/ed66f30b7161f185658e711a7a95a2a2#file-custom_parsers-repro-conf)
- [log file](https://gist.github.com/starteleport/ed66f30b7161f185658e711a7a95a2a2#file-repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d-log)

## Debug output

```
$ ../bin/fluent-bit -c bug2.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/21 11:29:17] [ info] Configuration:
[2021/11/21 11:29:17] [ info]  flush time     | 1.000000 seconds
[2021/11/21 11:29:17] [ info]  grace          | 5 seconds
[2021/11/21 11:29:17] [ info]  daemon         | 0
[2021/11/21 11:29:17] [ info] ___________
[2021/11/21 11:29:17] [ info]  inputs:
[2021/11/21 11:29:17] [ info]      tail
[2021/11/21 11:29:17] [ info] ___________
[2021/11/21 11:29:17] [ info]  filters:
[2021/11/21 11:29:17] [ info]      record_modifier.0
[2021/11/21 11:29:17] [ info]      rewrite_tag.1
[2021/11/21 11:29:17] [ info]      multiline.2
[2021/11/21 11:29:17] [ info] ___________
[2021/11/21 11:29:17] [ info]  outputs:
[2021/11/21 11:29:17] [ info]      stdout.0
[2021/11/21 11:29:17] [ info] ___________
[2021/11/21 11:29:17] [ info]  collectors:
[2021/11/21 11:29:17] [ info] [engine] started (pid=32311)
[2021/11/21 11:29:17] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2021/11/21 11:29:17] [debug] [storage] [cio stream] new stream registered: tail.0
[2021/11/21 11:29:17] [ info] [storage] version=1.1.5, initializing...
[2021/11/21 11:29:17] [ info] [storage] in-memory
[2021/11/21 11:29:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/21 11:29:17] [ info] [cmetrics] version=0.2.2
[2021/11/21 11:29:17] [ info] [input:tail:tail.0] multiline core started
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] inotify watch fd=24
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] scanning path ./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] inode=1453674 with offset=0 appended as ./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] scan_glob add(): ./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log, inode 1453674
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] 1 new files found on path './repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log'
[2021/11/21 11:29:17] [debug] [input:emitter:apps_tag_rewriter] async mode
[2021/11/21 11:29:17] [debug] [storage] [cio stream] new stream registered: emitter.1
[2021/11/21 11:29:17] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2021/11/21 11:29:17] [debug] [router] match rule tail.0:stdout.0
[2021/11/21 11:29:17] [debug] [router] match rule emitter.1:stdout.0
[2021/11/21 11:29:17] [ info] [sp] stream processor started
[2021/11/21 11:29:17] [debug] [input:tail:tail.0] inode=1453674 file=./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log promote to TAIL_EVENT
[2021/11/21 11:29:17] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1453674 watch_fd=1 name=./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log
[0] apps: [1636558774.790353236, {"log"=>"info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      => SpanId:01505dc18911774c, TraceId:b86129629f6999479b90a26bae122e46, ParentId:0000000000000000 => ConnectionId:0HMD3I6TBKKDA => RequestPath:/ RequestId:0HMD3I6TBKKDA:00000002
      Request finished HTTP/1.1 GET http://10.0.2.125:80/ - - - 200 - text/plain;+charset=utf-8 0.1316ms
[2021/11/21 11:29:18] [debug] [task] created task=0x7f5254025510 id=0 OK
", "stream"=>"stdout", "time"=>"2021-11-10T15:39:34.790353236Z", "kubernetes"=>"staging"}]
[1] apps: [1636558784.788911426, {"log"=>"info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      => SpanId:0418144220ef6845, TraceId:cfe54fe94ecaaa44ab09457f7f868752, ParentId:0000000000000000 => ConnectionId:0HMD3I6TBKKDC => RequestPath:/ RequestId:0HMD3I6TBKKDC:00000002
      Request starting HTTP/1.1 GET http://10.0.2.125:80/ - -
", "stream"=>"stdout", "time"=>"2021-11-10T15:39:44.788911426Z", "kubernetes"=>"staging"}]
[2] apps: [1636558784.789629801, {"log"=>"info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      => SpanId:0418144220ef6845, TraceId:cfe54fe94ecaaa44ab09457f7f868752, ParentId:0000000000000000 => ConnectionId:0HMD3I6TBKKDC => RequestPath:/ RequestId:0HMD3I6TBKKDC:00000002
      Request finished HTTP/1.1 GET http://10.0.2.125:80/ - - - 200 - text/plain;+charset=utf-8 0.1946ms
", "stream"=>"stdout", "time"=>"2021-11-10T15:39:44.789629801Z", "kubernetes"=>"staging"}]
[3] apps: [1636558784.789656241, {"log"=>"info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      => SpanId:5018968b4ab3f342, TraceId:94b3b5b666fba84ca420f0a336559e7b, ParentId:0000000000000000 => ConnectionId:0HMD3I6TBKKDD => RequestPath:/ RequestId:0HMD3I6TBKKDD:00000002
      Request starting HTTP/1.1 GET http://10.0.2.125:80/ - -
", "stream"=>"stdout", "time"=>"2021-11-10T15:39:44.789656241Z", "kubernetes"=>"staging"}]
[4] apps: [1636558784.789667968, {"log"=>"info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      => SpanId:5018968b4ab3f342, TraceId:94b3b5b666fba84ca420f0a336559e7b, ParentId:0000000000000000 => ConnectionId:0HMD3I6TBKKDD => RequestPath:/ RequestId:0HMD3I6TBKKDD:00000002
      Request finished HTTP/1.1 GET http://10.0.2.125:80/ - - - 200 - text/plain;+charset=utf-8 0.1048ms
", "stream"=>"stdout", "time"=>"2021-11-10T15:39:44.789667968Z", "kubernetes"=>"staging"}]
[2021/11/21 11:29:18] [debug] [out flush] cb_destroy coro_id=0
[2021/11/21 11:29:18] [debug] [task] destroy task=0x7f5254025510 (task_id=0)
```

## Valgrind output

When `Emitter_async_emit` is true.
```
$ valgrind --leak-check=full ../bin/fluent-bit -c bug2.conf 
==32317== Memcheck, a memory error detector
==32317== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32317== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==32317== Command: ../bin/fluent-bit -c bug2.conf
==32317== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/21 11:30:09] [ info] Configuration:
[2021/11/21 11:30:09] [ info]  flush time     | 1.000000 seconds
[2021/11/21 11:30:09] [ info]  grace          | 5 seconds
(snip)
[2021/11/21 11:30:16] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1453674 watch_fd=1
==32317== 
==32317== HEAP SUMMARY:
==32317==     in use at exit: 0 bytes in 0 blocks
==32317==   total heap usage: 2,192 allocs, 2,192 frees, 2,629,420 bytes allocated
==32317== 
==32317== All heap blocks were freed -- no leaks are possible
==32317== 
==32317== For lists of detected and suppressed errors, rerun with: -s
==32317== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
When `Emitter_async_emit` is false.
```
$ valgrind --leak-check=full ../bin/fluent-bit -c bug2.conf 
==32320== Memcheck, a memory error detector
==32320== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32320== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==32320== Command: ../bin/fluent-bit -c bug2.conf
==32320== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/21 11:31:28] [ info] Configuration:
[2021/11/21 11:31:28] [ info]  flush time     | 1.000000 seconds
[2021/11/21 11:31:28] [ info]  grace          | 5 seconds
[2021/11/21 11:31:28] [ info]  daemon         | 0
[2021/11/21 11:31:28] [ info] ___________
[2021/11/21 11:31:28] [ info]  inputs:
(snip)
[2021/11/21 11:31:34] [debug] [input:tail:tail.0] inode=1453674 removing file name ./repro-external-api-745f757c59-ndgg8_staging_repro-external-api-4303caf1c98782551d123e21f7ea93b56f87b3c59c27e1d325cb126abf6eda6d.log
[2021/11/21 11:31:34] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1453674 watch_fd=1
==32320== 
==32320== HEAP SUMMARY:
==32320==     in use at exit: 0 bytes in 0 blocks
==32320==   total heap usage: 2,281 allocs, 2,281 frees, 2,852,439 bytes allocated
==32320== 
==32320== All heap blocks were freed -- no leaks are possible
==32320== 
==32320== For lists of detected and suppressed errors, rerun with: -s
==32320== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
