### PR TITLE
plugins: in_http: memory leak correction

### DIFF
--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -261,6 +261,10 @@ int http_conn_del(struct http_conn *conn)
 
     ctx = conn->ctx;
 
+    if (conn->session.channel != NULL) {
+        mk_channel_release(conn->session.channel);
+    }
+
     mk_event_del(ctx->evl, &conn->event);
     mk_list_del(&conn->_head);
     flb_socket_close(conn->fd);


### PR DESCRIPTION
This PR fixes a memory leak in the in_http input plugin.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>