### PR TITLE
filter_record_modifier: support config map

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -32,89 +32,106 @@
 
 #define PLUGIN_NAME "filter_record_modifier"
 
+static int config_allowlist_key(struct record_modifier_ctx *ctx,
+                                struct mk_list *list)
+{
+    struct modifier_key    *mod_key = NULL;
+    struct mk_list *head = NULL;
+    struct flb_config_map_val *mv = NULL;
+
+    if (ctx == NULL || list == NULL) {
+        return -1;
+    }
+
+    flb_config_map_foreach(head, mv, ctx->allowlist_keys_map) {
+        mod_key = flb_malloc(sizeof(struct modifier_key));
+        if (!mod_key) {
+            flb_errno();
+            continue;
+        }
+        mod_key->key     = mv->val.str;
+        mod_key->key_len = flb_sds_len(mv->val.str);
+        if (mod_key->key[mod_key->key_len - 1] == '*') {
+            mod_key->dynamic_key = FLB_TRUE;
+            mod_key->key_len--;
+        }
+        else {
+            mod_key->dynamic_key = FLB_FALSE;
+        }
+        mk_list_add(&mod_key->_head, &ctx->allowlist_keys);
+        ctx->allowlist_keys_num++;
+    }
+    return 0;
+}
+
 static int configure(struct record_modifier_ctx *ctx,
                          struct flb_filter_instance *f_ins)
 {
-    struct flb_kv *kv = NULL;
     struct mk_list *head = NULL;
-    struct mk_list *split;
     struct modifier_key    *mod_key;
     struct modifier_record *mod_record;
-    struct flb_split_entry *sentry;
+    struct flb_config_map_val *mv;
+    struct flb_slist_entry *sentry = NULL;
 
     ctx->records_num = 0;
     ctx->remove_keys_num = 0;
     ctx->allowlist_keys_num = 0;
 
-    /* Iterate all filter properties */
-    mk_list_foreach(head, &f_ins->properties) {
-        kv = mk_list_entry(head, struct flb_kv, _head);
-
-        if (!strcasecmp(kv->key, "remove_key")) {
-            mod_key = flb_malloc(sizeof(struct modifier_key));
-            if (!mod_key) {
-                flb_errno();
-                continue;
-            }
-            mod_key->key     = kv->val;
-            mod_key->key_len = flb_sds_len(kv->val);
-            if (mod_key->key[mod_key->key_len - 1] == '*') {
-                mod_key->dynamic_key = FLB_TRUE;
-                mod_key->key_len--;
-            }
-            else {
-                mod_key->dynamic_key = FLB_FALSE;
-            }
-            mk_list_add(&mod_key->_head, &ctx->remove_keys);
-            ctx->remove_keys_num++;
-        }
-        else if (!strcasecmp(kv->key, "allowlist_key") ||
-                 !strcasecmp(kv->key, "whitelist_key")) {
-            mod_key = flb_malloc(sizeof(struct modifier_key));
-            if (!mod_key) {
-                flb_errno();
-                continue;
-            }
-            mod_key->key     = kv->val;
-            mod_key->key_len = flb_sds_len(kv->val);
-            if (mod_key->key[mod_key->key_len - 1] == '*') {
-                mod_key->dynamic_key = FLB_TRUE;
-                mod_key->key_len--;
-            }
-            else {
-                mod_key->dynamic_key = FLB_FALSE;
-            }
-            mk_list_add(&mod_key->_head, &ctx->allowlist_keys);
-            ctx->allowlist_keys_num++;
-        }
-        else if (!strcasecmp(kv->key, "record")) {
-            mod_record = flb_malloc(sizeof(struct modifier_record));
-            if (!mod_record) {
-                flb_errno();
-                continue;
-            }
-            split = flb_utils_split(kv->val, ' ', 1);
-            if (mk_list_size(split) != 2) {
-                flb_plg_error(ctx->ins, "invalid record parameters, "
-                              "expects 'KEY VALUE'");
-                flb_free(mod_record);
-                flb_utils_split_free(split);
-                continue;
-            }
-            /* Get first value (field) */
-            sentry = mk_list_entry_first(split, struct flb_split_entry, _head);
-            mod_record->key = flb_strndup(sentry->value, sentry->len);
-            mod_record->key_len = sentry->len;
-
-            sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
-            mod_record->val = flb_strndup(sentry->value, sentry->len);
-            mod_record->val_len = sentry->len;
-
-            flb_utils_split_free(split);
-            mk_list_add(&mod_record->_head, &ctx->records);
-            ctx->records_num++;
-        }
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_errno();
+        flb_plg_error(f_ins, "configuration error");
+        return -1;
     }
+
+    /* Check 'Record' properties */
+    flb_config_map_foreach(head, mv, ctx->records_map) {
+        mod_record = flb_malloc(sizeof(struct modifier_record));
+        if (!mod_record) {
+            flb_errno();
+            continue;
+        }
+
+        if (mk_list_size(mv->val.list) != 2) {
+            flb_plg_error(ctx->ins, "invalid record parameters, "
+                          "expects 'KEY VALUE'");
+            flb_free(mod_record);
+            continue;
+        }
+        /* Get first value (field) */
+        sentry = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+        mod_record->key_len = flb_sds_len(sentry->str);
+        mod_record->key = flb_strndup(sentry->str, mod_record->key_len);
+
+        sentry = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+        mod_record->val_len = flb_sds_len(sentry->str);
+        mod_record->val = flb_strndup(sentry->str, mod_record->val_len);
+
+        mk_list_add(&mod_record->_head, &ctx->records);
+        ctx->records_num++;
+    }
+    /* Check "Remove_Key" properties */
+    flb_config_map_foreach(head, mv, ctx->remove_keys_map) {
+        mod_key = flb_malloc(sizeof(struct modifier_key));
+        if (!mod_key) {
+            flb_errno();
+            continue;
+        }
+        mod_key->key     = mv->val.str;
+        mod_key->key_len = flb_sds_len(mv->val.str);
+        if (mod_key->key[mod_key->key_len - 1] == '*') {
+            mod_key->dynamic_key = FLB_TRUE;
+            mod_key->key_len--;
+        }
+        else {
+            mod_key->dynamic_key = FLB_FALSE;
+        }
+        mk_list_add(&mod_key->_head, &ctx->remove_keys);
+        ctx->remove_keys_num++;
+    }
+
+    /* Check "Allowlist_key" and "Whitelist_key" properties */
+    config_allowlist_key(ctx, ctx->allowlist_keys_map);
+    config_allowlist_key(ctx, ctx->whitelist_keys_map);
 
     if (ctx->remove_keys_num > 0 && ctx->allowlist_keys_num > 0) {
         flb_plg_error(ctx->ins, "remove_keys and allowlist_keys are exclusive "
@@ -148,7 +165,6 @@ static int delete_list(struct record_modifier_ctx *ctx)
         mk_list_del(&record->_head);
         flb_free(record);
     }
-
     return 0;
 }
 
@@ -382,11 +398,38 @@ static int cb_modifier_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_SLIST_2, "record", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct record_modifier_ctx, records_map),
+     "Append fields. This parameter needs key and value pair."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "remove_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct record_modifier_ctx, remove_keys_map),
+     "If the key is matched, that field is removed."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "allowlist_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct record_modifier_ctx, allowlist_keys_map),
+     "If the key is not matched, that field is removed."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "whitelist_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct record_modifier_ctx, whitelist_keys_map),
+     "(Alias of allowlist_key)"
+    },
+
+    {0}
+};
+
 struct flb_filter_plugin filter_record_modifier_plugin = {
     .name         = "record_modifier",
     .description  = "modify record",
     .cb_init      = cb_modifier_init,
     .cb_filter    = cb_modifier_filter,
     .cb_exit      = cb_modifier_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -42,6 +42,12 @@ struct record_modifier_ctx {
     int records_num;
     int remove_keys_num;
     int allowlist_keys_num;
+    /* config map */
+    struct mk_list *records_map;
+    struct mk_list *remove_keys_map;
+    struct mk_list *allowlist_keys_map;
+    struct mk_list *whitelist_keys_map;
+
     struct mk_list records;
     struct mk_list remove_keys;
     struct mk_list allowlist_keys;


### PR DESCRIPTION
This patch is to support config_map for filter_record_modifier.
See also #4863 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name cpu

[FILTER]
    Name record_modifier
    Match *
    Record key val
    Record key2 val2
    Allowlist_key cpu_p
    Allowlist_key user_p
    Allowlist_key system_p

[OUTPUT]
    Name stdout
    Match *
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 09:21:56] [ info] [engine] started (pid=43927)
[2022/02/19 09:21:56] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 09:21:56] [ info] [storage] in-memory
[2022/02/19 09:21:56] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 09:21:56] [ info] [cmetrics] version=0.2.3
[2022/02/19 09:21:56] [ info] [sp] stream processor started
[2022/02/19 09:21:56] [ info] [output:stdout:stdout.0] worker #0 started
[0] cpu.0: [1645230117.041478086, {"cpu_p"=>2.000000, "user_p"=>2.000000, "system_p"=>0.000000, "key"=>"val", "key2"=>"val2"}]
[1] cpu.0: [1645230118.041709948, {"cpu_p"=>4.000000, "user_p"=>3.000000, "system_p"=>1.000000, "key"=>"val", "key2"=>"val2"}]
[2] cpu.0: [1645230119.040985699, {"cpu_p"=>3.000000, "user_p"=>2.000000, "system_p"=>1.000000, "key"=>"val", "key2"=>"val2"}]
[3] cpu.0: [1645230120.041600995, {"cpu_p"=>5.000000, "user_p"=>4.000000, "system_p"=>1.000000, "key"=>"val", "key2"=>"val2"}]
^C[2022/02/19 09:22:01] [engine] caught signal (SIGINT)
[2022/02/19 09:22:01] [ info] [input] pausing cpu.0
[2022/02/19 09:22:01] [ warn] [engine] service will shutdown in max 5 seconds
[0] cpu.0: [1645230121.041023930, {"cpu_p"=>3.000000, "user_p"=>3.000000, "system_p"=>0.000000, "key"=>"val", "key2"=>"val2"}]
[2022/02/19 09:22:02] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 09:22:02] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 09:22:02] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==43932== Memcheck, a memory error detector
==43932== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43932== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43932== Command: bin/fluent-bit -c a.conf
==43932== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 09:22:31] [ info] [engine] started (pid=43932)
[2022/02/19 09:22:31] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 09:22:31] [ info] [storage] in-memory
[2022/02/19 09:22:31] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 09:22:31] [ info] [cmetrics] version=0.2.3
[2022/02/19 09:22:32] [ info] [sp] stream processor started
[2022/02/19 09:22:32] [ info] [output:stdout:stdout.0] worker #0 started
[0] cpu.0: [1645230153.062396567, {"cpu_p"=>22.000000, "user_p"=>20.000000, "system_p"=>2.000000, "key"=>"val", "key2"=>"val2"}]
[1] cpu.0: [1645230154.041761047, {"cpu_p"=>24.000000, "user_p"=>22.000000, "system_p"=>2.000000, "key"=>"val", "key2"=>"val2"}]
[2] cpu.0: [1645230155.041714469, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "key"=>"val", "key2"=>"val2"}]
[3] cpu.0: [1645230156.041411703, {"cpu_p"=>1.000000, "user_p"=>1.000000, "system_p"=>0.000000, "key"=>"val", "key2"=>"val2"}]
^C[2022/02/19 09:22:37] [engine] caught signal (SIGINT)
[2022/02/19 09:22:37] [ info] [input] pausing cpu.0
[0] cpu.0: [1645230157.101533615, {"cpu_p"=>7.000000, "user_p"=>7.000000, "system_p"=>0.000000, "key"=>"val", "key2"=>"val2"}]
[2022/02/19 09:22:37] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/19 09:22:38] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 09:22:38] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 09:22:38] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==43932== 
==43932== HEAP SUMMARY:
==43932==     in use at exit: 0 bytes in 0 blocks
==43932==   total heap usage: 1,252 allocs, 1,252 frees, 1,120,108 bytes allocated
==43932== 
==43932== All heap blocks were freed -- no leaks are possible
==43932== 
==43932== For lists of detected and suppressed errors, rerun with: -s
==43932== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Runtime test:
```
$ valgrind --leak-check=full bin/flb-rt-filter_record_modifier 
==43942== Memcheck, a memory error detector
==43942== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43942== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43942== Command: bin/flb-rt-filter_record_modifier
==43942== 
Test json_long...                               [ OK ]
Test remove_keys...                             [ OK ]
Test records...                                 [ OK ]
Test allowlist_keys...                          [ OK ]
Test multiple...                                [ OK ]
Test exclusive_setting...                       [2022/02/19 09:23:19] [error] [filter:record_modifier:record_modifier.0] remove_keys and allowlist_keys are exclusive with each other.
[2022/02/19 09:23:19] [error] Failed initialize filter record_modifier.0
[2022/02/19 09:23:19] [error] [lib] backend failed
[ OK ]
SUCCESS: All unit tests have passed.
==43942== 
==43942== HEAP SUMMARY:
==43942==     in use at exit: 0 bytes in 0 blocks
==43942==   total heap usage: 6,269 allocs, 6,269 frees, 3,625,899 bytes allocated
==43942== 
==43942== All heap blocks were freed -- no leaks are possible
==43942== 
==43942== For lists of detected and suppressed errors, rerun with: -s
==43942== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
