### PR TITLE
storage backlog: fix issues when it is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,10 @@ option(FLB_FILTER_RECORD_MODIFIER "Enable record_modifier filter"   Yes)
 option(FLB_FILTER_TENSORFLOW  "Enable tensorflow filter"             No)
 option(FLB_FILTER_GEOIP2      "Enable geoip2 filter"                Yes)
 
+if(FLB_IN_STORAGE_BACKLOG)
+  FLB_DEFINITION(FLB_HAVE_IN_STORAGE_BACKLOG)
+endif()
+
 # Debug callbacks
 option(FLB_HTTP_CLIENT_DEBUG  "Enable HTTP Client debug callbacks"   No)
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -181,7 +181,11 @@ REGISTER_IN_PLUGIN("in_health")
 REGISTER_IN_PLUGIN("in_http")
 REGISTER_IN_PLUGIN("in_collectd")
 REGISTER_IN_PLUGIN("in_statsd")
-REGISTER_IN_PLUGIN("in_storage_backlog")
+
+if (FLB_IN_STORAGE_BACKLOG)
+  REGISTER_IN_PLUGIN("in_storage_backlog")
+endif()
+
 REGISTER_IN_PLUGIN("in_nginx_exporter_metrics")
 
 if (FLB_STREAM_PROCESSOR)

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -497,7 +497,14 @@ static int flb_engine_log_start(struct flb_config *config)
     return 0;
 }
 
+#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
 extern int sb_segregate_chunks(struct flb_config *config);
+#else
+int sb_segregate_chunks(struct flb_config *config)
+{
+    return 0;
+}
+#endif
 
 int flb_engine_start(struct flb_config *config)
 {

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -42,11 +42,30 @@
 #define FLB_INPUT_CHUNK_RELEASE_SCOPE_LOCAL  0
 #define FLB_INPUT_CHUNK_RELEASE_SCOPE_GLOBAL 1
 
+#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
+
 extern ssize_t sb_get_releasable_output_queue_space(struct flb_output_instance *output_plugin,
                                                     size_t                      required_space);
 
 extern int sb_release_output_queue_space(struct flb_output_instance *output_plugin,
                                          size_t                      required_space);
+
+
+#else
+
+ssize_t sb_get_releasable_output_queue_space(struct flb_output_instance *output_plugin,
+                                             size_t                      required_space)
+{
+    return 0;
+}
+
+int sb_release_output_queue_space(struct flb_output_instance *output_plugin,
+                                  size_t                      required_space)
+{
+    return 0;
+}
+
+#endif
 
 static int flb_input_chunk_safe_delete(struct flb_input_chunk *ic,
                                        struct flb_input_chunk *old_ic,


### PR DESCRIPTION
This PR adds the required cmake statements to make storage backlog optional and the code changes required for it not to cause linkage issues.