### PR TITLE
Add error strings in the kafka plugin error configuration

### DIFF
--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -61,7 +61,7 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
     ret = rd_kafka_conf_set(ctx->conf, "client.id", "fluent-bit",
                             errstr, sizeof(errstr));
     if (ret != RD_KAFKA_CONF_OK) {
-        flb_plg_error(ctx->ins, "cannot configure client.id");
+        flb_plg_error(ctx->ins, "cannot configure client.id: %s", errstr);
     }
 
     /* Config: Brokers */
@@ -93,8 +93,8 @@ struct flb_kafka *flb_kafka_conf_create(struct flb_output_instance *ins,
             ret = rd_kafka_conf_set(ctx->conf, kv->key + 8, kv->val,
                                     errstr, sizeof(errstr));
             if (ret != RD_KAFKA_CONF_OK) {
-                flb_plg_error(ctx->ins, "cannot configure '%s' property",
-                              kv->key + 8);
+                flb_plg_error(ctx->ins, "cannot configure '%s' property: %s",
+                              kv->key + 8, errstr);
             }
         }
     }


### PR DESCRIPTION

<!-- Provide summary of changes -->

When diagnosing an issue with the librdkafka configuration, we were unable to determine the cause of some issues. Adding this error string to the plugin output was a significant gamechanger to diagnostics.

Debug log new output example:

```
[2021/12/20 20:38:39] [error] [output:kafka:kafka.0] cannot configure 'oauthbearer_token_refresh_cb' property: 'Property "oauthbearer_token_refresh_cb" must be set through dedicated .._set_..() function'
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
