### PR TITLE
workflows: nightly build updates

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -28,6 +28,7 @@ on:
         description: Optionally add metadata to build to indicate an unstable build, set to the contents you want to add.
         type: string
         required: false
+        default: ''
     secrets:
       token:
         description: The Github token or similar to authenticate with for the registry.

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -24,6 +24,7 @@ on:
         description: Optionally add metadata to build to indicate an unstable build, set to the contents you want to add.
         type: string
         required: false
+        default: ''
     secrets:
       token:
         description: The Github token or similar to authenticate with.

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -19,7 +19,7 @@ on:
 
   # Run nightly build
   schedule:
-  - cron: "0 2 * * *"
+  - cron: "0 6 * * *"
 
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -147,25 +147,10 @@ jobs:
         with:
           path: artifacts/
 
-      - name: Rename by target
-        # We need to include the directory name in every artefact otherwise the package is always called the same thing.
-        # This then means it is overwritten on release upload.
-        # https://github.com/actions/download-artifact#download-all-artifacts
-        #
-        # We essentially flatten a directory structure:
-        # artifacts/packages-master-debian-buster/debian/buster/master/staging/fluent-bit_1.9.0_amd64.deb ==>
-        # artifacts/packages-master-debian-buster-fluent-bit_1.9.0_amd64.deb
-        #
-        # This guarantees no duplicates even if it is quite verbose.
-        # We can look to remove some of the common strings as well later.
+      - name: Single packages tar
         run: |
-          while IFS= read -r -d '' file; do
-              # Strip off artifacts directory
-              tempfile=${file#artifacts/*}
-              # Concatenate the first directory (before /) and filename (after last /) together.
-              outputfile="artifacts/${tempfile%%/*}-${tempfile##*/}"
-              mv -f "$file" "$outputfile"
-          done < <(find artifacts/ -type f \( -iname '*.rpm' -o -iname '*.deb' \) -print0)
+          mkdir -p release-upload
+          tar -czvf release-upload/packages-unstable-${{ needs.staging-build-get-version.outputs.version }}.tar.gz -C artifacts/ .
         shell: bash
 
       - name: Log in to the Container registry
@@ -184,11 +169,11 @@ jobs:
           docker pull ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-version.outputs.version }}-debug
           docker save --output container-${{ needs.staging-build-get-version.outputs.version }}-debug.tar ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-version.outputs.version }}-debug
         shell: bash
-        working-directory: artifacts
+        working-directory: release-upload
 
-      - name: Display structure of downloaded files
+      - name: Display structure of files to upload
         run: ls -R
-        working-directory: artifacts
+        working-directory: release-upload
         shell: bash
 
       - name: Unstable release on push to master to make it easier to download
@@ -198,6 +183,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: 'unstable'
-          rm: true
           files: |
-            artifacts/**/*
+            release-upload/**/*

--- a/dockerfiles/Dockerfile.arm32v7
+++ b/dockerfiles/Dockerfile.arm32v7
@@ -9,6 +9,9 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
@@ -51,7 +54,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.arm64v8
+++ b/dockerfiles/Dockerfile.arm64v8
@@ -9,6 +9,9 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
@@ -50,7 +53,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -24,6 +24,9 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
@@ -66,7 +69,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_IN_EXEC=Off \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -126,8 +126,7 @@ RUN apt-get update && \
         libgmp10 \
         libffi7 \
         liblzma5 \
-        libyaml-0-2 \
-        && \
+        libyaml-0-2 && \
     mkdir -p /dpkg && \
     for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
 
@@ -180,6 +179,7 @@ RUN apt-get update && \
         ca-certificates \
         libatomic1 \
         libgcrypt20 \
+        libyaml-0-2 \
         bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -125,7 +125,9 @@ RUN apt-get update && \
         libhogweed6 \
         libgmp10 \
         libffi7 \
-        liblzma5 && \
+        liblzma5 \
+        libyaml-0-2 \
+        && \
     mkdir -p /dpkg && \
     for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
 

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -6,6 +6,9 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
@@ -48,7 +51,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_IN_EXEC=Off \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.x86_64-debug
+++ b/dockerfiles/Dockerfile.x86_64-debug
@@ -6,6 +6,9 @@ ENV FLB_MINOR 9
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.9.0
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
@@ -47,7 +50,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.x86_64-master
+++ b/dockerfiles/Dockerfile.x86_64-master
@@ -4,6 +4,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD . /source
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -37,7 +40,9 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_IN_EXEC=Off \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/dockerfiles/Dockerfile.x86_64-master_debug
+++ b/dockerfiles/Dockerfile.x86_64-master_debug
@@ -4,6 +4,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD . /source
 
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -37,7 +40,9 @@ RUN cmake -DFLB_DEBUG=On \
           -DFLB_HTTP_SERVER=On \
           -DFLB_IN_SYSTEMD=On \
           -DFLB_OUT_KAFKA=On \
-          -DFLB_OUT_PGSQL=On ..
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -105,11 +105,6 @@ else
     fi
 fi
 
-# The FLB_NIGHTLY_BUILD must not be empty so set to version if not defined
-if [[ -z "$FLB_NIGHTLY_BUILD" ]]; then
-    FLB_NIGHTLY_BUILD="$FLB_VERSION"
-fi
-
 # CMake configuration variables, override via environment rather than parameters
 CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-/opt/td-agent-bit/}
 FLB_TD=${FLB_TD:-On}


### PR DESCRIPTION
After #4831 we can now pass an empty string into the nightly build setting so doing that for packages instead of the version now.
Switched to uploading a single tarball of all packages as seems to be a bit flaky with lots of individual package uploads.
Updated containers to also include nightly build info

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
