### PR TITLE
parsing: performance improvements

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -63,13 +63,14 @@ struct flb_pack_state {
 
 int flb_json_tokenise(const char *js, size_t len, struct flb_pack_state *state);
 
-
 int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size, int *root_type);
-int flb_pack_json_recs(const char *js, size_t len, char **buffer, size_t *size,
+int flb_pack_json_recs(struct flb_pack_state *state,
+                       const char *js, size_t len, char **buffer, size_t *size,
                        int *root_type, int *out_records);
 
 int flb_pack_state_init(struct flb_pack_state *s);
 void flb_pack_state_reset(struct flb_pack_state *s);
+void flb_pack_state_recycle(struct flb_pack_state *s);
 
 int flb_pack_json_state(const char *js, size_t len,
                         char **buffer, int *size,

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -26,12 +26,14 @@
 #include <fluent-bit/flb_regex.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
 #include <msgpack.h>
 
-#define FLB_PARSER_REGEX 1
-#define FLB_PARSER_JSON  2
-#define FLB_PARSER_LTSV  3
-#define FLB_PARSER_LOGFMT 4
+#define FLB_PARSER_REGEX   1
+#define FLB_PARSER_JSON    2
+#define FLB_PARSER_DOCKER  3
+#define FLB_PARSER_LTSV    4
+#define FLB_PARSER_LOGFMT  5
 
 struct flb_parser_types {
     char *key;
@@ -47,7 +49,7 @@ struct flb_parser {
     int skip_empty;       /* skip empty regex matches */
     char *time_fmt;       /* time format */
     char *time_fmt_full;  /* original given time format */
-    char *time_key;       /* field name that contains the time */
+    flb_sds_t time_key;   /* field name that contains the time */
     int time_offset;      /* fixed UTC offset */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
@@ -62,7 +64,13 @@ struct flb_parser {
     int time_with_year;   /* do time_fmt consider a year (%Y) ? */
     char *time_fmt_year;
     int time_with_tz;     /* do time_fmt consider a timezone ?  */
+
+    /* backend: regex */
     struct flb_regex *regex;
+
+    /* backend: json */
+    struct flb_pack_state json_state;
+
     struct mk_list _head;
 };
 

--- a/include/fluent-bit/multiline/flb_ml.h
+++ b/include/fluent-bit/multiline/flb_ml.h
@@ -118,6 +118,17 @@ struct flb_ml_stream {
                      size_t buf_size);
     void *cb_data;
 
+    /*
+     * Packer: optional msgpack-c packer that user can set so the stream flusher
+     * will use the provider packer instead of creating a new one.
+     *
+     * Without a 'packer', the flush callback receives a new buffer with the
+     * data processed, by using the packer the multiline core writes to the
+     * packer and pass the flush callback a pointer to the new content added
+     * and it size.
+     */
+    msgpack_packer *mp_pck;
+
     struct flb_ml_stream_group *last_stream_group;
 
     /* reference to parent instance */
@@ -302,6 +313,15 @@ int flb_ml_stream_create(struct flb_ml *ml,
                                           size_t buf_size),
                          void *cb_data,
                          uint64_t *stream_id);
+
+int flb_ml_stream_create_with_packer(struct flb_ml *ml, char *name, int name_len,
+                                     int (*cb_flush) (struct flb_ml_parser *,
+                                                      struct flb_ml_stream *,
+                                                      void *cb_data,
+                                                      char *buf_data,
+                                                      size_t buf_size),
+                                    void *cb_data, msgpack_packer *mp_pck,
+                                    uint64_t *stream_id);
 
 int flb_ml_stream_destroy(struct flb_ml_stream *mst);
 

--- a/lib/jsmn/jsmn.h
+++ b/lib/jsmn/jsmn.h
@@ -74,6 +74,7 @@ typedef struct jsmntok {
 #ifdef JSMN_PARENT_LINKS
   int parent;
 #endif
+  int escaped;
 } jsmntok_t;
 
 /**
@@ -196,7 +197,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
   jsmntok_t *token;
 
   int start = parser->pos;
-
+  int escaped = 0;
   parser->pos++;
 
   /* Skip starting quote */
@@ -213,6 +214,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
         parser->pos = start;
         return JSMN_ERROR_NOMEM;
       }
+      token->escaped = escaped;
       jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
 #ifdef JSMN_PARENT_LINKS
       token->parent = parser->toksuper;
@@ -223,6 +225,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
     /* Backslash: Quoted symbol expected */
     if (c == '\\' && parser->pos + 1 < len) {
       int i;
+      escaped = 1;
       parser->pos++;
       switch (js[parser->pos]) {
       /* Allowed escaped symbols */

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -101,6 +101,7 @@ static int merge_log_handler(msgpack_object o,
     int root_type;
     int records = 0;
     char *tmp;
+    struct flb_pack_state state;
 
     /* Reset vars */
     *out_buf = NULL;
@@ -149,10 +150,14 @@ static int merge_log_handler(msgpack_object o,
             return MERGE_PARSED;
         }
     }
-    else { /* Default JSON parser */
-        ret = flb_pack_json_recs(ctx->unesc_buf, ctx->unesc_buf_len,
+    else {
+        /* Default JSON parser */
+        flb_pack_state_init(&state);
+        ret = flb_pack_json_recs(&state, ctx->unesc_buf, ctx->unesc_buf_len,
                                  (char **) out_buf, out_size, &root_type,
                                  &records);
+        flb_pack_state_reset(&state);
+
         if (ret == 0 && root_type != FLB_PACK_JSON_OBJECT) {
             flb_plg_debug(ctx->ins, "could not merge JSON, root_type=%i",
                       root_type);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -789,7 +789,6 @@ static int ml_flush_callback(struct flb_ml_parser *parser,
 
     /* Enqueue the records in our file->multiline buffer */
     file->mult_records++;
-    msgpack_sbuffer_write(&file->mult_sbuf, buf_data, buf_size);
 
     return 0;
 }
@@ -906,11 +905,13 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
          */
         inode_str = flb_sds_create_size(64);
         flb_sds_printf(&inode_str, "%"PRIu64, file->inode);
+
         /* Create a stream for this file */
-        ret = flb_ml_stream_create(ctx->ml_ctx,
-                                   inode_str, flb_sds_len(inode_str),
-                                   ml_flush_callback, file,
-                                   &stream_id);
+        ret = flb_ml_stream_create_with_packer(ctx->ml_ctx,
+                                               inode_str, flb_sds_len(inode_str),
+                                               ml_flush_callback, file,
+                                               &file->mult_pck,
+                                               &stream_id);
         if (ret != 0) {
             flb_plg_error(ctx->ins,
                           "could not create multiline stream for file: %s",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ if(FLB_PARSER)
     flb_parser.c
     flb_parser_regex.c
     flb_parser_json.c
+    flb_parser_docker.c
     flb_parser_decoder.c
     flb_parser_ltsv.c
     flb_parser_logfmt.c

--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -43,6 +43,7 @@ static int decode_json(struct flb_parser_dec *dec,
     const char *p;
     size_t size;
     size_t len;
+    struct flb_pack_state state;
 
     p = in_buf;
     while (*p == ' ') p++;
@@ -54,7 +55,10 @@ static int decode_json(struct flb_parser_dec *dec,
         return -1;
     }
 
-    ret = flb_pack_json_recs(p, len, &buf, &size, &root_type, &records);
+    flb_pack_state_init(&state);
+    ret = flb_pack_json_recs(&state, p, len, &buf, &size, &root_type, &records);
+    flb_pack_state_reset(&state);
+
     if (ret != 0) {
         return -1;
     }

--- a/src/flb_parser_docker.c
+++ b/src/flb_parser_docker.c
@@ -1,0 +1,252 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_unescape.h>
+
+/* pack JSON string */
+static inline int pack_string_token(struct flb_pack_state *state,
+                                    int unescape_utf8,
+                                    const char *str, int len,
+                                    msgpack_packer *pck)
+{
+    int s;
+    int out_len;
+    char *tmp;
+    char *out_buf;
+
+    if (state->buf_size < len + 1) {
+        s = len + 1;
+        tmp = flb_realloc(state->buf_data, s);
+        if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+        else {
+            state->buf_data = tmp;
+            state->buf_size = s;
+        }
+    }
+    out_buf = state->buf_data;
+
+    /* Unescape string if needed */
+    if (unescape_utf8) {
+        out_len = flb_unescape_string_utf8(str, len, out_buf);
+
+        /* Pack unescaped text */
+        msgpack_pack_str(pck, out_len);
+        msgpack_pack_str_body(pck, out_buf, out_len);
+    }
+    else {
+        /* Pack raw text */
+        msgpack_pack_str(pck, len);
+        msgpack_pack_str_body(pck, str, len);
+        out_len = len;
+    }
+
+    return out_len;
+}
+
+/* convert JSON tokens to msgpack */
+static int process_tokens(struct flb_pack_state *state, const char *js,
+                          char **out_buf, size_t *out_size, int *n_records,
+                          int *time_token)
+{
+    int i;
+    int ret;
+    int flen;
+    int arr_size;
+    int records = 0;
+    int time_id = -1;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    jsmntok_t *tokens;
+    const jsmntok_t *t;
+
+    tokens = state->tokens;
+    arr_size = state->tokens_count;
+
+    if (arr_size == 0) {
+        return -1;
+    }
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    for (i = 0; i < arr_size ; i++) {
+        t = &tokens[i];
+
+        if (t->start == -1 || t->end == -1 || (t->start == 0 && t->end == 0)) {
+            break;
+        }
+
+        if (t->parent == -1) {
+            records++;
+        }
+
+        flen = (t->end - t->start);
+
+        if (t->type == JSMN_STRING) {
+            if (t->escaped) {
+                ret = pack_string_token(state, FLB_TRUE,
+                                        js + t->start, flen, &mp_pck);
+            }
+            else {
+                ret = pack_string_token(state, FLB_FALSE,
+                                        js + t->start, flen, &mp_pck);
+
+                /* the time value is a non-scaped string field */
+                if (flen == 4 && (memcmp(js + t->start, "time", 4) == 0)) {
+                    /* 'time' value is the next token */
+                    time_id = i + 1;
+                }
+            }
+
+            if (ret == -1) {
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
+            }
+        }
+        else if (t->type == JSMN_OBJECT) {
+            msgpack_pack_map(&mp_pck, t->size);
+        }
+    }
+
+    *out_buf = mp_sbuf.data;
+    *out_size = mp_sbuf.size;
+    *n_records = records;
+
+    if (time_id <= state->tokens_count) {
+        *time_token = time_id;
+    }
+
+    return 0;
+}
+
+static int docker_json_to_msgpack(struct flb_parser *parser,
+                                  const char *js_buf, size_t js_len,
+                                  char **out_buf, size_t *out_size,
+                                  int *n_records, int *root_type,
+                                  struct flb_time *out_time)
+{
+    int len;
+    int ret;
+    int time_token = -1;
+    time_t time_lookup;
+    char *ptr;
+    char tmp[255];
+    struct tm tm = {0};
+    double tmfrac = 0;
+    const jsmntok_t *t;
+    struct flb_pack_state *state = &parser->json_state;
+
+    /* tokenize */
+    ret = flb_json_tokenise(js_buf, js_len, state);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (state->tokens_count == 0) {
+        return -1;
+    }
+
+    ret = process_tokens(state, js_buf, out_buf, out_size, n_records, &time_token);
+    if (ret != 0) {
+        return -1;
+    }
+
+    /* root token time */
+    *root_type = state->tokens[0].type;
+
+    /* process time lookup */
+    if (time_token >= 0) {
+        t = &state->tokens[time_token];
+
+        len = t->end - t->start;
+        ptr = (char *) js_buf + t->start;
+
+        /* Lookup time */
+        ret = flb_parser_time_lookup(ptr, len,
+                                     0, parser, &tm, &tmfrac);
+        if (ret == -1) {
+            if (len > sizeof(tmp) - 1) {
+                len = sizeof(tmp) - 1;
+            }
+
+            memcpy(tmp, ptr, len);
+            tmp[len] = '\0';
+            flb_warn("[parser:%s] invalid time format %s for '%s'",
+                     parser->name, parser->time_fmt_full, tmp);
+            time_lookup = 0;
+        }
+        else {
+            /* set timestamp */
+            time_lookup = flb_parser_tm2time(&tm);
+            out_time->tm.tv_sec  = time_lookup;
+            out_time->tm.tv_nsec = (tmfrac * 1000000000);
+        }
+    }
+
+    return 0;
+}
+
+int flb_parser_docker_do(struct flb_parser *parser,
+                         const char *in_buf, size_t in_size,
+                         void **out_buf, size_t *out_size,
+                         struct flb_time *out_time)
+{
+    int ret;
+    int total_records = 0;
+    int root_type = -1;
+    char *mp_buf = NULL;
+    size_t mp_size;
+
+    flb_pack_state_recycle(&parser->json_state);
+
+    /* Convert incoming in_buf JSON message to message pack format */
+    ret = docker_json_to_msgpack(parser, in_buf, in_size,
+                                 &mp_buf, &mp_size,
+                                 &total_records, &root_type, out_time);
+
+    /* check return */
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (total_records != 1) {
+        flb_free(mp_buf);
+        return -1;
+    }
+
+    /* Make sure object is a map */
+    if (root_type != FLB_PACK_JSON_OBJECT) {
+        flb_free(mp_buf);
+        return -1;
+    }
+
+    *out_buf = mp_buf;
+    *out_size = mp_size;
+
+    return *out_size;
+}

--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -26,22 +26,21 @@
 #include <string.h>
 #include <inttypes.h>
 
-static int octal_digit(char c)
+static inline int octal_digit(char c)
 {
     return (c >= '0' && c <= '7');
 }
 
-static int hex_digit(char c)
+static inline int hex_digit(char c)
 {
     return ((c >= '0' && c <= '9') ||
             (c >= 'A' && c <= 'F') ||
             (c >= 'a' && c <= 'f'));
 }
 
-static int u8_wc_toutf8(char *dest, uint32_t ch)
+static inline int u8_wc_toutf8(char *dest, uint32_t ch)
 {
     if (ch < 0x80) {
-        dest[0] = (char)ch;
         return 1;
     }
     if (ch < 0x800) {
@@ -67,7 +66,7 @@ static int u8_wc_toutf8(char *dest, uint32_t ch)
 
 /* assumes that src points to the character after a backslash
    returns number of input characters processed */
-static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
+static inline int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
 {
     uint32_t ch;
     char digs[9]="\0\0\0\0\0\0\0\0";
@@ -199,12 +198,12 @@ int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf)
             break;
         }
 
-        if (esc_out == 0) {
+        if (esc_out == 1) {
+            out_buf[count_out] = ch;
+        }
+        else if (esc_out == 0) {
             out_buf[count_out] = ch;
             esc_out = 1;
-        }
-        else if (esc_out == 1) {
-            out_buf[count_out] = (char) temp[0];
         }
         else {
             memcpy(&out_buf[count_out], temp, esc_out);

--- a/src/multiline/flb_ml_parser_docker.c
+++ b/src/multiline/flb_ml_parser_docker.c
@@ -28,7 +28,7 @@ static struct flb_parser *docker_parser_create(struct flb_config *config)
     struct flb_parser *p;
 
     p = flb_parser_create("_ml_json_docker",      /* parser name */
-                          "json",                 /* backend type */
+                          "docker",               /* backend type */
                           NULL,                   /* regex */
                           FLB_TRUE,               /* skip_empty */
                           "%Y-%m-%dT%H:%M:%S.%L", /* time format */
@@ -97,7 +97,7 @@ struct flb_ml_parser *flb_ml_parser_docker(struct flb_config *config)
                                FLB_FALSE,               /* negate         */
                                FLB_ML_FLUSH_TIMEOUT,    /* flush_ms  */
                                "log",                   /* key_content    */
-                               "stream",                /* key_group      */
+                               NULL /*"stream"*/,                /* key_group      */
                                NULL,                    /* key_pattern    */
                                parser,                  /* parser ctx     */
                                NULL);                   /* parser name    */


### PR DESCRIPTION
The following PR implements several performance improvements associated with Docker logs parsing and multiline mode.

In this PR we introduce a new `built-in` docker parser that reduces the number of memory allocations and computing time needed in a common JSON parser.  This new mode optimizes docker logs performance parsing by 20-40% in high workloads. 

note: more PRs about performance improvements will come shortly.