### PR TITLE
filter_parser: support config map

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -105,16 +105,17 @@ static int configure(struct filter_parser_ctx *ctx,
     ctx->preserve_key = FLB_FALSE;
     mk_list_init(&ctx->parsers);
 
-    /* Key name */
-    tmp = flb_filter_get_property("key_name", f_ins);
-    if (tmp) {
-        ctx->key_name = flb_strdup(tmp);
-        ctx->key_name_len = strlen(tmp);
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_errno();
+        flb_plg_error(f_ins, "configuration error");
+        return -1;
     }
-    else {
+
+    if (ctx->key_name == NULL) {
         flb_plg_error(ctx->ins, "missing 'key_name'");
         return -1;
     }
+    ctx->key_name_len = flb_sds_len(ctx->key_name);
 
     /* Read all Parsers */
     mk_list_foreach(head, &f_ins->properties) {
@@ -122,7 +123,6 @@ static int configure(struct filter_parser_ctx *ctx,
         if (strcasecmp("parser", kv->key) != 0) {
             continue;
         }
-
         ret = add_parser(kv->val, ctx, config);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "requested parser '%s' not found", kv->val);
@@ -132,18 +132,6 @@ static int configure(struct filter_parser_ctx *ctx,
     if (mk_list_size(&ctx->parsers) == 0) {
         flb_plg_error(ctx->ins, "Invalid 'parser'");
         return -1;
-    }
-
-    /* Reserve data */
-    tmp = flb_filter_get_property("reserve_data", f_ins);
-    if (tmp) {
-        ctx->reserve_data = flb_utils_bool(tmp);
-    }
-
-    /* Preserve key */
-    tmp = flb_filter_get_property("preserve_key", f_ins);
-    if (tmp) {
-        ctx->preserve_key = flb_utils_bool(tmp);
     }
 
     return 0;
@@ -361,10 +349,35 @@ static int cb_parser_exit(void *data, struct flb_config *config)
     }
 
     delete_parsers(ctx);
-    flb_free(ctx->key_name);
     flb_free(ctx);
     return 0;
 }
+
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "Key_Name", NULL,
+     0, FLB_TRUE, offsetof(struct filter_parser_ctx, key_name),
+     "Specify field name in record to parse."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Parser", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Specify the parser name to interpret the field. "
+     "Multiple Parser entries are allowed (one per line)."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "Preserve_Key", FLB_FALSE,
+     0, FLB_TRUE, offsetof(struct filter_parser_ctx, preserve_key),
+     "Keep original Key_Name field in the parsed result. If false, the field will be removed."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "Reserve_Data", FLB_FALSE,
+     0, FLB_TRUE, offsetof(struct filter_parser_ctx, reserve_data),
+     "Keep all other original fields in the parsed result. "
+     "If false, all other original fields will be removed."
+    },
+    {0}
+};
 
 struct flb_filter_plugin filter_parser_plugin = {
     .name         = "parser",
@@ -372,5 +385,6 @@ struct flb_filter_plugin filter_parser_plugin = {
     .cb_init      = cb_parser_init,
     .cb_filter    = cb_parser_filter,
     .cb_exit      = cb_parser_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_sds.h>
 
 struct filter_parser {
     struct flb_parser *parser;
@@ -30,7 +31,7 @@ struct filter_parser {
 };
 
 struct filter_parser_ctx {
-    char     *key_name;
+    flb_sds_t key_name;
     int    key_name_len;
     int    reserve_data;
     int    preserve_key;


### PR DESCRIPTION
This patch is to support config map for filter_parser.
#4863 


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[SERVICE]
    Parsers_File parsers.conf

[INPUT]
    Name tail
    path b.log
    Read_From_Head on

[FILTER]
    Name parser
    Match *
    key_name log
    Parser docker
    Parser json
    Preserve_Key on
    Reserve_Data on

[OUTPUT]
    Name stdout
    Match *
```

a.log:
```
{"aaa":"bbb", "ccc":"ddd"}

```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/20 09:32:17] [ info] [engine] started (pid=18004)
[2022/02/20 09:32:17] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:32:17] [ info] [storage] in-memory
[2022/02/20 09:32:17] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:32:17] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:32:17] [ info] [sp] stream processor started
[2022/02/20 09:32:17] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1450000 watch_fd=1 name=b.log
[2022/02/20 09:32:17] [ info] [output:stdout:stdout.0] worker #0 started
[0] tail.0: [1645317137.077762921, {"aaa"=>"bbb", "ccc"=>"ddd", "log"=>"{"aaa":"bbb", "ccc":"ddd"}"}]
^C[2022/02/20 09:32:22] [engine] caught signal (SIGINT)
[2022/02/20 09:32:22] [ info] [input] pausing tail.0
[2022/02/20 09:32:22] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/20 09:32:23] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/20 09:32:23] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1450000 watch_fd=1
[2022/02/20 09:32:23] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/20 09:32:23] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==18008== Memcheck, a memory error detector
==18008== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18008== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18008== Command: bin/fluent-bit -c a.conf
==18008== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/20 09:32:44] [ info] [engine] started (pid=18008)
[2022/02/20 09:32:44] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:32:44] [ info] [storage] in-memory
[2022/02/20 09:32:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:32:44] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:32:44] [ info] [output:stdout:stdout.0] worker #0 started
[2022/02/20 09:32:44] [ info] [sp] stream processor started
[2022/02/20 09:32:44] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1450000 watch_fd=1 name=b.log
[0] tail.0: [1645317164.448289235, {"aaa"=>"bbb", "ccc"=>"ddd", "log"=>"{"aaa":"bbb", "ccc":"ddd"}"}]
^C[2022/02/20 09:32:49] [engine] caught signal (SIGINT)
[2022/02/20 09:32:49] [ info] [input] pausing tail.0
[2022/02/20 09:32:49] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/20 09:32:50] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/20 09:32:50] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1450000 watch_fd=1
[2022/02/20 09:32:50] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/20 09:32:50] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==18008== 
==18008== HEAP SUMMARY:
==18008==     in use at exit: 0 bytes in 0 blocks
==18008==   total heap usage: 3,209 allocs, 3,209 frees, 954,642 bytes allocated
==18008== 
==18008== All heap blocks were freed -- no leaks are possible
==18008== 
==18008== For lists of detected and suppressed errors, rerun with: -s
==18008== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Runtime test:
```
$ valgrind --leak-check=full bin/flb-rt-filter_parser 
==18017== Memcheck, a memory error detector
==18017== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18017== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18017== Command: bin/flb-rt-filter_parser
==18017== 
Test filter_parser_extract_fields...            [2022/02/20 09:33:23] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:23] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:23] [ info] [storage] in-memory
[2022/02/20 09:33:23] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:23] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:23] [ info] [sp] stream processor started
[2022/02/20 09:33:25] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/20 09:33:26] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_reserve_data_off...          [2022/02/20 09:33:26] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:26] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/20 09:33:26] [debug] [storage] [cio stream] new stream registered: lib.0
[2022/02/20 09:33:26] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:26] [ info] [storage] in-memory
[2022/02/20 09:33:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:26] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:26] [debug] [lib:lib.0] created event channels: read=27 write=28
[2022/02/20 09:33:26] [debug] [router] match rule lib.0:lib.0
[2022/02/20 09:33:26] [ info] [sp] stream processor started
[2022/02/20 09:33:26] [debug] [input chunk] update output instances with new chunk size diff=66
[2022/02/20 09:33:27] [debug] [task] created task=0x4f7be20 id=0 OK
[2022/02/20 09:33:27] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example"}]
[2022/02/20 09:33:27] [debug] [out flush] cb_destroy coro_id=0
[2022/02/20 09:33:27] [debug] [task] destroy task=0x4f7be20 (task_id=0)
[2022/02/20 09:33:27] [ warn] [engine] service will shutdown in max 1 seconds
[2022/02/20 09:33:28] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_handle_time_key...           [2022/02/20 09:33:28] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:28] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/20 09:33:28] [debug] [storage] [cio stream] new stream registered: lib.0
[2022/02/20 09:33:28] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:28] [ info] [storage] in-memory
[2022/02/20 09:33:28] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:28] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:28] [debug] [lib:lib.0] created event channels: read=33 write=34
[2022/02/20 09:33:28] [debug] [router] match rule lib.0:lib.0
[2022/02/20 09:33:28] [ info] [sp] stream processor started
[2022/02/20 09:33:28] [debug] [input chunk] update output instances with new chunk size diff=39
[2022/02/20 09:33:29] [debug] [task] created task=0x502c2a0 id=0 OK
[2022/02/20 09:33:29] [debug] [test_filter_parser] received message: [1509575121.648000,{"message":"This is an example"}]
[2022/02/20 09:33:29] [debug] [out flush] cb_destroy coro_id=0
[2022/02/20 09:33:29] [debug] [task] destroy task=0x502c2a0 (task_id=0)
[2022/02/20 09:33:29] [ warn] [engine] service will shutdown in max 1 seconds
[2022/02/20 09:33:30] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_ignore_malformed_time...     [2022/02/20 09:33:30] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:30] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/20 09:33:30] [debug] [storage] [cio stream] new stream registered: lib.0
[2022/02/20 09:33:30] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:30] [ info] [storage] in-memory
[2022/02/20 09:33:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:30] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:30] [debug] [lib:lib.0] created event channels: read=39 write=40
[2022/02/20 09:33:30] [debug] [router] match rule lib.0:lib.0
[2022/02/20 09:33:30] [ info] [sp] stream processor started
[2022/02/20 09:33:30] [error] [parser] cannot parse '2017_$!^-11-01T22:25:21.648'
[2022/02/20 09:33:30] [ warn] [parser:timestamp] invalid time format %Y-%m-%dT%H:%M:%S.%L for '2017_$!^-11-01T22:25:21.648'
[2022/02/20 09:33:30] [debug] [input chunk] update output instances with new chunk size diff=66
[2022/02/20 09:33:31] [debug] [task] created task=0x50dc810 id=0 OK
[2022/02/20 09:33:31] [debug] [test_filter_parser] received message: [1448403340.000000,{"@timestamp":"2017_$!^-11-01T22:25:21.648","log":"An example"}]
[2022/02/20 09:33:31] [debug] [out flush] cb_destroy coro_id=0
[2022/02/20 09:33:31] [debug] [task] destroy task=0x50dc810 (task_id=0)
[2022/02/20 09:33:31] [ warn] [engine] service will shutdown in max 1 seconds
[2022/02/20 09:33:32] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_preserve_original_field...   [2022/02/20 09:33:32] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:32] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/20 09:33:32] [debug] [storage] [cio stream] new stream registered: lib.0
[2022/02/20 09:33:32] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:32] [ info] [storage] in-memory
[2022/02/20 09:33:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:32] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:32] [debug] [lib:lib.0] created event channels: read=45 write=46
[2022/02/20 09:33:32] [debug] [router] match rule lib.0:lib.0
[2022/02/20 09:33:32] [ info] [sp] stream processor started
[2022/02/20 09:33:32] [debug] [input chunk] update output instances with new chunk size diff=118
[2022/02/20 09:33:33] [debug] [task] created task=0x518dec0 id=0 OK
[2022/02/20 09:33:33] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example","data":"100 0.5 true This is an example","log":"An example"}]
[2022/02/20 09:33:33] [debug] [out flush] cb_destroy coro_id=0
[2022/02/20 09:33:33] [debug] [task] destroy task=0x518dec0 (task_id=0)
[2022/02/20 09:33:33] [ warn] [engine] service will shutdown in max 1 seconds
[2022/02/20 09:33:34] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_first_matched_when_multiple_parser... [2022/02/20 09:33:34] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:34] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:34] [ info] [storage] in-memory
[2022/02/20 09:33:34] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:34] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:34] [ info] [sp] stream processor started
[2022/02/20 09:33:35] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/20 09:33:36] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_skip_empty_values_false...   [2022/02/20 09:33:36] [ info] [engine] started (pid=18017)
[2022/02/20 09:33:36] [ info] [storage] version=1.1.6, initializing...
[2022/02/20 09:33:36] [ info] [storage] in-memory
[2022/02/20 09:33:36] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/20 09:33:36] [ info] [cmetrics] version=0.2.3
[2022/02/20 09:33:36] [ info] [sp] stream processor started
[2022/02/20 09:33:37] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/20 09:33:38] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==18017== 
==18017== HEAP SUMMARY:
==18017==     in use at exit: 0 bytes in 0 blocks
==18017==   total heap usage: 7,774 allocs, 7,774 frees, 4,520,573 bytes allocated
==18017== 
==18017== All heap blocks were freed -- no leaks are possible
==18017== 
==18017== For lists of detected and suppressed errors, rerun with: -s
==18017== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
