### PR TITLE
packaging: update ARM64 mirrors for CentOS 8

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -94,7 +94,8 @@ jobs:
             echo '"raspbian/buster", "raspbian/bullseye"'
             echo ']}'
           ) | jq -c .)
-          if [ -z "${{ github.event.inputs.target || '' }}" ]; then
+          if [ -n "${{ github.event.inputs.target || '' }}" ]; then
+            echo "Overriding matrix to build: ${{ github.event.inputs.target }}"
             matrix=$((
               echo '{ "distro" : ['
               echo '"${{ github.event.inputs.target }}"'

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -9,6 +9,16 @@ on:
         type: string
         description: The version we want to release from staging.
         required: true
+      docker-image:
+        type: string
+        description: Optionally override the image name to push to on Docker Hub.
+        default: fluent/fluent-bit
+        required: false
+      github-image:
+        type: string
+        description: Optionally override the image name to push to on Github Container Registry.
+        default: fluent/fluent-bit
+        required: false
 
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.
@@ -144,7 +154,7 @@ jobs:
               "docker://$STAGING_IMAGE_NAME:$TAG" \
               "docker://$RELEASE_IMAGE_NAME:$TAG"
         env:
-          RELEASE_IMAGE_NAME: docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}
+          RELEASE_IMAGE_NAME: docker.io/${{ github.event.inputs.docker-image || secrets.DOCKERHUB_ORGANIZATION }}
           RELEASE_CREDS: ${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}
           TAG: ${{ matrix.tag }}
         shell: bash
@@ -161,7 +171,7 @@ jobs:
               "docker://$STAGING_IMAGE_NAME:$TAG" \
               "docker://$RELEASE_IMAGE_NAME:$TAG"
         env:
-          RELEASE_IMAGE_NAME: ghcr.io/${{ github.repository }}
+          RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
           RELEASE_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ matrix.tag }}
         shell: bash
@@ -177,6 +187,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     needs: staging-release-images
+    env:
+      DH_RELEASE_IMAGE_NAME: docker.io/${{ github.event.inputs.docker-image || secrets.DOCKERHUB_ORGANIZATION }}
+      GHCR_RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@main
@@ -204,14 +217,14 @@ jobs:
             -a "repo=${{ github.repository }}" \
             -a "workflow=${{ github.workflow }}" \
             -a "release=${{ github.event.inputs.version }}" \
-            "ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}" \
-            "ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-debug" \
-            "ghcr.io/${{ github.repository }}:latest" \
-            "ghcr.io/${{ github.repository }}:latest-debug" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:${{ github.event.inputs.version }}" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:${{ github.event.inputs.version }}-debug" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:latest" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:latest-debug"
+            "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
+            "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
+            "$GHCR_RELEASE_IMAGE_NAME:latest" \
+            "$GHCR_RELEASE_IMAGE_NAME:latest-debug" \
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
+            "$DH_RELEASE_IMAGE_NAME:latest" \
+            "$DH_RELEASE_IMAGE_NAME:latest-debug"
           rm -f /tmp/my_cosign.key
         shell: bash
         env:
@@ -229,14 +242,14 @@ jobs:
             -a "repo=${{ github.repository }}" \
             -a "workflow=${{ github.workflow }}" \
             -a "release=${{ github.event.inputs.version }}" \
-            "ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}" \
-            "ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-debug" \
-            "ghcr.io/${{ github.repository }}:latest" \
-            "ghcr.io/${{ github.repository }}:latest-debug" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:${{ github.event.inputs.version }}" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:${{ github.event.inputs.version }}-debug" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:latest" \
-            "docker.io/${{ secrets.DOCKERHUB_ORGANIZATION }}:latest-debug"
+            "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
+            "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
+            "$GHCR_RELEASE_IMAGE_NAME:latest" \
+            "$GHCR_RELEASE_IMAGE_NAME:latest-debug" \
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
+            "$DH_RELEASE_IMAGE_NAME:latest" \
+            "$DH_RELEASE_IMAGE_NAME:latest-debug"
         shell: bash
         env:
           COSIGN_EXPERIMENTAL: "true"

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -69,6 +69,10 @@ FROM arm64v8/centos:8 as centos-8.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
+# CentOS is now EOL so have to use the vault repos
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \


### PR DESCRIPTION
Missed off ARM64v8 update as well from #4772, confirmed with a full local build now.

Also added some extra flexibility for release testing.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [X] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.
[build.log](https://github.com/fluent/fluent-bit/files/8033536/build.log)

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
