### PR TITLE
tests: runtime: out_es: remove op_type to fix failing test

### DIFF
--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -13,7 +13,7 @@ static void cb_check_index_type(void *ctx, int ffd,
 {
     char *p;
     char *out_js = res_data;
-    char *index_line = "{\"index\":{\"_index\":\"index_test\",\"_type\":\"type_test\"}";
+    char *index_line = ":{\"_index\":\"index_test\",\"_type\":\"type_test\"}";
 
     p = strstr(out_js, index_line);
     TEST_CHECK(p != NULL);
@@ -27,7 +27,7 @@ static void cb_check_logstash_format(void *ctx, int ffd,
 {
     char *p;
     char *out_js = res_data;
-    char *index_line = "{\"index\":{\"_index\":\"prefix-2015-11-24\",\"_type\":\"_doc\"}";
+    char *index_line = ":{\"_index\":\"prefix-2015-11-24\",\"_type\":\"_doc\"}";
 
     p = strstr(out_js, index_line);
     TEST_CHECK(p != NULL);


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/pull/4361#issuecomment-997111614

out_es test failed on `flb_test_index_type` and `flb_test_logstash_format` since they expect `index` op_type .
Currently we use `create` op_type and it causes test failing.
https://github.com/fluent/fluent-bit/commit/7f0db9ef07a6dcb6fd9c1af58c68301356747529

I removed `index` op_type from expected output string.
We try to support other op_type on https://github.com/fluent/fluent-bit/pull/4079.
I think we should not take care op_type on such test cases.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug output 

```
$ bin/flb-rt-out_elasticsearch 
Test div0_error...                              [2021/12/18 10:42:16] [ info] [engine] started (pid=32252)
[2021/12/18 10:42:16] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:16] [ info] [storage] in-memory
[2021/12/18 10:42:16] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:16] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:16] [ info] [sp] stream processor started
[2021/12/18 10:42:16] [ info] [task] cleanup test task
[2021/12/18 10:42:18] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:18] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test index_type...                              [2021/12/18 10:42:18] [ info] [engine] started (pid=32255)
[2021/12/18 10:42:18] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:18] [ info] [storage] in-memory
[2021/12/18 10:42:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:18] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:18] [ info] [sp] stream processor started
[2021/12/18 10:42:19] [ info] [task] cleanup test task
[2021/12/18 10:42:20] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:21] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test logstash_format...                         [2021/12/18 10:42:21] [ info] [engine] started (pid=32258)
[2021/12/18 10:42:21] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:21] [ info] [storage] in-memory
[2021/12/18 10:42:21] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:21] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:21] [ info] [sp] stream processor started
[2021/12/18 10:42:22] [ info] [task] cleanup test task
[2021/12/18 10:42:23] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:24] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test logstash_format_nanos...                   [2021/12/18 10:42:24] [ info] [engine] started (pid=32261)
[2021/12/18 10:42:24] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:24] [ info] [storage] in-memory
[2021/12/18 10:42:24] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:24] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:24] [ info] [sp] stream processor started
[2021/12/18 10:42:25] [ info] [task] cleanup test task
[2021/12/18 10:42:26] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:27] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test tag_key...                                 [2021/12/18 10:42:27] [ info] [engine] started (pid=32264)
[2021/12/18 10:42:27] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:27] [ info] [storage] in-memory
[2021/12/18 10:42:27] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:27] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:27] [ info] [sp] stream processor started
[2021/12/18 10:42:28] [ info] [task] cleanup test task
[2021/12/18 10:42:29] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:30] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test replace_dots...                            [2021/12/18 10:42:30] [ info] [engine] started (pid=32267)
[2021/12/18 10:42:30] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:30] [ info] [storage] in-memory
[2021/12/18 10:42:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:30] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:30] [ info] [sp] stream processor started
[2021/12/18 10:42:31] [ info] [task] cleanup test task
[2021/12/18 10:42:32] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:33] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test id_key...                                  [2021/12/18 10:42:33] [ info] [engine] started (pid=32270)
[2021/12/18 10:42:33] [ info] [storage] version=1.1.5, initializing...
[2021/12/18 10:42:33] [ info] [storage] in-memory
[2021/12/18 10:42:33] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/18 10:42:33] [ info] [cmetrics] version=0.2.2
[2021/12/18 10:42:33] [ info] [sp] stream processor started
[2021/12/18 10:42:34] [ info] [task] cleanup test task
[2021/12/18 10:42:35] [ warn] [engine] service will shutdown in max 1 seconds
[2021/12/18 10:42:36] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
