### PR TITLE
pack: performance improvement on packer and output plugins

### DIFF
--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -19,16 +19,80 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_utils.h>
 
-int cb_null_init(struct flb_output_instance *ins,
-                 struct flb_config *config,
+struct flb_null {
+    struct flb_output_instance *ins;
+
+    /* config map properties */
+    int out_format;
+    int json_date_format;
+    flb_sds_t json_date_key;
+    flb_sds_t date_key;
+};
+
+int cb_null_init(struct flb_output_instance *ins, struct flb_config *config,
                  void *data)
 {
-    (void) ins;
+    int ret;
     (void) config;
     (void) data;
+    const char *tmp;
+    struct flb_null *ctx;
 
-    flb_output_set_context(ins, ins);
+    ctx = flb_malloc(sizeof(struct flb_null));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+    ctx->ins = ins;
+
+    ret = flb_output_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
+    ctx->out_format = FLB_PACK_JSON_FORMAT_NONE;
+    tmp = flb_output_get_property("format", ins);
+    if (tmp) {
+        ret = flb_pack_to_json_format_type(tmp);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "unrecognized 'format' option. "
+                          "Using 'msgpack'");
+        }
+        else {
+            ctx->out_format = ret;
+        }
+    }
+
+    /* Date key */
+    ctx->date_key = ctx->json_date_key;
+    tmp = flb_output_get_property("json_date_key", ins);
+    if (tmp) {
+        /* Just check if we have to disable it */
+        if (flb_utils_bool(tmp) == FLB_FALSE) {
+            ctx->date_key = NULL;
+        }
+    }
+
+    /* Date format for JSON output */
+    ctx->json_date_format = FLB_PACK_JSON_DATE_DOUBLE;
+    tmp = flb_output_get_property("json_date_format", ins);
+    if (tmp) {
+        ret = flb_pack_to_json_date_type(tmp);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "invalid json_date_format '%s'. "
+                          "Using 'double' type", tmp);
+        }
+        else {
+            ctx->json_date_format = ret;
+        }
+    }
+
+    flb_output_set_context(ins, ctx);
+
     return 0;
 }
 
@@ -40,10 +104,66 @@ static void cb_null_flush(struct flb_event_chunk *event_chunk,
 {
     (void) out_context;
     (void) config;
-    struct flb_output_instance *ins = out_context;
+    flb_sds_t json;
+    struct flb_null *ctx = out_context;
 
-    flb_plg_debug(ins, "discarding %lu bytes", event_chunk->size);
+#ifdef FLB_HAVE_METRICS
+    /* Check if the event type is metrics, just return */
+    if (event_chunk->type == FLB_EVENT_TYPE_METRIC) {
+        FLB_OUTPUT_RETURN(FLB_OK);
+    }
+#endif
+
+    /*
+     * There are cases where the user might want to test the performance
+     * of msgpack payload conversion to JSON. Nothing will be printed,
+     * just encodeed and destroyed.
+     */
+    if (ctx->out_format != FLB_PACK_JSON_FORMAT_NONE) {
+        json = flb_pack_msgpack_to_json_format(event_chunk->data,
+                                               event_chunk->size,
+                                               ctx->out_format,
+                                               ctx->json_date_format,
+                                               ctx->date_key);
+        flb_sds_destroy(json);
+    }
+
+    flb_plg_debug(ctx->ins, "discarding %lu bytes", event_chunk->size);
     FLB_OUTPUT_RETURN(FLB_OK);
+}
+
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "format", NULL,
+     0, FLB_FALSE, 0,
+     "Specifies the data format to be printed. Supported formats are msgpack json, json_lines and json_stream."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "json_date_format", NULL,
+     0, FLB_FALSE, 0,
+    "Specifies the name of the date field in output."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "json_date_key", "date",
+     0, FLB_TRUE, offsetof(struct flb_null, json_date_key),
+    "Specifies the format of the date. Supported formats are double, iso8601 and epoch."
+    },
+
+    /* EOF */
+    {0}
+};
+
+static int cb_null_exit(void *data, struct flb_config *config)
+{
+    struct flb_null *ctx = data;
+
+    if (!ctx) {
+        return 0;
+    }
+
+    flb_free(ctx);
+    return 0;
 }
 
 struct flb_output_plugin out_null_plugin = {
@@ -51,6 +171,8 @@ struct flb_output_plugin out_null_plugin = {
     .description  = "Throws away events",
     .cb_init      = cb_null_init,
     .cb_flush     = cb_null_flush,
+    .cb_exit      = cb_null_exit,
     .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
+    .config_map   = config_map,
     .flags        = 0,
 };

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1432,13 +1432,10 @@ static int pack_json_payload(int insert_id_extracted,
         return ret;
 }
 
-static int stackdriver_format(struct flb_config *config,
-                              struct flb_input_instance *ins,
-                              void *plugin_context,
-                              void *flush_ctx,
-                              const char *tag, int tag_len,
-                              const void *data, size_t bytes,
-                              void **out_data, size_t *out_size)
+static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
+                                    int total_records,
+                                    const char *tag, int tag_len,
+                                    const void *data, size_t bytes)
 {
     int len;
     int ret;
@@ -1457,7 +1454,6 @@ static int stackdriver_format(struct flb_config *config,
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
     flb_sds_t out_buf;
-    struct flb_stackdriver *ctx = plugin_context;
 
     /* Parameters for severity */
     int severity_extracted = FLB_FALSE;
@@ -1506,7 +1502,7 @@ static int stackdriver_format(struct flb_config *config,
     timestamp_status tms_status;
 
     /* Count number of records */
-    array_size = flb_mp_count(data, bytes);
+    array_size = total_records;
 
     /*
      * Search each entry and validate insertId.
@@ -1530,8 +1526,7 @@ static int stackdriver_format(struct flb_config *config,
     msgpack_unpacked_destroy(&result);
 
     if (array_size == 0) {
-        *out_size = 0;
-        return -1;
+        return NULL;
     }
 
     /* Create temporal msgpack buffer */
@@ -1567,7 +1562,7 @@ static int stackdriver_format(struct flb_config *config,
         if (ret != 0) {
             flb_plg_error(ctx->ins, "fail to construct local_resource_id");
             msgpack_sbuffer_destroy(&mp_sbuf);
-            return -1;
+            return NULL;
         }
     }
 
@@ -1662,7 +1657,7 @@ static int stackdriver_format(struct flb_config *config,
                 flb_plg_error(ctx->ins, "fail to extract resource labels "
                               "for k8s_container resource type");
                 msgpack_sbuffer_destroy(&mp_sbuf);
-                return -1;
+                return NULL;
             }
 
             msgpack_pack_map(&mp_pck, 6);
@@ -1715,7 +1710,7 @@ static int stackdriver_format(struct flb_config *config,
                 flb_plg_error(ctx->ins, "fail to process local_resource_id from "
                               "log entry for k8s_node");
                 msgpack_sbuffer_destroy(&mp_sbuf);
-                return -1;
+                return NULL;
             }
 
             msgpack_pack_map(&mp_pck, 4);
@@ -1757,7 +1752,7 @@ static int stackdriver_format(struct flb_config *config,
                 flb_plg_error(ctx->ins, "fail to process local_resource_id from "
                               "log entry for k8s_pod");
                 msgpack_sbuffer_destroy(&mp_sbuf);
-                return -1;
+                return NULL;
             }
 
             msgpack_pack_map(&mp_pck, 5);
@@ -1796,7 +1791,7 @@ static int stackdriver_format(struct flb_config *config,
             flb_plg_error(ctx->ins, "unsupported resource type '%s'",
                           ctx->resource);
             msgpack_sbuffer_destroy(&mp_sbuf);
-            return -1;
+            return NULL;
         }
     }
     msgpack_pack_str(&mp_pck, 7);
@@ -1912,7 +1907,7 @@ static int stackdriver_format(struct flb_config *config,
                 flb_sds_destroy(operation_producer);
                 msgpack_unpacked_destroy(&result);
                 msgpack_sbuffer_destroy(&mp_sbuf);
-                return -1;
+                return NULL;
             }
             entry_size += 1;
         }
@@ -2063,13 +2058,38 @@ static int stackdriver_format(struct flb_config *config,
     if (!out_buf) {
         flb_plg_error(ctx->ins, "error formatting JSON payload");
         msgpack_unpacked_destroy(&result);
+        return NULL;
+    }
+
+    return out_buf;
+}
+
+static int stackdriver_format_test(struct flb_config *config,
+                                   struct flb_input_instance *ins,
+                                   void *plugin_context,
+                                   void *flush_ctx,
+                                   const char *tag, int tag_len,
+                                   const void *data, size_t bytes,
+                                   void **out_data, size_t *out_size)
+{
+    int total_records;
+    flb_sds_t payload = NULL;
+    struct flb_stackdriver *ctx = plugin_context;
+
+    /* Count number of records */
+    total_records = flb_mp_count(data, bytes);
+
+    payload = stackdriver_format(ctx, total_records,
+                                (char *) tag, tag_len, data, bytes);
+    if (payload == NULL) {
         return -1;
     }
 
-    *out_data = out_buf;
-    *out_size = flb_sds_len(out_buf);
+    *out_data = payload;
+    *out_size = flb_sds_len(payload);
 
     return 0;
+
 }
 
 static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
@@ -2086,8 +2106,6 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     flb_sds_t token;
     flb_sds_t payload_buf;
     size_t payload_size;
-    void *out_buf;
-    size_t out_size;
     struct flb_stackdriver *ctx = out_context;
     struct flb_upstream_conn *u_conn;
     struct flb_http_client *c;
@@ -2110,12 +2128,11 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Reformat msgpack to stackdriver JSON payload */
-    ret = stackdriver_format(config, i_ins,
-                             ctx, NULL,
-                             event_chunk->tag, flb_sds_len(event_chunk->tag),
-                             event_chunk->data, event_chunk->size,
-                             &out_buf, &out_size);
-    if (ret != 0) {
+    payload_buf = stackdriver_format(ctx,
+                                     event_chunk->total_events,
+                                     event_chunk->tag, flb_sds_len(event_chunk->tag),
+                                     event_chunk->data, event_chunk->size);
+    if (!payload_buf) {
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
                         ts, 1, (char *[]) {name});
@@ -2126,9 +2143,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
-
-    payload_buf = (flb_sds_t) out_buf;
-    payload_size = out_size;
+    payload_size = flb_sds_len(payload_buf);
 
     /* Get or renew Token */
     token = get_google_token(ctx);
@@ -2245,7 +2260,7 @@ struct flb_output_plugin out_stackdriver_plugin = {
     .cb_exit      = cb_stackdriver_exit,
 
     /* Test */
-    .test_formatter.callback = stackdriver_format,
+    .test_formatter.callback = stackdriver_format_test,
 
     /* Plugin flags */
     .flags          = FLB_OUTPUT_NET | FLB_IO_TLS,

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -829,12 +829,6 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
     struct tm tm;
     struct flb_time tms;
 
-    /* Iterate the original buffer and perform adjustments */
-    records = flb_mp_count(data, bytes);
-    if (records <= 0) {
-        return NULL;
-    }
-
     /* For json lines and streams mode we need a pre-allocated buffer */
     if (json_format == FLB_PACK_JSON_FORMAT_LINES ||
         json_format == FLB_PACK_JSON_FORMAT_STREAM) {
@@ -860,6 +854,12 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
      * ]
      */
     if (json_format == FLB_PACK_JSON_FORMAT_JSON) {
+        records = flb_mp_count(data, bytes);
+        if (records <= 0) {
+            flb_sds_destroy(out_buf);
+            msgpack_sbuffer_destroy(&tmp_sbuf);
+            return NULL;
+        }
         msgpack_pack_array(&tmp_pck, records);
     }
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -59,7 +59,7 @@ int flb_json_tokenise(const char *js, size_t len,
         /* New size: add capacity for new 256 entries */
         new_size = old_size + (sizeof(jsmntok_t) * new_tokens);
 
-        tmp = flb_realloc_z(state->tokens, old_size, new_size);
+        tmp = flb_realloc(state->tokens, new_size);
         if (!tmp) {
             flb_errno();
             return -1;
@@ -299,7 +299,7 @@ int flb_pack_state_init(struct flb_pack_state *s)
     jsmn_init(&s->parser);
 
     size = sizeof(jsmntok_t) * tokens;
-    s->tokens = flb_calloc(1, size);
+    s->tokens = flb_malloc(size);
     if (!s->tokens) {
         flb_errno();
         return -1;
@@ -365,18 +365,13 @@ int flb_pack_json_state(const char *js, size_t len,
         int i;
         int found = 0;
 
-        for (i = 1; i < state->tokens_size; i++) {
+        for (i = 1; i < state->tokens_count; i++) {
             t = &state->tokens[i];
-
-            if (t->start < (state->tokens[i - 1]).start) {
-                break;
-            }
 
             if (t->parent == -1 && (t->end != 0)) {
                 found++;
                 delim = i;
             }
-
         }
 
         if (found > 0) {


### PR DESCRIPTION
The following PR implement some performance improvements on the packer interface, specifically in the JSON parser, expect a gain of 2.1% for common use cases. 

In addition, the following changes are done:

- out_null: implement new `format`, `json_date_format` and `json_date_key` options. These new options are only intended to be used by developers to test the performance of msgpack<>json encoder.  
- out_loki: improve performance by removing records counter
- out_stackdriver: improve performance by removing records counter