### PR TITLE
input_chunk: warn the user about tag truncation due to limits

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -32,7 +32,6 @@
  * value is passed to Chunk I/O.
  */
 #define FLB_INPUT_CHUNK_SIZE           262144  /* 256KB (hint) */
-
 /*
  * Defines a maximum size for a Chunk in the file system: note that despite
  * this is considered a limit, a Chunk size might get greater than this.
@@ -49,6 +48,9 @@
 /* Chunk types: Log and Metrics are supported */
 #define FLB_INPUT_CHUNK_TYPE_LOG      0
 #define FLB_INPUT_CHUNK_TYPE_METRIC   1
+
+/* Max length for Tag */
+#define FLB_INPUT_CHUNK_TAG_MAX        (65535 - FLB_INPUT_CHUNK_META_HEADER)
 
 struct flb_input_chunk {
     int  event_type;                 /* chunk type: logs or metrics */

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1092,6 +1092,13 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     size_t out_size;
     struct flb_input_chunk *ic = NULL;
 
+    if (tag_len > FLB_INPUT_CHUNK_TAG_MAX) {
+        flb_plg_warn(in,
+                     "Tag set exceeds limit, truncating from %lu to %lu bytes",
+                     tag_len, FLB_INPUT_CHUNK_TAG_MAX);
+        tag_len = FLB_INPUT_CHUNK_TAG_MAX;
+    }
+
     if (in->event_type == FLB_INPUT_LOGS) {
         id = flb_hash_get(in->ht_log_chunks, tag, tag_len,
                           (void *) &ic, &out_size);


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>
