### PR TITLE
out_loki: add comment about label key removal

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -193,6 +193,7 @@ int flb_loki_kv_append(struct flb_loki *ctx, char *key, char *val)
             flb_loki_kv_destroy(kv);
             return -1;
         }
+        /* remove record keys placed as stream labels via 'labels' and 'label_keys' */
         ret = flb_slist_add(&ctx->remove_keys_derived, key);
         if (ret < 0) {
             flb_loki_kv_destroy(kv);


### PR DESCRIPTION
Add comment about https://github.com/fluent/fluent-bit/pull/2995#issuecomment-777940946. This is upstream-intended behavior, see https://github.com/grafana/loki/blob/v2.2.1/cmd/fluent-bit/loki.go#L62.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
