### PR TITLE
dockerfiles: fix issue with YAML build

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,8 +17,6 @@
 | Label name | Description |
 | :----------|-------------|
 | docs-required| default tag used to request documentation, has to be removed before merge |
-| ok-container-test | run all image tests |
-| ci/container-test-ok | image tests pass |
 | ok-package-test | run all package tests |
 | ok-to-test | run all integration tests |
 | ok-to-merge | run mergebot and merge (rebase) current PR |

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -69,7 +69,6 @@ jobs:
 
     pr-image-tests-classic-docker-build:
       name: PR - Classic docker build test
-      needs: pr-get-latest-tag
       runs-on: ubuntu-latest
       environment: pr
       strategy:

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -1,75 +1,71 @@
-name: Build and run image tests for all architectures
+name: Build images for all architectures
 on:
-  # We cannot trigger just on PRs as these do not have write permissions to GHCR from forks.
-  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-  # Instead we use the label to gate running this.
-  pull_request_target:
+  pull_request:
     types:
-      - labeled
       - opened
       - reopened
       - synchronize
+    paths:
+      - 'dockerfiles/**'
+
+  workflow_dispatch:
 
 jobs:
-    pr-get-latest-tag:
-      if: contains(github.event.pull_request.labels.*.name, 'ok-container-test')
-      name: PR - get latest tag for source build
+    pr-image-tests-build-images:
+      name: PR - Buildkit docker build test
       runs-on: ubuntu-latest
       environment: pr
-      outputs:
-        latest_tag: ${{ steps.formatted_version.outputs.replaced }}
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions-ecosystem/action-get-latest-tag@v1
-          id: get-latest-tag
+        - name: Checkout code
+          uses: actions/checkout@v2
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v1
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+
+        - name: Build the master image
+          uses: docker/build-push-action@v2
           with:
-            semver_only: true
-        - uses: frabert/replace-string-action@v2.0
-          id: formatted_version
+            file: ./dockerfiles/Dockerfile.x86-64-master
+            context: .
+            platforms: linux/amd64
+            push: false
+            load: false
+
+        - name: Build the multi-arch images using current master tarball
+          uses: docker/build-push-action@v2
           with:
-            pattern: '[v]*(.*)$'
-            string: ${{ steps.get-latest-tag.outputs.tag }}
-            replace-with: '$1'
-            flags: 'g'
+            file: ./dockerfiles/Dockerfile.multiarch
+            context: .
+            platforms: linux/amd64
+            target: production
+            push: false
+            load: false
+            build-args: |
+              FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master
 
-    pr-image-tests-build-images:
-      name: PR - build images
-      uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
-      needs: pr-get-latest-tag
-      with:
-        version: ${{ needs.pr-get-latest-tag.outputs.latest_tag }}
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        image: ${{ github.repository }}/pr-${{ github.event.number }}
-        environment: pr
-      secrets:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build the master debug image
+          uses: docker/build-push-action@v2
+          with:
+            file: ./dockerfiles/Dockerfile.x86-64-master_debug
+            context: .
+            platforms: linux/amd64
+            push: false
+            load: false
 
-    pr-image-tests-smoke-test-images:
-      name: PR - smoke test images
-      needs: [pr-get-latest-tag, pr-image-tests-build-images]
-      uses: fluent/fluent-bit/.github/workflows/call-test-images.yaml@master
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        image: ${{ github.repository }}/pr-${{ github.event.number }}
-        image-tag: ${{ needs.pr-get-latest-tag.outputs.latest_tag }}
-        environment: pr
-      secrets:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    pr-image-tests-smoke-test-multiarch-images:
-      name: PR - multiarch smoke test images
-      needs: [pr-get-latest-tag, pr-image-tests-build-images]
-      uses: fluent/fluent-bit/.github/workflows/call-test-images.yaml@master
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        image: ${{ github.repository }}/pr-${{ github.event.number }}/multiarch
-        image-tag: ${{ needs.pr-get-latest-tag.outputs.latest_tag }}
-        environment: pr
-      secrets:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build the debug multi-arch images
+          uses: docker/build-push-action@v2
+          with:
+            file: ./dockerfiles/Dockerfile.multiarch
+            context: .
+            platforms: linux/amd64
+            target: debug
+            push: false
+            load: false
+            build-args: |
+              FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master
 
     pr-image-tests-classic-docker-build:
       name: PR - Classic docker build test
@@ -95,27 +91,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - name: Build the ${{ matrix.suffix }} classic build test image
+      - name: Build the ${{ matrix.suffix }} classic test image
         # We only want to confirm it builds with classic mode, nothing else
         run: |
           docker build --platform=linux/${{ matrix.arch }} --build-arg FLB_TARBALL="$FLB_TARBALL" -f ./dockerfiles/Dockerfile.${{ matrix.suffix }} ./dockerfiles/
         env:
           # Ensure we disable buildkit
           DOCKER_BUILDKIT: 0
-          FLB_TARBALL: https://github.com/fluent/fluent-bit/archive/v${{ needs.pr-get-latest-tag.outputs.latest_tag }}.tar.gz
+          FLB_TARBALL: https://github.com/fluent/fluent-bit/tarball/master
         shell: bash
-
-    pr-image-tests-post-label:
-      name: PR - image tests complete
-      runs-on: ubuntu-latest
-      needs:
-        - pr-image-tests-smoke-test-multiarch-images
-        - pr-image-tests-classic-docker-build
-      steps:
-        - uses: actions-ecosystem/action-add-labels@v1
-          name: Label the PR
-          with:
-            labels: ci/container-test-ok
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            number: ${{ github.event.pull_request.number }}
-            repo: fluent/fluent-bit

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         - name: Build the master image
           uses: docker/build-push-action@v2
           with:
-            file: ./dockerfiles/Dockerfile.x86-64-master
+            file: ./dockerfiles/Dockerfile.x86_64-master
             context: .
             platforms: linux/amd64
             push: false
@@ -49,7 +49,7 @@ jobs:
         - name: Build the master debug image
           uses: docker/build-push-action@v2
           with:
-            file: ./dockerfiles/Dockerfile.x86-64-master_debug
+            file: ./dockerfiles/Dockerfile.x86_64-master_debug
             context: .
             platforms: linux/amd64
             push: false

--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -121,8 +121,8 @@ RUN apt-get update && \
         libhogweed6 \
         libgmp10 \
         libffi7 \
-        liblzma5 && \
-        libyaml-0-2 \
+        liblzma5 \
+        libyaml-0-2 && \
     mkdir -p /dpkg && \
     for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
 

--- a/dockerfiles/Dockerfile.x86_64-debug
+++ b/dockerfiles/Dockerfile.x86_64-debug
@@ -90,7 +90,7 @@ RUN apt-get update && \
       ca-certificates \
       libatomic1 \
       libgcrypt20 \
-      libyaml \
+      libyaml-0-2 \
       bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.x86_64-master_debug
+++ b/dockerfiles/Dockerfile.x86_64-master_debug
@@ -70,7 +70,7 @@ RUN apt-get update && \
       ca-certificates \
       libatomic1 \
       libgcrypt20 \
-      libyaml \
+      libyaml-0-2 \
       bash gdb valgrind build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Recent change introduced a failure in the multi-arch and debug Dockerfiles.

The PR image tests are verifying against `master` rather than the changes introduced in the PR so updated now to build local changes to Dockerfiles as a bare minimum.

Previously we were using `pull_request_target` with labels to gate for security reasons, however this then means workflows run on the destination branch. As we have nightly staging builds now the PR checks have been reduced to simple build tests using `pull_request` so do not need write permissions to push images. This is much simpler to work with, particularly for forks.

This new PR test is run on this PR itself and verifies all of the Dockerfiles at least build.

Verified all containers build now manually:
```
$ docker buildx build -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master .
$ docker buildx build -f ./dockerfiles/Dockerfile.x86_64 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master .
$ docker buildx build -f ./dockerfiles/Dockerfile.x86_64-debug --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master .
$ docker buildx build -f ./dockerfiles/Dockerfile.arm32v7 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master .
$ docker buildx build -f ./dockerfiles/Dockerfile.arm64v8 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/master .
$ docker buildx build -f ./dockerfiles/Dockerfile.x86_64-master .
$ docker buildx build -f ./dockerfiles/Dockerfile.x86_64-master_debug .
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
