### PR TITLE
dockerfiles: Added missing dependency for libatomic.so.1

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -80,7 +80,8 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
       libpq5 \
       libsystemd0/buster-backports \
       zlib1g \
-      ca-certificates
+      ca-certificates \
+      libatomic1
 
 COPY --from=builder /fluent-bit /fluent-bit
 RUN rm /usr/bin/qemu-arm-static


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #4404 for ARM32 builds missing a dependency.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] 
Repeated tests for #4404 with the changes here and confirmed it now runs up with default configuration correctly.
```
docker build --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.10.tar.gz -t arm32-test -f dockerfiles/Dockerfile.arm32v7 .
docker run --rm -it arm32-test
WARNING: The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
Fluent Bit v1.8.10
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/08 11:22:52] [ info] [engine] started (pid=1)
[2021/12/08 11:22:52] [ info] [storage] version=1.1.5, initializing...
[2021/12/08 11:22:52] [ info] [storage] in-memory
[2021/12/08 11:22:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/08 11:22:52] [ info] [cmetrics] version=0.2.2
[2021/12/08 11:22:52] [ info] [sp] stream processor started
^C[2021/12/08 11:22:54] [engine] caught signal (SIGINT)
[2021/12/08 11:22:54] [ info] [input] pausing cpu.0
[0] cpu.local: [1638962573.489172024, {"cpu_p"=>6.625000, "user_p"=>5.625000, "system_p"=>1.000000, "cpu0.p_cpu"=>9.000000, "cpu0.p_user"=>8.000000, "cpu0.p_system"=>1.000000, "cpu1.p_cpu"=>8.000000, "cpu1.p_user"=>8.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>12.000000, "cpu2.p_user"=>11.000000, "cpu2.p_system"=>1.000000, "cpu3.p_cpu"=>10.000000, "cpu3.p_user"=>9.000000, "cpu3.p_system"=>1.000000, "cpu4.p_cpu"=>7.000000, "cpu4.p_user"=>6.000000, "cpu4.p_system"=>1.000000, "cpu5.p_cpu"=>12.000000, "cpu5.p_user"=>11.000000, "cpu5.p_system"=>1.000000, "cpu6.p_cpu"=>4.000000, "cpu6.p_user"=>2.000000, "cpu6.p_system"=>2.000000, "cpu7.p_cpu"=>10.000000, "cpu7.p_user"=>8.000000, "cpu7.p_system"=>2.000000, "cpu8.p_cpu"=>4.000000, "cpu8.p_user"=>3.000000, "cpu8.p_system"=>1.000000, "cpu9.p_cpu"=>5.000000, "cpu9.p_user"=>4.000000, "cpu9.p_system"=>1.000000, "cpu10.p_cpu"=>5.000000, "cpu10.p_user"=>5.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>4.000000, "cpu11.p_user"=>2.000000, "cpu11.p_system"=>2.000000, "cpu12.p_cpu"=>4.000000, "cpu12.p_user"=>3.000000, "cpu12.p_system"=>1.000000, "cpu13.p_cpu"=>5.000000, "cpu13.p_user"=>4.000000, "cpu13.p_system"=>1.000000, "cpu14.p_cpu"=>5.000000, "cpu14.p_user"=>4.000000, "cpu14.p_system"=>1.000000, "cpu15.p_cpu"=>3.000000, "cpu15.p_user"=>3.000000, "cpu15.p_system"=>0.000000}]
[2021/12/08 11:22:54] [ warn] [engine] service will stop in 5 seconds
[2021/12/08 11:22:58] [ info] [engine] service stopped
```
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
