### PR TITLE
filter_expect: exit with 255 on failure

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -629,6 +629,7 @@ static void flb_lib_worker(void *data)
         flb_engine_failed(config);
         flb_engine_shutdown(config);
     }
+    config->exit_status_code = ret;
     ctx->status = FLB_LIB_NONE;
 }
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1286,6 +1286,7 @@ int flb_main(int argc, char **argv)
     if (exit_signal) {
         flb_signal_exit(exit_signal);
     }
+    ret = config->exit_status_code;
     flb_destroy(ctx);
 
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #3268 by backporting #3086

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Using the original test file from #3086 it still gives a zero exit code with 1.8.12 on failure: 
```
$ docker run --rm -it -v $PWD/issue.conf:/fluent-bit/etc/fluent-bit.conf fluent/fluent-bit:1.8.12; echo $?
Fluent Bit v1.8.12
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/17 11:23:45] [error] [filter:expect:expect.0] exception on rule #0 'key_val_eq', key value 'dummy' is different than expected: 'foo'. Record content:
{"message":"dummy"}
0
```
This now works with the latest code to exit with 255:
```
$ docker buildx build -f ./dockerfiles/Dockerfile.x86_64-master -t expect-test .
$ docker run --rm -it -v $PWD/issue.conf:/fluent-bit/etc/fluent-bit.conf expect-test; echo $?
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/17 11:24:49] [error] [filter:expect:expect.0] exception on rule #0 'key_val_eq', key value 'dummy' is different than expected: 'foo'. Record content:
{"message":"dummy"}
255
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
