### PR TITLE
input_chunk: don't pause ingestion if filesystem storage is enabled (#4221)

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1227,9 +1227,14 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
  */
 static inline int flb_input_chunk_protect(struct flb_input_instance *i)
 {
-    if (flb_input_chunk_is_mem_overlimit(i) == FLB_TRUE) {
-        flb_warn("[input] %s paused (mem buf overlimit)",
-                 i->name);
+    struct flb_storage_input *storage = i->storage;
+
+    if (flb_input_chunk_is_storage_overlimit(i) == FLB_TRUE) {
+        flb_warn("[input] %s paused (storage buf overlimit %d/%d)",
+                 i->name,
+                 storage->cio->total_chunks,
+                 storage->cio->max_chunks_up);
+
         if (!flb_input_buf_paused(i)) {
             if (i->p->cb_pause) {
                 i->p->cb_pause(i->context, i->config);
@@ -1238,11 +1243,14 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i)
         i->mem_buf_status = FLB_INPUT_PAUSED;
         return FLB_TRUE;
     }
-    if (flb_input_chunk_is_storage_overlimit(i) == FLB_TRUE) {
-        flb_warn("[input] %s paused (storage buf overlimit %d/%d)",
-                 i->name,
-                 ((struct flb_storage_input *)i->storage)->cio->total_chunks,
-                 ((struct flb_storage_input *)i->storage)->cio->max_chunks_up);
+
+    if (storage->type == CIO_STORE_FS) {
+        return FLB_FALSE;
+    }
+
+    if (flb_input_chunk_is_mem_overlimit(i) == FLB_TRUE) {
+        flb_warn("[input] %s paused (mem buf overlimit)",
+                 i->name);
         if (!flb_input_buf_paused(i)) {
             if (i->p->cb_pause) {
                 i->p->cb_pause(i->context, i->config);


### PR DESCRIPTION
In Fluent Bit v1.8.7, we introduced a couple of fixes to enhance how the
Chunks were handled at different extreme conditions. The change added a
regression where if the filesystem type was enabled in the input, it was
restricted by mem_buf_limit due to a missing condition that ended up
pausing the data ingestion.

This patch makes sure to do not stop data ingestion if the input plugin
has enabled filesystem storage type.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>
