### PR TITLE
out_stackdriver: Use correct env variable for custom service accounts

### DIFF
--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -172,6 +172,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
 {
     int ret;
     const char *tmp;
+    const char *backwards_compatible_env_var;
     struct flb_stackdriver *ctx;
     flb_sds_t http_request_key;
     size_t http_request_key_size;
@@ -207,9 +208,22 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->credentials_file = flb_sds_create(tmp);
     }
     else {
-        tmp = getenv("GOOGLE_SERVICE_CREDENTIALS");
+        /*
+         * Use GOOGLE_APPLICATION_CREDENTIALS to fetch the credentials.
+         * GOOGLE_SERVICE_CREDENTIALS is checked for backwards compatibility.
+         */
+        tmp = getenv("GOOGLE_APPLICATION_CREDENTIALS");
+        backwards_compatible_env_var = getenv("GOOGLE_SERVICE_CREDENTIALS");
+        if (tmp && backwards_compatible_env_var) {
+            flb_plg_warn(ctx->ins, "GOOGLE_APPLICATION_CREDENTIALS and "
+                "GOOGLE_SERVICE_CREDENTIALS are both defined. "
+                "Defaulting to GOOGLE_APPLICATION_CREDENTIALS");
+        }
         if (tmp) {
             ctx->credentials_file = flb_sds_create(tmp);
+        }
+        else if (backwards_compatible_env_var) {
+            ctx->credentials_file = flb_sds_create(backwards_compatible_env_var);
         }
     }
 


### PR DESCRIPTION
Resolves #4617.

 It will also warn if the both `GOOGLE_APPLCIATION_CREDENTIALS` and `GOOGLE_SERVICE_CREDENTIALS` are
being used.

Example config (used in an environment where the env variable was defined):
```
[INPUT]
    Name              forward
    Listen            0.0.0.0
    Port              24224
    Buffer_Chunk_Size 1M
    Buffer_Max_Size   6M

[OUTPUT]
    Name   stdout
    Match  *

[OUTPUT]
    Match                         *
    Name                          stackdriver
    Retry_Limit                   3
    net.connect_timeout_log_error False
    resource                      gce_instance
    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/2.8.2 (BuildDistro=buster;Platform=linux;ShortName=debian;ShortVersion=10.11)
    tls                           On
    tls.verify                    Off
    workers                       8
```

Sent logs to FB using: `echo '{"key": "value_4"}' | bin/fluent-bit -i stdin -o forward://127.0.0.1:24224` and it reached stackdriver correctly:
![image](https://user-images.githubusercontent.com/18472685/152571547-d9568f3c-4138-44fe-896f-7d659c4de9b5.png)

Debug logs for FB:
```
[1mFluent Bit v1.9.0[0m
* [1m[93mCopyright (C) 2015-2021 The Fluent Bit Authors[0m
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/04 17:09:35] [ info] Configuration:
[2022/02/04 17:09:35] [ info]  flush time     | 5.000000 seconds
[2022/02/04 17:09:35] [ info]  grace          | 5 seconds
[2022/02/04 17:09:35] [ info]  daemon         | 0
[2022/02/04 17:09:35] [ info] ___________
[2022/02/04 17:09:35] [ info]  inputs:
[2022/02/04 17:09:35] [ info]      forward
[2022/02/04 17:09:35] [ info] ___________
[2022/02/04 17:09:35] [ info]  filters:
[2022/02/04 17:09:35] [ info] ___________
[2022/02/04 17:09:35] [ info]  outputs:
[2022/02/04 17:09:35] [ info]      stdout.0
[2022/02/04 17:09:35] [ info]      stackdriver.1
[2022/02/04 17:09:35] [ info] ___________
[2022/02/04 17:09:35] [ info]  collectors:
[2022/02/04 17:09:35] [ info] [engine] started (pid=541146)
[2022/02/04 17:09:35] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/04 17:09:35] [debug] [storage] [cio stream] new stream registered: forward.0
[2022/02/04 17:09:35] [ info] [storage] version=1.1.6, initializing...
[2022/02/04 17:09:35] [ info] [storage] in-memory
[2022/02/04 17:09:35] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/04 17:09:35] [ info] [cmetrics] version=0.2.2
[2022/02/04 17:09:35] [debug] [in_fw] Listen='0.0.0.0' TCP_Port=24224
[2022/02/04 17:09:35] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/02/04 17:09:35] [debug] [stdout:stdout.0] created event channels: read=20 write=21
[2022/02/04 17:09:35] [debug] [stackdriver:stackdriver.1] created event channels: read=22 write=23
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] metadata_server set to http://metadata.google.internal
[2022/02/04 17:09:35] [ warn] [output:stackdriver:stackdriver.1] GOOGLE_APPLICATION_CREDENTIALS and GOOGLE_SERVICE_CREDENTIALS are both defined. Defaulting to GOOGLE_APPLICATION_CREDENTIALS
< JWT SIGNATURE REMOVED MANUALLY FOR PR >
[2022/02/04 17:09:35] [debug] [http_client] not using http_proxy for header
[2022/02/04 17:09:35] [ info] [oauth2] HTTP Status=200
[2022/02/04 17:09:35] [debug] [oauth2] payload:
<ACCESS TOKEN REMOVED MANUALLY FOR THE PR>
[2022/02/04 17:09:35] [ info] [oauth2] access token from 'www.googleapis.com:443' retrieved
[2022/02/04 17:09:35] [debug] [upstream] KA connection #24 to www.googleapis.com:443 is now available
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #0 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #1 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #2 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #3 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #4 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #5 started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #6 started
[2022/02/04 17:09:35] [debug] [router] match rule forward.0:stdout.0
[2022/02/04 17:09:35] [debug] [router] match rule forward.0:stackdriver.1
[2022/02/04 17:09:35] [ info] [sp] stream processor started
[2022/02/04 17:09:35] [ info] [output:stackdriver:stackdriver.1] worker #7 started
[2022/02/04 17:09:37] [engine] caught signal (SIGINT)
[2022/02/04 17:09:37] [ info] [input] pausing forward.0
[2022/02/04 17:09:37] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/04 17:09:38] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #0 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #0 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #1 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #1 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #2 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #2 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #3 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #3 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #4 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #4 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #5 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #5 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #6 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #6 stopped
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #7 stopping...
[2022/02/04 17:09:38] [ info] [output:stackdriver:stackdriver.1] thread worker #7 stopped
[2022/02/04 17:09:38] [debug] [socket] could not validate socket status for #24 (don't worry)
```

Valgrind summary:
```
==544459== 
==544459== HEAP SUMMARY:
==544459==     in use at exit: 108,307 bytes in 3,683 blocks
==544459==   total heap usage: 8,396 allocs, 4,713 frees, 983,136 bytes allocated
==544459== 
==544459== LEAK SUMMARY:
==544459==    definitely lost: 0 bytes in 0 blocks
==544459==    indirectly lost: 0 bytes in 0 blocks
==544459==      possibly lost: 0 bytes in 0 blocks
==544459==    still reachable: 108,307 bytes in 3,683 blocks
==544459==         suppressed: 0 bytes in 0 blocks
```


Signed-off-by: Ridwan Sharif <ridwanmsharif@google.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature: https://github.com/fluent/fluent-bit-docs/pull/702

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
