### PR TITLE
storage: don't ingest metrics when storage.metrics is off

### DIFF
--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -247,7 +247,7 @@ static void cb_storage_metrics_collect(struct flb_config *ctx, void *data)
     metrics_append_input(&mp_pck, ctx, data);
 
 #ifdef FLB_HAVE_HTTP_SERVER
-    if (ctx->http_server == FLB_TRUE) {
+    if (ctx->http_server == FLB_TRUE && ctx->storage_metrics == FLB_TRUE) {
         flb_hs_push_storage_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
     }
 #endif


### PR DESCRIPTION
Storage metrics is configurable and fluent-bit ingests metrics even if `storage.metrics off`.
https://github.com/fluent/fluent-bit/blob/v1.8.11/src/http_server/api/v1/register.c#L40

I added a code to check if `storage.metrics` is enabled or not.

Note: Similar PR for health is #4537 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Example Configuration

```
[SERVICE]
        HTTP_Server    On
        HTTP_Listen    0.0.0.0
        HTTP_PORT      2020
        Flush          1
        Daemon         Off
        Storage.metrics on

[INPUT]
        Name dummy
        Dummy {"top": {".dotted": "value"}}
[OUTPUT]
        Name stdout
```

## Debug output
```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/26 09:53:10] [ info] [engine] started (pid=32093)
[2021/12/26 09:53:10] [ info] [storage] version=1.1.5, initializing...
[2021/12/26 09:53:10] [ info] [storage] in-memory
[2021/12/26 09:53:10] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/26 09:53:10] [ info] [cmetrics] version=0.2.2
[2021/12/26 09:53:10] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/12/26 09:53:10] [ info] [sp] stream processor started
[0] dummy.0: [1640479990.785383405, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479991.785102057, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479992.785156667, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479993.785217930, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479994.785034614, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479995.786098257, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479996.785432826, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479997.785773290, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479998.784998385, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640479999.785098221, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480000.784975668, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480001.785071272, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480002.784993093, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480003.784961835, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480004.785044100, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480005.784974495, {"top"=>{".dotted"=>"value"}}]
^C[2021/12/26 09:53:27] [engine] caught signal (SIGINT)
[0] dummy.0: [1640480006.785137700, {"top"=>{".dotted"=>"value"}}]
[2021/12/26 09:53:27] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/26 09:53:27] [ info] [engine] service has stopped (0 pending tasks)

```

```
$ curl localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"31b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":0,"busy_size":"0b"}}}}taka@locals:~/git/fluent-bit/build/4063$ curl localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"31b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":0,"busy_size":"0b"}}}}taka@locals:~/git/fluent-bit/build/4063$ curl localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"31b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":0,"busy_size":"0b"}}}}taka@locals:~/git/fluent-bit/build/4063$ curl localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"31b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":0,"busy_size":"0b"}}}}taka@locals:~/git/fluent-bit/build/4063$ curl localhost:2020/api/v1/storage
{"storage_layer":{"chunks":{"total_chunks":1,"mem_chunks":1,"fs_chunks":0,"fs_chunks_up":0,"fs_chunks_down":0}},"input_chunks":{"dummy.0":{"status":{"overlimit":false,"mem_size":"31b","mem_limit":"0b"},"chunks":{"total":1,"up":1,"down":0,"busy":0,"busy_size":"0b"}}}}taka@locals:~/git/fluent-bit/build/4063$ 
```

## Valgrind output

The leak is reported , but I think it is not related this PR.

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==32111== Memcheck, a memory error detector
==32111== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32111== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==32111== Command: ../bin/fluent-bit -c a.conf
==32111== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/12/26 09:53:34] [ info] [engine] started (pid=32111)
[2021/12/26 09:53:34] [ info] [storage] version=1.1.5, initializing...
[2021/12/26 09:53:34] [ info] [storage] in-memory
[2021/12/26 09:53:34] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/12/26 09:53:34] [ info] [cmetrics] version=0.2.2
[2021/12/26 09:53:34] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2021/12/26 09:53:34] [ info] [sp] stream processor started
==32111== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4ca1670
==32111==          to suppress, use: --max-stackframe=11813768 or greater
==32111== Warning: client switching stacks?  SP change: 0x4ca1618 --> 0x57e59f8
==32111==          to suppress, use: --max-stackframe=11813856 or greater
==32111== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4ca1618
==32111==          to suppress, use: --max-stackframe=11813856 or greater
==32111==          further instances of this message will not be shown.
[0] dummy.0: [1640480014.799097974, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480015.811124927, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480016.786435242, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480017.785541105, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480018.802718379, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480019.785401776, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480020.785308329, {"top"=>{".dotted"=>"value"}}]
[0] dummy.0: [1640480021.785620523, {"top"=>{".dotted"=>"value"}}]
^C[2021/12/26 09:53:43] [engine] caught signal (SIGINT)
[0] dummy.0: [1640480022.785712335, {"top"=>{".dotted"=>"value"}}]
[2021/12/26 09:53:43] [ warn] [engine] service will shutdown in max 5 seconds
[2021/12/26 09:53:43] [ info] [engine] service has stopped (0 pending tasks)
==32111== 
==32111== HEAP SUMMARY:
==32111==     in use at exit: 56 bytes in 1 blocks
==32111==   total heap usage: 1,617 allocs, 1,616 frees, 4,020,320 bytes allocated
==32111== 
==32111== 56 bytes in 1 blocks are definitely lost in loss record 1 of 1
==32111==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==32111==    by 0x71FE08: mk_mem_alloc_z (mk_memory.h:70)
==32111==    by 0x71FF7F: thread_get_libco_params (mk_http_thread.c:60)
==32111==    by 0x720167: thread_params_set (mk_http_thread.c:168)
==32111==    by 0x72035A: mk_http_thread_create (mk_http_thread.c:226)
==32111==    by 0x71C52A: mk_http_init (mk_http.c:748)
==32111==    by 0x71B373: mk_http_request_prepare (mk_http.c:232)
==32111==    by 0x71E36F: mk_http_sched_read (mk_http.c:1576)
==32111==    by 0x719F71: mk_sched_event_read (mk_scheduler.c:693)
==32111==    by 0x722D0C: mk_server_worker_loop (mk_server.c:487)
==32111==    by 0x7198CC: mk_sched_launch_worker_loop (mk_scheduler.c:416)
==32111==    by 0x4865608: start_thread (pthread_create.c:477)
==32111== 
==32111== LEAK SUMMARY:
==32111==    definitely lost: 56 bytes in 1 blocks
==32111==    indirectly lost: 0 bytes in 0 blocks
==32111==      possibly lost: 0 bytes in 0 blocks
==32111==    still reachable: 0 bytes in 0 blocks
==32111==         suppressed: 0 bytes in 0 blocks
==32111== 
==32111== For lists of detected and suppressed errors, rerun with: -s
==32111== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
