### PR TITLE
filter_rewrite_tag: set 'keep' before emitting(#4518)

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -323,6 +323,9 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
 
     mk_list_foreach(head, &ctx->rules) {
         rule = mk_list_entry(head, struct rewrite_rule, _head);
+        if (rule) {
+            *keep = rule->keep_record;
+        }
         ret = flb_ra_regex_match(rule->ra_key, map, rule->regex, &result);
         if (ret < 0) { /* no match */
             rule = NULL;
@@ -359,7 +362,7 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
         return FLB_FALSE;
     }
 
-    *keep = rule->keep_record;
+
     return FLB_TRUE;
 }
 


### PR DESCRIPTION
Fixes #4518.

## The problem 
The variable 'keep' of `cb_rewrite_tag_filter` is initialized when `process_record` returns FLB_TRUE.
https://github.com/fluent/fluent-bit/blob/v1.8.11/plugins/filter_rewrite_tag/rewrite_tag.c#L364

It means 'keep' is undefined and it indicates some records can be dropped since undefined value can be different from FLB_TRUE.
https://github.com/fluent/fluent-bit/blob/v1.8.11/plugins/filter_rewrite_tag/rewrite_tag.c#L425

## Question

If user set a rule `Rule $test  ^(true)$ test true`, what records should be kept?
All of them ? Only 1 and 3 ?

1. {"i"=>0, "test"=>"true"}
1. {"i"=>0, "aaa"=>"true"}
1. {"i"=>1, "test"=>"true"}
1. {"i"=>1, "aaa"=>"true"}

## This patch

My patch is to keep all of above records.
'keep' is initialized when some rule is found.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->


## Configuration 

https://github.com/fluent/fluent-bit/issues/4518#issuecomment-1007886281

## Debug output

All records are kept.
```
taka@locals:~/git/fluent-bit/build/4518$ cat test3
test3: [1641629045.880070421, {"message":"DEBUG","i":0,"test3":"true"}]
test3: [1641629046.880063552, {"message":"DEBUG","i":1,"test3":"true"}]
test3: [1641629047.881831784, {"message":"DEBUG","i":2,"test3":"true"}]
test3: [1641629048.883403435, {"message":"DEBUG","i":3,"test3":"true"}]
test3: [1641629049.885002862, {"message":"DEBUG","i":4,"test3":"true"}]
test3: [1641629050.886182699, {"message":"DEBUG","i":5,"test3":"true"}]
test3: [1641629051.887762579, {"message":"DEBUG","i":6,"test3":"true"}]
test3: [1641629052.889147899, {"message":"DEBUG","i":7,"test3":"true"}]
test3: [1641629053.890186761, {"message":"DEBUG","i":8,"test3":"true"}]
test3: [1641629054.891048520, {"message":"DEBUG","i":9,"test3":"true"}]

```

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/08 17:30:30] [ info] [engine] started (pid=56205)
[2022/01/08 17:30:30] [ info] [storage] version=1.1.5, initializing...
[2022/01/08 17:30:30] [ info] [storage] in-memory
[2022/01/08 17:30:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/08 17:30:30] [ info] [cmetrics] version=0.2.2
[2022/01/08 17:30:30] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/08 17:30:30] [ info] [sp] stream processor started
[0] dummy: [1641630635.681057703, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] dummy: [1641630635.681059958, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[2] dummy: [1641630636.681037118, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[3] dummy: [1641630636.681040224, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[4] dummy: [1641630637.682300759, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[5] dummy: [1641630637.682304837, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[6] dummy: [1641630638.683727572, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[7] dummy: [1641630638.683732812, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[8] dummy: [1641630639.685075112, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[9] dummy: [1641630639.685077867, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test2: [1641630635.681059958, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[1] test2: [1641630636.681040224, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[2] test2: [1641630637.682304837, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[3] test2: [1641630638.683732812, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[4] test2: [1641630639.685077867, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test3: [1641630635.681057703, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] test3: [1641630636.681037118, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[2] test3: [1641630637.682300759, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[3] test3: [1641630638.683727572, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[4] test3: [1641630639.685075112, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[0] dummy: [1641630640.687018642, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] dummy: [1641630640.687023992, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[2] dummy: [1641630641.688321161, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[3] dummy: [1641630641.688324357, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[4] dummy: [1641630642.689289588, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[5] dummy: [1641630642.689292824, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[6] dummy: [1641630643.690114586, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[7] dummy: [1641630643.690117261, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[8] dummy: [1641630644.691052516, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
[9] dummy: [1641630644.691055492, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test2: [1641630640.687023992, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[1] test2: [1641630641.688324357, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[2] test2: [1641630642.689292824, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[3] test2: [1641630643.690117261, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[4] test2: [1641630644.691055492, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test3: [1641630640.687018642, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] test3: [1641630641.688321161, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[2] test3: [1641630642.689289588, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[3] test3: [1641630643.690114586, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[4] test3: [1641630644.691052516, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]

```

## Valgrind output

No leaks.

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==56231== Memcheck, a memory error detector
==56231== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==56231== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==56231== Command: ../bin/fluent-bit -c a.conf
==56231== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/08 17:31:58] [ info] [engine] started (pid=56231)
[2022/01/08 17:31:58] [ info] [storage] version=1.1.5, initializing...
[2022/01/08 17:31:58] [ info] [storage] in-memory
[2022/01/08 17:31:58] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/08 17:31:58] [ info] [cmetrics] version=0.2.2
[2022/01/08 17:31:58] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/08 17:31:58] [ info] [sp] stream processor started
==56231== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4fa6e10
==56231==          to suppress, use: --max-stackframe=8645608 or greater
==56231== Warning: client switching stacks?  SP change: 0x4fa6db8 --> 0x57e59f8
==56231==          to suppress, use: --max-stackframe=8645696 or greater
==56231== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4fa6db8
==56231==          to suppress, use: --max-stackframe=8645696 or greater
==56231==          further instances of this message will not be shown.
[0] dummy: [1641630720.793869074, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] dummy: [1641630720.793873943, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[2] dummy: [1641630721.793828184, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[3] dummy: [1641630721.793831230, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[4] dummy: [1641630722.794830448, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[5] dummy: [1641630722.794833313, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[6] dummy: [1641630723.795910051, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[7] dummy: [1641630723.795915422, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[8] dummy: [1641630724.797473345, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[9] dummy: [1641630724.797476300, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test2: [1641630720.793873943, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[1] test2: [1641630721.793831230, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[2] test2: [1641630722.794833313, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[3] test2: [1641630723.795915422, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[4] test2: [1641630724.797476300, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test3: [1641630720.793869074, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] test3: [1641630721.793828184, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[2] test3: [1641630722.794830448, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[3] test3: [1641630723.795910051, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[4] test3: [1641630724.797473345, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[0] dummy: [1641630725.798508482, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] dummy: [1641630725.798512650, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[2] dummy: [1641630726.800005923, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[3] dummy: [1641630726.800008648, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[4] dummy: [1641630727.800897956, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[5] dummy: [1641630727.800901002, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[6] dummy: [1641630728.801945420, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[7] dummy: [1641630728.801949408, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[8] dummy: [1641630729.803247214, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
[9] dummy: [1641630729.803251231, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test2: [1641630725.798512650, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[1] test2: [1641630726.800008648, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[2] test2: [1641630727.800901002, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[3] test2: [1641630728.801949408, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[4] test2: [1641630729.803251231, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test3: [1641630725.798508482, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] test3: [1641630726.800005923, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[2] test3: [1641630727.800897956, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[3] test3: [1641630728.801945420, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[4] test3: [1641630729.803247214, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
^C[2022/01/08 17:32:14] [engine] caught signal (SIGINT)
[2022/01/08 17:32:14] [ info] [input] pausing forward.0
[2022/01/08 17:32:14] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/08 17:32:14] [ info] [engine] service has stopped (0 pending tasks)
==56231== 
==56231== HEAP SUMMARY:
==56231==     in use at exit: 0 bytes in 0 blocks
==56231==   total heap usage: 3,193 allocs, 3,193 frees, 6,912,625 bytes allocated
==56231== 
==56231== All heap blocks were freed -- no leaks are possible
==56231== 
==56231== For lists of detected and suppressed errors, rerun with: -s
==56231== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build/4518$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
