### PR TITLE
1.8: backport #4596

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -425,6 +425,85 @@ static inline int splunk_format(const void *in_buf, size_t in_bytes,
     return 0;
 }
 
+static void debug_request_response(struct flb_splunk *ctx,
+                                   struct flb_http_client *c)
+{
+    int ret;
+    int uncompressed = FLB_FALSE;
+    time_t now;
+    void *tmp_buf = NULL;
+    size_t tmp_size;
+    size_t req_size;
+    char *req_buf = NULL;
+    struct tm result;
+    struct tm *current;
+    unsigned char *ptr;
+    flb_sds_t req_headers = NULL;
+    flb_sds_t req_body = NULL;
+
+    if (c->body_len > 3) {
+        ptr = (unsigned char *) c->body_buf;
+        if (ptr[0] == 0x1F && ptr[1] == 0x8B && ptr[2] == 0x08) {
+            /* uncompress payload */
+            ret = flb_gzip_uncompress((void *) c->body_buf, c->body_len,
+                                      &tmp_buf, &tmp_size);
+            if (ret == -1) {
+                fprintf(stdout, "[out_splunk] could not uncompress data\n");
+            }
+            else {
+                req_buf = (char *) tmp_buf;
+                req_size = tmp_size;
+                uncompressed = FLB_TRUE;
+            }
+        }
+        else {
+            req_buf = (char *) c->body_buf;
+            req_size = c->body_len;
+        }
+
+        /* create a safe buffer */
+        if (req_buf) {
+            req_body = flb_sds_create_len(req_buf, req_size);
+        }
+    }
+
+    req_headers = flb_sds_create_len(c->header_buf, c->header_len);
+
+    if (c->resp.data)
+    now = time(NULL);
+    current = localtime_r(&now, &result);
+
+    fprintf(stdout,
+            "[%i/%02i/%02i %02i:%02i:%02i] "
+            "[out_splunk] debug HTTP 400 (bad request)\n"
+            ">>> request\n"
+            "%s%s\n\n"
+            "<<< response\n"
+            "%s\n\n",
+
+            current->tm_year + 1900,
+            current->tm_mon + 1,
+            current->tm_mday,
+            current->tm_hour,
+            current->tm_min,
+            current->tm_sec,
+
+            req_headers,
+            req_body,
+            c->resp.data);
+
+    if (uncompressed) {
+        flb_free(tmp_buf);
+    }
+
+    if (req_headers) {
+        flb_sds_destroy(req_headers);
+    }
+    if (req_body) {
+        flb_sds_destroy(req_body);
+    }
+}
+
 static void cb_splunk_flush(const void *data, size_t bytes,
                             const char *tag, int tag_len,
                             struct flb_input_instance *i_ins,
@@ -502,6 +581,9 @@ static void cb_splunk_flush(const void *data, size_t bytes,
          * if something goes wrong, so we don't get a partial response.
          */
         resp_size = payload_size * 1.5;
+        if (resp_size < 4096) {
+            resp_size = 4096;
+        }
         flb_http_buffer_size(c, resp_size);
     }
 
@@ -556,6 +638,11 @@ static void cb_splunk_flush(const void *data, size_t bytes,
              */
             ret = (c->resp.status < 400 || c->resp.status >= 500) ?
                 FLB_RETRY : FLB_ERROR;
+
+
+            if (c->resp.status == 400 && ctx->http_debug_bad_request) {
+                debug_request_response(ctx, c);
+            }
         }
         else {
             ret = FLB_OK;
@@ -615,6 +702,14 @@ static struct flb_config_map config_map[] = {
      "full responses, note that response size grows depending of the number of records "
      "inserted. To set an unlimited amount of memory set this value to 'false', "
      "otherwise the value must be according to the Unit Size specification"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "http_debug_bad_request", "false",
+     0, FLB_TRUE, offsetof(struct flb_splunk, http_debug_bad_request),
+     "If the HTTP server response code is 400 (bad request) and this flag is "
+     "enabled, it will print the full HTTP request and response to the stdout "
+     "interface. This feature is available for debugging purposes."
     },
 
     {

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -49,7 +49,6 @@ static int cb_splunk_init(struct flb_output_instance *ins,
      * it debugging callbacks.
      */
     flb_output_set_http_debug_callbacks(ins);
-
     return 0;
 }
 
@@ -436,6 +435,7 @@ static void cb_splunk_flush(const void *data, size_t bytes,
     int compressed = FLB_FALSE;
     size_t b_sent;
     flb_sds_t buf_data;
+    size_t resp_size;
     size_t buf_size;
     char *endpoint;
     struct flb_splunk *ctx = out_context;
@@ -490,7 +490,22 @@ static void cb_splunk_flush(const void *data, size_t bytes,
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, endpoint,
                         payload_buf, payload_size, NULL, 0, NULL, 0);
-    flb_http_buffer_size(c, ctx->buffer_size);
+
+    /* HTTP Response buffer size, honor value set by the user */
+    if (ctx->buffer_size > 0) {
+        flb_http_buffer_size(c, ctx->buffer_size);
+    }
+    else {
+        /*
+         * If no value was set, we try to accomodate by using our post
+         * payload size * 1.5, on that way we make room for large responses
+         * if something goes wrong, so we don't get a partial response.
+         */
+        resp_size = payload_size * 1.5;
+        flb_http_buffer_size(c, resp_size);
+    }
+
+    /* HTTP Client */
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
 
     /* Try to use http_user and http_passwd if not, fallback to auth_header */
@@ -593,8 +608,8 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_SIZE, "http_buffer_size", FLB_SPLUNK_DEFAULT_HTTP_MAX,
-     0, FLB_TRUE, offsetof(struct flb_splunk, buffer_size),
+     FLB_CONFIG_MAP_SIZE, "http_buffer_size", NULL,
+     0, FLB_FALSE, 0,
      "Specify the buffer size used to read the response from the Splunk HTTP "
      "service. This option is useful for debugging purposes where is required to read "
      "full responses, note that response size grows depending of the number of records "

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -107,6 +107,9 @@ struct flb_splunk {
     /* HTTP Client Setup */
     size_t buffer_size;
 
+    /* HTTP: Debug bad requests (HTTP status 400) to stdout */
+    int http_debug_bad_request;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -151,6 +151,9 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
             flb_splunk_conf_destroy(ctx);
             return NULL;
         }
+        if (size < 4 *1024) {
+            size = 4 * 1024;
+        }
         ctx->buffer_size = size;
     }
 

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -90,6 +90,7 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
 {
     int ret;
     int io_flags = 0;
+    size_t size;
     flb_sds_t t;
     const char *tmp;
     struct flb_upstream *upstream;
@@ -138,6 +139,20 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
 
     /* Set manual Index and Type */
     ctx->u = upstream;
+
+    tmp = flb_output_get_property("http_buffer_size", ins);
+    if (!tmp) {
+        ctx->buffer_size = 0;
+    }
+    else {
+        size = flb_utils_size_to_bytes(tmp);
+        if (size == -1) {
+            flb_plg_error(ctx->ins, "invalid 'buffer_size' value");
+            flb_splunk_conf_destroy(ctx);
+            return NULL;
+        }
+        ctx->buffer_size = size;
+    }
 
     /* Compress (gzip) */
     tmp = flb_output_get_property("compress", ins);


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
