### PR TITLE
lib: monkey: sync channel release addition

### DIFF
--- a/lib/monkey/include/monkey/mk_stream.h
+++ b/lib/monkey/include/monkey/mk_stream.h
@@ -390,6 +390,7 @@ struct mk_stream *mk_stream_new(int type, struct mk_channel *channel,
 int mk_channel_stream_write(struct mk_stream *stream, size_t *count);
 
 struct mk_channel *mk_channel_new(int type, int fd);
+int mk_channel_release(struct mk_channel *channel);
 
 int mk_channel_flush(struct mk_channel *channel);
 int mk_channel_write(struct mk_channel *channel, size_t *count);

--- a/lib/monkey/mk_server/mk_stream.c
+++ b/lib/monkey/mk_server/mk_stream.c
@@ -35,6 +35,11 @@ struct mk_channel *mk_channel_new(int type, int fd)
     return channel;
 }
 
+int mk_channel_release(struct mk_channel *channel)
+{
+    mk_mem_free(channel);
+}
+
 static inline size_t channel_write_in_file(struct mk_channel *channel,
                                            struct mk_stream_input *in)
 {


### PR DESCRIPTION
This PR syncs monkey to allow fluent-bit to use `mk_channel_release` to fix a leak in in_http.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>