### PR TITLE
workflows: reverse stale order

### DIFF
--- a/.github/workflows/pr-stale.yaml
+++ b/.github/workflows/pr-stale.yaml
@@ -20,3 +20,5 @@ jobs:
           exempt-all-pr-assignees: true
           exempt-all-pr-milestones: true
           exempt-issue-labels: 'long-term,enhancement,exempt-stale'
+          # start with the oldest
+          ascending: true


### PR DESCRIPTION
The current stale check is running out of operations before it processes the oldest PRs.

On this run we get to 2265 so all the others are ignored: https://github.com/fluent/fluent-bit/runs/4876542871?check_suite_focus=true#step:2:4751
![Screenshot from 2022-01-20 20-50-21](https://user-images.githubusercontent.com/6388272/150422695-d4b5ad8a-b573-44f7-be80-a47e0c3ffafa.png)

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [NA] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [NA] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
