### PR TITLE
upstream: add new option 'net.connect_timeout_log_error' (#4473)

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -40,6 +40,9 @@ struct flb_net_setup {
     /* max time in seconds to wait for a established connection */
     int connect_timeout;
 
+    /* connect timeout log error (default: true) */
+    int connect_timeout_log_error;
+
     /* network interface to bind and use to send data */
     flb_sds_t source_address;
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -66,6 +66,13 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "net.connect_timeout_log_error", "true",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, connect_timeout_log_error),
+     "On connection timeout, specify if it should log an error. When disabled, "
+     "the timeout is logged as a debug message"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "net.source_address", NULL,
      0, FLB_TRUE, offsetof(struct flb_net_setup, source_address),
      "Specify network address to bind for data traffic"
@@ -806,10 +813,19 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
                 drop = FLB_TRUE;
 
                 if (!flb_upstream_is_shutting_down(u)) {
-                    flb_error("[upstream] connection #%i to %s:%i timed out after "
-                              "%i seconds",
-                              u_conn->fd,
-                              u->tcp_host, u->tcp_port, u->net.connect_timeout);
+
+                    if (u->net.connect_timeout_log_error) {
+                        flb_error("[upstream] connection #%i to %s:%i timed out after "
+                                  "%i seconds",
+                                  u_conn->fd,
+                                  u->tcp_host, u->tcp_port, u->net.connect_timeout);
+                    }
+                    else {
+                        flb_debug("[upstream] connection #%i to %s:%i timed out after "
+                                  "%i seconds",
+                                  u_conn->fd,
+                                  u->tcp_host, u->tcp_port, u->net.connect_timeout);
+                    }
                 }
             }
 


### PR DESCRIPTION
When a connection times out, an error message is dispatched informing
the user about the event. In some cases the user would prefer to silent
those messages by making them available only as 'debug' messages instead
of an 'error'.

This patch adds a new option to the upstream configuration:

   net.connect_timeout_log_error  (default: true)

This boolean option is enabled by default to keep the usual behavior but
the user can turn it off in the OUTPUT section of the plugin so when
a connection timeout is faced, it will be send a 'debug' message.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
