### PR TITLE
workflows: reduce fuzz calls to just C source changes

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,5 +1,10 @@
 name: CIFuzz
-on: [pull_request]
+on: 
+  pull_request:
+    # Only fuzz when C source files change
+    paths:
+      - '**.c'
+      - '**.h'
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reduce fuzz workflow calls to just when C source code changes.
It takes ~20 minutes to run otherwise.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [nNA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
