### PR TITLE
workflows: support building from branch

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -25,7 +25,8 @@ jobs:
 
   master-build-packages:
     needs: master-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    # TODO: only to test, remove for merge
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@workflows_resolve_master_packaging
     with:
       version: master
       branch: master

--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -28,6 +28,7 @@ jobs:
     uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
     with:
       version: master
+      branch: master
       build_matrix: ${{ needs.master-build-generate-matrix.outputs.build-matrix }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -25,8 +25,7 @@ jobs:
 
   master-build-packages:
     needs: master-build-generate-matrix
-    # TODO: only to test, remove for merge
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@workflows_resolve_master_packaging
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
     with:
       version: master
       branch: master

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -16,6 +16,10 @@ on:
         description: The Github environment to run this workflow on.
         type: string
         required: false
+      branch:
+        description: The optional source code branch to use for building against.
+        type: string
+        required: false
     secrets:
       token:
         description: The Github token or similar to authenticate with.
@@ -61,9 +65,12 @@ jobs:
 
       - name: Build the ${{ matrix.distro }} artifacts
         run: |
-          ./build.sh -v "${{ inputs.version }}" -d "${{ matrix.distro }}"
+          ./build.sh
         env:
+          FLB_VERSION: ${{ inputs.version }}
+          FLB_DISTRO: ${{ matrix.distro }}
           FLB_OUT_DIR: staging
+          FLB_BRANCH: ${{ inputs.branch }}
         working-directory: packaging
 
       - name: Upload the ${{ matrix.distro }} artifacts
@@ -90,12 +97,13 @@ jobs:
                   exit 1
               fi
           fi
+          echo "$TARGET"
           echo ::set-output name=echo ::set-output name=target::$TARGET
         env:
           DISTRO: ${{ matrix.distro }}
         shell: bash
 
-      - name: Push packages to S3
+      - name: Push ${{ steps.get-target-info.outputs.target }} packages to S3
         # Only upload for staging
         if: ${{ inputs.environment == 'staging' }}
         # Make sure not to do a --delete on sync as it will remove the other architecture

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: packages-${{ inputs.version }}-${{ steps.formatted_distro.outputs.replaced }}
-          path: packaging/packages/staging/
+          path: packaging/packages/
           if-no-files-found: error
 
       - name: Retrieve target info for repo creation

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -103,7 +103,7 @@ jobs:
           DISTRO: ${{ matrix.distro }}
         shell: bash
 
-      - name: Push ${{ steps.get-target-info.outputs.target }} packages to S3
+      - name: Push packages to S3
         # Only upload for staging
         if: ${{ inputs.environment == 'staging' }}
         # Make sure not to do a --delete on sync as it will remove the other architecture

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -81,7 +81,7 @@ jobs:
             echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
             echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8",'
             echo '"debian/stretch", "debian/stretch.arm64v8", "debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
-            echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8"'
+            echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
             echo '"raspbian/buster", "raspbian/bullseye"'
             echo ']}'
           ) | jq -c .)


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

The master build needs to set the branch to build from so added support for this.
Resolves failure seen here: https://github.com/fluent/fluent-bit/runs/4596148061?check_suite_focus=true

Due to called workflows not supporting calling by branch, temporarily fixed it to the PR branch and invoked here: https://github.com/fluent/fluent-bit/runs/4596963860?check_suite_focus=true

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
