### PR TITLE
tests: runtime: out_file: add test cases

### DIFF
--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -1,7 +1,10 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
 #include "flb_tests_runtime.h"
+#include <sys/stat.h>
+#include <sys/types.h>
 
 /* Test data */
 #include "data/common/json_invalid.h" /* JSON_INVALID */
@@ -16,9 +19,23 @@ void flb_test_file_format_csv(void);
 void flb_test_file_format_ltsv(void);
 void flb_test_file_format_invalid(void);
 void flb_test_file_format_out_file(void);
+void flb_test_file_path_file(void);
+void flb_test_file_path(void);
+void flb_test_file_delim_csv(void);
+void flb_test_file_delim_ltsv(void);
+void flb_test_file_label_delim(void);
+void flb_test_file_template(void);
+void flb_test_file_mkdir(void);
 
 /* Test list */
 TEST_LIST = {
+    {"path",            flb_test_file_path},
+    {"path_file",       flb_test_file_path_file},
+    {"mkdir",           flb_test_file_mkdir},
+    {"template",        flb_test_file_template},
+    {"delimiter_ltsv",  flb_test_file_delim_ltsv},
+    {"delimiter_csv",   flb_test_file_delim_csv},
+    {"label_delimiter", flb_test_file_label_delim},
     {"json_invalid",    flb_test_file_json_invalid   },
     {"json_long",       flb_test_file_json_long      },
     {"json_small",      flb_test_file_json_small     },
@@ -26,11 +43,13 @@ TEST_LIST = {
     {"format_ltsv",     flb_test_file_format_ltsv    },
     {"format_invalid",  flb_test_file_format_invalid },
     {"format_out_file", flb_test_file_format_out_file},
+
     {NULL, NULL}
 };
 
 
 #define TEST_LOGFILE "flb_test_file_dummy.log"
+#define TEST_LOGPATH "out_file"
 
 void flb_test_file_json_invalid(void)
 {
@@ -355,4 +374,438 @@ void flb_test_file_format_invalid(void)
     else {
         flb_destroy(ctx);
     }
+}
+
+void flb_test_file_path(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+    flb_sds_t path;
+    flb_sds_t file;
+
+    file = flb_sds_create("test");
+    if (!TEST_CHECK(file != NULL)) {
+        TEST_MSG("flb_sds_create failed");
+        return;
+    }
+
+    path = flb_sds_create_size(256);
+    if (!TEST_CHECK(path != NULL)) {
+        TEST_MSG("flb_sds_create_size failed");
+        flb_sds_destroy(file);
+        return;
+    }
+    flb_sds_printf(&path, "%s/%s", TEST_LOGPATH, file);
+
+    remove(path);
+    remove(TEST_LOGPATH);
+    ret = mkdir(TEST_LOGPATH, S_IRUSR | S_IWUSR | S_IXUSR);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("mkdir failed:path=%s errno=%d",TEST_LOGPATH, errno);
+        flb_sds_destroy(path);
+        flb_sds_destroy(file);
+        return;
+    }
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", file, NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "path", TEST_LOGPATH, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        TEST_CHECK(bytes == 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(path, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        fclose(fp);
+        remove(path);
+    }
+    flb_sds_destroy(path);
+    flb_sds_destroy(file);
+    remove(TEST_LOGPATH);
+}
+
+void flb_test_file_path_file(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+    flb_sds_t path;
+
+    path = flb_sds_create_size(256);
+    if (!TEST_CHECK(path != NULL)) {
+        TEST_MSG("flb_sds_create_size failed");
+        return;
+    }
+    flb_sds_printf(&path, "%s/%s", TEST_LOGPATH, TEST_LOGFILE);
+
+    remove(path);
+    remove(TEST_LOGPATH);
+    ret = mkdir(TEST_LOGPATH, S_IRUSR | S_IWUSR | S_IXUSR);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("mkdir failed:path=%s errno=%d",TEST_LOGPATH, errno);
+        flb_sds_destroy(path);
+        return;
+    }
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "path", TEST_LOGPATH, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        TEST_CHECK(bytes == 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(path, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        fclose(fp);
+        remove(path);
+    }
+    flb_sds_destroy(path);
+    remove(TEST_LOGPATH);
+}
+
+#define JSON_BASIC "[1448403340,{\"key1\":\"val1\", \"key2\":\"val2\"}]"
+void flb_test_file_delim_csv(void)
+{
+    int ret;
+    int bytes;
+    char *p = JSON_BASIC;
+    char output[256] = {0};
+    char *expect = "1448403340.000000000 \"val1\" \"val2\"";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "format", "csv", NULL);
+    flb_output_set(ctx, out_ffd, "delimiter", "space", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        bytes = fread(&output[0], sizeof(output), 1, fp);
+        if(!TEST_CHECK(bytes > 0 || feof(fp))) {
+            TEST_MSG("fread error bytes=%d", bytes);
+        }
+        if (!TEST_CHECK(strncmp(expect, &output[0], strlen(expect)) == 0)) {
+            TEST_MSG("format error\n");
+            TEST_MSG("expect: %s\n", expect);
+            TEST_MSG("got   : %s",output);
+        }
+
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+void flb_test_file_delim_ltsv(void)
+{
+    int ret;
+    int bytes;
+    char *p = JSON_BASIC;
+    char output[256] = {0};
+    char *expect = "\"time\":1448403340.000000 \"key1\":\"val1\" \"key2\":\"val2\"";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "format", "ltsv", NULL);
+    flb_output_set(ctx, out_ffd, "delimiter", "space", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        bytes = fread(&output[0], sizeof(output), 1, fp);
+        if(!TEST_CHECK(bytes > 0 || feof(fp))) {
+            TEST_MSG("fread error bytes=%d", bytes);
+        }
+        if (!TEST_CHECK(strncmp(expect, &output[0], strlen(expect)) == 0)) {
+            TEST_MSG("format error\n");
+            TEST_MSG("expect: %s\n", expect);
+            TEST_MSG("got   : %s",output);
+        }
+
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+void flb_test_file_label_delim(void)
+{
+    int ret;
+    int bytes;
+    char *p = JSON_BASIC;
+    char output[256] = {0};
+    char *expect = "\"time\" 1448403340.000000 \"key1\" \"val1\" \"key2\" \"val2\"";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "format", "ltsv", NULL);
+    flb_output_set(ctx, out_ffd, "delimiter", "space", NULL);
+    flb_output_set(ctx, out_ffd, "label_delimiter", "space", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        bytes = fread(&output[0], sizeof(output), 1, fp);
+        if(!TEST_CHECK(bytes > 0 || feof(fp))) {
+            TEST_MSG("fread error bytes=%d", bytes);
+        }
+        if (!TEST_CHECK(strncmp(expect, &output[0], strlen(expect)) == 0)) {
+            TEST_MSG("format error\n");
+            TEST_MSG("expect: %s\n", expect);
+            TEST_MSG("got   : %s",output);
+        }
+
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+void flb_test_file_template(void)
+{
+    int ret;
+    int bytes;
+    char *p = JSON_BASIC;
+    char output[256] = {0};
+    char *expect = "1448403340.000000 KEY1=val1 KEY2=val2";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+
+    remove(TEST_LOGFILE);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "file", TEST_LOGFILE, NULL);
+    flb_output_set(ctx, out_ffd, "format", "template", NULL);
+    flb_output_set(ctx, out_ffd, "template", "{time} KEY1={key1} KEY2={key2}", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(TEST_LOGFILE, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        bytes = fread(&output[0], sizeof(output), 1, fp);
+        if(!TEST_CHECK(bytes > 0 || feof(fp))) {
+            TEST_MSG("fread error bytes=%d", bytes);
+        }
+        if (!TEST_CHECK(strncmp(expect, &output[0], strlen(expect)) == 0)) {
+            TEST_MSG("format error\n");
+            TEST_MSG("expect: %s\n", expect);
+            TEST_MSG("got   : %s",output);
+        }
+
+        fclose(fp);
+        remove(TEST_LOGFILE);
+    }
+}
+
+void flb_test_file_mkdir(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char *p = (char *) JSON_LONG;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    FILE *fp;
+    flb_sds_t path;
+    flb_sds_t file;
+
+    file = flb_sds_create("test");
+    if (!TEST_CHECK(file != NULL)) {
+        TEST_MSG("flb_sds_create failed");
+        return;
+    }
+
+    path = flb_sds_create_size(256);
+    if (!TEST_CHECK(path != NULL)) {
+        TEST_MSG("flb_sds_create_size failed");
+        flb_sds_destroy(file);
+        return;
+    }
+    flb_sds_printf(&path, "%s/%s", TEST_LOGPATH, file);
+
+    remove(path);
+    remove(TEST_LOGPATH);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", file, NULL);
+
+    out_ffd = flb_output(ctx, (char *) "file", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "path", TEST_LOGPATH, NULL);
+    flb_output_set(ctx, out_ffd, "mkdir", "true", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < (int) sizeof(JSON_LONG) - 1; i++) {
+        bytes = flb_lib_push(ctx, in_ffd, p + i, 1);
+        TEST_CHECK(bytes == 1);
+    }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    fp = fopen(path, "r");
+    TEST_CHECK(fp != NULL);
+    if (fp != NULL) {
+        fclose(fp);
+        remove(path);
+    }
+    flb_sds_destroy(path);
+    flb_sds_destroy(file);
+    remove(TEST_LOGPATH);
 }


### PR DESCRIPTION
This patch is to add test cases for `out_file`

It checks `mkdir`, `delimiter`, `label_delimiter` and `template`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.


## Debug log

```
$ bin/flb-rt-out_file 
Test path...                                    [ OK ]
Test path_file...                               [ OK ]
Test mkdir...                                   [ OK ]
Test template...                                [ OK ]
Test delimiter_ltsv...                          [ OK ]
Test delimiter_csv...                           [ OK ]
Test label_delimiter...                         [ OK ]
Test json_invalid...                            [ OK ]
Test json_long...                               [ OK ]
Test json_small...                              [ OK ]
Test format_csv...                              [ OK ]
Test format_ltsv...                             [ OK ]
Test format_invalid...                          [2022/02/05 13:31:57] [error] [lib] backend failed
[ OK ]
Test format_out_file...                         [ OK ]
SUCCESS: All unit tests have passed.
taka@locals:~/git/WORKTREE/out_file_name/build$ 
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-out_file 
==67580== Memcheck, a memory error detector
==67580== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==67580== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==67580== Command: bin/flb-rt-out_file
==67580== 
Test path...                                    [ OK ]
Test path_file...                               [ OK ]
Test mkdir...                                   [ OK ]
Test template...                                [ OK ]
Test delimiter_ltsv...                          [ OK ]
Test delimiter_csv...                           [ OK ]
Test label_delimiter...                         [ OK ]
Test json_invalid...                            [ OK ]
Test json_long...                               [ OK ]
Test json_small...                              [ OK ]
Test format_csv...                              [ OK ]
Test format_ltsv...                             [ OK ]
Test format_invalid...                          [2022/02/05 13:33:27] [error] [lib] backend failed
[ OK ]
Test format_out_file...                         [ OK ]
SUCCESS: All unit tests have passed.
==67580== 
==67580== HEAP SUMMARY:
==67580==     in use at exit: 0 bytes in 0 blocks
==67580==   total heap usage: 14,253 allocs, 14,253 frees, 11,127,472 bytes allocated
==67580== 
==67580== All heap blocks were freed -- no leaks are possible
==67580== 
==67580== For lists of detected and suppressed errors, rerun with: -s
==67580== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
