### PR TITLE
out_stackdriver: Correct env variable for SAs

### DIFF
--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -173,6 +173,7 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
 {
     int ret;
     const char *tmp;
+    const char *backwards_compatible_env_var;
     struct flb_stackdriver *ctx;
     flb_sds_t http_request_key;
     size_t http_request_key_size;
@@ -208,9 +209,22 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->credentials_file = flb_sds_create(tmp);
     }
     else {
-        tmp = getenv("GOOGLE_SERVICE_CREDENTIALS");
+        /*
+         * Use GOOGLE_APPLICATION_CREDENTIALS to fetch the credentials.
+         * GOOGLE_SERVICE_CREDENTIALS is checked for backwards compatibility.
+         */
+        tmp = getenv("GOOGLE_APPLICATION_CREDENTIALS");
+        backwards_compatible_env_var = getenv("GOOGLE_SERVICE_CREDENTIALS");
+        if (tmp && backwards_compatible_env_var) {
+            flb_plg_warn(ctx->ins, "GOOGLE_APPLICATION_CREDENTIALS and "
+                "GOOGLE_SERVICE_CREDENTIALS are both defined. "
+                "Defaulting to GOOGLE_APPLICATION_CREDENTIALS");
+        }
         if (tmp) {
             ctx->credentials_file = flb_sds_create(tmp);
+        }
+        else if (backwards_compatible_env_var) {
+            ctx->credentials_file = flb_sds_create(backwards_compatible_env_var);
         }
     }
 


### PR DESCRIPTION
Backport PR for https://github.com/fluent/fluent-bit/pull/4753
