### PR TITLE
upstream: fix deadlock when destroying connections

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -45,6 +45,7 @@ struct flb_config {
 
     int support_mode;         /* enterprise support mode ?      */
     int is_ingestion_active;  /* date ingestion active/allowed  */
+    int is_shutting_down;     /* is the service shutting down ? */
     int is_running;           /* service running ?              */
     double flush;             /* Flush timeout                  */
     int grace;                /* Maximum grace time on shutdown */

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -82,8 +82,15 @@ struct flb_upstream {
     struct flb_tls *tls;
 #endif
 
+    struct flb_config *config;
     struct mk_list _head;
 };
+
+
+static inline int flb_upstream_is_shutting_down(struct flb_upstream *u)
+{
+    return u->config->is_shutting_down;
+}
 
 void flb_upstream_queue_init(struct flb_upstream_queue *uq);
 struct flb_upstream_queue *flb_upstream_queue_get(struct flb_upstream *u);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -234,7 +234,7 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
         flb_task_retry_clean(task, ins);
         flb_task_users_dec(task, FLB_TRUE);
     }
-    else if (ret == FLB_RETRY) {
+    else if (ret == FLB_RETRY && config->is_running && !config->is_shutting_down) {
         if (ins->retry_limit == FLB_OUT_RETRY_NONE) {
             /* cmetrics: output_dropped_records_total */
             cmt_counter_add(ins->cmt_dropped_records, ts, task->records,
@@ -859,6 +859,7 @@ int flb_engine_exit(struct flb_config *config)
     uint64_t val = FLB_ENGINE_EV_STOP;
 
     config->is_ingestion_active = FLB_FALSE;
+    config->is_shutting_down = FLB_TRUE;
 
     flb_input_pause_all(config);
 

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -444,6 +444,16 @@ static int net_connect_async(int fd,
     /* Save the mask before the event handler do a reset */
     mask = u_conn->event.mask;
 
+    /*
+     * If the socket has been invalidated (e.g: timeout or shutdown), just
+     * print a debug message and return.
+     */
+    if (u_conn->fd == -1) {
+        flb_debug("[net] TCP connection not longer available: %s:%i",
+                  u->tcp_host, u->tcp_port);
+        return -1;
+    }
+
     /* We got a notification, remove the event registered */
     ret = mk_event_del(u_conn->evl, &u_conn->event);
     if (ret == -1) {

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1218,7 +1218,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
     }
 
     if (fd == -1) {
-        flb_error("[net] could not connect to %s:%s",
+        flb_debug("[net] could not connect to %s:%s",
                   host, _port);
     }
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -441,7 +441,7 @@ static inline int prepare_destroy_conn_safe(struct flb_upstream_conn *u_conn)
 
     ret = prepare_destroy_conn(u_conn);
 
-    if (u->thread_safe == FLB_TRUE && locked) {
+    if (locked) {
         pthread_mutex_unlock(&u->mutex_lists);
     }
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -429,15 +429,19 @@ static int prepare_destroy_conn(struct flb_upstream_conn *u_conn)
 static inline int prepare_destroy_conn_safe(struct flb_upstream_conn *u_conn)
 {
     int ret;
+    int locked = FLB_FALSE;
     struct flb_upstream *u = u_conn->u;
 
     if (u->thread_safe == FLB_TRUE) {
-        pthread_mutex_lock(&u->mutex_lists);
+        ret = pthread_mutex_trylock(&u->mutex_lists);
+        if (ret == 0) {
+            locked = FLB_TRUE;
+        }
     }
 
     ret = prepare_destroy_conn(u_conn);
 
-    if (u->thread_safe == FLB_TRUE) {
+    if (u->thread_safe == FLB_TRUE && locked) {
         pthread_mutex_unlock(&u->mutex_lists);
     }
 


### PR DESCRIPTION
When workers are enabled and a timeout occurs in a connection most of
cases a deadlock is held in the active worker:

  ==1654992== Thread #4: Attempt to re-lock a non-recursive lock I already hold
  ==1654992==    at 0x484BB44: ??? (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
  ==1654992==    by 0x197579: prepare_destroy_conn_safe (flb_upstream.c:435)
  ==1654992==    by 0x197887: create_conn (flb_upstream.c:533)
  ==1654992==    by 0x197DBB: flb_upstream_conn_get (flb_upstream.c:674)
  ==1654992==    by 0x2396D3: http_post (http.c:86)
  ==1654992==    by 0x23A5E5: cb_http_flush (http.c:338)
  ==1654992==    by 0x17FE6B: output_pre_cb_flush (flb_output.h:511)
  ==1654992==    by 0x503DAA: co_init (amd64.c:117)
  ==1654992==  Lock was previously acquired
  ==1654992==    at 0x484BC0F: ??? (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
  ==1654992==    by 0x19815F: flb_upstream_conn_timeouts (flb_upstream.c:780)
  ==1654992==    by 0x17FEFC: cb_thread_sched_timer (flb_output_thread.c:58)
  ==1654992==    by 0x193ED7: flb_sched_event_handler (flb_scheduler.c:422)
  ==1654992==    by 0x180672: output_thread (flb_output_thread.c:265)
  ==1654992==    by 0x199602: step_callback (flb_worker.c:44)
  ==1654992==    by 0x484E8AA: ??? (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
  ==1654992==    by 0x4E3F926: start_thread (pthread_create.c:435)
  ==1654992==    by 0x4ECF9E3: clone (clone.S:100)

The following patch fix the behavior on prepare_destroy_conn_safe by 'trying to acquire'
the mutex lock, if it fails to acquire it, it will asssume it's already locked and no
new lock is required.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
