### PR TITLE
parser: initialize multiline parser_ctx to NULL

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -706,7 +706,7 @@ static int multiline_parser_conf_file(const char *cfg, struct flb_cf *cf,
     flb_sds_t parser;
     flb_sds_t tmp;
     int flush_timeout;
-    struct flb_parser *parser_ctx;
+    struct flb_parser *parser_ctx = NULL;
     struct mk_list *head;
     struct flb_cf_section *s;
     struct flb_ml_parser *ml_parser;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes a uninitialized read that was causing #4818 (compiler on Ubuntu probably some option to automatically initialize function variables, which is why it was not reproducible there). Credit to @patrick-stephens for catching the bug

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #4818 

----
Here's valgrind before the fix:

```
==80702== Memcheck, a memory error detector
==80702== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==80702== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==80702== Command: ./build/bin/fluent-bit -c ../fluentbit-multiline-issue/etc/fluent.conf
==80702== Parent PID: 48283
==80702== 
==80702== Thread 2 flb-pipeline:
==80702== Conditional jump or move depends on uninitialised value(s)
==80702==    at 0x1AF096: ml_append_try_parser_type_text (flb_ml.c:521)
==80702==    by 0x1AF402: ml_append_try_parser (flb_ml.c:616)
==80702==    by 0x1AF78A: flb_ml_append (flb_ml.c:726)
==80702==    by 0x1F32BC: process_content (tail_file.c:434)
==80702==    by 0x1F59B4: flb_tail_file_chunk (tail_file.c:1313)
==80702==    by 0x1ECCE2: in_tail_collect_static (tail.c:170)
==80702==    by 0x189982: flb_input_collector_fd (flb_input.c:1103)
==80702==    by 0x19DD29: flb_engine_handle_event (flb_engine.c:412)
==80702==    by 0x19DD29: flb_engine_start (flb_engine.c:704)
==80702==    by 0x17D6CA: flb_lib_worker (flb_lib.c:626)
==80702==    by 0x486FEA6: start_thread (pthread_create.c:477)
==80702==    by 0x4AEADEE: clone (clone.S:95)
==80702== 
==80702== Use of uninitialised value of size 8
==80702==    at 0x1B2F54: flb_parser_do (flb_parser.c:910)
==80702==    by 0x1AF0C8: ml_append_try_parser_type_text (flb_ml.c:523)
==80702==    by 0x1AF402: ml_append_try_parser (flb_ml.c:616)
==80702==    by 0x1AF78A: flb_ml_append (flb_ml.c:726)
==80702==    by 0x1F32BC: process_content (tail_file.c:434)
==80702==    by 0x1F59B4: flb_tail_file_chunk (tail_file.c:1313)
==80702==    by 0x1ECCE2: in_tail_collect_static (tail.c:170)
==80702==    by 0x189982: flb_input_collector_fd (flb_input.c:1103)
==80702==    by 0x19DD29: flb_engine_handle_event (flb_engine.c:412)
==80702==    by 0x19DD29: flb_engine_start (flb_engine.c:704)
==80702==    by 0x17D6CA: flb_lib_worker (flb_lib.c:626)
==80702==    by 0x486FEA6: start_thread (pthread_create.c:477)
==80702==    by 0x4AEADEE: clone (clone.S:95)
==80702== 
==80702== Use of uninitialised value of size 8
==80702==    at 0x1B2F8A: flb_parser_do (flb_parser.c:914)
==80702==    by 0x1AF0C8: ml_append_try_parser_type_text (flb_ml.c:523)
==80702==    by 0x1AF402: ml_append_try_parser (flb_ml.c:616)
==80702==    by 0x1AF78A: flb_ml_append (flb_ml.c:726)
==80702==    by 0x1F32BC: process_content (tail_file.c:434)
==80702==    by 0x1F59B4: flb_tail_file_chunk (tail_file.c:1313)
==80702==    by 0x1ECCE2: in_tail_collect_static (tail.c:170)
==80702==    by 0x189982: flb_input_collector_fd (flb_input.c:1103)
==80702==    by 0x19DD29: flb_engine_handle_event (flb_engine.c:412)
==80702==    by 0x19DD29: flb_engine_start (flb_engine.c:704)
==80702==    by 0x17D6CA: flb_lib_worker (flb_lib.c:626)
==80702==    by 0x486FEA6: start_thread (pthread_create.c:477)
==80702==    by 0x4AEADEE: clone (clone.S:95)
==80702== 
==80702== Use of uninitialised value of size 8
==80702==    at 0x1B2FBD: flb_parser_do (flb_parser.c:918)
==80702==    by 0x1AF0C8: ml_append_try_parser_type_text (flb_ml.c:523)
==80702==    by 0x1AF402: ml_append_try_parser (flb_ml.c:616)
==80702==    by 0x1AF78A: flb_ml_append (flb_ml.c:726)
==80702==    by 0x1F32BC: process_content (tail_file.c:434)
==80702==    by 0x1F59B4: flb_tail_file_chunk (tail_file.c:1313)
==80702==    by 0x1ECCE2: in_tail_collect_static (tail.c:170)
==80702==    by 0x189982: flb_input_collector_fd (flb_input.c:1103)
==80702==    by 0x19DD29: flb_engine_handle_event (flb_engine.c:412)
==80702==    by 0x19DD29: flb_engine_start (flb_engine.c:704)
==80702==    by 0x17D6CA: flb_lib_worker (flb_lib.c:626)
==80702==    by 0x486FEA6: start_thread (pthread_create.c:477)
==80702==    by 0x4AEADEE: clone (clone.S:95)
==80702== 
==80702== Use of uninitialised value of size 8
==80702==    at 0x1B2FF0: flb_parser_do (flb_parser.c:922)
==80702==    by 0x1AF0C8: ml_append_try_parser_type_text (flb_ml.c:523)
==80702==    by 0x1AF402: ml_append_try_parser (flb_ml.c:616)
==80702==    by 0x1AF78A: flb_ml_append (flb_ml.c:726)
==80702==    by 0x1F32BC: process_content (tail_file.c:434)
==80702==    by 0x1F59B4: flb_tail_file_chunk (tail_file.c:1313)
==80702==    by 0x1ECCE2: in_tail_collect_static (tail.c:170)
==80702==    by 0x189982: flb_input_collector_fd (flb_input.c:1103)
==80702==    by 0x19DD29: flb_engine_handle_event (flb_engine.c:412)
==80702==    by 0x19DD29: flb_engine_start (flb_engine.c:704)
==80702==    by 0x17D6CA: flb_lib_worker (flb_lib.c:626)
==80702==    by 0x486FEA6: start_thread (pthread_create.c:477)
==80702==    by 0x4AEADEE: clone (clone.S:95)
==80702== 
==80702== 
==80702== HEAP SUMMARY:
==80702==     in use at exit: 0 bytes in 0 blocks
==80702==   total heap usage: 1,802 allocs, 1,802 frees, 1,748,701 bytes allocated
==80702== 
==80702== All heap blocks were freed -- no leaks are possible
==80702== 
==80702== Use --track-origins=yes to see where uninitialised values come from
==80702== For lists of detected and suppressed errors, rerun with: -s
==80702== ERROR SUMMARY: 340 errors from 5 contexts (suppressed: 0 from 0)
```

After:

```
==84716== Memcheck, a memory error detector
==84716== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==84716== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==84716== Command: ./build/bin/fluent-bit -c ../fluentbit-multiline-issue/etc/fluent.conf
==84716== Parent PID: 48283
==84716== 
==84716== 
==84716== HEAP SUMMARY:
==84716==     in use at exit: 0 bytes in 0 blocks
==84716==   total heap usage: 1,563 allocs, 1,563 frees, 782,750 bytes allocated
==84716== 
==84716== All heap blocks were freed -- no leaks are possible
==84716== 
==84716== For lists of detected and suppressed errors, rerun with: -s
==84716== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```