### PR TITLE
workflows: lint reusable target branch

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -35,3 +35,9 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=
         shell: bash
+
+  # Special lint to handle reusable workflows requiring an explicit branch.
+  # We cannot just reference the current/default but have to make sure it is `master`.
+  reusable-workflow_lint-pr:
+    runs-on: ubuntu-latest
+    name: PR - Reusable workflow linting

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -41,3 +41,15 @@ jobs:
   reusable-workflow_lint-pr:
     runs-on: ubuntu-latest
     name: PR - Reusable workflow linting
+    steps:
+      # We probably should target this on only workflow changes but the complexity of doing that is a lot more than just letting the grep run.
+      - uses: actions/checkout@v2
+      # Recursive grep or any workflow using a local reusable workflow but not ending in @master
+      - run: |
+          if [[ $(grep -R -E 'uses:[ ]*fluent/fluent-bit/.github/workflows/.*@[^master].*$' .github/workflows/*.y*ml| wc -l) -gt 0 ]]; then
+            echo "Found reusable workflow on non-master branch"
+            grep -R -E 'uses:[ ]*fluent/fluent-bit/.github/workflows/.*@[^master].*$' .github/workflows/*.y*ml
+            exit 1
+          fi
+          echo "Passed reusable workflow checks"
+        shell: bash


### PR DESCRIPTION
Reusable workflows currently require explicit targeting - you cannot use any variable syntax.
For us this means making sure we're calling `@master` branch but occasionally we want to test a change so have to switch it to the explicit branch before merge - this extra check should then catch that we've reverted it before merge to target `master`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
