### PR TITLE
in_forward: clear out_tag before using(#4670)

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -381,6 +381,7 @@ int fw_prot_process(struct fw_conn *conn)
             stag_len = tag.via.str.size;
 
             /* Copy the tag to the new buffer, prefix it if required */
+            flb_sds_len_set(out_tag, 0); /* clear out_tag before using */
             if (ctx->tag_prefix) {
                 flb_sds_cat_safe(&out_tag,
                                  ctx->tag_prefix, flb_sds_len(ctx->tag_prefix));


### PR DESCRIPTION
Fixes #4670

`out_tag` is not clear and re-used.
It causes `out_tag` is increasing for each loop.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
     Name forward
     Listen 0.0.0.0
     Port 24224
     Tag *

[OUTPUT]
     name                  stdout
     match                 *
     json_date_key         false
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/23 14:56:11] [ info] [engine] started (pid=19874)
[2022/01/23 14:56:11] [ info] [storage] version=1.1.5, initializing...
[2022/01/23 14:56:11] [ info] [storage] in-memory
[2022/01/23 14:56:11] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/23 14:56:11] [ info] [cmetrics] version=0.2.2
[2022/01/23 14:56:11] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/23 14:56:11] [ info] [sp] stream processor started
[0] 2cbb69924a23: [1642917374.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"/
[0] 2cbb69924a23: [1642917376.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"root@2cbb69924a23:/# pwd
", "container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]
[0] 2cbb69924a23: [1642917384.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"root@2cbb69924a23:/# lspwd
[1] 2cbb69924a23: [1642917384.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"bash: lspwd: command not found
^C[2022/01/23 14:56:32] [engine] caught signal (SIGINT)
[2022/01/23 14:56:32] [ info] [input] pausing forward.0
[2022/01/23 14:56:32] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/23 14:56:32] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==19871== Memcheck, a memory error detector
==19871== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==19871== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==19871== Command: ../bin/fluent-bit -c a.conf
==19871== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/23 14:55:27] [ info] [engine] started (pid=19871)
[2022/01/23 14:55:27] [ info] [storage] version=1.1.5, initializing...
[2022/01/23 14:55:27] [ info] [storage] in-memory
[2022/01/23 14:55:27] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/23 14:55:27] [ info] [cmetrics] version=0.2.2
[2022/01/23 14:55:27] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/01/23 14:55:27] [ info] [sp] stream processor started
==19871== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4d84fd0
==19871==          to suppress, use: --max-stackframe=10881576 or greater
==19871== Warning: client switching stacks?  SP change: 0x4d84f78 --> 0x57e59f8
==19871==          to suppress, use: --max-stackframe=10881664 or greater
==19871== Warning: client switching stacks?  SP change: 0x57e59f8 --> 0x4d84f78
==19871==          to suppress, use: --max-stackframe=10881664 or greater
==19871==          further instances of this message will not be shown.
", "container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]
[0] 2cbb69924a23: [1642917333.000000000, {"container_name"=>"/pedantic_rubin", "", "container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884"}]
[1] 2cbb69924a23: [1642917333.000000000, {"container_name"=>"/pedantic_rubin", "", "container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884"}]
[0] 2cbb69924a23: [1642917338.000000000, {"container_name"=>"/pedantic_rubin", "", "container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884"}]
[1] 2cbb69924a23: [1642917338.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"/
[2] 2cbb69924a23: [1642917340.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"root@2cbb69924a23:/# pwd
[3] 2cbb69924a23: [1642917340.000000000, {"container_id"=>"2cbb69924a2349c23280f1ef413c1128f4f9d6d5019c382babb8926a5fa39884", "container_name"=>"/pedantic_rubin"}]"source"=>"stdout", "log"=>"/
^C[2022/01/23 14:55:43] [engine] caught signal (SIGINT)
[2022/01/23 14:55:43] [ info] [input] pausing forward.0
[2022/01/23 14:55:43] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/23 14:55:44] [ info] [engine] service has stopped (0 pending tasks)
==19871== 
==19871== HEAP SUMMARY:
==19871==     in use at exit: 0 bytes in 0 blocks
==19871==   total heap usage: 1,202 allocs, 1,202 frees, 2,658,677 bytes allocated
==19871== 
==19871== All heap blocks were freed -- no leaks are possible
==19871== 
==19871== For lists of detected and suppressed errors, rerun with: -s
==19871== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
