### PR TITLE
out_opentelemetry: set default uri to /v1/metrics

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -311,9 +311,9 @@ static struct flb_config_map config_map[] = {
      "Add a HTTP header key/value pair. Multiple headers can be set"
     },
     {
-     FLB_CONFIG_MAP_STR, "uri", NULL,
+     FLB_CONFIG_MAP_STR, "uri", "/v1/metrics",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, uri),
-     "Specify an optional HTTP URI for the target web server, e.g: /something"
+     "Specify an optional HTTP URI for the target OTel endpoint."
     },
     {
      FLB_CONFIG_MAP_BOOL, "log_response_payload", "true",


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
