### PR TITLE
1.8: bin: fix wrong host header when using proxy

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -66,7 +66,11 @@ int flb_http_strip_port_from_host(struct flb_http_client *c)
     struct flb_upstream *u = c->u_conn->u;
 
     if (!c->host) {
-        out_host = u->tcp_host;
+        if (!u->proxied_host) {
+            out_host = u->tcp_host;
+        } else {
+            out_host = u->proxied_host;
+        }
     } else {
         out_host = (char *) c->host;
     }


### PR DESCRIPTION
When the Host header isn't the target host (elastic-cluster) but instead the proxy-host the AWS signature
signing in src/flb_signv4.c 's flb_signv4_canonical_request() will create a signature which will not match the expected values from AWS. Which will result in the following error message: `User is not authorized to perform this action` from AWS

Signed-off-by: Hannes Doyle (marulkan) <marulkan@dev0.nu>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
