### PR TITLE
dockerfiles: resolve ARM64 build issues

### DIFF
--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -1,5 +1,4 @@
-# Build on amd64 and cross-compile to arch for max speed
-FROM --platform=linux/amd64 debian:buster as builder
+FROM --platform=linux/arm64 debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -7,38 +6,37 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
+ENV FLB_SOURCE $FLB_TARBALL
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN dpkg --add-architecture arm64
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
-RUN apt update && apt install -y --no-remove --no-install-recommends \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     build-essential \
-    g++-aarch64-linux-gnu \
-    gcc-aarch64-linux-gnu \
+    curl \
     ca-certificates \
-    pkg-config \
     cmake \
     make \
+    tar \
+    libssl-dev \
+    libsasl2-dev \
+    pkg-config \
+    libsystemd-dev/buster-backports \
+    zlib1g-dev \
+    libpq-dev \
+    postgresql-server-dev-all \
     flex \
     bison \
-    dpkg-dev \
-    libssl-dev:arm64 \
-    libsasl2-dev:arm64 \
-    libsystemd-dev:arm64/buster-backports \
-    libzstd-dev:arm64 \
-    zlib1g-dev:arm64 \
-    libpq-dev:arm64
+    && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
+    && cd tmp/ && mkdir fluent-bit \
+    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
+    && cd fluent-bit/build/ \
+    && rm -rf /tmp/fluent-bit/build/*
 
-# postgresql-server-dev-11:arm64 has conflicts if installed using apt. hack here to manually force install with dpkg
-WORKDIR /tmp
-RUN apt download postgresql-server-dev-11:arm64
-RUN dpkg --force-all -i postgresql-server-*.deb
-
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
-COPY . /tmp/src/
-RUN rm -rf /tmp/src/build/*
-WORKDIR /tmp/src/build/
-
+WORKDIR /tmp/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
@@ -48,11 +46,21 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On \
-          -DCMAKE_TOOLCHAIN_FILE=/tmp/src/cmake/linux-arm64.cmake ../
+          -DFLB_OUT_PGSQL=On ..
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
+
+# Configuration files
+COPY conf/fluent-bit.conf \
+     conf/parsers.conf \
+     conf/parsers_ambassador.conf \
+     conf/parsers_java.conf \
+     conf/parsers_extra.conf \
+     conf/parsers_openstack.conf \
+     conf/parsers_cinder.conf \
+     conf/plugins.conf \
+     /fluent-bit/etc/
 
 FROM --platform=linux/arm64 debian:buster-slim
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
@@ -70,7 +78,7 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
 
 # These below are all needed for systemd
-COPY --from=builder /lib/aarch64-linux-gnu/libsystemd* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libsystemd* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so* /lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/liblz4.so* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/libgcrypt.so* /lib/aarch64-linux-gnu/
@@ -95,17 +103,6 @@ COPY --from=builder /lib/aarch64-linux-gnu/libkeyutils* /lib/aarch64-linux-gnu/
 
 # Build artifact
 COPY --from=builder /fluent-bit /fluent-bit
-
-# Configuration files
-COPY conf/fluent-bit.conf \
-     conf/parsers.conf \
-     conf/parsers_ambassador.conf \
-     conf/parsers_java.conf \
-     conf/parsers_extra.conf \
-     conf/parsers_openstack.conf \
-     conf/parsers_cinder.conf \
-     conf/plugins.conf \
-     /fluent-bit/etc/
 
 EXPOSE 2020
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Changes from #4406 without the strange git merging failures.

Aligned the Arm and Amd builds to use almost identical approaches to resolve issues with managing cross compilation dependencies based on backports. This also will help with a multi-arch build eventually. No longer uses amd64 build now but native arm64 which seems to be almost as fast.

Also noticed that the arm64 build relies on copying the source in unlike all the others so updated that too.

Fixes #4404 for arm64.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [X] Debug log output from testing the change
```
cd dockerfiles
docker build --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.10.tar.gz -t arm64-test -f Dockerfile.arm64v8 .
docker run --rm -it arm64-test
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
Fluent Bit v1.8.10
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/08 11:50:56] [ info] [engine] started (pid=1)
[2021/12/08 11:50:56] [ info] [storage] version=1.1.5, initializing...
[2021/12/08 11:50:56] [ info] [storage] in-memory
[2021/12/08 11:50:56] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/08 11:50:56] [ info] [cmetrics] version=0.2.2
[2021/12/08 11:50:56] [ info] [sp] stream processor started
^C[2021/12/08 11:50:57] [engine] caught signal (SIGINT)
[2021/12/08 11:50:57] [ info] [input] pausing cpu.0
[0] cpu.local: [1638964257.492756921, {"cpu_p"=>0.750000, "user_p"=>0.437500, "system_p"=>0.312500, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>4.000000, "cpu1.p_user"=>1.000000, "cpu1.p_system"=>3.000000, "cpu2.p_cpu"=>0.000000, "cpu2.p_user"=>0.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>1.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>1.000000, "cpu4.p_cpu"=>1.000000, "cpu4.p_user"=>1.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>0.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>0.000000, "cpu6.p_cpu"=>1.000000, "cpu6.p_user"=>1.000000, "cpu6.p_system"=>0.000000, "cpu7.p_cpu"=>0.000000, "cpu7.p_user"=>0.000000, "cpu7.p_system"=>0.000000, "cpu8.p_cpu"=>1.000000, "cpu8.p_user"=>1.000000, "cpu8.p_system"=>0.000000, "cpu9.p_cpu"=>0.000000, "cpu9.p_user"=>0.000000, "cpu9.p_system"=>0.000000, "cpu10.p_cpu"=>0.000000, "cpu10.p_user"=>0.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>0.000000, "cpu11.p_user"=>0.000000, "cpu11.p_system"=>0.000000, "cpu12.p_cpu"=>1.000000, "cpu12.p_user"=>1.000000, "cpu12.p_system"=>0.000000, "cpu13.p_cpu"=>0.000000, "cpu13.p_user"=>0.000000, "cpu13.p_system"=>0.000000, "cpu14.p_cpu"=>1.000000, "cpu14.p_user"=>1.000000, "cpu14.p_system"=>0.000000, "cpu15.p_cpu"=>0.000000, "cpu15.p_user"=>0.000000, "cpu15.p_system"=>0.000000}]
[2021/12/08 11:50:57] [ warn] [engine] service will stop in 5 seconds
^C[2021/12/08 11:51:02] [ info] [engine] service stopped
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
