### PR TITLE
packaging: update Windows build to detain fluent-bit artefacts

### DIFF
--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -9,6 +9,7 @@ on:
       - 'docker_compose/**'
       - 'packaging/**'
       - '.gitignore'
+      - 'appveyor.yml'
 
 jobs:
   run-all-unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,6 +11,7 @@ on:
       - 'docker_compose/**'
       - 'packaging/**'
       - '.gitignore'
+      - 'appveyor.yml'
     branches:
       - master
       - 1.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ build_script:
   - powershell ".\ci\do-ut.ps1;exit $LASTEXITCODE"
   - cd build
   - cpack
+  - cpack -DFLB_TD=On
 
 artifacts:
   - path: build/td-agent-bit-*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,12 @@ environment:
 
 configuration:
   - Release
-  
+
 skip_commits:
   files:
-    - '.github/**'
-    - 'packaging/**'
-    - './dockerfiles/**'
+    - '.github/**/*'
+    - 'packaging/**/*'
+    - 'dockerfiles/**/*'
     - '**/*.md'
     - '**/*.sh'
 
@@ -44,3 +44,7 @@ artifacts:
     name: td-agent-bit
   - path: build/td-agent-bit-*.zip
     name: td-agent-bit-zip
+  - path: build/fluent-bit-*.exe
+    name: fluent-bit-installer
+  - path: build/fluent-bit-*.zip
+    name: fluent-bit-zip


### PR DESCRIPTION
During smoke testing for #4635 I noticed that the Appveyor builds are no longer detaining any artefacts.
The reason is a change in the default name to `fluent-bit` for the packages unless `FLB_TD=On` is defined.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
