### PR TITLE
packaging: fix syntax error in AL2 test

### DIFF
--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -25,7 +25,7 @@ ENV STAGING_VERSION=${STAGING_VERSION}
 RUN rpm --import "$AWS_URL/fluentbit.key" && \
     wget -q "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo && \
     yum update -y && yum install -y fluent-bit && \
-    systemctl fluent-bit
+    systemctl enable fluent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh


### PR DESCRIPTION
Resolves syntax error in AL2 test case.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

Ran `PACKAGE_TEST=amazonlinux2 ./packaging/testing/smoke/packages/run-package-tests.sh` to confirm.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
