### PR TITLE
filter_rewrite_tag: set 'keep' before emitting(#4518) for 1.8

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -325,6 +325,9 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
 
     mk_list_foreach(head, &ctx->rules) {
         rule = mk_list_entry(head, struct rewrite_rule, _head);
+        if (rule) {
+            *keep = rule->keep_record;
+        }
         ret = flb_ra_regex_match(rule->ra_key, map, rule->regex, &result);
         if (ret < 0) { /* no match */
             rule = NULL;
@@ -361,7 +364,7 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
         return FLB_FALSE;
     }
 
-    *keep = rule->keep_record;
+
     return FLB_TRUE;
 }
 


### PR DESCRIPTION
This patch is to port for v1.8 branch.
Detail: https://github.com/fluent/fluent-bit/pull/4591


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

https://github.com/fluent/fluent-bit/issues/4518#issuecomment-1007886281

## Debug output

All records are kept.

```
$ cat test3 
test3: [1642914297.288678413, {"message":"DEBUG","i":0,"test3":"true"}]
test3: [1642914298.290666521, {"message":"DEBUG","i":1,"test3":"true"}]
test3: [1642914299.291848785, {"message":"DEBUG","i":2,"test3":"true"}]
test3: [1642914300.292755413, {"message":"DEBUG","i":3,"test3":"true"}]
test3: [1642914301.293838651, {"message":"DEBUG","i":4,"test3":"true"}]
test3: [1642914302.294988828, {"message":"DEBUG","i":5,"test3":"true"}]
test3: [1642914303.296905952, {"message":"DEBUG","i":6,"test3":"true"}]
test3: [1642914304.301876508, {"message":"DEBUG","i":7,"test3":"true"}]
test3: [1642914305.302891117, {"message":"DEBUG","i":8,"test3":"true"}]
test3: [1642914306.304283149, {"message":"DEBUG","i":9,"test3":"true"}]
```

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.12
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/23 14:04:15] [ info] [engine] started (pid=11039)
[2022/01/23 14:04:15] [ info] [storage] version=1.1.5, initializing...
[2022/01/23 14:04:15] [ info] [storage] in-memory
[2022/01/23 14:04:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/23 14:04:15] [ info] [cmetrics] version=0.2.2
[2022/01/23 14:04:15] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/23 14:04:15] [ info] [sp] stream processor started
[0] dummy: [1642914297.288678413, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] dummy: [1642914297.288681248, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[2] dummy: [1642914298.290666521, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[3] dummy: [1642914298.290669196, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[4] dummy: [1642914299.291848785, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[5] dummy: [1642914299.291851660, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[6] dummy: [1642914300.292755413, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[7] dummy: [1642914300.292758318, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[8] dummy: [1642914301.293838651, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[9] dummy: [1642914301.293841707, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test2: [1642914297.288681248, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[1] test2: [1642914298.290669196, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[2] test2: [1642914299.291851660, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[3] test2: [1642914300.292758318, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[4] test2: [1642914301.293841707, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test3: [1642914297.288678413, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] test3: [1642914298.290666521, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[2] test3: [1642914299.291848785, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[3] test3: [1642914300.292755413, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[4] test3: [1642914301.293838651, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[0] dummy: [1642914302.294988828, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] dummy: [1642914302.294992114, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[2] dummy: [1642914303.296905952, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[3] dummy: [1642914303.296908918, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[4] dummy: [1642914304.301876508, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[5] dummy: [1642914304.301879153, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[6] dummy: [1642914305.302891117, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[7] dummy: [1642914305.302895365, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[8] dummy: [1642914306.304283149, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
[9] dummy: [1642914306.304285804, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test2: [1642914302.294992114, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[1] test2: [1642914303.296908918, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[2] test2: [1642914304.301879153, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[3] test2: [1642914305.302895365, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[4] test2: [1642914306.304285804, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test3: [1642914302.294988828, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] test3: [1642914303.296905952, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[2] test3: [1642914304.301876508, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[3] test3: [1642914305.302891117, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[4] test3: [1642914306.304283149, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
^C[2022/01/23 14:05:17] [engine] caught signal (SIGINT)
[2022/01/23 14:05:17] [ info] [input] pausing forward.0
[2022/01/23 14:05:17] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/23 14:05:17] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

No leaks.
```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==11105== Memcheck, a memory error detector
==11105== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11105== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==11105== Command: ../bin/fluent-bit -c a.conf
==11105== 
Fluent Bit v1.8.12
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/23 14:06:55] [ info] [engine] started (pid=11105)
[2022/01/23 14:06:55] [ info] [storage] version=1.1.5, initializing...
[2022/01/23 14:06:55] [ info] [storage] in-memory
[2022/01/23 14:06:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/23 14:06:55] [ info] [cmetrics] version=0.2.2
[2022/01/23 14:06:55] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/23 14:06:55] [ info] [sp] stream processor started
==11105== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x6021980
==11105==          to suppress, use: --max-stackframe=8634296 or greater
==11105== Warning: client switching stacks?  SP change: 0x60218f8 --> 0x57e59c8
==11105==          to suppress, use: --max-stackframe=8634160 or greater
==11105== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x60218f8
==11105==          to suppress, use: --max-stackframe=8634160 or greater
==11105==          further instances of this message will not be shown.
[0] dummy: [1642914423.368954055, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] dummy: [1642914423.368962761, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[2] dummy: [1642914424.369502867, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[3] dummy: [1642914424.369505933, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[4] dummy: [1642914425.370851550, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[5] dummy: [1642914425.370856710, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[6] dummy: [1642914426.372760676, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[7] dummy: [1642914426.372765815, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[8] dummy: [1642914427.374626668, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[9] dummy: [1642914427.374630776, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test2: [1642914423.368962761, {"message"=>"ERROR", "i"=>0, "test2"=>"true"}]
[1] test2: [1642914424.369505933, {"message"=>"ERROR", "i"=>1, "test2"=>"true"}]
[2] test2: [1642914425.370856710, {"message"=>"ERROR", "i"=>2, "test2"=>"true"}]
[3] test2: [1642914426.372765815, {"message"=>"ERROR", "i"=>3, "test2"=>"true"}]
[4] test2: [1642914427.374630776, {"message"=>"ERROR", "i"=>4, "test2"=>"true"}]
[0] test3: [1642914423.368954055, {"message"=>"DEBUG", "i"=>0, "test3"=>"true"}]
[1] test3: [1642914424.369502867, {"message"=>"DEBUG", "i"=>1, "test3"=>"true"}]
[2] test3: [1642914425.370851550, {"message"=>"DEBUG", "i"=>2, "test3"=>"true"}]
[3] test3: [1642914426.372760676, {"message"=>"DEBUG", "i"=>3, "test3"=>"true"}]
[4] test3: [1642914427.374626668, {"message"=>"DEBUG", "i"=>4, "test3"=>"true"}]
[0] dummy: [1642914428.375918478, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] dummy: [1642914428.375921704, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[2] dummy: [1642914429.378489970, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[3] dummy: [1642914429.378493547, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[4] dummy: [1642914430.387168914, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[5] dummy: [1642914430.387174083, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[6] dummy: [1642914431.389141951, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[7] dummy: [1642914431.389147321, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[8] dummy: [1642914432.390948223, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
[9] dummy: [1642914432.390951249, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test2: [1642914428.375921704, {"message"=>"ERROR", "i"=>5, "test2"=>"true"}]
[1] test2: [1642914429.378493547, {"message"=>"ERROR", "i"=>6, "test2"=>"true"}]
[2] test2: [1642914430.387174083, {"message"=>"ERROR", "i"=>7, "test2"=>"true"}]
[3] test2: [1642914431.389147321, {"message"=>"ERROR", "i"=>8, "test2"=>"true"}]
[4] test2: [1642914432.390951249, {"message"=>"ERROR", "i"=>9, "test2"=>"true"}]
[0] test3: [1642914428.375918478, {"message"=>"DEBUG", "i"=>5, "test3"=>"true"}]
[1] test3: [1642914429.378489970, {"message"=>"DEBUG", "i"=>6, "test3"=>"true"}]
[2] test3: [1642914430.387168914, {"message"=>"DEBUG", "i"=>7, "test3"=>"true"}]
[3] test3: [1642914431.389141951, {"message"=>"DEBUG", "i"=>8, "test3"=>"true"}]
[4] test3: [1642914432.390948223, {"message"=>"DEBUG", "i"=>9, "test3"=>"true"}]
^C[2022/01/23 14:07:17] [engine] caught signal (SIGINT)
[2022/01/23 14:07:17] [ info] [input] pausing forward.0
[2022/01/23 14:07:17] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/23 14:07:17] [ info] [engine] service has stopped (0 pending tasks)
==11105== 
==11105== HEAP SUMMARY:
==11105==     in use at exit: 0 bytes in 0 blocks
==11105==   total heap usage: 3,274 allocs, 3,274 frees, 7,600,165 bytes allocated
==11105== 
==11105== All heap blocks were freed -- no leaks are possible
==11105== 
==11105== For lists of detected and suppressed errors, rerun with: -s
==11105== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
