### PR TITLE
out_es: out_es: use snprintf wrapper function for bulk header(#4311)

### DIFF
--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -108,6 +108,6 @@ flb_sds_t flb_sds_increase(flb_sds_t s, size_t len);
 flb_sds_t flb_sds_copy(flb_sds_t s, const char *str, int len);
 void flb_sds_destroy(flb_sds_t s);
 flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...);
-int flb_sds_snprintf_realloc(flb_sds_t *str, size_t size, const char *fmt, ...);
+int flb_sds_snprintf(flb_sds_t *str, size_t size, const char *fmt, ...);
 
 #endif

--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -108,5 +108,6 @@ flb_sds_t flb_sds_increase(flb_sds_t s, size_t len);
 flb_sds_t flb_sds_copy(flb_sds_t s, const char *str, int len);
 void flb_sds_destroy(flb_sds_t s);
 flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...);
+int flb_sds_snprintf_realloc(flb_sds_t *str, size_t size, const char *fmt, ...);
 
 #endif

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -343,16 +343,16 @@ static int elasticsearch_format(struct flb_config *config,
                  ctx->index, &tm);
         es_index = index_formatted;
         if (ctx->suppress_type_name) {
-            index_len = flb_sds_snprintf_realloc(&j_index,
-                                                 flb_sds_alloc(j_index),
-                                                 ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                 es_index);
+            index_len = flb_sds_snprintf(&j_index,
+                                         flb_sds_alloc(j_index),
+                                         ES_BULK_INDEX_FMT_WITHOUT_TYPE,
+                                         es_index);
         }
         else {
-            index_len = flb_sds_snprintf_realloc(&j_index,
-                                                 flb_sds_alloc(j_index),
-                                                 ES_BULK_INDEX_FMT,
-                                                 es_index, ctx->type);
+            index_len = flb_sds_snprintf(&j_index,
+                                         flb_sds_alloc(j_index),
+                                         ES_BULK_INDEX_FMT,
+                                         es_index, ctx->type);
         }
     }
 
@@ -455,16 +455,16 @@ static int elasticsearch_format(struct flb_config *config,
             es_index = logstash_index;
             if (ctx->generate_id == FLB_FALSE) {
                 if (ctx->suppress_type_name) {
-                    index_len = flb_sds_snprintf_realloc(&j_index,
-                                                         flb_sds_alloc(j_index),
-                                                         ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                         es_index);
+                    index_len = flb_sds_snprintf(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT_WITHOUT_TYPE,
+                                                 es_index);
                 }
                 else {
-                    index_len = flb_sds_snprintf_realloc(&j_index,
-                                                         flb_sds_alloc(j_index),
-                                                         ES_BULK_INDEX_FMT,
-                                                         es_index, ctx->type);
+                    index_len = flb_sds_snprintf(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT,
+                                                 es_index, ctx->type);
                 }
             }
         }
@@ -506,32 +506,32 @@ static int elasticsearch_format(struct flb_config *config,
                      hash[0], hash[1], hash[2], hash[3],
                      hash[4], hash[5], hash[6], hash[7]);
             if (ctx->suppress_type_name) {
-                index_len = flb_sds_snprintf_realloc(&j_index,
-                                                     flb_sds_alloc(j_index),
-                                                     ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                                     es_index,  es_uuid);
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
+                                             es_index,  es_uuid);
             }
             else {
-                index_len = flb_sds_snprintf_realloc(&j_index,
-                                                     flb_sds_alloc(j_index),
-                                                     ES_BULK_INDEX_FMT_ID,
-                                                     es_index, ctx->type, es_uuid);
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             ES_BULK_INDEX_FMT_ID,
+                                             es_index, ctx->type, es_uuid);
             }
         }
         if (ctx->ra_id_key) {
             id_key_str = es_get_id_value(ctx ,&map);
             if (id_key_str) {
                 if (ctx->suppress_type_name) {
-                    index_len = flb_sds_snprintf_realloc(&j_index,
-                                                         flb_sds_alloc(j_index),
-                                                         ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                                         es_index,  id_key_str);
+                    index_len = flb_sds_snprintf(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
+                                                 es_index,  id_key_str);
                 }
                 else {
-                    index_len = flb_sds_snprintf_realloc(&j_index,
-                                                         flb_sds_alloc(j_index),
-                                                         ES_BULK_INDEX_FMT_ID,
-                                                         es_index, ctx->type, id_key_str);
+                    index_len = flb_sds_snprintf(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT_ID,
+                                                 es_index, ctx->type, id_key_str);
                 }
                 flb_sds_destroy(id_key_str);
                 id_key_str = NULL;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -265,7 +265,7 @@ static int elasticsearch_format(struct flb_config *config,
     msgpack_object root;
     msgpack_object map;
     msgpack_object *obj;
-    char j_index[ES_BULK_HEADER];
+    flb_sds_t j_index;
     struct es_bulk *bulk;
     struct tm tm;
     struct flb_time tms;
@@ -275,6 +275,12 @@ static int elasticsearch_format(struct flb_config *config,
     int es_index_custom_len;
     struct flb_elasticsearch *ctx = plugin_context;
 
+    j_index = flb_sds_create_size(ES_BULK_HEADER);
+    if (j_index == NULL) {
+        flb_errno();
+        return -1;
+    }
+
     /* Iterate the original buffer and perform adjustments */
     msgpack_unpacked_init(&result);
 
@@ -282,6 +288,7 @@ static int elasticsearch_format(struct flb_config *config,
     ret = msgpack_unpack_next(&result, data, bytes, &off);
     if (ret != MSGPACK_UNPACK_SUCCESS) {
         msgpack_unpacked_destroy(&result);
+        flb_sds_destroy(j_index);
         return -1;
     }
 
@@ -292,17 +299,22 @@ static int elasticsearch_format(struct flb_config *config,
          * doing, we just duplicate the content in a new buffer and cleanup.
          */
         msgpack_unpacked_destroy(&result);
+        flb_sds_destroy(j_index);
         return -1;
     }
 
     root = result.data;
     if (root.via.array.size == 0) {
+        msgpack_unpacked_destroy(&result);
+        flb_sds_destroy(j_index);
         return -1;
     }
 
     /* Create the bulk composer */
     bulk = es_bulk_create(bytes);
     if (!bulk) {
+        msgpack_unpacked_destroy(&result);
+        flb_sds_destroy(j_index);
         return -1;
     }
 
@@ -331,16 +343,16 @@ static int elasticsearch_format(struct flb_config *config,
                  ctx->index, &tm);
         es_index = index_formatted;
         if (ctx->suppress_type_name) {
-            index_len = snprintf(j_index,
-                                 ES_BULK_HEADER,
-                                 ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                 es_index);
+            index_len = flb_sds_snprintf_realloc(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT_WITHOUT_TYPE,
+                                                 es_index);
         }
         else {
-            index_len = snprintf(j_index,
-                                 ES_BULK_HEADER,
-                                 ES_BULK_INDEX_FMT,
-                                 es_index, ctx->type);
+            index_len = flb_sds_snprintf_realloc(&j_index,
+                                                 flb_sds_alloc(j_index),
+                                                 ES_BULK_INDEX_FMT,
+                                                 es_index, ctx->type);
         }
     }
 
@@ -443,16 +455,16 @@ static int elasticsearch_format(struct flb_config *config,
             es_index = logstash_index;
             if (ctx->generate_id == FLB_FALSE) {
                 if (ctx->suppress_type_name) {
-                    index_len = snprintf(j_index,
-                                         ES_BULK_HEADER,
-                                         ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                         es_index);
+                    index_len = flb_sds_snprintf_realloc(&j_index,
+                                                         flb_sds_alloc(j_index),
+                                                         ES_BULK_INDEX_FMT_WITHOUT_TYPE,
+                                                         es_index);
                 }
                 else {
-                    index_len = snprintf(j_index,
-                                         ES_BULK_HEADER,
-                                         ES_BULK_INDEX_FMT,
-                                         es_index, ctx->type);
+                    index_len = flb_sds_snprintf_realloc(&j_index,
+                                                         flb_sds_alloc(j_index),
+                                                         ES_BULK_INDEX_FMT,
+                                                         es_index, ctx->type);
                 }
             }
         }
@@ -483,6 +495,7 @@ static int elasticsearch_format(struct flb_config *config,
             msgpack_unpacked_destroy(&result);
             msgpack_sbuffer_destroy(&tmp_sbuf);
             es_bulk_destroy(bulk);
+            flb_sds_destroy(j_index);
             return -1;
         }
 
@@ -493,32 +506,32 @@ static int elasticsearch_format(struct flb_config *config,
                      hash[0], hash[1], hash[2], hash[3],
                      hash[4], hash[5], hash[6], hash[7]);
             if (ctx->suppress_type_name) {
-                index_len = snprintf(j_index,
-                                     ES_BULK_HEADER,
-                                     ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                     es_index,  es_uuid);
+                index_len = flb_sds_snprintf_realloc(&j_index,
+                                                     flb_sds_alloc(j_index),
+                                                     ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
+                                                     es_index,  es_uuid);
             }
             else {
-                index_len = snprintf(j_index,
-                                     ES_BULK_HEADER,
-                                     ES_BULK_INDEX_FMT_ID,
-                                     es_index, ctx->type, es_uuid);
+                index_len = flb_sds_snprintf_realloc(&j_index,
+                                                     flb_sds_alloc(j_index),
+                                                     ES_BULK_INDEX_FMT_ID,
+                                                     es_index, ctx->type, es_uuid);
             }
         }
         if (ctx->ra_id_key) {
             id_key_str = es_get_id_value(ctx ,&map);
             if (id_key_str) {
                 if (ctx->suppress_type_name) {
-                    index_len = snprintf(j_index,
-                                         ES_BULK_HEADER,
-                                         ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                         es_index,  id_key_str);
+                    index_len = flb_sds_snprintf_realloc(&j_index,
+                                                         flb_sds_alloc(j_index),
+                                                         ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
+                                                         es_index,  id_key_str);
                 }
                 else {
-                    index_len = snprintf(j_index,
-                                         ES_BULK_HEADER,
-                                         ES_BULK_INDEX_FMT_ID,
-                                         es_index, ctx->type, id_key_str);
+                    index_len = flb_sds_snprintf_realloc(&j_index,
+                                                         flb_sds_alloc(j_index),
+                                                         ES_BULK_INDEX_FMT_ID,
+                                                         es_index, ctx->type, id_key_str);
                 }
                 flb_sds_destroy(id_key_str);
                 id_key_str = NULL;
@@ -531,6 +544,7 @@ static int elasticsearch_format(struct flb_config *config,
         if (!out_buf) {
             msgpack_unpacked_destroy(&result);
             es_bulk_destroy(bulk);
+            flb_sds_destroy(j_index);
             return -1;
         }
 
@@ -544,6 +558,7 @@ static int elasticsearch_format(struct flb_config *config,
             msgpack_unpacked_destroy(&result);
             *out_size = 0;
             es_bulk_destroy(bulk);
+            flb_sds_destroy(j_index);
             return -1;
         }
     }
@@ -563,7 +578,7 @@ static int elasticsearch_format(struct flb_config *config,
         fwrite(*out_data, 1, *out_size, stdout);
         fflush(stdout);
     }
-
+    flb_sds_destroy(j_index);
     return 0;
 }
 

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -407,3 +407,31 @@ void flb_sds_destroy(flb_sds_t s)
     head = FLB_SDS_HEADER(s);
     flb_free(head);
 }
+
+/*
+ * flb_sds_snprintf_realloc is a wrapper of snprintf.
+ * The difference is that this function can increase the buffer of flb_sds_t.
+ */
+int flb_sds_snprintf_realloc(flb_sds_t *str, size_t size, const char *fmt, ...)
+{
+    va_list va;
+    flb_sds_t tmp;
+    int ret;
+
+ retry_snprintf:
+    va_start(va, fmt);
+    ret = vsnprintf(*str, size, fmt, va);
+    if (ret > size) {
+        tmp = flb_sds_increase(*str, ret-size);
+        if (tmp == NULL) {
+            return -1;
+        }
+        *str = tmp;
+        size = ret;
+        va_end(va);
+        goto retry_snprintf;
+    }
+    va_end(va);
+
+    return ret;
+}

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -409,10 +409,10 @@ void flb_sds_destroy(flb_sds_t s)
 }
 
 /*
- * flb_sds_snprintf_realloc is a wrapper of snprintf.
+ * flb_sds_snprintf is a wrapper of snprintf.
  * The difference is that this function can increase the buffer of flb_sds_t.
  */
-int flb_sds_snprintf_realloc(flb_sds_t *str, size_t size, const char *fmt, ...)
+int flb_sds_snprintf(flb_sds_t *str, size_t size, const char *fmt, ...)
 {
     va_list va;
     flb_sds_t tmp;

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -420,8 +420,80 @@ void flb_test_div0()
     flb_destroy(ctx);
 }
 
+
+static void cb_check_long_index(void *ctx, int ffd,
+                                int res_ret, void *res_data, size_t res_size,
+                                void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char long_index[256] = {0};
+    int i;
+
+    for (i=0; i<sizeof(long_index)-1; i++) {
+        long_index[i] = '0' + (i%10);
+    }
+
+    p = strstr(out_js, &long_index[0]);
+    TEST_CHECK(p != NULL);
+    flb_free(res_data);
+}
+
+/* https://github.com/fluent/fluent-bit/issues/4311 */
+void flb_test_long_index()
+{
+    int ret;
+    int size = sizeof(JSON_ES) -1;
+    char long_index[256] = {0};
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int i;
+
+    for (i=0; i<sizeof(long_index)-1; i++) {
+        long_index[i] = '0' + (i%10);
+    }
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "generate_id", "true",
+                   "index", &long_index[0],
+                   NULL);
+
+    /* Override defaults of index and type */
+    flb_output_set(ctx, out_ffd,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_long_index,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *)JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
+    {"long_index"           , flb_test_long_index },
     {"div0_error"           , flb_test_div0 },
     {"index_type"           , flb_test_index_type },
     {"logstash_format"      , flb_test_logstash_format },


### PR DESCRIPTION
Fixes #4311.

We used fixed char array to construct bulk header.
If long index( the length is greater than 80) , out_es creates broken json since the buffer is small and fixed.
We can reproduce the issue using below command.
```
fluent-bit -i cpu -o es -p generate_id=on -p index=123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
```

This PR is to
- Add test case for the issue
- Add new API `flb_sds_snprintf_realloc` 
  - It is similar to snprintf. The difference is that the API increases the buffer of flb_sds_t if there is no room to snprintf.
- Use flb_sds_t to construct header and use new API to increase the buffer

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature


## Example Configuration

1. `nc -l 9200`
2. exec fluent-bit using below command

```
fluent-bit -i cpu -o es -p generate_id=on -p index=123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
```

## Debug output

```
$ nc -l 9200
POST /_bulk HTTP/1.1
Host: 127.0.0.1:9200
Content-Length: 1216
Content-Type: application/x-ndjson
User-Agent: Fluent-Bit

{"create":{"_index":"123456789012345678901234567890123456789012345678901234567890123456789012345678901","_type":"_doc","_id":"b9042b24-930a-1f00-d630-03b0ef375788"}}{"@timestamp":"2021-11-23T12:25:01.173Z","cpu_p":29,"user_p":28,"system_p":1.0,"cpu0.p_cpu":29.0,"cpu0.p_user":28.0,"cpu0.p_system":1.0}
```

```
$ bin/fluent-bit -i cpu -o es -p generate_id=on -p index=123456789012345678901234567890123456789012345678901234567890123456789012345678901
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/23 21:25:00] [ info] [engine] started (pid=115228)
[2021/11/23 21:25:00] [ info] [storage] version=1.1.5, initializing...
[2021/11/23 21:25:00] [ info] [storage] in-memory
[2021/11/23 21:25:00] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/23 21:25:00] [ info] [cmetrics] version=0.2.2
[2021/11/23 21:25:00] [ info] [sp] stream processor started
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o es -p generate_id=on -p index=123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 -p logstash_format=on
==115578== Memcheck, a memory error detector
==115578== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==115578== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==115578== Command: bin/fluent-bit -i cpu -o es -p generate_id=on -p index=123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 -p logstash_format=on
==115578== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/11/23 21:30:39] [ info] [engine] started (pid=115578)
[2021/11/23 21:30:39] [ info] [storage] version=1.1.5, initializing...
[2021/11/23 21:30:39] [ info] [storage] in-memory
[2021/11/23 21:30:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/11/23 21:30:39] [ info] [cmetrics] version=0.2.2
[2021/11/23 21:30:39] [ info] [sp] stream processor started
==115578== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4c8da80
==115578==          to suppress, use: --max-stackframe=11894648 or greater
==115578== Warning: client switching stacks?  SP change: 0x4c8da28 --> 0x57e59f8
==115578==          to suppress, use: --max-stackframe=11894736 or greater
==115578== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4c8da28
==115578==          to suppress, use: --max-stackframe=11894736 or greater
==115578==          further instances of this message will not be shown.
^C[2021/11/23 21:30:48] [engine] caught signal (SIGINT)
[2021/11/23 21:30:48] [ info] [input] pausing cpu.0
[2021/11/23 21:30:48] [ warn] [engine] service will shutdown in max 5 seconds
[2021/11/23 21:30:49] [ info] [engine] service has stopped (0 pending tasks)
==115578== 
==115578== HEAP SUMMARY:
==115578==     in use at exit: 0 bytes in 0 blocks
==115578==   total heap usage: 1,323 allocs, 1,323 frees, 1,476,024 bytes allocated
==115578== 
==115578== All heap blocks were freed -- no leaks are possible
==115578== 
==115578== For lists of detected and suppressed errors, rerun with: -s
==115578== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
