### PR TITLE
workflows: revert use of ishworkh/docker-image-artifact-upload 

### DIFF
--- a/.github/workflows/integration-build-master.yaml
+++ b/.github/workflows/integration-build-master.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           images: fluentbitdev/fluent-bit
           tags: |
-            raw,x86_64-master-${{ matrix.tag }}
+            raw,x86_64-${{ matrix.tag }}
 
       - name: Build the staging image
         uses: docker/build-push-action@v2
@@ -30,5 +30,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          push: true
-          load: false
+          push: false
+          load: true
+
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "fluentbitdev/fluent-bit:x86_64-${{ matrix.tag }}"

--- a/.github/workflows/integration-build-pr.yaml
+++ b/.github/workflows/integration-build-pr.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           images: fluentbitdev/fluent-bit
           tags: |
-            raw,x86_64-master-${{ env.pr }}
+            raw,x86_64-master-pr-${{ env.pr }}
 
       - name: Build the staging image
         uses: docker/build-push-action@v2
@@ -32,5 +32,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          push: true
-          load: false
+          push: false
+          load: true
+
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "fluentbitdev/fluent-bit:x86_64-master-pr-${{ env.pr }}"

--- a/.github/workflows/integration-run-master.yaml
+++ b/.github/workflows/integration-run-master.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: calyptia/fluent-bit-ci
           path: ci
-      
+
       - name: Download docker image from build artifacts
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
The current integration tests rely on building an image first, uploading as an artifact for the job then triggering another job that downloads and pushes it to DockerHub. This change reverts to using the action that did that: ishworkh/docker-image-artifact-upload.

Testing with the PR label.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
