### PR TITLE
1.8: pack: added java_sql_timestamp, a format string used by amazon athena 

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -36,12 +36,16 @@
 #define FLB_PACK_JSON_PRIMITIVE     JSMN_PRIMITIVE
 
 /* Date formats */
-#define FLB_PACK_JSON_DATE_DOUBLE   0
-#define FLB_PACK_JSON_DATE_ISO8601  1
-#define FLB_PACK_JSON_DATE_EPOCH    2
+#define FLB_PACK_JSON_DATE_DOUBLE                0
+#define FLB_PACK_JSON_DATE_ISO8601               1
+#define FLB_PACK_JSON_DATE_EPOCH                 2
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP    3
 
 /* Specific ISO8601 format */
 #define FLB_PACK_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
+/* Specific Java SQL Timestamp format */
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT "%Y-%m-%d %H:%M:%S"
 
 /* JSON formats (modes) */
 #define FLB_PACK_JSON_FORMAT_NONE        0

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -774,6 +774,9 @@ int flb_pack_to_json_date_type(const char *str)
     if (strcasecmp(str, "double") == 0) {
         return FLB_PACK_JSON_DATE_DOUBLE;
     }
+    else if (strcasecmp(str, "java_sql_timestamp") == 0) {
+        return FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP;
+    }
     else if (strcasecmp(str, "iso8601") == 0) {
         return FLB_PACK_JSON_DATE_ISO8601;
     }
@@ -882,6 +885,20 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
             switch (date_format) {
             case FLB_PACK_JSON_DATE_DOUBLE:
                 msgpack_pack_double(&tmp_pck, flb_time_to_double(&tms));
+                break;
+            case FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP:
+            /* Format the time, use microsecond precision not nanoseconds */
+                gmtime_r(&tms.tm.tv_sec, &tm);
+                s = strftime(time_formatted, sizeof(time_formatted) - 1,
+                             FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT, &tm);
+
+                len = snprintf(time_formatted + s,
+                               sizeof(time_formatted) - 1 - s,
+                               ".%06" PRIu64,
+                               (uint64_t) tms.tm.tv_nsec / 1000);
+                s += len;
+                msgpack_pack_str(&tmp_pck, s);
+                msgpack_pack_str_body(&tmp_pck, time_formatted, s);
                 break;
             case FLB_PACK_JSON_DATE_ISO8601:
             /* Format the time, use microsecond precision not nanoseconds */


### PR DESCRIPTION
This is the 1.8 backport of #4811

To keep things simpler, I only cherry-picked the first commit, so the refactoring part won't get back ported. All the info (example configuraton, etc) from this PR is the same as the original one.

Just like the other commit, https://github.com/fluent/fluent-bit-docs/pull/708 is the documentation that should be merged as well.

<!-- Provide summary of changes -->



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ X] Example configuration file for the change
- [X ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X ] Backport to latest stable release.


**Debug log output from testing the change**

```
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/14 19:12:17] [Warning] [config] I cannot open /mnt/extra/u/rootfs/home/ubuntu/code/fluent-bit/build/plugins.conf file
[2022/02/14 19:12:17] [ info] [engine] started (pid=561691)
[2022/02/14 19:12:17] [ info] [storage] version=1.1.6, initializing...
[2022/02/14 19:12:17] [ info] [storage] in-memory
[2022/02/14 19:12:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/14 19:12:17] [ info] [cmetrics] version=0.2.2
[2022/02/14 19:12:17] [ info] [sp] stream processor started
[{"date":"2022-02-14 22:12:18.183701","message":"dummy"}]
```

**valgrind***

```
==561694== Memcheck, a memory error detector
==561694== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==561694== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==561694== Command: ./fluent-bit -c ../test.conf
==561694==
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/14 19:12:31] [Warning] [config] I cannot open /mnt/extra/u/rootfs/home/ubuntu/code/fluent-bit/build/plugins.conf file
[2022/02/14 19:12:31] [ info] [engine] started (pid=561694)
[2022/02/14 19:12:31] [ info] [storage] version=1.1.6, initializing...
[2022/02/14 19:12:31] [ info] [storage] in-memory
[2022/02/14 19:12:31] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/14 19:12:31] [ info] [cmetrics] version=0.2.2
[2022/02/14 19:12:31] [ info] [sp] stream processor started
[{"date":"2022-02-14 22:12:32.189422","message":"dummy"}]
^C[2022/02/14 19:12:37] [engine] caught signal (SIGINT)
[2022/02/14 19:12:37] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/14 19:12:38] [ info] [engine] service has stopped (0 pending tasks)
==561694==
==561694== HEAP SUMMARY:
==561694==     in use at exit: 0 bytes in 0 blocks
==561694==   total heap usage: 3,247 allocs, 3,247 frees, 806,504 bytes allocated
==561694==
==561694== All heap blocks were freed -- no leaks are possible
==561694==
==561694== For lists of detected and suppressed errors, rerun with: -s
==561694== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
