### PR TITLE
workfows: Only add labels when PR opens

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,9 +3,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - edited
-      - reopened
-      - synchronize
 jobs:
   apply-default-labels:
     name: apply default labels


### PR DESCRIPTION
@edsiper I've updated so it only does on open - then if removed it won't do again.

Another option is we filter it down to specific types of file? Which ones though?

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
