### PR TITLE
tests: internal: fuzzers: fix compiler warnings

### DIFF
--- a/tests/internal/fuzzers/multiline_fuzzer.c
+++ b/tests/internal/fuzzers/multiline_fuzzer.c
@@ -44,7 +44,7 @@ struct expected_result {
     struct record_check *out_records;
 };
 
-int test_multiline_parser(msgpack_object *root2, char *str1, size_t str1_len) {
+void test_multiline_parser(msgpack_object *root2, char *str1, size_t str1_len) {
     uint64_t stream_id;
     struct expected_result res = {0};
     struct flb_config *config = NULL;
@@ -81,7 +81,7 @@ int test_multiline_parser(msgpack_object *root2, char *str1, size_t str1_len) {
     flb_config_exit(config);
 }
 
-int LLVMFuzzerTestOneInput(unsigned char *data, size_t size) {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 		TIMEOUT_GUARD
 
     if (size < 50) {
@@ -109,4 +109,5 @@ int LLVMFuzzerTestOneInput(unsigned char *data, size_t size) {
         free(out_buf);
     }
     free(raw_data_to_parse);
+    return 0;
 }

--- a/tests/internal/fuzzers/strp_fuzzer.c
+++ b/tests/internal/fuzzers/strp_fuzzer.c
@@ -27,4 +27,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     flb_free(buf);
     flb_free(fmt);
+    return 0;
 }

--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -22,6 +22,7 @@
 #include <msgpack.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_slist.h>
 #include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_uri.h>
@@ -122,7 +123,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         char *out_buf = NULL;
         size_t out_size;
-        flb_hash_get(ht, null_terminated, size, (const char **)&out_buf, &out_size);
+        flb_hash_get(ht, null_terminated, size, (void **)&out_buf, &out_size);
 
         /* now let's create some more instances */
         char *instances1[128] = { NULL };
@@ -198,8 +199,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     flb_regex_init();
     struct flb_regex *freg = flb_regex_create(pregex);
     if (freg != NULL) {
-        struct flb_regex_search res;
-        flb_regex_match(freg, null_terminated, size);
+        flb_regex_match(freg, (unsigned char*)null_terminated, size);
         flb_regex_destroy(freg);
     }
     flb_regex_exit();


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
