### PR TITLE
workflows: disable unnecessary workflows

### DIFF
--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -1,6 +1,10 @@
 name: 'Pull requests compile checks'
 on:
   pull_request:
+    # Only trigger if there is a code change
+    paths:
+      - '**.h'
+      - '**.c'
     types:
       - opened
       - edited

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -9,13 +9,14 @@ on:
       - '.github/**'
       - 'dockerfiles/**'
       - 'docker_compose/**'
+      - 'packaging/**'
     branches:
       - master
       - 1.8
     types: [opened, edited, synchronize]
 jobs:
   run-unit-tests-amd64:
-    name: Run unit tests on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }}
+    name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }} unit tests run on AMD64
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 48
@@ -80,13 +81,3 @@ jobs:
           CC: gcc
           CXX: g++
           FLB_OPT: ${{ matrix.flb_option }}
-
-  run-all-unit-tests:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: Unit tests (matrix)
-    needs: run-unit-tests-amd64
-    steps:
-      - name: Check build matrix status
-        if: ${{ needs.run-unit-tests-amd64.result != 'success' }}
-        run: exit 1


### PR DESCRIPTION
Disable unit testing for packaging changes.
Disable compile checks unless it is a C source file change.
Updated unit test matrix calls to include the most variable components first.
Also removed unnecessary end stage.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
