### PR TITLE
tiger 1.8.8: 20210127 updates

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -274,7 +274,8 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
                                                   struct flb_sb     *context)
 {
     struct flb_input_chunk  dummy_input_chunk;
-    struct mk_list         *backlog_iterator;
+    struct mk_list         *tmp;
+    struct mk_list         *head;
     size_t                  chunk_size;
     struct sb_out_queue    *backlog;
     int                     tag_len;
@@ -289,25 +290,24 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
     chunk_size = cio_chunk_get_real_size(target_chunk);
 
     if (chunk_size < 0) {
-        flb_warn("[storage backlog] could not retrieve chunk real size");
-
+        flb_warn("[storage backlog] could not get real size of chunk %s/%s",
+                  stream->name, target_chunk->name);
         return -1;
     }
 
     result = flb_input_chunk_get_tag(&dummy_input_chunk, &tag_buf, &tag_len);
-
     if (result == -1) {
-        flb_error("[storage backlog] could not retrieve chunk tag");
-
+        flb_error("[storage backlog] could not retrieve chunk tag from %s/%s, "
+                  "removing it from the queue",
+                  stream->name, target_chunk->name);
         return -2;
     }
 
     flb_routes_mask_set_by_tag(dummy_input_chunk.routes_mask, tag_buf, tag_len,
                                context->ins);
 
-    mk_list_foreach(backlog_iterator, &context->backlogs) {
-        backlog = mk_list_entry(backlog_iterator, struct sb_out_queue, _head);
-
+    mk_list_foreach_safe(head, tmp, &context->backlogs) {
+        backlog = mk_list_entry(head, struct sb_out_queue, _head);
         if (flb_routes_mask_get_bit(dummy_input_chunk.routes_mask,
                                     backlog->ins->id)) {
             result = sb_append_chunk_to_segregated_backlog(target_chunk, stream,
@@ -323,10 +323,12 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
 
 int sb_segregate_chunks(struct flb_config *config)
 {
+    int                ret;
+    size_t             size;
+    struct mk_list    *tmp;
     struct mk_list    *stream_iterator;
     struct mk_list    *chunk_iterator;
     struct flb_sb     *context;
-    int                result;
     struct cio_stream *stream;
     struct cio_chunk  *chunk;
 
@@ -336,16 +338,15 @@ int sb_segregate_chunks(struct flb_config *config)
         return 0;
     }
 
-    result = sb_allocate_backlogs(context);
-
-    if (result) {
+    ret = sb_allocate_backlogs(context);
+    if (ret) {
         return -2;
     }
 
     mk_list_foreach(stream_iterator, &context->cio->streams) {
         stream = mk_list_entry(stream_iterator, struct cio_stream, _head);
 
-        mk_list_foreach(chunk_iterator, &stream->chunks) {
+        mk_list_foreach_safe(chunk_iterator, tmp, &stream->chunks) {
             chunk = mk_list_entry(chunk_iterator, struct cio_chunk, _head);
 
             if (!cio_chunk_is_up(chunk)) {
@@ -356,11 +357,23 @@ int sb_segregate_chunks(struct flb_config *config)
                 return -3;
             }
 
-            result = sb_append_chunk_to_segregated_backlogs(chunk, stream, context);
-
-            if (result) {
-                flb_error("[storage backlog] error distributing chunk references");
-                return -4;
+            /* try to segregate a chunk */
+            ret = sb_append_chunk_to_segregated_backlogs(chunk, stream, context);
+            if (ret) {
+                /*
+                 * if the chunk could not be segregated, just remove it from the
+                 * queue and continue.
+                 *
+                 * if content size is zero, it's safe to 'delete it'.
+                 */
+                size = cio_chunk_get_content_size(chunk);
+                if (size <= 0) {
+                    cio_chunk_close(chunk, CIO_TRUE);
+                }
+                else {
+                    cio_chunk_close(chunk, CIO_FALSE);
+                }
+                continue;
             }
 
             /* lock the chunk */

--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -84,7 +84,7 @@ static int ra_key_val_id(flb_sds_t ckey, msgpack_object map)
     }
 
     map_size = map.via.map.size;
-    for (i = 0; i < map_size; i++) {
+    for (i = map_size - 1; i >= 0; i--) {
         key = map.via.map.ptr[i].key;
 
         if (key.type != MSGPACK_OBJECT_STR) {

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -409,12 +409,220 @@ void cb_get_kv_pair()
     msgpack_unpacked_destroy(&result);
 }
 
+void cb_dash_key()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Sample JSON message */
+    json = "{\"key-dash\": \"something\"}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key-dash");
+    fmt_out = "something";
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, out_buf, out_size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+}
+
+void cb_dot_and_slash_key()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Sample JSON message */
+    json = "{\"root.with/symbols\": \"something\"}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$root.with/symbols");
+    if (!TEST_CHECK(fmt != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    fmt_out = "something";
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, out_buf, out_size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+}
+
+static int order_lookup_check(char *buf, size_t size,
+                              char *fmt, char *expected_out)
+{
+    size_t off = 0;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Check bool is 'true' */
+    fmt = flb_sds_create(fmt);
+    if (!TEST_CHECK(fmt != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+    fmt_out = expected_out;
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, buf, size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(expected_out));
+    if (flb_sds_len(str) != strlen(expected_out)) {
+        printf("received: '%s', expected: '%s'\n", str, fmt_out);
+    }
+
+    TEST_CHECK(memcmp(str, expected_out, strlen(expected_out)) == 0);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(ra);
+    msgpack_unpacked_destroy(&result);
+
+    return 0;
+}
+
+void cb_key_order_lookup()
+{
+    int len;
+    int ret;
+    int type;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+
+    /* Sample JSON message */
+    json = "{\"key\": \"abc\", \"bool\": false, \"bool\": true, "
+             "\"str\": \"bad\", \"str\": \"good\", "
+             "\"num\": 0, \"num\": 1}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    printf("\n-- record --\n");
+    flb_pack_print(out_buf, out_size);
+
+    /* check expected outputs per record accessor pattern */
+    order_lookup_check(out_buf, out_size, "$bool", "true");
+    order_lookup_check(out_buf, out_size, "$str" , "good");
+    order_lookup_check(out_buf, out_size, "$num" , "1");
+
+    flb_free(out_buf);
+}
+
 TEST_LIST = {
-    { "keys"         , cb_keys},
-    { "translate"    , cb_translate},
-    { "translate_tag", cb_translate_tag},
-    { "dots_subkeys" , cb_dots_subkeys},
-    { "array_id"     , cb_array_id},
-    { "get_kv_pair"  , cb_get_kv_pair},
+    { "keys"            , cb_keys},
+    { "translate"       , cb_translate},
+    { "translate_tag"   , cb_translate_tag},
+    { "dots_subkeys"    , cb_dots_subkeys},
+    { "array_id"        , cb_array_id},
+    { "get_kv_pair"     , cb_get_kv_pair},
+    { "key_order_lookup", cb_key_order_lookup},
     { NULL }
 };


### PR DESCRIPTION
Backported changes:

- bbcbd7bb1 in_storage_backlog: do not abort if chunk cannot be processed
- 95fe04522 tests: internal: ra: add unit test for lookup order
- bc46578fe ra_key: reverse order of map lookup when extracting values
