### PR TITLE
Add support use system TimeZone

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -40,6 +40,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include <string.h>
+#include <time.h>
 
 static inline uint32_t digits10(uint64_t v) {
     if (v < 10) return 1;
@@ -934,11 +935,22 @@ int flb_parser_tzone_offset(const char *str, int len, int *tmdiff)
     long min;
     const char *end;
     const char *p = str;
+    time_t t = time(NULL);
+    struct tm lt = {0};
 
     /* Check timezones */
     if (*p == 'Z') {
         /* This is UTC, no changes required */
         *tmdiff = 0;
+        return 0;
+    }
+
+    /* Check timezones */
+    if (*p == 'S') {
+        /* This is Timezone of the System */
+
+        localtime_r(&t, &lt);
+        *tmdiff = lt.tm_gmtoff;
         return 0;
     }
 


### PR DESCRIPTION
As explain in the issue :
#593
Defined parameter : Time_Offset to "S"
This will use the system local timestamp.

Very useful when the timezone depending on Summer/Winter

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
