### PR TITLE
windows: cmake: Add version information metadata with version.rc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,20 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
 endif()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if (MSVC)
+    enable_language(RC)
+    # use English language (0x409) in resource compiler
+    set(rc_flags "/l0x409")
+    set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_flags} <DEFINES> /fo <OBJECT> <SOURCE>")
+  endif()
+
+  configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/src/version.rc
+  @ONLY)
+endif()
+
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,20 +51,6 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
 endif()
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  if (MSVC)
-    enable_language(RC)
-    # use English language (0x409) in resource compiler
-    set(rc_flags "/l0x409")
-    set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_flags} <DEFINES> /fo <OBJECT> <SOURCE>")
-  endif()
-
-  configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/src/version.rc
-  @ONLY)
-endif()
-
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)

--- a/cmake/version.rc.in
+++ b/cmake/version.rc.in
@@ -1,0 +1,43 @@
+#include <windows.h>
+
+#define FLB_VER_FILEVERSION             @FLB_VERSION_MAJOR@,@FLB_VERSION_MINOR@,@FLB_VERSION_PATCH@,0
+#define FLB_VER_FILEVERSION_STR         "@FLB_VERSION_MAJOR@.@FLB_VERSION_MINOR@.@FLB_VERSION_PATCH@.0\0"
+
+#define FLB_VER_PRODUCTVERSION          @FLB_VERSION_MAJOR@,@FLB_VERSION_MINOR@,@FLB_VERSION_PATCH@,0
+#define FLB_VER_PRODUCTVERSION_STR      "@FLB_VERSION_MAJOR@.@FLB_VERSION_MINOR@.@FLB_VERSION_PATCH@.0\0"
+
+#ifndef DEBUG
+#define VER_DEBUG 0
+#else
+#define VER_DEBUG VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    FLB_VER_FILEVERSION
+  PRODUCTVERSION FLB_VER_PRODUCTVERSION
+  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+  FILEFLAGS      VER_DEBUG
+  FILEOS         VOS__WINDOWS32
+  FILETYPE       VFT_APP
+BEGIN
+    BLOCK "VarFileInfo"
+    BEGIN
+        // English language (0x409) and the Windows Unicode codepage (1200)
+        VALUE "Translation", 0x409, 1200
+    END
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "Compiled with @CMAKE_C_COMPILER_ID@ @CMAKE_C_COMPILER_VERSION@\0"
+            VALUE "ProductVersion", FLB_VER_PRODUCTVERSION_STR
+            VALUE "FileVersion", FLB_VER_FILEVERSION_STR
+            VALUE "InternalName", "fluent-bit\0"
+            VALUE "ProductName", "Fluent Bit - Fast and Lightweight Logs and Metrics processor for Linux, BSD, OSX and Windows\0"
+            VALUE "CompanyName", "Calyptia Inc.\0"
+            VALUE "LegalCopyright", "Copyright (C) 2015-2018 Treasure Data Inc.\nCopyright (C) 2019-2021 The Fluent Bit Authors.\nAll rights reserved.\0"
+            VALUE "Licence", "Apache-2.0\0"
+            VALUE "Info", "https://docs.fluentbit.io/manual/0"
+        END
+    END
+END

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -99,3 +99,17 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(FLB_RECORD_ACCESSOR  No)
   endif()
 endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if (MSVC)
+    enable_language(RC)
+    # use English language (0x409) in resource compiler
+    set(rc_flags "/l0x409")
+    set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_flags} <DEFINES> /fo <OBJECT> <SOURCE>")
+  endif()
+
+  configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/src/version.rc
+  @ONLY)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,6 +353,12 @@ if(FLB_STREAM_PROCESSOR)
     )
 endif()
 
+if (MSVC)
+set(flb_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+  )
+endif()
+
 # Shared Library
 if(FLB_SHARED_LIB)
   add_library(fluent-bit-shared SHARED ${src})
@@ -401,7 +407,7 @@ endif()
 if(FLB_BINARY)
   find_package (Threads)
   if (FLB_SYSTEM_WINDOWS)
-    add_executable(fluent-bit-bin fluent-bit.c flb_dump.c win32/winsvc.c)
+    add_executable(fluent-bit-bin fluent-bit.c flb_dump.c win32/winsvc.c ${flb_rc_files})
   else()
     add_executable(fluent-bit-bin fluent-bit.c flb_dump.c)
   endif()


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->
In Windows, `rc.exe` and `version.rc` should provide version information and its related metadata.
With this PR, `fluent-bit.exe` executable should provide them:


```powershell
PS>  (Get-Item .\bin\Debug\fluent-bit.exe).VersionInfo | Format-List

OriginalFilename  :
FileDescription   : Compiled with MSVC 19.29.30038.1
ProductName       : Fluent Bit - Fast and Lightweight Logs and Metrics processor for Linux, BSD, OSX and Windows
Comments          :
CompanyName       : Calyptia Inc.
FileName          : C:\Users\cosmo\Documents\GitHub\fluent-bit\build\bin\Debug\fluent-bit.exe
FileVersion       : 1.9.0.0
ProductVersion    : 1.9.0.0
IsDebug           : False
IsPatched         : False
IsPreRelease      : False
IsPrivateBuild    : False
IsSpecialBuild    : False
Language          : 英語 (米国)
LegalCopyright    : Copyright (C) 2015-2018 Treasure Data Inc.
                    Copyright (C) 2019-2021 The Fluent Bit Authors.
                    All rights reserved.
LegalTrademarks   :
PrivateBuild      :
SpecialBuild      :
FileVersionRaw    : 1.9.0.0
ProductVersionRaw : 1.9.0.0

```

Related to #4526 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
