### PR TITLE
filter_kubernetes: add option kube_token_ttl (#4352)

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -83,6 +83,7 @@ struct flb_kube {
     int dummy_meta;
     int tls_debug;
     int tls_verify;
+    int kube_token_ttl;
     flb_sds_t meta_preload_cache_dir;
 
     /* Configuration proposed through Annotations (boolean) */

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -46,7 +46,6 @@
 #define FLB_KUBE_META_INIT_CONTAINER_STATUSES_KEY_LEN \
     (sizeof(FLB_KUBE_META_INIT_CONTAINER_STATUSES_KEY) - 1)
 #define FLB_KUBE_TOKEN_BUF_SIZE 8192       /* 8KB */
-#define FLB_KUBE_TOKEN_TTL 600             /* 10 minutes */
 
 static int file_to_buffer(const char *path,
                           char **out_buf, size_t *out_size)
@@ -162,17 +161,15 @@ static int get_http_auth_header(struct flb_kube *ctx)
         if (ret == -1) {
             flb_plg_warn(ctx->ins, "failed to run command %s", ctx->kube_token_command);
         }
-        ctx->kube_token_create = time(NULL);
-    } 
+    }
     else {
         ret = file_to_buffer(ctx->token_file, &tk, &tk_size);
         if (ret == -1) {
             flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
         }
-        /* Token from token file will not expire */
-        /* Set the creation time to 0 to aviod refresh */
-        ctx->kube_token_create = 0;
+        flb_plg_info(ctx->ins, " token updated", FLB_KUBE_TOKEN);
     }
+    ctx->kube_token_create = time(NULL);
 
     /* Token */
     if (ctx->token != NULL) {
@@ -211,19 +208,17 @@ static int refresh_token_if_needed(struct flb_kube *ctx)
     int expired = 0;
     int ret;
 
-    if (ctx->kube_token_command != NULL) {
-        if (ctx->kube_token_create > 0) {
-            if (time(NULL) > ctx->kube_token_create + FLB_KUBE_TOKEN_TTL) {
-                expired = FLB_TRUE;
-            }
+    if (ctx->kube_token_create > 0) {
+        if (time(NULL) > ctx->kube_token_create + ctx->kube_token_ttl) {
+            expired = FLB_TRUE;
         }
-        
-        if (expired || ctx->kube_token_create == 0) {
-            ret = get_http_auth_header(ctx);
-            if (ret == -1) {
-                flb_plg_warn(ctx->ins, "failed to set http auth header");
-                return -1;
-            }
+    }
+
+    if (expired || ctx->kube_token_create == 0) {
+        ret = get_http_auth_header(ctx);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to set http auth header");
+            return -1;
         }
     }
 

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -848,9 +848,9 @@ static struct flb_config_map config_map[] = {
      "kubelet port to connect with when using kubelet"
     },
     {
-     FLB_CONFIG_MAP_INT, "kube_token_ttl", "600",
+     FLB_CONFIG_MAP_TIME, "kube_token_ttl", "10m",
      0, FLB_TRUE, offsetof(struct flb_kube, kube_token_ttl),
-     "kubelet token ttl"
+     "kubernetes token ttl, until it is reread from the token file. Default: 10m"
     },
     /*
      * Set TTL for K8s cached metadata 

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -848,7 +848,7 @@ static struct flb_config_map config_map[] = {
      "kubelet port to connect with when using kubelet"
     },
     {
-     FLB_CONFIG_MAP_INT, "kube_token_ttl", "60",
+     FLB_CONFIG_MAP_INT, "kube_token_ttl", "600",
      0, FLB_TRUE, offsetof(struct flb_kube, kube_token_ttl),
      "kubelet token ttl"
     },

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -847,6 +847,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kube, kubelet_port),
      "kubelet port to connect with when using kubelet"
     },
+    {
+     FLB_CONFIG_MAP_INT, "kube_token_ttl", "60",
+     0, FLB_TRUE, offsetof(struct flb_kube, kube_token_ttl),
+     "kubelet token ttl"
+    },
     /*
      * Set TTL for K8s cached metadata 
      */


### PR DESCRIPTION
The option sets the re-read frequency of the token for the
"read serviceaccount file" method and for option Kube_Token_Command. Default is 600 seconds.
Before this change, the token was reloaded only for the Kube_Token_Command with fixed default value 600s.


Signed-off-by: Michael Voelker <novecento@gmx.de>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
