### PR TITLE
Systemd unit file: minor improvements

### DIFF
--- a/init/systemd.in
+++ b/init/systemd.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=@FLB_PROG_NAME@
+Documentation=https://docs.fluentbit.io/manual/
 Requires=network.target
 After=network.target
 

--- a/init/systemd.in
+++ b/init/systemd.in
@@ -6,7 +6,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c @CMAKE_INSTALL_SYSCONFDIR@/@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c /@CMAKE_INSTALL_SYSCONFDIR@/@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
 Restart=always
 
 [Install]


### PR DESCRIPTION
Add Documentation= line to systemd unit file and use absolute path to fluent-bit config when invoking with `-c`.

The file is rendered with CMake. The result would look normally like this
```
$ systemctl cat fluent-bit.service 
# /usr/lib/systemd/system/fluent-bit.service
[Unit]
Description=Fluent Bit
Documentation=https://docs.fluentbit.io/manual/
Requires=network.target
After=network.target

[Service]
Type=simple
ExecStart=/usr/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
Restart=always

[Install]
WantedBy=multi-user.target
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
