### PR TITLE
filter_type_converter: support config map

### DIFF
--- a/plugins/filter_type_converter/type_converter.c
+++ b/plugins/filter_type_converter/type_converter.c
@@ -51,78 +51,80 @@ static int delete_conv_entry(struct conv_entry *conv)
     return 0;
 }
 
+static int config_rule(struct type_converter_ctx *ctx, char* type_name,
+                       struct flb_config_map_val *mv)
+{
+    struct conv_entry      *entry = NULL;
+    struct flb_slist_entry *sentry = NULL;
+
+    if (ctx == NULL || mv == NULL) {
+        return -1;
+    }
+
+    entry = flb_malloc(sizeof(struct conv_entry));
+    if (entry == NULL) {
+        flb_errno();
+        return -1;
+    }
+    entry->rule = NULL;
+    if (mk_list_size(mv->val.list) != 3) {
+        flb_plg_error(ctx->ins, "invalid record parameters, "
+                      "expects 'from_key to_key type' %d", mk_list_size(mv->val.list));
+        flb_free(entry);
+        return -1;
+    }
+    /* from_key name */
+    sentry          = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+    entry->from_key = flb_sds_create_len(sentry->str, flb_sds_len(sentry->str));
+
+    /* to_key name */
+    sentry = mk_list_entry_next(&sentry->_head, struct flb_slist_entry,
+                                _head, mv->val.list);
+    entry->to_key   = flb_sds_create_len(sentry->str, flb_sds_len(sentry->str));
+
+    sentry = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+    entry->rule = flb_typecast_rule_create(type_name, strlen(type_name),
+                                           sentry->str,
+                                           flb_sds_len(sentry->str));
+    entry->from_ra = flb_ra_create(entry->from_key, FLB_FALSE);
+    if (entry->rule == NULL || entry->from_ra == NULL) {
+        flb_plg_error(ctx->ins,
+                      "configuration error. ignore the key=%s",
+                      entry->from_key);
+        delete_conv_entry(entry);
+        return -1;
+    }
+    mk_list_add(&entry->_head, &ctx->conv_entries);
+
+    return 0;
+}
+
 static int configure(struct type_converter_ctx *ctx,
                      struct flb_filter_instance *f_ins)
 {
-    struct flb_kv          *kv = NULL;
     struct mk_list         *head = NULL;
-    struct conv_entry      *entry = NULL;
-    struct mk_list         *split = NULL;
-    struct flb_split_entry *sentry = NULL;
+    struct flb_config_map_val *mv = NULL;
 
-    /* Iterate all filter properties */
-    mk_list_foreach(head, &f_ins->properties) {
-        kv = mk_list_entry(head, struct flb_kv, _head);
-        if ((!strcasecmp(kv->key, "int_key")) || (!strcasecmp(kv->key, "str_key")) || 
-            !strcasecmp(kv->key, "uint_key") ||(!strcasecmp(kv->key, "float_key"))) {
-            entry = flb_malloc(sizeof(struct conv_entry));
-            if (entry == NULL) {
-                flb_errno();
-                continue;
-            }
-            entry->rule = NULL;
-
-            split = flb_utils_split(kv->val, ' ', 3);
-            if (mk_list_size(split) != 3) {
-                flb_plg_error(ctx->ins, "invalid record parameters, "
-                              "expects 'from_key to_key type' %d", mk_list_size(split));
-                flb_free(entry);
-                flb_utils_split_free(split);
-                continue;
-            }
-            /* from_key name */
-            sentry          = mk_list_entry_first(split, struct flb_split_entry, _head);
-            entry->from_key = flb_sds_create_len(sentry->value, sentry->len);
-
-            /* to_key name */
-            sentry = mk_list_entry_next(&sentry->_head, struct flb_split_entry,
-                                        _head, split);
-            entry->to_key   = flb_sds_create_len(sentry->value, sentry->len);
-
-            sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
-            if (!strcasecmp(kv->key, "int_key")) {
-                entry->rule = flb_typecast_rule_create("int", 3,
-                                                       sentry->value,
-                                                       sentry->len);
-            }
-            else if (!strcasecmp(kv->key, "uint_key")) {
-                entry->rule = flb_typecast_rule_create("uint", 4,
-                                                       sentry->value,
-                                                       sentry->len);
-            }
-            else if(!strcasecmp(kv->key, "float_key")) {
-                entry->rule = flb_typecast_rule_create("float", 5,
-                                                       sentry->value,
-                                                       sentry->len);
-            }
-            else if(!strcasecmp(kv->key, "str_key")) {
-                entry->rule = flb_typecast_rule_create("string", 6,
-                                                       sentry->value,
-                                                       sentry->len);
-            }
-            entry->from_ra = flb_ra_create(entry->from_key, FLB_FALSE);
-            if (entry->rule == NULL || entry->from_ra == NULL) {
-                flb_plg_error(ctx->ins,
-                              "configuration error. ignore the key=%s",
-                              entry->from_key);
-                flb_utils_split_free(split);
-                delete_conv_entry(entry);
-                continue;
-            }
-            flb_utils_split_free(split);
-            mk_list_add(&entry->_head, &ctx->conv_entries);
-        }
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_errno();
+        flb_plg_error(f_ins, "configuration error");
+        return -1;
     }
+
+    /* Create rules for each type */
+    flb_config_map_foreach(head, mv, ctx->str_keys) {
+        config_rule(ctx, "string", mv);
+    }
+    flb_config_map_foreach(head, mv, ctx->int_keys) {
+        config_rule(ctx, "int", mv);
+    }
+    flb_config_map_foreach(head, mv, ctx->uint_keys) {
+        config_rule(ctx, "uint", mv);
+    }
+    flb_config_map_foreach(head, mv, ctx->float_keys) {
+        config_rule(ctx, "float", mv);
+    }
+
     if (mk_list_size(&ctx->conv_entries) == 0) {
         flb_plg_error(ctx->ins, "no rules");
         return -1;
@@ -274,6 +276,29 @@ static int cb_type_converter_exit(void *data, struct flb_config *config) {
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_SLIST_3, "int_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, int_keys),
+     "Convert integer to other type. e.g. int_key id id_str string"
+    },
+    {
+     FLB_CONFIG_MAP_SLIST_3, "uint_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, uint_keys),
+     "Convert unsinged integer to other type. e.g. uint_key id id_str string"
+    },
+    {
+     FLB_CONFIG_MAP_SLIST_3, "float_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, float_keys),
+     "Convert float to other type. e.g. float_key ratio id_str string"
+    },
+    {
+     FLB_CONFIG_MAP_SLIST_3, "str_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, str_keys),
+     "Convert string to other type. e.g. str_key id id_val integer"
+    },
+    {0}
+};
   
 
 struct flb_filter_plugin filter_type_converter_plugin = {
@@ -282,5 +307,6 @@ struct flb_filter_plugin filter_type_converter_plugin = {
     .cb_init     = cb_type_converter_init,
     .cb_filter   = cb_type_converter_filter,
     .cb_exit     = cb_type_converter_exit,
+    .config_map  = config_map,
     .flags       = 0,
 };

--- a/plugins/filter_type_converter/type_converter.h
+++ b/plugins/filter_type_converter/type_converter.h
@@ -36,6 +36,11 @@ struct conv_entry {
 struct type_converter_ctx {
     struct mk_list conv_entries;
     struct flb_filter_instance *ins;
+    /* config maps */
+    struct mk_list *int_keys;
+    struct mk_list *uint_keys;
+    struct mk_list *float_keys;
+    struct mk_list *str_keys;
 };
 
 #endif


### PR DESCRIPTION
This patch is to support config map for filter_type_converter.
See also #4863 


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"k_int":1234, "k_float":123.456, "k_str":"123456"}
    Samples 1

[FILTER]
    Name type_converter
    Match *
    int_key    k_int    int_s    string
    float_key  k_float  float_s  string
    str_key    k_str    str_i    int


[OUTPUT]
    Name stdout
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 11:25:18] [ info] [engine] started (pid=49940)
[2022/02/19 11:25:18] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 11:25:18] [ info] [storage] in-memory
[2022/02/19 11:25:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 11:25:18] [ info] [cmetrics] version=0.2.3
[2022/02/19 11:25:18] [ info] [sp] stream processor started
[2022/02/19 11:25:18] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1645237518.880201968, {"k_int"=>1234, "k_float"=>123.456000, "k_str"=>"123456", "str_i"=>123456, "int_s"=>"1234", "float_s"=>"123.456"}]
^C[2022/02/19 11:25:23] [engine] caught signal (SIGINT)
[2022/02/19 11:25:23] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/19 11:25:23] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 11:25:23] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 11:25:23] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==49944== Memcheck, a memory error detector
==49944== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==49944== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==49944== Command: bin/fluent-bit -c a.conf
==49944== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 11:25:53] [ info] [engine] started (pid=49944)
[2022/02/19 11:25:54] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 11:25:54] [ info] [storage] in-memory
[2022/02/19 11:25:54] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 11:25:54] [ info] [cmetrics] version=0.2.3
[2022/02/19 11:25:54] [ info] [sp] stream processor started
[2022/02/19 11:25:54] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1645237554.909772595, {"k_int"=>1234, "k_float"=>123.456000, "k_str"=>"123456", "str_i"=>123456, "int_s"=>"1234", "float_s"=>"123.456"}]
^C[2022/02/19 11:25:59] [engine] caught signal (SIGINT)
[2022/02/19 11:25:59] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/19 11:25:59] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 11:25:59] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 11:25:59] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==49944== 
==49944== HEAP SUMMARY:
==49944==     in use at exit: 0 bytes in 0 blocks
==49944==   total heap usage: 1,240 allocs, 1,240 frees, 719,397 bytes allocated
==49944== 
==49944== All heap blocks were freed -- no leaks are possible
==49944== 
==49944== For lists of detected and suppressed errors, rerun with: -s
==49944== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Runtime test
```
$ valgrind --leak-check=full bin/flb-rt-filter_type_converter 
==49955== Memcheck, a memory error detector
==49955== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==49955== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==49955== Command: bin/flb-rt-filter_type_converter
==49955== 
Test str_to_int...                              [ OK ]
Test str_to_float...                            [ OK ]
Test str_to_hex...                              [ OK ]
Test int_to_str...                              [ OK ]
Test int_to_float...                            [ OK ]
Test str<->int...                               [ OK ]
Test nest_key...                                [ OK ]
SUCCESS: All unit tests have passed.
==49955== 
==49955== HEAP SUMMARY:
==49955==     in use at exit: 0 bytes in 0 blocks
==49955==   total heap usage: 7,596 allocs, 7,596 frees, 4,335,497 bytes allocated
==49955== 
==49955== All heap blocks were freed -- no leaks are possible
==49955== 
==49955== For lists of detected and suppressed errors, rerun with: -s
==49955== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
