### PR TITLE
out_forward: support 'unix_path'

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -33,6 +33,11 @@
 #include "forward.h"
 #include "forward_format.h"
 
+#ifdef FLB_HAVE_UNIX_SOCKET
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
 #define SECURED_BY "Fluent Bit"
 
 #ifdef FLB_HAVE_TLS
@@ -47,6 +52,18 @@ void _secure_forward_tls_error(struct flb_forward *ctx,
 
     mbedtls_strerror(ret, err_buf, sizeof(err_buf));
     flb_plg_error(ctx->ins, "flb_io_tls.c:%i %s", line, err_buf);
+}
+
+static int io_net_write(struct flb_upstream_conn *conn, int unused_fd,
+                        const void* data, size_t len, size_t *out_len)
+{
+    return flb_io_net_write(conn, data, len, out_len);
+}
+
+static int io_net_read(struct flb_upstream_conn *conn, int unused_fd,
+                       void* buf, size_t len)
+{
+    return flb_io_net_read(conn, buf, len);
 }
 
 static int secure_forward_init(struct flb_forward *ctx,
@@ -93,6 +110,7 @@ static inline void print_msgpack_status(struct flb_forward *ctx,
 /* Read a secure forward msgpack message */
 static int secure_forward_read(struct flb_forward *ctx,
                                struct flb_upstream_conn *u_conn,
+                               struct flb_forward_config *fc,
                                char *buf, size_t size, size_t *out_len)
 {
     int ret;
@@ -109,7 +127,7 @@ static int secure_forward_read(struct flb_forward *ctx,
         }
 
         /* Read the message */
-        ret = flb_io_net_read(u_conn, buf + buf_off, size - buf_off);
+        ret = fc->io_read(u_conn, fc->unix_fd, buf + buf_off, size - buf_off);
         if (ret <= 0) {
             goto error;
         }
@@ -280,7 +298,7 @@ static int secure_forward_ping(struct flb_upstream_conn *u_conn,
         msgpack_pack_str_body(&mp_pck, "", 0);
     }
 
-    ret = flb_io_net_write(u_conn, mp_sbuf.data, mp_sbuf.size, &bytes_sent);
+    ret = fc->io_write(u_conn, fc->unix_fd, mp_sbuf.data, mp_sbuf.size, &bytes_sent);
     flb_plg_debug(ctx->ins, "PING sent: ret=%i bytes sent=%lu", ret, bytes_sent);
 
     msgpack_sbuffer_destroy(&mp_sbuf);
@@ -358,7 +376,7 @@ static int secure_forward_handshake(struct flb_upstream_conn *u_conn,
     msgpack_object o;
 
     /* Wait for server HELO */
-    ret = secure_forward_read(ctx, u_conn, buf, sizeof(buf) - 1, &out_len);
+    ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "handshake error expecting HELO");
         return -1;
@@ -406,7 +424,7 @@ static int secure_forward_handshake(struct flb_upstream_conn *u_conn,
     }
 
     /* Expect a PONG */
-    ret = secure_forward_read(ctx, u_conn, buf, sizeof(buf) - 1, &out_len);
+    ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "handshake error expecting HELO");
         msgpack_unpacked_destroy(&result);
@@ -445,7 +463,7 @@ static int forward_read_ack(struct flb_forward *ctx,
     flb_plg_trace(ctx->ins, "wait ACK (%.*s)", chunk_len, chunk);
 
     /* Wait for server ACK */
-    ret = secure_forward_read(ctx, u_conn, buf, sizeof(buf) - 1, &out_len);
+    ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "cannot get ack");
         return -1;
@@ -512,6 +530,11 @@ static int forward_read_ack(struct flb_forward *ctx,
 static int forward_config_init(struct flb_forward_config *fc,
                                struct flb_forward *ctx)
 {
+    if (fc->io_read == NULL || fc->io_write == NULL) {
+        flb_plg_error(ctx->ins, "io_read/io_write is NULL");
+        return -1;
+    }
+
 #ifdef FLB_HAVE_TLS
     /* Initialize Secure Forward mode */
     if (fc->secured == FLB_TRUE) {
@@ -724,7 +747,10 @@ static int forward_config_ha(const char *upstream_file,
             flb_plg_error(ctx->ins, "failed config allocation");
             continue;
         }
+        fc->unix_fd = -1;
         fc->secured = FLB_FALSE;
+        fc->io_write = io_net_write;
+        fc->io_read  = io_net_read;
 
         /* Is TLS enabled ? */
         if (node->tls_enabled == FLB_TRUE) {
@@ -751,6 +777,53 @@ static int forward_config_ha(const char *upstream_file,
 
     return 0;
 }
+#ifdef FLB_HAVE_UNIX_SOCKET
+static int forward_unix_create(struct flb_forward_config *config,
+                               struct flb_forward *ctx)
+{
+    flb_sockfd_t fd = -1;
+    struct sockaddr_un address;
+
+    if (sizeof(address.sun_path) <= flb_sds_len(config->unix_path)) {
+        flb_plg_error(ctx->ins, "unix_path is too long");
+        return -1;
+    }
+
+    memset(&address, 0, sizeof(struct sockaddr_un));
+
+    fd = flb_net_socket_create(AF_UNIX, FLB_TRUE);
+    if (fd < 0) {
+        flb_plg_error(ctx->ins, "flb_net_socket_create error");
+        return -1;
+    }
+    config->unix_fd = fd;
+
+    address.sun_family = AF_UNIX;
+    strncpy(address.sun_path, config->unix_path, flb_sds_len(config->unix_path));
+
+    if(connect(fd, (const struct sockaddr*) &address, sizeof(address)) < 0) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+
+    flb_net_socket_nonblocking(config->unix_fd);
+
+    return 0;
+}
+
+static int io_unix_write(struct flb_upstream_conn *unused, int fd, const void* data,
+                         size_t len, size_t *out_len)
+{
+    return flb_io_fd_write(fd, data, len, out_len);
+}
+
+static int io_unix_read(struct flb_upstream_conn *unused, int fd, void* buf,size_t len)
+{
+    return flb_io_fd_read(fd, buf, len);
+}
+
+#endif
 
 static int forward_config_simple(struct flb_forward *ctx,
                                  struct flb_output_instance *ins,
@@ -770,7 +843,10 @@ static int forward_config_simple(struct flb_forward *ctx,
         flb_errno();
         return -1;
     }
+    fc->unix_fd = -1;
     fc->secured = FLB_FALSE;
+    fc->io_write = NULL;
+    fc->io_read  = NULL;
 
     /* Set default values */
     ret = flb_output_config_map_set(ins, fc);
@@ -796,19 +872,38 @@ static int forward_config_simple(struct flb_forward *ctx,
         io_flags |= FLB_IO_IPV6;
     }
 
-    /* Prepare an upstream handler */
-    upstream = flb_upstream_create(config,
-                                   ins->host.name,
-                                   ins->host.port,
-                                   io_flags, ins->tls);
-    if (!upstream) {
+    if (fc->unix_path) {
+#ifdef FLB_HAVE_UNIX_SOCKET
+        if(forward_unix_create(fc, ctx) < 0) {
+            flb_free(fc);
+            flb_free(ctx);
+            return -1;
+        }
+        fc->io_write = io_unix_write;
+        fc->io_read  = io_unix_read;
+#else
+        flb_plg_error(ctx->ins, "unix_path is not supported");
         flb_free(fc);
         flb_free(ctx);
         return -1;
+#endif /* FLB_HAVE_UNIX_SOCKET */
     }
-    ctx->u = upstream;
-    flb_output_upstream_set(ctx->u, ins);
-
+    else {
+        /* Prepare an upstream handler */
+        upstream = flb_upstream_create(config,
+                                       ins->host.name,
+                                       ins->host.port,
+                                       io_flags, ins->tls);
+        if (!upstream) {
+            flb_free(fc);
+            flb_free(ctx);
+            return -1;
+        }
+        fc->io_write = io_net_write;
+        fc->io_read  = io_net_read;
+        ctx->u = upstream;
+        flb_output_upstream_set(ctx->u, ins);
+    }
     /* Read properties into 'fc' context */
     config_set_properties(NULL, fc, ctx);
 
@@ -902,7 +997,7 @@ static int flush_message_mode(struct flb_forward *ctx,
             rec_size = off - pre;
 
             /* write single message */
-            ret = flb_io_net_write(u_conn,
+            ret = fc->io_write(u_conn,fc->unix_fd,
                                    buf + pre, rec_size, &sent);
             pre = off;
 
@@ -937,7 +1032,7 @@ static int flush_message_mode(struct flb_forward *ctx,
     }
 
     /* Normal data write */
-    ret = flb_io_net_write(u_conn, buf, size, &sent);
+    ret = fc->io_write(u_conn, fc->unix_fd, buf, size, &sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "message_mode: error sending data");
         return FLB_RETRY;
@@ -1004,7 +1099,7 @@ static int flush_forward_mode(struct flb_forward *ctx,
     }
 
     /* Write message header */
-    ret = flb_io_net_write(u_conn, mp_sbuf.data, mp_sbuf.size, &bytes_sent);
+    ret = fc->io_write(u_conn, fc->unix_fd, mp_sbuf.data, mp_sbuf.size, &bytes_sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not write forward header");
         msgpack_sbuffer_destroy(&mp_sbuf);
@@ -1016,7 +1111,7 @@ static int flush_forward_mode(struct flb_forward *ctx,
     msgpack_sbuffer_destroy(&mp_sbuf);
 
     /* Write entries */
-    ret = flb_io_net_write(u_conn, final_data, final_bytes, &bytes_sent);
+    ret = fc->io_write(u_conn, fc->unix_fd, final_data, final_bytes, &bytes_sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not write forward entries");
         if (fc->compress == COMPRESS_GZIP) {
@@ -1031,7 +1126,7 @@ static int flush_forward_mode(struct flb_forward *ctx,
 
     /* Write options */
     if (fc->send_options == FLB_TRUE) {
-        ret = flb_io_net_write(u_conn, opts_buf, opts_size, &bytes_sent);
+        ret = fc->io_write(u_conn, fc->unix_fd, opts_buf, opts_size, &bytes_sent);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "could not write forward options");
             return FLB_RETRY;
@@ -1088,7 +1183,7 @@ static int flush_forward_compat_mode(struct flb_forward *ctx,
     msgpack_unpacked result;
 
     /* Write message header */
-    ret = flb_io_net_write(u_conn, data, bytes, &bytes_sent);
+    ret = fc->io_write(u_conn, fc->unix_fd, data, bytes, &bytes_sent);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not write forward compat mode records");
         return FLB_RETRY;
@@ -1142,7 +1237,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
     size_t out_size = 0;
     struct flb_forward *ctx = out_context;
     struct flb_forward_config *fc = NULL;
-    struct flb_upstream_conn *u_conn;
+    struct flb_upstream_conn *u_conn = NULL;
     struct flb_upstream_node *node = NULL;
     struct flb_forward_flush *flush_ctx;
     (void) i_ins;
@@ -1179,21 +1274,23 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
                               &out_buf, &out_size);
 
     /* Get a TCP connection instance */
-    if (ctx->ha_mode == FLB_TRUE) {
-        u_conn = flb_upstream_conn_get(node->u);
-    }
-    else {
-        u_conn = flb_upstream_conn_get(ctx->u);
-    }
-
-    if (!u_conn) {
-        flb_plg_error(ctx->ins, "no upstream connections available");
-        msgpack_sbuffer_destroy(&mp_sbuf);
-        if (fc->time_as_integer == FLB_TRUE) {
-            flb_free(tmp_buf);
+    if (fc->unix_path == NULL) {
+        if (ctx->ha_mode == FLB_TRUE) {
+            u_conn = flb_upstream_conn_get(node->u);
         }
-        flb_free(flush_ctx);
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+        else {
+            u_conn = flb_upstream_conn_get(ctx->u);
+        }
+
+        if (!u_conn) {
+            flb_plg_error(ctx->ins, "no upstream connections available");
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            if (fc->time_as_integer == FLB_TRUE) {
+                flb_free(tmp_buf);
+            }
+            flb_free(flush_ctx);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
     }
 
     /*
@@ -1203,7 +1300,9 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
         ret = secure_forward_handshake(u_conn, fc, ctx);
         flb_plg_debug(ctx->ins, "handshake status = %i", ret);
         if (ret == -1) {
-            flb_upstream_conn_release(u_conn);
+            if (u_conn) {
+                flb_upstream_conn_release(u_conn);
+            }
             msgpack_sbuffer_destroy(&mp_sbuf);
             if (fc->time_as_integer == FLB_TRUE) {
                 flb_free(tmp_buf);
@@ -1232,7 +1331,9 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
         flb_free(out_buf);
     }
 
-    flb_upstream_conn_release(u_conn);
+    if (u_conn) {
+        flb_upstream_conn_release(u_conn);
+    }
     flb_free(flush_ctx);
     FLB_OUTPUT_RETURN(ret);
 }
@@ -1252,6 +1353,9 @@ static int cb_forward_exit(void *data, struct flb_config *config)
     /* Destroy forward_config contexts */
     mk_list_foreach_safe(head, tmp, &ctx->configs) {
         fc = mk_list_entry(head, struct flb_forward_config, _head);
+        if (fc->unix_path && fc->unix_fd > 0) {
+            close(fc->unix_fd);
+        }
         mk_list_del(&fc->_head);
         forward_config_destroy(fc);
     }
@@ -1266,6 +1370,7 @@ static int cb_forward_exit(void *data, struct flb_config *config)
             flb_upstream_destroy(ctx->u);
         }
     }
+
     flb_free(ctx);
 
     return 0;
@@ -1311,6 +1416,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "password", "",
      0, FLB_TRUE, offsetof(struct flb_forward_config, password),
      "Password for authentication"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "unix_path", NULL,
+     0, FLB_TRUE, offsetof(struct flb_forward_config, unix_path),
+     "Path to unix socket. It is ignored when 'upstream' property is set"
     },
     {
      FLB_CONFIG_MAP_STR, "upstream", NULL,

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_upstream_ha.h>
 #include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_upstream_conn.h>
 
 #ifdef FLB_HAVE_TLS
 #include <mbedtls/entropy.h>
@@ -62,6 +63,8 @@ struct flb_forward_config {
     int empty_shared_key;        /* use an empty string as shared key */
     int require_ack_response;    /* Require acknowledge for "chunk" */
     int send_options;            /* send options in messages */
+    flb_sds_t unix_path;         /* unix socket path */
+    int       unix_fd;
 
     const char *username;
     const char *password;
@@ -77,7 +80,9 @@ struct flb_forward_config {
     struct flb_record_accessor *ra_tag; /* Tag Record accessor */
     int ra_static;                      /* Is the record accessor static ? */
 #endif
-
+    int (*io_write)(struct flb_upstream_conn* conn, int fd, const void* data,
+                        size_t len, size_t *out_len);
+    int (*io_read)(struct flb_upstream_conn* conn, int fd, void* buf, size_t len);
     struct mk_list _head;     /* Link to list flb_forward->configs */
 };
 


### PR DESCRIPTION
Fixes #2181

This patch is to add 'unix_path' to forward via unix socket.

|Key|Description|Default|
|--|--|--|
|Unix_Path|Specify the path to unix socket to send a Forward message. If set, `Upstream` is ignored.||

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

1. `fluent-bit -c server.conf`
2. `fluent-bit -c client.conf`

server.conf:
```
[INPUT]
    Name forward
    unix_path hoge.sock

[OUTPUT]
    Name stdout
```

client.conf:
```
[INPUT]
    Name cpu

[OUTPUT]
    Name forward
    unix_path hoge.sock
```

## Debug output


```
$ bin/fluent-bit -c server.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/29 08:27:01] [ info] [engine] started (pid=5692)
[2022/01/29 08:27:01] [ info] [storage] version=1.1.5, initializing...
[2022/01/29 08:27:01] [ info] [storage] in-memory
[2022/01/29 08:27:01] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/29 08:27:01] [ info] [cmetrics] version=0.2.2
[2022/01/29 08:27:01] [ info] [input:forward:forward.0] listening on unix://hoge.sock
[2022/01/29 08:27:01] [ info] [sp] stream processor started
[0] cpu.0: [1643412427.909546068, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000}]
[1] cpu.0: [1643412428.910456124, {"cpu_p"=>2.000000, "user_p"=>2.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>0.000000}]
[2] cpu.0: [1643412429.910156104, {"cpu_p"=>2.000000, "user_p"=>2.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>0.000000}]
[3] cpu.0: [1643412430.909589692, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000}]
^C[2022/01/29 08:27:18] [engine] caught signal (SIGINT)
[2022/01/29 08:27:18] [ info] [input] pausing forward.0
[0] cpu.0: [1643412431.910034126, {"cpu_p"=>2.000000, "user_p"=>1.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>1.000000}]
[1] cpu.0: [1643412432.909600487, {"cpu_p"=>0.000000, "user_p"=>0.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000}]
[2] cpu.0: [1643412433.909575726, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000}]
[3] cpu.0: [1643412434.909893060, {"cpu_p"=>29.000000, "user_p"=>28.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>29.000000, "cpu0.p_user"=>28.000000, "cpu0.p_system"=>1.000000}]
[4] cpu.0: [1643412435.909501993, {"cpu_p"=>2.000000, "user_p"=>1.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>2.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>1.000000}]
[2022/01/29 08:27:18] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/29 08:27:18] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c client.conf 
==5706== Memcheck, a memory error detector
==5706== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5706== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5706== Command: bin/fluent-bit -c client.conf
==5706== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/29 08:29:19] [ info] [engine] started (pid=5706)
[2022/01/29 08:29:19] [ info] [storage] version=1.1.5, initializing...
[2022/01/29 08:29:19] [ info] [storage] in-memory
[2022/01/29 08:29:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/29 08:29:19] [ info] [cmetrics] version=0.2.2
[2022/01/29 08:29:19] [ info] [sp] stream processor started
^C[2022/01/29 08:29:29] [engine] caught signal (SIGINT)
[2022/01/29 08:29:29] [ info] [input] pausing cpu.0
[2022/01/29 08:29:29] [ warn] [engine] service will shutdown in max 5 seconds
[2022/01/29 08:29:29] [ info] [engine] service has stopped (0 pending tasks)
==5706== 
==5706== HEAP SUMMARY:
==5706==     in use at exit: 0 bytes in 0 blocks
==5706==   total heap usage: 1,154 allocs, 1,154 frees, 1,420,881 bytes allocated
==5706== 
==5706== All heap blocks were freed -- no leaks are possible
==5706== 
==5706== For lists of detected and suppressed errors, rerun with: -s
==5706== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
