### PR TITLE
1.8: in_tail: replace files linked list with a hash table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,10 +830,16 @@ endif()
 # ============================
 
 set(CPACK_PACKAGE_VERSION ${FLB_VERSION_STR})
-set(CPACK_PACKAGE_NAME "td-agent-bit")
+
+if(FLB_TD)
+  set(CPACK_PACKAGE_NAME "td-agent-bit")
+else()
+  set(CPACK_PACKAGE_NAME "fluent-bit")
+endif()
+
 set(CPACK_PACKAGE_RELEASE 1)
-set(CPACK_PACKAGE_CONTACT "Eduardo Silva <eduardo@treasure-data.com>")
-set(CPACK_PACKAGE_VENDOR "Treasure Data")
+set(CPACK_PACKAGE_CONTACT "Eduardo Silva <eduardo@calyptia.com>")
+set(CPACK_PACKAGE_VENDOR "Calyptia Inc.")
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGING_INSTALL_PREFIX "/")
 
@@ -926,7 +932,11 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 # CPack: Windows System
 if(CPACK_GENERATOR MATCHES "NSIS")
   set(CPACK_MONOLITHIC_INSTALL 1)
-  set(CPACK_PACKAGE_INSTALL_DIRECTORY "td-agent-bit")
+  if(FLB_TD)
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "td-agent-bit")
+  else()
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "fluent-bit")
+  endif()
 endif()
 
 include(CPack)

--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -36,6 +36,7 @@
 struct flb_hash_entry {
     time_t created;
     uint64_t hits;
+    uint64_t hash;
     char *key;
     size_t key_len;
     void *val;
@@ -71,6 +72,8 @@ int flb_hash_add(struct flb_hash *ht,
 int flb_hash_get(struct flb_hash *ht,
                  const char *key, int key_len,
                  void **out_buf, size_t *out_size);
+
+int flb_hash_exists(struct flb_hash *ht, uint64_t hash);
 int flb_hash_get_by_id(struct flb_hash *ht, int id,
                        const char *key,
                        const char **out_buf, size_t *out_size);

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -190,7 +190,7 @@ static int in_tail_collect_static(struct flb_input_instance *ins,
             if (file->config->exit_on_eof) {
                 flb_plg_info(ctx->ins, "inode=%"PRIu64" file=%s ended, stop",
                              file->inode, file->name);
-                if (mk_list_size(&ctx->files_static) == 1) {
+                if (ctx->files_static_count == 1) {
                     flb_engine_exit(config);
                 }
             }
@@ -227,7 +227,7 @@ static int in_tail_collect_static(struct flb_input_instance *ins,
              * when to stop processing the static list.
              */
             if (alter_size == 0) {
-                pre_size = mk_list_size(&ctx->files_static);
+                pre_size = ctx->files_static_count;
             }
             ret = flb_tail_file_to_event(file);
             if (ret == -1) {
@@ -237,7 +237,7 @@ static int in_tail_collect_static(struct flb_input_instance *ins,
             }
 
             if (alter_size == 0) {
-                pos_size = mk_list_size(&ctx->files_static);
+                pos_size = ctx->files_static_count;
                 if (pre_size == pos_size) {
                     alter_size++;
                 }

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -135,7 +135,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     /* Config: path/pattern to read files */
     if (!ctx->path_list || mk_list_size(ctx->path_list) == 0) {
         flb_plg_error(ctx->ins, "no input 'path' was given");
-        flb_free(ctx);
+        flb_tail_config_destroy(ctx);
         return NULL;
     }
 
@@ -168,7 +168,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
             flb_plg_error(ctx->ins,
                           "invalid 'refresh_interval' config value (%s)",
                       tmp);
-            flb_free(ctx);
+            flb_tail_config_destroy(ctx);
             return NULL;
         }
     }
@@ -221,6 +221,22 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     mk_list_init(&ctx->files_static);
     mk_list_init(&ctx->files_event);
     mk_list_init(&ctx->files_rotated);
+
+    /* hash table for files lookups */
+    ctx->static_hash = flb_hash_create(FLB_HASH_EVICT_NONE, 1000, 0);
+    if (!ctx->static_hash) {
+        flb_plg_error(ctx->ins, "could not create static hash");
+        flb_tail_config_destroy(ctx);
+        return NULL;
+    }
+
+    ctx->event_hash = flb_hash_create(FLB_HASH_EVICT_NONE, 1000, 0);
+    if (!ctx->event_hash) {
+        flb_plg_error(ctx->ins, "could not create event hash");
+        flb_tail_config_destroy(ctx);
+        return NULL;
+    }
+
 #ifdef FLB_HAVE_SQLDB
     ctx->db = NULL;
 #endif
@@ -447,6 +463,13 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
         flb_tail_db_close(config->db);
     }
 #endif
+
+    if (config->static_hash) {
+        flb_hash_destroy(config->static_hash);
+    }
+    if (config->event_hash) {
+        flb_hash_destroy(config->event_hash);
+    }
 
     flb_free(config);
     return 0;

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -34,6 +34,7 @@
 #include <fluent-bit/multiline/flb_ml.h>
 #endif
 
+#include <xxhash.h>
 
 /* Metrics */
 #ifdef FLB_HAVE_METRICS
@@ -125,7 +126,7 @@ struct flb_tail_config {
     struct flb_ml *ml_ctx;
     struct mk_list *multiline_parsers;
 
-    /* Lists head for files consumed statically (read) and by events (inotify) */
+    uint64_t files_static_count;   /* number of items in the static file list */
     struct mk_list files_static;
     struct mk_list files_event;
 
@@ -142,6 +143,10 @@ struct flb_tail_config {
     struct cmt_counter *cmt_files_opened;
     struct cmt_counter *cmt_files_closed;
     struct cmt_counter *cmt_files_rotated;
+
+    /* Hash: hash tables for quick acess to registered files */
+    struct flb_hash *static_hash;
+    struct flb_hash *event_hash;
 
     struct flb_config *config;
 };

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -52,14 +52,27 @@ static inline void consume_bytes(char *buf, int bytes, int length)
     memmove(buf, buf + bytes, length - bytes);
 }
 
+static uint64_t stat_get_st_dev(struct stat *st)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    /* do you want to contribute with a way to extract volume serial number ? */
+    return 0;
+#else
+    return st->st_dev;
+#endif
+}
+
 static int stat_to_hash_bits(struct flb_tail_config *ctx, struct stat *st,
                              uint64_t *out_hash)
 {
     int len;
+    uint64_t st_dev;
     char tmp[64];
 
+    st_dev = stat_get_st_dev(st);
+
     len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 ":%" PRIu64,
-                   st->st_dev, st->st_ino);
+                   st_dev, st->st_ino);
 
     *out_hash = XXH3_64bits(tmp, len);
     return 0;
@@ -68,6 +81,7 @@ static int stat_to_hash_bits(struct flb_tail_config *ctx, struct stat *st,
 static int stat_to_hash_key(struct flb_tail_config *ctx, struct stat *st,
                             flb_sds_t *key)
 {
+    uint64_t st_dev;
     flb_sds_t tmp;
     flb_sds_t buf;
 
@@ -76,8 +90,9 @@ static int stat_to_hash_key(struct flb_tail_config *ctx, struct stat *st,
         return -1;
     }
 
+    st_dev = stat_get_st_dev(st);
     tmp = flb_sds_printf(&buf, "%" PRIu64 ":%" PRIu64,
-                         st->st_dev, st->st_ino);
+                         st_dev, st->st_ino);
     if (!tmp) {
         flb_sds_destroy(buf);
         return -1;

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -45,11 +45,49 @@
 #include "win32.h"
 #endif
 
+#include <xxhash.h>
+
 static inline void consume_bytes(char *buf, int bytes, int length)
 {
     memmove(buf, buf + bytes, length - bytes);
 }
 
+static int stat_to_hash_bits(struct flb_tail_config *ctx, struct stat *st,
+                             uint64_t *out_hash)
+{
+    int len;
+    char tmp[64];
+
+    len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 ":%" PRIu64,
+                   st->st_dev, st->st_ino);
+
+    *out_hash = XXH3_64bits(tmp, len);
+    return 0;
+}
+
+static int stat_to_hash_key(struct flb_tail_config *ctx, struct stat *st,
+                            flb_sds_t *key)
+{
+    flb_sds_t tmp;
+    flb_sds_t buf;
+
+    buf = flb_sds_create_size(64);
+    if (!buf) {
+        return -1;
+    }
+
+    tmp = flb_sds_printf(&buf, "%" PRIu64 ":%" PRIu64,
+                         st->st_dev, st->st_ino);
+    if (!tmp) {
+        flb_sds_destroy(buf);
+        return -1;
+    }
+
+    *key = buf;
+    return 0;
+}
+
+/* Append custom keys and report the number of records processed */
 static int record_append_custom_keys(struct flb_tail_file *file,
                                      char *in_data, size_t in_size,
                                      char **out_data, size_t *out_size)
@@ -663,7 +701,7 @@ static int tag_compose(char *tag, char *fname, char *out_buf, size_t *out_size,
     return 0;
 }
 
-static inline int flb_tail_file_exists(struct stat *st,
+static inline int flb_tail_file_exists_old(struct stat *st,
                                        struct flb_tail_config *ctx)
 {
     struct mk_list *head;
@@ -683,6 +721,30 @@ static inline int flb_tail_file_exists(struct stat *st,
         if (file->inode == st->st_ino) {
             return FLB_TRUE;
         }
+    }
+
+    return FLB_FALSE;
+}
+
+static inline int flb_tail_file_exists(struct stat *st,
+                                       struct flb_tail_config *ctx)
+{
+    int ret;
+    uint64_t hash;
+
+    ret = stat_to_hash_bits(ctx, st, &hash);
+    if (ret != 0) {
+        return -1;
+    }
+
+    /* static hash */
+    if (flb_hash_exists(ctx->static_hash, hash)) {
+        return FLB_TRUE;
+    }
+
+    /* event hash */
+    if (flb_hash_exists(ctx->event_hash, hash)) {
+        return FLB_TRUE;
     }
 
     return FLB_FALSE;
@@ -784,6 +846,8 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     int ret;
     uint64_t stream_id;
     uint64_t ts;
+    uint64_t hash_bits;
+    flb_sds_t hash_key;
     size_t len;
     char *tag;
     char *name;
@@ -826,22 +890,21 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         }
     }
 
-    /*
-     * Duplicate string into 'file' structure, the called function
-     * take cares to resolve real-name of the file in case we are
-     * running in a non-Linux system.
-     *
-     * Depending of the operating system, the way to obtain the file
-     * name associated to it file descriptor can have different behaviors
-     * specifically if it root path it's under a symbolic link. On Linux
-     * we can trust the file name but in others it's better to solve it
-     * with some extra calls.
-     */
-    ret = flb_tail_file_name_dup(path, file);
-    if (!file->name) {
-        flb_errno();
+    /* get unique hash for this file */
+    ret = stat_to_hash_bits(ctx, st, &hash_bits);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "error procesisng hash bits for file %s", path);
         goto error;
     }
+    file->hash_bits = hash_bits;
+
+    /* store the hash key used for hash_bits */
+    ret = stat_to_hash_key(ctx, st, &hash_key);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "error procesisng hash key for file %s", path);
+        goto error;
+    }
+    file->hash_key = hash_key;
 
     file->inode     = st->st_ino;
     file->offset    = 0;
@@ -858,6 +921,23 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->mult_keys = 0;
     file->mult_flush_timeout = 0;
     file->mult_skipping = FLB_FALSE;
+
+    /*
+     * Duplicate string into 'file' structure, the called function
+     * take cares to resolve real-name of the file in case we are
+     * running in a non-Linux system.
+     *
+     * Depending of the operating system, the way to obtain the file
+     * name associated to it file descriptor can have different behaviors
+     * specifically if it root path it's under a symbolic link. On Linux
+     * we can trust the file name but in others it's better to solve it
+     * with some extra calls.
+     */
+    ret = flb_tail_file_name_dup(path, file);
+    if (!file->name) {
+        flb_errno();
+        goto error;
+    }
 
     /* multiline msgpack buffers */
     msgpack_sbuffer_init(&file->mult_sbuf);
@@ -948,10 +1028,15 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
 
     if (mode == FLB_TAIL_STATIC) {
         mk_list_add(&file->_head, &ctx->files_static);
+        ctx->files_static_count++;
+        flb_hash_add(ctx->static_hash, file->hash_key, flb_sds_len(file->hash_key),
+                     file, sizeof(file));
         tail_signal_manager(file->config);
     }
     else if (mode == FLB_TAIL_EVENT) {
         mk_list_add(&file->_head, &ctx->files_event);
+        flb_hash_add(ctx->event_hash, file->hash_key, flb_sds_len(file->hash_key),
+                     file, sizeof(file));
 
         /* Register this file into the fs_event monitoring */
         ret = flb_tail_fs_add(ctx, file);
@@ -1047,6 +1132,7 @@ void flb_tail_file_remove(struct flb_tail_file *file)
     flb_free(file->buf_data);
     flb_free(file->name);
     flb_free(file->real_name);
+    flb_sds_destroy(file->hash_key);
 
 #ifdef FLB_HAVE_METRICS
     name = (char *) flb_input_name(ctx->ins);
@@ -1069,12 +1155,14 @@ int flb_tail_file_remove_all(struct flb_tail_config *ctx)
 
     mk_list_foreach_safe(head, tmp, &ctx->files_static) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
+        flb_hash_del(ctx->static_hash, file->hash_key);
         flb_tail_file_remove(file);
         count++;
     }
 
     mk_list_foreach_safe(head, tmp, &ctx->files_event) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
+        flb_hash_del(ctx->event_hash, file->hash_key);
         flb_tail_file_remove(file);
         count++;
     }
@@ -1361,9 +1449,15 @@ int flb_tail_file_to_event(struct flb_tail_file *file)
         return -1;
     }
 
-    /* List change */
+    /* List swap: change from 'static' to 'event' list */
     mk_list_del(&file->_head);
+    ctx->files_static_count--;
+    flb_hash_del(ctx->static_hash, file->hash_key);
+
     mk_list_add(&file->_head, &file->config->files_event);
+    flb_hash_add(ctx->event_hash, file->hash_key, flb_sds_len(file->hash_key),
+                 file, sizeof(file));
+
     file->tail_mode = FLB_TAIL_EVENT;
 
     return 0;
@@ -1460,6 +1554,7 @@ int flb_tail_file_name_dup(char *path, struct flb_tail_file *file)
     if (file->real_name) {
         flb_free(file->real_name);
     }
+
     file->real_name = flb_tail_file_name(file);
     if (!file->real_name) {
         flb_errno();

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -41,6 +41,7 @@ struct flb_tail_file {
     int64_t size;
     int64_t offset;
     int64_t last_line;
+    uint64_t  dev_id;
     uint64_t  inode;
     uint64_t  link_inode;
     int   is_link;
@@ -103,6 +104,9 @@ struct flb_tail_file {
 
     /* database reference */
     uint64_t db_id;
+
+    uint64_t hash_bits;
+    flb_sds_t hash_key;
 
     /* reference */
     int tail_mode;

--- a/src/flb_hash.c
+++ b/src/flb_hash.c
@@ -292,8 +292,7 @@ static int entry_set_value(struct flb_hash_entry *entry, void *val, size_t val_s
     return 0;
 }
 
-int flb_hash_add(struct flb_hash *ht,
-                 const char *key, int key_len,
+int flb_hash_add(struct flb_hash *ht, const char *key, int key_len,
                  void *val, ssize_t val_size)
 {
     int id;
@@ -352,6 +351,7 @@ int flb_hash_add(struct flb_hash *ht,
         return -1;
     }
     entry->created = time(NULL);
+    entry->hash = hash;
     entry->hits = 0;
 
     /* Store the key and value as a new memory region */
@@ -409,6 +409,28 @@ int flb_hash_get(struct flb_hash *ht,
     return id;
 }
 
+/* check if a hash exists */
+int flb_hash_exists(struct flb_hash *ht, uint64_t hash)
+{
+    int id;
+    struct mk_list *head;
+    struct flb_hash_table *table;
+    struct flb_hash_entry *entry;
+
+    id = (hash % ht->size);
+    table = &ht->table[id];
+
+    /* Iterate entries */
+    mk_list_foreach(head, &table->chains) {
+        entry = mk_list_entry(head, struct flb_hash_entry, _head);
+        if (entry->hash == hash) {
+            return FLB_TRUE;
+        }
+    }
+
+    return FLB_FALSE;
+}
+
 /*
  * Get an entry based in the table id. Note that a table id might have multiple
  * entries so the 'key' parameter is required to get an exact match.
@@ -454,8 +476,7 @@ int flb_hash_get_by_id(struct flb_hash *ht, int id,
     return 0;
 }
 
-void *flb_hash_get_ptr(struct flb_hash *ht,
-                 const char *key, int key_len)
+void *flb_hash_get_ptr(struct flb_hash *ht, const char *key, int key_len)
 {
     int id;
     struct flb_hash_entry *entry;


### PR DESCRIPTION
The current implementation of the code uses a linked list to keep the state/context of each file. When the number of files is
high in the scanning path, this generates high-performance degradation, the tests were performed with > 50k files.

The current patch implements hash tables to keep references of each file context, avoiding the linear scanning of files and improving the performance more than 20x. This design scales times better when high number of files exists.

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
