### PR TITLE
workflows: add source code upload on release

### DIFF
--- a/.github/workflows/release-source-upload.yaml
+++ b/.github/workflows/release-source-upload.yaml
@@ -9,6 +9,7 @@ jobs:
   upload-source-artefact:
     name: Upload source code to packaging server
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Hashed known hosts value
         id: known_hosts

--- a/.github/workflows/release-source-upload.yaml
+++ b/.github/workflows/release-source-upload.yaml
@@ -1,0 +1,38 @@
+---
+name: Upload source for release to fluentbit.io
+
+on:
+  release:
+    # Only run when a release is pushed out
+    types: [released]
+jobs:
+  upload-source-artefact:
+    name: Upload source code to packaging server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hashed known hosts value
+        id: known_hosts
+        run: |
+          OUTPUT=$(ssh-keyscan -H ${{ secrets.FLUENTBITIO_HOST }})
+          echo ::set-output name=OUTPUT::$OUTPUT
+        shell: bash
+
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+          known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
+
+      - name: Grab source on server
+        # This puts it in the top-level releases directory, the docs indicate directories per
+        # major version, i.e. 1.8/fluent-bit-v1.8.12.tar.gz. However this seems simpler. We can
+        # update the docs once in use or have a final step set up a symlink or move.
+        run: |
+          ssh $USERNAME@$HOST wget --no-clobber \
+            -O /var/www/fluentbit-website/releases/fluent-bit-$VERSION.tar.gz \
+            https://github.com/fluent/fluent-bit/archive/refs/tags/v$VERSION.tar.gz
+        env:
+          HOST: ${{ secrets.FLUENTBITIO_HOST }}
+          USERNAME: ${{ secrets.FLUENTBITIO_USERNAME }}
+          VERSION: ${{ github.ref }}
+        shell: bash


### PR DESCRIPTION
Ensure we fully automate source artefact upload when a release is created, remove any manual requirements.
Intention is to prevent issues like #4709 from occurring by ensuring automation.

The SSH key we use will need access to write to the output directory to run this workflow to completion but we also prevent clobbering. The only concern is other workflows may have access to this key so added to `release` environment only which requires approval to try to mitigate issues.

Currently this is targeting the top-level release directory rather than per major version so we may need to update the docs when it is deployed.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
