### PR TITLE
filter: allow case-insensitive plugin name

### DIFF
--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -316,7 +316,7 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
 
     mk_list_foreach(head, &config->filter_plugins) {
         plugin = mk_list_entry(head, struct flb_filter_plugin, _head);
-        if (strcmp(plugin->name, filter) == 0) {
+        if (strcasecmp(plugin->name, filter) == 0) {
             break;
         }
         plugin = NULL;

--- a/tests/runtime/filter_stdout.c
+++ b/tests/runtime/filter_stdout.c
@@ -7,12 +7,35 @@
 
 /* Test functions */
 void flb_test_filter_stdout_json_multiple(void);
+void flb_test_filter_stdout_case_insensitive(void);
 
 /* Test list */
 TEST_LIST = {
     {"json_multiple", flb_test_filter_stdout_json_multiple },
+    {"case_insensitive_name", flb_test_filter_stdout_case_insensitive},
     {NULL, NULL}
 };
+
+/* 
+ * This test case is to check if fluent-bit allows case-insensitive plugin name.
+ * This test is not unique to filter_stdout, but we test here :) ,
+ */
+
+void flb_test_filter_stdout_case_insensitive(void)
+{
+    int filter_ffd;
+    char filter_name[] = "stDoUt";
+    flb_ctx_t *ctx;
+
+    ctx = flb_create();
+
+    filter_ffd = flb_filter(ctx, (char *) filter_name, NULL);
+    if(!TEST_CHECK(filter_ffd >= 0)) {
+        TEST_MSG("%s should be valid\n", filter_name);
+    }
+
+    flb_destroy(ctx);
+}
 
 void flb_test_filter_stdout_json_multiple(void)
 {


### PR DESCRIPTION
Fixes #4509 

I added test case to filter_stdout testcase.
It is not specific for filter_stdout, but it easy to add test case...

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration file

```
[INPUT]
    Name mEm

[FILTER]
    Name stDOut
    Match *

[OUTPUT]
    Name nULl
    Match *
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/22 16:40:30] [ info] [engine] started (pid=46957)
[2021/12/22 16:40:30] [ info] [storage] version=1.1.5, initializing...
[2021/12/22 16:40:30] [ info] [storage] in-memory
[2021/12/22 16:40:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/22 16:40:30] [ info] [cmetrics] version=0.2.2
[2021/12/22 16:40:30] [ info] [sp] stream processor started
[0] mem.0: [1640158831.030324377, {"Mem.total"=>8146052, "Mem.used"=>3911268, "Mem.free"=>4234784, "Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356}]
[0] mem.0: [1640158832.030757389, {"Mem.total"=>8146052, "Mem.used"=>3911276, "Mem.free"=>4234776, "Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356}]
^C[2021/12/22 16:40:32] [engine] caught signal (SIGINT)
[2021/12/22 16:40:32] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/22 16:40:33] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==46961== Memcheck, a memory error detector
==46961== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==46961== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==46961== Command: bin/fluent-bit -c a.conf
==46961== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/22 16:40:59] [ info] [engine] started (pid=46961)
[2021/12/22 16:40:59] [ info] [storage] version=1.1.5, initializing...
[2021/12/22 16:40:59] [ info] [storage] in-memory
[2021/12/22 16:40:59] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/22 16:40:59] [ info] [cmetrics] version=0.2.2
[2021/12/22 16:40:59] [ info] [sp] stream processor started
[0] mem.0: [1640158860.042333559, {"Mem.total"=>8146052, "Mem.used"=>3972780, "Mem.free"=>4173272, "Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356}]
^C[2021/12/22 16:41:00] [engine] caught signal (SIGINT)
==46961== Warning: client switching stacks?  SP change: 0x57e5958 --> 0x4c79e10
==46961==          to suppress, use: --max-stackframe=11975496 or greater
==46961== Warning: client switching stacks?  SP change: 0x4c79db8 --> 0x57e5958
==46961==          to suppress, use: --max-stackframe=11975584 or greater
==46961== Warning: client switching stacks?  SP change: 0x57e5958 --> 0x4c79db8
==46961==          to suppress, use: --max-stackframe=11975584 or greater
==46961==          further instances of this message will not be shown.
[2021/12/22 16:41:00] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/22 16:41:01] [ info] [engine] service has stopped (0 pending tasks)
==46961== 
==46961== HEAP SUMMARY:
==46961==     in use at exit: 0 bytes in 0 blocks
==46961==   total heap usage: 1,059 allocs, 1,059 frees, 540,570 bytes allocated
==46961== 
==46961== All heap blocks were freed -- no leaks are possible
==46961== 
==46961== For lists of detected and suppressed errors, rerun with: -s
==46961== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
