### PR TITLE
signv4: fix NULL dereference

### DIFF
--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -92,7 +92,22 @@ static int kv_key_cmp(const void *a_arg, const void *b_arg)
 
     ret = strcmp(kv_a->key, kv_b->key);
     if (ret == 0) {
-        ret = strcmp(kv_a->val, kv_b->val);
+        /*
+         * NULL pointer is allowed in kv_a->val and kv_b->val.
+         * Handle NULL pointer cases before passing to strcmp.
+         */
+        if (kv_a->val == NULL && kv_b->val == NULL) {
+            ret = 0;
+        }
+        else if (kv_a->val == NULL) {
+            ret = -1;
+        }
+        else if (kv_b->val == NULL) {
+            ret = 1;
+        }
+        else {
+            ret = strcmp(kv_a->val, kv_b->val);
+        }
     }
 
     return ret;


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

This PR supersedes https://github.com/fluent/fluent-bit/pull/4052

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
