### PR TITLE
plugins: in_exec: don't eat last character of plugin output

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -69,10 +69,12 @@ static int in_exec_collect(struct flb_input_instance *ins,
     if (ctx->parser) {
         while (fgets(ctx->buf, ctx->buf_size, cmdp) != NULL) {
             str_len = strnlen(ctx->buf, ctx->buf_size);
-            ctx->buf[str_len - 1] = '\0'; /* chomp */
+            if (ctx->buf[str_len - 1] == '\n') {
+                ctx->buf[--str_len] = '\0'; /* chomp */
+            }
 
             flb_time_get(&out_time);
-            parser_ret = flb_parser_do(ctx->parser, ctx->buf, str_len - 1,
+            parser_ret = flb_parser_do(ctx->parser, ctx->buf, str_len,
                                        &out_buf, &out_size, &out_time);
             if (parser_ret >= 0) {
                 if (flb_time_to_double(&out_time) == 0.0) {
@@ -102,7 +104,9 @@ static int in_exec_collect(struct flb_input_instance *ins,
     else {
         while (fgets(ctx->buf, ctx->buf_size, cmdp) != NULL) {
             str_len = strnlen(ctx->buf, ctx->buf_size);
-            ctx->buf[str_len - 1] = '\0'; /* chomp */
+            if (ctx->buf[str_len - 1] == '\n') {
+                ctx->buf[--str_len] = '\0'; /* chomp */
+            }
 
             /* Initialize local msgpack buffer */
             msgpack_sbuffer_init(&mp_sbuf);
@@ -114,9 +118,9 @@ static int in_exec_collect(struct flb_input_instance *ins,
 
             msgpack_pack_str(&mp_pck, 4);
             msgpack_pack_str_body(&mp_pck, "exec", 4);
-            msgpack_pack_str(&mp_pck, str_len - 1);
+            msgpack_pack_str(&mp_pck, str_len);
             msgpack_pack_str_body(&mp_pck,
-                                  ctx->buf, str_len - 1);
+                                  ctx->buf, str_len);
 
             flb_input_chunk_append_raw(ins, NULL, 0,
                                        mp_sbuf.data, mp_sbuf.size);


### PR DESCRIPTION
The plugin works if the execed command outputs a trailing newline,
because in that case that newline is replaced by the clamping \0.
However, when the command does not print a trailing newline, the last
character is overwritten.

This can be tested with:

[INPUT]
     Name          exec
     Tag           exec_adc
     Command       echo -n '{"foo": "bar"}'
     Parser        json
     Interval_Sec  5
     Interval_NSec 0
     Buf_Size      8mb

With "-n" in the Command line, we end up with

[2021/12/01 03:11:44] [error] [input:exec:exec.0] parser returned an error

without this patch.

Fixes: #4493 

Signed-off-by: Robert Schwebel <r.schwebel@pengutronix.de>