### PR TITLE
workflows: unstable release protection

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -26,6 +26,21 @@ concurrency: staging-build-release
 
 jobs:
 
+  staging-release-version-check:
+    name: Check staging release matches
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get the version on staging
+      run: |
+        curl --fail -LO "$AWS_URL/latest-version.txt"
+        cat latest-version.txt
+        STAGING_VERSION=$(cat latest-version.txt)
+        if [[ "$STAGING_VERSION" != "$RELEASE_VERSION" ]] && echo "Latest version mismatch: $STAGING_VERSION != $RELEASE_VERSION" && exit 1
+      shell: bash
+      env:
+        AWS_URL: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com
+        RELEASE_VERSION: ${{ github.event.inputs.version }}
+
   # 1. Take packages from the staging bucket
   # 2. Sign them with the release GPG key
   # 3. Also take existing release packages from the release bucket.
@@ -36,6 +51,7 @@ jobs:
     name: S3 - create release
     runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
     environment: release
+    needs: staging-release-version-check
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -124,6 +140,7 @@ jobs:
   # Unfortunately skopeo currently does not support Cosign: https://github.com/containers/skopeo/issues/1533
   staging-release-images:
     runs-on: ubuntu-latest
+    needs: staging-release-version-check
     environment: release
     env:
       STAGING_IMAGE_NAME: ghcr.io/${{ github.repository }}/staging

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -35,7 +35,7 @@ jobs:
         curl --fail -LO "$AWS_URL/latest-version.txt"
         cat latest-version.txt
         STAGING_VERSION=$(cat latest-version.txt)
-        if [[ "$STAGING_VERSION" != "$RELEASE_VERSION" ]] && echo "Latest version mismatch: $STAGING_VERSION != $RELEASE_VERSION" && exit 1
+        [[ "$STAGING_VERSION" != "$RELEASE_VERSION" ]] && echo "Latest version mismatch: $STAGING_VERSION != $RELEASE_VERSION" && exit 1
       shell: bash
       env:
         AWS_URL: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com


### PR DESCRIPTION
Simple check of the version we're trying to release matches the version in staging.

This should protect against the use case of: staging build & test then an unstable master build before releasing the original staging build.
Subsequent work underway to split the nightly and staging builds at least in their storage location.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
