### PR TITLE
metrics: initialize input, filter and output metrics to zero

### DIFF
--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -369,6 +369,7 @@ const char *flb_filter_name(struct flb_filter_instance *ins)
 int flb_filter_init_all(struct flb_config *config)
 {
     int ret;
+    uint64_t ts;
     char *name;
     struct mk_list *tmp;
     struct mk_list *head;
@@ -398,6 +399,7 @@ int flb_filter_init_all(struct flb_config *config)
 
         /* Get name or alias for the instance */
         name = (char *) flb_filter_name(ins);
+        ts = cmt_time_now();
 
         /* CMetrics */
         ins->cmt = cmt_create();
@@ -413,6 +415,7 @@ int flb_filter_init_all(struct flb_config *config)
                                                   "add_records_total",
                                                   "Total number of new added records.",
                                                   1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_add_records, ts, 0, 1, (char *[]) {name});
 
         /* Register generic filter plugin metrics */
         ins->cmt_drop_records = cmt_counter_create(ins->cmt,
@@ -420,6 +423,8 @@ int flb_filter_init_all(struct flb_config *config)
                                                   "drop_records_total",
                                                   "Total number of dropped records.",
                                                   1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_drop_records, ts, 0, 1, (char *[]) {name});
+
         /* OLD Metrics API */
 #ifdef FLB_HAVE_METRICS
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -475,9 +475,6 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                             struct flb_config *config)
 {
     int ret;
-#ifdef FLB_HAVE_METRICS
-    const char *name;
-#endif
     struct mk_list *config_map;
     struct flb_input_plugin *p = ins->p;
 
@@ -489,6 +486,13 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     if (!p) {
         return 0;
     }
+
+#ifdef FLB_HAVE_METRICS
+    uint64_t ts;
+    char *name;
+
+    name = (char *) flb_input_name(ins);
+    ts = cmt_time_now();
 
     /* CMetrics */
     ins->cmt = cmt_create();
@@ -503,17 +507,15 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                                         "fluentbit", "input", "bytes_total",
                                         "Number of input bytes.",
                                         1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_bytes, ts, 0, 1, (char *[]) {name});
+
     ins->cmt_records = cmt_counter_create(ins->cmt,
                                         "fluentbit", "input", "records_total",
                                         "Number of input records.",
                                         1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_records, ts, 0, 1, (char *[]) {name});
 
     /* OLD Metrics */
-#ifdef FLB_HAVE_METRICS
-    /* Get name or alias for the instance */
-    name = flb_input_name(ins);
-
-    /* [OLD METRICS] Create the metrics context */
     ins->metrics = flb_metrics_create(name);
     if (ins->metrics) {
         flb_metrics_add(FLB_METRIC_N_RECORDS, "records", ins->metrics);

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -814,6 +814,7 @@ int flb_output_init_all(struct flb_config *config)
     struct mk_list *config_map;
     struct flb_output_instance *ins;
     struct flb_output_plugin *p;
+    uint64_t ts;
 
     /* Retrieve the plugin reference */
     mk_list_foreach_safe(head, tmp, &config->outputs) {
@@ -850,6 +851,9 @@ int flb_output_init_all(struct flb_config *config)
         /* Get name or alias for the instance */
         name = (char *) flb_output_name(ins);
 
+        /* get timestamp */
+        ts = cmt_time_now();
+
         /* CMetrics */
         ins->cmt = cmt_create();
         if (!ins->cmt) {
@@ -857,43 +861,64 @@ int flb_output_init_all(struct flb_config *config)
             return -1;
         }
 
-        /* Register generic output plugin metrics */
+        /*
+         * Register generic output plugin metrics
+         */
+
+        /* fluentbit_output_proc_records_total */
         ins->cmt_proc_records = cmt_counter_create(ins->cmt, "fluentbit",
                                                    "output", "proc_records_total",
                                                    "Number of processed output records.",
                                                    1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_proc_records, ts, 0, 1, (char *[]) {name});
 
+
+        /* fluentbit_output_proc_bytes_total */
         ins->cmt_proc_bytes = cmt_counter_create(ins->cmt, "fluentbit",
                                                  "output", "proc_bytes_total",
                                                  "Number of processed output bytes.",
                                                  1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_proc_bytes, ts, 0, 1, (char *[]) {name});
 
+
+        /* fluentbit_output_errors_total */
         ins->cmt_errors = cmt_counter_create(ins->cmt, "fluentbit",
                                              "output", "errors_total",
                                              "Number of output errors.",
                                              1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_errors, ts, 0, 1, (char *[]) {name});
 
+
+        /* fluentbit_output_retries_total */
         ins->cmt_retries = cmt_counter_create(ins->cmt, "fluentbit",
                                              "output", "retries_total",
                                              "Number of output retries.",
                                              1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_retries, ts, 0, 1, (char *[]) {name});
 
+        /* fluentbit_output_retries_failed_total */
         ins->cmt_retries_failed = cmt_counter_create(ins->cmt, "fluentbit",
                                              "output", "retries_failed_total",
                                              "Number of abandoned batches because "
                                              "the maximum number of re-tries was "
                                              "reached.",
                                              1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_retries_failed, ts, 0, 1, (char *[]) {name});
 
+
+        /* fluentbit_output_dropped_records_total */
         ins->cmt_dropped_records = cmt_counter_create(ins->cmt, "fluentbit",
                                              "output", "dropped_records_total",
                                              "Number of dropped records.",
                                              1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_dropped_records, ts, 0, 1, (char *[]) {name});
 
+        /* fluentbit_output_retried_records_total */
         ins->cmt_retried_records = cmt_counter_create(ins->cmt, "fluentbit",
                                              "output", "retried_records_total",
                                              "Number of retried records.",
                                              1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_retried_records, ts, 0, 1, (char *[]) {name});
 
         /* old API */
         ins->metrics = flb_metrics_create(name);


### PR DESCRIPTION
If cmetrics are not initialized, and since they depend on a label they won't show up until the value is updated, that's ok, but it's better to show a zero value than a missing metric

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
