### PR TITLE
installation: add script to install in one liner

### DIFF
--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -10,6 +10,7 @@ on:
       - 'packaging/**'
       - '.gitignore'
       - 'appveyor.yml'
+      - '**.sh'
 
 jobs:
   run-all-unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,10 +12,11 @@ on:
       - 'packaging/**'
       - '.gitignore'
       - 'appveyor.yml'
+      - '**.sh'
     branches:
       - master
       - 1.8
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ EOF
 yum -y install fluent-bit
 SCRIPT
     ;;
-    centos|redhatenterpriselinuxserver)
+    centos|centoslinux|redhatenterpriselinuxserver)
         sudo sh <<SCRIPT
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "================================"
@@ -8,16 +8,16 @@ echo "This script requires superuser access to install packages."
 echo "You will be prompted for your password by sudo."
 
 # Determine package type to install: https://unix.stackexchange.com/a/6348
-# OS used by all
+# OS used by all - for Debs it must be Ubuntu or Debian
 # CODENAME only used for Debs
-if lsb_release &>/dev/null; then
-    OS=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-    CODENAME=$(lsb_release -cs)
-elif [[ -f /etc/os-release ]]; then
+if [[ -f /etc/os-release ]]; then
     # shellcheck source=/dev/null
     source /etc/os-release
-    OS=$( echo "${NAME// /}" | tr '[:upper:]' '[:lower:]')
+    OS=$( echo "${ID}" | tr '[:upper:]' '[:lower:]')
     CODENAME=$( echo "${VERSION_CODENAME}" | tr '[:upper:]' '[:lower:]')
+elif lsb_release &>/dev/null; then
+    OS=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+    CODENAME=$(lsb_release -cs)
 else
     OS=$(uname -s)
 fi
@@ -28,7 +28,7 @@ sudo -k
 # Now set up repos and install dependent on OS, version, etc.
 # Will require sudo
 case ${OS} in
-    amazonlinux)
+    amzn|amazonlinux)
         sudo sh <<'SCRIPT'
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
@@ -42,7 +42,7 @@ EOF
 yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
-    centos|centoslinux|redhatenterpriselinuxserver)
+    centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora)
         sudo sh <<'SCRIPT'
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF

--- a/install.sh
+++ b/install.sh
@@ -9,18 +9,14 @@ echo "You will be prompted for your password by sudo."
 
 # Determine package type to install: https://unix.stackexchange.com/a/6348
 # OS used by all
-# VER only used for RPMs
 # CODENAME only used for Debs
 if lsb_release &>/dev/null; then
     OS=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-    VER=$(lsb_release -rs | tr '[:upper:]' '[:lower:]')
     CODENAME=$(lsb_release -cs)
 elif [[ -f /etc/os-release ]]; then
     # shellcheck source=/dev/null
     source /etc/os-release
     OS=$( echo "${NAME// /}" | tr '[:upper:]' '[:lower:]')
-    # Only want a number
-    VER=$( echo "${VERSION_ID%.*}" | tr '[:upper:]' '[:lower:]')
     CODENAME=$( echo "${VERSION_CODENAME}" | tr '[:upper:]' '[:lower:]')
 else
     OS=$(uname -s)
@@ -33,12 +29,12 @@ sudo -k
 # Will require sudo
 case ${OS} in
     amazonlinux)
-        sudo sh <<SCRIPT
+        sudo sh <<'SCRIPT'
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
 [fluent-bit]
 name = Fluent Bit
-baseurl = https://packages.fluentbit.io/amazonlinux/${VER}/\$basearch/
+baseurl = https://packages.fluentbit.io/amazonlinux/\$releasever/\$basearch/
 gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
@@ -47,12 +43,12 @@ yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
     centos|centoslinux|redhatenterpriselinuxserver)
-        sudo sh <<SCRIPT
+        sudo sh <<'SCRIPT'
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
 [fluent-bit]
 name = Fluent Bit
-baseurl = https://packages.fluentbit.io/centos/${VER}/\$basearch/
+baseurl = https://packages.fluentbit.io/centos/\$releasever/\$basearch/
 gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -e
 
 echo "================================"
 echo " Fluent Bit Installation Script "

--- a/install.sh
+++ b/install.sh
@@ -11,8 +11,9 @@ echo "You will be prompted for your password by sudo."
 # OS used by all - for Debs it must be Ubuntu or Debian
 # CODENAME only used for Debs
 if [ -f /etc/os-release ]; then
+    # Debian uses Dash which does not support source
     # shellcheck source=/dev/null
-    source /etc/os-release
+    . /etc/os-release
     OS=$( echo "${ID}" | tr '[:upper:]' '[:lower:]')
     CODENAME=$( echo "${VERSION_CODENAME}" | tr '[:upper:]' '[:lower:]')
 elif lsb_release &>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -eu
+
+echo "================================"
+echo " Fluent Bit Installation Script "
+echo "================================"
+echo "This script requires superuser access to install packages."
+echo "You will be prompted for your password by sudo."
+
+# Determine package type to install: https://unix.stackexchange.com/a/6348
+if lsb_release &>/dev/null; then
+    OS=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+    VER=$(lsb_release -rs | tr '[:upper:]' '[:lower:]')
+    CODENAME=$(lsb_release -cs)
+elif [[ -f /etc/os-release ]]; then
+    # shellcheck source=/dev/null
+    source /etc/os-release
+    OS=$( echo "${NAME// /}" | tr '[:upper:]' '[:lower:]')
+    VER=$( echo "${VERSION%.*}" | tr '[:upper:]' '[:lower:]')
+    CODENAME=$( echo "${VERSION_CODENAME}" | tr '[:upper:]' '[:lower:]')
+else
+    OS=$(uname -s)
+fi
+
+# Clear any previous sudo permission
+sudo -k
+
+# Now set up repos and install dependent on OS, version, etc.
+# Will require sudo
+case ${OS} in
+    amazonlinux)
+        sudo sh <<SCRIPT
+rpm --import https://packages.fluentbit.io/fluentbit.key
+cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
+[fluent-bit]
+name = Fluent Bit
+baseurl = https://packages.fluentbit.io/amazonlinux/2/\$basearch/
+gpgcheck=1
+gpgkey=https://packages.fluentbit.io/fluentbit.key
+enabled=1
+EOF
+yum -y install fluent-bit
+SCRIPT
+    ;;
+    centos|redhatenterpriselinuxserver)
+        sudo sh <<SCRIPT
+rpm --import https://packages.fluentbit.io/fluentbit.key
+cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
+[fluent-bit]
+name = Fluent Bit
+baseurl = https://packages.fluentbit.io/centos/${VER}/\$basearch/
+gpgcheck=1
+gpgkey=https://packages.fluentbit.io/fluentbit.key
+enabled=1
+EOF
+yum -y install fluent-bit
+SCRIPT
+    ;;
+    ubuntu|debian)
+        # Remember apt-key add is deprecated
+        # https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution
+        sudo sh <<SCRIPT
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p /usr/share/keyrings/
+curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
+cat > /etc/apt/sources.list.d/fluent-bit.list <<EOF
+deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/${OS}/${CODENAME} ${CODENAME} main
+EOF
+apt-get -y update
+apt-get -y install fluent-bit
+SCRIPT
+    ;;
+    *)
+        echo "${OS} not supported."
+        exit 1
+    ;;
+esac
+
+echo ""
+echo "Installation completed. Happy Logging!"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
 EOF
-yum -y install fluent-bit
+yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
     centos|centoslinux|redhatenterpriselinuxserver)
@@ -57,7 +57,7 @@ gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
 EOF
-yum -y install fluent-bit
+yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
     ubuntu|debian)
@@ -71,7 +71,7 @@ cat > /etc/apt/sources.list.d/fluent-bit.list <<EOF
 deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/${OS}/${CODENAME} ${CODENAME} main
 EOF
 apt-get -y update
-apt-get -y install fluent-bit
+apt-get -y install fluent-bit || apt-get -y install td-agent-bit
 SCRIPT
     ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,9 @@ echo "This script requires superuser access to install packages."
 echo "You will be prompted for your password by sudo."
 
 # Determine package type to install: https://unix.stackexchange.com/a/6348
+# OS used by all
+# VER only used for RPMs
+# CODENAME only used for Debs
 if lsb_release &>/dev/null; then
     OS=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
     VER=$(lsb_release -rs | tr '[:upper:]' '[:lower:]')
@@ -16,7 +19,8 @@ elif [[ -f /etc/os-release ]]; then
     # shellcheck source=/dev/null
     source /etc/os-release
     OS=$( echo "${NAME// /}" | tr '[:upper:]' '[:lower:]')
-    VER=$( echo "${VERSION%.*}" | tr '[:upper:]' '[:lower:]')
+    # Only want a number
+    VER=$( echo "${VERSION_ID%.*}" | tr '[:upper:]' '[:lower:]')
     CODENAME=$( echo "${VERSION_CODENAME}" | tr '[:upper:]' '[:lower:]')
 else
     OS=$(uname -s)
@@ -34,7 +38,7 @@ rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
 [fluent-bit]
 name = Fluent Bit
-baseurl = https://packages.fluentbit.io/amazonlinux/2/\$basearch/
+baseurl = https://packages.fluentbit.io/amazonlinux/${VER}/\$basearch/
 gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ echo "You will be prompted for your password by sudo."
 # Determine package type to install: https://unix.stackexchange.com/a/6348
 # OS used by all - for Debs it must be Ubuntu or Debian
 # CODENAME only used for Debs
-if [[ -f /etc/os-release ]]; then
+if [ -f /etc/os-release ]; then
     # shellcheck source=/dev/null
     source /etc/os-release
     OS=$( echo "${ID}" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Resolves #4733 by providing a one liner you can use to install Fluent Bit.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Confirmed this works with containers:
```
$ docker run --rm -it centos:7 sh -c "yum install -y sudo curl && curl https://raw.githubusercontent.com/fluent/fluent-bit/645c366f61d24df9959f6e51ea75b0b6054eaac0/install.sh|sh"
$ docker run --rm -it amazonlinux:2 sh -c "yum install -y sudo curl && curl https://raw.githubusercontent.com/fluent/fluent-bit/645c366f61d24df9959f6e51ea75b0b6054eaac0/install.sh|sh"
$ docker run --rm -it ubuntu:20 sh -c "apt-get update && apt-get upgrade && apt-get install -y sudo curl gnupg && curl https://raw.githubusercontent.com/fluent/fluent-bit/645c366f61d24df9959f6e51ea75b0b6054eaac0/install.sh|sh"
$ docker run --rm -it ubuntu:20.04 sh -c "apt-get update && apt-get upgrade && apt-get install -y sudo curl gnupg && curl https://raw.githubusercontent.com/fluent/fluent-bit/645c366f61d24df9959f6e51ea75b0b6054eaac0/install.sh|sh"
```
Have to add the relevant tooling to the containers to support everything.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/696 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
