### PR TITLE
io: check connection error only on net_io_read

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -317,14 +317,9 @@ static ssize_t fd_io_read(int fd, void *buf, size_t len);
 static ssize_t net_io_read(struct flb_upstream_conn *u_conn,
                            void *buf, size_t len)
 {
-    return fd_io_read(u_conn->fd, buf, len);
-}
-
-static ssize_t fd_io_read(int fd, void *buf, size_t len)
-{
     int ret;
 
-    ret = recv(fd, buf, len, 0);
+    ret = fd_io_read(u_conn->fd, buf, len);
     if (ret == -1) {
         ret = FLB_WOULDBLOCK();
         if (ret) {
@@ -334,6 +329,18 @@ static ssize_t fd_io_read(int fd, void *buf, size_t len)
                     u_conn->fd, u_conn->u->net.io_timeout,
                     u_conn->u->tcp_host, u_conn->u->tcp_port);
         }
+        return -1;
+    }
+
+    return ret;
+}
+
+static ssize_t fd_io_read(int fd, void *buf, size_t len)
+{
+    int ret;
+
+    ret = recv(fd, buf, len, 0);
+    if (ret == -1) {
         return -1;
     }
 


### PR DESCRIPTION
This patch is to fix current ci error.
https://github.com/fluent/fluent-bit/runs/4910718570?check_suite_focus=true

## Issue

This error is caused by https://github.com/fluent/fluent-bit/pull/4184 and https://github.com/fluent/fluent-bit/pull/4592 .

#4184 is modified to report connection error at `net_io_read`. https://github.com/fluent/fluent-bit/pull/4184/files#diff-f72622960cc4585851e369191a03e722650d566ea3ecd47e6482b69c41ead32b
On the other hand, #4592 is to split `net_io_read` to extract fd based functionality as `fd_io_read`.

However reporting connection error is added to `fd_io_read` and it doesn't pass `u_conn`.

## Patch

This patch is to move reporting connection error from `fd_io_read` to `net_io_read` .

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
