### PR TITLE
tests: runtime: in_tail: remove unused val

### DIFF
--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -503,9 +503,6 @@ void flb_test_in_tail_multiline_json_and_regex()
     int out_ffd;
     int n_expected;
     int t_expected;
-    va_list va;
-    char *key;
-    char *value;
     char *target;
     char path[PATH_MAX];
     struct tail_test_result result = {0};


### PR DESCRIPTION
To fix below warnings.

```
Scanning dependencies of target flb-rt-in_tail
[ 88%] Building C object tests/runtime/CMakeFiles/flb-rt-in_tail.dir/in_tail.c.o
/home/taka/git/fluent-bit/tests/runtime/in_tail.c: In function ‘flb_test_in_tail_multiline_json_and_regex’:
/home/taka/git/fluent-bit/tests/runtime/in_tail.c:508:11: warning: unused variable ‘value’ [-Wunused-variable]
  508 |     char *value;
      |           ^~~~~
/home/taka/git/fluent-bit/tests/runtime/in_tail.c:507:11: warning: unused variable ‘key’ [-Wunused-variable]
  507 |     char *key;
      |           ^~~
/home/taka/git/fluent-bit/tests/runtime/in_tail.c:506:13: warning: unused variable ‘va’ [-Wunused-variable]
  506 |     va_list va;
      |             ^~
[ 88%] Linking C executable ../../bin/flb-rt-in_tail
[ 88%] Built target flb-rt-in_tail
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

## Debug log

```
taka@locals:~/git/fluent-bit/build$ bin/flb-rt-in_tail 
Test issue_3943...                              [2022/01/08 08:07:42] [ info] [input] pausing tail.0
[ OK ]
Test skip_long_lines...                         [2022/01/08 08:07:44] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_dockermode...                      [2022/01/08 08:07:45] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_dockermode_splitted_line...        [2022/01/08 08:07:46] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_dockermode_multiple_lines...       [2022/01/08 08:07:51] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_dockermode_splitted_multiple_lines... [2022/01/08 08:07:56] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_dockermode_firstline_detection...  [2022/01/08 08:08:01] [ info] [input] pausing tail.0
[ OK ]
Test in_tail_multiline_json_and_regex...        [2022/01/08 08:08:02] [ info] [engine] started (pid=29550)
[2022/01/08 08:08:02] [ info] [storage] version=1.1.5, initializing...
[2022/01/08 08:08:02] [ info] [storage] in-memory
[2022/01/08 08:08:02] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/08 08:08:02] [ info] [cmetrics] version=0.2.2
[2022/01/08 08:08:02] [ info] [input:tail:tail.0] multiline core started
[2022/01/08 08:08:02] [ info] [sp] stream processor started
[2022/01/08 08:08:02] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1453933 watch_fd=1 name=/home/taka/git/fluent-bit/tests/runtime/data/tail/log/multiline_001.log
[2022/01/08 08:08:05] [ info] [input] pausing tail.0
[2022/01/08 08:08:05] [ warn] [engine] service will shutdown in max 1 seconds
[2022/01/08 08:08:06] [ info] [engine] service has stopped (0 pending tasks)
[2022/01/08 08:08:06] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1453933 watch_fd=1
[ OK ]
SUCCESS: All unit tests have passed.
taka@locals:~/git/fluent-bit/build$ 
```

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
