### PR TITLE
1.8: backport of network: connection timeout handling improvement 

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -456,6 +456,12 @@ static int net_connect_async(int fd,
         return -1;
     }
 
+    if (u_conn->net_error == ETIMEDOUT) {
+        flb_debug("[net] TCP connection timed out: %s:%i",
+                  u->tcp_host, u->tcp_port);
+        return -1;
+    }
+
     /* Check the connection status */
     if (mask & MK_EVENT_WRITE) {
         error = flb_socket_error(u_conn->fd);
@@ -1199,6 +1205,17 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         else {
             ret = net_connect_sync(fd, rp->ai_addr, rp->ai_addrlen,
                                    (char *) host, port, connect_timeout);
+        }
+
+        if (u_conn->net_error == ETIMEDOUT) {
+            /* flb_upstream_conn_timeouts called prepare_destroy_conn which
+             * closed the file descriptor and removed it from the event so
+             * we can safely ignore it.
+             */
+
+            fd = -1;
+
+            break;
         }
 
         if (ret == -1) {

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -849,9 +849,9 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
         mk_list_foreach_safe(u_head, tmp, &uq->av_queue) {
             u_conn = mk_list_entry(u_head, struct flb_upstream_conn, _head);
             if ((now - u_conn->ts_available) >= u->net.keepalive_idle_timeout) {
-                if (u_conn->fd != -1) {
-                    shutdown(u_conn->fd, SHUT_RDWR);
-                }
+                mk_event_inject(u_conn->evl, &u_conn->event,
+                                MK_EVENT_READ | MK_EVENT_WRITE,
+                                FLB_TRUE);
 
                 prepare_destroy_conn(u_conn);
                 flb_debug("[upstream] drop keepalive connection #%i to %s:%i "


### PR DESCRIPTION
This PR switches the coroutine wakeup mechanism upon timeouts by injecting an event in the event loop which causes fluent-bit to handle the process in a less intrusive way.

Note : This is a backport of PR #4624