### PR TITLE
tests: internal: fuzzer: extend config fuzzer

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UNIT_TESTS_FILES
   engine_fuzzer.c
   config_fuzzer.c
+  config_random_fuzzer.c
   signv4_fuzzer.c
   flb_json_fuzzer.c
   parser_fuzzer.c

--- a/tests/internal/fuzzers/config_fuzzer.c
+++ b/tests/internal/fuzzers/config_fuzzer.c
@@ -308,8 +308,13 @@ char conf_file[] = "# Parser: no_year\n"
 "    Time_Format %Y-%M-%S %H:%M:%S\n"
 "    Time_Keep   On\n"
 "    Decode_Field_As   json key001\n"
-"    Types A1:integer A2:string A3:bool A4:float A5:hex\n";
-
+"    Types A1:integer A2:string A3:bool A4:float A5:hex\n"
+"[MULTILINE_PARSER]\n"
+"    name          exception_test\n"
+"    type          regex\n"
+"    flush_timeout 1000\n"
+"    rule          \"start_state\"  \"/(Dec \d+ \d+\:\d+\:\d+)(.*)/\" \"cont\"\n"
+"    rule          \"cont\" \"/^\s+at.*/\" \"cont\"\n";
 
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
@@ -401,23 +406,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     /* clean up the file */
-    unlink(filename);
-
-    /* finally try to parser a random file */
-    fp = fopen(filename, "wb");
-    if (!fp) {
-        return 0;
-    }
-    fwrite(data, size, 1, fp);
-    fclose(fp);
-
-    config = NULL;
-    config = flb_config_init();
-    flb_parser_conf_file(filename, config);
-    flb_parser_exit(config);
-    flb_config_exit(config);
-
-    /* Cleanup written config file */
     unlink(filename);
 
     return 0;

--- a/tests/internal/fuzzers/config_random_fuzzer.c
+++ b/tests/internal/fuzzers/config_random_fuzzer.c
@@ -1,0 +1,53 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_slist.h>
+#include "flb_fuzz_header.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    /* Limit the size of the config files to 32KB. */
+    if (size > 32768) {
+        return 0;
+    }
+
+    /* Write the config file to a location we know OSS-Fuzz has */
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    /* Now parse a random config file */
+    struct flb_config *config = NULL;
+    config = flb_config_init();
+    flb_parser_conf_file(filename, config);
+    flb_parser_exit(config);
+    flb_config_exit(config);
+
+    /* Cleanup written config file */
+    unlink(filename);
+
+    return 0;
+}


### PR DESCRIPTION
Splits config fuzzer in two and adds multi-line parser in config template.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
