### PR TITLE
dockerfiles: add status handling for distroless packages

### DIFF
--- a/dockerfiles/Dockerfile.multiarch
+++ b/dockerfiles/Dockerfile.multiarch
@@ -94,7 +94,8 @@ FROM debian:bullseye-slim as deb-extractor
 COPY --from=qemu-arm32 /usr/bin/qemu-arm-static /usr/bin/
 COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 
-# We download all debs locally then extract them into a directory we can use as the root for distroless
+# We download all debs locally then extract them into a directory we can use as the root for distroless.
+# We also include some extra handling for the status files that some tooling uses for scanning, etc.
 WORKDIR /tmp
 RUN apt-get update && \
     apt-get download \
@@ -128,8 +129,17 @@ RUN apt-get update && \
         libffi7 \
         liblzma5 \
         libyaml-0-2 && \
-    mkdir -p /dpkg && \
-    for deb in *.deb; do dpkg --extract "$deb" /dpkg || exit 10; done
+    mkdir -p /dpkg/var/lib/dpkg/status.d/ && \
+    for deb in *.deb; do \
+        package_name=$(dpkg-deb -I ${deb} | awk '/^ Package: .*$/ {print $2}'); \
+        echo "Processing: ${package_name}"; \
+        dpkg --ctrl-tarfile $deb | tar -Oxf - ./control > /dpkg/var/lib/dpkg/status.d/${package_name}; \
+        dpkg --extract $deb /dpkg || exit 10; \
+    done
+
+# Remove unnecessary files extracted from deb packages like man pages and docs etc.
+RUN find /dpkg/ -type d -empty -delete && \
+    rm -r /dpkg/usr/share/doc/
 
 # We want latest at time of build
 # hadolint ignore=DL3006


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Improves the distroless handling of packages to include the status files that vulnerability scanners use. 
This is updated based on the improved examples from the original issue: https://github.com/GoogleContainerTools/distroless/issues/863#issuecomment-1032477471 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
