### PR TITLE
packaging: fix RPM check for fluent bit

### DIFF
--- a/packaging/testing/smoke/packages/test.sh
+++ b/packaging/testing/smoke/packages/test.sh
@@ -7,14 +7,14 @@ if [ "$SKIP_TEST" = "yes" ]; then
 fi
 
 echo "Check package installed"
-rpm -q td-agent-bit || dpkg -l td-agent-bit
+rpm -q fluent-bit || rpm -q td-agent-bit || dpkg -l fluent-bit || dpkg -l td-agent-bit
 
 echo "Check service enabled"
-systemctl is-enabled td-agent-bit
+systemctl is-enabled fluent-bit || systemctl is-enabled td-agent-bit
 
 until systemctl is-system-running; do
     sleep 10
 done
 
 echo "Check service running"
-systemctl status -q --no-pager td-agent-bit
+systemctl status -q --no-pager fluent-bit || systemctl status -q --no-pager td-agent-bit


### PR DESCRIPTION
Now we're building `fluent-bit` and preference is to install that we need to make sure we include it in tests.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
