### PR TITLE
config: support lowercase proxy environment variables

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -202,13 +202,19 @@ struct flb_config *flb_config_init()
 
     config->http_proxy = getenv("HTTP_PROXY");
     if (flb_str_emptyval(config->http_proxy) == FLB_TRUE) {
-        /* Proxy should not be set when the `HTTP_PROXY` is set to "" */
-        config->http_proxy = NULL;
+        config->http_proxy = getenv("http_proxy");
+        if (flb_str_emptyval(config->http_proxy) == FLB_TRUE) {
+            /* Proxy should not be set when `HTTP_PROXY` or `http_proxy` are set to "" */
+            config->http_proxy = NULL;
+        }
     }
     config->no_proxy = getenv("NO_PROXY");
     if (flb_str_emptyval(config->no_proxy) == FLB_TRUE || config->http_proxy == NULL) {
-        /* NoProxy  should not be set when the `NO_PROXYY` is set to "" or there is no Proxy. */
-        config->no_proxy = NULL;
+        config->no_proxy = getenv("no_proxy");
+        if (flb_str_emptyval(config->no_proxy) == FLB_TRUE || config->http_proxy == NULL) {
+            /* NoProxy  should not be set when `NO_PROXY` or `no_proxy` are set to "" or there is no Proxy. */
+            config->no_proxy = NULL;
+        }
     }
 
     config->cio          = NULL;


### PR DESCRIPTION
To my knowledge, there is no industry standard for the casing of proxy
environment variables. Applications can choose which case to honor (i.e.
`http_proxy` versus `HTTP_PROXY`).

Up to this point, Fluent Bit has only honored the uppercase proxy
environment variables `HTTP_PROXY` and `NO_PROXY`. This change adds
support for the lowercase variants of these environment variables
(`http_proxy` and `no_proxy`) while maintaining preference for the
uppercase variants when both uppercase and lowercase variants are
defined.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
  - [x] https://github.com/fluent/fluent-bit-docs/pull/658

<!--  Doc PR (not required but highly recommended) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
