### PR TITLE
workflows: yaml build support

### DIFF
--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -34,6 +34,7 @@ RUN apt-get update && \
     flex \
     bison \
     openssl \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && c_rehash \
@@ -94,6 +95,7 @@ RUN apt-get update && \
       ca-certificates \
       libatomic1 \
       libgcrypt20 \
+      libyaml-0-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -34,6 +34,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
@@ -89,6 +90,9 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libz* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/libz* /lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
+
+# YAML stuff
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libyaml* /usr/lib/aarch64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libsystemd* /usr/lib/aarch64-linux-gnu/

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -49,6 +49,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
@@ -121,6 +122,7 @@ RUN apt-get update && \
         libgmp10 \
         libffi7 \
         liblzma5 && \
+        libyaml-dev \
     mkdir -p /dpkg && \
     for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
 
@@ -173,6 +175,7 @@ RUN apt-get update && \
         ca-certificates \
         libatomic1 \
         libgcrypt20 \
+        libyaml \
         bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -122,7 +122,7 @@ RUN apt-get update && \
         libgmp10 \
         libffi7 \
         liblzma5 && \
-        libyaml-dev \
+        libyaml-0-2 \
     mkdir -p /dpkg && \
     for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
 
@@ -175,7 +175,7 @@ RUN apt-get update && \
         ca-certificates \
         libatomic1 \
         libgcrypt20 \
-        libyaml \
+        libyaml-0-2 \
         bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -31,6 +31,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
@@ -88,6 +89,9 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+
+# YAML stuff
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libyaml* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/

--- a/dockerfiles/Dockerfile.x86_64-debug
+++ b/dockerfiles/Dockerfile.x86_64-debug
@@ -31,6 +31,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
@@ -89,6 +90,7 @@ RUN apt-get update && \
       ca-certificates \
       libatomic1 \
       libgcrypt20 \
+      libyaml \
       bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.x86_64-master
+++ b/dockerfiles/Dockerfile.x86_64-master
@@ -22,6 +22,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -67,6 +68,9 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+
+# YAML stuff
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libyaml* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/

--- a/dockerfiles/Dockerfile.x86_64-master_debug
+++ b/dockerfiles/Dockerfile.x86_64-master_debug
@@ -22,6 +22,7 @@ RUN apt-get update && \
     postgresql-server-dev-all \
     flex \
     bison \
+    libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -69,6 +70,7 @@ RUN apt-get update && \
       ca-certificates \
       libatomic1 \
       libgcrypt20 \
+      libyaml \
       bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update && \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
                    postgresql-devel postgresql-libs \
-                   cmake3 && \
+                   cmake3 libyaml-devel && \
     yum clean all
 
 # amazonlinux/2.arm64v8 base image
@@ -32,7 +32,7 @@ RUN yum -y update && \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
                    postgresql-devel postgresql-libs \
-                   cmake3 && \
+                   cmake3 libyaml-devel && \
     yum clean all
 
 # Common build for all distributions now

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -53,6 +53,9 @@ FROM centos:8 as centos-8-base
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
+
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
@@ -72,6 +75,9 @@ COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
 # CentOS is now EOL so have to use the vault repos
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
 
 # hadolint ignore=DL3033
 RUN yum -y update && \

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -17,7 +17,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
-                   postgresql-libs postgresql-devel postgresql-server postgresql && \
+                   postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3 && \
@@ -36,7 +36,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib openssl openss-libs openssl-devel \
-                   postgresql-libs postgresql-devel postgresql-server postgresql && \
+                   postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3 && \
@@ -58,7 +58,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    postgresql-libs postgresql-devel postgresql-server postgresql \
-                   cyrus-sasl-lib openssl openssl-libs openssl-devel && \
+                   cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -78,7 +78,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    postgresql-libs postgresql-devel postgresql-server postgresql \
-                   cyrus-sasl-lib openssl openssl-libs openssl-devel && \
+                   cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On

--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # debian/buster.arm64v8 base image
@@ -34,7 +34,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # debian/bullseye base image
@@ -47,7 +47,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # debian/bullseye.arm64v8 base image
@@ -62,7 +62,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
@@ -32,7 +32,7 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev && \
+                           libsasl2-2 libsasl2-dev libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev cmake \
     make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all software-properties-common \
-    software-properties-common \
+    software-properties-common libyaml-dev \
     apt-transport-https ca-certificates && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
          gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
@@ -38,7 +38,7 @@ RUN apt-get -qq update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common \
+    software-properties-common libyaml-dev \
     apt-transport-https ca-certificates && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
          gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common \
+    software-properties-common libyaml-dev \
     apt-transport-https ca-certificates && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
          gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
@@ -75,7 +75,7 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # ubuntu/20.04.arm64v8 base image
@@ -89,7 +89,7 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/local-build-all.sh
+++ b/packaging/local-build-all.sh
@@ -15,10 +15,10 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 #
 
 # Ensure this is updated for new targets
-declare -a TARGETS=("centos/7" "centos/7.arm64v8" "centos/8" "centos/8.arm64v8"
-"debian/buster" "debian/buster.arm64v8" "debian/bullseye" "debian/bullseye.arm64v8"
-"raspbian/buster" "raspbian/bullseye"
-"ubuntu/16.04" "ubuntu/18.04" "ubuntu/18.04.arm64v8" "ubuntu/20.04" "ubuntu/20.04.arm64v8"
+# We do the arm64 targets at the end as ideally the amd64 ones trigger any issues with dependencies.
+declare -a TARGETS=("centos/7" "centos/8"
+"debian/buster" "debian/bullseye" "raspbian/buster" "raspbian/bullseye" "ubuntu/16.04" "ubuntu/18.04" "ubuntu/20.04"
+"centos/7.arm64v8" "centos/8.arm64v8" "debian/buster.arm64v8" "debian/bullseye.arm64v8" "ubuntu/18.04.arm64v8" "ubuntu/20.04.arm64v8"
 )
 
 # Output checks are easier plus do not want to fill up git

--- a/packaging/local-build-all.sh
+++ b/packaging/local-build-all.sh
@@ -16,9 +16,9 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Ensure this is updated for new targets
 # We do the arm64 targets at the end as ideally the amd64 ones trigger any issues with dependencies.
-declare -a TARGETS=("centos/7" "centos/8"
-"debian/buster" "debian/bullseye" "raspbian/buster" "raspbian/bullseye" "ubuntu/16.04" "ubuntu/18.04" "ubuntu/20.04"
-"centos/7.arm64v8" "centos/8.arm64v8" "debian/buster.arm64v8" "debian/bullseye.arm64v8" "ubuntu/18.04.arm64v8" "ubuntu/20.04.arm64v8"
+declare -a TARGETS=("amazonlinux/2"
+"centos/7" "centos/8" "debian/buster" "debian/bullseye" "raspbian/buster" "raspbian/bullseye" "ubuntu/16.04" "ubuntu/18.04" "ubuntu/20.04"
+"amazonlinux/2.arm64v8" "centos/7.arm64v8" "centos/8.arm64v8" "debian/buster.arm64v8" "debian/bullseye.arm64v8" "ubuntu/18.04.arm64v8" "ubuntu/20.04.arm64v8"
 )
 
 # Output checks are easier plus do not want to fill up git

--- a/packaging/testing/smoke/container/container-smoke-test.sh
+++ b/packaging/testing/smoke/container/container-smoke-test.sh
@@ -28,38 +28,51 @@ IMAGE_TAG=${IMAGE_TAG:-latest}
 # Remove any existing container
 docker rm -f "$CONTAINER_NAME"
 
-# Run up the container
-docker run --name "$CONTAINER_NAME" -d \
-    --platform "$CONTAINER_ARCH" \
-    --pull=always \
-    --publish-all \
-    --restart=no \
-    -v "$SCRIPT_DIR/fluent-bit.conf":/fluent-bit/etc/fluent-bit.conf:ro \
-    "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+# Repeat for YAML and legacy config
+declare -a CONFIG_FILES=("fluent-bit.conf" "fluent-bit.yaml")
 
-# Get debug details
-docker image inspect "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+for CONFIG_FILE in "${CONFIG_FILES[@]}"
+do
+    if [[ ! -f "$SCRIPT_DIR/$CONFIG_FILE" ]]; then
+        echo "Missing config file: $SCRIPT_DIR/$CONFIG_FILE"
+        exit 1
+    fi
 
-# Stream the logs live
-docker logs -f "$CONTAINER_NAME" &
+    echo "Testing: $CONFIG_FILE"
 
-# # Wait for the container to start up as we have to pull it
-until [[ $(docker ps --filter "status=running" --filter "name=$CONTAINER_NAME" --quiet | wc -l) -gt 0 ]] ; do
-    sleep 2
+    # Run up the container
+    docker run --name "$CONTAINER_NAME" -d \
+        --platform "$CONTAINER_ARCH" \
+        --pull=always \
+        --publish-all \
+        --restart=no \
+        -v "$SCRIPT_DIR/$CONFIG_FILE":"/fluent-bit/etc/$CONFIG_FILE":ro \
+        "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+
+    # Get debug details
+    docker image inspect "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+
+    # Stream the logs live
+    docker logs -f "$CONTAINER_NAME" &
+
+    # # Wait for the container to start up as we have to pull it
+    until [[ $(docker ps --filter "status=running" --filter "name=$CONTAINER_NAME" --quiet | wc -l) -gt 0 ]] ; do
+        sleep 2
+    done
+    docker ps
+    # Grab the ephemeral port
+    docker container inspect "$CONTAINER_NAME"
+    LOCAL_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "2020/tcp") 0).HostPort}}' "$CONTAINER_NAME")
+    # Allow to run for a bit
+    sleep 60
+    docker ps
+    docker logs "$CONTAINER_NAME"
+    # Check we are still ok
+    curl -v localhost:"$LOCAL_PORT"                 | jq
+    curl -v localhost:"$LOCAL_PORT"/api/v1/metrics  | jq
+    curl -v localhost:"$LOCAL_PORT"/api/v1/uptime   | jq
+    curl -v localhost:"$LOCAL_PORT"/api/v1/health
+
+    # Clean up
+    docker stop "$CONTAINER_NAME"
 done
-docker ps
-# Grab the ephemeral port
-docker container inspect "$CONTAINER_NAME"
-LOCAL_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "2020/tcp") 0).HostPort}}' "$CONTAINER_NAME")
-# Allow to run for a bit
-sleep 60
-docker ps
-docker logs "$CONTAINER_NAME"
-# Check we are still ok
-curl -v localhost:"$LOCAL_PORT"                 | jq
-curl -v localhost:"$LOCAL_PORT"/api/v1/metrics  | jq
-curl -v localhost:"$LOCAL_PORT"/api/v1/uptime   | jq
-curl -v localhost:"$LOCAL_PORT"/api/v1/health
-
-# Clean up
-docker stop "$CONTAINER_NAME"

--- a/packaging/testing/smoke/container/container-smoke-test.sh
+++ b/packaging/testing/smoke/container/container-smoke-test.sh
@@ -28,7 +28,7 @@ IMAGE_TAG=${IMAGE_TAG:-latest}
 # Remove any existing container
 docker rm -f "$CONTAINER_NAME"
 
-# Repeat for YAML and legacy config
+# Repeat for YAML and legacy config - note the config file extension is important for format detection
 declare -a CONFIG_FILES=("fluent-bit.conf" "fluent-bit.yaml")
 
 for CONFIG_FILE in "${CONFIG_FILES[@]}"
@@ -47,7 +47,8 @@ do
         --publish-all \
         --restart=no \
         -v "$SCRIPT_DIR/$CONFIG_FILE":"/fluent-bit/etc/$CONFIG_FILE":ro \
-        "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"
+        "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG" \
+        "/fluent-bit/bin/fluent-bit" "-c" "/fluent-bit/etc/$CONFIG_FILE"
 
     # Get debug details
     docker image inspect "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"

--- a/packaging/testing/smoke/container/fluent-bit.yaml
+++ b/packaging/testing/smoke/container/fluent-bit.yaml
@@ -1,3 +1,4 @@
+# Translated according to https://github.com/fluent/fluent-bit/pull/4621
 service:
     http_server: on
     Health_Check: on

--- a/packaging/testing/smoke/container/fluent-bit.yaml
+++ b/packaging/testing/smoke/container/fluent-bit.yaml
@@ -5,6 +5,7 @@ service:
 pipeline:
     inputs:
         cpu:
+          tag: input
     outputs:
         stdout:
             match: '*'

--- a/packaging/testing/smoke/container/fluent-bit.yaml
+++ b/packaging/testing/smoke/container/fluent-bit.yaml
@@ -1,0 +1,10 @@
+service:
+    http_server: on
+    Health_Check: on
+
+pipeline:
+    inputs:
+        cpu:
+    outputs:
+        stdout:
+            match: '*'

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -2,6 +2,7 @@
 ARG STAGING_BASE=dokken/centos-7
 
 FROM dokken/centos-7 as official-install
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Use the one-line install
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 RUN systemctl enable fluent-bit || systemctl enable td-agent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -2,18 +2,15 @@
 ARG STAGING_BASE=dokken/centos-7
 
 FROM dokken/centos-7 as official-install
-ARG RELEASE_URL
-RUN rpm --import $RELEASE_URL/fluentbit.key
-RUN echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/centos/7/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo
-# hadolint ignore=DL3032
-RUN yum update -y && yum install -y td-agent-bit
-RUN systemctl enable td-agent-bit
+# Use the one-line install
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 
 FROM official-install as staging-upgrade-prep
-RUN rm -f /etc/yum.repos.d/td-agent-bit.repo
+RUN rm -f /etc/yum.repos.d/*-bit.repo
 
 FROM ${STAGING_BASE} as staging-install
 ARG AWS_URL

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -2,11 +2,9 @@
 ARG STAGING_BASE=dokken/ubuntu-20.04
 
 FROM dokken/ubuntu-20.04 as official-install
-ARG RELEASE_URL
-RUN wget -qO - $RELEASE_URL/fluentbit.key | apt-key add -
-RUN echo "deb $RELEASE_URL/ubuntu/focal focal main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y td-agent-bit
-RUN systemctl enable td-agent-bit
+# Use the one-line install
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -2,6 +2,7 @@
 ARG STAGING_BASE=dokken/ubuntu-20.04
 
 FROM dokken/ubuntu-20.04 as official-install
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Use the one-line install
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 RUN systemctl enable fluent-bit || systemctl enable td-agent-bit


### PR DESCRIPTION
Add YAML support to build and runtime to ensure we provide #4690

Built and tested AMD64 container locally:
```
$ docker build -t test -f dockerfiles/Dockerfile.x86_64-master .
...
$ docker run --rm -it -v $PWD/packaging/testing/smoke/container/fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml test /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/14 17:46:28] [ info] [engine] started (pid=1)
[2022/02/14 17:46:28] [ info] [storage] version=1.1.6, initializing...
[2022/02/14 17:46:28] [ info] [storage] in-memory
[2022/02/14 17:46:28] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/14 17:46:28] [ info] [cmetrics] version=0.2.3
[2022/02/14 17:46:28] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2022/02/14 17:46:28] [ info] [sp] stream processor started
[0] input: [1644860788.889459285, {"cpu_p"=>1.750000, "user_p"=>1.250000, "system_p"=>0.500000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>2.000000, "cpu1.p_user"=>1.000000, "cpu1.p_system"=>1.000000, "cpu2.p_cpu"=>3.000000, "cpu2.p_user"=>3.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>0.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>0.000000, "cpu4.p_cpu"=>0.000000, "cpu4.p_user"=>0.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>1.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>1.000000, "cpu6.p_cpu"=>3.000000, "cpu6.p_user"=>3.000000, "cpu6.p_system"=>0.000000, "cpu7.p_cpu"=>1.000000, "cpu7.p_user"=>1.000000, "cpu7.p_system"=>0.000000, "cpu8.p_cpu"=>3.000000, "cpu8.p_user"=>2.000000, "cpu8.p_system"=>1.000000, "cpu9.p_cpu"=>2.000000, "cpu9.p_user"=>1.000000, "cpu9.p_system"=>1.000000, "cpu10.p_cpu"=>1.000000, "cpu10.p_user"=>1.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>1.000000, "cpu11.p_user"=>1.000000, "cpu11.p_system"=>0.000000, "cpu12.p_cpu"=>2.000000, "cpu12.p_user"=>1.000000, "cpu12.p_system"=>1.000000, "cpu13.p_cpu"=>2.000000, "cpu13.p_user"=>2.000000, "cpu13.p_system"=>0.000000, "cpu14.p_cpu"=>2.000000, "cpu14.p_user"=>1.000000, "cpu14.p_system"=>1.000000, "cpu15.p_cpu"=>4.000000, "cpu15.p_user"=>3.000000, "cpu15.p_system"=>1.000000}]
...
```
Also built the multi-arch container (for the AMD64 target only):
```
$ docker build -t test-multiarch -f dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/master.tar.gz .
...
$ docker run --rm -it -v $PWD/packaging/testing/smoke/container/fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml test-multiarch /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
```

Ran local packaging tests as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
