### PR TITLE
lib: monkey: sync capacity improvement

### DIFF
--- a/lib/monkey/mk_server/mk_scheduler.c
+++ b/lib/monkey/mk_server/mk_scheduler.c
@@ -83,7 +83,8 @@ static inline int _next_target(struct mk_server *server)
      * If sched_ctx->workers[target] worker is full then the whole server too,
      * because it has the lowest load.
      */
-    if (mk_unlikely(cur >= server->server_capacity)) {
+    if (mk_unlikely(server->server_capacity > 0 &&
+                    server->server_capacity <= cur)) {
         MK_TRACE("Too many clients: %i", server->server_capacity);
 
         /* Instruct to close the connection anyways, we lie, it will die */


### PR DESCRIPTION
This PR syncs a change in monkey to make the capacity limit not be enforced unless explicitly set to avoid false positives.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>
