### PR TITLE
1.8: backport ra check #4517

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -670,7 +670,8 @@ static int config_set_properties(struct flb_upstream_node *node,
     }
 
 #ifdef FLB_HAVE_RECORD_ACCESSOR
-    if (fc->compress != COMPRESS_NONE && fc->ra_static == FLB_FALSE) {
+    if (fc->compress != COMPRESS_NONE &&
+        (fc->ra_tag && fc->ra_static == FLB_FALSE) ) {
         flb_plg_error(ctx->ins, "compress mode %s is incompatible with dynamic "
                       "tags", tmp);
         return -1;


### PR DESCRIPTION
Signed-off-by: Takahiro Yamashita <nokute78@gmail.com>
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
