### PR TITLE
WIP: priority queue eventloop 1.8

### DIFF
--- a/include/fluent-bit/flb_bucket_queue.h
+++ b/include/fluent-bit/flb_bucket_queue.h
@@ -1,0 +1,140 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Note: This implementation can handle priority item removal via
+ * flb_bucket_queue_delete_min(bucket_queue) and direct item removal
+ * via mk_list_del(&item)
+ */
+
+#ifndef   	FLB_BUCKET_QUEUE_H_
+#define   	FLB_BUCKET_QUEUE_H_
+
+#include <stddef.h>
+#include <fluent-bit/flb_mem.h>
+#include <monkey/mk_core/mk_list.h>
+
+
+struct flb_bucket_queue
+{
+    struct mk_list *buckets;
+    size_t n_buckets;
+    struct mk_list *top;
+    size_t n_items;
+};
+
+static inline struct flb_bucket_queue *flb_bucket_queue_create(size_t priorities)
+{
+    size_t i;
+    struct flb_bucket_queue *bucket_queue;
+
+    bucket_queue = (struct flb_bucket_queue *)
+                   flb_malloc(sizeof(struct flb_bucket_queue));
+    if (!bucket_queue) {
+        return NULL;
+    }
+    bucket_queue->buckets = (struct mk_list *)
+                            flb_malloc(sizeof(struct mk_list) *priorities);
+    if (!bucket_queue->buckets) {
+        flb_free(bucket_queue);
+        return NULL;
+    }
+    for (i = 0; i < priorities; ++i) {
+        mk_list_init(&bucket_queue->buckets[i]);
+    }
+    bucket_queue->n_buckets = priorities;
+    bucket_queue->top = (bucket_queue->buckets + bucket_queue->n_buckets); /* one past the last element */
+    bucket_queue->n_items = 0;
+    return bucket_queue;
+}
+
+static inline int flb_bucket_queue_is_empty(struct flb_bucket_queue *bucket_queue)
+{
+    return bucket_queue->top == (bucket_queue->buckets + bucket_queue->n_buckets);
+}
+
+static inline void flb_bucket_queue_seek(struct flb_bucket_queue *bucket_queue) {
+    while (!flb_bucket_queue_is_empty(bucket_queue)
+          && (mk_list_is_empty(bucket_queue->top) == 0)) {
+        ++bucket_queue->top;
+    }
+}
+
+static inline int flb_bucket_queue_add(struct flb_bucket_queue *bucket_queue,
+                                      struct mk_list *item, size_t priority)
+{
+    if (priority >= bucket_queue->n_buckets) {
+        /* flb_error("Error: attempting to add item of priority %zu to bucket_queue out "
+               "of priority range", priority); */
+        return -1;
+    }
+    flb_bucket_queue_seek(bucket_queue);
+    mk_list_add(item, &bucket_queue->buckets[priority]);
+    if (&bucket_queue->buckets[priority] < bucket_queue->top) {
+        bucket_queue->top = &bucket_queue->buckets[priority];
+    }
+    ++bucket_queue->n_items;
+    return 0;
+}
+
+/* fifo based on priority */
+static inline struct mk_list *flb_bucket_queue_find_min(struct flb_bucket_queue *bucket_queue)
+{
+    flb_bucket_queue_seek(bucket_queue);
+    if (flb_bucket_queue_is_empty(bucket_queue)) {
+        return NULL;
+    }
+    return bucket_queue->top->next;
+}
+
+static inline void flb_bucket_queue_delete_min(struct flb_bucket_queue *bucket_queue)
+{
+    flb_bucket_queue_seek(bucket_queue);
+    if (flb_bucket_queue_is_empty(bucket_queue)) {
+        return;
+    }
+    mk_list_del(bucket_queue->top->next);
+    flb_bucket_queue_seek(bucket_queue); /* this line can be removed. Debugging is harder */
+    --bucket_queue->n_items;
+}
+
+static inline struct mk_list *flb_bucket_queue_pop_min(struct flb_bucket_queue *bucket_queue)
+{
+    struct mk_list *item;
+    item = flb_bucket_queue_find_min(bucket_queue);
+    flb_bucket_queue_delete_min(bucket_queue);
+    return item;
+}
+
+static inline int flb_bucket_queue_destroy(
+                                     struct flb_bucket_queue *bucket_queue)
+{
+    flb_bucket_queue_seek(bucket_queue);
+    if (!flb_bucket_queue_is_empty(bucket_queue)) {
+        /* flb_error("Error: attempting to destroy non empty bucket_queue. Remove all "
+                  "items first."); */
+        return -1;
+    }
+    flb_free(bucket_queue->buckets);
+    flb_free(bucket_queue);
+    return 0;
+}
+
+#endif /* !FLB_BUCKET_QUEUE_H_ */

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -59,10 +59,12 @@ struct flb_config {
     time_t init_time;      /* Time when Fluent Bit started   */
 
     /* Used in library mode */
-    pthread_t worker;            /* worker tid */
-    flb_pipefd_t ch_data[2];     /* pipe to communicate caller with worker */
-    flb_pipefd_t ch_manager[2];  /* channel to administrate fluent bit     */
-    flb_pipefd_t ch_notif[2];    /* channel to receive notifications       */
+    pthread_t worker;               /* worker tid */
+    flb_pipefd_t ch_data[2];        /* pipe to communicate caller with worker */
+    flb_pipefd_t ch_manager[2];     /* channel to administrate fluent bit     */
+    flb_pipefd_t ch_notif[2];       /* channel to receive notifications       */
+
+    flb_pipefd_t ch_self_events[2]; /* channel to recieve thread tasks        */
 
     /* Channel event loop (just for ch_notif) */
     struct mk_event_loop *ch_evl;
@@ -80,6 +82,7 @@ struct flb_config {
     /* Event */
     struct mk_event event_flush;
     struct mk_event event_shutdown;
+    struct mk_event event_thread_init;  /* event to initiate thread in engine */
 
     /* Collectors */
     struct mk_list collectors;
@@ -113,6 +116,8 @@ struct flb_config {
     struct mk_list filters;
 
     struct mk_event_loop *evl;          /* the event loop (mk_core) */
+
+    struct flb_bucket_queue *evl_bktq;   /* bucket queue for evl track event priority */
 
     /* Proxies */
     struct mk_list proxies;

--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -36,6 +36,7 @@
 #define FLB_ENGINE_EV_SCHED_FRAME   (FLB_ENGINE_EV_SCHED + 4096)
 #define FLB_ENGINE_EV_OUTPUT        8192
 #define FLB_ENGINE_EV_THREAD_OUTPUT 16384
+#define FLB_ENGINE_EV_THREAD_ENGINE 32768
 
 /* Engine events: all engine events set the left 32 bits to '1' */
 #define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */
@@ -52,6 +53,27 @@
 /* Engine signals: Task, it only refer to the type */
 #define FLB_ENGINE_TASK         2
 #define FLB_ENGINE_IN_THREAD    3
+
+/* Engine priority queue configuration */
+#define FLB_ENGINE_LOOP_MAX_ITER        10 /* Max events processed per round */
+
+/* Engine event priorities: min value prioritized */
+#define FLB_ENGINE_PRIORITY_DEFAULT     MK_EVENT_PRIORITY_DEFAULT
+#define FLB_ENGINE_PRIORITY_COUNT       8
+#define FLB_ENGINE_PRIORITY_TOP         0
+#define FLB_ENGINE_PRIORITY_BOTTOM      (FLB_ENGINE_PRIORITY_COUNT - 1)
+#define FLB_ENGINE_PRIORITY_NETWORK     1
+
+#define FLB_ENGINE_PRIORITY_CB_SCHED    FLB_ENGINE_PRIORITY_TOP
+#define FLB_ENGINE_PRIORITY_CB_TIMER    FLB_ENGINE_PRIORITY_TOP
+#define FLB_ENGINE_PRIORITY_SHUTDOWN    FLB_ENGINE_PRIORITY_TOP
+#define FLB_ENGINE_PRIORITY_FLUSH       FLB_ENGINE_PRIORITY_TOP
+
+#define FLB_ENGINE_PRIORITY_DNS         FLB_ENGINE_PRIORITY_NETWORK
+#define FLB_ENGINE_PRIORITY_CONNECT     FLB_ENGINE_PRIORITY_NETWORK
+#define FLB_ENGINE_PRIORITY_SEND_RECV   FLB_ENGINE_PRIORITY_NETWORK
+
+#define FLB_ENGINE_PRIORITY_THREAD      FLB_ENGINE_PRIORITY_DEFAULT
 
 int flb_engine_start(struct flb_config *config);
 int flb_engine_failed(struct flb_config *config);

--- a/include/fluent-bit/flb_event_loop.h
+++ b/include/fluent-bit/flb_event_loop.h
@@ -1,0 +1,64 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_EVENT_LOOP_H
+#define FLB_EVENT_LOOP_H
+
+#include <monkey/mk_core/mk_event.h>
+#include <fluent-bit/flb_bucket_queue.h>
+
+/* priority queue utility */
+static inline void flb_event_load_bucket_queue(struct mk_event *event,
+                                      struct flb_bucket_queue *bktq,
+                                      struct mk_event_loop *evl)
+{
+    mk_event_foreach(event, evl) {
+        if (event->_priority_head.prev == NULL) {
+            flb_bucket_queue_add(bktq, &event->_priority_head, event->priority);
+        }
+    }
+}
+
+#define flb_event_priority_live_foreach(event, bktq, evl, max_iter)                     \
+    int __flb_event_priority_live_foreach_iter;                                         \
+    for (                                                                               \
+        /* init */                                                                      \
+        __flb_event_priority_live_foreach_iter = 0,                                     \
+        flb_event_load_bucket_queue(event, bktq, evl),                                  \
+        event = flb_bucket_queue_find_min(bktq) ?                                       \
+                mk_list_entry(                                                          \
+                    flb_bucket_queue_pop_min(bktq), struct mk_event, _priority_head) :  \
+                NULL;                                                                   \
+                                                                                        \
+        /* condition */                                                                 \
+        event != NULL &&                                                                \
+        (__flb_event_priority_live_foreach_iter < max_iter || max_iter == -1);          \
+                                                                                        \
+        /* update */                                                                    \
+        ++__flb_event_priority_live_foreach_iter,                                       \
+        mk_event_wait_2(evl, 0),                                                        \
+        flb_event_load_bucket_queue(event, bktq, evl),                                  \
+        event = flb_bucket_queue_find_min(bktq) ?                                       \
+                mk_list_entry(                                                          \
+                    flb_bucket_queue_pop_min(bktq), struct mk_event, _priority_head) :  \
+                NULL                                                                    \
+    )
+
+#endif /* !FLB_EVENT_LOOP_H */

--- a/include/fluent-bit/flb_event_loop.h
+++ b/include/fluent-bit/flb_event_loop.h
@@ -24,13 +24,14 @@
 #include <monkey/mk_core/mk_event.h>
 #include <fluent-bit/flb_bucket_queue.h>
 
-/* priority queue utility */
+/* Priority queue utility */
 static inline void flb_event_load_bucket_queue(struct flb_bucket_queue *bktq,
                                               struct mk_event_loop *evl)
 {
     struct mk_event *event;
     mk_event_foreach(event, evl) {
-        if (event->_priority_head.prev == NULL) {
+        if (event->_priority_head.prev == NULL      /* not in bktq */
+            && event->status != MK_EVENT_NONE) {    /* not deleted event */
             flb_bucket_queue_add(bktq, &event->_priority_head, event->priority);
         }
     }

--- a/include/fluent-bit/flb_output_thread.h
+++ b/include/fluent-bit/flb_output_thread.h
@@ -61,6 +61,7 @@ struct flb_out_thread_upstream {
 struct flb_out_thread_instance {
     struct mk_event event;               /* event context to associate events */
     struct mk_event_loop *evl;           /* thread event loop context */
+    struct flb_bucket_queue *evl_bktq;    /* bucket queue for evl track event priority */
     flb_pipefd_t ch_parent_events[2];    /* channel to receive parent notifications */
     flb_pipefd_t ch_thread_events[2];    /* channel to send messages local event loop */
     struct flb_output_instance *ins;     /* output plugin instance */

--- a/lib/monkey/include/monkey/mk_core/mk_event.h
+++ b/lib/monkey/include/monkey/mk_core/mk_event.h
@@ -52,6 +52,9 @@
 #define MK_EVENT_NONE            1    /* nothing */
 #define MK_EVENT_REGISTERED      2    /* event is registered into the ev loop */
 
+/* Priority bucket queue */
+#define MK_EVENT_PRIORITY_DEFAULT 6   /* default priority */
+
 /* Legacy definitions: temporal
  *  ----------------------------
  *
@@ -91,6 +94,8 @@ struct mk_event {
     /* function handler for custom type */
     int     (*handler)(void *data);
     struct mk_list _head;
+    struct mk_list _priority_head;
+    char    priority;  /* optional priority */
 };
 
 struct mk_event_loop {
@@ -138,6 +143,7 @@ int mk_event_timeout_destroy(struct mk_event_loop *loop, void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);
+int mk_event_wait_2(struct mk_event_loop *loop, int timeout);
 int mk_event_translate(struct mk_event_loop *loop);
 char *mk_event_backend();
 struct mk_event_fdt *mk_event_get_fdt();

--- a/lib/monkey/mk_core/mk_event.c
+++ b/lib/monkey/mk_core/mk_event.c
@@ -181,7 +181,17 @@ int mk_event_channel_create(struct mk_event_loop *loop,
 /* Poll events */
 int mk_event_wait(struct mk_event_loop *loop)
 {
-    return _mk_event_wait(loop);
+    return _mk_event_wait_2(loop, -1);
+}
+
+/*
+ * Poll events with timeout in milliseconds
+ * zero timeout for non blocking wait
+ * -1 timeout for infinite wait
+ */
+int mk_event_wait_2(struct mk_event_loop *loop, int timeout)
+{
+    return _mk_event_wait_2(loop, timeout);
 }
 
 /* Return the backend name */

--- a/lib/monkey/mk_core/mk_event_epoll.c
+++ b/lib/monkey/mk_core/mk_event_epoll.c
@@ -138,6 +138,9 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     }
 
     event->mask = events;
+    event->priority = MK_EVENT_PRIORITY_DEFAULT;
+    event->_priority_head.next = NULL;
+    event->_priority_head.prev = NULL;
     return ret;
 }
 
@@ -157,6 +160,12 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 #ifdef MK_HAVE_TRACE
         mk_libc_warn("epoll_ctl");
 #endif
+    }
+
+    /* Remove from priority queue */
+    if (event->_priority_head.next != NULL &&
+        event->_priority_head.prev != NULL) {
+        mk_list_del(&event->_priority_head);
     }
 
     MK_EVENT_NEW(event);
@@ -386,11 +395,11 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     return 0;
 }
 
-static inline int _mk_event_wait(struct mk_event_loop *loop)
+static inline int _mk_event_wait_2(struct mk_event_loop *loop, int timeout)
 {
     struct mk_event_ctx *ctx = loop->data;
 
-    loop->n_events = epoll_wait(ctx->efd, ctx->events, ctx->queue_size, -1);
+    loop->n_events = epoll_wait(ctx->efd, ctx->events, ctx->queue_size, timeout);
     return loop->n_events;
 }
 

--- a/lib/monkey/mk_core/mk_event_kqueue.c
+++ b/lib/monkey/mk_core/mk_event_kqueue.c
@@ -129,6 +129,9 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     }
 
     event->mask = events;
+    event->priority = MK_EVENT_PRIORITY_DEFAULT;
+    event->_priority_head.next = NULL;
+    event->_priority_head.prev = NULL;
     return 0;
 }
 
@@ -157,6 +160,12 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
             mk_libc_error("kevent");
             return ret;
         }
+    }
+
+    /* Remove from priority queue */
+    if (event->_priority_head.next != NULL &&
+        event->_priority_head.prev != NULL) {
+        mk_list_del(&event->_priority_head);
     }
 
     MK_EVENT_NEW(event);
@@ -287,12 +296,11 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     return 0;
 }
 
-static inline int _mk_event_wait(struct mk_event_loop *loop)
+static inline int _mk_event_wait_2(struct mk_event_loop *loop, int timeout)
 {
-    struct mk_event_ctx *ctx = loop->data;
-
-    loop->n_events = kevent(ctx->kfd, NULL, 0, ctx->events, ctx->queue_size, NULL);
-    return loop->n_events;
+    struct timespec timev = {timeout / 1000, (timeout % 1000) * 1000000};
+    loop->n_events = kevent(ctx->kfd, NULL, 0, ctx->events, ctx->queue_size,
+                            (timeout != -1) ? &timev : NULL);
 }
 
 static inline char *_mk_event_backend()

--- a/lib/monkey/mk_core/mk_event_libevent.c
+++ b/lib/monkey/mk_core/mk_event_libevent.c
@@ -188,6 +188,9 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, evutil_socket_t fd,
     event->fd   = fd;
     event->type = type;
     event->mask = events;
+    event->priority = MK_EVENT_PRIORITY_DEFAULT;
+    event->_priority_head.next = NULL;
+    event->_priority_head.prev = NULL;
     event->status = MK_EVENT_REGISTERED;
     event->data   = ev_map;
 
@@ -227,6 +230,12 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     ret = event_del(ev_map->event);
     event_free(ev_map->event);
     mk_mem_free(ev_map);
+
+    /* Remove from priority queue */
+    if (event->_priority_head.next != NULL &&
+        event->_priority_head.prev != NULL) {
+        mk_list_del(&event->_priority_head);
+    }
 
     MK_EVENT_NEW(event);
 
@@ -376,7 +385,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     return 0;
 }
 
-static inline int _mk_event_wait(struct mk_event_loop *loop)
+static inline int _mk_event_wait_with_flags(struct mk_event_loop *loop, int flags)
 {
     struct mk_event_ctx *ctx = loop->data;
 
@@ -387,10 +396,53 @@ static inline int _mk_event_wait(struct mk_event_loop *loop)
      */
 
     ctx->fired_count = 0;
-    event_base_loop(ctx->base, EVLOOP_ONCE);
+    event_base_loop(ctx->base, flags);
     loop->n_events = ctx->fired_count;
 
     return loop->n_events;
+}
+
+static void cb_wait_2_timeout(evutil_socket_t fd, short flags, void *data)
+{
+    int *timedout_flag = (int *) data;
+    *timedout_flag = 1;
+}
+
+static inline int _mk_event_wait_2(struct mk_event_loop *loop, int timeout)
+{
+    struct mk_event_ctx *ctx = loop->data;
+    struct timeval timev = {timeout / 1000, (timeout % 1000) * 1000}; /* (tv_sec, tv_usec} */
+    int timedout_flag = 0;
+    struct event *timeout_event;
+    int ret;
+
+    /* Infinite wait */
+    if (timeout == -1) {
+        return _mk_event_wait_with_flags(loop, EVLOOP_ONCE);
+    }
+
+    /* No wait: fast path, zero second timeout is nonblocking wait */
+    if (timeout == 0) {
+        return _mk_event_wait_with_flags(loop, EVLOOP_ONCE | EVLOOP_NONBLOCK);
+    }
+
+    /* Timed wait: slow path, blocking wait with timeout via timeout event */
+    /* Add timeout */
+    timeout_event = event_new(ctx->base, -1,
+                      EV_TIMEOUT,
+                      cb_timeout, &timedout_flag);
+    event_add(timeout_event, &timev);
+
+    /* Blocking wait */
+    ret = _mk_event_wait_with_flags(loop, EVLOOP_ONCE);
+
+    /* Remove timeout */
+    if (!timedout_flag) {
+        ret = event_del(timeout_event);
+    }
+    event_free(timeout_event);
+
+    return ret;
 }
 
 static inline char *_mk_event_backend()

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -42,6 +42,7 @@
 #include <fluent-bit/flb_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/multiline/flb_ml.h>
+#include <fluent-bit/flb_bucket_queue.h>
 
 const char *FLB_CONF_ENV_LOGLEVEL = "FLB_LOG_LEVEL";
 
@@ -430,6 +431,9 @@ void flb_config_exit(struct flb_config *config)
 
     if (config->evl) {
         mk_event_loop_destroy(config->evl);
+    }
+    if (config->evl_bktq) {
+        flb_bucket_queue_destroy(config->evl_bktq);
     }
 
     flb_plugins_unregister(config);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -22,6 +22,8 @@
 #include <stdlib.h>
 
 #include <monkey/mk_core.h>
+#include <fluent-bit/flb_bucket_queue.h>
+#include <fluent-bit/flb_event_loop.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_bits.h>
@@ -505,6 +507,7 @@ int flb_engine_start(struct flb_config *config)
     struct flb_time t_flush;
     struct mk_event *event;
     struct mk_event_loop *evl;
+    struct flb_bucket_queue *evl_bktq;
     struct flb_sched *sched;
     struct flb_net_dns dns_ctx;
 
@@ -521,6 +524,34 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
     config->evl = evl;
+
+    /* Create the bucket queue (FLB_ENGINE_PRIORITY_COUNT priorities) */
+    evl_bktq = flb_bucket_queue_create(FLB_ENGINE_PRIORITY_COUNT);
+    if (!evl_bktq) {
+        return -1;
+    }
+    config->evl_bktq = evl_bktq;
+
+    /*
+     * Event loop channel to ingest flush events from flb_engine_flush()
+     *
+     *  - FLB engine uses 'ch_self_events[1]' to dispatch tasks to self
+     *  - Self to receive message on ch_parent_events[0]
+     *
+     * The mk_event_channel_create() will attach the pipe read end ch_self_events[0]
+     * to the local event loop 'evl'.
+     */
+    ret = mk_event_channel_create(config->evl,
+                                    &config->ch_self_events[0],
+                                    &config->ch_self_events[1],
+                                    &config->event_thread_init);
+    if (ret == -1) {
+        flb_error("[engine] could not create engine thread channel");
+        return -1;
+    }
+    /* Signal type to indicate a "flush" request */
+    config->event_thread_init.type = FLB_ENGINE_EV_THREAD_ENGINE;
+    config->event_thread_init.priority = FLB_ENGINE_PRIORITY_THREAD;
 
     /* Register the event loop on this thread */
     flb_engine_evl_init();
@@ -617,6 +648,7 @@ int flb_engine_start(struct flb_config *config)
                                                t_flush.tm.tv_sec,
                                                t_flush.tm.tv_nsec,
                                                event);
+    event->priority = FLB_ENGINE_PRIORITY_FLUSH;
     if (config->flush_fd == -1) {
         flb_utils_error(FLB_ERR_CFG_FLUSH_CREATE);
     }
@@ -690,8 +722,8 @@ int flb_engine_start(struct flb_config *config)
     }
 
     while (1) {
-        mk_event_wait(evl);
-        mk_event_foreach(event, evl) {
+        mk_event_wait(evl); /* potentially conditional mk_event_wait or mk_event_wait_2 based on bucket queue capacity for one shot events */
+        flb_event_priority_live_foreach(event, evl_bktq, evl, FLB_ENGINE_LOOP_MAX_ITER) {
             if (event->type == FLB_ENGINE_EV_CORE) {
                 ret = flb_engine_handle_event(event->fd, event->mask, config);
                 if (ret == FLB_ENGINE_STOP) {
@@ -721,6 +753,7 @@ int flb_engine_start(struct flb_config *config)
                                                                   1,
                                                                   0,
                                                                   event);
+                    event->priority = FLB_ENGINE_PRIORITY_SHUTDOWN;
                 }
                 else if (ret == FLB_ENGINE_SHUTDOWN) {
                     if (config->shutdown_fd > 0) {
@@ -761,6 +794,19 @@ int flb_engine_start(struct flb_config *config)
             else if (event->type & FLB_ENGINE_EV_SCHED) {
                 /* Event type registered by the Scheduler */
                 flb_sched_event_handler(config, event);
+            }
+            else if (event->type == FLB_ENGINE_EV_THREAD_ENGINE) {
+                struct flb_output_coro *output_coro;
+
+                /* Read the coroutine reference */
+                ret = flb_pipe_r(event->fd, &output_coro, sizeof(struct flb_output_coro *));
+                if (ret <= 0 || output_coro == 0) {
+                    flb_errno();
+                    continue;
+                }
+
+                /* Init coroutine */
+                flb_coro_resume(output_coro->coro);
             }
             else if (event->type == FLB_ENGINE_EV_CUSTOM) {
                 event->handler(event);

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -210,6 +210,7 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
                                u_conn->fd,
                                FLB_ENGINE_EV_THREAD,
                                MK_EVENT_WRITE, &u_conn->event);
+            u_conn->event.priority = FLB_ENGINE_PRIORITY_SEND_RECV;
             if (ret == -1) {
                 /*
                  * If we failed here there no much that we can do, just
@@ -269,6 +270,7 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
                                u_conn->fd,
                                FLB_ENGINE_EV_THREAD,
                                MK_EVENT_WRITE, &u_conn->event);
+            u_conn->event.priority = FLB_ENGINE_PRIORITY_SEND_RECV;
             if (ret == -1) {
                 /*
                  * If we failed here there no much that we can do, just
@@ -319,6 +321,7 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
                                u_conn->fd,
                                FLB_ENGINE_EV_THREAD,
                                MK_EVENT_READ, &u_conn->event);
+            u_conn->event.priority = FLB_ENGINE_PRIORITY_SEND_RECV;
             if (ret == -1) {
                 /*
                  * If we failed here there no much that we can do, just

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -423,6 +423,7 @@ static int net_connect_async(int fd,
                        fd,
                        FLB_ENGINE_EV_THREAD,
                        MK_EVENT_WRITE, &u_conn->event);
+    u_conn->event.priority = FLB_ENGINE_PRIORITY_CONNECT;
     if (ret == -1) {
         /*
          * If we failed here there no much that we can do, just
@@ -827,6 +828,7 @@ static ares_socket_t flb_dns_ares_socket(int af, int type, int protocol, void *u
 
     result = mk_event_add(lookup_context->event_loop, sockfd, FLB_ENGINE_EV_CUSTOM,
                           event_mask, &lookup_context->response_event);
+    lookup_context->response_event.priority = FLB_ENGINE_PRIORITY_DNS;
     if (result) {
         flb_socket_close(sockfd);
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -195,7 +195,7 @@ int flb_output_task_flush(struct flb_task *task,
         }
     }
     else {
-        /* Direct co-routine handling */
+        /* Queue co-routine handling */
         out_coro = flb_output_coro_create(task,
                                           task->i_ins,
                                           out_ins,
@@ -208,7 +208,12 @@ int flb_output_task_flush(struct flb_task *task,
         }
 
         flb_task_users_inc(task);
-        flb_coro_resume(out_coro->coro);
+        ret = flb_pipe_w(config->ch_self_events[1], &out_coro,
+                        sizeof(struct flb_output_coro*));
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
     }
 
     return 0;

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -20,6 +20,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_event_loop.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_output_plugin.h>
@@ -246,7 +247,8 @@ static void output_thread(void *data)
     /* Thread event loop */
     while (running) {
         mk_event_wait(th_ins->evl);
-        mk_event_foreach(event, th_ins->evl) {
+        flb_event_priority_live_foreach(event, th_ins->evl_bktq, th_ins->evl,
+                                      FLB_ENGINE_LOOP_MAX_ITER) {
             /*
              * FIXME
              * -----
@@ -357,6 +359,7 @@ static void output_thread(void *data)
     flb_upstream_conn_active_destroy_list(&th_ins->upstreams);
     flb_upstream_conn_pending_destroy_list(&th_ins->upstreams);
     mk_event_loop_destroy(th_ins->evl);
+    flb_bucket_queue_destroy(th_ins->evl_bktq);
 
     flb_sched_destroy(sched);
     params = FLB_TLS_GET(out_coro_params);
@@ -404,6 +407,7 @@ int flb_output_thread_pool_create(struct flb_config *config,
     struct flb_tp *tp;
     struct flb_tp_thread *th;
     struct mk_event_loop *evl;
+    struct flb_bucket_queue *evl_bktq;
     struct flb_out_thread_instance *th_ins;
 
     /* Create the thread pool context */
@@ -446,7 +450,15 @@ int flb_output_thread_pool_create(struct flb_config *config,
             flb_free(th_ins);
             continue;
         }
+        evl_bktq = flb_bucket_queue_create(FLB_ENGINE_PRIORITY_COUNT);
+        if (!evl_bktq) {
+            flb_plg_error(ins, "could not create thread event loop bucket queue");
+            flb_free(evl);
+            flb_free(th_ins);
+            continue;
+        }
         th_ins->evl = evl;
+        th_ins->evl_bktq = evl_bktq;
 
         /*
          * Event loop setup between parent engine and this thread
@@ -464,11 +476,13 @@ int flb_output_thread_pool_create(struct flb_config *config,
         if (ret == -1) {
             flb_plg_error(th_ins->ins, "could not create thread channel");
             mk_event_loop_destroy(th_ins->evl);
+            flb_bucket_queue_destroy(th_ins->evl_bktq);
             flb_free(th_ins);
             continue;
         }
         /* Signal type to indicate a "flush" request */
         th_ins->event.type = FLB_ENGINE_EV_THREAD_OUTPUT;
+        th_ins->event.priority = FLB_ENGINE_PRIORITY_THREAD;
 
         /* Spawn the thread */
         th = flb_tp_thread_create(tp, output_thread, th_ins, config);

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -129,6 +129,7 @@ static int schedule_request_now(int seconds,
 
     /* Create a timeout into the main event loop */
     fd = mk_event_timeout_create(config->evl, seconds, 0, event);
+    event->priority = FLB_ENGINE_PRIORITY_CB_SCHED;
     if (fd == -1) {
         return -1;
     }
@@ -467,6 +468,7 @@ int flb_sched_timer_cb_create(struct flb_sched *sched, int type, int ms,
 
     /* Create the frame timer */
     fd = mk_event_timeout_create(sched->evl, sec, nsec, event);
+    event->priority = FLB_ENGINE_PRIORITY_CB_TIMER;
     if (fd == -1) {
         flb_error("[sched] cannot do timeout_create()");
         flb_sched_timer_destroy(timer);
@@ -547,6 +549,7 @@ struct flb_sched *flb_sched_create(struct flb_config *config,
     /* Create the frame timer */
     fd = mk_event_timeout_create(evl, FLB_SCHED_REQUEST_FRAME, 0,
                                  event);
+    event->priority = FLB_ENGINE_PRIORITY_CB_SCHED;
     if (fd == -1) {
         flb_sched_timer_destroy(timer);
         flb_free(sched);

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -762,6 +762,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
         ret = mk_event_add(conn->evl, conn->fd,
                            FLB_ENGINE_EV_CUSTOM,
                            MK_EVENT_CLOSE, &conn->event);
+        conn->event.priority = FLB_ENGINE_PRIORITY_CONNECT;
         if (ret == -1) {
             /* We failed the registration, for safety just destroy the connection */
             flb_debug("[upstream] KA connection #%i to %s:%i could not be "

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -103,6 +103,7 @@ static inline int io_tls_event_switch(struct flb_upstream_conn *u_conn,
                            event->fd,
                            FLB_ENGINE_EV_THREAD,
                            mask, &u_conn->event);
+        u_conn->event.priority = FLB_ENGINE_PRIORITY_CONNECT;
         if (ret == -1) {
             flb_error("[io_tls] error changing mask to %i", mask);
             return -1;
@@ -373,6 +374,7 @@ int flb_tls_session_create(struct flb_tls *tls,
                            u_conn->event.fd,
                            FLB_ENGINE_EV_THREAD,
                            flag, &u_conn->event);
+        u_conn->event.priority = FLB_ENGINE_PRIORITY_CONNECT;
         if (ret == -1) {
             goto error;
         }

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -23,6 +23,7 @@ set(UNIT_TESTS_FILES
   multiline.c
   timeout.c
   base64.c
+  bucket_queue.c
   )
 
 if (NOT WIN32)

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UNIT_TESTS_FILES
   timeout.c
   base64.c
   bucket_queue.c
+  flb_event_loop.c
   )
 
 if (NOT WIN32)

--- a/tests/internal/bucket_queue.c
+++ b/tests/internal/bucket_queue.c
@@ -1,0 +1,248 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_mp.h>
+#include <msgpack.h>
+
+#include "flb_tests_internal.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <fluent-bit/flb_bucket_queue.h>
+#include <monkey/mk_core/mk_list.h>
+
+#define TST_PRIORITY_OP_ADD    1
+#define TST_PRIORITY_OP_DELETE 2
+#define TST_PRIORITY_OP_EXPECT 3
+#define TST_PRIORITY_OP_POP    3
+
+
+struct bucket_queue_entry {
+    char *tag;
+    size_t priority;
+    struct mk_list item;
+    size_t add_idx;
+};
+
+struct bucket_queue_op_add {
+    struct bucket_queue_entry *entries;
+};
+
+struct bucket_queue_op_expect {
+    char *tag;
+};
+
+struct bucket_queue_op_pop {
+    char *tag;
+};
+
+union bucket_queue_op_union {
+    struct bucket_queue_op_pop pop;
+    struct bucket_queue_op_add add;
+    struct bucket_queue_op_expect expect;
+};
+
+struct bucket_queue_op {
+    char op;
+    void *op_description;
+};
+
+void test_create_destroy()
+{
+    struct flb_bucket_queue *bucket_queue;
+    bucket_queue = flb_bucket_queue_create(100);
+    flb_bucket_queue_destroy(bucket_queue);
+}
+
+void test_add_priorities()
+{
+    struct flb_bucket_queue *bucket_queue;
+
+    struct bucket_queue_op operations[] = {
+        {
+            TST_PRIORITY_OP_ADD,
+            &(struct bucket_queue_op_add) {
+                (struct bucket_queue_entry[]) {
+                    {
+                        "a",
+                        2 /* priority */
+                    },
+                    {
+                        "b",
+                        2 /* priority */
+                    },
+                    {
+                        "c",
+                        0 /* priority */
+                    },
+                    {
+                        "d",
+                        2 /* priority */
+                    },
+                    {
+                        "e",
+                        3 /* priority */
+                    },
+                    { 0 }
+                }
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "c"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "a"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "b"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "d"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "e"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "<EXPECT_NULL>"
+            }
+        },
+        {
+            TST_PRIORITY_OP_ADD,
+            &(struct bucket_queue_op_add) {
+                (struct bucket_queue_entry[]) {
+                    {
+                        "f",
+                        1 /* priority */
+                    },
+                    {
+                        "g",
+                        1 /* priority */
+                    },
+                    {
+                        "h",
+                        0
+                    },
+                    { 0 }
+                }
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "h"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "f"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "g"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "<EXPECT_NULL>"
+            }
+        },
+        {
+            TST_PRIORITY_OP_POP,
+            &(struct bucket_queue_op_pop) {
+                "<EXPECT_NULL>"
+            }
+        },
+        { 0 }
+    };
+    
+    bucket_queue = flb_bucket_queue_create(4);
+    struct bucket_queue_op *op;
+    struct bucket_queue_op_add *op_desc_add;
+    struct bucket_queue_op_pop *op_desc_pop;
+    struct bucket_queue_entry *bucket_queue_entry;
+    struct mk_list *list_entry;
+    size_t add_idx = 0;
+    int ret;
+    int retB;
+
+    for (op = operations; op->op != 0; ++op) {
+        if (op->op == TST_PRIORITY_OP_ADD) {
+            op_desc_add = (struct bucket_queue_op_add *) op->op_description;
+            for (bucket_queue_entry = op_desc_add->entries; bucket_queue_entry->tag != 0;
+                                                            ++bucket_queue_entry) {
+                bucket_queue_entry->add_idx = add_idx++;
+                ret = flb_bucket_queue_add(bucket_queue, &bucket_queue_entry->item,
+                                   bucket_queue_entry->priority);
+                TEST_CHECK(ret == 0);
+                TEST_MSG("[op %zu][entry %zu] Add failed. Returned %d", op - operations,
+                        bucket_queue_entry - op_desc_add->entries, ret);
+            }
+        }
+
+        else if (op->op == TST_PRIORITY_OP_POP) {
+            op_desc_pop = (struct bucket_queue_op_pop *) op->op_description;
+            list_entry = flb_bucket_queue_pop_min(bucket_queue);
+            ret = strcmp("<EXPECT_NULL>", op_desc_pop->tag);
+            
+            if (ret == 0) {
+                TEST_CHECK(list_entry == NULL);
+                TEST_MSG("[op %zu] Pop failed.", op - operations);
+                TEST_MSG("Expect: null");
+                TEST_MSG("Produced: list_entry %p", list_entry);
+            }
+            else {
+                TEST_CHECK(list_entry != NULL);
+                TEST_MSG("[op %zu] Pop failed.", op - operations);
+                TEST_MSG("Expect: non-null");
+                TEST_MSG("Produced: null");
+
+                bucket_queue_entry = mk_list_entry(list_entry, struct bucket_queue_entry, item);
+                ret = strcmp(bucket_queue_entry->tag, op_desc_pop->tag);
+                TEST_CHECK(ret == 0);
+                TEST_MSG("[op %zu] Pop failed.", op - operations);
+                TEST_MSG("Expect tag: %s", op_desc_pop->tag);
+                TEST_MSG("Produced tag: %s", bucket_queue_entry->tag);
+
+                ret = strlen(bucket_queue_entry->tag);
+                retB = strlen(op_desc_pop->tag);
+                TEST_CHECK(ret == retB);
+                TEST_MSG("[op %zu] Pop failed.", op - operations);
+                TEST_MSG("Expect tag len: %d", retB);
+                TEST_MSG("Produced tag len: %d", ret);
+            }
+        }
+    }
+
+    flb_bucket_queue_destroy(bucket_queue);
+}
+
+TEST_LIST = {
+    {"create_destroy"                , test_create_destroy},
+    {"add_priorities"                , test_add_priorities},
+    { 0 }
+};

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -104,7 +104,7 @@ void test_non_blocking_and_blocking_timeout()
 
     flb_time_diff(&end_time, &start_time, &diff_time);
     elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
-    TEST_CHECK(elapsed_time_flb == target);
+    TEST_CHECK(elapsed_time_flb <= target + TIME_EPSILON_MS);
     TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
              (int) elapsed_time_flb);
     TEST_CHECK(n_events == 0);
@@ -121,7 +121,7 @@ void test_non_blocking_and_blocking_timeout()
 
     flb_time_diff(&end_time, &start_time, &diff_time);
     elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
-    TEST_CHECK(elapsed_time_flb == target);
+    TEST_CHECK(elapsed_time_flb <= target + TIME_EPSILON_MS);
     TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
              (int) elapsed_time_flb);
     TEST_CHECK(n_events == 0);
@@ -148,7 +148,7 @@ void test_non_blocking_and_blocking_timeout()
 
     flb_time_diff(&end_time, &start_time, &diff_time);
     elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
-    TEST_CHECK(elapsed_time_flb == target);
+    TEST_CHECK(elapsed_time_flb <= target + TIME_EPSILON_MS);
     TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
              (int) elapsed_time_flb);
     TEST_CHECK(n_events == 1);
@@ -223,15 +223,6 @@ void synchronize_tests()
 {
     test_non_blocking_and_blocking_timeout();
     test_infinite_wait();
-}
-
-/*
- * Add 5x 0second timers, 3 with different priority, 2 with same
- * Loop though and confirm order
- */
-void event_loop_priority_iter()
-{
-
 }
 
 /*
@@ -469,12 +460,14 @@ void event_loop_stress_priority_add_delete()
         TEST_CHECK(delayed_timers[i] == 0);
         TEST_MSG("Not all delayed timers processed");
     }
+
+    evl_context_destroy(ctx);
 }
 
 TEST_LIST = {
-    //{"test_simple_timeout_1000ms", test_simple_timeout_1000ms},
-    //{"test_non_blocking_and_blocking_timeout", test_non_blocking_and_blocking_timeout},
-    //{"test_infinite_wait", test_infinite_wait},
+    {"test_simple_timeout_1000ms", test_simple_timeout_1000ms},
+    {"test_non_blocking_and_blocking_timeout", test_non_blocking_and_blocking_timeout},
+    {"test_infinite_wait", test_infinite_wait},
     {"event_loop_stress_priority_add_delete", event_loop_stress_priority_add_delete},
     { 0 }
 };

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -1,0 +1,480 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_mp.h>
+#include <msgpack.h>
+
+#include "flb_tests_internal.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <fluent-bit/flb_event_loop.h>
+#include <fluent-bit/flb_bucket_queue.h>
+#include <monkey/mk_core/mk_list.h>
+
+#define EVENT_LOOP_TEST_PRIORITIES 7
+#define EVENT_LOOP_MAX_EVENTS 64
+#define TIME_EPSILON_MS 10
+#define TIMER_COARSE_EPSION_MS 300
+
+struct test_evl_context {
+    struct mk_event_loop *evl;
+    struct flb_bucket_queue *bktq;
+};
+
+struct test_evl_context *evl_context_create()
+{
+    struct test_evl_context *ctx = flb_malloc(sizeof(struct test_evl_context));
+  ctx->evl = mk_event_loop_create(EVENT_LOOP_MAX_EVENTS);
+    ctx->bktq = flb_bucket_queue_create(EVENT_LOOP_TEST_PRIORITIES);
+    return ctx;
+}
+
+void evl_context_destroy(struct test_evl_context *ctx)
+{
+    flb_bucket_queue_destroy(ctx->bktq);
+    mk_event_loop_destroy(ctx->evl);
+    flb_free(ctx);
+}
+
+void test_simple_timeout_1000ms()
+{   
+    struct test_evl_context *ctx;
+
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb;
+
+    int target = 1000;
+
+    ctx = evl_context_create();
+
+    flb_time_get(&start_time);
+
+    mk_event_wait_2(ctx->evl, target);
+
+    flb_time_get(&end_time);
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb < target + TIME_EPSILON_MS
+              && elapsed_time_flb > target - TIME_EPSILON_MS);
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+
+    evl_context_destroy(ctx);
+    return;
+}
+
+/*
+ * Non-block wait: 0ms, no event
+ * Add timer - 1s (very inexact)
+ * Non-block wait: 0ms, no event
+ * Blocking wait with 2.1s timeout: ~1s (very inexact), 1event
+ * Non-blocking wait: 0ms, 1 event
+ * Remove timer event
+ * Blocking wait with 2.1s timeout: 2.1s, no event
+ */
+void test_non_blocking_and_blocking_timeout()
+{   
+    struct test_evl_context *ctx;
+
+    struct mk_event event;
+
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb;
+    int n_events;
+
+    int target;
+    int wait_2_timeout = 2100;
+
+    ctx = evl_context_create();
+
+    /* Non blocking wait -- no event */
+    target = 0;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait_2(ctx->evl, 0);
+    flb_time_get(&end_time);
+
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb == target);
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 0);
+
+    /* Add somewhat inexact 1 second timer */
+    target = 1000;
+    mk_event_timeout_create(ctx->evl, target / 1000, 0, &event);
+
+    /* Non blocking wait -- one event */
+    target = 0;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait_2(ctx->evl, 0);
+    flb_time_get(&end_time);
+
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb == target);
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 0);
+
+    /* Blocking wait with unused timeout */
+    target = 1000;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait_2(ctx->evl, wait_2_timeout);
+    flb_time_get(&end_time);
+
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb < target + TIMER_COARSE_EPSION_MS
+              && elapsed_time_flb > 100); /* accommodate for timer inaccuracy */
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 1);
+
+    /* Non blocking wait -- one event */
+    target = 0;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait_2(ctx->evl, 0);
+    flb_time_get(&end_time);
+
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb == target);
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 1);
+
+    /* Remove triggered 1s timer event */
+    mk_event_timeout_destroy(ctx->evl, &event);
+
+    /* Blocking wait, used timeout */
+    target = wait_2_timeout;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait_2(ctx->evl, wait_2_timeout);
+    flb_time_get(&end_time);
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb < target + TIME_EPSILON_MS
+              && elapsed_time_flb > target - TIME_EPSILON_MS);
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 0);
+
+    evl_context_destroy(ctx);
+    return;
+}
+
+/*
+ * Add 1s timer
+ * Infinite wait: 1 event, < 1s + epsilon
+ * Remove timer
+ */
+void test_infinite_wait()
+{   
+    struct test_evl_context *ctx;
+
+    struct mk_event event;
+
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb;
+    int n_events;
+
+    int target;
+
+    ctx = evl_context_create();
+
+    /* Add somewhat inexact 1 second timer */
+    target = 1000;
+    mk_event_timeout_create(ctx->evl, target / 1000, 0, &event);
+
+    /* Infinite wait -- 1 event */
+    target = 1000;
+    flb_time_get(&start_time);
+    n_events = mk_event_wait(ctx->evl);
+    flb_time_get(&end_time);
+
+    flb_time_diff(&end_time, &start_time, &diff_time);
+    elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+    TEST_CHECK(elapsed_time_flb < target + TIMER_COARSE_EPSION_MS
+                && elapsed_time_flb > 100); /* expect timer to be inexact */
+    TEST_MSG("Target time failed for mk_wait_2. Expect %d ms. Waited %d ms\n", target,
+             (int) elapsed_time_flb);
+    TEST_CHECK(n_events == 1);
+
+    /* Remove triggered 1s timer event */
+    mk_event_timeout_destroy(ctx->evl, &event);
+
+    evl_context_destroy(ctx);
+    return;
+}
+
+void synchronize_tests()
+{
+    test_non_blocking_and_blocking_timeout();
+    test_infinite_wait();
+}
+
+/*
+ * Add 5x 0second timers, 3 with different priority, 2 with same
+ * Loop though and confirm order
+ */
+void event_loop_priority_iter()
+{
+
+}
+
+/*
+ * Add non-delayed and delayed timers of varying priority to priority event loop, and
+ * verify timers are processed by order of priority and order of activation. Delete also
+ * checked by deleting events in several cases and confirming deleted events are not
+ * processed.
+ * 
+ * Method: 
+ * Add n_timers / 2 non-delayed timers
+ * delete 1/4th of the non-delayed timers
+ * Wait for non_delayed timers to activate
+ * delete 1/4th of the non-delayed timers
+ * Process events with mk_event_loop deleting each processed event
+ * Add n_timers / 2 non-delayed timers
+ * Add n_timers / 2 2s delayed timers
+ * Wait for non_delayed timers to activate
+ * Start looping though processing the events
+ *      on the first iteration, (after initial events are tracked)
+ *          Delete 1/2 of the non-delayed timers
+ *          Wait for the delayed timers to activate
+ *      Check that deleted events are not processed
+ *      Check that non-delayed timers which are tracked first are processed before
+ *          non-delayed events.
+ * 
+ * Summary:
+ * Track priorities and confirm that all added events were processed
+ * Verify non-delayed timers are triggered before delayed timers
+ * Confirm delete properly deletes events before ready, after ready,
+ *      and after tracked by event loop.
+ */
+void event_loop_stress_priority_add_delete()
+{
+    struct test_evl_context *ctx;
+
+    const int n_timers = EVENT_LOOP_MAX_EVENTS;
+    struct mk_event events[n_timers];
+    struct mk_event *event_cronology[EVENT_LOOP_TEST_PRIORITIES] = {0}; /* event loop priority fifo */
+    int priority_cronology = 0;
+
+    struct mk_event *event;
+    int immediate_timers[EVENT_LOOP_TEST_PRIORITIES] = {0}; /* by priority */
+    int delayed_timers[EVENT_LOOP_TEST_PRIORITIES] = {0}; /* by priority */
+
+    int immediate_timers_triggered[EVENT_LOOP_TEST_PRIORITIES] = {0};
+    int delayed_timers_triggered[EVENT_LOOP_TEST_PRIORITIES] = {0};
+    
+    int priority;
+    int n_events;
+    int target;
+
+    int i;
+    int j;
+    int ret = 0;
+    int immediate_timer_count;
+
+    ctx = evl_context_create();
+    srand(20);
+
+    /* Add timers with no delay */
+    for (i = 0; i < n_timers / 2; ++i) {
+        priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
+        target = 0;
+        mk_event_timeout_create(ctx->evl, 0, 0, &events[i]);
+        events[i].priority = priority;
+        ++immediate_timers[priority];
+    }
+
+    usleep(400000); /* sleep 400 milliseconds for the 0delay events to register */
+
+    /* Remove the first n/8 events */
+    for (i = 0; i < n_timers / 8; ++i) {
+        mk_event_timeout_destroy(ctx->evl, &events[i]);
+        --immediate_timers[(int) events[i].priority];
+    }
+
+    /* Wait on the no delay timers */
+    n_events = mk_event_wait(ctx->evl);
+    TEST_CHECK(n_events == n_timers / 2 - n_timers / 8);
+    TEST_MSG("Expected %i ready events from the no delay timers. Recieved %i",
+            n_timers / 2 - n_timers / 8, ret);
+    
+    /* Remove the first n/8 events */
+    for (i = n_timers / 8; i < n_timers / 4; ++i) {
+        mk_event_timeout_destroy(ctx->evl, &events[i]);
+        --immediate_timers[(int) events[i].priority];
+    }
+    
+    i = 0;
+    flb_event_priority_live_foreach(event, ctx->bktq, ctx->evl, n_timers) {
+        /* check priority cronology */
+        TEST_CHECK(event->priority >= priority_cronology);
+        TEST_MSG("Priority event loop processed events out of order.");
+        priority_cronology = event->priority;
+        
+        /* check none of the deleted records appear */
+        TEST_CHECK(event >= &events[n_timers / 4]);
+        TEST_MSG("Deleted event appeared in priority event loop.");
+
+        /* update records */
+
+        /* delete event */
+        mk_event_timeout_destroy(ctx->evl, event);
+
+        /* update records */
+        mk_event_timeout_destroy(ctx->evl, event);
+        if (event < &events[n_timers/2]) {
+            /* immediate timer */
+            --immediate_timers[(int) event->priority];
+            ++immediate_timers_triggered[(int) event->priority];
+        }
+        else {
+            /* delayed timer */
+            --delayed_timers[(int) event->priority];
+            ++delayed_timers_triggered[(int) event->priority];
+        }
+        ++i;
+    }
+    TEST_CHECK(i == n_timers / 4);
+    TEST_MSG("Not all no-wait timers activated");
+
+    /* verify number of immediate timers triggered */
+    for (i = 0; i < EVENT_LOOP_TEST_PRIORITIES; ++i) {
+        TEST_CHECK(immediate_timers[i] == 0);
+        TEST_MSG("Priority event register and triggered mismatch for priority %i. "
+                "Remaining: %i out of: %i", i, immediate_timers[i],
+                immediate_timers_triggered[i]);
+    }
+
+    /* Re-add timers with no delay */
+    for (i = 0; i < n_timers / 2; ++i) {
+        priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
+        target = 0;
+        mk_event_timeout_create(ctx->evl, target, 0, &events[i]);
+        events[i].priority = priority;
+        ++immediate_timers[priority];
+    }
+
+    usleep(400000); /* sleep 200 milliseconds for the 0delay events to register */
+
+    /* Add timers with delay */
+    for (i = n_timers / 2; i < n_timers; ++i) {
+        priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
+        target = 2; /* 2 second delay */
+        mk_event_timeout_create(ctx->evl, target, 0, &events[i]);
+        events[i].priority = priority;
+        ++delayed_timers[priority];
+    }
+
+    /* Wait on the timers */
+    n_events = mk_event_wait(ctx->evl);
+    TEST_CHECK(n_events == n_timers / 2);
+    TEST_MSG("Expected %i ready events from the no delay timers. Recieved %i", n_timers / 2, ret);
+    j = 0;
+    priority_cronology = 0;
+    flb_event_priority_live_foreach(event, ctx->bktq, ctx->evl, n_timers) {
+
+        /* first round, delete half of all 0delay timers */
+        if (j == 0) {
+            
+            /* this tests propper removal from bucket queue */
+            for (i = 0; i < n_timers/4; ++i) {
+                if (&events[i] == event) {
+                    continue;
+                }
+                mk_event_timeout_destroy(ctx->evl, &events[i]);
+                --immediate_timers[(int) events[i].priority];
+            }
+
+            /* check priority cronology */
+            TEST_CHECK(event->priority >= priority_cronology);
+            priority_cronology = event->priority;
+
+            /* delete actual event */
+            mk_event_timeout_destroy(ctx->evl, event);
+            --immediate_timers[(int) event->priority];
+            TEST_CHECK(event < &events[n_timers/2]);
+            TEST_MSG("Processed delayed timer first. Should process immediate timer first");
+
+            /* delay for the delayed timers to register */
+            usleep(2500000); /* 2.5 seconds */
+            ++j;
+            continue;
+        }
+
+        /* validate fifo nature. inspect cross from no-timeout to timeout event */
+        /* check event fifo cronology */
+        /* (priority A) [immediate timer] -> [delay timer]: check all immediate timers processed */
+        if (event_cronology[(int) event->priority] < &events[n_timers / 2]
+           && event >= &events[n_timers / 2]) {
+            /* verify that all of the immediate_timers in priority have been removed */
+            immediate_timer_count = 0;
+            for (i = 0; i < EVENT_LOOP_TEST_PRIORITIES; ++i) {
+                immediate_timer_count += immediate_timers[i];
+            }
+            TEST_CHECK(immediate_timers[(int) event->priority] == 0);
+            TEST_MSG("immediate timer events are not all processed before delayed timer events for priority %i", event->priority);
+        }
+        /* check for non fifo behavior */
+        /* (priority A) [delay timer] -> [immediate timer]: disallow */
+        if (!TEST_CHECK(!(event_cronology[(int) event->priority] >= &events[n_timers / 2]
+           && event < &events[n_timers / 2]))) {
+            TEST_MSG("Non fifo behavior within priority. Delayed event processed before immediate event.");
+        }
+        event_cronology[(int) event->priority] = event;
+
+        /* check priority cronology */
+        TEST_CHECK(event->priority >= priority_cronology);
+        TEST_MSG("Priority event loop processed events out of order.");
+        priority_cronology = event->priority;
+
+        /* verify none of the deleted timers are processed */
+        TEST_CHECK(event >= &events[n_timers / 4]);
+        TEST_MSG("Processed a deleted timer. Delete performed after event is registered in the event loop bucket queue.");
+
+        /* update records */
+        mk_event_timeout_destroy(ctx->evl, event);
+        if (event < &events[n_timers/2]) {
+            /* immediate timer */
+            --immediate_timers[(int) event->priority];
+        }
+        else {
+            /* delayed timer */
+            --delayed_timers[(int) event->priority];
+        }
+        ++j;
+    }
+
+    /* validate all timers processed */
+    for (i = 0; i < EVENT_LOOP_TEST_PRIORITIES; ++i) {
+        TEST_CHECK(immediate_timers[i] == 0);
+        TEST_MSG("Not all immediate timers processed");
+    }
+    for (i = 0; i < EVENT_LOOP_TEST_PRIORITIES; ++i) {
+        TEST_CHECK(delayed_timers[i] == 0);
+        TEST_MSG("Not all delayed timers processed");
+    }
+}
+
+TEST_LIST = {
+    //{"test_simple_timeout_1000ms", test_simple_timeout_1000ms},
+    //{"test_non_blocking_and_blocking_timeout", test_non_blocking_and_blocking_timeout},
+    //{"test_infinite_wait", test_infinite_wait},
+    {"event_loop_stress_priority_add_delete", event_loop_stress_priority_add_delete},
+    { 0 }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
The following is a work in progress implementation of the priority queue event loop.
It creates a system for prioritizing events in the event loop and enabling ready events be processed by order of priority.

It is PR'd against 1.8 temporarily, since tests have only been so far conducted so far on 1.8.
Will be PR'd eventually against 1.9 and Master.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
