### PR TITLE
metrics: silent gcc warning

### DIFF
--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -324,8 +324,7 @@ int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
     /* get hostname */
     ret = gethostname(hostname, sizeof(hostname) - 1);
     if (ret == -1) {
-        strncpy(hostname, "unknown", 7);
-        hostname[7] = '\0';
+        strcpy(hostname, "unknown");
     }
 
     /* Attach metrics to cmetrics context */


### PR DESCRIPTION
Signed-off-by: Lionel Cons <lionel.cons@cern.ch>

This fixes https://github.com/fluent/fluent-bit/issues/4439.