### PR TITLE
out_es: Fix buffer size when converted_size is equal to 0.

### DIFF
--- a/plugins/out_es/es_bulk.c
+++ b/plugins/out_es/es_bulk.c
@@ -81,14 +81,14 @@ int es_bulk_append(struct es_bulk *bulk, char *index, int i_len,
         if (converted_size == 0) {
             /* converted_size = 0 causes div/0 */
             flb_debug("[out_es] converted_size is 0");
-            append_size = ES_BULK_CHUNK;
+            append_size = required - available;
         } else {
             append_size = (whole_size - converted_size) /* rest of size to convert */
                         * (bulk->size / converted_size); /* = json size / msgpack size */
-            if (append_size < ES_BULK_CHUNK) {
-                /* append at least ES_BULK_CHUNK size */
-                append_size = ES_BULK_CHUNK;
-            }
+        }
+        if (append_size < ES_BULK_CHUNK) {
+            /* append at least ES_BULK_CHUNK size */
+            append_size = ES_BULK_CHUNK;
         }
         ptr = flb_realloc(bulk->ptr, bulk->size + append_size);
         if (!ptr) {


### PR DESCRIPTION
In some case, ES_BULK_CHUNK is not enough to increase size of thebuffer

Fix #4412

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[valgrind.log](https://github.com/fluent/fluent-bit/files/7685837/valgrind.log)

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


I didn't find a way to add a test because it seems already cover by the div0 test because the buffer size is `8000` which is superior to chunk size `#define ES_BULK_CHUNK      4096`
https://github.com/fluent/fluent-bit/blob/f207f446876403f9fe62087c14ad65ec1244d042/tests/runtime/out_elasticsearch.c#L368-L421
