### PR TITLE
multiline: fix typo

### DIFF
--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -73,7 +73,7 @@ struct flb_ml_parser *flb_ml_parser_cri(struct flb_config *config)
                                NULL);                /* parser name */
 
     if (!mlp) {
-        flb_error("[multiline] could not create 'docker mode'");
+        flb_error("[multiline] could not create 'cri mode'");
         return NULL;
     }
 

--- a/src/multiline/flb_ml_parser_go.c
+++ b/src/multiline/flb_ml_parser_go.c
@@ -53,7 +53,7 @@ struct flb_ml_parser *flb_ml_parser_go(struct flb_config *config, char *key)
                                NULL);                /* parser name */
 
     if (!mlp) {
-        flb_error("[multiline] could not create 'python mode'");
+        flb_error("[multiline] could not create 'go mode'");
         return NULL;
     }
 

--- a/src/multiline/flb_ml_parser_java.c
+++ b/src/multiline/flb_ml_parser_java.c
@@ -135,7 +135,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
     /* Map the rules (mandatory for regex rules) */
     ret = flb_ml_parser_init(mlp);
     if (ret != 0) {
-        flb_error("[multiline: python] error on mapping rules");
+        flb_error("[multiline: java] error on mapping rules");
         flb_ml_parser_destroy(mlp);
         return NULL;
     }


### PR DESCRIPTION
I fixed typo of multiline parser logs.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
