### PR TITLE
tls: Load system certificates on Windows

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -134,6 +134,55 @@ static void tls_context_destroy(void *ctx_backend)
     flb_free(ctx);
 }
 
+#ifdef _MSC_VER
+static int windows_load_system_certificates(struct tls_context *ctx)
+{
+    int ret;
+    HANDLE win_store;
+    PCCERT_CONTEXT win_cert = NULL;
+    const unsigned char *win_cert_data;
+    X509_STORE *ossl_store = SSL_CTX_get_cert_store(ctx->ctx);
+    X509 *ossl_cert;
+
+    win_store = CertOpenSystemStoreA(0, "Root");
+    if (win_store == NULL) {
+        flb_error("[tls] Cannot open cert store: %i", GetLastError());
+        return -1;
+    }
+
+    while (win_cert = CertEnumCertificatesInStore(win_store, win_cert)) {
+        if (win_cert->dwCertEncodingType & X509_ASN_ENCODING) {
+            /*
+             * Decode the certificate into X509 struct.
+             *
+             * The additional pointer variable is necessary per OpenSSL docs because the
+             * pointer is incremented by d2i_X509.
+             */
+            win_cert_data = win_cert->pbCertEncoded;
+            ossl_cert = d2i_X509(NULL, &win_cert_data, win_cert->cbCertEncoded);
+            if (!ossl_cert) {
+                flb_debug("[tls] Cannot parse a certificate. skipping...");
+                continue;
+            }
+
+            /* Add X509 struct to the openssl cert store */
+            ret = X509_STORE_add_cert(ossl_store, ossl_cert);
+            if (!ret) {
+                flb_warn("[tls] Failed to add a certificate to the store: %lu: %s",
+                         ERR_get_error(), ERR_error_string(ERR_get_error(), NULL));
+            }
+            X509_free(ossl_cert);
+        }
+    }
+
+    if (!CertCloseStore(win_store, 0)) {
+        flb_error("[tls] Cannot close cert store: %i", GetLastError());
+        return -1;
+    }
+    return 0;
+}
+#endif
+
 static int load_system_certificates(struct tls_context *ctx)
 {
     int ret;
@@ -141,7 +190,7 @@ static int load_system_certificates(struct tls_context *ctx)
 
     /* For Windows use specific API to read the certs store */
 #ifdef _MSC_VER
-    //return windows_load_system_certificates(ctx);
+    return windows_load_system_certificates(ctx);
 #endif
 
     if (access(RHEL_DEFAULT_CA, R_OK) == 0) {


### PR DESCRIPTION
Signed-off-by: Jesse Schwartzentruber <truber@mozilla.com>

This change ports the code from the mbed implementation to iterate over the Windows CA store and load each into the OpenSSL CA store.

Port #4751 to 1.8 branch.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change

  See #4751 

- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
master: #4751

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

