### PR TITLE
workflows: Add PR check for CentOS 7 compilation

### DIFF
--- a/.github/workflows/README.workflows.md
+++ b/.github/workflows/README.workflows.md
@@ -6,6 +6,7 @@
 | [build-release](./build-release.yaml)            | Builds the distro packages and docker images from a tagged release| on new release/tag|
 | [publish-release](./publish-release.yaml)        | Publishes the docker images/manifest on hub.docker.io/fluent/ and the distro packages | on new release/tag on build-release completes|
 | [pr-closed-docker](./pr-closed-docker.yaml)      | Removes docker images for PR on hub.docker.io/fluentbitdev/| on pr closed|
+| [pr-compile-check](./pr-compile-check.yaml)      | Runs some compilation sanity checks on a PR |
 | [pr-stale](./pr-stale.yaml)                      | Closes stale PR(s) with no activity in 30 days | scheduled daily 01:30 AM UTC|
 | [integration-build-master](./integration-build-master.yaml)     | Builds a docker image to be used in integration testing (master branch) | on new commit/push on master|
 | [integration-build-pr](./integration-build-pr.yaml)     | Builds a docker image to be used in integration testing (pr branch) | on new commit/push on PR(s) |
@@ -15,7 +16,7 @@
 
 ### Available labels
 
-| Label name | Description | 
+| Label name | Description |
 | :----------|-------------|
 | docs-required| default tag used to request documentation, has to be removed before merge |
 | ok-to-test | run all integration tests |

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -1,0 +1,61 @@
+name: 'Pull requests compile checks'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or commit SHA to use
+        required: false
+        default: master
+jobs:
+  # Reuse all the actual CentOS 7 existing packaging container to test.
+  # This way if any changes are made there then they will be reflected here.
+  # Once packaging is migrated into the source repo it will be simpler.
+  pr-compile-centos-7:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Fluent Bit code
+      uses: actions/checkout@v2
+      with:
+        ref:  ${{ github.event.inputs.ref || github.event.pull_request.head.sha }}
+
+    - name: Checkout packaging code
+      uses: actions/checkout@v2
+      with:
+        repository: fluent/fluent-bit-packaging
+        fetch-depth: 1
+        path: packaging
+
+    - name: Tar up local source to use with packaging container
+      run: |
+        tar --exclude='./packaging' --exclude='./.git' --transform 's,^,fluent-bit-pr/,' -czvf packaging/distros/centos/7/fluent-bit-pr.tgz .
+      shell: bash
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build base image to use
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        load: true
+        context: packaging/distros/centos/7/
+        file: packaging/distros/centos/7/Dockerfile.base
+        tags: flb-build-base-centos/7
+
+    - name: Attempt to build current source from tarball
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        load: true
+        no-cache: true
+        context: packaging/distros/centos/7/
+        file: packaging/distros/centos/7/Dockerfile
+        build-args:
+          FLB_SRC=fluent-bit-pr.tgz
+          FLB_VERSION=pr

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -7,55 +7,24 @@ on:
       - reopened
       - synchronize
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Branch, tag, or commit SHA to use
-        required: false
-        default: master
+
 jobs:
-  # Reuse all the actual CentOS 7 existing packaging container to test.
-  # This way if any changes are made there then they will be reflected here.
-  # Once packaging is migrated into the source repo it will be simpler.
+  # Sanity check for compilation using older compiler on CentOS 7
   pr-compile-centos-7:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout Fluent Bit code
       uses: actions/checkout@v2
-      with:
-        ref:  ${{ github.event.inputs.ref || github.event.pull_request.head.sha }}
-
-    - name: Checkout packaging code
-      uses: actions/checkout@v2
-      with:
-        repository: fluent/fluent-bit-packaging
-        fetch-depth: 1
-        path: packaging
-
-    - name: Tar up local source to use with packaging container
-      run: |
-        tar --exclude='./packaging' --exclude='./.git' --transform 's,^,fluent-bit-pr/,' -czvf packaging/distros/centos/7/sources/fluent-bit-pr.tgz .
-      shell: bash
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-      with:
-        # Required to share the images
-        driver: docker
 
-    - name: Build base image to use
+    - name: Attempt to build current source for CentOS 7
       uses: docker/build-push-action@v2
       with:
+        context: .
+        file: ./dockerfiles/Dockerfile.centos7
+        # No need to use after this so discard completely
         push: false
-        context: packaging/distros/centos/7/
-        file: packaging/distros/centos/7/Dockerfile.base
-        tags: flb-build-base-centos/7
-
-    - name: Attempt to build current source from tarball
-      uses: docker/build-push-action@v2
-      with:
-        push: false
-        context: packaging/distros/centos/7/
-        file: packaging/distros/centos/7/Dockerfile
-        build-args:
-          FLB_SRC=fluent-bit-pr.tgz
-          FLB_VERSION=pr
+        load: false

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -33,17 +33,19 @@ jobs:
 
     - name: Tar up local source to use with packaging container
       run: |
-        tar --exclude='./packaging' --exclude='./.git' --transform 's,^,fluent-bit-pr/,' -czvf packaging/distros/centos/7/fluent-bit-pr.tgz .
+        tar --exclude='./packaging' --exclude='./.git' --transform 's,^,fluent-bit-pr/,' -czvf packaging/distros/centos/7/sources/fluent-bit-pr.tgz .
       shell: bash
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        # Required to share the images
+        driver: docker
 
     - name: Build base image to use
       uses: docker/build-push-action@v2
       with:
         push: false
-        load: true
         context: packaging/distros/centos/7/
         file: packaging/distros/centos/7/Dockerfile.base
         tags: flb-build-base-centos/7
@@ -52,8 +54,6 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: false
-        load: true
-        no-cache: true
         context: packaging/distros/centos/7/
         file: packaging/distros/centos/7/Dockerfile
         build-args:

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -1,0 +1,24 @@
+# This container image is primarily used to test compilation works for CentOS 7, it is
+# not intended for production usage.
+# Based on https://github.com/fluent/fluent-bit-packaging/tree/master/distros/centos/7
+FROM centos:7
+
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+                   wget unzip systemd-devel wget flex bison \
+                   cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+                   postgresql-libs postgresql-devel postgresql-server postgresql && \
+    wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    rpm -ivh epel-release-latest-7.noarch.rpm && \
+    yum install -y cmake3
+
+COPY . /src/
+WORKDIR /src/build
+
+RUN cmake3 -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
+           -DFLB_RELEASE=On -DFLB_TRACE=On -DFLB_TD=On \
+           -DFLB_SQLDB=On -DFLB_HTTP_SERVER=On \
+           -DFLB_OUT_KAFKA=On \
+           -DFLB_OUT_PGSQL=On ../
+
+RUN make -j $(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Simple workflow to run during a PR in order to ensure the code still compiles with the older compiler versions required for CentOS 7 support. Uses a container to do the build to make it portable and easy to share across runners or locally.

Reused the packaging container setup but simplified and kept in this repo to make it easy to use.
The container is not intended for production usage.

Initially used a workflow that cloned the packaging repository then built the two images required there (base + source) using a tarball created during the workflow for the source. However that approach is unnecessarily complex and will take longer too, the only downside now is drift in the packaging container configuration vs the local one here. Although we can also optimise them for their separate use cases.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- Tested with a local nektos/act run to confirm the action functions correctly.

**Documentation**
- [N/A] Documentation required for this feature
- The [Github Actions README.md](./.github/workflows/README.workflows.md) has been updated for this new workflow.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
