### PR TITLE
packaging: fix incorrect repo filename

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -10,8 +10,7 @@ jobs:
     name: Hadolint
     steps:
       - uses: actions/checkout@v2
-        # Until https://github.com/reviewdog/action-hadolint/issues/35 is resolved
-      - run: rm -f packaging/testing/smoke/packages/Dockerfile.*
+        # Ignores do no work: https://github.com/reviewdog/action-hadolint/issues/35 is resolved
       - uses: reviewdog/action-hadolint@v1
         with:
           exclude: |

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -10,6 +10,8 @@ jobs:
     name: Hadolint
     steps:
       - uses: actions/checkout@v2
+        # Until https://github.com/reviewdog/action-hadolint/issues/35 is resolved
+      - run: rm -f packaging/testing/smoke/packages/Dockerfile.*
       - uses: reviewdog/action-hadolint@v1
         with:
           exclude: |

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: reviewdog/action-hadolint@v1
         with:
           exclude: |
-            packaging/testing/smoke/packages/
+            packaging/testing/smoke/packages/Dockerfile.*
 
   shellcheck-pr:
     runs-on: ubuntu-latest

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -3,10 +3,10 @@ ARG STAGING_BASE=dokken/amazonlinux-2
 
 FROM dokken/amazonlinux-2 as official-install
 ARG RELEASE_URL
-RUN rpm --import $RELEASE_URL/fluentbit.key
-RUN echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/amazonlinux/2/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo
-RUN yum update -y && yum install -y td-agent-bit
-RUN systemctl enable td-agent-bit
+RUN rpm --import $RELEASE_URL/fluentbit.key && \
+    echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/amazonlinux/2/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo && \
+    yum update -y && yum install -y td-agent-bit && \
+    systemctl enable td-agent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
@@ -18,10 +18,10 @@ FROM ${STAGING_BASE} as staging-install
 ARG AWS_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo
-RUN yum update -y && yum install -y td-agent-bit
-RUN systemctl enable td-agent-bit
+RUN rpm --import "$AWS_URL/fluentbit.key" && \
+    wget -q "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo && \
+    yum update -y && yum install -y td-agent-bit && \
+    systemctl enable td-agent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -3,6 +3,9 @@ ARG STAGING_BASE=dokken/amazonlinux-2
 
 FROM dokken/amazonlinux-2 as official-install
 ARG RELEASE_URL
+# For echo flags
+SHELL ["/bin/bash", "-c"]
+# hadolint ignore=DL3032
 RUN rpm --import $RELEASE_URL/fluentbit.key && \
     echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/amazonlinux/2/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo && \
     yum update -y && yum install -y td-agent-bit && \
@@ -18,6 +21,7 @@ FROM ${STAGING_BASE} as staging-install
 ARG AWS_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
+# hadolint ignore=DL3032
 RUN rpm --import "$AWS_URL/fluentbit.key" && \
     wget -q "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo && \
     yum update -y && yum install -y td-agent-bit && \

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -19,7 +19,7 @@ ARG AWS_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
 RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/amazonlinux.repo" -O /etc/yum.repos.d/staging.repo
+RUN wget "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo
 RUN yum update -y && yum install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 


### PR DESCRIPTION
See https://github.com/fluent/fluent-bit/runs/4626311280?check_suite_focus=true#step:4:304, filename should be `amazonlinux-2.repo` now after a fix to handle the CentOS versions: 

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Confirmed locally with: 
`PACKAGE_TEST=amazonlinux2 ./packaging/testing/smoke/packages/run-package-tests.sh`

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
