### PR TITLE
output_thread: fix type cast that caused issues in win32

### DIFF
--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -276,7 +276,7 @@ static void output_thread(void *data)
                  * If the address receives 0xdeadbeef, means the thread must
                  * be terminated.
                  */
-                if ((uint64_t) task == 0xdeadbeef) {
+                if (task == (struct flb_task *) 0xdeadbeef) {
                     stopping = FLB_TRUE;
                     flb_plg_info(th_ins->ins, "thread worker #%i stopping...",
                                  thread_id);


### PR DESCRIPTION
Fixed a type cast that caused a check to fail resulting in an invalid memory read.