### PR TITLE
io: support fd based read/write

### DIFF
--- a/include/fluent-bit/flb_io.h
+++ b/include/fluent-bit/flb_io.h
@@ -48,5 +48,7 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
 int flb_io_net_write(struct flb_upstream_conn *u, const void *data,
                      size_t len, size_t *out_len);
 ssize_t flb_io_net_read(struct flb_upstream_conn *u, void *buf, size_t len);
+int flb_io_fd_write(int fd, const void *data, size_t len, size_t *out_len);
+ssize_t flb_io_fd_read(int fd, void *buf, size_t len);
 
 #endif

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -118,12 +118,11 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     return 0;
 }
 
+static int fd_io_write(int fd, const void *data, size_t len, size_t *out_len);
 static int net_io_write(struct flb_upstream_conn *u_conn,
                         const void *data, size_t len, size_t *out_len)
 {
     int ret;
-    int tries = 0;
-    size_t total = 0;
     struct flb_coro *coro;
 
     if (u_conn->fd <= 0) {
@@ -134,8 +133,17 @@ static int net_io_write(struct flb_upstream_conn *u_conn,
         }
     }
 
+    return fd_io_write(u_conn->fd, data, len, out_len);
+}
+
+static int fd_io_write(int fd, const void *data, size_t len, size_t *out_len)
+{
+    int ret;
+    int tries = 0;
+    size_t total = 0;
+
     while (total < len) {
-        ret = send(u_conn->fd, (char *) data + total, len - total, 0);
+        ret = send(fd, (char *) data + total, len - total, 0);
         if (ret == -1) {
             if (FLB_WOULDBLOCK()) {
                 /*
@@ -305,12 +313,18 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
     return bytes;
 }
 
+static ssize_t fd_io_read(int fd, void *buf, size_t len);
 static ssize_t net_io_read(struct flb_upstream_conn *u_conn,
                            void *buf, size_t len)
 {
+    return fd_io_read(u_conn->fd, buf, len);
+}
+
+static ssize_t fd_io_read(int fd, void *buf, size_t len)
+{
     int ret;
 
-    ret = recv(u_conn->fd, buf, len, 0);
+    ret = recv(fd, buf, len, 0);
     if (ret == -1) {
         return -1;
     }
@@ -360,6 +374,13 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
     return ret;
 }
 
+/* Write data to fd. For unix socket. */
+int flb_io_fd_write(int fd, const void *data, size_t len, size_t *out_len)
+{
+    /* TODO: support async mode */
+    return fd_io_write(fd, data, len, out_len);
+}
+
 /* Write data to an upstream connection/server */
 int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
                      size_t len, size_t *out_len)
@@ -398,6 +419,12 @@ int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
     flb_trace("[io coro=%p] [net_write] ret=%i total=%lu/%lu",
               coro, ret, *out_len, len);
     return ret;
+}
+
+ssize_t flb_io_fd_read(int fd, void *buf, size_t len)
+{
+    /* TODO: support async mode */
+    return fd_io_read(fd, buf, len);
 }
 
 ssize_t flb_io_net_read(struct flb_upstream_conn *u_conn, void *buf, size_t len)


### PR DESCRIPTION
This patch is to add io_read/write function using fd.
It will be useful for unix socket io.

This patch is to add `fd_io_read/write`.
They comes from `net_io_read/net_io_write`.
`net_io_read/net_io_write` will be a wrapper of `fd_io_read/write` to pass `u_conn->fd`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
