### PR TITLE
1.8:  http_server: fix health implementation - backport #4537

### DIFF
--- a/include/fluent-bit/http_server/flb_hs.h
+++ b/include/fluent-bit/http_server/flb_hs.h
@@ -55,6 +55,7 @@ struct flb_hs {
 
 struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config);
+int flb_hs_push_health_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_storage_metrics(struct flb_hs *hs, void *data, size_t size);
 

--- a/src/flb_metrics_exporter.c
+++ b/src/flb_metrics_exporter.c
@@ -170,6 +170,9 @@ static int collect_metrics(struct flb_me *me)
     if (ctx->http_server == FLB_TRUE) {
         /* v1 metrics (old) */
         flb_hs_push_pipeline_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
+        if (ctx->health_check == FLB_TRUE) {
+            flb_hs_push_health_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
+        }
     }
 #endif
     msgpack_sbuffer_destroy(&mp_sbuf);

--- a/src/http_server/api/v1/health.c
+++ b/src/http_server/api/v1/health.c
@@ -323,7 +323,7 @@ int api_v1_health(struct flb_hs *hs)
 
     counter_init(hs);
     /* Create a message queue */
-    hs->qid_metrics = mk_mq_create(hs->ctx, "/health",
+    hs->qid_health = mk_mq_create(hs->ctx, "/health",
                                    cb_mq_health, NULL);
 
     mk_vhost_handler(hs->ctx, hs->vid, "/api/v1/health", cb_health, hs);

--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -37,10 +37,15 @@ static void cb_root(mk_request_t *request, void *data)
     mk_http_done(request);
 }
 
+/* Ingest health metrics into the web service context */
+int flb_hs_push_health_metrics(struct flb_hs *hs, void *data, size_t size)
+{
+    return mk_mq_send(hs->ctx, hs->qid_health, data, size);
+}
+
 /* Ingest pipeline metrics into the web service context */
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size)
 {
-    mk_mq_send(hs->ctx, hs->qid_health, data, size);
     return mk_mq_send(hs->ctx, hs->qid_metrics, data, size);
 }
 


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
