### PR TITLE
time: use flb_time_to_nanosec for unset time check

### DIFF
--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -132,7 +132,7 @@ static int merge_log_handler(msgpack_object o,
         ret = flb_parser_do(parser, ctx->unesc_buf, ctx->unesc_buf_len,
                             out_buf, out_size, log_time);
         if (ret >= 0) {
-            if (flb_time_to_double(log_time) == 0.0) {
+            if (flb_time_to_nanosec(log_time) == 0L) {
                 flb_time_get(log_time);
             }
             return MERGE_PARSED;
@@ -143,7 +143,7 @@ static int merge_log_handler(msgpack_object o,
                             ctx->unesc_buf, ctx->unesc_buf_len,
                             out_buf, out_size, log_time);
         if (ret >= 0) {
-            if (flb_time_to_double(log_time) == 0.0) {
+            if (flb_time_to_nanosec(log_time) == 0L) {
                 flb_time_get(log_time);
             }
             return MERGE_PARSED;
@@ -273,7 +273,7 @@ static int pack_map_content(msgpack_packer *pck, msgpack_sbuffer *sbuf,
 
     /* Append record timestamp */
     if (merge_status == MERGE_PARSED) {
-        if (flb_time_to_double(&log_time) == 0.0) {
+        if (flb_time_to_nanosec(&log_time) == 0L) {
             flb_time_append_to_msgpack(time_lookup, pck, 0);
         }
         else {

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -282,7 +282,7 @@ static int cb_parser_filter(const void *data, size_t bytes,
                              * holder with the new value, otherwise keep the
                              * original.
                              */
-                            if (flb_time_to_double(&parsed_time) != 0.0) {
+                            if (flb_time_to_nanosec(&parsed_time) != 0L) {
                                 flb_time_copy(&tm, &parsed_time);
                             }
 

--- a/plugins/in_docker_events/docker_events.c
+++ b/plugins/in_docker_events/docker_events.c
@@ -274,7 +274,7 @@ static int in_de_collect(struct flb_input_instance *ins,
             parser_ret = flb_parser_do(ctx->parser, ctx->buf, str_len - 1,
                                        &out_buf, &out_size, &out_time);
             if (parser_ret >= 0) {
-                if (flb_time_to_double(&out_time) == 0.0) {
+                if (flb_time_to_nanosec(&out_time) == 0L) {
                     flb_time_get(&out_time);
                 }
 

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -75,7 +75,7 @@ static int in_exec_collect(struct flb_input_instance *ins,
             parser_ret = flb_parser_do(ctx->parser, ctx->buf, str_len - 1,
                                        &out_buf, &out_size, &out_time);
             if (parser_ret >= 0) {
-                if (flb_time_to_double(&out_time) == 0.0) {
+                if (flb_time_to_nanosec(&out_time) == 0L) {
                     flb_time_get(&out_time);
                 }
 

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -173,7 +173,7 @@ static int in_stdin_collect(struct flb_input_instance *ins,
             ret = flb_parser_do(ctx->parser, ctx->buf, ctx->buf_len,
                                 &out_buf, &out_size, &out_time);
             if (ret >= 0) {
-                if (flb_time_to_double(&out_time) == 0.0) {
+                if (flb_time_to_nanosec(&out_time) == 0L) {
                     flb_time_get(&out_time);
                 }
                 pack_regex(&mp_sbuf, &mp_pck,

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -100,7 +100,7 @@ int syslog_prot_process(struct syslog_conn *conn)
         ret = flb_parser_do(ctx->parser, p, len,
                             &out_buf, &out_size, &out_time);
         if (ret >= 0) {
-            if (flb_time_to_double(&out_time) == 0.0) {
+            if (flb_time_to_nanosec(&out_time) == 0L) {
                 flb_time_get(&out_time);
             }
             pack_line(ctx, &out_time, out_buf, out_size);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -403,7 +403,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
             ret = flb_parser_do(ctx->parser, line, line_len,
                                 &out_buf, &out_size, &out_time);
             if (ret >= 0) {
-                if (flb_time_to_double(&out_time) == 0.0) {
+                if (flb_time_to_nanosec(&out_time) == 0L) {
                     flb_time_get(&out_time);
                 }
 

--- a/plugins/in_tail/tail_multiline.c
+++ b/plugins/in_tail/tail_multiline.c
@@ -175,7 +175,7 @@ int flb_tail_mult_process_first(time_t now,
     file->mult_firstline = FLB_TRUE;
 
     /* Validate obtained time, if not set, set the current time */
-    if (flb_time_to_double(out_time) == 0.0) {
+    if (flb_time_to_nanosec(out_time) == 0L) {
         flb_time_get(out_time);
     }
 

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -523,7 +523,7 @@ static int ml_append_try_parser_type_text(struct flb_ml_parser_ins *parser,
         /* Parse incoming content */
         ret = flb_parser_do(parser->ml_parser->parser, (char *) buf, size,
                             out_buf, out_size, out_time);
-        if (flb_time_to_double(out_time) == 0.0) {
+        if (flb_time_to_nanosec(out_time) == 0L) {
             flb_time_copy(out_time, tm);
         }
         if (ret >= 0) {
@@ -640,8 +640,8 @@ static int ml_append_try_parser(struct flb_ml_parser_ins *parser,
         return -1;
     }
 
-    if (flb_time_to_double(&out_time) == 0.0) {
-        if (tm && flb_time_to_double(tm) != 0.0) {
+    if (flb_time_to_nanosec(&out_time) == 0L) {
+        if (tm && flb_time_to_nanosec(tm) != 0L) {
             flb_time_copy(&out_time, tm);
         }
         else {
@@ -1022,7 +1022,7 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     /* if the group don't have a time set, use current time */
-    if (flb_time_to_double(&group->mp_time) == 0.0) {
+    if (flb_time_to_nanosec(&group->mp_time) == 0L) {
         flb_time_get(&group->mp_time);
     }
 

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -379,7 +379,7 @@ static int flush_callback(struct flb_ml_parser *parser,
 
     flb_time_pop_from_msgpack(&tm, &result, &map);
 
-    TEST_CHECK(flb_time_to_double(&tm) != 0.0);
+    TEST_CHECK(flb_time_to_nanosec(&tm) != 0L);
 
     exp = &res->out_records[res->current_record];
     len = strlen(res->key);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Operations on floating-point numbers are usually less efficient than integer arithmetic.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
