### PR TITLE
coro: rename coro stack size define

### DIFF
--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -63,9 +63,9 @@ struct flb_coro {
 };
 
 #ifdef FLB_CORO_STACK_SIZE
-#define FLB_CORO_STACK_SIZE      FLB_CORO_STACK_SIZE
+#define FLB_CORO_STACK_SIZE_BYTE      FLB_CORO_STACK_SIZE
 #else
-#define FLB_CORO_STACK_SIZE      ((3 * PTHREAD_STACK_MIN) / 2)
+#define FLB_CORO_STACK_SIZE_BYTE      ((3 * PTHREAD_STACK_MIN) / 2)
 #endif
 
 #define FLB_CORO_DATA(coro)      (((char *) coro) + sizeof(struct flb_coro))

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -231,7 +231,7 @@ struct flb_config *flb_config_init()
 #endif
 
     /* Set default coroutines stack size */
-    config->coro_stack_size = FLB_CORO_STACK_SIZE;
+    config->coro_stack_size = FLB_CORO_STACK_SIZE_BYTE;
 
     /* Initialize linked lists */
     mk_list_init(&config->collectors);


### PR DESCRIPTION
Fixes #4374

This patch is to be able to build with `-DFLB_CORO_STACK_SIZE=xyz`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log (with `-DFLB_CORO_STACK_SIZE=4096`)

```
$ bin/fluent-bit -h
Usage: fluent-bit [OPTION]

Available Options
(snip)
  -s, --coro_stack_size   set coroutines stack size in bytes (default: 4096)
```

## Debug log (without `-DFLB_CORO_STACK_SIZE`)

```
$ bin/fluent-bit -h
Usage: fluent-bit [OPTION]

Available Options
(snip)
  -s, --coro_stack_size   set coroutines stack size in bytes (default: 24576)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
