### PR TITLE
network: prefer ipv4 DNS results option

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -189,6 +189,7 @@ struct flb_config {
     /* DNS */
     char *dns_mode;
     char *dns_resolver;
+    int   dns_prefer_ipv4;
 
     /* Chunk I/O Buffering */
     void *cio;
@@ -294,6 +295,7 @@ enum conf_type {
 /* DNS */
 #define FLB_CONF_DNS_MODE              "dns.mode"
 #define FLB_CONF_DNS_RESOLVER          "dns.resolver"
+#define FLB_CONF_DNS_PREFER_IPV4       "dns.prefer_ipv4"
 
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -49,8 +49,11 @@ struct flb_net_setup {
     /* dns mode : TCP or UDP */
     char *dns_mode;
 
-    /* dns reolver : LEGACY or ASYNC */
+    /* dns resolver : LEGACY or ASYNC */
     char *dns_resolver;
+
+    /* prioritize ipv4 results when trying to establish a connection*/
+    int   dns_prefer_ipv4;
 };
 
 /* Defines a host service and it properties */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -115,6 +115,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, dns_resolver)},
 
+    {FLB_CONF_DNS_PREFER_IPV4,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, dns_prefer_ipv4)},
+
     /* Storage */
     {FLB_CONF_STORAGE_PATH,
      FLB_CONF_TYPE_STR,

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -47,6 +47,12 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "net.dns.prefer_ipv4", "false",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, dns_prefer_ipv4),
+     "Prioritize IPv4 DNS results when trying to establish a connection"
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
      "Enable or disable Keepalive support"
@@ -121,6 +127,12 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
         if (config->dns_resolver != NULL) {
             if (strcmp(upstream_net[config_index].name, "net.dns.resolver") == 0) {
                 upstream_net[config_index].def_value = config->dns_resolver;
+            }
+        }
+        if (config->dns_prefer_ipv4) {
+            if (strcmp(upstream_net[config_index].name,
+                       "net.dns.prefer_ipv4") == 0) {
+                upstream_net[config_index].def_value = "true";
             }
         }
     }


### PR DESCRIPTION
This PR adds a new configuration option that can be specified either at service level or output plugin level meant to prioritize IPv4 DNS results when trying to establish a connection.

When used at `SERVICE` level it will set the default system wide value that will be inherited by any output plugins (unless they actively override it).

Usage examples : 

```
[SERVICE]
    Dns.prefer_ipv4 on
```

Plugin level usage example :

```
[OUTPUT]
    Match                     *
    Name                      tcp
    Retry_Limit               false
    Host                      problematic_host   
    Net.dns.prefer_ipv4       on
```