### PR TITLE
network: prefer ipv4 DNS results option

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -189,6 +189,7 @@ struct flb_config {
     /* DNS */
     char *dns_mode;
     char *dns_resolver;
+    int   dns_prefer_ipv4;
 
     /* Chunk I/O Buffering */
     void *cio;
@@ -294,6 +295,7 @@ enum conf_type {
 /* DNS */
 #define FLB_CONF_DNS_MODE              "dns.mode"
 #define FLB_CONF_DNS_RESOLVER          "dns.resolver"
+#define FLB_CONF_DNS_PREFER_IPV4       "dns.prefer_ipv4"
 
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -49,8 +49,11 @@ struct flb_net_setup {
     /* dns mode : TCP or UDP */
     char *dns_mode;
 
-    /* dns reolver : LEGACY or ASYNC */
+    /* dns resolver : LEGACY or ASYNC */
     char *dns_resolver;
+
+    /* prioritize ipv4 results when trying to establish a connection*/
+    int   dns_prefer_ipv4;
 };
 
 /* Defines a host service and it properties */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -115,6 +115,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, dns_resolver)},
 
+    {FLB_CONF_DNS_PREFER_IPV4,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, dns_prefer_ipv4)},
+
     /* Storage */
     {FLB_CONF_STORAGE_PATH,
      FLB_CONF_TYPE_STR,

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1215,6 +1215,8 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         return -1;
     }
 
+    sorted_res = res;
+
     if (u_conn->u->net.dns_prefer_ipv4) {
         sorted_res = flb_net_sort_addrinfo_list(res, AF_INET);
 
@@ -1230,15 +1232,13 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
 
             return -1;
         }
-
-        res = sorted_res;
     }
 
     /*
      * Try to connect: on this iteration we try to connect to the first
      * available address.
      */
-    for (rp = res; rp != NULL; rp = rp->ai_next) {
+    for (rp = sorted_res; rp != NULL; rp = rp->ai_next) {
         if (u_conn->net_error > 0) {
             if (u_conn->net_error == ETIMEDOUT) {
                 flb_warn("[net] timeout detected between connection attempts");

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -104,6 +104,7 @@ void flb_net_setup_init(struct flb_net_setup *net)
 {
     net->dns_mode = NULL;
     net->dns_resolver = NULL;
+    net->dns_prefer_ipv4 = FLB_FALSE;
     net->keepalive = FLB_TRUE;
     net->keepalive_idle_timeout = 30;
     net->keepalive_max_recycle = 0;
@@ -557,6 +558,67 @@ static void flb_net_free_translated_addrinfo(struct addrinfo *input)
             flb_free(current_record);
         }
     }
+}
+
+static void flb_net_append_addrinfo_entry(struct addrinfo **head,
+                                          struct addrinfo **tail,
+                                          struct addrinfo  *entry)
+{
+    if (*head == NULL) {
+        *head = entry;
+    }
+    else {
+        (*tail)->ai_next = entry;
+    }
+
+    *tail = entry;
+}
+
+static struct addrinfo *flb_net_sort_addrinfo_list(struct ares_addrinfo *input,
+                                                   int preferred_family)
+{
+    struct addrinfo *preferred_results_head;
+    struct addrinfo *remainder_results_head;
+    struct addrinfo *preferred_results_tail;
+    struct addrinfo *remainder_results_tail;
+    struct addrinfo *current_record;
+    struct addrinfo *next_record;
+
+    remainder_results_head = NULL;
+    preferred_results_head = NULL;
+    remainder_results_tail = NULL;
+    preferred_results_tail = NULL;
+    current_record = NULL;
+    next_record = NULL;
+
+    for (current_record = input ;
+         current_record != NULL ;
+         current_record = next_record) {
+        next_record = current_record->ai_next;
+        current_record->ai_next = NULL;
+
+        if (preferred_family == current_record->ai_family) {
+            flb_net_append_addrinfo_entry(&preferred_results_head,
+                                          &preferred_results_tail,
+                                          current_record);
+        }
+        else
+        {
+            flb_net_append_addrinfo_entry(&remainder_results_head,
+                                          &remainder_results_tail,
+                                          current_record);
+        }
+    }
+
+    if (preferred_results_tail != NULL) {
+        preferred_results_tail->ai_next = remainder_results_head;
+    }
+
+    if (preferred_results_head == NULL) {
+        return remainder_results_head;
+    }
+
+    return preferred_results_head;
 }
 
 static struct addrinfo *flb_net_translate_ares_addrinfo(struct ares_addrinfo *input)
@@ -1091,7 +1153,7 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
     char _port[6];
     char address[41];
     struct addrinfo hints;
-    struct addrinfo *res, *rp;
+    struct addrinfo *sorted_res, *res, *rp;
 
     if (is_async == FLB_TRUE && !u_conn) {
         flb_error("[net] invalid async mode with not set upstream connection");
@@ -1151,6 +1213,25 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         }
 
         return -1;
+    }
+
+    if (u_conn->u->net.dns_prefer_ipv4) {
+        sorted_res = flb_net_sort_addrinfo_list(res, AF_INET);
+
+        if (sorted_res == NULL) {
+            flb_debug("[net] error sorting getaddrinfo results");
+
+            if (use_async_dns) {
+                flb_net_free_translated_addrinfo(res);
+            }
+            else {
+                freeaddrinfo(res);
+            }
+
+            return -1;
+        }
+
+        res = sorted_res;
     }
 
     /*

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -574,7 +574,7 @@ static void flb_net_append_addrinfo_entry(struct addrinfo **head,
     *tail = entry;
 }
 
-static struct addrinfo *flb_net_sort_addrinfo_list(struct ares_addrinfo *input,
+static struct addrinfo *flb_net_sort_addrinfo_list(struct addrinfo *input,
                                                    int preferred_family)
 {
     struct addrinfo *preferred_results_head;

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -47,6 +47,12 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "net.dns.prefer_ipv4", "false",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, dns_prefer_ipv4),
+     "Prioritize IPv4 DNS results when trying to establish a connection"
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
      "Enable or disable Keepalive support"
@@ -121,6 +127,12 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
         if (config->dns_resolver != NULL) {
             if (strcmp(upstream_net[config_index].name, "net.dns.resolver") == 0) {
                 upstream_net[config_index].def_value = config->dns_resolver;
+            }
+        }
+        if (config->dns_prefer_ipv4) {
+            if (strcmp(upstream_net[config_index].name,
+                       "net.dns.prefer_ipv4") == 0) {
+                upstream_net[config_index].def_value = "true";
             }
         }
     }


### PR DESCRIPTION
This PR adds a new configuration option that can be specified either at service level or output plugin level meant to prioritize IPv4 DNS results when trying to establish a connection.

When used at `SERVICE` level it will set the default system wide value that will be inherited by any output plugins (unless they actively override it).

Usage examples : 

```
[SERVICE]
    Dns.prefer_ipv4 on
```

Plugin level usage example :

```
[OUTPUT]
    Match                     *
    Name                      tcp
    Retry_Limit               false
    Host                      problematic_host   
    Net.dns.prefer_ipv4       on
```