### PR TITLE
parser: initialize multiline parser_ctx to NULL

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -692,7 +692,7 @@ static int multiline_parser_conf_file(const char *cfg, struct mk_rconf *fconf,
     flb_sds_t parser;
     flb_sds_t tmp;
     int flush_timeout;
-    struct flb_parser *parser_ctx;
+    struct flb_parser *parser_ctx = NULL;
     struct mk_list *head;
     struct mk_rconf_section *section;
     struct flb_ml_parser *ml_parser;


### PR DESCRIPTION
Just pulling #4852 into 1.8 branch
