### PR TITLE
out_cloudwatch_logs: Fix invalid memory access bug #4425 backport to v1.8

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -666,24 +666,24 @@ int should_add_to_emf(struct flb_intermediate_metric *an_item)
     return 0;
 }
 
-struct msgpack_object pack_emf_payload(struct flb_cloudwatch *ctx, 
+int pack_emf_payload(struct flb_cloudwatch *ctx,
                                        struct mk_list *flb_intermediate_metrics, 
                                        const char *input_plugin, 
-                                       struct flb_time tms)
+                                       struct flb_time tms,
+                                       msgpack_sbuffer *mp_sbuf,
+                                       msgpack_unpacked *mp_result,
+                                       msgpack_object *emf_payload)
 {
     int total_items = mk_list_size(flb_intermediate_metrics) + 1;
 
     struct mk_list *metric_temp;
     struct mk_list *metric_head;
     struct flb_intermediate_metric *an_item;
-
-    /* msgpack::sbuffer is a simple buffer implementation. */
-    msgpack_sbuffer mp_sbuf;
-    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_unpack_return mp_ret;
 
     /* Serialize values into the buffer using msgpack_sbuffer_write */
     msgpack_packer mp_pck;
-    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
     msgpack_pack_map(&mp_pck, total_items);
 
     /* Pack the _aws map */
@@ -778,20 +778,17 @@ struct msgpack_object pack_emf_payload(struct flb_cloudwatch *ctx,
 
     /* 
      * Deserialize the buffer into msgpack_object instance.
-     * Deserialized object is valid during the msgpack_zone instance alive. 
      */
-    msgpack_zone mempool;
-    msgpack_zone_init(&mempool, 2048);
 
-    msgpack_object deserialized_emf_object;
-    msgpack_unpack(mp_sbuf.data, mp_sbuf.size, NULL, &mempool, 
-                   &deserialized_emf_object);
+    mp_ret = msgpack_unpack_next(mp_result, mp_sbuf->data, mp_sbuf->size, NULL);
 
-    /* free allocated memory */
-    msgpack_zone_destroy(&mempool);
-    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (mp_ret != MSGPACK_UNPACK_SUCCESS) {
+        flb_plg_error(ctx->ins, "msgpack_unpack returned non-success value %i", mp_ret);
+        return -1;
+    }
 
-    return deserialized_emf_object;
+    *emf_payload = mp_result->data;
+    return 0;
 }
 
 /*
@@ -812,6 +809,11 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
     msgpack_object_kv *kv;
     msgpack_object  key;
     msgpack_object  val;
+    msgpack_unpacked mp_emf_result;
+    msgpack_object emf_payload;
+    /* msgpack::sbuffer is a simple buffer implementation. */
+    msgpack_sbuffer mp_sbuf;
+
     char *key_str = NULL;
     size_t key_str_size = 0;
     int j;
@@ -927,10 +929,19 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                 
             }  
 
-            struct msgpack_object emf_payload = pack_emf_payload(ctx, 
-                                                                &flb_intermediate_metrics, 
-                                                                input_plugin, 
-                                                                tms);
+            /* The msgpack object is only valid during the lifetime of the
+             * sbuffer & the unpacked result.
+            */
+            msgpack_sbuffer_init(&mp_sbuf);
+            msgpack_unpacked_init(&mp_emf_result);
+
+            ret = pack_emf_payload(ctx,
+                                    &flb_intermediate_metrics,
+                                    input_plugin,
+                                    tms,
+                                    &mp_sbuf,
+                                    &mp_emf_result,
+                                    &emf_payload);
             
             /* free the intermediate metric list */
             
@@ -940,7 +951,17 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                 flb_free(an_item);
             }
 
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "Failed to convert EMF metrics to msgpack object. ret=%i", ret);
+                msgpack_unpacked_destroy(&mp_emf_result);
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                goto error;
+            }
             ret = add_event(ctx, buf, stream, &emf_payload, &tms);
+
+            msgpack_unpacked_destroy(&mp_emf_result);
+            msgpack_sbuffer_destroy(&mp_sbuf);
+
         } else {
             ret = add_event(ctx, buf, stream, &map, &tms);
         }


### PR DESCRIPTION
PR to backport the fix for #4425 to v1.8
[Original PR](https://github.com/fluent/fluent-bit/pull/4563) for the fix was merged to `master`

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
