### PR TITLE
flb_engine: use sb_segregate_chunks() only if in_storage_backlog provides it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,10 @@ if(FLB_DEV)
   set(FLB_TESTS_INTERNAL    On)
 endif()
 
+if(FLB_IN_STORAGE_BACKLOG)
+  FLB_DEFINITION(FLB_HAVE_IN_STORAGE_BACKLOG)
+endif()
+
 # SSL/TLS: add encryption support
 if(FLB_OUT_TD)
   set(FLB_TLS ON)

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -497,7 +497,9 @@ static int flb_engine_log_start(struct flb_config *config)
     return 0;
 }
 
+#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
 extern int sb_segregate_chunks(struct flb_config *config);
+#endif
 
 int flb_engine_start(struct flb_config *config)
 {
@@ -683,6 +685,7 @@ int flb_engine_start(struct flb_config *config)
     /* Signal that we have started */
     flb_engine_started(config);
 
+#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
     ret = sb_segregate_chunks(config);
 
     if (ret)
@@ -690,6 +693,7 @@ int flb_engine_start(struct flb_config *config)
         flb_error("[engine] could not segregate backlog chunks");
         return -2;
     }
+#endif
 
     while (1) {
         mk_event_wait(evl);


### PR DESCRIPTION
Without this patch, we get this linker error:

  [100%] Linking C executable ../bin/fluent-bit
  <toolchai-path>/bin/ld: ../library/libfluent-bit.a(flb_engine.c.o): in function `flb_engine_start':
  src/platform-v7a/build-target/fluent-bit-1.8.11/src/flb_engine.c:684: undefined reference to `sb_segregate_chunks'

when fluent-bit was configured with -DFLB_IN_STORAGE_BACKLOG=Off, because in
this case the called function wasn't compiled in.

Fixes: ba58aa0783d6b5029c51f9524f0df303b2250417
Signed-off-by: Robert Schwebel <r.schwebel@pengutronix.de>

<!-- Provide summary of changes -->

Addresses #4464