### PR TITLE
filter_multiline: implemented buffered mode using in_emitter

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -59,6 +59,7 @@ struct flb_filter_plugin {
                       const char *, int,
                       void **, size_t *,
                       struct flb_filter_instance *,
+                      struct flb_input_instance *,
                       void *, struct flb_config *);
     int (*cb_exit) (void *, struct flb_config *);
 

--- a/plugins/filter_alter_size/alter_size.c
+++ b/plugins/filter_alter_size/alter_size.c
@@ -63,6 +63,7 @@ static int cb_alter_size_filter(const void *data, size_t bytes,
                                 const char *tag, int tag_len,
                                 void **out_buf, size_t *out_size,
                                 struct flb_filter_instance *ins,
+                                struct flb_input_instance *i_ins,
                                 void *filter_context,
                                 struct flb_config *config)
 {
@@ -73,6 +74,7 @@ static int cb_alter_size_filter(const void *data, size_t bytes,
     int count = 0;
     size_t off = 0;
     (void) config;
+    (void) i_ins;
     char tmp[32];
     msgpack_unpacked result;
     msgpack_object root;

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -475,11 +475,13 @@ static int cb_aws_filter(const void *data, size_t bytes,
                          const char *tag, int tag_len,
                          void **out_buf, size_t *out_size,
                          struct flb_filter_instance *f_ins,
+                         struct flb_input_instance *i_ins,
                          void *context,
                          struct flb_config *config)
 {
     struct flb_filter_aws *ctx = context;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     size_t off = 0;
     int i = 0;

--- a/plugins/filter_checklist/checklist.c
+++ b/plugins/filter_checklist/checklist.c
@@ -381,6 +381,7 @@ static int cb_checklist_filter(const void *data, size_t bytes,
                                const char *tag, int tag_len,
                                void **out_buf, size_t *out_bytes,
                                struct flb_filter_instance *ins,
+                               struct flb_input_instance *i_ins,
                                void *filter_context,
                                struct flb_config *config)
 {
@@ -406,6 +407,7 @@ static int cb_checklist_filter(const void *data, size_t bytes,
     struct flb_time t_diff;
 
     (void) ins;
+    (void) i_ins;
     (void) config;
 
     msgpack_sbuffer_init(&mp_sbuf);

--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -390,6 +390,7 @@ static int cb_expect_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **out_buf, size_t *out_bytes,
                             struct flb_filter_instance *f_ins,
+                            struct flb_input_instance *i_ins,
                             void *filter_context,
                             struct flb_config *config)
 {
@@ -399,6 +400,7 @@ static int cb_expect_filter(const void *data, size_t bytes,
     (void) out_buf;
     (void) out_bytes;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     msgpack_object map;
     msgpack_object root;

--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -379,6 +379,7 @@ static int cb_geoip2_filter(const void *data, size_t bytes,
                             void *context,
                             struct flb_config *config)
 {
+    (void) i_ins;
     struct geoip2_ctx *ctx = context;
     size_t off = 0;
     int map_num = 0;

--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -375,6 +375,7 @@ static int cb_geoip2_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **out_buf, size_t *out_size,
                             struct flb_filter_instance *f_ins,
+                            struct flb_input_instance *i_ins,
                             void *context,
                             struct flb_config *config)
 {

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -206,6 +206,7 @@ static int cb_grep_filter(const void *data, size_t bytes,
                           const char *tag, int tag_len,
                           void **out_buf, size_t *out_size,
                           struct flb_filter_instance *f_ins,
+                          struct flb_input_instance *i_ins,
                           void *context,
                           struct flb_config *config)
 {
@@ -217,6 +218,7 @@ static int cb_grep_filter(const void *data, size_t bytes,
     msgpack_object root;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -437,6 +437,7 @@ static int cb_kube_filter(const void *data, size_t bytes,
                           const char *tag, int tag_len,
                           void **out_buf, size_t *out_bytes,
                           struct flb_filter_instance *f_ins,
+                          struct flb_input_instance *i_ins,
                           void *filter_context,
                           struct flb_config *config)
 {
@@ -458,6 +459,7 @@ static int cb_kube_filter(const void *data, size_t bytes,
     struct flb_kube_props props = {0};
     struct flb_time time_lookup;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
 
     if (ctx->use_journal == FLB_FALSE || ctx->dummy_meta == FLB_TRUE) {

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -490,12 +490,14 @@ static int cb_lua_filter(const void *data, size_t bytes,
                          const char *tag, int tag_len,
                          void **out_buf, size_t *out_bytes,
                          struct flb_filter_instance *f_ins,
+                         struct flb_input_instance *i_ins,
                          void *filter_context,
                          struct flb_config *config)
 {
     int ret;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     double ts = 0;
     msgpack_object *p;

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1283,11 +1283,13 @@ static int cb_modify_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **out_buf, size_t * out_size,
                             struct flb_filter_instance *f_ins,
+                            struct flb_input_instance *i_ins,
                             void *context, struct flb_config *config)
 {
     msgpack_unpacked result;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
 
     struct filter_modify_ctx *ctx = context;

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -22,10 +22,83 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_metrics.h>
+#include <fluent-bit/flb_storage.h>
 #include <fluent-bit/multiline/flb_ml.h>
 #include <fluent-bit/multiline/flb_ml_parser.h>
 
 #include "ml.h"
+
+static struct ml_stream *get_by_id(struct ml_ctx *ctx, uint64_t stream_id);
+
+/* Create an emitter input instance */
+static int emitter_create(struct ml_ctx *ctx)
+{
+    int ret;
+    struct flb_input_instance *ins;
+
+    ret = flb_input_name_exists(ctx->emitter_name, ctx->config);
+    if (ret == FLB_TRUE) {
+        flb_plg_error(ctx->ins, "emitter_name '%s' already exists",
+                      ctx->emitter_name);
+        return -1;
+    }
+
+    ins = flb_input_new(ctx->config, "emitter", NULL, FLB_FALSE);
+    if (!ins) {
+        flb_plg_error(ctx->ins, "cannot create emitter instance");
+        return -1;
+    }
+
+    /* Set the alias name */
+    ret = flb_input_set_property(ins, "alias", ctx->emitter_name);
+    if (ret == -1) {
+        flb_plg_warn(ctx->ins,
+                     "cannot set emitter_name, using fallback name '%s'",
+                     ins->name);
+    }
+
+    /* Set the emitter_mem_buf_limit */
+    if(ctx->emitter_mem_buf_limit > 0) {
+        ins->mem_buf_limit = ctx->emitter_mem_buf_limit;
+    }
+
+    /* Set the storage type */
+    ret = flb_input_set_property(ins, "storage.type",
+                                 ctx->emitter_storage_type);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "cannot set storage.type");
+    }
+
+    /* Initialize emitter plugin */
+    ret = flb_input_instance_init(ins, ctx->config);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "cannot initialize emitter instance '%s'",
+                      ins->name);
+        flb_input_instance_exit(ins, ctx->config);
+        flb_input_instance_destroy(ins);
+        return -1;
+    }
+
+#ifdef FLB_HAVE_METRICS
+    /* Override Metrics title */
+    ret = flb_metrics_title(ctx->emitter_name, ins->metrics);
+    if (ret == -1) {
+        flb_plg_warn(ctx->ins, "cannot set metrics title, using fallback name %s",
+                     ins->name);
+    }
+#endif
+
+    /* Storage context */
+    ret = flb_storage_input_create(ctx->config->cio, ins);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "cannot initialize storage for stream '%s'",
+                      ctx->emitter_name);
+        return -1;
+    }
+    ctx->ins_emitter = ins;
+    return 0;
+}
 
 static int multiline_load_parsers(struct ml_ctx *ctx)
 {
@@ -74,16 +147,33 @@ static int flush_callback(struct flb_ml_parser *parser,
                           struct flb_ml_stream *mst,
                           void *data, char *buf_data, size_t buf_size)
 {
+    int ret;
     struct ml_ctx *ctx = data;
+    struct ml_stream *stream;
 
     if (ctx->debug_flush) {
         flb_ml_flush_stdout(parser, mst, data, buf_data, buf_size);
     }
 
-    /* Append incoming record to our msgpack context buffer */
-    msgpack_sbuffer_write(&ctx->mp_sbuf, buf_data, buf_size);
+    if (ctx->use_buffer == FLB_FALSE) {
+        /* Append incoming record to our msgpack context buffer */
+        msgpack_sbuffer_write(&ctx->mp_sbuf, buf_data, buf_size);
+        return 0;
 
-    return 0;
+    } else { /* buffered mode */
+        stream = get_by_id(ctx, mst->id);
+        if (!stream) {
+            flb_plg_error(ctx->ins, "Could not find tag to re-emit from stream %s",
+                        mst->name);
+            return -1;
+        }
+
+        /* Emit record with original tag */
+        ret = in_emitter_add_record(stream->tag, flb_sds_len(stream->tag), buf_data, buf_size,
+                                    ctx->ins_emitter);
+
+        return ret;
+    }
 }
 
 static int cb_ml_init(struct flb_filter_instance *ins,
@@ -91,11 +181,12 @@ static int cb_ml_init(struct flb_filter_instance *ins,
                       void *data)
 {
     int ret;
+    struct ml_ctx *ctx;
+    flb_sds_t tmp;
+    flb_sds_t emitter_name = NULL;
     int len;
     uint64_t stream_id;
-    struct ml_ctx *ctx;
     (void) config;
-    (void) data;
 
     ctx = flb_calloc(1, sizeof(struct ml_ctx));
     if (!ctx) {
@@ -104,10 +195,50 @@ static int cb_ml_init(struct flb_filter_instance *ins,
     }
     ctx->ins = ins;
     ctx->debug_flush = FLB_FALSE;
+    ctx->config = config;
 
-    /* Init buffers */
-    msgpack_sbuffer_init(&ctx->mp_sbuf);
-    msgpack_packer_init(&ctx->mp_pck, &ctx->mp_sbuf, msgpack_sbuffer_write);
+    /* 
+     * Config map is not yet set at this point in the code
+     * user must explicitly set buffer to false to turn it off 
+     */
+    tmp = (char *) flb_filter_get_property("buffer", ins);
+    if (tmp && (strcasecmp(tmp, "Off") == 0 || strcasecmp(tmp, "false") == 0)) {
+            /* Init buffers */
+            msgpack_sbuffer_init(&ctx->mp_sbuf);
+            msgpack_packer_init(&ctx->mp_pck, &ctx->mp_sbuf, msgpack_sbuffer_write);
+    } else {
+        /*
+        * Emitter name: every buffered multiline instance needs an emitter input plugin,
+        * with that one is able to emit records. We use a unique instance so we
+        * can use the metrics interface.
+        *
+        * If not set, we define an emitter name
+        *
+        * Validate if the emitter_name has been set before to check with the
+        * config map. If is not set, do a manual set of the property, so we let the
+        * config map handle the memory allocation.
+        */
+        tmp = (char *) flb_filter_get_property("emitter_name", ins);
+        if (!tmp) {
+            emitter_name = flb_sds_create_size(64);
+            if (!emitter_name) {
+                flb_free(ctx);
+                return -1;
+            }
+
+            tmp = flb_sds_printf(&emitter_name, "emitter_for_%s",
+                                flb_filter_name(ins));
+            if (!tmp) {
+                flb_error("[filter multiline] cannot compose emitter_name");
+                flb_sds_destroy(emitter_name);
+                flb_free(ctx);
+                return -1;
+            }
+
+            flb_filter_set_property(ins, "emitter_name", emitter_name);
+            flb_sds_destroy(emitter_name);
+        }
+    }
 
     /* Load the config map */
     ret = flb_filter_config_map_set(ins, (void *) ctx);
@@ -118,6 +249,42 @@ static int cb_ml_init(struct flb_filter_instance *ins,
 
     /* Set plugin context */
     flb_filter_set_context(ins, ctx);
+
+    if (ctx->use_buffer == FLB_TRUE) {
+        /*
+        * Emitter Storage Type: the emitter input plugin to be created by default
+        * uses memory buffer, this option allows to define a filesystem mechanism
+        * for new records created (only if the main service is also filesystem
+        * enabled).
+        *
+        * On this code we just validate the input type: 'memory' or 'filesystem'.
+        */
+        tmp = ctx->emitter_storage_type;
+        if (strcasecmp(tmp, "memory") != 0 && strcasecmp(tmp, "filesystem") != 0) {
+            flb_plg_error(ins, "invalid 'emitter_storage.type' value. Only "
+                        "'memory' or 'filesystem' types are allowed");
+            flb_free(ctx);
+            return -1;
+        }
+        
+        /* Create the emitter context */
+        ret = emitter_create(ctx);
+        if (ret == -1) {
+            return -1;
+        }
+
+        /* Register a metric to count the number of emitted records */
+#ifdef FLB_HAVE_METRICS
+        ctx->cmt_emitted = cmt_counter_create(ins->cmt,
+                                            "fluentbit", "filter", "emit_records_total",
+                                            "Total number of emitted records",
+                                            1, (char *[]) {"name"});
+
+        /* OLD api */
+        flb_metrics_add(FLB_MULTILINE_METRIC_EMITTED,
+                        "emit_records", ctx->ins->metrics);
+#endif
+    }
 
     /* Create multiline context */
     ctx->m = flb_ml_create(config, ctx->ins->name);
@@ -135,25 +302,154 @@ static int cb_ml_init(struct flb_filter_instance *ins,
         return -1;
     }
 
-    /* Create a stream for this file */
-    len = strlen(ins->name);
+    mk_list_init(&ctx->ml_streams);
+
+    if (ctx->use_buffer == FLB_TRUE) {
+
+        ctx->m->flush_ms = ctx->flush_ms;
+        ret = flb_ml_auto_flush_init(ctx->m);
+        if (ret == -1) {
+            return -1;
+        }
+    } else {
+        /* Create a stream for this file */
+        len = strlen(ins->name);
+        ret = flb_ml_stream_create(ctx->m,
+                                ins->name, len,
+                                flush_callback, ctx,
+                                &stream_id);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "could not create multiline stream");
+            return -1;
+        }
+        ctx->stream_id = stream_id;
+    }
+
+    return 0;
+}
+
+void ml_stream_destroy(struct ml_stream *stream)
+{
+    if (!stream) {
+        return;
+    }
+
+    if (stream->input_name) {
+        flb_sds_destroy(stream->input_name);
+    }
+    if (stream->tag) {
+        flb_sds_destroy(stream->tag);
+    }
+    flb_free(stream);
+    return;
+}
+
+static struct ml_stream *get_by_id(struct ml_ctx *ctx, uint64_t stream_id)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct ml_stream *stream;
+
+    mk_list_foreach_safe(head, tmp, &ctx->ml_streams) {
+        stream = mk_list_entry(head, struct ml_stream, _head);
+        if (stream->stream_id == stream_id) {
+            flb_debug("emitting to %s_%s", stream->input_name, stream->tag);
+            return stream;
+        }
+    }
+
+    return NULL;
+}
+
+static struct ml_stream *get_or_create_stream(struct ml_ctx *ctx,
+                                              struct flb_input_instance *i_ins, 
+                                              const char *tag, int tag_len)
+{
+    uint64_t stream_id;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct ml_stream *stream;
+    flb_sds_t stream_name;
+    flb_sds_t tmp_sds;
+    int name_check;
+    int tag_check;
+    int len;
+    int ret;
+
+    mk_list_foreach_safe(head, tmp, &ctx->ml_streams) {
+        stream = mk_list_entry(head, struct ml_stream, _head);
+        name_check = strcmp(stream->input_name, i_ins->name);
+        tag_check = strcmp(stream->tag, tag);
+        if (tag_check == 0 && name_check == 0) {
+            flb_debug("debug: using stream %s_%s", stream->input_name, stream->tag);
+            return stream;
+        }
+    }
+
+    /* create a new stream */
+
+    stream_name = flb_sds_create_size(64);
+
+    tmp_sds = flb_sds_printf(&stream_name, "%s_%s", i_ins->name, tag);
+    if (!tmp_sds) {
+        flb_errno();
+        flb_sds_destroy(stream_name);
+        return NULL;
+    }
+    stream_name = tmp_sds;
+
+    stream = flb_calloc(1, sizeof(struct ml_stream));
+    if (!stream) {
+        flb_errno();
+        flb_sds_destroy(stream_name);
+        return NULL;
+    }
+
+    tmp_sds = flb_sds_create(tag);
+    if (!tmp) {
+        flb_errno();
+        flb_sds_destroy(stream_name);
+        ml_stream_destroy(stream);
+        return NULL;
+    }
+    stream->tag = tmp_sds;
+
+    tmp_sds = flb_sds_create(i_ins->name);
+    if (!tmp_sds) {
+        flb_errno();
+        flb_sds_destroy(stream_name);
+        ml_stream_destroy(stream);
+        return NULL;
+    }
+    stream->input_name = tmp_sds;
+
+    /* Create an flb_ml_stream for this stream */
+    flb_plg_info(ctx->ins, "created new multiline stream for %s", stream_name);
+    len = flb_sds_len(stream_name);
     ret = flb_ml_stream_create(ctx->m,
-                               ins->name, len,
+                               stream_name, len,
                                flush_callback, ctx,
                                &stream_id);
     if (ret != 0) {
-        flb_plg_error(ctx->ins, "could not create multiline stream");
-        return -1;
+        flb_plg_error(ctx->ins, "could not create multiline stream for %s",
+                      stream_name);
+        flb_sds_destroy(stream_name);
+        ml_stream_destroy(stream);
+        return NULL;
     }
-    ctx->stream_id = stream_id;
+    stream->stream_id = stream_id;
+    mk_list_add(&stream->_head, &ctx->ml_streams);
+    flb_plg_debug(ctx->ins, "Created new ML stream for %s", stream_name);
+    flb_sds_destroy(stream_name);
 
-    return 0;
+    return stream;
 }
 
 static int cb_ml_filter(const void *data, size_t bytes,
                         const char *tag, int tag_len,
                         void **out_buf, size_t *out_bytes,
                         struct flb_filter_instance *f_ins,
+                        struct flb_input_instance *i_ins,
                         void *filter_context,
                         struct flb_config *config)
 {
@@ -163,7 +459,6 @@ static int cb_ml_filter(const void *data, size_t bytes,
     (void) out_buf;
     (void) out_bytes;
     (void) f_ins;
-    (void) filter_context;
     (void) config;
     msgpack_unpacked result;
     msgpack_object *obj;
@@ -171,54 +466,91 @@ static int cb_ml_filter(const void *data, size_t bytes,
     size_t tmp_size;
     struct ml_ctx *ctx = filter_context;
     struct flb_time tm;
+    struct ml_stream *stream;
 
-    /* reset mspgack size content */
-    ctx->mp_sbuf.size = 0;
-
-    /* process records */
-    msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
-        flb_time_pop_from_msgpack(&tm, &result, &obj);
-        ret = flb_ml_append_object(ctx->m, ctx->stream_id, &tm, obj);
-        if (ret != 0) {
-            flb_plg_debug(ctx->ins,
-                          "could not append object from tag: %s", tag);
-        }
-    }
-    msgpack_unpacked_destroy(&result);
-
-    /* flush all pending buffered data (there is no auto-flush in filters) */
-    flb_ml_flush_pending_now(ctx->m);
-
-    if (ctx->mp_sbuf.size > 0) {
-        /*
-         * If the filter will report a new set of records because the
-         * original data was modified, we make a copy to a new memory
-         * area, since the buffer might be invalidated in the filter
-         * chain.
-         */
-
-        tmp_buf = flb_malloc(ctx->mp_sbuf.size);
-        if (!tmp_buf) {
-            flb_errno();
-            return FLB_FILTER_NOTOUCH;
-        }
-        tmp_size = ctx->mp_sbuf.size;
-        memcpy(tmp_buf, ctx->mp_sbuf.data, tmp_size);
-        *out_buf = tmp_buf;
-        *out_bytes = tmp_size;
+    if (ctx->use_buffer == FLB_FALSE) {
+        /* reset mspgack size content */
         ctx->mp_sbuf.size = 0;
 
+        /* process records */
+        msgpack_unpacked_init(&result);
+        while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+            flb_time_pop_from_msgpack(&tm, &result, &obj);
+            ret = flb_ml_append_object(ctx->m, ctx->stream_id, &tm, obj);
+            if (ret != 0) {
+                flb_plg_debug(ctx->ins,
+                            "could not append object from tag: %s", tag);
+            }
+        }
+        msgpack_unpacked_destroy(&result);
+
+        /* flush all pending data (there is no auto-flush when unbuffered) */
+        flb_ml_flush_pending_now(ctx->m);
+
+        if (ctx->mp_sbuf.size > 0) {
+            /*
+            * If the filter will report a new set of records because the
+            * original data was modified, we make a copy to a new memory
+            * area, since the buffer might be invalidated in the filter
+            * chain.
+            */
+
+            tmp_buf = flb_malloc(ctx->mp_sbuf.size);
+            if (!tmp_buf) {
+                flb_errno();
+                return FLB_FILTER_NOTOUCH;
+            }
+            tmp_size = ctx->mp_sbuf.size;
+            memcpy(tmp_buf, ctx->mp_sbuf.data, tmp_size);
+            *out_buf = tmp_buf;
+            *out_bytes = tmp_size;
+            ctx->mp_sbuf.size = 0;
+
+            return FLB_FILTER_MODIFIED;
+        }
+
+        /* unlikely to happen.. but just in case */
+        return FLB_FILTER_NOTOUCH;
+    
+    } else { /* buffered mode */
+        if (i_ins == ctx->ins_emitter) {
+            flb_plg_debug(ctx->ins, "not processing record from the emitter");
+            return FLB_FILTER_NOTOUCH;
+        }
+        
+        stream = get_or_create_stream(ctx, i_ins, tag, tag_len);
+
+        if (!stream) {
+            flb_plg_error(ctx->ins, "Could not find or create ML stream for %s", tag);
+            return FLB_FILTER_NOTOUCH;
+        }
+
+        /* process records */
+        msgpack_unpacked_init(&result);
+        while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+            flb_time_pop_from_msgpack(&tm, &result, &obj);
+            ret = flb_ml_append_object(ctx->m, stream->stream_id, &tm, obj);
+            if (ret != 0) {
+                flb_plg_debug(ctx->ins,
+                            "could not append object from tag: %s", tag);
+            }
+        }
+        msgpack_unpacked_destroy(&result);
+
+        /* 
+         * always returned modified, which will be 0 records, since the emitter takes
+         * all records.
+        */
         return FLB_FILTER_MODIFIED;
     }
-
-    /* unlikely to happen.. but just in case */
-    return FLB_FILTER_NOTOUCH;
 }
 
 static int cb_ml_exit(void *data, struct flb_config *config)
 {
     struct ml_ctx *ctx = data;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct ml_stream *stream;
 
     if (!ctx) {
         return 0;
@@ -226,6 +558,12 @@ static int cb_ml_exit(void *data, struct flb_config *config)
 
     if (ctx->m) {
         flb_ml_destroy(ctx->m);
+    }
+
+    mk_list_foreach_safe(head, tmp, &ctx->ml_streams) {
+        stream = mk_list_entry(head, struct ml_stream, _head);
+        mk_list_del(&stream->_head);
+        ml_stream_destroy(stream);
     }
 
     msgpack_sbuffer_destroy(&ctx->mp_sbuf);
@@ -242,6 +580,22 @@ static struct flb_config_map config_map[] = {
      "enable debugging for concatenation flush to stdout"
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "buffer", "true",
+     0, FLB_TRUE, offsetof(struct ml_ctx, use_buffer),
+     "Enable buffered mode. In buffered mode, the filter can concatenate "
+     "multilines from inputs that ingest records one by one (ex: Forward), "
+     "rather than in chunks, re-emitting them into the beggining of the "
+     "pipeline using the in_emitter instance. "
+     "With buffer off, this filter will not work with most inputs, except tail."
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "flush_ms", "2000",
+     0, FLB_TRUE, offsetof(struct ml_ctx, flush_ms),
+     "Flush time for pending multiline records"
+    },
+
     /* Multiline Core Engine based API */
     {
      FLB_CONFIG_MAP_CLIST, "multiline.parser", NULL,
@@ -253,6 +607,23 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "multiline.key_content", NULL,
      0, FLB_TRUE, offsetof(struct ml_ctx, key_content),
      "specify the key name that holds the content to process."
+    },
+
+    /* emitter config */
+    {
+     FLB_CONFIG_MAP_STR, "emitter_name", NULL,
+     FLB_FALSE, FLB_TRUE, offsetof(struct ml_ctx, emitter_name),
+     NULL
+    },
+    {
+     FLB_CONFIG_MAP_STR, "emitter_storage.type", "memory",
+     FLB_FALSE, FLB_TRUE, offsetof(struct ml_ctx, emitter_storage_type),
+     NULL
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "emitter_mem_buf_limit", FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT,
+     FLB_FALSE, FLB_TRUE, offsetof(struct ml_ctx, emitter_mem_buf_limit),
+     "set a memory buffer limit to restrict memory usage of emitter"
     },
 
     /* EOF */

--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -23,8 +23,25 @@
 
 #include <fluent-bit/flb_filter_plugin.h>
 
+#define FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT  "10M"
+#define FLB_MULTILINE_METRIC_EMITTED    200
+
+/* 
+ * input instance + tag is the unique identifier
+ * for a multiline stream
+ * TODO: implement clean up of streams that haven't been used recently
+ */
+struct ml_stream {
+    flb_sds_t tag;
+    flb_sds_t input_name;
+    uint64_t stream_id;
+
+    struct mk_list _head;
+};
+
 struct ml_ctx {
     int debug_flush;
+    int use_buffer;
     flb_sds_t key_content;
 
     /* packaging buffers */
@@ -35,8 +52,27 @@ struct ml_ctx {
     uint64_t stream_id;
     struct flb_ml *m;
     struct mk_list *multiline_parsers;
+    int flush_ms;
+
+    struct mk_list ml_streams;
 
     struct flb_filter_instance *ins;
+
+    /* emitter */
+    flb_sds_t emitter_name;                 /* emitter input plugin name */
+    flb_sds_t emitter_storage_type;         /* emitter storage type */
+    size_t emitter_mem_buf_limit;           /* Emitter buffer limit */
+    struct flb_input_instance *ins_emitter; /* emitter input plugin instance */
+    struct flb_config *config;              /* Fluent Bit context */
+
+#ifdef FLB_HAVE_METRICS
+    struct cmt_counter *cmt_emitted;
+#endif
 };
+
+/* Register external function to emit records, check 'plugins/in_emitter' */
+int in_emitter_add_record(const char *tag, int tag_len,
+                          const char *buf_data, size_t buf_size,
+                          struct flb_input_instance *in);
 
 #endif

--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -552,11 +552,13 @@ static int cb_nest_filter(const void *data, size_t bytes,
                           const char *tag, int tag_len,
                           void **out_buf, size_t * out_size,
                           struct flb_filter_instance *f_ins,
+                          struct flb_input_instance *i_ins,
                           void *context, struct flb_config *config)
 {
     msgpack_unpacked result;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
 
     struct filter_nest_ctx *ctx = context;

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -182,6 +182,7 @@ static int cb_parser_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **ret_buf, size_t *ret_bytes,
                             struct flb_filter_instance *f_ins,
+                            struct flb_input_instance *i_ins,
                             void *context,
                             struct flb_config *config)
 {
@@ -190,6 +191,7 @@ static int cb_parser_filter(const void *data, size_t bytes,
     msgpack_unpacked result;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     struct flb_time tm;
     msgpack_object *obj;

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -254,6 +254,7 @@ static int cb_modifier_filter(const void *data, size_t bytes,
                               const char *tag, int tag_len,
                               void **out_buf, size_t *out_size,
                               struct flb_filter_instance *f_ins,
+                              struct flb_input_instance *i_ins,
                               void *context,
                               struct flb_config *config)
 {
@@ -265,6 +266,7 @@ static int cb_modifier_filter(const void *data, size_t bytes,
     int map_num          = 0;
     bool_map_t *bool_map = NULL;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     struct flb_time tm;
     struct modifier_record *mod_rec;

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -369,6 +369,7 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
                                  const char *tag, int tag_len,
                                  void **out_buf, size_t *out_bytes,
                                  struct flb_filter_instance *f_ins,
+                                 struct flb_input_instance *i_ins,
                                  void *filter_context,
                                  struct flb_config *config)
 {
@@ -388,6 +389,7 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
     msgpack_unpacked result;
     struct flb_rewrite_tag *ctx = (struct flb_rewrite_tag *) filter_context;
     (void) config;
+    (void) i_ins;
 
 #ifdef FLB_HAVE_METRICS
     ts = cmt_time_now();

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -41,6 +41,7 @@ static int cb_stdout_filter(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             void **out_buf, size_t *out_bytes,
                             struct flb_filter_instance *f_ins,
+                            struct flb_input_instance *i_ins,
                             void *filter_context,
                             struct flb_config *config)
 {
@@ -49,6 +50,7 @@ static int cb_stdout_filter(const void *data, size_t bytes,
     (void) out_buf;
     (void) out_bytes;
     (void) f_ins;
+    (void) i_ins;
     (void) filter_context;
     (void) config;
     struct flb_time tmp;

--- a/plugins/filter_tensorflow/tensorflow.c
+++ b/plugins/filter_tensorflow/tensorflow.c
@@ -225,6 +225,7 @@ static int cb_tf_filter(const void *data, size_t bytes,
                         const char *tag, int tag_len,
                         void **out_buf, size_t *out_bytes,
                         struct flb_filter_instance *f_ins,
+                        struct flb_input_instance *i_ins,
                         void *filter_context,
                         struct flb_config *config)
 {
@@ -235,6 +236,7 @@ static int cb_tf_filter(const void *data, size_t bytes,
     (void) out_buf;
     (void) out_bytes;
     (void) f_ins;
+    (void) i_ins;
     int map_size;
 
     msgpack_object root;

--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -218,6 +218,7 @@ static int cb_throttle_filter(const void *data, size_t bytes,
                               const char *tag, int tag_len,
                               void **out_buf, size_t *out_size,
                               struct flb_filter_instance *f_ins,
+                              struct flb_input_instance *i_ins,
                               void *context,
                               struct flb_config *config)
 {
@@ -228,6 +229,7 @@ static int cb_throttle_filter(const void *data, size_t bytes,
     msgpack_object root;
     size_t off = 0;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;

--- a/plugins/filter_throttle_size/throttle_size.c
+++ b/plugins/filter_throttle_size/throttle_size.c
@@ -659,6 +659,7 @@ static int cb_throttle_size_filter(const void *data, size_t bytes,
                                    const char *tag, int tag_len,
                                    void **out_buf, size_t * out_size,
                                    struct flb_filter_instance *ins,
+                                   struct flb_input_instance *i_ins,
                                    void *context, struct flb_config *config)
 {
     int ret;
@@ -669,6 +670,7 @@ static int cb_throttle_size_filter(const void *data, size_t bytes,
     msgpack_object map;
     size_t off = 0;
     (void) ins;
+    (void) i_ins;
     (void) config;
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -78,6 +78,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
     ssize_t write_at;
     struct mk_list *head;
     struct flb_filter_instance *f_ins;
+    struct flb_input_instance *i_ins = ic->in;
 
     /* For the incoming Tag make sure to create a NULL terminated reference */
     ntag = flb_malloc(tag_len + 1);
@@ -127,6 +128,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
                                       &out_buf,       /* new data         */
                                       &out_size,      /* new data size    */
                                       f_ins,          /* filter instance  */
+                                      i_ins,          /* input instance   */
                                       f_ins->context, /* filter priv data */
                                       config);
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -42,6 +42,7 @@ if(FLB_IN_LIB AND FLB_OUT_LIB)
   FLB_RT_TEST(FLB_FILTER_PARSER     "filter_parser.c")
   FLB_RT_TEST(FLB_FILTER_MODIFY     "filter_modify.c")
   FLB_RT_TEST(FLB_FILTER_LUA        "filter_lua.c")
+  FLB_RT_TEST(FLB_FILTER_MULTILINE  "filter_multiline.c")
 endif()
 
 

--- a/tests/runtime/filter_multiline.c
+++ b/tests/runtime/filter_multiline.c
@@ -1,0 +1,323 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include "flb_tests_runtime.h"
+
+struct filter_test {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd */
+};
+
+struct filter_test_result {
+    char *expected_pattern;     /* string that must occur in output */
+    int expected_pattern_index; /* which record to check for the pattern */
+    int expected_records;       /* expected number of outputted records */
+    int actual_records;         /* actual number of outputted records */
+};
+
+/* Callback to check expected results */
+static int cb_check_result(void *record, size_t size, void *data)
+{
+    char *p;
+    struct filter_test_result *expected;
+    char *result;
+
+    expected = (struct filter_test_result *) data;
+    result = (char *) record;
+
+    if (expected->expected_pattern_index == expected->actual_records) {
+        p = strstr(result, expected->expected_pattern);
+        TEST_CHECK(p != NULL);
+
+        if (!p) {
+            flb_error("Expected to find: '%s' in result '%s'",
+                    expected->expected_pattern, result);
+        }
+        /*
+        * If you want to debug your test
+        *
+        * printf("Expect: '%s' in result '%s'\n", expected->expected_pattern, result);
+        */
+    }
+
+    expected->actual_records++;
+
+    flb_free(record);
+    return 0;
+}
+
+
+
+static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int f_ffd;
+    int o_ffd;
+    struct filter_test *ctx;
+
+    ctx = flb_malloc(sizeof(struct filter_test));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    NULL);
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "lib", NULL);
+    TEST_CHECK(i_ffd >= 0);
+    flb_input_set(ctx->flb, i_ffd, "tag", "test", NULL);
+    ctx->i_ffd = i_ffd;
+
+    /* Filter configuration */
+    f_ffd = flb_filter(ctx->flb, (char *) "multiline", NULL);
+    TEST_CHECK(f_ffd >= 0);
+    flb_filter_set(ctx->flb, f_ffd, "match", "*", NULL);
+    ctx->f_ffd = f_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    TEST_CHECK(o_ffd >= 0);
+    flb_output_set(ctx->flb, o_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    return ctx;
+}
+
+static void filter_test_destroy(struct filter_test *ctx)
+{
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+static void flb_test_multiline_buffered_two_output_record()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct filter_test_result expected = { 0 };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "go",
+                         "buffer", "on",
+                         "debug_flush", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    expected.expected_records = 1; /* 1 record with all lines concatenated */
+    expected.expected_pattern = "main.main.func1(0xc420024120)";
+    expected.expected_pattern_index = 0;
+    cb_data.cb = cb_check_result;
+    cb_data.data = (void *) &expected;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"log\":\"panic: my panic\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"\n\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"goroutine 4 [running]:\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"panic(0x45cb40, 0x47ad70)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent separately */
+    p = "[0, {\"log\":\"  /usr/local/go/src/runtime/panic.go:542 +0x46c fp=0xc42003f7b8 sp=0xc42003f710 pc=0x422f7c\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"main.main.func1(0xc420024120)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    /* check number of outputted records */
+    sleep(2);
+    TEST_CHECK(expected.actual_records == expected.expected_records);
+    filter_test_destroy(ctx);
+}
+
+static void flb_test_multiline_buffered_one_output_record()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct filter_test_result expected = { 0 };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "go",
+                         "buffer", "on",
+                         "debug_flush", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    expected.expected_records = 2; /* 1 record with all lines concatenated */
+    expected.expected_pattern = "main.main.func1(0xc420024120)";
+    cb_data.cb = cb_check_result;
+    cb_data.data = (void *) &expected;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"log\":\"panic: my panic\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"\n\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"goroutine 4 [running]:\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"panic(0x45cb40, 0x47ad70)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent separately */
+    p = "[0, {\"log\":\"  /usr/local/go/src/runtime/panic.go:542 +0x46c fp=0xc42003f7b8 sp=0xc42003f710 pc=0x422f7c\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"main.main.func1(0xc420024120)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    p = "[0, {\"log\":\"one more line, no multiline\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    /* check number of outputted records */
+    sleep(2);
+    TEST_CHECK(expected.actual_records == expected.expected_records);
+    filter_test_destroy(ctx);
+}
+
+static void flb_test_multiline_unbuffered()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct filter_test_result expected = { 0 };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "go",
+                         "buffer", "off",
+                         "debug_flush", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    expected.expected_records = 6; /* no concatenation */
+    expected.expected_pattern = "panic";
+    expected.expected_pattern_index = 0;
+    cb_data.cb = cb_check_result;
+    cb_data.data = (void *) &expected;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"log\":\"panic: my panic\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent one by one */
+    p = "[0, {\"log\":\"\n\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent one by one */
+    p = "[0, {\"log\":\"goroutine 4 [running]:\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent one by one */
+    p = "[0, {\"log\":\"panic(0x45cb40, 0x47ad70)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent one by one */
+    p = "[0, {\"log\":\"  /usr/local/go/src/runtime/panic.go:542 +0x46c fp=0xc42003f7b8 sp=0xc42003f710 pc=0x422f7c\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+    sleep(1); /* ensure records get sent one by one */
+    p = "[0, {\"log\":\"main.main.func1(0xc420024120)\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    /* check number of outputted records */
+    sleep(2);
+    TEST_CHECK(expected.actual_records == expected.expected_records);
+    filter_test_destroy(ctx);
+}
+
+TEST_LIST = {
+    {"multiline_buffered_one_record"            , flb_test_multiline_buffered_one_output_record },
+    {"multiline_buffered_two_record"            , flb_test_multiline_buffered_two_output_record },
+    {"flb_test_multiline_unbuffered"            , flb_test_multiline_unbuffered },
+
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is the first part of the multiline filter re-design #4309 


**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Example config:

```
[FILTER]
     name                  multiline
     match                 *
     multiline.key_content log
     multiline.parser      go, multiline-regex-test
     Buffer                 On
```

Debug logs:

```
TODO
```

Valgrind:


Buffered (new) mode:
```
[2021/12/01 08:11:08] [ info] [input] pausing forward.0
[2021/12/01 08:11:08] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/01 08:11:09] [ info] [engine] service has stopped (0 pending tasks)
==6961==
==6961== HEAP SUMMARY:
==6961==     in use at exit: 0 bytes in 0 blocks
==6961==   total heap usage: 3,151 allocs, 3,151 frees, 8,405,333 bytes allocated
==6961==
==6961== All heap blocks were freed -- no leaks are possible
==6961==
==6961== For counts of detected and suppressed errors, rerun with: -v
==6961== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
Un-buffered (old) mode:

```
==6811== HEAP SUMMARY:
==6811==     in use at exit: 0 bytes in 0 blocks
==6811==   total heap usage: 3,653 allocs, 3,653 frees, 24,229,263 bytes allocated
==6811==
==6811== All heap blocks were freed -- no leaks are possible
==6811==
==6811== For counts of detected and suppressed errors, rerun with: -v
==6811== Use --track-origins=yes to see where uninitialised values come from
==6811== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
[ec2-user@ip-10-192-11-149 build]$ valgrind --leak-check=full ./bin/fluent-bit -c ~/ecs-mutliline/unbuffered.conf
==6961== Memcheck, a memory error detector
==6961== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==6961== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==6961== Command: ./bin/fluent-bit -c /home/ec2-user/ecs-mutliline/unbuffered.conf
```


**Documentation**

TODO

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
