### PR TITLE
security_policy: add announcements section

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,8 @@
 
 Please get in touch with the team at fluentbit-security@googlegroups.com, and we'll take it from there.  
 Thank you in advance for helping to keep Fluent-bit secure.
+
+
+## Announcements
+
+For related CVEs that may or not affect Fluent Bit we'll be doing the corresponding announcement through [discussions](https://github.com/fluent/fluent-bit/discussions).


### PR DESCRIPTION
Add announcements section to the Security Policy

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
