### PR TITLE
workflows: staging updates for 1.9

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -17,9 +17,9 @@ on:
         required: false
         default: ""
 
-  # Run nightly build
-  schedule:
-  - cron: "0 6 * * *"
+  # Run nightly build - disable until after 1.9 release
+  # schedule:
+  # - cron: "0 6 * * *"
 
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -38,6 +38,10 @@ jobs:
       version: ${{ steps.formatted_version.outputs.replaced }}
       date: ${{ steps.date.outputs.date }}
     steps:
+      # This step is to consolidate the three different triggers into a single "version"
+      # 1. If manual dispatch - use the version provided.
+      # 2. If cron/regular build - use master.
+      # 3. If tag trigger, use that tag.
       - name: Get the version
         id: get_version
         # Use the input variable if defined, if not attempt to get a tag
@@ -56,6 +60,7 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version || '' }}
 
+      # String the 'v' prefix for tags.
       - uses: frabert/replace-string-action@v2.0
         id: formatted_version
         with:
@@ -64,6 +69,7 @@ jobs:
           replace-with: '$1'
           flags: 'g'
 
+      # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -3,6 +3,8 @@ name: Deploy to staging
 
 on:
   push:
+    branches:
+      - master
     tags:
       - '*'
 

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -46,21 +46,18 @@ jobs:
       # 3. If tag trigger, use that tag.
       - name: Get the version
         id: get_version
-        # Use the input variable if defined, if not attempt to get a tag
         run: |
             VERSION="${INPUT_VERSION}"
             if [ -z "${VERSION}" ]; then
-              if [ -z "${GITHUB_REF/refs\/tags\//}" ]; then
-                VERSION="${GITHUB_REF/refs\/tags\//}"
-              else
-                echo "Defaulting to master"
-                VERSION=master
-              fi
+              echo "Defaulting to master"
+              VERSION=master
             fi
             echo ::set-output name=VERSION::$VERSION
         shell: bash
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+          # Use the dispatch variable in preference, if empty use the context ref_name which should
+          # only ever be a tag or the master branch for cron builds.
+          INPUT_VERSION: ${{ github.event.inputs.version || github.ref_name }}
 
       # String the 'v' prefix for tags.
       - uses: frabert/replace-string-action@v2.0

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: master
       target:
-        description: Only build a specific target
+        description: Only build a specific target, intended for debug/test/quick builds only.
         required: false
         default: ""
 

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -37,6 +37,8 @@ jobs:
         cat latest-version.txt
         STAGING_VERSION=$(cat latest-version.txt)
         [[ "$STAGING_VERSION" != "$RELEASE_VERSION" ]] && echo "Latest version mismatch: $STAGING_VERSION != $RELEASE_VERSION" && exit 1
+        # Must end in something that exits 0
+        echo "Successfully confirmed version is as expected: $STAGING_VERSION"
       shell: bash
       env:
         AWS_URL: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com
@@ -94,7 +96,6 @@ jobs:
       run: |
         rm -f packaging/releases/*.repo
         LATEST_VERSION=$(cat packaging/releases/latest-version.txt)
-        [[ "$LATEST_VERSION" != "$VERSION" ]] && echo "Latest version mismatch: $LATEST_VERSION != $VERSION"
         packaging/update-repos.sh "$VERSION" packaging/releases/
         rm -f packaging/releases/latest-version.txt
       env:

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -64,7 +64,7 @@ jobs:
     with:
       registry: ghcr.io
       username: ${{ github.actor }}
-      image: ${{ github.repository }}/multiarch
+      image: ${{ github.repository }}/staging/multiarch
       image-tag: latest
       environment: staging
     secrets:
@@ -77,7 +77,7 @@ jobs:
     needs: [ staging-test-multiarch-images, staging-test-images-integration-gcp ]
     uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
     with:
-      image_name: ghcr.io/${{ github.repository }}/multiarch
+      image_name: ghcr.io/${{ github.repository }}/staging/multiarch
       image_tag: latest
     secrets:
       grafana_username: ${{ secrets.GRAFANA_USERNAME }}


### PR DESCRIPTION
Addresses #4864 by ensuring only tagged (or manually dispatched) builds update staging.
Primarily to enable 1.9 RC candidates to be built and tested without overwriting with regular nightly builds.

Follow on work is identified in #4875, this is a change to keep things simple and using the well trodden workflows only for the imminent release tags.

Also resolves testing of multiarch images using the wrong registry name in #4877.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested with a `v1.1` tag here: https://github.com/patrick-stephens/fluent-bit-release-test/runs/5272950966?check_suite_focus=true#step:2:4
```
Version: 1.1
```

Tested with a manual dispatch of `9.9`: https://github.com/patrick-stephens/fluent-bit-release-test/runs/5272981133?check_suite_focus=true#step:2:4
```
Version: 9.9
```

Confirmed release check should work:
- Current failing approach: https://github.com/patrick-stephens/fluent-bit-release-test/runs/5273062461?check_suite_focus=true
```
master
Error: Process completed with exit code 1.
```
- Changes in this PR now pass: https://github.com/patrick-stephens/fluent-bit-release-test/runs/5273075250?check_suite_focus=true#step:2:18
```
master
Successfully confirmed version is as expected: master
```
---

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
