### PR TITLE
libco: always use fiber API for co-routines on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ compile_commands.json
 
 workflow/
 .kitchen/
+
+# vs files
+.vs/
+out/

--- a/lib/monkey/deps/flb_libco/libco.c
+++ b/lib/monkey/deps/flb_libco/libco.c
@@ -8,7 +8,9 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__)
-  #if defined(__i386__)
+  #if defined(_WIN32)
+    #include "fiber.c"
+  #elif defined(__i386__)
     #include "x86.c"
   #elif defined(__amd64__)
     #include "amd64.c"
@@ -18,13 +20,13 @@
     #include "aarch64.c"
   #elif defined(_ARCH_PPC)
     #include "ppc.c"
-  #elif defined(_WIN32)
-    #include "fiber.c"
   #else
     #include "sjlj.c"
   #endif
 #elif defined(_MSC_VER)
-  #if defined(_M_IX86)
+  #if defined(_WIN32)
+    #include "fiber.c"
+  #elif defined(_M_IX86)
     #include "x86.c"
 // Commented out due to SIGSEGV bug
 //  #elif defined(_M_AMD64)


### PR DESCRIPTION
<!-- Provide summary of changes -->

The intention of this PR is to fix an issue that started happening since v1.7.6 where the Ares DNS lib was integrated. Fluent-bit started crashing on our production machines immediately once something was supposed to be flushed through HTTP output. I was able to track it down to the `GetAdaptersAddresses` function call in Ares. Also, Windows reported the `DBG_PRINTEXCEPTION_C` exception in the event log which did not make any sense. After more research and debugging changes, I found out that fluent-bit starts crashing in the `GetAdaptersAddresses` immediately once this function is called in the co-routine but not before. But it only happens in the 32bit version, the 64bit version works fine. The problem is in the libco implementation for win32.

The implementation of co-routines does not work well on Windows 10 when the 32-bit version of fluent-bit is executed. Some API functions on Windows can throw exceptions that have special meaning, used for debuggers, for example. The Windows `OutputDebugString` function (or the `DbgPrint`) throws the DBG_PRINTEXCEPTION_C which is basically just a signal for the debugger to print a string and not a real fault exception. Under normal conditions, this exception is automatically handled by Windows so nothing wrong happens but this gets somehow broken once the code is executed under the co-routine, most likely because of how the stack modification and the function call is implemented in the libco. But only x86 is affected because x64 libco uses `Fiber` Windows API that works properly. 

Therefore I modified the libco to always use the `Fiber` on Windows platform. This fixed the issue.


<!-- Issue number  -->
Will add later
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
