### PR TITLE
time: fix warning

### DIFF
--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -322,7 +322,7 @@ int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader)
         case mpack_type_ext:
             ext_len = mpack_tag_ext_length(&tag);
             if (ext_len != 8) {
-                flb_warn("expecting positive integer, got %" PRId64, i);
+                flb_warn("expecting ext_len is 8, got %" PRId64, ext_len);
                 return -1;
             }
             mpack_read_bytes(reader, extbuf, ext_len);


### PR DESCRIPTION
This patch is to fix below warning.
Fluent-bit tries to print out uninitialized `i` in case of `mpack_type_ext`.

```
In file included from /home/taka/git/fluent-bit/src/flb_time.c:26:
/home/taka/git/fluent-bit/src/flb_time.c: In function ‘flb_time_pop_from_mpack’:
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:120:9: warning: ‘i’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  120 |         flb_log_print(FLB_LOG_WARN, NULL, 0, fmt, ##__VA_ARGS__)
      |         ^~~~~~~~~~~~~
/home/taka/git/fluent-bit/src/flb_time.c:281:13: note: ‘i’ was declared here
  281 |     int64_t i;
      |             ^

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
