### PR TITLE
out_forward: add missing ra check(#4511)

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -670,7 +670,8 @@ static int config_set_properties(struct flb_upstream_node *node,
     }
 
 #ifdef FLB_HAVE_RECORD_ACCESSOR
-    if (fc->compress != COMPRESS_NONE && fc->ra_static == FLB_FALSE) {
+    if (fc->compress != COMPRESS_NONE &&
+        (fc->ra_tag && fc->ra_static == FLB_FALSE) ) {
         flb_plg_error(ctx->ins, "compress mode %s is incompatible with dynamic "
                       "tags", tmp);
         return -1;


### PR DESCRIPTION
Fixes #4511

Currently, out_forward only checks if `fc->ra_static == FLB_FALSE` on init.
The value is 0 as a default and it means `FLB_FALSE`.
The value should be checked when user sets `tag` property since out_forward creates record accessor instance by the property.

This patch is to check if the record accessor instance is created or not.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Configuration

```
fluent-bit -i mem -o forward -p compress=gzip
```

## Debug output

There is no `[2021/12/23 08:44:42] [error] [output:forward:forward.0] compress mode gzip is incompatible with dynamic tags` log.

```
$ bin/fluent-bit -i mem -o forward -p compress=gzip 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/23 08:43:42] [ info] [engine] started (pid=71532)
[2021/12/23 08:43:42] [ info] [storage] version=1.1.5, initializing...
[2021/12/23 08:43:42] [ info] [storage] in-memory
[2021/12/23 08:43:42] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/23 08:43:42] [ info] [cmetrics] version=0.2.2
[2021/12/23 08:43:42] [ info] [sp] stream processor started
[2021/12/23 08:43:46] [error] [output:forward:forward.0] no upstream connections available
[2021/12/23 08:43:46] [ warn] [engine] failed to flush chunk '71532-1640216622.775123467.flb', retry in 7 seconds: task_id=0, input=mem.0 > output=forward.0 (out_id=0)
^C[2021/12/23 08:43:47] [engine] caught signal (SIGINT)
[2021/12/23 08:43:47] [error] [output:forward:forward.0] no upstream connections available
[2021/12/23 08:43:47] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/23 08:43:47] [ info] [task] mem/mem.0 has 2 pending task(s):
[2021/12/23 08:43:47] [ info] [task]   task_id=0 still running on route(s): forward/forward.0 
[2021/12/23 08:43:47] [ info] [task]   task_id=1 still running on route(s): forward/forward.0 
[2021/12/23 08:43:51] [ info] [task] mem/mem.0 has 2 pending task(s):
[2021/12/23 08:43:51] [ info] [task]   task_id=0 still running on route(s): forward/forward.0 
taka@locals:~/git/fluent-bit/build$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
