### PR TITLE
workflows: increase stale checks to 90 days for issues

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PR(s)'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '90 1 * * *'
 
 jobs:
   stale:
@@ -10,12 +10,12 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 5 days. Maintainers can add the `exempt-stale` label.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          days-before-stale: 30
+          days-before-stale: 90
           days-before-close: 5
           days-before-pr-close: -1
           exempt-all-pr-assignees: true
           exempt-all-pr-milestones: true
-          exempt-issue-labels: 'long-term,enhancement'
+          exempt-issue-labels: 'long-term,enhancement,exempt-stale'


### PR DESCRIPTION
Per various requests, extend the stale checks to 90 days.
Completely removing them may lead to an unmanageable backlog so trying to walk the line between the two extremes.

Added a new `exempt-stale` label to be used if we want to disable stale checks, although note that currently doing any of the following should prevent auto-stale checks:
* Assign
* Set milestone
* Add labels `long-term` or `enhancement`

cc @edsiper @agup006 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
