### PR TITLE
logfmt: don't omit last item if it does not have a value

### DIFF
--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -98,9 +98,6 @@ static int logfmt_parser(struct flb_parser *parser,
         while ((c < end) && ident_byte[*c]) {
             c++;
         }
-        if (c == end) {
-            break;
-        }
 
         key_len = c - key;
         /* value */
@@ -108,7 +105,7 @@ static int logfmt_parser(struct flb_parser *parser,
         value_str = FLB_FALSE;
         value_escape =  FLB_FALSE;
 
-        if (*c == '=') {
+        if (c < end && *c == '=') {
             c++;
             if (c < end) {
                 if (*c == '"') {


### PR DESCRIPTION
<!-- Provide summary of changes -->

A line like `foo=bar baz` should be parsed to `{"foo"=>"bar", "baz"=>nil}`, but `baz` was silently omitted by returning early from the parser.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.