### PR TITLE
workflows: release promotion job updates

### DIFF
--- a/.github/actions/release-server-sync/action.yaml
+++ b/.github/actions/release-server-sync/action.yaml
@@ -1,0 +1,70 @@
+name: Composite action to sync release to server
+description: Carry out all the tasks to sync from a bucket to the release server.
+
+inputs:
+  bucket:
+    description: The name of the S3 (US-East) bucket to sync packages from.
+    required: true
+  access_key_id:
+    description: The S3 access key id for the bucket.
+    required: true
+  secret_access_key:
+    description: The S3 secret access key for the bucket.
+    required: true
+  server_hostname:
+    description: The server hostname to sync to.
+    required: true
+  server_username:
+    description: The username to authenticate with on the server.
+    required: true
+  server_key:
+    description: The SSH key to use for authentication.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+  - name: Setup runner
+    run: |
+      sudo apt-get install rsync
+    shell: bash
+
+  - name: Hashed known hosts value
+    id: known_hosts
+    run: |
+      OUTPUT=$(ssh-keyscan -H ${{ inputs.server_hostname }})
+      echo ::set-output name=OUTPUT::$OUTPUT
+    shell: bash
+
+  - name: Install SSH Key
+    uses: shimataro/ssh-key-action@v2
+    with:
+      key: ${{ inputs.server_key }}
+      known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
+
+  - name: Sync packages from release bucket on S3
+    run: |
+      mkdir -p packaging/releases
+      aws s3 sync "s3://$BUCKET" packaging/releases/ --no-progress
+    env:
+      AWS_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
+      AWS_SECRET_ACCESS_KEY: ${{ inputs.secret_access_key }}
+      BUCKET: ${{ inputs.bucket }}
+    shell: bash
+
+  - name: Upload to build server
+    run: |
+      ssh $USERNAME@$HOST mkdir -p /home/$USERNAME/apt
+      rsync --include="*/" --include="*.rpm" --include="*.deb" --exclude="*" -amvz packaging/releases/ $USERNAME@$HOST:/home/$USERNAME/apt
+    env:
+      HOST: ${{ inputs.server_hostname }}
+      USERNAME: ${{ inputs.server_username }}
+    shell: bash
+
+  # We could also automate the final step here eventually to get the packages "live"
+  # - name: Publish on build server
+  #   run: |
+  #     ssh $USERNAME@$HOST /bin/bash /home/$USERNAME/publish_all.sh "$VERSION"
+  #   env:
+  #     VERSION: ${{ inputs.version }}
+  #   shell: bash

--- a/.github/workflows/remove-release.yaml
+++ b/.github/workflows/remove-release.yaml
@@ -1,20 +1,19 @@
 ---
-name: Release from staging
+name: Remove a published release [WARNING]
 
 # This is only expected to be invoked on-demand by a specific user.
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: The version to remove from release.
+        type: string
 
 jobs:
 
-  # 1. Take packages from the staging bucket
-  # 2. Sign them with the release GPG key
-  # 3. Also take existing release packages from the release bucket.
-  # 4. Create a full repo configuration using the existing releases as well.
-  # 5. Upload to release bucket.
-  # Note we could resign all packages as well potentially if we wanted to update the key.
-  staging-release-packages-s3:
-    name: S3 - create release
+  remove-release-packages-s3:
+    name: S3 - remove release
     runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
     environment: release
     steps:
@@ -32,16 +31,10 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
-    # Download the current release bucket
-    # Add everything from staging
-    # Sign and set up metadata for it all
-    # Upload to release bucket
-
-    - name: Sync packages from buckets on S3
+    - name: Sync packages from bucket on S3
       run: |
         mkdir -p packaging/releases
         aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}" packaging/releases/ --no-progress
-        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" packaging/releases/ --no-progress
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -53,12 +46,9 @@ jobs:
         rpm --import packaging/releases/fluentbit.key
       shell: bash
 
-    - name: Update repo info and remove any staging details
+    - name: Remove versions and update repo info
       run: |
-        rm -f packaging/releases/*.repo
-        VERSION=$(cat packaging/releases/latest-version.txt)
-        packaging/update-repos.sh "$VERSION" packaging/releases/
-        rm -f packaging/releases/latest-version.txt
+        packaging/remove-version.sh "$VERSION" packaging/releases/
       env:
         GPG_KEY: ${{ steps.import_gpg.outputs.name }}
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_RELEASE }}
@@ -72,17 +62,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       shell: bash
 
-  # We have two options here:
-  # 1. Sync the signed packages direct from the release bucket.
-  # 2. Sync the staged packages from the staging bucket, resign on the server.
-  #
-  # Option 1 may involve more transfer fees as the release bucket grows but is
-  # simpler plus tests the whole pipeline.
-  # The assumption being we would remove this step eventually anyway.
-  staging-release-packages-server:
-    name: fluentbit.io - upload packages
-    # Not required if using the staging bucket
-    needs: staging-release-packages-s3
+  # This removes the package from the set sync'd to the server but some manual work is required on the server
+  # to republish it without the packages.
+  remove-release-packages-server:
+    name: fluentbit.io - remove packages
+    needs: remove-release-packages-s3
     runs-on: ubuntu-18.04 # failures with AWS client on latest
     environment: release
     steps:

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -96,3 +96,25 @@ jobs:
         server_hostname: ${{ secrets.FLUENTBITIO_HOST }}
         server_username: ${{ secrets.FLUENTBITIO_USERNAME }}
         server_key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+
+  staging-release-images:
+    runs-on: ubuntu-latest
+    environment: release
+    # Use skopeo to do all the work - run the container to keep it easy to use.
+    steps:
+      - name: Sync container images from staging to release
+        run: |
+          docker run --rm quay.io/skopeo/stable:latest \
+            sync --all \
+            --src-creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+            --dest-creds ${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }} \
+            --src docker --dest docker \
+            ${{ env.STAGING_REGISTRY }}/${{ env.STAGING_IMAGE_NAME }} \
+            ${{ env.RELEASE_REGISTRY }}//${{ env.RELEASE_IMAGE_NAME }}
+        env:
+          STAGING_REGISTRY: ghcr.io
+          STAGING_IMAGE_NAME: ${{ github.repository }}
+
+          # docker.io/fluent/fluent-bit
+          RELEASE_REGISTRY: docker.io
+          RELEASE_IMAGE_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION }}

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -1,57 +1,21 @@
 ---
 name: Release from staging
 
+# This is only expected to be invoked on-demand by a specific user.
 on:
   workflow_dispatch:
 
 jobs:
 
-  staging-release-packages-server:
-    name: fluentbit.io - upload packages
-    runs-on: ubuntu-18.04 # failures with AWS client on latest
-    environment: release
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Setup runner
-      run: |
-        sudo apt-get install rsync
-      shell: bash
-
-    - name: Hashed known hosts value
-      id: known_hosts
-      run: |
-          OUTPUT=$(ssh-keyscan -H ${{ secrets.FLUENTBITIO_HOST }})
-          echo ::set-output name=OUTPUT::$OUTPUT
-
-    - name: Install SSH Key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.FLUENTBITIO_SSHKEY }}
-        known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
-
-    - name: Sync packages from staging on S3
-      run: |
-        mkdir -p packaging/releases
-        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" packaging/releases/ --no-progress
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      shell: bash
-
-    - name: Upload to build server
-      run: |
-        ssh $USERNAME@$HOST mkdir -p /home/$USERNAME/apt
-        rsync -avz packaging/releases/ $USERNAME@$HOST:/home/$USERNAME/apt
-      env:
-        HOST: ${{ secrets.FLUENTBITIO_HOST }}
-        USERNAME: ${{ secrets.FLUENTBITIO_USERNAME }}
-      shell: bash
-
+  # 1. Take packages from the staging bucket
+  # 2. Sign them with the release GPG key
+  # 3. Also take existing release packages from the release bucket.
+  # 4. Create a full repo configuration using the existing releases as well.
+  # 5. Upload to release bucket.
+  # Note we could resign all packages as well potentially if we wanted to update the key.
   staging-release-packages-s3:
     name: S3 - create release
-    runs-on: ubuntu-18.04 # no createrepo on more recent runners
+    runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
     environment: release
     steps:
     - name: Checkout code
@@ -104,4 +68,58 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      shell: bash
+
+  # We have two options here:
+  # 1. Sync the signed packages direct from the release bucket.
+  # 2. Sync the staged packages from the staging bucket, resign on the server.
+  #
+  # Option 1 may involve more transfer fees as the release bucket grows but is
+  # simpler plus tests the whole pipeline.
+  # The assumption being we would remove this step eventually anyway.
+  staging-release-packages-server:
+    name: fluentbit.io - upload packages
+    runs-on: ubuntu-18.04 # failures with AWS client on latest
+    environment: release
+    # Not required if using the staging bucket
+    needs: staging-release-packages-s3
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup runner
+      run: |
+        sudo apt-get install rsync
+      shell: bash
+
+    - name: Hashed known hosts value
+      id: known_hosts
+      run: |
+          OUTPUT=$(ssh-keyscan -H ${{ secrets.FLUENTBITIO_HOST }})
+          echo ::set-output name=OUTPUT::$OUTPUT
+
+    - name: Install SSH Key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+        known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
+
+    - name: Sync packages from staging on S3
+      run: |
+        mkdir -p packaging/releases
+        aws s3 sync "s3://$BUCKET" packaging/releases/ --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # Replace with staging bucket if required later
+        BUCKET: ${{ secrets.AWS_S3_BUCKET_RELEASE }}
+      shell: bash
+
+    - name: Upload to build server
+      run: |
+        ssh $USERNAME@$HOST mkdir -p /home/$USERNAME/apt
+        rsync -avz packaging/releases/ $USERNAME@$HOST:/home/$USERNAME/apt
+      env:
+        HOST: ${{ secrets.FLUENTBITIO_HOST }}
+        USERNAME: ${{ secrets.FLUENTBITIO_USERNAME }}
       shell: bash

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -5,11 +5,20 @@ on:
   workflow_dispatch:
 
 jobs:
+
   staging-release-packages-server:
-    runs-on: ubuntu-latest
+    name: fluentbit.io - upload packages
+    runs-on: ubuntu-18.04 # failures with AWS client on latest
     environment: release
-    # Just sync everything to the release server
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup runner
+      run: |
+        sudo apt-get install rsync
+      shell: bash
+
     - name: Hashed known hosts value
       id: known_hosts
       run: |
@@ -24,38 +33,34 @@ jobs:
 
     - name: Sync packages from staging on S3
       run: |
-        rm -rf ./releases/
-        mkdir -p ./releases/
+        mkdir -p packaging/releases
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" packaging/releases/ --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      shell: bash
 
-        if [ -n "${AWS_S3_ENDPOINT}" ]; then
-          ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
-        fi
-        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" ./releases/ --no-progress ${ENDPOINT}
-
-        rsync -avz ./releases/ $USERNAME@$HOST:/home/$USERNAME/apt
+    - name: Upload to build server
+      run: |
+        ssh $USERNAME@$HOST mkdir -p /home/$USERNAME/apt
+        rsync -avz packaging/releases/ $USERNAME@$HOST:/home/$USERNAME/apt
       env:
         HOST: ${{ secrets.FLUENTBITIO_HOST }}
         USERNAME: ${{ secrets.FLUENTBITIO_USERNAME }}
-        KEY: ${{ secrets.FLUENTBITIO_SSHKEY }}
       shell: bash
-      working-directory: packaging
 
   staging-release-packages-s3:
+    name: S3 - create release
     runs-on: ubuntu-18.04 # no createrepo on more recent runners
     environment: release
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Get the version
-      id: get_version
+    - name: Setup runner
       run: |
-        curl --fail -LO "$AWS_URL/latest-version.txt"
-        VERSION=$(cat latest-version.txt)
-        echo ::set-output name=VERSION::$VERSION
+        sudo apt-get install debsigs createrepo aptly rsync
       shell: bash
-      env:
-        AWS_URL: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com
 
     - name: Import GPG key for signing
       id: import_gpg
@@ -63,59 +68,40 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
-    - name: GPG set up RPM keys for signing
-      run: |
-        KEYFILE=$(mktemp)
-        gpg --export -a "${{ steps.import_gpg.outputs.name }}" > $KEYFILE
-        rpm --import $KEYFILE
-        rm -f $KEYFILE
+    # Download the current release bucket
+    # Add everything from staging
+    # Sign and set up metadata for it all
+    # Upload to release bucket
 
-    - name: Sync packages from staging on S3
-      # Download the current release bucket
-      # Add everything from staging
-      # Sign and set up metadata for it all
-      # Upload to release bucket
+    - name: Sync packages from buckets on S3
       run: |
-        rm -rf ./releases/
-        mkdir -p ./releases/
-        if [ -n "${AWS_S3_ENDPOINT}" ]; then
-          ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
-        fi
-        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}" ./releases/ --no-progress ${ENDPOINT}
-        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" ./releases/ --no-progress ${ENDPOINT}
-        VERSION=$(cat ./releases/latest-version.txt)
-
-        sudo apt-get install debsigs createrepo
-        ./update-repos.sh "$VERSION" ./releases/
-        aws s3 sync ./releases/ "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}" --follow-symlinks --no-progress ${ENDPOINT}
+        mkdir -p packaging/releases
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}" packaging/releases/ --no-progress
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}" packaging/releases/ --no-progress
       env:
-        GPG_KEY: ${{ steps.import_gpg.outputs.name }}
-        AWS_REGION: "us-east-1"
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        # To use with Minio locally
-        # AWS_S3_ENDPOINT: http://localhost:9000
       shell: bash
-      working-directory: packaging
 
-  staging-release-images:
-    runs-on: ubuntu-latest
-    environment: release
-    # Use skopeo to do all the work - run the container to keep it easy to use.
-    steps:
-      - name: Sync container images from staging to release
-        run: |
-          docker run --rm quay.io/skopeo/stable:latest \
-            sync --all \
-            --src-creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-            --dest-creds ${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }} \
-            --src docker --dest docker \
-            ${{ env.STAGING_REGISTRY }}/${{ env.STAGING_IMAGE_NAME }} \
-            ${{ env.RELEASE_REGISTRY }}//${{ env.RELEASE_IMAGE_NAME }}
-        env:
-          STAGING_REGISTRY: ghcr.io
-          STAGING_IMAGE_NAME: ${{ github.repository }}
+    - name: GPG set up keys for signing
+      run: |
+        gpg --export -a "${{ steps.import_gpg.outputs.name }}" > packaging/releases/fluentbit.key
+        rpm --import packaging/releases/fluentbit.key
+      shell: bash
 
-          # docker.io/fluent/fluent-bit
-          RELEASE_REGISTRY: docker.io
-          RELEASE_IMAGE_NAME: ${{ secrets.DOCKERHUB_ORGANIZATION }}
+    - name: Update repo info
+      run: |
+        VERSION=$(cat packaging/releases/latest-version.txt)
+        packaging/update-repos.sh "$VERSION" packaging/releases/
+        rm -f packaging/releases/latest-version.txt
+      env:
+        GPG_KEY: ${{ steps.import_gpg.outputs.name }}
+      shell: bash
+
+    - name: Sync to release bucket on S3
+      run: |
+        aws s3 sync packaging/releases/ "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}" --follow-symlinks --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      shell: bash

--- a/packaging/remove-version.sh
+++ b/packaging/remove-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# VERSION must be defined - this is the version to demote/remove from release
+VERSION=${VERSION:-$1}
+# Where the base of all the repos is
+BASE_PATH=${BASE_PATH:-$2}
+
+# Remove the RPM and DEB packages for this VERSION
+find "$BASE_PATH" -type f \( -iname "*-bit-${VERSION}*.rpm" -o -iname "*-bit-${VERSION}*.deb" \) -exec rm -rf {} \;
+
+# Update the repo metadata now
+# VERSION is only used to find the RPM to sign so without it will skip signing
+"$SCRIPT_DIR/update-repos.sh" "$VERSION" "$BASE_PATH"

--- a/packaging/testing/smoke/packages/local-test-all.sh
+++ b/packaging/testing/smoke/packages/local-test-all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Simple script to test all supported targets easily.
+
+PACKAGE_TEST=${PACKAGE_TEST:-centos7}
+RELEASE_URL=${RELEASE_URL:-https://packages.fluentbit.io}
+AWS_URL=${AWS_URL:-https://fluentbit-staging.s3.amazonaws.com}
+
+for DOCKERFILE in "$SCRIPT_DIR"/Dockerfile.*; do
+    DISTRO=${DOCKERFILE##*.}
+    echo "Testing $DISTRO"
+    PACKAGE_TEST="$DISTRO" RELEASE_URL="$RELEASE_URL" AWS_URL="$AWS_URL" "$SCRIPT_DIR"/run-package-tests.sh
+done

--- a/packaging/testing/smoke/packages/local-test-all.sh
+++ b/packaging/testing/smoke/packages/local-test-all.sh
@@ -4,7 +4,6 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Simple script to test all supported targets easily.
 
-PACKAGE_TEST=${PACKAGE_TEST:-centos7}
 RELEASE_URL=${RELEASE_URL:-https://packages.fluentbit.io}
 AWS_URL=${AWS_URL:-https://fluentbit-staging.s3.amazonaws.com}
 

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -76,8 +76,7 @@ EOF
     aptly -config="$APTLY_CONFIG" repo add "$APTLY_REPO_NAME" "$REPO_DIR/"
     aptly -config="$APTLY_CONFIG" repo show "$APTLY_REPO_NAME"
     aptly -config="$APTLY_CONFIG" publish repo -gpg-key="$GPG_KEY" "$APTLY_REPO_NAME"
-    mv "$APTLY_ROOTDIR"/public/* "$REPO_DIR"/
-
+    rsync -av "$APTLY_ROOTDIR"/public/* "$REPO_DIR"
     # Remove unnecessary files
     rm -rf "$REPO_DIR/conf/" "$REPO_DIR/db/" "$APTLY_ROOTDIR" "$APTLY_CONFIG"
 done


### PR DESCRIPTION
Resolves #4566, tested on https://github.com/patrick-stephens/fluent-bit-release-test/runs/4788880583?check_suite_focus=true using disposable server and bucket.

Confirmed to function with environment secrets only as well:
![Screenshot from 2022-01-11 16-34-22](https://user-images.githubusercontent.com/6388272/149010704-3d546353-8d09-4a3d-9c89-edb4f969c38f.png)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [NA] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

Verified the packages pass tests as well:
```
$ AWS_URL=https://pat-fluent-bit-release.s3.amazonaws.com ./packaging/testing/smoke/packages/run-package-tests.sh 
$ PACKAGE_TEST=debian11 AWS_URL=https://pat-fluent-bit-release.s3.amazonaws.com ./packaging/testing/smoke/packages/run-package-tests.sh 
$ PACKAGE_TEST=centos8 AWS_URL=https://pat-fluent-bit-release.s3.amazonaws.com ./packaging/testing/smoke/packages/run-package-tests.sh 
```
Added a wrapper script that runs all these which also passes too.
`AWS_URL=https://pat-fluent-bit-release.s3.amazonaws.com ./packaging/testing/smoke/packages/local-test-all.sh`

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [NA] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
