### PR TITLE
1.8: output: enable default workers

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -194,6 +194,9 @@ struct flb_output_plugin {
     /* Exit */
     int (*cb_exit) (void *, struct flb_config *);
 
+    /* Default number of worker threads */
+    int workers;
+
     /* Tests */
     struct flb_test_out_formatter test_formatter;
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -1094,6 +1094,7 @@ struct flb_output_plugin out_es_plugin = {
     .cb_pre_run     = NULL,
     .cb_flush       = cb_es_flush,
     .cb_exit        = cb_es_exit,
+    .workers        = 2,
 
     /* Configuration */
     .config_map     = config_map,

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -575,6 +575,7 @@ struct flb_output_plugin out_file_plugin = {
     .cb_flush     = cb_file_flush,
     .cb_exit      = cb_file_exit,
     .flags        = 0,
+    .workers      = 1,
     .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
     .config_map   = config_map,
 };

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1336,6 +1336,7 @@ struct flb_output_plugin out_forward_plugin = {
     .cb_pre_run   = NULL,
     .cb_flush     = cb_forward_flush,
     .cb_exit      = cb_forward_exit,
+    .workers      = 2,
 
     /* Config map validator */
     .config_map   = config_map,

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -449,4 +449,5 @@ struct flb_output_plugin out_http_plugin = {
     .cb_exit     = cb_http_exit,
     .config_map  = config_map,
     .flags       = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
+    .workers     = 2
 };

--- a/plugins/out_null/null.c
+++ b/plugins/out_null/null.c
@@ -56,4 +56,5 @@ struct flb_output_plugin out_null_plugin = {
     .cb_init      = cb_null_init,
     .cb_flush     = cb_null_flush,
     .flags        = 0,
+    .workers      = 1,
 };

--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -356,5 +356,6 @@ struct flb_output_plugin out_prometheus_remote_write_plugin = {
     .cb_exit     = cb_prom_exit,
     .config_map  = config_map,
     .event_type  = FLB_OUTPUT_METRICS,
+    .workers     = 2,
     .flags       = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -810,6 +810,7 @@ struct flb_output_plugin out_splunk_plugin = {
     .cb_flush     = cb_splunk_flush,
     .cb_exit      = cb_splunk_exit,
     .config_map   = config_map,
+    .workers      = 2,
 
     /* for testing */
     .test_formatter.callback = cb_splunk_format_test,

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2345,6 +2345,7 @@ struct flb_output_plugin out_stackdriver_plugin = {
     .cb_init      = cb_stackdriver_init,
     .cb_flush     = cb_stackdriver_flush,
     .cb_exit      = cb_stackdriver_exit,
+    .workers      = 2,
 
     /* Test */
     .test_formatter.callback = stackdriver_format,

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -233,6 +233,7 @@ struct flb_output_plugin out_stdout_plugin = {
     .cb_flush     = cb_stdout_flush,
     .cb_exit      = cb_stdout_exit,
     .flags        = 0,
+    .workers      = 1,
     .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
     .config_map   = config_map
 };

--- a/plugins/out_tcp/tcp.c
+++ b/plugins/out_tcp/tcp.c
@@ -144,5 +144,6 @@ struct flb_output_plugin out_tcp_plugin = {
     .cb_flush       = cb_tcp_flush,
     .cb_exit        = cb_tcp_exit,
     .config_map     = config_map,
+    .workers        = 2,
     .flags          = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -449,7 +449,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->log_level = -1;
     instance->test_mode = FLB_FALSE;
     instance->is_threaded = FLB_FALSE;
-
+    instance->tp_workers = plugin->workers;
 
     /* Retrieve an instance id for the output instance */
     instance->id = instance_id(config);


### PR DESCRIPTION
Ship better defaults by setting up a default number of worker threads for the following plugins:

- out_elasticsearch: 2
- out_file: 1
- out_forward: 2
- out_http: 2
- out_prometheus_remote_write: 2
- out_splunk: 2
- out_stackdriver: 2
- out_stdout: 1
- out_tcp: 2
- out_null: 1

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
