### PR TITLE
input: performance improvements

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -85,6 +85,11 @@ int flb_input_chunk_append_obj(struct flb_input_instance *in,
 int flb_input_chunk_append_raw(struct flb_input_instance *in,
                                const char *tag, size_t tag_len,
                                const void *buf, size_t buf_size);
+int flb_input_chunk_append_raw2(struct flb_input_instance *in,
+                                size_t records,
+                                const char *tag, size_t tag_len,
+                                const void *buf, size_t buf_size);
+
 const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size);
 int flb_input_chunk_release_lock(struct flb_input_chunk *ic);
 flb_sds_t flb_input_chunk_get_name(struct flb_input_chunk *ic);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -50,6 +50,7 @@ static inline void consume_bytes(char *buf, int bytes, int length)
     memmove(buf, buf + bytes, length - bytes);
 }
 
+/* Append custom keys and report the number of records processed */
 static int record_append_custom_keys(struct flb_tail_file *file,
                                      size_t processed_bytes,
                                      char *in_data, size_t in_size,
@@ -58,6 +59,7 @@ static int record_append_custom_keys(struct flb_tail_file *file,
     int i;
     int ok = MSGPACK_UNPACK_SUCCESS;
     int len;
+    int records = 0;
     size_t off = 0;
     size_t total;
     msgpack_unpacked result;
@@ -127,12 +129,15 @@ static int record_append_custom_keys(struct flb_tail_file *file,
 
         /* finalize map */
         flb_mp_map_header_end(&mh);
+
+        /* counter */
+        records++;
     }
 
     *out_data = mp_sbuf.data;
     *out_size = mp_sbuf.size;
 
-    return 0;
+    return records;
 }
 
 static int unpack_and_pack(msgpack_packer *pck, msgpack_object *root,
@@ -288,6 +293,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
 {
     size_t len;
     int lines = 0;
+    int records = 0;
     int ret;
     size_t processed_bytes = 0;
     char *data;
@@ -473,41 +479,45 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         *bytes = processed_bytes;
 
         if (out_sbuf->size > 0) {
-            flb_input_chunk_append_raw(ctx->ins,
-                                       file->tag_buf,
-                                       file->tag_len,
-                                       out_sbuf->data,
-                                       out_sbuf->size);
+            flb_input_chunk_append_raw2(ctx->ins,
+                                        lines,
+                                        file->tag_buf,
+                                        file->tag_len,
+                                        out_sbuf->data,
+                                        out_sbuf->size);
         }
         else if (ctx->ml_ctx && file->mult_sbuf.size > 0) {
             /* If no extra keys are needed, just enqueue the buffer */
             if (file->config->path_key == NULL &&
                 file->config->offset_key == NULL) {
-                flb_input_chunk_append_raw(ctx->ins,
-                                           file->tag_buf,
-                                           file->tag_len,
-                                           file->mult_sbuf.data,
-                                           file->mult_sbuf.size);
 
+                flb_input_chunk_append_raw2(ctx->ins,
+                                            file->mult_records,
+                                            file->tag_buf,
+                                            file->tag_len,
+                                            file->mult_sbuf.data,
+                                            file->mult_sbuf.size);
             }
             else {
                 char *mult_buf = NULL;
                 size_t mult_size = 0;
 
                 /* adjust the records in a new buffer */
-                record_append_custom_keys(file,
-                                          processed_bytes,
-                                          file->mult_sbuf.data,
-                                          file->mult_sbuf.size,
-                                          &mult_buf, &mult_size);
+                records = record_append_custom_keys(file,
+                                                    processed_bytes,
+                                                    file->mult_sbuf.data,
+                                                    file->mult_sbuf.size,
+                                                    &mult_buf, &mult_size);
 
-                flb_input_chunk_append_raw(ctx->ins,
-                                           file->tag_buf,
-                                           file->tag_len,
-                                           mult_buf,
-                                           mult_size);
+                flb_input_chunk_append_raw2(ctx->ins,
+                                            records,
+                                            file->tag_buf,
+                                            file->tag_len,
+                                            mult_buf,
+                                            mult_size);
                 flb_free(mult_buf);
             }
+            file->mult_records = 0;
             file->mult_sbuf.size = 0;
         }
     }
@@ -778,7 +788,9 @@ static int ml_flush_callback(struct flb_ml_parser *parser,
     struct flb_tail_file *file = data;
 
     /* Enqueue the records in our file->multiline buffer */
+    file->mult_records++;
     msgpack_sbuffer_write(&file->mult_sbuf, buf_data, buf_size);
+
     return 0;
 }
 
@@ -865,6 +877,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->mult_skipping = FLB_FALSE;
 
     /* multiline msgpack buffers */
+    file->mult_records = 0;
     msgpack_sbuffer_init(&file->mult_sbuf);
     msgpack_packer_init(&file->mult_pck, &file->mult_sbuf,
                         msgpack_sbuffer_write);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -60,6 +60,9 @@ struct flb_tail_file {
     int mult_firstline_append;  /* bool: mult firstline appendable ?     */
     int mult_skipping;          /* skipping because ignode_older than ?  */
     int mult_keys;              /* total number of buffered keys         */
+
+
+    int mult_records;           /* multiline records counter mult_sbuf   */
     msgpack_sbuffer mult_sbuf;  /* temporary msgpack buffer              */
     msgpack_packer mult_pck;    /* temporary msgpack packer              */
     struct flb_time mult_time;  /* multiline time parsed from first line */

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -266,13 +266,6 @@ int flb_input_chunk_write(void *data, const char *buf, size_t len)
     ic = (struct flb_input_chunk *) data;
 
     ret = cio_chunk_write(ic->chunk, buf, len);
-#ifdef FLB_HAVE_METRICS
-    if (ret == CIO_OK) {
-        ic->added_records = flb_mp_count(buf, len);
-        ic->total_records += ic->added_records;
-    }
-#endif
-
     return ret;
 }
 
@@ -1365,9 +1358,10 @@ int flb_input_chunk_set_up(struct flb_input_chunk *ic)
 }
 
 /* Append a RAW MessagPack buffer to the input instance */
-int flb_input_chunk_append_raw(struct flb_input_instance *in,
-                               const char *tag, size_t tag_len,
-                               const void *buf, size_t buf_size)
+static int input_chunk_append_raw(struct flb_input_instance *in,
+                                  size_t n_records,
+                                  const char *tag, size_t tag_len,
+                                  const void *buf, size_t buf_size)
 {
     int ret;
     int set_down = FLB_FALSE;
@@ -1457,6 +1451,11 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
 
     /* Update 'input' metrics */
 #ifdef FLB_HAVE_METRICS
+    if (ret == CIO_OK) {
+        ic->added_records =  n_records;
+        ic->total_records += n_records;
+    }
+
     if (ic->total_records > 0) {
         /* timestamp */
         ts = cmt_time_now();
@@ -1582,6 +1581,24 @@ int flb_input_chunk_append_raw(struct flb_input_instance *in,
     flb_input_chunk_protect(in);
 
     return 0;
+}
+
+int flb_input_chunk_append_raw(struct flb_input_instance *in,
+                               const char *tag, size_t tag_len,
+                               const void *buf, size_t buf_size)
+{
+    size_t records;
+
+    records = flb_mp_count(buf, buf_size);
+    return input_chunk_append_raw(in, records, tag, tag_len, buf, buf_size);
+}
+
+int flb_input_chunk_append_raw2(struct flb_input_instance *in,
+                                size_t records,
+                                const char *tag, size_t tag_len,
+                                const void *buf, size_t buf_size)
+{
+    return input_chunk_append_raw(in, records, tag, tag_len, buf, buf_size);
 }
 
 /* Retrieve a raw buffer from a dyntag node */


### PR DESCRIPTION
The following PR adds a new flb_input_chunk interface allowing now to report the number of records being ingested on every msgpack payload. This help us to reduce the overall counting of records. 

The first plugin to take advantage of this API is Tail, in a normal test we see a performance gain of 13.32%: 

Test case:

  - Log file of 1.2G with 10 million records

Before this patch, the pipeline invested 80.67% of the time processing the whole lines: read, parse, encode as 
msgpack and report to the engine.

By switching to flb_input_append_raw2() we reduced from __80.67%__ to __67.34%__, which give us a __13.32%__ overall time processing reduction.
