### PR TITLE
workflows: staging build deb repo fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "workflows: "

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: true
       matrix:
         distro: [ amazonlinux/2, amazonlinux/2.arm64v8,
-                  centos/7, centos/7.arm64v8,
+                  centos/7, centos/7.arm64v8, centos/8, centos/8.arm64v8,
                   debian/stretch, debian/stretch.arm64v8, debian/buster, debian/buster.arm64v8,
                   ubuntu/16.04, ubuntu/18.04, ubuntu/20.04, ubuntu/18.04.arm64v8, ubuntu/20.04.arm64v8,
                   raspbian/buster ]
@@ -50,6 +50,12 @@ jobs:
 
           - distro: centos/7.arm64v8
             target: centos/7/
+
+          - distro: centos/8
+            target: centos/8/
+
+          - distro: centos/8.arm64v8
+            target: centos/8/
 
           - distro: debian/stretch
             target: debian/stretch/
@@ -139,7 +145,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo debsigs apt-utils
+          sudo apt-get install -y createrepo reprepro
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo reprepro
+          sudo apt-get install -y createrepo aptly
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -21,6 +21,8 @@ jobs:
     name: ${{ matrix.distro }} package tests
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    env:
+        AWS_URL: https://${{ secrets.bucket }}.s3.amazonaws.com
     strategy:
       fail-fast: false
       matrix:
@@ -43,4 +45,3 @@ jobs:
       env:
         PACKAGE_TEST: ${{ matrix.distro }}
         RELEASE_URL: https://packages.fluentbit.io
-        AWS_URL: https://${{ secrets.bucket }}.s3.amazonaws.com

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -13,7 +13,7 @@ on:
       version:
         description: Version of Fluent Bit to build
         required: true
-        default: 1.8.10
+        default: 1.8.11
 jobs:
 
   # This job copes with the variable approach of either being triggered by a tag,

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,6 +10,7 @@ on:
       - 'dockerfiles/**'
       - 'docker_compose/**'
       - 'packaging/**'
+      - '.gitignore'
     branches:
       - master
       - 1.8

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib/monkey/include/monkey/mk_core/mk_core_info.h
 
 packaging/packages
 packaging/releases
+packaging/latest/
 workflow/
 *.key
 *.log

--- a/packaging/testing/smoke/packages/Dockerfile.debian10
+++ b/packaging/testing/smoke/packages/Dockerfile.debian10
@@ -4,7 +4,7 @@ ARG STAGING_BASE=dokken/debian-10
 FROM dokken/debian-10 as official-install
 ARG RELEASE_URL
 RUN wget -qO - $RELEASE_URL/fluentbit.key | apt-key add -
-RUN echo "deb $RELEASE_URL/debian/buster buster" >> /etc/apt/sources.list
+RUN echo "deb $RELEASE_URL/debian/buster buster main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -59,9 +59,9 @@ for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do
 Origin: Fluent Bit
 Label: Fluent Bit
 Codename: $CODENAME
-Architectures: amd64 arm64
+Architectures: amd64 arm64 armhf
 Components: main
-Description: Apt repository for project Fluent Bit
+Description: Apt repository for Fluent Bit
 SignWith: $GPG_KEY
 EOF
     cat << EOF > "$REPO_DIR/conf/options"


### PR DESCRIPTION
Switched to `aptly` to easily add the .deb files with the benefit it actually works! Tested with local Debian 10 container to install from S3 repo.

Added Centos 8 builds.

Incremented to latest version for default manual builds.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
