### PR TITLE
1.8: filter_rewrite_tag: fix Match aborting issue (#4276)

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -215,9 +215,7 @@ static int cb_rewrite_tag_init(struct flb_filter_instance *ins,
         return -1;
     }
     if (is_wildcard(ins->match)) {
-        flb_plg_error(ins, "'Match' causes infinite loop. abort.");
-        flb_free(ctx);
-        return -1;
+        flb_plg_warn(ins, "'Match' may cause infinite loop.");
     }
     ctx->ins = ins;
     ctx->config = config;


### PR DESCRIPTION
This patch is https://github.com/fluent/fluent-bit/pull/4288 for 1.8 branch.

Users requested .
https://github.com/fluent/fluent-bit/issues/4800
https://github.com/fluent/fluent-bit/issues/4552

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
[INPUT]
    Name Dummy
    Dummy {"msg":"hoge", "_forward":"true"}

# if _forward is not set, set to false
[FILTER]
    Name       modify
    Match      *
    Add        _forward false

# set _forward key to false, if tag is prefixed with _forward. If not we get an endless rewrite_tag filter loop.
[FILTER]
    Name       modify
    Match      _forward.*
    Set        _forward false

# prefix tag with _forward, where _forward key is true
[FILTER]
    Name          rewrite_tag
    Match         *
    Rule          $_forward ^true$  _forward.$TAG true
    Emitter_Name  re_emitted

# delete _forward key from tags prefixed with _forward
[FILTER]
    Name       modify
    Match      _forward.*
    Remove     _forward

[OUTPUT]
    Name stdout
    Match *
```

## Debug output

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/12 07:49:18] [ info] [engine] started (pid=10126)
[2022/02/12 07:49:18] [ info] [storage] version=1.1.6, initializing...
[2022/02/12 07:49:18] [ info] [storage] in-memory
[2022/02/12 07:49:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/12 07:49:18] [ info] [cmetrics] version=0.2.2
[2022/02/12 07:49:18] [ warn] [filter:rewrite_tag:rewrite_tag.2] 'Match' may cause infinite loop.
[2022/02/12 07:49:18] [ info] [sp] stream processor started
[0] dummy.0: [1644619759.405099329, {"msg"=>"hoge", "_forward"=>"true"}]
[1] dummy.0: [1644619760.404718656, {"msg"=>"hoge", "_forward"=>"true"}]
[2] dummy.0: [1644619761.404839283, {"msg"=>"hoge", "_forward"=>"true"}]
[3] dummy.0: [1644619762.404683524, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1644619759.405099329, {"msg"=>"hoge"}]
[1] _forward.dummy.0: [1644619760.404718656, {"msg"=>"hoge"}]
[2] _forward.dummy.0: [1644619761.404839283, {"msg"=>"hoge"}]
[3] _forward.dummy.0: [1644619762.404683524, {"msg"=>"hoge"}]
^C[2022/02/12 07:49:24] [engine] caught signal (SIGINT)
[0] dummy.0: [1644619763.405660384, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1644619763.405660384, {"msg"=>"hoge"}]
[2022/02/12 07:49:24] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/12 07:49:24] [ info] [engine] service has stopped (0 pending tasks)
taka@locals:~/git/fluent-bit/build/4276$
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==10158== Memcheck, a memory error detector
==10158== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10158== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==10158== Command: ../bin/fluent-bit -c a.conf
==10158== 
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/12 07:52:49] [ info] [engine] started (pid=10158)
[2022/02/12 07:52:49] [ info] [storage] version=1.1.6, initializing...
[2022/02/12 07:52:49] [ info] [storage] in-memory
[2022/02/12 07:52:49] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/12 07:52:49] [ info] [cmetrics] version=0.2.2
[2022/02/12 07:52:50] [ warn] [filter:rewrite_tag:rewrite_tag.2] 'Match' may cause infinite loop.
[2022/02/12 07:52:50] [ info] [sp] stream processor started
==10158== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc8c50
==10158==          to suppress, use: --max-stackframe=10603896 or greater
==10158== Warning: client switching stacks?  SP change: 0x4dc8bc8 --> 0x57e59c8
==10158==          to suppress, use: --max-stackframe=10604032 or greater
==10158== Warning: client switching stacks?  SP change: 0x57e59c8 --> 0x4dc8bc8
==10158==          to suppress, use: --max-stackframe=10604032 or greater
==10158==          further instances of this message will not be shown.
[0] dummy.0: [1644619970.416902397, {"msg"=>"hoge", "_forward"=>"true"}]
[1] dummy.0: [1644619971.404785465, {"msg"=>"hoge", "_forward"=>"true"}]
[2] dummy.0: [1644619972.404963782, {"msg"=>"hoge", "_forward"=>"true"}]
[3] dummy.0: [1644619973.405562415, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1644619970.416902397, {"msg"=>"hoge"}]
[1] _forward.dummy.0: [1644619971.404785465, {"msg"=>"hoge"}]
[2] _forward.dummy.0: [1644619972.404963782, {"msg"=>"hoge"}]
[3] _forward.dummy.0: [1644619973.405562415, {"msg"=>"hoge"}]
^C[2022/02/12 07:52:54] [engine] caught signal (SIGINT)
[0] dummy.0: [1644619974.437828388, {"msg"=>"hoge", "_forward"=>"true"}]
[0] _forward.dummy.0: [1644619974.437828388, {"msg"=>"hoge"}]
[2022/02/12 07:52:54] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/12 07:52:55] [ info] [engine] service has stopped (0 pending tasks)
==10158== 
==10158== HEAP SUMMARY:
==10158==     in use at exit: 0 bytes in 0 blocks
==10158==   total heap usage: 1,814 allocs, 1,814 frees, 2,857,494 bytes allocated
==10158== 
==10158== All heap blocks were freed -- no leaks are possible
==10158== 
==10158== For lists of detected and suppressed errors, rerun with: -s
==10158== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
