### PR TITLE
workflows: call integration test on staging test

### DIFF
--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -23,7 +23,18 @@ on:
         required: true
       cosign_key:
         required: false
-
+      terraform_api_token:
+        description: Terraform API Token
+        required: true
+      gcp_service_account_key:
+        description: The GCP service account we want to use provides this token.
+        required: true
+      grafana_username:
+        description: The Grafana (Cloud) username to deploy with.
+        required: true
+      grafana_password:
+        description: The Grafana (Cloud) credentials to deploy with.
+        required: true
 jobs:
   call-test-images-cosign-verify:
     name: Cosign verification of container image
@@ -187,3 +198,23 @@ jobs:
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image }}
           IMAGE_TAG: ${{ inputs.image-tag }}
+
+  call-test-images-gcp-integration:
+    name: run integration tests on GCP
+    # Wait for other tests to succeed
+    needs: [ call-test-images-container-smoke, call-test-images-k8s-smoke ]
+    uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
+    with:
+      image_name: ${{ inputs.registry }}/${{ inputs.image }}
+      image_tag: ${{ inputs.image-tag }}
+    secrets:
+      grafana_username: ${{ secrets.grafana_username }}
+      terraform_api_token: ${{ secrets.terraform_api_token }}
+      gcp_service_account_key: ${{ secrets.gcp_service_account_key }}
+      grafana_password: ${{ secrets.grafana_password }}
+
+  # TODO
+  # call-test-images-soak-test:
+  #   name: Soak test for any issues
+  #   needs: call-test-images-gcp-integration
+  #   uses: calyptia/fluent-bit-ci/.github/workflows/reusable-soak-test.yaml@main

--- a/.github/workflows/integration-build-master.yaml
+++ b/.github/workflows/integration-build-master.yaml
@@ -6,30 +6,29 @@ on:
 jobs:
   docker_build:
     strategy:
-      max-parallel: 3
       fail-fast: false
       matrix:
         tag: [ 'master', 'master_debug' ]
     runs-on: ubuntu-latest
     steps:
-      - name: Setup environment
-        run: |
-          sudo apt-get --yes update
-          sudo apt-get install --yes docker.io containerd runc
-          sudo systemctl unmask docker && sudo systemctl start docker
-
       - uses: actions/checkout@v2
-      - name: Build a docker image for master branch
-        run: |
-          DOCKER_BUILDKIT=1 docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }}-${{ matrix.tag }} -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ matrix.tag }} .
-        env:
-          arch: x86_64
-          dockerhub_organization: fluentbitdev
+      - uses: docker/setup-buildx-action@v1
 
-      - name: Archive the docker images
-        uses: ishworkh/docker-image-artifact-upload@v1
+      - name: Extract metadata from Github
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          image: ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-${{ matrix.tag }}
-        env:
-          arch: x86_64
-          dockerhub_organization: fluentbitdev
+          images: fluentbitdev/fluent-bit
+          tags: |
+            raw,x86_64-master-${{ matrix.tag }}
+
+      - name: Build the staging image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/Dockerfile.x86_64-master
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          load: false

--- a/.github/workflows/integration-build-pr.yaml
+++ b/.github/workflows/integration-build-pr.yaml
@@ -9,29 +9,28 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
-      - name: Setup environment
-        run: |
-          sudo apt-get --yes update
-          sudo apt-get install --yes docker.io containerd runc
-          sudo systemctl unmask docker && sudo systemctl start docker
-
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Build the docker images for PR ${{ github.event.number }}
-        run: |
-          docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }}-master -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.pr }} .
-        env:
-          pr: ${{ github.event.number }}
-          arch: x86_64
-          dockerhub_organization: fluentbitdev
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Archive the docker images
-        uses: ishworkh/docker-image-artifact-upload@v1
+      - name: Extract metadata from Github
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          image: ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-master-pr-${{ env.pr }}
-        env:
-          pr: ${{ github.event.number }}
-          arch: x86_64
-          dockerhub_organization: fluentbitdev
+          images: fluentbitdev/fluent-bit
+          tags: |
+            raw,x86_64-master-${{ env.pr }}
+
+      - name: Build the staging image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/Dockerfile.x86_64-master
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          load: false

--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -62,128 +62,14 @@ jobs:
         working-directory: ci/
 
   run-integration-gcp:
-    name: run integration tests on GCP - k8s ${{ matrix.k8s-release }}
+    name: run integration tests on GCP
     needs: publish-docker-images
-    strategy:
-      max-parallel: 3
-      fail-fast: false
-      matrix:
-        k8s-release: [ '1.21' ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: calyptia/fluent-bit-ci
-          path: ci
-
-      - uses: frabert/replace-string-action@master
-        id: formatted_release
-        with:
-          pattern: '(.*)\.(.*)$'
-          string: ${{ matrix.k8s-release }}
-          replace-with: '$1-$2'
-          flags: 'g'
-
-      - name: Replace the k8s release
-        run: |
-          sed -i -e "s/\$K8S_RELEASE/${{ env.k8s_release }}/g" default.auto.tfvars
-          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" default.auto.tfvars
-          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" config.tf
-        working-directory: ci/terraform/gcp/
-        env:
-          k8s_release: ${{ matrix.k8s-release }}
-          k8s_release_formatted: ${{ steps.formatted_release.outputs.replaced }}
-
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-      - name: Replace the GCP service account key
-        run: |
-          cat <<EOT >> default.auto.tfvars
-          gcp-sa-key    =  <<-EOF
-          ${{ secrets.GCP_SA_KEY }}
-          EOF
-          EOT
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check
-        continue-on-error: true
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Init
-        id: init
-        run: terraform init
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Apply
-        id: apply
-        run: |
-          terraform apply -input=false -auto-approve
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s cluster name from terraform output
-        id: get-k8s-cluster-name
-        run: terraform output -no-color -raw k8s-cluster-name
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s cluster location from terraform output
-        id: get-k8s-cluster-location
-        run: terraform output -no-color -raw k8s-cluster-location
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s project id from terraform output
-        id: get-gcp-project-id
-        run: terraform output -no-color -raw gcp-project-id
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the bigquery dataset id from terraform output
-        id: get-gcp-bigquery-dataset-id
-        run: terraform output -no-color -raw gcp-bigquery-dataset-id
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the bigquery table id from terraform output
-        id: get-gcp-bigquery-table-id
-        run: terraform output -no-color -raw gcp-bigquery-table-id
-        working-directory: ci/terraform/gcp/
-
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - uses: google-github-actions/get-gke-credentials@main
-        with:
-          cluster_name: ${{ steps.get-k8s-cluster-name.outputs.stdout }}
-          location: ${{ steps.get-k8s-cluster-location.outputs.stdout }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16' # The Go version to download (if necessary) and use.
-
-      - uses: azure/setup-helm@v1
-        id: install
-
-      - run: go mod download
-        working-directory: ci/integration/
-
-      - run: make integration
-        env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_BQ_DATASET_ID: ${{ steps.get-gcp-bigquery-dataset-id.outputs.stdout }}
-          GCP_BQ_TABLE_ID: ${{ steps.get-gcp-bigquery-table-id.outputs.stdout }}
-          GCP_PROJECT_ID: fluent-bit-ci
-          IMAGE_REPOSITORY: fluentbitdev/fluent-bit
-          IMAGE_TAG: x86_64-master
-          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
-          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
-        working-directory: ci/
+    uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
+    with:
+      image_name: fluentbitdev/fluent-bit
+      image_tag: x86_64-master
+    secrets:
+      grafana_username: ${{ secrets.GRAFANA_USERNAME }}
+      terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp_service_account_key: ${{ secrets.GCP_SA_KEY }}
+      grafana_password: ${{ secrets.GRAFANA_PASSWORD }}

--- a/.github/workflows/integration-run-pr.yaml
+++ b/.github/workflows/integration-run-pr.yaml
@@ -75,132 +75,21 @@ jobs:
           repo: fluent/fluent-bit
 
   run-integration-gcp:
-    name: run-integration on GCP - k8s ${{ matrix.k8s-release }}
     needs: publish-docker-images
-    strategy:
-      max-parallel: 3
-      fail-fast: false
-      matrix:
-        k8s-release: [ '1.19' ] #, '1.20' ] #, 1.19/stable, 1.18/stable ]
+    uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
+    with:
+      image_name: fluentbitdev/fluent-bit
+      image_tag: x86_64-master-pr-${{ github.event.pull_request.number }}
+    secrets:
+      grafana_username: ${{ secrets.GRAFANA_USERNAME }}
+      terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp_service_account_key: ${{ secrets.GCP_SA_KEY }}
+      grafana_password: ${{ secrets.GRAFANA_PASSWORD }}
+
+  run-integration-post-label:
     runs-on: ubuntu-latest
+    needs: run-integration-gcp
     steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: calyptia/fluent-bit-ci
-          path: ci
-
-      - uses: frabert/replace-string-action@master
-        id: formatted_release
-        with:
-          pattern: '(.*)\.(.*)$'
-          string: ${{ matrix.k8s-release }}
-          replace-with: '$1-$2'
-          flags: 'g'
-
-      - name: Replace the k8s release
-        run: |
-          sed -i -e "s/\$K8S_RELEASE/${{ env.k8s_release }}/g" default.auto.tfvars
-          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" default.auto.tfvars
-          sed -i -e "s/\$K8S_FORMATTED/${{ env.k8s_release_formatted }}/g" config.tf
-        working-directory: ci/terraform/gcp/
-        env:
-          k8s_release: ${{ matrix.k8s-release }}
-          k8s_release_formatted: ${{ steps.formatted_release.outputs.replaced }}
-
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-      - name: Replace the GCP service account key
-        run: |
-          cat <<EOT >> default.auto.tfvars
-          gcp-sa-key    =  <<-EOF
-          ${{ secrets.GCP_SA_KEY }}
-          EOF
-          EOT
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check
-        continue-on-error: true
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Init
-        id: init
-        run: terraform init
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-        working-directory: ci/terraform/gcp/
-
-      - name: Terraform Apply
-        id: apply
-        run: |
-          terraform apply -input=false -auto-approve
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s cluster name from terraform output
-        id: get-k8s-cluster-name
-        run: terraform output -no-color -raw k8s-cluster-name
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s cluster location from terraform output
-        id: get-k8s-cluster-location
-        run: terraform output -no-color -raw k8s-cluster-location
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the k8s project id from terraform output
-        id: get-gcp-project-id
-        run: terraform output -no-color -raw gcp-project-id
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the bigquery dataset id from terraform output
-        id: get-gcp-bigquery-dataset-id
-        run: terraform output -no-color -raw gcp-bigquery-dataset-id
-        working-directory: ci/terraform/gcp/
-
-      - name: Get the bigquery table id from terraform output
-        id: get-gcp-bigquery-table-id
-        run: terraform output -no-color -raw gcp-bigquery-table-id
-        working-directory: ci/terraform/gcp/
-
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - uses: google-github-actions/get-gke-credentials@main
-        with:
-          cluster_name: ${{ steps.get-k8s-cluster-name.outputs.stdout }}
-          location: ${{ steps.get-k8s-cluster-location.outputs.stdout }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16' # The Go version to download (if necessary) and use.
-
-      - uses: azure/setup-helm@v1
-        id: install
-
-      - run: go mod download
-        working-directory: ci/integration/
-
-      - run: make integration
-        env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          GCP_BQ_DATASET_ID: ${{ steps.get-gcp-bigquery-dataset-id.outputs.stdout }}
-          GCP_BQ_TABLE_ID: ${{ steps.get-gcp-bigquery-table-id.outputs.stdout }}
-          GCP_PROJECT_ID: fluent-bit-ci
-          IMAGE_REPOSITORY: fluentbitdev/fluent-bit
-          IMAGE_TAG: x86_64-master-pr-${{ github.event.pull_request.number }}
-          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
-          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
-        working-directory: ci/
-
       - uses: actions-ecosystem/action-add-labels@v1
         name: Label the PR
         with:

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -25,6 +25,10 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       cosign_key: ${{ secrets.COSIGN_PUBLIC_KEY }}
+      grafana_username: ${{ secrets.GRAFANA_USERNAME }}
+      terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp_service_account_key: ${{ secrets.GCP_SA_KEY }}
+      grafana_password: ${{ secrets.GRAFANA_PASSWORD }}
 
   staging-test-packages:
     name: Binary packages staging test


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Provides integration tests automatically once staging tests are triggered, and after the sanity checks have succeeded. Uses reusable workflow in calyptia/fluent-bit-ci to do the work.

Also simplified the current integration test actions. Next step is to invoke the reusable ones but baby step here.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
