### PR TITLE
workflows: fix missing character for debug tag

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -115,7 +115,7 @@ jobs:
         images: ${{ inputs.registry }}/${{ inputs.image }}
         tags: |
           raw,x86_64-${{ inputs.version }}-debug
-          raw,{{ inputs.version }}-debug
+          raw,${{ inputs.version }}-debug
           raw,latest-debug
 
     - name: Build the debug staging image


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Fixes the issue with building debug images in the reusable workflow: https://github.com/fluent/fluent-bit/runs/4874097302?check_suite_focus=true

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [NA] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [NA] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
