### PR TITLE
packaging: split centos repo config in twain

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-hadolint@v1
+        with:
+          exclude: |
+            packaging/testing/smoke/packages/
 
   shellcheck-pr:
     runs-on: ubuntu-latest

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -19,7 +19,7 @@ ARG AWS_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
 RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/centos.repo" -O /etc/yum.repos.d/staging.repo
+RUN wget "$AWS_URL/centos-7.repo" -O /etc/yum.repos.d/staging.repo
 RUN yum update -y && yum install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -22,7 +22,7 @@ ARG AWS_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
 RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/centos.repo" -O /etc/yum.repos.d/staging.repo
+RUN wget "$AWS_URL/centos-8.repo" -O /etc/yum.repos.d/staging.repo
 RUN yum update -y && yum install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -23,11 +23,14 @@ for RPM_REPO in "${RPM_REPO_PATHS[@]}"; do
 
     # Set up repo info
     if [[ -n "${AWS_S3_BUCKET:-}" ]]; then
-        REPO_TYPE=${RPM_REPO%%/*}
+        # Create top-level file so replace path separator with dash
+        # centos/8 --> centos-8.repo
+        # This way we make sure not to have a mixed repo or overwrite files for each target.
+        REPO_TYPE=${RPM_REPO/\//-}
         echo "Setting up $BASE_PATH/$REPO_TYPE.repo"
         cat << EOF > "$BASE_PATH/$REPO_TYPE.repo"
 [Fluent-Bit]
-name=Fluent Bit Packages - $REPO_TYPE - \$releasever - \$basearch
+name=Fluent Bit Packages - $REPO_TYPE - \$basearch
 baseurl=https://$AWS_S3_BUCKET.s3.amazonaws.com/$RPM_REPO/
 enabled=1
 gpgkey=https://$AWS_S3_BUCKET.s3.amazonaws.com/fluentbit.key


### PR DESCRIPTION
The CentOS repo configuration has a race so whichever finishes last (7 or 8) will overwrite the config with that version.
This triggers a test failure on the other target: https://github.com/fluent/fluent-bit/actions/runs/1615790804
Here we are trying to install CentOS 8 RPMs on CentOS 7 so the dependencies break.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Tested by using a fixed config to confirm the dependencies now install correctly on a local CentOS 7 container.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
