### PR TITLE
workflows: add centos check

### DIFF
--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -1,0 +1,34 @@
+name: 'Pull requests compile checks'
+on:
+  pull_request:
+    # Only trigger if there is a code change
+    paths:
+      - '**.h'
+      - '**.c'
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  # Sanity check for compilation using older compiler on CentOS 7
+  pr-compile-centos-7:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout Fluent Bit code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Attempt to build current source for CentOS 7
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./dockerfiles/Dockerfile.centos7
+        # No need to use after this so discard completely
+        push: false
+        load: false

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -1,0 +1,25 @@
+# This container image is primarily used to test compilation works for CentOS 7, it is
+# not intended for production usage.
+# Based on https://github.com/fluent/fluent-bit-packaging/tree/master/distros/centos/7
+FROM centos:7
+
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+                   wget unzip systemd-devel wget flex bison \
+                   cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+                   postgresql-libs postgresql-devel postgresql-server postgresql && \
+    wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    rpm -ivh epel-release-latest-7.noarch.rpm && \
+    yum install -y cmake3
+
+COPY . /src/
+WORKDIR /src/build
+
+RUN cmake3 -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
+           -DFLB_RELEASE=On -DFLB_TRACE=On -DFLB_TD=On \
+           -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On \
+           -DFLB_SQLDB=On -DFLB_HTTP_SERVER=On \
+           -DFLB_OUT_KAFKA=On \
+           -DFLB_OUT_PGSQL=On ../
+
+RUN make -j $(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Merges workflow from `master` to `1.8` to check for CentOS 7 compilation issues.
Aims to catch issues like #4709 

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [NA] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [NA] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [NA] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

This is the backport PR.
<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
