### PR TITLE
dockerfiles: backport systemd lib fixes from #3177 to 1.8

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -80,7 +80,8 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
       libpq5 \
       libsystemd0/buster-backports \
       zlib1g \
-      ca-certificates
+      ca-certificates \
+      libatomic1
 
 COPY --from=builder /fluent-bit /fluent-bit
 RUN rm /usr/bin/qemu-arm-static

--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -14,7 +14,8 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-mas
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -25,7 +26,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -70,13 +71,14 @@ FROM arm32v7/debian:buster-slim
 
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
       libsasl2-2 \
       pkg-config \
       libpq5 \
-      libsystemd0 \
+      libsystemd0/buster-backports \
       zlib1g \
       ca-certificates
 

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -1,5 +1,4 @@
-# Build on amd64 and cross-compile to arch for max speed
-FROM --platform=linux/amd64 debian:buster as builder
+FROM --platform=linux/arm64 debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -7,38 +6,37 @@ ENV FLB_MINOR 8
 ENV FLB_PATCH 12
 ENV FLB_VERSION 1.8.12
 
+ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
+ENV FLB_SOURCE $FLB_TARBALL
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN dpkg --add-architecture arm64
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
-RUN apt update && apt install -y --no-remove --no-install-recommends \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     build-essential \
-    g++-aarch64-linux-gnu \
-    gcc-aarch64-linux-gnu \
+    curl \
     ca-certificates \
-    pkg-config \
     cmake \
     make \
+    tar \
+    libssl-dev \
+    libsasl2-dev \
+    pkg-config \
+    libsystemd-dev/buster-backports \
+    zlib1g-dev \
+    libpq-dev \
+    postgresql-server-dev-all \
     flex \
     bison \
-    dpkg-dev \
-    libssl-dev:arm64 \
-    libsasl2-dev:arm64 \
-    libsystemd-dev:arm64/buster-backports \
-    libzstd-dev:arm64 \
-    zlib1g-dev:arm64 \
-    libpq-dev:arm64
+    && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
+    && cd tmp/ && mkdir fluent-bit \
+    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
+    && cd fluent-bit/build/ \
+    && rm -rf /tmp/fluent-bit/build/*
 
-# postgresql-server-dev-11:arm64 has conflicts if installed using apt. hack here to manually force install with dpkg
-WORKDIR /tmp
-RUN apt download postgresql-server-dev-11:arm64
-RUN dpkg --force-all -i postgresql-server-*.deb
-
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/src/
-COPY . /tmp/src/
-RUN rm -rf /tmp/src/build/*
-WORKDIR /tmp/src/build/
-
+WORKDIR /tmp/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
@@ -48,11 +46,21 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On \
-          -DCMAKE_TOOLCHAIN_FILE=/tmp/src/cmake/linux-arm64.cmake ../
+          -DFLB_OUT_PGSQL=On ..
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
+
+# Configuration files
+COPY conf/fluent-bit.conf \
+     conf/parsers.conf \
+     conf/parsers_ambassador.conf \
+     conf/parsers_java.conf \
+     conf/parsers_extra.conf \
+     conf/parsers_openstack.conf \
+     conf/parsers_cinder.conf \
+     conf/plugins.conf \
+     /fluent-bit/etc/
 
 FROM --platform=linux/arm64 debian:buster-slim
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
@@ -70,7 +78,7 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
 
 # These below are all needed for systemd
-COPY --from=builder /lib/aarch64-linux-gnu/libsystemd* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libsystemd* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so* /lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/liblz4.so* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/libgcrypt.so* /lib/aarch64-linux-gnu/
@@ -95,17 +103,6 @@ COPY --from=builder /lib/aarch64-linux-gnu/libkeyutils* /lib/aarch64-linux-gnu/
 
 # Build artifact
 COPY --from=builder /fluent-bit /fluent-bit
-
-# Configuration files
-COPY conf/fluent-bit.conf \
-     conf/parsers.conf \
-     conf/parsers_ambassador.conf \
-     conf/parsers_java.conf \
-     conf/parsers_extra.conf \
-     conf/parsers_openstack.conf \
-     conf/parsers_cinder.conf \
-     conf/plugins.conf \
-     /fluent-bit/etc/
 
 EXPOSE 2020
 

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -10,6 +10,7 @@ ENV FLB_VERSION 1.8.12
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN dpkg --add-architecture arm64
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
 RUN apt update && apt install -y --no-remove --no-install-recommends \
     build-essential \
     g++-aarch64-linux-gnu \
@@ -23,7 +24,7 @@ RUN apt update && apt install -y --no-remove --no-install-recommends \
     dpkg-dev \
     libssl-dev:arm64 \
     libsasl2-dev:arm64 \
-    libsystemd-dev:arm64 \
+    libsystemd-dev:arm64/buster-backports \
     libzstd-dev:arm64 \
     zlib1g-dev:arm64 \
     libpq-dev:arm64

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -12,7 +12,8 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-mas
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -23,7 +24,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -77,7 +78,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-g
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
-COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/

--- a/dockerfiles/Dockerfile.x86_64-master
+++ b/dockerfiles/Dockerfile.x86_64-master
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD . /source
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -15,7 +16,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -65,7 +66,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-g
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
-COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/

--- a/dockerfiles/Dockerfile.x86_64-master_debug
+++ b/dockerfiles/Dockerfile.x86_64-master_debug
@@ -12,6 +12,7 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-mas
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -23,7 +24,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -86,7 +87,7 @@ COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 # These below are all needed for systemd
-COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

The 1.8 branch is not working on recent Flatcar Linux systems, because of incompatibility in systemd libs. #3177 took care of that, but targets master (ie, future 1.9). This PR is a cherry pick of @yasn77's commit, but targets 1.8.

What I did to test:
- `git checkout v1.8.11`
- `git cherry-pick 3f991077`
- `docker build -f dockerfiles/Dockerfile.x86_64-master`
- use that image on modern Flatcar Linux machines
