### PR TITLE
aws: Add external_id support in output plugins

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -264,7 +264,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         ctx->aws_provider = flb_sts_provider_create(config,
                                                     ctx->sts_tls,
                                                     ctx->base_aws_provider,
-                                                    NULL,
+                                                    (char *) ctx->external_id,
                                                     (char *) ctx->role_arn,
                                                     session_name,
                                                     (char *) ctx->region,
@@ -590,6 +590,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
      0, FLB_FALSE, 0,
      "Specify a custom endpoint for the STS API, can be used with the role_arn parameter"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "external_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_cloudwatch, external_id),
+    "Specify an external ID for the STS API, can be used with the role_arn parameter if your role "
+     "requires an external ID."
     },
 
     {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -118,6 +118,7 @@ struct flb_cloudwatch {
     const char *role_arn;
     const char *log_key;
     const char *extra_user_agent;
+    const char *external_id;
     int custom_endpoint;
     /* Should the plugin create the log group */
     int create_group;

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -205,7 +205,7 @@ static int cb_firehose_init(struct flb_output_instance *ins,
         ctx->aws_provider = flb_sts_provider_create(config,
                                                     ctx->sts_tls,
                                                     ctx->base_aws_provider,
-                                                    NULL,
+                                                    ctx->external_id,
                                                     (char *) ctx->role_arn,
                                                     session_name,
                                                     (char *) ctx->region,
@@ -426,6 +426,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
      0, FLB_TRUE, offsetof(struct flb_firehose, sts_endpoint),
     "Custom endpoint for the STS API."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "external_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_firehose, external_id),
+    "Specify an external ID for the STS API, can be used with the role_arn parameter if your role "
+     "requires an external ID."
     },
 
     {

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -86,6 +86,7 @@ struct flb_firehose {
     const char *region;
     const char *role_arn;
     const char *log_key;
+    const char *external_id;
     char *sts_endpoint;
     int custom_endpoint;
     int retry_requests;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -212,7 +212,7 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
         ctx->aws_provider = flb_sts_provider_create(config,
                                                     ctx->sts_tls,
                                                     ctx->base_aws_provider,
-                                                    NULL,
+                                                    (char *) ctx->external_id,
                                                     (char *) ctx->role_arn,
                                                     session_name,
                                                     (char *) ctx->region,
@@ -441,6 +441,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "sts_endpoint", NULL,
      0, FLB_TRUE, offsetof(struct flb_kinesis, sts_endpoint),
     "Custom endpoint for the STS API."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "external_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_kinesis, external_id),
+     "Specify an external ID for the STS API, can be used with the role_arn parameter if your role "
+     "requires an external ID."
     },
 
     {

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -89,6 +89,7 @@ struct flb_kinesis {
     const char *region;
     const char *role_arn;
     const char *log_key;
+    const char *external_id;
     int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -493,7 +493,6 @@ static int cb_s3_init(struct flb_output_instance *ins,
     int async_flags;
     int len;
     char *role_arn = NULL;
-    char *external_id = NULL;
     char *session_name;
     const char *tmp;
     struct flb_s3 *ctx = NULL;
@@ -795,10 +794,6 @@ static int cb_s3_init(struct flb_output_instance *ins,
         /* Use the STS Provider */
         ctx->base_provider = ctx->provider;
         role_arn = (char *) tmp;
-        tmp = flb_output_get_property("external_id", ins);
-        if (tmp) {
-            external_id = (char *) tmp;
-        }
 
         /* STS provider needs yet another separate TLS instance */
         ctx->sts_provider_tls = flb_tls_create(FLB_TRUE,
@@ -826,7 +821,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
         ctx->provider = flb_sts_provider_create(config,
                                                 ctx->sts_provider_tls,
                                                 ctx->base_provider,
-                                                external_id,
+                                                ctx->external_id,
                                                 role_arn,
                                                 session_name,
                                                 ctx->region,
@@ -2389,6 +2384,13 @@ static struct flb_config_map config_map[] = {
      "By default, the whole log record will be sent to S3. "
      "If you specify a key name with this option, then only the value of "
      "that key will be sent to S3."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "external_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_s3, external_id),
+     "Specify an external ID for the STS API, can be used with the role_arn parameter if your role "
+     "requires an external ID."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -113,6 +113,7 @@ struct flb_s3 {
     char *canned_acl;
     char *content_type;
     char *log_key;
+    char *external_id;
     int free_endpoint;
     int retry_requests;
     int use_put_object;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
