### PR TITLE
packaging: fix container smoke test

### DIFF
--- a/packaging/testing/smoke/container/container-smoke-test.sh
+++ b/packaging/testing/smoke/container/container-smoke-test.sh
@@ -75,5 +75,5 @@ do
     curl -v localhost:"$LOCAL_PORT"/api/v1/health
 
     # Clean up
-    docker stop "$CONTAINER_NAME"
+    docker rm -f "$CONTAINER_NAME"
 done


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves failures in container smoke tests like: https://github.com/fluent/fluent-bit/runs/5235573882?check_suite_focus=true

The issue is that we are now testing two configs: one legacy and one YAML.
However, the container is using the same name and is not removed so it errors on the second run:
```
+ docker run --name local-smoke-x86_64 -d --platform linux/amd64 --pull=always --publish-all --restart=no -v /home/runner/work/fluent-bit/fluent-bit/packaging/testing/smoke/container/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro ghcr.io/fluent/fluent-bit/master:x86_64 /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
...
+ docker run --name local-smoke-x86_64 -d --platform linux/amd64 --pull=always --publish-all --restart=no -v /home/runner/work/fluent-bit/fluent-bit/packaging/testing/smoke/container/fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml:ro ghcr.io/fluent/fluent-bit/master:x86_64 /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
Testing: fluent-bit.yaml
x86_64: Pulling from fluent/fluent-bit/master
Digest: sha256:7f687d6bcb783d3fc406703c7c594e539fe8c8c172492f2a8b868163d1570c28
Status: Image is up to date for ghcr.io/fluent/fluent-bit/master:x86_64
docker: Error response from daemon: Conflict. The container name "/local-smoke-x86_64" is already in use by container "2e656a754e0252b4cbd3063b41ba3fed3b32f2411dbc20d96cb4b878e2f27f07". You have to remove (or rename) that container to be able to reuse that name.
```

----

**Testing**

Verified now functions correctly:
```
$ IMAGE_NAME=fluent/fluent-bit/master IMAGE_TAG=x86_64 CONTAINER_NAME=test ./packaging/testing/smoke/container/container-smoke-test.sh
```
Same command on `master` currently fails as per the links.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
