### PR TITLE
config: added dns resolver selector

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -188,6 +188,7 @@ struct flb_config {
 
     /* DNS */
     char *dns_mode;
+    char *dns_resolver;
 
     /* Chunk I/O Buffering */
     void *cio;
@@ -292,6 +293,7 @@ enum conf_type {
 
 /* DNS */
 #define FLB_CONF_DNS_MODE              "dns.mode"
+#define FLB_CONF_DNS_RESOLVER          "dns.resolver"
 
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -48,6 +48,9 @@ struct flb_net_setup {
 
     /* dns mode : TCP or UDP */
     char *dns_mode;
+
+    /* dns reolver : LEGACY or ASYNC */
+    char *dns_resolver;
 };
 
 /* Defines a host service and it properties */
@@ -85,11 +88,11 @@ struct flb_dns_lookup_context {
     ((struct flb_dns_lookup_context *) \
         &((uint8_t *) event)[-offsetof(struct flb_dns_lookup_context, response_event)])
 
+#define FLB_DNS_LEGACY  'L'
+#define FLB_DNS_ASYNC   'A'
+
 #define FLB_DNS_USE_TCP 'T'
 #define FLB_DNS_USE_UDP 'U'
-
-#define FLB_ARES_SOCKET_TYPE_TCP 1
-#define FLB_ARES_SOCKET_TYPE_UDP 2
 
 #ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN  23

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -111,6 +111,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, dns_mode)},
 
+    {FLB_CONF_DNS_RESOLVER,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, dns_resolver)},
+
     /* Storage */
     {FLB_CONF_STORAGE_PATH,
      FLB_CONF_TYPE_STR,

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1108,7 +1108,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
     /* fomart the TCP port */
     snprintf(_port, sizeof(_port), "%lu", port);
 
-    use_async_dns = FLB_TRUE;
+    use_async_dns = is_async;
 
     if (u_conn->u->net.dns_resolver != NULL) {
         resolver_initial = toupper(u_conn->u->net.dns_resolver[0]);

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -41,6 +41,12 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_STR, "net.dns.resolver", NULL,
+     0, FLB_TRUE, offsetof(struct flb_net_setup, dns_resolver),
+     "Select the primary DNS resolver type (LEGACY or ASYNC)"
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
      "Enable or disable Keepalive support"
@@ -106,12 +112,15 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
      * flb_net_setup structure (and not lose it when flb_output_upstream_set overwrites
      * the structure) we need to do it this way (or at least that's what I think)
      */
-    if (config->dns_mode != NULL) {
-
-        for (config_index = 0 ; upstream_net[config_index].name != NULL ; config_index++) {
-            if(strcmp(upstream_net[config_index].name, "net.dns.mode") == 0)
-            {
+    for (config_index = 0 ; upstream_net[config_index].name != NULL ; config_index++) {
+        if (config->dns_mode != NULL) {
+            if (strcmp(upstream_net[config_index].name, "net.dns.mode") == 0) {
                 upstream_net[config_index].def_value = config->dns_mode;
+            }
+        }
+        if (config->dns_resolver != NULL) {
+            if (strcmp(upstream_net[config_index].name, "net.dns.resolver") == 0) {
+                upstream_net[config_index].def_value = config->dns_resolver;
             }
         }
     }


### PR DESCRIPTION
This PR makes it possible to select if we want fluent-bit to use c-ares or the systems resolver.

The new configuration keys are  `dns.resolver` which goes in the `[SERVICE]` section and acts as a global default and ` net.dns.resolver` which can be placed on each output plugin and acts as a localized override.

The values for this option are `LEGACY` and `ASYNC` with the latter being the default one.