### PR TITLE
in_systemd: skip broken entry

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -75,6 +75,7 @@ static int in_systemd_collect(struct flb_input_instance *ins,
     int ret_j;
     int len;
     int entries = 0;
+    int skip_entries = 0;
     int rows = 0;
     time_t sec;
     long nsec;
@@ -202,6 +203,7 @@ static int in_systemd_collect(struct flb_input_instance *ins,
 
         /* Pack every field in the entry */
         entries = 0;
+        skip_entries = 0;
         while (sd_journal_enumerate_data(ctx->j, &data, &length) > 0 &&
                entries < ctx->max_fields) {
             key = (const char *) data;
@@ -210,6 +212,10 @@ static int in_systemd_collect(struct flb_input_instance *ins,
                 length--;
             }
             sep = strchr(key, '=');
+            if (sep == NULL) {
+                skip_entries++;
+                continue;
+            }
             len = (sep - key);
             msgpack_pack_str(&mp_pck, len);
             msgpack_pack_str_body(&mp_pck, key, len);
@@ -226,6 +232,9 @@ static int in_systemd_collect(struct flb_input_instance *ins,
             flb_plg_debug(ctx->ins,
                           "max number of fields is reached: %i; all other "
                           "fields are discarded", ctx->max_fields);
+        }
+        if (skip_entries > 0) {
+            flb_plg_error(ctx->ins, "Skip %d broken entries", skip_entries);
         }
 
         /*


### PR DESCRIPTION
in_systemd expects every entries contain '='.
If it doesn't , fluent-bit will cause SIGSEGV.
https://github.com/fluent/fluent-bit/issues/4407#issuecomment-1037807469

This patch is to mitigate the issue #4407 .
Fluent-bit will skip broken entry and logging.

Currently, we can't reproduce issue since there is no corruped journal log.
I only tested normal case.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

## Configuration

```
[INPUT]
    Name systemd

[OUTPUT]
    Name null
    Match *
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/13 15:09:40] [ info] [engine] started (pid=65093)
[2022/02/13 15:09:40] [ info] [storage] version=1.1.6, initializing...
[2022/02/13 15:09:40] [ info] [storage] in-memory
[2022/02/13 15:09:40] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/13 15:09:40] [ info] [cmetrics] version=0.2.3
[2022/02/13 15:09:40] [ info] [sp] stream processor started
^C[2022/02/13 15:09:44] [engine] caught signal (SIGINT)
[2022/02/13 15:09:44] [ info] [input] pausing systemd.0
[2022/02/13 15:09:44] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/13 15:09:44] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==65096== Memcheck, a memory error detector
==65096== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==65096== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==65096== Command: bin/fluent-bit -c a.conf
==65096== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/13 15:10:06] [ info] [engine] started (pid=65096)
[2022/02/13 15:10:06] [ info] [storage] version=1.1.6, initializing...
[2022/02/13 15:10:06] [ info] [storage] in-memory
[2022/02/13 15:10:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/13 15:10:06] [ info] [cmetrics] version=0.2.3
[2022/02/13 15:10:07] [ info] [sp] stream processor started
^C[2022/02/13 15:10:08] [engine] caught signal (SIGINT)
[2022/02/13 15:10:08] [ info] [input] pausing systemd.0
[2022/02/13 15:10:09] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/13 15:10:10] [ info] [engine] service has stopped (0 pending tasks)
==65096== 
==65096== HEAP SUMMARY:
==65096==     in use at exit: 0 bytes in 0 blocks
==65096==   total heap usage: 1,571 allocs, 1,571 frees, 6,020,358 bytes allocated
==65096== 
==65096== All heap blocks were freed -- no leaks are possible
==65096== 
==65096== For lists of detected and suppressed errors, rerun with: -s
==65096== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
