### PR TITLE
mpack: Implement lua <-> messagepack conversion using mpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ option(FLB_FILTER_TYPE_CONVERTER "Enable type converter filter"     Yes)
 option(FLB_FILTER_MULTILINE   "Enable multiline filter"             Yes)
 option(FLB_FILTER_NEST        "Enable nest filter"                  Yes)
 option(FLB_FILTER_LUA         "Enable Lua scripting filter"         Yes)
+option(FLB_FILTER_LUA_USE_MPACK  "Enable mpack on the lua filter"   Yes)
 option(FLB_FILTER_RECORD_MODIFIER "Enable record_modifier filter"   Yes)
 option(FLB_FILTER_TENSORFLOW  "Enable tensorflow filter"             No)
 option(FLB_FILTER_GEOIP2      "Enable geoip2 filter"                Yes)
@@ -382,6 +383,7 @@ option(MSGPACK_BUILD_EXAMPLES         OFF)
 add_subdirectory(${FLB_PATH_LIB_MSGPACK} EXCLUDE_FROM_ALL)
 
 # MPack
+add_definitions(-DMPACK_EXTENSIONS=1)
 add_subdirectory(${FLB_PATH_LIB_MPACK} EXCLUDE_FROM_ALL)
 
 # Miniz (zip)

--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -50,10 +50,15 @@ struct flb_lua_l2c_config {
 
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm);
 int flb_lua_is_valid_func(lua_State *l, flb_sds_t func);
+int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader);
 void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o);
 void flb_lua_tomsgpack(lua_State *l,
                        msgpack_packer *pck,
                        int index,
                        struct flb_lua_l2c_config *l2cc);
+void flb_lua_tompack(lua_State *l,
+                     mpack_writer_t *writer,
+                     int index,
+                     struct flb_lua_l2c_config *l2cc);
 
 #endif

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -26,6 +26,7 @@
 
 #include <time.h>
 #include <msgpack.h>
+#include <mpack/mpack.h>
 struct flb_time {
     struct timespec tm;
 };
@@ -80,8 +81,10 @@ int flb_time_add(struct flb_time *base, struct flb_time *duration,
                  struct flb_time *result);
 int flb_time_diff(struct flb_time *time1,
                   struct flb_time *time0, struct flb_time *result);
+int flb_time_append_to_mpack(mpack_writer_t *writer, struct flb_time *tm, int fmt);
 int flb_time_append_to_msgpack(struct flb_time *tm, msgpack_packer *pk, int fmt);
 int flb_time_msgpack_to_time(struct flb_time *time, msgpack_object *obj);
+int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader);
 int flb_time_pop_from_msgpack(struct flb_time *time, msgpack_unpacked *upk,
                               msgpack_object **map);
 long flb_time_tz_offset_to_second();

--- a/plugins/filter_lua/CMakeLists.txt
+++ b/plugins/filter_lua/CMakeLists.txt
@@ -7,3 +7,7 @@ if(MSVC)
 else()
   FLB_PLUGIN(filter_lua "${src}" "m")
 endif()
+
+if(FLB_FILTER_LUA_USE_MPACK)
+    add_definitions(-DFLB_FILTER_LUA_USE_MPACK)
+endif()

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -190,5 +190,6 @@ void lua_config_destroy(struct lua_filter *lf)
         }
     }
 
+    flb_sds_destroy(lf->packbuf);
     flb_free(lf);
 }

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -38,6 +38,7 @@ struct lua_filter {
     struct flb_lua_l2c_config l2cc;   /* lua -> C config */
     struct flb_luajit *lua;           /* state context   */
     struct flb_filter_instance *ins;  /* filter instance */
+    flb_sds_t packbuf;                /* dynamic buffer used for mpack write */
 };
 
 struct lua_filter *lua_config_create(struct flb_filter_instance *ins,

--- a/src/flb_lua.c
+++ b/src/flb_lua.c
@@ -19,9 +19,12 @@
  */
 
 #include "lua.h"
+#include "mpack/mpack.h"
+#include "msgpack/unpack.h"
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_lua.h>
+#include <stdint.h>
 
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm)
 {
@@ -49,6 +52,72 @@ int flb_lua_is_valid_func(lua_State *lua, flb_sds_t func)
     lua_pop(lua, -1); /* discard return value of isfunction */
 
     return ret;
+}
+
+int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader)
+{
+    int ret = 0;
+    mpack_tag_t tag;
+    uint32_t length;
+    uint32_t i;
+
+    tag = mpack_read_tag(reader);
+    switch (mpack_tag_type(&tag)) {
+        case mpack_type_nil:
+            lua_pushnil(l);
+            break;
+        case mpack_type_bool:
+            lua_pushboolean(l, mpack_tag_bool_value(&tag));
+            break;
+        case mpack_type_int:
+            lua_pushinteger(l, mpack_tag_int_value(&tag));
+            break;
+        case mpack_type_uint:
+            lua_pushinteger(l, mpack_tag_uint_value(&tag));
+            break;
+        case mpack_type_float:
+            lua_pushnumber(l, mpack_tag_float_value(&tag));
+            break;
+        case mpack_type_double:
+            lua_pushnumber(l, mpack_tag_double_value(&tag));
+            break;
+        case mpack_type_str:
+        case mpack_type_bin:
+        case mpack_type_ext:
+            length = mpack_tag_bytes(&tag);
+            lua_pushlstring(l, reader->data, length);
+            reader->data += length;
+            break;
+        case mpack_type_array:
+            length = mpack_tag_array_count(&tag);
+            lua_createtable(l, length, 0);
+            for (i = 0; i < length; i++) {
+                ret = flb_lua_pushmpack(l, reader);
+                if (ret) {
+                    return ret;
+                }
+                lua_rawseti(l, -2, i+1);
+            }
+            break;
+        case mpack_type_map:
+            length = mpack_tag_map_count(&tag);
+            lua_createtable(l, length, 0);
+            for (i = 0; i < length; i++) {
+                ret = flb_lua_pushmpack(l, reader);
+                if (ret) {
+                    return ret;
+                }
+                ret = flb_lua_pushmpack(l, reader);
+                if (ret) {
+                    return ret;
+                }
+                lua_settable(l, -3);
+            }
+            break;
+        default:
+            return -1;
+    }
+    return 0;
 }
 
 void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o)
@@ -226,6 +295,26 @@ static void lua_toarray(lua_State *l,
     }
 }
 
+static void lua_toarray_mpack(lua_State *l,
+                              mpack_writer_t *writer,
+                              int index,
+                              struct flb_lua_l2c_config *l2cc)
+{
+    int len;
+    int i;
+
+    lua_pushnumber(l, (lua_Number)lua_objlen(l, -1)); // lua_len
+    len = (int)lua_tointeger(l, -1);
+    lua_pop(l, 1);
+
+    mpack_write_tag(writer, mpack_tag_array(len));
+    for (i = 1; i <= len; i++) {
+        lua_rawgeti(l, -1, i);
+        flb_lua_tompack(l, writer, 0, l2cc);
+        lua_pop(l, 1);
+    }
+}
+
 static void try_to_convert_data_type(lua_State *l,
                                      msgpack_packer *pck,
                                      int index,
@@ -269,6 +358,141 @@ static void try_to_convert_data_type(lua_State *l,
     /* not matched */
     flb_lua_tomsgpack(l, pck, -1, l2cc);
     flb_lua_tomsgpack(l, pck, 0, l2cc);
+}
+
+static void try_to_convert_data_type_mpack(lua_State *l,
+                                           mpack_writer_t *writer,
+                                           int index,
+                                           struct flb_lua_l2c_config *l2cc)
+{
+    size_t   len;
+    const char *tmp = NULL;
+
+    struct mk_list  *tmp_list = NULL;
+    struct mk_list  *head     = NULL;
+    struct flb_lua_l2c_type *l2c      = NULL;
+
+    // convert to int
+    if ((lua_type(l, -2) == LUA_TSTRING)
+        && lua_type(l, -1) == LUA_TNUMBER){
+        tmp = lua_tolstring(l, -2, &len);
+
+        mk_list_foreach_safe(head, tmp_list, &l2cc->l2c_types) {
+            l2c = mk_list_entry(head, struct flb_lua_l2c_type, _head);
+            if (!strncmp(l2c->key, tmp, len) && l2c->type == FLB_LUA_L2C_TYPE_INT) {
+                flb_lua_tompack(l, writer, -1, l2cc);
+                mpack_write_int(writer, (int64_t)lua_tonumber(l, -1));
+                return;
+            }
+        }
+    }
+    else if ((lua_type(l, -2) == LUA_TSTRING)
+             && lua_type(l, -1) == LUA_TTABLE){
+        tmp = lua_tolstring(l, -2, &len);
+
+        mk_list_foreach_safe(head, tmp_list, &l2cc->l2c_types) {
+            l2c = mk_list_entry(head, struct flb_lua_l2c_type, _head);
+            if (!strncmp(l2c->key, tmp, len) && l2c->type == FLB_LUA_L2C_TYPE_ARRAY) {
+                flb_lua_tompack(l, writer, -1, l2cc);
+                lua_toarray_mpack(l, writer, 0, l2cc);
+                return;
+            }
+        }
+    }
+
+    /* not matched */
+    flb_lua_tompack(l, writer, -1, l2cc);
+    flb_lua_tompack(l, writer, 0, l2cc);
+}
+
+void flb_lua_tompack(lua_State *l,
+                     mpack_writer_t *writer,
+                     int index,
+                     struct flb_lua_l2c_config *l2cc)
+{
+    int len;
+    int i;
+
+    switch (lua_type(l, -1 + index)) {
+        case LUA_TSTRING:
+            {
+                const char *str;
+                size_t len;
+
+                str = lua_tolstring(l, -1 + index, &len);
+
+                mpack_write_str(writer, str, len);
+            }
+            break;
+        case LUA_TNUMBER:
+            {
+                if (lua_isinteger(l, -1 + index)) {
+                    int64_t num = lua_tointeger(l, -1 + index);
+                    mpack_write_int(writer, num);
+                }
+                else {
+                    double num = lua_tonumber(l, -1 + index);
+                    mpack_write_double(writer, num);
+                }
+            }
+            break;
+        case LUA_TBOOLEAN:
+            if (lua_toboolean(l, -1 + index))
+                mpack_write_true(writer);
+            else
+                mpack_write_false(writer);
+            break;
+        case LUA_TTABLE:
+            len = lua_arraylength(l);
+            if (len > 0) {
+                mpack_write_tag(writer, mpack_tag_array(len));
+                for (i = 1; i <= len; i++) {
+                    lua_rawgeti(l, -1, i);
+                    flb_lua_tompack(l, writer, 0, l2cc);
+                    lua_pop(l, 1);
+                }
+            } else
+            {
+                len = 0;
+                lua_pushnil(l);
+                while (lua_next(l, -2) != 0) {
+                    lua_pop(l, 1);
+                    len++;
+                }
+                mpack_write_tag(writer, mpack_tag_map(len));
+
+                lua_pushnil(l);
+
+                if (l2cc->l2c_types_num > 0) {
+                    /* type conversion */
+                    while (lua_next(l, -2) != 0) {
+                        try_to_convert_data_type_mpack(l, writer, index, l2cc);
+                        lua_pop(l, 1);
+                    }
+                } else {
+                    while (lua_next(l, -2) != 0) {
+                        flb_lua_tompack(l, writer, -1, l2cc);
+                        flb_lua_tompack(l, writer, 0, l2cc);
+                        lua_pop(l, 1);
+                    }
+                }
+            }
+            break;
+        case LUA_TNIL:
+            mpack_write_nil(writer);
+            break;
+
+         case LUA_TLIGHTUSERDATA:
+            if (lua_touserdata(l, -1 + index) == NULL) {
+                mpack_write_nil(writer);
+                break;
+            }
+         case LUA_TFUNCTION:
+         case LUA_TUSERDATA:
+         case LUA_TTHREAD:
+           /* cannot serialize */
+           break;
+    }
 }
 
 void flb_lua_tomsgpack(lua_State *l,

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -18,11 +18,14 @@
  *  limitations under the License.
  */
 
+#include "cmetrics/lib/mpack/src/mpack/mpack.h"
 #include <msgpack.h>
+#include <mpack/mpack.h>
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_time.h>
+#include <stdint.h>
 #ifdef FLB_HAVE_CLOCK_GET_TIME
 #  include <mach/clock.h>
 #  include <mach/mach.h>
@@ -142,6 +145,54 @@ int flb_time_diff(struct flb_time *time1,
     return 0;
 }
 
+int flb_time_append_to_mpack(mpack_writer_t *writer, struct flb_time *tm, int fmt)
+{
+    int ret = 0;
+    struct flb_time l_time;
+    char ext_data[8];
+    uint32_t tmp;
+
+    if (!is_valid_format(fmt)) {
+#ifdef FLB_TIME_FORCE_FMT_INT
+        fmt = FLB_TIME_ETFMT_INT;
+#else
+        fmt = FLB_TIME_ETFMT_V1_FIXEXT;
+#endif
+    }
+
+    if (tm == NULL) {
+      if (fmt == FLB_TIME_ETFMT_INT) {
+         l_time.tm.tv_sec = time(NULL);
+      }
+      else {
+        _flb_time_get(&l_time);
+      }
+      tm = &l_time;
+    }
+
+    switch(fmt) {
+    case FLB_TIME_ETFMT_INT:
+        mpack_write_uint(writer, tm->tm.tv_sec);
+        break;
+
+    case FLB_TIME_ETFMT_V0:
+    case FLB_TIME_ETFMT_V1_EXT:
+        /* We can't set with msgpack-c !! */
+        /* see pack_template.h and msgpack_pack_inline_func(_ext) */
+    case FLB_TIME_ETFMT_V1_FIXEXT:
+        tmp = htonl((uint32_t)tm->tm.tv_sec); /* second from epoch */
+        memcpy(&ext_data, &tmp, 4);
+        tmp = htonl((uint32_t)tm->tm.tv_nsec);/* nanosecond */
+        memcpy(&ext_data[4], &tmp, 4);
+        mpack_write_ext(writer, 8/*fixext8*/, ext_data, sizeof(ext_data));
+        break;
+
+    default:
+        ret = -1;
+    }
+
+    return ret;
+}
 
 int flb_time_append_to_msgpack(struct flb_time *tm, msgpack_packer *pk, int fmt)
 {
@@ -217,6 +268,72 @@ int flb_time_msgpack_to_time(struct flb_time *time, msgpack_object *obj)
     default:
         flb_warn("unknown time format %x", obj->type);
         return -1;
+    }
+
+    return 0;
+}
+
+int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+    double d;
+    float f;
+    int64_t i;
+    uint32_t tmp;
+    char extbuf[8];
+    size_t ext_len;
+
+    if (time == NULL) {
+        return -1;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok ||
+        mpack_tag_type(&tag) != mpack_type_array ||
+        mpack_tag_array_count(&tag) == 0) {
+        return -1;
+    }
+
+    tag = mpack_read_tag(reader);
+    switch (mpack_tag_type(&tag)) {
+        case mpack_type_int:
+            i = mpack_tag_int_value(&tag);
+            if (i < 0) {
+                flb_warn("expecting positive integer, got %" PRId64, i);
+                return -1;
+            }
+            time->tm.tv_sec  = i;
+            time->tm.tv_nsec = 0;
+            break;
+        case mpack_type_uint:
+            time->tm.tv_sec  = mpack_tag_uint_value(&tag);
+            time->tm.tv_nsec = 0;
+            break;
+        case mpack_type_float:
+            f = mpack_tag_float_value(&tag);
+            time->tm.tv_sec = f;
+            time->tm.tv_nsec = ((f - time->tm.tv_sec) * ONESEC_IN_NSEC);
+        case mpack_type_double:
+            d = mpack_tag_double_value(&tag);
+            time->tm.tv_sec  = d;
+            time->tm.tv_nsec = ((d - time->tm.tv_sec) * ONESEC_IN_NSEC);
+            break;
+        case mpack_type_ext:
+            ext_len = mpack_tag_ext_length(&tag);
+            if (ext_len != 8) {
+                flb_warn("expecting positive integer, got %" PRId64, i);
+                return -1;
+            }
+            mpack_read_bytes(reader, extbuf, ext_len);
+            memcpy(&tmp, extbuf, 4);
+            time->tm.tv_sec = (uint32_t) ntohl(tmp);
+            memcpy(&tmp, extbuf + 4, 4);
+            time->tm.tv_nsec = (uint32_t) ntohl(tmp);
+            break;
+        default:
+            flb_warn("unknown time format %s", tag.type);
+            return -1;
     }
 
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->

The goal is to replace msgpack-c with mpack for the lua <-> messagepack conversion. Here we implement alternative conversion functions using mpack, as well as a separate filter/lua callback which uses those functions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [n/a] Example configuration file for the change
- [n/a] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [n/a] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
