### PR TITLE
workflows: resolve issues with required checks

### DIFF
--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -1,0 +1,19 @@
+# For skipped checks that are required to merge we trigger a fake job that succeeds.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run unit tests
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'dockerfiles/**'
+      - 'docker_compose/**'
+      - 'packaging/**'
+      - '.gitignore'
+  workflow_dispatch:
+
+jobs:
+  run-all-unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests (matrix)
+    steps:
+      - run: echo "No unit tests required"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,6 +15,8 @@ on:
       - master
       - 1.8
     types: [opened, edited, synchronize]
+  workflow_dispatch:
+
 jobs:
   run-unit-tests-amd64:
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }} unit tests run on AMD64
@@ -82,3 +84,14 @@ jobs:
           CC: gcc
           CXX: g++
           FLB_OPT: ${{ matrix.flb_option }}
+
+  # Required check looks at this so do not remove
+  run-all-unit-tests:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Unit tests (matrix)
+    needs: run-unit-tests-amd64
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.run-unit-tests-amd64.result != 'success' }}
+        run: exit 1

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -17,6 +17,7 @@ WORKDIR /src/build
 
 RUN cmake3 -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
            -DFLB_RELEASE=On -DFLB_TRACE=On -DFLB_TD=On \
+           -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On \
            -DFLB_SQLDB=On -DFLB_HTTP_SERVER=On \
            -DFLB_OUT_KAFKA=On \
            -DFLB_OUT_PGSQL=On ../


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Required checks need to be included even if skipped so following the advice here: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
Create another workflow of the same name that fires on the inverse check and always succeeds.

Added test build as well for Centos 7 per @edsiper request.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
