### PR TITLE
workflows: increase smoke test timeouts

### DIFF
--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -151,7 +151,7 @@ jobs:
           docker run --rm --platform=${{ matrix.arch }} alpine uname -a
 
       - name: Test the HTTP server is responding
-        timeout-minutes: 2
+        timeout-minutes: 10
         run: |
           packaging/testing/smoke/container/container-smoke-test.sh
         shell: bash
@@ -184,7 +184,7 @@ jobs:
         uses: azure/setup-kubectl@v2.0
 
       - name: Test the HTTP server is responding
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           packaging/testing/smoke/k8s/k8s-smoke-test.sh
         shell: bash


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

The container smoke test is timing out now as we run it twice: once for legacy format and once for YAML.
Increased the timeout to prevent these spurious failures.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
