### PR TITLE
workflows: resolve staging test failures

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -14,6 +14,7 @@ general:
     - CVE-2020-1751
     - CVE-2020-1752
     - CVE-2021-3326
+    - CVE-2020-16156
     - CVE-2021-33560
     - CVE-2021-43618
   bestPracticeViolations:

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -98,7 +98,7 @@ jobs:
               fi
           fi
           echo "$TARGET"
-          echo ::set-output name=echo ::set-output name=target::$TARGET
+          echo ::set-output name=target::$TARGET
         env:
           DISTRO: ${{ matrix.distro }}
         shell: bash
@@ -108,6 +108,10 @@ jobs:
         if: ${{ inputs.environment == 'staging' }}
         # Make sure not to do a --delete on sync as it will remove the other architecture
         run: |
+          if [ -z "${{ steps.get-target-info.outputs.target }}" ]; then
+            echo "Invalid (empty) target defined"
+            exit 1
+          fi
           if [ -n "${AWS_S3_ENDPOINT}" ]; then
             ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
           fi
@@ -119,8 +123,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}
           AWS_S3_BUCKET: ${{ secrets.bucket }}
-          # To use with Minio locally (or update to whatever endpoint you want)
-          # AWS_S3_ENDPOINT: http://localhost:9000
 
   call-build-packages-repo:
     name: Create repo metadata in S3

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ amazonlinux, centos7, centos8, debian10, debian11, ubuntu1804, ubuntu2004 ]
+        distro: [ amazonlinux2, centos7, centos8, debian10, debian11, ubuntu1804, ubuntu2004 ]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -4,10 +4,13 @@ ARG STAGING_BASE=dokken/centos-8
 FROM dokken/centos-8 as official-install
 ARG RELEASE_URL
 RUN rpm --import $RELEASE_URL/fluentbit.key
-RUN echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/centos/\$releasever/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo
-RUN yum update -y && yum install -y td-agent-bit
-RUN systemctl enable td-agent-bit
 
+# No official packages available yet
+# RUN echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/centos/\$releasever/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo
+# RUN yum update -y && yum install -y td-agent-bit
+# RUN systemctl enable td-agent-bit
+
+ENV SKIP_TEST=yes
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 
@@ -23,6 +26,7 @@ RUN wget "$AWS_URL/centos.repo" -O /etc/yum.repos.d/staging.repo
 RUN yum update -y && yum install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 
+ENV SKIP_TEST=no
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 

--- a/packaging/testing/smoke/packages/Dockerfile.debian11
+++ b/packaging/testing/smoke/packages/Dockerfile.debian11
@@ -4,10 +4,13 @@ ARG STAGING_BASE=dokken/debian-11
 FROM dokken/debian-11 as official-install
 ARG RELEASE_URL
 RUN wget -qO - $RELEASE_URL/fluentbit.key | apt-key add -
-RUN echo "deb $RELEASE_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y td-agent-bit
-RUN systemctl enable td-agent-bit
 
+# No official packages yet
+# RUN echo "deb $RELEASE_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
+# RUN apt-get update && apt-get install -y td-agent-bit
+# RUN systemctl enable td-agent-bit
+
+ENV SKIP_TEST=yes
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 
@@ -23,6 +26,7 @@ RUN echo "deb $AWS_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 
+ENV SKIP_TEST=no
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 

--- a/packaging/testing/smoke/packages/run-package-tests.sh
+++ b/packaging/testing/smoke/packages/run-package-tests.sh
@@ -53,7 +53,7 @@ do
         --name "$CONTAINER_NAME" \
         "$CONTAINER_NAME"
 
-    docker exec -it "$CONTAINER_NAME" /test.sh
+    docker exec -t "$CONTAINER_NAME" /test.sh
 
     docker rm -f "$CONTAINER_NAME"
 done

--- a/packaging/testing/smoke/packages/test.sh
+++ b/packaging/testing/smoke/packages/test.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eux
 
+if [ "$SKIP_TEST" = "yes" ]; then
+    echo "Skipping test"
+    exit 0
+fi
+
 echo "Check package installed"
 rpm -q td-agent-bit || dpkg -l td-agent-bit
 

--- a/packaging/testing/smoke/packages/test.sh
+++ b/packaging/testing/smoke/packages/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux
+set -ex
 
 if [ "$SKIP_TEST" = "yes" ]; then
     echo "Skipping test"


### PR DESCRIPTION
Fixes an issue with the staging repo creation.
Skip tests for official package installation on unsupported targets, i.e. CentOS 8 & Debian 11, as the test correctly fails when it cannot install a non-existent package!
Fix test usage of non-TTY.
Ignore CVE in Debian 10 images for now to allow staging builds to complete. Will be reviewed on #4515 anyway.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Local testing verified as much as possible.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
