### PR TITLE
workflows: resolve missing version for cleanup

### DIFF
--- a/.github/workflows/pr-closed-docker.yaml
+++ b/.github/workflows/pr-closed-docker.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete image
-        uses: bots-house/ghcr-delete-image-action@v1
+        uses: bots-house/ghcr-delete-image-action@v1.0.1
         with:
           owner: fluent
           name: fluent-bit


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

PR image cleanup action does not follow semantic versioning so this should pin it to a valid version.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
