### PR TITLE
plugin_proxy: fail on missing FLBPluginRegister symbol

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -144,6 +144,9 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
 
     /* Lookup the registration callback */
     cb_register = flb_plugin_proxy_symbol(proxy, "FLBPluginRegister");
+    if (!cb_register) {
+        return -1;
+    }
 
     /*
      * Create a temporary definition used for registration. This definition


### PR DESCRIPTION
Fail on missing FLBPluginRegister symbol.
This prevents a segmentation fault in case a non-Go library is accidentally provided, and instead causes a proper error message to be emitted.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.