### PR TITLE
out_stackdriver: check for proper http request key

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1980,8 +1980,10 @@ static int stackdriver_format(struct flb_config *config,
         /* Extract httpRequest */
         init_http_request(&http_request);
         http_request_extra_size = 0;
-        http_request_extracted = extract_http_request(&http_request, obj,
-                                                      &http_request_extra_size);
+        http_request_extracted = extract_http_request(&http_request, 
+                                                      ctx->http_request_key,
+                                                      ctx->http_request_key_size,
+                                                      obj, &http_request_extra_size);
         if (http_request_extracted == FLB_TRUE) {
             entry_size += 1;
         }

--- a/plugins/out_stackdriver/stackdriver_http_request.c
+++ b/plugins/out_stackdriver/stackdriver_http_request.c
@@ -231,6 +231,8 @@ static void validate_latency(msgpack_object_str latency_in_payload,
 
 /* Return true if httpRequest extracted */
 int extract_http_request(struct http_request_field *http_request,
+                         flb_sds_t http_request_key,
+                         int http_request_key_size,
                          msgpack_object *obj, int *extra_subfields)
 {
     http_request_status op_status = NO_HTTPREQUEST;
@@ -249,8 +251,8 @@ int extract_http_request(struct http_request_field *http_request,
     for (; p < pend && op_status == NO_HTTPREQUEST; ++p) {
 
         if (p->val.type != MSGPACK_OBJECT_MAP
-            || !validate_key(p->key, HTTPREQUEST_FIELD_IN_JSON,
-                             HTTP_REQUEST_KEY_SIZE)) {
+            || !validate_key(p->key, http_request_key,
+                             http_request_key_size)) {
 
             continue;
         }

--- a/plugins/out_stackdriver/stackdriver_http_request.h
+++ b/plugins/out_stackdriver/stackdriver_http_request.h
@@ -91,7 +91,9 @@ void add_http_request_field(struct http_request_field *http_request,
  *  If the httpRequest field exists, return TRUE and store the subfields.
  *  If there are extra subfields, count the number.
  */
-int extract_http_request(struct http_request_field *http_request, 
+int extract_http_request(struct http_request_field *http_request,
+                         flb_sds_t http_request_key,
+                         int http_request_key_size,
                          msgpack_object *obj, int *extra_subfields);
 
 /*


### PR DESCRIPTION
<!-- Provide summary of changes -->
1.8 backport of #4770. Description from that PR:
The extract_http_request function did not previously respect the http_request_key if it was specified in the config. Pass in the http request key and size to the function as arguments and check for that instead.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
