### PR TITLE
workflows: add release branch PR info

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,11 +22,10 @@ Before we can approve your change; please submit the following in a comment:
 <!--
 PRs targeting the default master branch will go into the next major release usually.
 If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-For example, to merge a change to the 1.8.X series then provide a PR for the 1.8 branch.
 -->
-- [ ] Changes should be applied to another release.
+- [ ] Backport to latest stable release.
 
-<!--  Other release PR (not required but highly recommended) -->
+<!--  Other release PR (not required but highly recommended for quick turnaround) -->
 ----
 
 Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Before we can approve your change; please submit the following in a comment:
 
 **Backporting**
 <!--
-PRs targeting the default master branch will go into the next major release.
+PRs targeting the default master branch will go into the next major release usually.
 If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
 For example, to merge a change to the 1.8.X series then provide a PR for the 1.8 branch.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,15 @@ Before we can approve your change; please submit the following in a comment:
 
 <!--  Doc PR (not required but highly recommended) -->
 
+**Backporting**
+<!--
+PRs targeting the default master branch will go into the next major release.
+If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
+For example, to merge a change to the 1.8.X series then provide a PR for the 1.8 branch.
+-->
+- [ ] Changes should be applied to another release.
+
+<!--  Other release PR (not required but highly recommended) -->
 ----
 
 Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ Despite the effort that took for you to create the contribution, that is not an 
 
 ## Release branches
 
-Fluent Bit follow this general branching strategy:
+Fluent Bit follows this general branching strategy:
 
 * `master` is the next major version (not yet released)
 * `<major>` is the branch for an existing stable release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,3 +214,11 @@ When we review your code submission, they must follow our coding style, the code
 If your code needs some improvement, someone of the reviewers or core developers will write a comment in your Pull Request, so please take in count the suggestion there, otherwise your request will never be merged.
 
 Despite the effort that took for you to create the contribution, that is not an indication that the code have to be merged into upstream, everything will be reviewed and must be aligned as the code base.
+
+## Release branches
+
+Generally a PR will target the default `master` branch so the changes will go into the next major release.
+
+Once merged, this does not mean they will automatically go into the next minor release of the current series.
+
+A particular set of changes might want to be applied to the current or previous releases so please also submit a PR targeting the branch for the particular release series you want or think it should be applied to, e.g. if a change should go into a 1.8.X release then target the `1.8` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,6 +217,11 @@ Despite the effort that took for you to create the contribution, that is not an 
 
 ## Release branches
 
+Fluent Bit follow this general branching strategy:
+
+* `master` is the next major version (not yet released)
+* `<major>` is the branch for an existing stable release
+
 Generally a PR will target the default `master` branch so the changes will go into the next major release.
 
 Once merged, this does not mean they will automatically go into the next minor release of the current series.


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Improves the visibility of needing to submit PRs for release branches.
See https://github.com/fluent/fluent-bit/pull/3177#issuecomment-1004890321 for an example.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
