### PR TITLE
windows: build legacy td-agent-bit package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,10 @@ build_script:
   - powershell ".\ci\do-ut.ps1;exit $LASTEXITCODE"
   - cd build
   - cpack
-  - cpack -DFLB_TD=On
+  - if %PLATFORM%==Win32 cmake -G "NMake Makefiles" -D FLB_TD=On -D OPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win32" ../
+  - if %PLATFORM%==x64   cmake -G "NMake Makefiles" -D FLB_TD=On -D OPENSSL_ROOT_DIR=C:\OpenSSL-v111-Win64" ../
+  - cmake --build .
+  - cpack
 
 artifacts:
   - path: build/td-agent-bit-*.exe


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #4837 by building legacy package as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
