### PR TITLE
plugins/in_forward: removed unused variables

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -193,11 +193,8 @@ static void in_fw_pause(void *data, struct flb_config *config)
 
 static int in_fw_exit(void *data, struct flb_config *config)
 {
-    struct mk_list *tmp;
-    struct mk_list *head;
     (void) *config;
     struct flb_in_fw_config *ctx = data;
-    struct fw_conn *conn;
 
     if (!ctx) {
         return 0;


### PR DESCRIPTION
Signed-off-by: Lionel Cons <lionel.cons@cern.ch>

This fixes https://github.com/fluent/fluent-bit/issues/4428.