### PR TITLE
ra: allow / and .

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -182,7 +182,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
                 /* ignore '.' if it is inside a string/subkey */
                 continue;
             }
-            else if (buf[end] == '.' || buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
+            else if (buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
                 break;
             }
         }

--- a/src/record_accessor/ra.l
+++ b/src/record_accessor/ra.l
@@ -53,7 +53,7 @@ static inline char *remove_dup_quotes(const char *s, size_t n)
 
 [1-9][0-9]*|0            { yylval->integer = atoi(yytext);  return INTEGER; }
 \'([^']|'{2})*\'           { yylval->string = remove_dup_quotes(yytext + 1, yyleng - 2); return STRING; }
-[_A-Za-z][A-Za-z0-9_.-]*	   { yylval->string = flb_strdup(yytext); return IDENTIFIER; }
+[_A-Za-z][A-Za-z0-9_.\-/]*	   { yylval->string = flb_strdup(yytext); return IDENTIFIER; }
 
 "$"                     |
 "["                     |

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -469,9 +469,74 @@ void cb_dash_key()
     msgpack_unpacked_destroy(&result);
 }
 
+void cb_dot_and_slash_key()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Sample JSON message */
+    json = "{\"root.with/symbols\": \"something\"}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$root.with/symbols");
+    if (!TEST_CHECK(fmt != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    fmt_out = "something";
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, out_buf, out_size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+}
+
 TEST_LIST = {
     { "keys"         , cb_keys},
     { "dash_key"     , cb_dash_key},
+    { "dot_slash_key", cb_dot_and_slash_key},
     { "translate"    , cb_translate},
     { "translate_tag", cb_translate_tag},
     { "dots_subkeys" , cb_dots_subkeys},


### PR DESCRIPTION
Fixes #4370

This patch is to allow / and . as a record accessor key character.
e.g. `logging.googleapis.com/severity`

Fluentd also allows dot(.) as a key.
https://github.com/fluent/fluentd/blob/c297456eedf046bd352e7438002d855c1fbfb30c/test/plugin_helper/test_record_accessor.rb#L23

Fluentd may allow slash(/). 
https://github.com/fluent/fluentd/blob/c297456eedf046bd352e7438002d855c1fbfb30c/lib/fluent/plugin_helper/record_accessor.rb

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    name   dummy

[FILTER]
    name   modify
    add    logging.googleapis.com/severity INFO
    match  *
[FILTER]
    name     grep
    match    *
    regex  logging.googleapis.com/severity INFO
[OUTPUT]
    name   stdout
    match  *
```

## Debug log

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/15 17:34:52] [ info] [engine] started (pid=26221)
[2022/01/15 17:34:52] [ info] [storage] version=1.1.5, initializing...
[2022/01/15 17:34:52] [ info] [storage] in-memory
[2022/01/15 17:34:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/15 17:34:52] [ info] [cmetrics] version=0.2.2
[2022/01/15 17:34:52] [ info] [sp] stream processor started
[0] dummy.0: [1642235693.088242372, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[1] dummy.0: [1642235694.088818734, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[2] dummy.0: [1642235695.088618346, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[3] dummy.0: [1642235696.088256842, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
^C[2022/01/15 17:34:57] [engine] caught signal (SIGINT)
[0] dummy.0: [1642235697.089153719, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[2022/01/15 17:34:57] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/15 17:34:58] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==26225== Memcheck, a memory error detector
==26225== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26225== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==26225== Command: ../bin/fluent-bit -c a.conf
==26225== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/15 17:35:20] [ info] [engine] started (pid=26225)
[2022/01/15 17:35:20] [ info] [storage] version=1.1.5, initializing...
[2022/01/15 17:35:20] [ info] [storage] in-memory
[2022/01/15 17:35:20] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/15 17:35:20] [ info] [cmetrics] version=0.2.2
[2022/01/15 17:35:20] [ info] [sp] stream processor started
==26225== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4cea400
==26225==          to suppress, use: --max-stackframe=11515384 or greater
==26225== Warning: client switching stacks?  SP change: 0x4cea3a8 --> 0x57e59f8
==26225==          to suppress, use: --max-stackframe=11515472 or greater
==26225== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4cea3a8
==26225==          to suppress, use: --max-stackframe=11515472 or greater
==26225==          further instances of this message will not be shown.
[0] dummy.0: [1642235721.111543702, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[1] dummy.0: [1642235722.088508567, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[2] dummy.0: [1642235723.088685407, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[3] dummy.0: [1642235724.088804253, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
^C[2022/01/15 17:35:25] [engine] caught signal (SIGINT)
[0] dummy.0: [1642235725.137547232, {"message"=>"dummy", "logging.googleapis.com/severity"=>"INFO"}]
[2022/01/15 17:35:25] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/15 17:35:26] [ info] [engine] service has stopped (0 pending tasks)
==26225== 
==26225== HEAP SUMMARY:
==26225==     in use at exit: 0 bytes in 0 blocks
==26225==   total heap usage: 1,342 allocs, 1,342 frees, 1,448,283 bytes allocated
==26225== 
==26225== All heap blocks were freed -- no leaks are possible
==26225== 
==26225== For lists of detected and suppressed errors, rerun with: -s
==26225== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Internal test

```
$ bin/flb-it-record_accessor 
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a

type       : STRING
string     : ' extra '

type       : KEYMAP
key name   : bbb
 - subkey  : b

type       : STRING
string     : ' final access'

=== test ===
type       : KEYMAP
key name   : b
 - subkey  : x
 - subkey  : y

=== test ===
type       : KEYMAP
key name   : z

=== test ===
type       : STRING
string     : 'abc'
[2022/01/15 17:35:51] [error] [record accessor] syntax error, unexpected $end, expecting ']' at '$abc['a''
[ OK ]
Test dash_key...                                == input ==
something
== output ==
something
[ OK ]
Test dot_slash_key...                           == input ==
something
== output ==
something
[ OK ]
Test translate...                               == input ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
== output ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
[ OK ]
Test translate_tag...                           [ OK ]
Test dots_subkeys...                            == input ==
thetag
== output ==
thetag
[ OK ]
Test array_id...                                == input ==
thetag
== output ==
thetag
[ OK ]
Test get_kv_pair...                             [ OK ]
SUCCESS: All unit tests have passed.
$ 
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
