### PR TITLE
packaging: resolve CentOS 8 mirror issues

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -14,6 +14,10 @@ on:
         description: Version of Fluent Bit to build
         required: true
         default: 1.8.12
+      target:
+        description: Only build a specific target
+        required: false
+        default: ""
 
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.
@@ -90,6 +94,13 @@ jobs:
             echo '"raspbian/buster", "raspbian/bullseye"'
             echo ']}'
           ) | jq -c .)
+          if [ -z "${{ github.event.inputs.target || '' }}" ]; then
+            matrix=$((
+              echo '{ "distro" : ['
+              echo '"${{ github.event.inputs.target }}"'
+              echo ']}'
+            ) | jq -c .)
+          fi
           echo $matrix
           echo $matrix| jq .
           echo "::set-output name=matrix::$matrix"

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -49,6 +49,10 @@ ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
 # centos/8 base image
 FROM centos:8 as centos-8-base
 
+# CentOS is now EOL so have to use the vault repos
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \

--- a/packaging/local-build-all.sh
+++ b/packaging/local-build-all.sh
@@ -27,7 +27,7 @@ echo "Cleaning any existing output"
 rm -rf "${PACKAGING_OUTPUT_DIR:?}/*"
 
 # We need a version of the source code to build
-FLB_VERSION=${FLB_VERSION:-1.8.11}
+FLB_VERSION=${FLB_VERSION:-1.8.12}
 
 # Iterate over each target and attempt to build it.
 # Verify that an RPM or DEB is created.


### PR DESCRIPTION
CentOS 8 is EOL now which means the mirrors are no longer available and builds fail: https://github.com/fluent/fluent-bit/runs/5124001271?check_suite_focus=true
This PR updates it to use the permanently archived `vault.centos.org` mirrors instead to allow us to build CentOS 8 targets still.
Also add support for a quick staging build of a single target.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

Easy to reproduce locally, this was failing previously and now passes:
```
$ ./packaging/build.sh -d "centos/8" -v 1.8.12
FLB_PREFIX  => v
FLB_VERSION => 1.8.12
FLB_DISTRO  => centos/8
FLB_SRC     => 
FLB_OUT_DIR => 
IMAGE_CONTEXT_DIR => /home/pat/github/fluent/fluent-bit/packaging/distros/centos
CMAKE_INSTALL_PREFIX  => /opt/td-agent-bit/
FLB_TD                => On
FLB_ARG               => --build-arg BASE_BUILDER=centos-8-base --target builder
[+] Building 0.8s (6/11)                                                                                                                                                                                   
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 4.74kB                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/centos:8                                                                                                                                           0.0s
 => [centos-8-base 1/2] FROM docker.io/library/centos:8                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 29B                                                                                                                                                                      0.0s
 => ERROR [centos-8-base 2/2] RUN yum -y update &&     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash                    wget unzip systemd-devel wget flex bison          0.7s
------
 > [centos-8-base 2/2] RUN yum -y update &&     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash                    wget unzip systemd-devel wget flex bison                    postgresql-libs postgresql-devel postgresql-server postgresql                    cyrus-sasl-lib openssl openssl-libs openssl-devel &&     yum clean all:
#5 0.688 CentOS Linux 8 - AppStream                      115  B/s |  38  B     00:00    
#5 0.689 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
------
executor failed running [/bin/sh -c yum -y update &&     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash                    wget unzip systemd-devel wget flex bison                    postgresql-libs postgresql-devel postgresql-server postgresql                    cyrus-sasl-lib openssl openssl-libs openssl-devel &&     yum clean all]: exit code: 1
Error building main docker image flb-1.8.12-centos/8
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
