### PR TITLE
pack: added java_sql_timestamp, a format string used by amazon athena

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -429,10 +429,10 @@ Config maps are an improvement to the previous Fluent Bit API that was used by p
 
 There are various types of supported configuration types. Full list available [here](https://github.com/fluent/fluent-bit/blob/v1.4.2/include/fluent-bit/flb_config_map.h#L29). The most used ones are:
 
-| Type                   | Description           | 
-| -----------------------|:---------------------:| 
-| FLB_CONFIG_MAP_INT     | Represents integer data type | 
-| FLB_CONFIG_MAP_BOOL    | Represents boolean data type | 
+| Type                   | Description           |
+| -----------------------|:---------------------:|
+| FLB_CONFIG_MAP_INT     | Represents integer data type |
+| FLB_CONFIG_MAP_BOOL    | Represents boolean data type |
 | FLB_CONFIG_MAP_DOUBLE  | Represents a double |
 | FLB_CONFIG_MAP_SIZE    | Provides size_type as an integer datatype large enough to represent any possible string size. |
 | FLB_CONFIG_MAP_STR     | Represents string data type |
@@ -441,8 +441,8 @@ There are various types of supported configuration types. Full list available [h
 
 A config map expects certain public fields at registration.
 
-| Public Fields | Description           | 
-| --------------|:---------------------| 
+| Public Fields | Description           |
+| --------------|:---------------------|
 | Type          | This field is the data type of the property that we are writing to the config map. If the property is of type `int` we use `FLB_CONFIG_MAP_INT`, if `string` `FLB_CONFIG_MAP_STR` etc. |
 | Name          | This field is the name of the configuration property. For example for the property flush count we use `flush_count`|
 | Default Value | This field allows the user to set the default value of the property. For example, for a property of type `FLB_CONFIG_MAP_BOOL` (boolean), the default value may be false. Then we have to give `false` as default value. If there is no default value, `NULL` is given.|
@@ -469,7 +469,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",
      0, FLB_TRUE, offsetof(struct flb_stdout, json_date_key),
-     "Specifies the format of the date. Supported formats are double,  iso8601 and epoch."
+     "Specifies the format of the date. Supported formats are double,  iso8601, java_sql_timestamp and epoch."
     },
 
     /* EOF */

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -35,12 +35,16 @@
 #define FLB_PACK_JSON_PRIMITIVE     JSMN_PRIMITIVE
 
 /* Date formats */
-#define FLB_PACK_JSON_DATE_DOUBLE   0
-#define FLB_PACK_JSON_DATE_ISO8601  1
-#define FLB_PACK_JSON_DATE_EPOCH    2
+#define FLB_PACK_JSON_DATE_DOUBLE                0
+#define FLB_PACK_JSON_DATE_ISO8601               1
+#define FLB_PACK_JSON_DATE_EPOCH                 2
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP    3
 
 /* Specific ISO8601 format */
 #define FLB_PACK_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
+/* Specific Java SQL Timestamp format */
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT "%Y-%m-%d %H:%M:%S"
 
 /* JSON formats (modes) */
 #define FLB_PACK_JSON_FORMAT_NONE        0

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -46,6 +46,12 @@
 /* Specific Java SQL Timestamp format */
 #define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT "%Y-%m-%d %H:%M:%S"
 
+#define FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION   "Specify the format of the date, " \
+    "supported formats: double, " \
+     "iso8601 (e.g: 2018-05-30T09:39:52.000681Z), " \
+     "java_sql_timestamp (e.g: 2018-05-30 09:39:52.000681, useful for AWS Athena), "\
+     "and epoch."
+
 /* JSON formats (modes) */
 #define FLB_PACK_JSON_FORMAT_NONE        0
 #define FLB_PACK_JSON_FORMAT_JSON        1

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -390,7 +390,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_format", NULL,
      0, FLB_FALSE, 0,
-     "Specify the format of the date. Supported formats are 'double' and 'iso8601'"
+     FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION
     },
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",

--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -146,7 +146,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",
      0, FLB_TRUE, offsetof(struct flb_null, json_date_key),
-    "Specifies the format of the date. Supported formats are double, iso8601 and epoch."
+    FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -146,7 +146,7 @@ static int create_headers(struct flb_s3 *ctx, char *body_md5, struct flb_aws_hea
         *headers = s3_headers;
         return 0;
     }
-    
+
     s3_headers = flb_malloc(sizeof(struct flb_aws_header) * headers_len);
     if (s3_headers == NULL) {
         flb_errno();
@@ -174,7 +174,7 @@ static int create_headers(struct flb_s3 *ctx, char *body_md5, struct flb_aws_hea
         s3_headers[n].val = body_md5;
         s3_headers[n].val_len = strlen(body_md5);
     }
-    
+
     *num_headers = headers_len;
     *headers = s3_headers;
     return 0;
@@ -374,7 +374,7 @@ static int init_seq_index(void *context) {
             flb_plg_error(ctx->ins, "Failed to write to sequential index metadata file");
             return -1;
         }
-    } 
+    }
     else {
         ret = read_seq_index(ctx->seq_index_file, &ctx->seq_index);
         if (ret < 0) {
@@ -725,7 +725,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
     tmp = flb_output_get_property("compression", ins);
     if (tmp) {
         if (ctx->use_put_object == FLB_FALSE) {
-            flb_plg_error(ctx->ins, 
+            flb_plg_error(ctx->ins,
                           "use_put_object must be enabled when compression is enabled");
             return -1;
         }
@@ -1366,7 +1366,7 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
             return -1;
         }
     }
-    
+
     s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
         c = mock_s3_call("TEST_PUT_OBJECT_ERROR", "PutObject");
@@ -1872,7 +1872,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
     }
 
     msgpack_unpacked_init(&result);
-    while (!alloc_error && 
+    while (!alloc_error &&
            msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         /* Each array must have two entries: time and record */
         root = result.data;
@@ -1914,7 +1914,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
                 if (strncmp(ctx->log_key, key_str, key_str_size) == 0) {
                     found = FLB_TRUE;
 
-                    /* 
+                    /*
                      * Copy contents of value into buffer. Necessary to copy
                      * strings because flb_msgpack_to_json does not handle nested
                      * JSON gracefully and double escapes them.
@@ -1932,7 +1932,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
                         val_offset++;
                     }
                     else {
-                        ret = flb_msgpack_to_json(val_buf + val_offset, 
+                        ret = flb_msgpack_to_json(val_buf + val_offset,
                                                   msgpack_size - val_offset, &val);
                         if (ret < 0) {
                             break;
@@ -1955,7 +1955,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
 
     /* Throw error once per chunk if at least one log key was not found */
     if (log_key_missing == FLB_TRUE) {
-        flb_plg_error(ctx->ins, "Could not find log_key '%s' in %d records", 
+        flb_plg_error(ctx->ins, "Could not find log_key '%s' in %d records",
                       ctx->log_key, log_key_missing);
     }
 
@@ -2241,7 +2241,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_format", NULL,
      0, FLB_FALSE, 0,
-    "Specifies the format of the date. Supported formats are double, iso8601 and epoch."
+    FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION
     },
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -209,7 +209,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_format", NULL,
      0, FLB_FALSE, 0,
-    "Specifies the format of the date. Supported formats are double, iso8601 and epoch."
+    FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION
     },
     {
      FLB_CONFIG_MAP_STR, "json_date_key", "date",

--- a/plugins/out_tcp/tcp.c
+++ b/plugins/out_tcp/tcp.c
@@ -124,8 +124,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "json_date_format", "double",
      0, FLB_FALSE, 0,
-     "Specify the format of the date, supported formats: double, iso8601 "
-     "(e.g: 2018-05-30T09:39:52.000681Z) and epoch."
+     FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION
     },
 
     {


### PR DESCRIPTION
<!-- Provide summary of changes -->

    This commit adds a new timestamp format, the java_sql_timestamp,
    which is very similar to iso8601, except that it has a space instead
    of a T between the date and the hour and does not end with Z
    (or any other timestamp delimiter)

    This is the format: "%Y-%m-%d %H:%M:%S"

    This is unfortunately the only format accepted by Amazon Athena.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature 

https://github.com/fluent/fluent-bit-docs/pull/708


<!--  Doc PR (not required but highly recommended) -->


**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.
https://github.com/fluent/fluent-bit/pull/4822


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
This PR will break https://github.com/fluent/fluent-bit/pull/4131, but I can adopt it if this one gets merged before

**Example Configuration snippet**
```
[INPUT]
    name              dummy
    Samples           1

[OUTPUT]
    name  stdout
    match *
    Format json
    json_date_key date
    json_date_format java_sql_timestamp
```

**Debug log output from testing the change**

```
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/14 10:22:59] [ info] [engine] started (pid=542166)
[2022/02/14 10:22:59] [ info] [storage] version=1.1.6, initializing...
[2022/02/14 10:22:59] [ info] [storage] in-memory
[2022/02/14 10:22:59] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/14 10:22:59] [ info] [cmetrics] version=0.2.3
[2022/02/14 10:22:59] [ info] [sp] stream processor started
[{"date":"2022-02-14 13:22:59.927113","message":"dummy"}]

```

**valgrind**
```
==542169== Memcheck, a memory error detector
==542169== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==542169== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==542169== Command: bin/fluent-bit -c test.conf
==542169==
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/14 10:24:19] [ info] [engine] started (pid=542169)
[2022/02/14 10:24:19] [ info] [storage] version=1.1.6, initializing...
[2022/02/14 10:24:19] [ info] [storage] in-memory
[2022/02/14 10:24:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/14 10:24:19] [ info] [cmetrics] version=0.2.3
[2022/02/14 10:24:19] [ info] [sp] stream processor started
[{"date":"2022-02-14 13:24:19.925510","message":"dummy"}]
^C[2022/02/14 10:24:25] [engine] caught signal (SIGINT)
[2022/02/14 10:24:25] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/14 10:24:25] [ info] [engine] service has stopped (0 pending tasks)
==542169==
==542169== HEAP SUMMARY:
==542169==     in use at exit: 0 bytes in 0 blocks
==542169==   total heap usage: 2,976 allocs, 2,976 frees, 804,426 bytes allocated
==542169==
==542169== All heap blocks were freed -- no leaks are possible
==542169==
==542169== For lists of detected and suppressed errors, rerun with: -s
==542169== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
