### PR TITLE
http_server: fix health implementation

### DIFF
--- a/include/fluent-bit/http_server/flb_hs.h
+++ b/include/fluent-bit/http_server/flb_hs.h
@@ -55,6 +55,7 @@ struct flb_hs {
 
 struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config);
+int flb_hs_push_health_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_storage_metrics(struct flb_hs *hs, void *data, size_t size);
 

--- a/src/flb_metrics_exporter.c
+++ b/src/flb_metrics_exporter.c
@@ -170,6 +170,9 @@ static int collect_metrics(struct flb_me *me)
     if (ctx->http_server == FLB_TRUE) {
         /* v1 metrics (old) */
         flb_hs_push_pipeline_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
+        if (ctx->health_check == FLB_TRUE) {
+            flb_hs_push_health_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
+        }
     }
 #endif
     msgpack_sbuffer_destroy(&mp_sbuf);

--- a/src/http_server/api/v1/health.c
+++ b/src/http_server/api/v1/health.c
@@ -323,7 +323,7 @@ int api_v1_health(struct flb_hs *hs)
 
     counter_init(hs);
     /* Create a message queue */
-    hs->qid_metrics = mk_mq_create(hs->ctx, "/health",
+    hs->qid_health = mk_mq_create(hs->ctx, "/health",
                                    cb_mq_health, NULL);
 
     mk_vhost_handler(hs->ctx, hs->vid, "/api/v1/health", cb_health, hs);

--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -38,10 +38,15 @@ static void cb_root(mk_request_t *request, void *data)
     mk_http_done(request);
 }
 
+/* Ingest health metrics into the web service context */
+int flb_hs_push_health_metrics(struct flb_hs *hs, void *data, size_t size)
+{
+    return mk_mq_send(hs->ctx, hs->qid_health, data, size);
+}
+
 /* Ingest pipeline metrics into the web service context */
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size)
 {
-    mk_mq_send(hs->ctx, hs->qid_health, data, size);
     return mk_mq_send(hs->ctx, hs->qid_metrics, data, size);
 }
 


### PR DESCRIPTION
Users reported http_server issue. e.g. https://github.com/fluent/fluent-bit/issues/4063

I reviewed health check and I found suspicious points.
I modified these points.

## Suspicious points

* Use wrong queue to ingest health metrics. Health uses `hs->qid_metrics` and it should be for another metrics.
* Ingest health metrics when `health_check off`. When `health_check` is off, [the api is not registered](https://github.com/fluent/fluent-bit/blob/v1.8.11/src/http_server/api/v1/register.c#L36) and it should not be ingested.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example configuration

```
[SERVICE]
        HTTP_Server    On
        HTTP_Listen    0.0.0.0
        HTTP_PORT      2020
        Flush          1
        Daemon         Off
        Health_Check   On

[INPUT]
        Name dummy
        Dummy {"top": {".dotted": "value"}}
[OUTPUT]
        Name stdout
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/26 09:44:03] [ info] [engine] started (pid=30755)
[2021/12/26 09:44:03] [ info] [storage] version=1.1.5, initializing...
[2021/12/26 09:44:03] [ info] [storage] in-memory
[2021/12/26 09:44:03] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/26 09:44:03] [ info] [cmetrics] version=0.2.2
[2021/12/26 09:44:03] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/12/26 09:44:03] [ info] [sp] stream processor started
[0] dummy.0: [1640479443.785211931, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479444.785157485, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479445.785145782, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479446.785023262, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479447.784977028, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479448.785726607, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479449.784976589, {"top"=>{".dotted"=>"value"}}]
^C[2021/12/26 09:44:11] [engine] caught signal (SIGINT)
[0] dummy.0: [1640479450.785058982, {"top"=>{".dotted"=>"value"}}]
[2021/12/26 09:44:11] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/26 09:44:11] [ info] [engine] service has stopped (0 pending tasks)
```

```
$ curl  localhost:2020/api/v1/health
ok
$ curl  localhost:2020/api/v1/metrics
{"input":{"dummy.0":{"records":5,"bytes":155}},"filter":{},"output":{"stdout.0":{"proc_records":3,"proc_bytes":93,"errors":0,"retries":0,"retries_failed":0,"dropped_records":0,"retried_records":0}}}
```

## Valgrind output

The leak is reported , but I think it is not related this PR.
```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==30768== Memcheck, a memory error detector
==30768== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==30768== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==30768== Command: ../bin/fluent-bit -c a.conf
==30768== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/26 09:45:44] [ info] [engine] started (pid=30768)
[2021/12/26 09:45:44] [ info] [storage] version=1.1.5, initializing...
[2021/12/26 09:45:44] [ info] [storage] in-memory
[2021/12/26 09:45:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/26 09:45:44] [ info] [cmetrics] version=0.2.2
[2021/12/26 09:45:44] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/12/26 09:45:44] [ info] [sp] stream processor started
==30768== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4ca13f0
==30768==          to suppress, use: --max-stackframe=11814408 or greater
==30768== Warning: client switching stacks?  SP change: 0x4ca1398 --> 0x57e59f8
==30768==          to suppress, use: --max-stackframe=11814496 or greater
==30768== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4ca1398
==30768==          to suppress, use: --max-stackframe=11814496 or greater
==30768==          further instances of this message will not be shown.
[0] dummy.0: [1640479544.942462327, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479545.813486601, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479546.786466458, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479547.785579819, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479548.785752334, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479549.785353173, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479550.785313057, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479551.785599601, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479552.785335272, {"top"=>{".dotted"=>"value"}}]
^C[2021/12/26 09:45:54] [engine] caught signal (SIGINT)
[0] dummy.0: [1640479553.786321876, {"top"=>{".dotted"=>"value"}}]
[2021/12/26 09:45:54] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/26 09:45:54] [ info] [engine] service has stopped (0 pending tasks)
==30768== 
==30768== HEAP SUMMARY:
==30768==     in use at exit: 56 bytes in 1 blocks
==30768==   total heap usage: 1,551 allocs, 1,550 frees, 3,976,119 bytes allocated
==30768== 
==30768== 56 bytes in 1 blocks are definitely lost in loss record 1 of 1
==30768==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==30768==    by 0x71FE48: mk_mem_alloc_z (mk_memory.h:70)
==30768==    by 0x71FFBF: thread_get_libco_params (mk_http_thread.c:60)
==30768==    by 0x7201A7: thread_params_set (mk_http_thread.c:168)
==30768==    by 0x72039A: mk_http_thread_create (mk_http_thread.c:226)
==30768==    by 0x71C56A: mk_http_init (mk_http.c:748)
==30768==    by 0x71B3B3: mk_http_request_prepare (mk_http.c:232)
==30768==    by 0x71E3AF: mk_http_sched_read (mk_http.c:1576)
==30768==    by 0x719FB1: mk_sched_event_read (mk_scheduler.c:693)
==30768==    by 0x722D4C: mk_server_worker_loop (mk_server.c:487)
==30768==    by 0x71990C: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==30768==    by 0x4865608: start_thread (pthread_create.c:477)
==30768== 
==30768== LEAK SUMMARY:
==30768==    definitely lost: 56 bytes in 1 blocks
==30768==    indirectly lost: 0 bytes in 0 blocks
==30768==      possibly lost: 0 bytes in 0 blocks
==30768==    still reachable: 0 bytes in 0 blocks
==30768==         suppressed: 0 bytes in 0 blocks
==30768== 
==30768== For lists of detected and suppressed errors, rerun with: -s
==30768== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build/4063$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
