### PR TITLE
1.8: out_stackdriver: add new metric 'fluentbit_stackdriver_requests_total' (#2698)

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -157,6 +157,7 @@ struct flb_stackdriver {
     /* metrics */
     struct cmt_counter *cmt_successful_requests;
     struct cmt_counter *cmt_failed_requests;
+    struct cmt_counter *cmt_requests_total;
 #endif
 
     /* plugin instance */

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -487,6 +487,13 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                                                   "requests.",
                                                   1, (char *[]) {"name"});
 
+    ctx->cmt_requests_total = cmt_counter_create(ins->cmt,
+                                                 "fluentbit",
+                                                 "stackdriver",
+                                                 "requests_total",
+                                                 "Total number of requests.",
+                                                  1, (char *[]) {"status"});
+
     /* OLD api */
     flb_metrics_add(FLB_STACKDRIVER_SUCCESSFUL_REQUESTS,
                     "stackdriver_successful_requests", ctx->ins->metrics);


### PR DESCRIPTION
The following patch extends Stackdriver output plugin by adding a new metric called 'fluentbit_stackdriver_requests_total'. The main difference between this metric and the previous one is that it uses the HTTP response status to compose metrics with labels for a better of understanding success and failures.

This is an example of the new metrics output:

```
fluentbit_output_proc_records_total{name="stackdriver.0"} 15 1644433072741
fluentbit_output_proc_bytes_total{name="stackdriver.0"} 390 1644433072741
fluentbit_stackdriver_successful_requests{name="stackdriver.0"} 14 1644433072584
fluentbit_stackdriver_requests_total{status="200"} 14 1644433072584
Note that this metric is only available through the new 'fluentbit_metrics' input plugin (new metrics mechanism)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
