### PR TITLE
workflows: restrict concurrency of integration tests

### DIFF
--- a/.github/workflows/master-integration-test.yaml
+++ b/.github/workflows/master-integration-test.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+
+concurrency: integration-test
+
 jobs:
   master-integration-test-build:
     name: Master - integration build

--- a/.github/workflows/pr-integration-test.yaml
+++ b/.github/workflows/pr-integration-test.yaml
@@ -9,6 +9,9 @@ on:
       - edited
       - reopened
       - synchronize
+
+concurrency: integration-test
+
 jobs:
   pr-integration-test-build:
     name: PR - GCP build

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -9,6 +9,8 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency: integration-test
+
 jobs:
   staging-test-images:
     name: Container images staging tests
@@ -71,8 +73,8 @@ jobs:
 
   staging-test-images-multiarch-integration-gcp:
     name: Multi-arch - run integration tests on GCP
-    # Wait for other tests to succeed
-    needs: staging-test-images
+    # Wait for other tests to succeed, ensure one set of GCP tests at a time
+    needs: [ staging-test-multiarch-images, staging-test-images-integration-gcp ]
     uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
     with:
       image_name: ghcr.io/${{ github.repository }}/multiarch


### PR DESCRIPTION
Noticed that all integration jobs can actually be run in parallel but they execute on a single node GKE cluster which is "sub-optimal". Looking at a separate update to the fluent-bit-ci repo to use autopilot and allow more parallelism there but for now this should protect all usage of integration tests to only one at a time.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
