### PR TITLE
workflows: restrict concurrency of staging/release process

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -14,6 +14,11 @@ on:
         description: Version of Fluent Bit to build
         required: true
         default: 1.8.11
+
+# We do not want a new staging build to run whilst we are releasing the current staging build.
+# We also do not want multiples to run for the same version.
+concurrency: staging-build-release
+
 jobs:
 
   # This job copes with the variable approach of either being triggered by a tag,

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -137,6 +137,7 @@ jobs:
             quay.io/skopeo/stable:latest \
             copy \
               --all \
+              --retry-times 10 \
               --src-no-creds \
               --dest-creds "$RELEASE_CREDS" \
               "docker://$STAGING_IMAGE_NAME:$TAG" \
@@ -153,6 +154,7 @@ jobs:
             quay.io/skopeo/stable:latest \
             copy \
               --all \
+              --retry-times 10 \
               --src-no-creds \
               --dest-creds "$RELEASE_CREDS" \
               "docker://$STAGING_IMAGE_NAME:$TAG" \

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -9,6 +9,11 @@ on:
         type: string
         description: The version we want to release from staging.
         required: true
+
+# We do not want a new staging build to run whilst we are releasing the current staging build.
+# We also do not want multiples to run for the same version.
+concurrency: staging-build-release
+
 jobs:
 
   # 1. Take packages from the staging bucket


### PR DESCRIPTION
Simple mutual exclusion of jobs to create a staging build and the release one.

Also added retry to container promotion as ghcr.io seems to have some flakiness.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
