### PR TITLE
out_prometheus_exporter: add new option 'add_timestamp', disabled by default

### DIFF
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -172,6 +172,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
                           struct flb_config *config)
 {
     int ret;
+    int add_ts;
     size_t off = 0;
     flb_sds_t metrics;
     cmt_sds_t text;
@@ -193,8 +194,16 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     /* append labels set by config */
     append_labels(ctx, cmt);
 
+    /* add timestamp in the output format ? */
+    if (ctx->add_timestamp) {
+        add_ts = CMT_TRUE;
+    }
+    else {
+        add_ts = CMT_FALSE;
+    }
+
     /* convert to text representation */
-    text = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    text = cmt_encode_prometheus_create(cmt, add_ts);
     if (!text) {
         cmt_destroy(cmt);
         FLB_OUTPUT_RETURN(FLB_ERROR);
@@ -260,6 +269,12 @@ static int cb_prom_exit(void *data, struct flb_config *config)
 
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_BOOL, "add_timestamp", "false",
+     0, FLB_TRUE, offsetof(struct prom_exporter, add_timestamp),
+     "Add timestamp to every metric honoring collection time."
+    },
+
     {
      FLB_CONFIG_MAP_SLIST_1, "add_label", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct prom_exporter, add_labels),

--- a/plugins/out_prometheus_exporter/prom.h
+++ b/plugins/out_prometheus_exporter/prom.h
@@ -30,6 +30,9 @@ struct prom_exporter {
     /* hash table for metrics reported */
     struct flb_hash *ht_metrics;
 
+    /* add timestamp to every metric */
+    int add_timestamp;
+
     /* config reader for 'add_label' */
     struct mk_list *add_labels;
 


### PR DESCRIPTION
The following patch adds a new option called 'add_timestamp' that allows the user to specify if every metric should be formatted with a timestamp or not, note that this timestamp is optional for Prometheus clients, on that case the value is set by the client.

This patch also changes the default behavior since timestamp was always included, now we are changing it to behave as more exporters do.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
