### PR TITLE
tests: runtime: filter_record_modifier: add basic tests

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -173,6 +173,7 @@ static int cb_modifier_init(struct flb_filter_instance *f_ins,
 
     if ( configure(ctx, f_ins) < 0 ){
         delete_list(ctx);
+        flb_free(ctx);
         return -1;
     }
 

--- a/tests/runtime/filter_record_modifier.c
+++ b/tests/runtime/filter_record_modifier.c
@@ -23,6 +23,301 @@
 #include "flb_tests_runtime.h"
 #include "data/common/json_long.h"    /* JSON_LONG    */
 
+struct filter_test {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd */
+};
+
+struct expect_str {
+    char *str;
+    int  found;
+};
+
+
+/* Callback to check expected results */
+static int cb_check_result(void *record, size_t size, void *data)
+{
+    char *p;
+    char *result;
+    struct expect_str *expected;
+
+    expected = (struct expect_str*)data;
+    result = (char *) record;
+
+    if (!TEST_CHECK(expected != NULL)) {
+        flb_error("expected is NULL");
+    }
+    if (!TEST_CHECK(result != NULL)) {
+        flb_error("result is NULL");
+    }
+
+    while(expected != NULL && expected->str != NULL) {
+        if (expected->found == FLB_TRUE) {
+            p = strstr(result, expected->str);
+            if(!TEST_CHECK(p != NULL)) {
+                flb_error("Expected to find: '%s' in result '%s'",
+                          expected->str, result);
+            }
+        }
+        else {
+            p = strstr(result, expected->str);
+            if(!TEST_CHECK(p == NULL)) {
+                flb_error("'%s' should be removed in result '%s'",
+                          expected->str, result);
+            }
+        }
+
+        /*
+         * If you want to debug your test
+         *
+         * printf("Expect: '%s' in result '%s'", expected, result);
+         */
+
+        expected++;
+    }
+
+    flb_free(record);
+    return 0;
+}
+
+static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int f_ffd;
+    int o_ffd;
+    struct filter_test *ctx;
+
+    ctx = flb_malloc(sizeof(struct filter_test));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "lib", NULL);
+    TEST_CHECK(i_ffd >= 0);
+    flb_input_set(ctx->flb, i_ffd, "tag", "test", NULL);
+    ctx->i_ffd = i_ffd;
+
+    /* Filter configuration */
+    f_ffd = flb_filter(ctx->flb, (char *) "record_modifier", NULL);
+    TEST_CHECK(f_ffd >= 0);
+    flb_filter_set(ctx->flb, f_ffd, "match", "*", NULL);
+    ctx->f_ffd = f_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    TEST_CHECK(o_ffd >= 0);
+    flb_output_set(ctx->flb, o_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    return ctx;
+}
+
+static void filter_test_destroy(struct filter_test *ctx)
+{
+    sleep(1);
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+static void flb_records()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct expect_str expect[] = {
+      {"\"new_key\":\"new_val\"", FLB_TRUE},
+      {"\"add_key\":\"add_val\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "record", "new_key new_val",
+                         "record", "add_key add_val",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"k\":\"sample\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+static void flb_allowlist_keys()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct expect_str expect[] = {
+      {"\"aaa\":\"ok\"", FLB_TRUE},
+      {"\"bbb\":\"ok\"", FLB_TRUE},
+      {"\"ccc\":\"removed\"", FLB_FALSE},
+      {NULL, FLB_TRUE}
+    };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "allowlist_key", "aaa",
+                         "allowlist_key", "bbb",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    /* The pair "ccc":"removed" should be removed */
+    p = "[0, {\"aaa\":\"ok\",\"ccc\":\"removed\",\"bbb\":\"ok\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+static void flb_remove_keys()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct expect_str expect[] = {
+      {"\"aaa\":\"ok\"", FLB_TRUE},
+      {"\"bbb\":\"ok\"", FLB_TRUE},
+      {"\"ccc\":\"removed\"", FLB_FALSE},
+      {"\"ddd\":\"removed\"", FLB_FALSE},
+      {NULL, FLB_TRUE}
+    };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "remove_key", "ccc",
+                         "remove_key", "ddd",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    /* The pairs "ccc" and "ddd" should be removed */
+    p = "[0, {\"aaa\":\"ok\",\"ccc\":\"removed\",\"ddd\":\"removed\",\"bbb\":\"ok\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+static void flb_multiple()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct expect_str expect[] = {
+      {"\"aaa\":\"ok\"", FLB_TRUE},
+      {"\"new_key\":\"new_val\"", FLB_TRUE},
+      {"\"ddd\":\"removed\"", FLB_FALSE},
+      {NULL, FLB_TRUE}
+    };
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "record",     "new_key new_val",
+                         "allowlist_key", "new_key",
+                         "allowlist_key", "aaa",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"aaa\":\"ok\",\"ddd\":\"removed\",\"bbb\":\"ok\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
+
 /* https://github.com/fluent/fluent-bit/issues/3968 */
 void flb_test_json_long()
 {
@@ -64,8 +359,55 @@ void flb_test_json_long()
     flb_destroy(ctx);
 }
 
+void flb_exclusive_setting()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "record_modifier", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    flb_filter_set(ctx, filter_ffd, "match", "test", NULL);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "allowlist_key", "aaa",
+                         "remove_key", "bbb",
+                         NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+
+    /* It should be error since "allowlist_key" and "remove_key" are exclusive */
+    TEST_CHECK(ret != 0);
+
+     flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* test list */
 TEST_LIST = {
-    {"json_long"      , flb_test_json_long },
+    {"json_long"           , flb_test_json_long },
+    {"remove_keys"         , flb_remove_keys},
+    {"records"             , flb_records},
+    {"allowlist_keys"      , flb_allowlist_keys},
+    {"multiple"            , flb_multiple},
+    {"exclusive_setting"   , flb_exclusive_setting},
     {NULL, NULL}
 };


### PR DESCRIPTION

<!-- Provide summary of changes -->

This patch is to add some test cases for filter_record_modifier.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-filter_record_modifier 
Test json_long...                               [ OK ]
Test remove_keys...                             [ OK ]
Test records...                                 [ OK ]
Test allowlist_keys...                          [ OK ]
Test multiple...                                [ OK ]
Test exclusive_setting...                       [2022/01/16 21:39:12] [error] [lib] backend failed
[2022/01/16 21:39:12] [error] [filter:record_modifier:record_modifier.0] remove_keys and allowlist_keys are exclusive with each other.
[ OK ]
SUCCESS: All unit tests have passed.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
