### PR TITLE
filter_grep: support config map

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -51,94 +51,76 @@ static void delete_rules(struct grep_ctx *ctx)
     }
 }
 
-static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
+static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins,
+                     struct flb_config_map_val *mv, int type)
 {
     flb_sds_t tmp;
-    struct mk_list *head;
-    struct mk_list *split;
-    struct flb_split_entry *sentry;
-    struct flb_kv *kv;
     struct grep_rule *rule;
+    struct flb_slist_entry *sentry;
 
-    /* Iterate all filter properties */
-    mk_list_foreach(head, &f_ins->properties) {
-        kv = mk_list_entry(head, struct flb_kv, _head);
-
-        /* Create a new rule */
-        rule = flb_malloc(sizeof(struct grep_rule));
-        if (!rule) {
-            flb_errno();
-            return -1;
-        }
-
-        /* Get the type */
-        if (strcasecmp(kv->key, "regex") == 0) {
-            rule->type = GREP_REGEX;
-        }
-        else if (strcasecmp(kv->key, "exclude") == 0) {
-            rule->type = GREP_EXCLUDE;
-        }
-        else {
-            flb_plg_error(ctx->ins, "unknown rule type '%s'", kv->key);
-            delete_rules(ctx);
-            flb_free(rule);
-            return -1;
-        }
-
-        /* As a value we expect a pair of field name and a regular expression */
-        split = flb_utils_split(kv->val, ' ', 1);
-        if (mk_list_size(split) != 2) {
-            flb_plg_error(ctx->ins,
-                          "invalid regex, expected field and regular expression");
-            delete_rules(ctx);
-            flb_free(rule);
-            flb_utils_split_free(split);
-            return -1;
-        }
-
-        /* Get first value (field) */
-        sentry = mk_list_entry_first(split, struct flb_split_entry, _head);
-        if (*sentry->value == '$') {
-            rule->field = flb_sds_create_len(sentry->value, sentry->len);
-        }
-        else {
-            rule->field = flb_sds_create_size(sentry->len + 2);
-            tmp = flb_sds_cat(rule->field, "$", 1);
-            rule->field = tmp;
-
-            tmp = flb_sds_cat(rule->field, sentry->value, sentry->len);
-            rule->field = tmp;
-        }
-
-        /* Get remaining content (regular expression) */
-        sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
-        rule->regex_pattern = flb_strndup(sentry->value, sentry->len);
-
-        /* Release split */
-        flb_utils_split_free(split);
-
-        /* Create a record accessor context for this rule */
-        rule->ra = flb_ra_create(rule->field, FLB_FALSE);
-        if (!rule->ra) {
-            flb_plg_error(ctx->ins, "invalid record accessor? '%s'", rule->field);
-            delete_rules(ctx);
-            flb_free(rule);
-            return -1;
-        }
-
-        /* Convert string to regex pattern */
-        rule->regex = flb_regex_create(rule->regex_pattern);
-        if (!rule->regex) {
-            flb_plg_error(ctx->ins, "could not compile regex pattern '%s'",
-                      rule->regex_pattern);
-            delete_rules(ctx);
-            flb_free(rule);
-            return -1;
-        }
-
-        /* Link to parent list */
-        mk_list_add(&rule->_head, &ctx->rules);
+    /* Create a new rule */
+    rule = flb_malloc(sizeof(struct grep_rule));
+    if (!rule) {
+        flb_errno();
+        return -1;
     }
+
+    if (type != GREP_REGEX && type != GREP_EXCLUDE) {
+        flb_plg_error(ctx->ins, "unknown rule type: %d", type);
+        delete_rules(ctx);
+        flb_free(rule);
+        return -1;
+    }
+    rule->type = type;
+
+    /* As a value we expect a pair of field name and a regular expression */
+    if (mk_list_size(mv->val.list) != 2) {
+        flb_plg_error(ctx->ins,
+                      "invalid regex, expected field and regular expression");
+        delete_rules(ctx);
+        flb_free(rule);
+        return -1;
+    }
+
+    /* Get first value (field) */
+    sentry = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+    if (*sentry->str == '$') {
+        rule->field = flb_sds_create_len(sentry->str, flb_sds_len(sentry->str));
+    }
+    else {
+        rule->field = flb_sds_create_size(flb_sds_len(sentry->str) + 2);
+        tmp = flb_sds_cat(rule->field, "$", 1);
+        rule->field = tmp;
+
+        tmp = flb_sds_cat(rule->field, sentry->str, flb_sds_len(sentry->str));
+        rule->field = tmp;
+    }
+
+    /* Get remaining content (regular expression) */
+    sentry = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+    rule->regex_pattern = flb_strndup(sentry->str, flb_sds_len(sentry->str));
+
+    /* Create a record accessor context for this rule */
+    rule->ra = flb_ra_create(rule->field, FLB_FALSE);
+    if (!rule->ra) {
+        flb_plg_error(ctx->ins, "invalid record accessor? '%s'", rule->field);
+        delete_rules(ctx);
+        flb_free(rule);
+        return -1;
+    }
+
+    /* Convert string to regex pattern */
+    rule->regex = flb_regex_create(rule->regex_pattern);
+    if (!rule->regex) {
+        flb_plg_error(ctx->ins, "could not compile regex pattern '%s'",
+                      rule->regex_pattern);
+        delete_rules(ctx);
+        flb_free(rule);
+        return -1;
+    }
+
+    /* Link to parent list */
+    mk_list_add(&rule->_head, &ctx->rules);
 
     return 0;
 }
@@ -179,6 +161,8 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
 {
     int ret;
     struct grep_ctx *ctx;
+    struct flb_config_map_val *mv = NULL;
+    struct mk_list *head = NULL;
 
     /* Create context */
     ctx = flb_malloc(sizeof(struct grep_ctx));
@@ -186,14 +170,30 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
         flb_errno();
         return -1;
     }
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_errno();
+        flb_plg_error(f_ins, "configuration error");
+        flb_free(ctx);
+        return -1;
+    }
+
     mk_list_init(&ctx->rules);
     ctx->ins = f_ins;
 
     /* Load rules */
-    ret = set_rules(ctx, f_ins);
-    if (ret == -1) {
-        flb_free(ctx);
-        return -1;
+    flb_config_map_foreach(head, mv, ctx->regex_map) {
+        ret = set_rules(ctx, f_ins, mv, GREP_REGEX);
+        if (ret == -1) {
+            flb_free(ctx);
+            return -1;
+        }
+    }
+    flb_config_map_foreach(head, mv, ctx->exclude_map) {
+        ret = set_rules(ctx, f_ins, mv, GREP_EXCLUDE);
+        if (ret == -1) {
+            flb_free(ctx);
+            return -1;
+        }
     }
 
     /* Set our context */
@@ -275,11 +275,26 @@ static int cb_grep_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_SLIST_2, "regex", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct grep_ctx, regex_map),
+     "Keep records in which the content of KEY matches the regular expression."
+    },
+    {
+     FLB_CONFIG_MAP_SLIST_2, "exclude", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct grep_ctx, exclude_map),
+     "Exclude records in which the content of KEY matches the regular expression."
+    },
+    {0}
+};
+
 struct flb_filter_plugin filter_grep_plugin = {
     .name         = "grep",
     .description  = "grep events by specified field values",
     .cb_init      = cb_grep_init,
     .cb_filter    = cb_grep_filter,
     .cb_exit      = cb_grep_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/filter_grep/grep.h
+++ b/plugins/filter_grep/grep.h
@@ -36,6 +36,9 @@
 struct grep_ctx {
     struct mk_list rules;
     struct flb_filter_instance *ins;
+    /* config map */
+    struct mk_list *regex_map;
+    struct mk_list *exclude_map;
 };
 
 struct grep_rule {


### PR DESCRIPTION
This patch is to support config map for filter_grep.
See also #4863 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"test":{"match":"true"}, "key":"val"}
    Samples 1

[FILTER]
    Name grep
    Match *
    Regex $test['match'] true

[OUTPUT]
    Name stdout
    Match *
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 14:04:17] [ info] [engine] started (pid=59185)
[2022/02/19 14:04:17] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 14:04:17] [ info] [storage] in-memory
[2022/02/19 14:04:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 14:04:17] [ info] [cmetrics] version=0.2.3
[2022/02/19 14:04:17] [ info] [sp] stream processor started
[2022/02/19 14:04:17] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1645247058.025984754, {"test"=>{"match"=>"true"}, "key"=>"val"}]
^C[2022/02/19 14:04:23] [engine] caught signal (SIGINT)
[2022/02/19 14:04:23] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/19 14:04:24] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 14:04:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 14:04:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped

```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==59181== Memcheck, a memory error detector
==59181== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==59181== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==59181== Command: bin/fluent-bit -c a.conf
==59181== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/19 14:03:47] [ info] [engine] started (pid=59181)
[2022/02/19 14:03:47] [ info] [storage] version=1.1.6, initializing...
[2022/02/19 14:03:47] [ info] [storage] in-memory
[2022/02/19 14:03:47] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/19 14:03:47] [ info] [cmetrics] version=0.2.3
[2022/02/19 14:03:48] [ info] [sp] stream processor started
[2022/02/19 14:03:48] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1645247029.053374002, {"test"=>{"match"=>"true"}, "key"=>"val"}]
^C[2022/02/19 14:03:53] [engine] caught signal (SIGINT)
[2022/02/19 14:03:53] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/19 14:03:54] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/19 14:03:54] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/19 14:03:54] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==59181== 
==59181== HEAP SUMMARY:
==59181==     in use at exit: 0 bytes in 0 blocks
==59181==   total heap usage: 1,197 allocs, 1,197 frees, 718,531 bytes allocated
==59181== 
==59181== All heap blocks were freed -- no leaks are possible
==59181== 
==59181== For lists of detected and suppressed errors, rerun with: -s
==59181== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
