### PR TITLE
Removing word redundancy on workflows

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Run unit tests
+name: Unit Tests
 on:
   push:
     branches:
@@ -15,7 +15,7 @@ on:
     types: [opened, edited, synchronize]
 jobs:
   run-unit-tests-amd64:
-    name: Run unit tests on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }}
+    name: amd64 for ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 48


### PR DESCRIPTION
## Description

The current unit tests workflow is awesome, but I noticed that we are repeating words in the job description. Optimally the text should fit in the check box that GitHub provides. 

today it looks like this:
![image](https://user-images.githubusercontent.com/226559/145643325-82fab847-592a-4b16-808a-2bb584a8b9e4.png)


 
**Testing**

Making sure the message is shorter in the box, given that this change is purely cosmetic 