### PR TITLE
input: refactor coroutines implementation

### DIFF
--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -21,36 +21,10 @@
 #define FLB_ENGINE_H
 
 #include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_bits.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_thread_storage.h>
-
-/* Types of events handled by the Server engine */
-#define FLB_ENGINE_EV_CORE          MK_EVENT_NOTIFICATION
-#define FLB_ENGINE_EV_CUSTOM        MK_EVENT_CUSTOM
-#define FLB_ENGINE_EV_THREAD        1024
-#define FLB_ENGINE_EV_SCHED         2048
-#define FLB_ENGINE_EV_SCHED_FRAME   (FLB_ENGINE_EV_SCHED + 4096)
-#define FLB_ENGINE_EV_OUTPUT        8192
-#define FLB_ENGINE_EV_THREAD_OUTPUT 16384
-
-/* Engine events: all engine events set the left 32 bits to '1' */
-#define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */
-#define FLB_ENGINE_EV_FAILED    FLB_BITS_U64_SET(1, 2) /* Engine started    */
-#define FLB_ENGINE_EV_STOP      FLB_BITS_U64_SET(1, 3) /* Requested to stop */
-#define FLB_ENGINE_EV_SHUTDOWN  FLB_BITS_U64_SET(1, 4) /* Engine shutdown   */
-
-/* Similar to engine events, but used as return values */
-#define FLB_ENGINE_STARTED      FLB_BITS_U64_LOW(FLB_ENGINE_EV_STARTED)
-#define FLB_ENGINE_FAILED       FLB_BITS_U64_LOW(FLB_ENGINE_EV_FAILED)
-#define FLB_ENGINE_STOP         FLB_BITS_U64_LOW(FLB_ENGINE_EV_STOP)
-#define FLB_ENGINE_SHUTDOWN     FLB_BITS_U64_LOW(FLB_ENGINE_EV_SHUTDOWN)
-
-/* Engine signals: Task, it only refer to the type */
-#define FLB_ENGINE_TASK         2
-#define FLB_ENGINE_IN_THREAD    3
 
 int flb_engine_start(struct flb_config *config);
 int flb_engine_failed(struct flb_config *config);

--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -1,0 +1,55 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_ENGINE_MACROS_H
+#define FLB_ENGINE_MACROS_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_bits.h>
+
+/* Types of events handled by the Server engine */
+#define FLB_ENGINE_EV_CORE          MK_EVENT_NOTIFICATION
+#define FLB_ENGINE_EV_CUSTOM        MK_EVENT_CUSTOM
+#define FLB_ENGINE_EV_THREAD        1024
+#define FLB_ENGINE_EV_SCHED         2048
+#define FLB_ENGINE_EV_SCHED_FRAME   (FLB_ENGINE_EV_SCHED + 4096)
+
+#define FLB_ENGINE_EV_INPUT          8192
+#define FLB_ENGINE_EV_THREAD_INPUT  16384  /* reserved, not used yet */
+
+#define FLB_ENGINE_EV_OUTPUT        32768
+#define FLB_ENGINE_EV_THREAD_OUTPUT 65536
+
+/* Engine events: all engine events set the left 32 bits to '1' */
+#define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */
+#define FLB_ENGINE_EV_FAILED    FLB_BITS_U64_SET(1, 2) /* Engine started    */
+#define FLB_ENGINE_EV_STOP      FLB_BITS_U64_SET(1, 3) /* Requested to stop */
+#define FLB_ENGINE_EV_SHUTDOWN  FLB_BITS_U64_SET(1, 4) /* Engine shutdown   */
+
+/* Similar to engine events, but used as return values */
+#define FLB_ENGINE_STARTED      FLB_BITS_U64_LOW(FLB_ENGINE_EV_STARTED)
+#define FLB_ENGINE_FAILED       FLB_BITS_U64_LOW(FLB_ENGINE_EV_FAILED)
+#define FLB_ENGINE_STOP         FLB_BITS_U64_LOW(FLB_ENGINE_EV_STOP)
+#define FLB_ENGINE_SHUTDOWN     FLB_BITS_U64_LOW(FLB_ENGINE_EV_SHUTDOWN)
+
+/* Engine signals: Task, it only refer to the type */
+#define FLB_ENGINE_TASK         2
+#define FLB_ENGINE_IN_CORO      3
+
+#endif

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -333,7 +333,8 @@ struct flb_input_coro *flb_input_coro_create(struct flb_input_instance *ins,
     struct flb_input_coro *input_coro;
 
     /* input_coro context */
-    input_coro = flb_calloc(1, sizeof(struct flb_input_coro));
+    input_coro = (struct flb_input_coro *) flb_calloc(1,
+                                                      sizeof(struct flb_input_coro));
     if (!input_coro) {
         flb_errno();
         return NULL;

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_engine_macros.h>
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_network.h>
@@ -128,6 +129,7 @@ struct flb_input_plugin {
  * and the variable one that is generated when the plugin is invoked.
  */
 struct flb_input_instance {
+    struct mk_event event;           /* events handler */
     int event_type;                  /* FLB_INPUT_LOGS, FLB_INPUT_METRICS */
 
     /*
@@ -144,10 +146,11 @@ struct flb_input_instance {
     int id;                              /* instance id                  */
     int log_level;                       /* log level for this plugin    */
     flb_pipefd_t channel[2];             /* pipe(2) channel              */
-    int threaded;                        /* bool / Threaded instance ?   */
+    int runs_in_coroutine;               /* instance runs in coroutine ? */
     char name[32];                       /* numbered name (cpu -> cpu.0) */
     char *alias;                         /* alias name for the instance  */
     void *context;                       /* plugin configuration context */
+    flb_pipefd_t ch_events[2];           /* channel for events           */
     struct flb_input_plugin *p;          /* original plugin              */
 
     /* Plugin properties */
@@ -252,7 +255,10 @@ struct flb_input_instance {
      */
     struct mk_list tasks;
 
-    struct mk_list coros;                /* list of input coros         */
+    /* co-routines for input plugins with FLB_INPUT_CORO flag */
+    int input_coro_id;
+    struct mk_list input_coro_list;
+    struct mk_list input_coro_list_destroy;
 
 #ifdef FLB_HAVE_METRICS
 
@@ -308,107 +314,47 @@ struct flb_input_collector {
 };
 
 struct flb_input_coro {
-    int id;                      /* ID obtained from config->in_table_id */
-    time_t start_time;           /* start time  */
-    time_t end_time;             /* end time    */
-    struct flb_config *config;   /* FLB context */
-    struct flb_coro *coro;       /* Back reference to parent thread */
-    struct mk_list _head;        /* link to list on input_instance->coros */
+    int id;                         /* id returned from flb_input_coro_id_get() */
+    time_t start_time;              /* start time  */
+    time_t end_time;                /* end time    */
+    struct flb_input_instance *ins; /* parent input instance */
+    struct flb_coro *coro;          /* coroutine context */
+    struct flb_config *config;      /* FLB context */
+    struct mk_list _head;           /* link to list on input_instance->coros */
 };
 
-/*
- * Every thread created for an input instance plugin, requires to have an
- * unique Thread-ID. This function lookup the static table in the context
- * and return the lowest available ID.
- */
-static FLB_INLINE
-int flb_input_coro_get_id(struct flb_config *config)
-{
-    unsigned int i;
-
-    for (i = 0; i < (sizeof(config->in_table_id)/sizeof(uint16_t)); i++) {
-        if (config->in_table_id[i] == 0) {
-            config->in_table_id[i] = FLB_TRUE;
-            return i;
-        }
-    }
-
-    return -1;
-}
-
-/*
- * When an input thread ends, it needs to release it ID. This function
- * just mark the ID as unused.
- */
-static FLB_INLINE
-void flb_input_coro_del_id(int id, struct flb_config *config)
-{
-    config->in_table_id[id] = FLB_FALSE;
-}
+int flb_input_coro_id_get(struct flb_input_instance *ins);
 
 static FLB_INLINE
-int flb_input_coro_destroy_id(int id, struct flb_config *config)
+struct flb_input_coro *flb_input_coro_create(struct flb_input_instance *ins,
+                                             struct flb_config *config)
 {
-    struct mk_list *tmp;
-    struct mk_list *head;
-    struct mk_list *head_th;
-    struct flb_input_coro *in_coro;
-    struct flb_input_instance *i_ins;
-
-    /* Iterate input-instances to find the thread */
-    mk_list_foreach(head, &config->inputs) {
-        i_ins = mk_list_entry(head, struct flb_input_instance, _head);
-        mk_list_foreach_safe(head_th, tmp, &i_ins->coros) {
-            in_coro = mk_list_entry(head_th, struct flb_input_coro, _head);
-            if (in_coro->id != id) {
-                continue;
-            }
-
-            mk_list_del(&in_coro->_head);
-            flb_input_coro_del_id(id, config);
-            flb_coro_destroy(in_coro->coro);
-            flb_debug("[input] destroy input_thread id=%i", id);
-            return 0;
-        }
-    }
-
-    return -1;
-}
-
-static FLB_INLINE
-struct flb_coro *flb_input_coro_create(struct flb_input_instance *ins,
-                                       struct flb_config *config)
-{
-    int id;
     struct flb_coro *coro;
-    struct flb_input_coro *in_coro;
+    struct flb_input_coro *input_coro;
 
-    /* Try to obtain an id */
-    id = flb_input_coro_get_id(config);
-    if (id == -1) {
-        return NULL;
-    }
-
-    /* Setup thread specific data */
-    in_coro = (struct flb_input_coro *) flb_calloc(1, sizeof(struct flb_input_coro));
-    if (!in_coro) {
+    /* input_coro context */
+    input_coro = flb_calloc(1, sizeof(struct flb_input_coro));
+    if (!input_coro) {
         flb_errno();
         return NULL;
     }
 
-    coro = flb_coro_create(in_coro);
+    /* coroutine context */
+    coro = flb_coro_create(input_coro);
     if (!coro) {
-        flb_free(in_coro);
+        flb_free(input_coro);
         return NULL;
     }
 
-    in_coro->id         = id;
-    in_coro->start_time = time(NULL);
-    in_coro->coro       = coro;
-    in_coro->config     = config;
-    mk_list_add(&in_coro->_head, &ins->coros);
+    input_coro->id         = flb_input_coro_id_get(ins);
+    input_coro->ins        = ins;
+    input_coro->start_time = time(NULL);
+    input_coro->coro       = coro;
+    input_coro->config     = config;
 
-    return coro;
+    mk_list_add(&input_coro->_head, &ins->input_coro_list);
+
+    return input_coro;
 }
 
 struct flb_libco_in_params {
@@ -418,6 +364,7 @@ struct flb_libco_in_params {
 };
 
 extern struct flb_libco_in_params libco_in_param;
+void flb_input_coro_prepare_destroy(struct flb_input_coro *input_coro);
 
 static FLB_INLINE void input_params_set(struct flb_coro *coro,
                              struct flb_input_collector *coll,
@@ -441,14 +388,25 @@ static FLB_INLINE void input_pre_cb_collect(void)
     coll->cb_collect(coll->instance, config, coll->instance->context);
 }
 
+static FLB_INLINE void flb_input_coro_resume(struct flb_input_coro *input_coro)
+{
+    flb_coro_resume(input_coro->coro);
+}
+
 static FLB_INLINE
-struct flb_coro *flb_input_coro_collect(struct flb_input_collector *coll,
-                                          struct flb_config *config)
+struct flb_input_coro *flb_input_coro_collect(struct flb_input_collector *coll,
+                                              struct flb_config *config)
 {
     size_t stack_size;
     struct flb_coro *coro;
+    struct flb_input_coro *input_coro;
 
-    coro = flb_input_coro_create(coll->instance, config);
+    input_coro = flb_input_coro_create(coll->instance, config);
+    if (!input_coro) {
+        return NULL;
+    }
+
+    coro = input_coro->coro;
     if (!coro) {
         return NULL;
     }
@@ -464,7 +422,7 @@ struct flb_coro *flb_input_coro_collect(struct flb_input_collector *coll,
 
     /* Set parameters */
     input_params_set(coro, coll, config, coll->instance->context);
-    return coro;
+    return input_coro;
 }
 
 /*
@@ -482,24 +440,23 @@ struct flb_coro *flb_input_coro_collect(struct flb_input_collector *coll,
 static inline void flb_input_return(struct flb_coro *coro) {
     int n;
     uint64_t val;
-    struct flb_input_coro *in_coro;
+    struct flb_input_coro *input_coro;
+    struct flb_input_instance *ins;
 
-    in_coro = (struct flb_input_coro *) coro->data;
+    input_coro = (struct flb_input_coro *) coro->data;
+    ins = input_coro->ins;
 
     /*
-     * To compose the signal event the relevant info is:
-     *
-     * - Unique Task events id: 2 in this case
-     * - Return value: FLB_OK (0) or FLB_ERROR (1)
-     * - Task ID
-     *
-     * We put together the return value with the task_id on the 32 bits at right
+     * Message the event loop by identifying the message comming from an input
+     * coroutine and passing the input plugin ID that triggered the event.
      */
-    val = FLB_BITS_U64_SET(3 /* FLB_ENGINE_IN_COROREAD */, in_coro->id);
-    n = flb_pipe_w(in_coro->config->ch_manager[1], (void *) &val, sizeof(val));
+    val = FLB_BITS_U64_SET(FLB_ENGINE_IN_CORO, ins->id);
+    n = flb_pipe_w(ins->ch_events[1], (void *) &val, sizeof(val));
     if (n == -1) {
         flb_errno();
     }
+
+    flb_input_coro_prepare_destroy(input_coro);
 }
 
 static inline void flb_input_return_do(int ret) {
@@ -535,6 +492,9 @@ int flb_input_register_all(struct flb_config *config);
 struct flb_input_instance *flb_input_new(struct flb_config *config,
                                          const char *input, void *data,
                                          int public_only);
+struct flb_input_instance *flb_input_get_instance(struct flb_config *config,
+                                                  int ins_id);
+
 int flb_input_set_property(struct flb_input_instance *ins,
                            const char *k, const char *v);
 const char *flb_input_get_property(const char *key,
@@ -543,6 +503,7 @@ const char *flb_input_get_property(const char *key,
 int flb_input_check(struct flb_config *config);
 void flb_input_set_context(struct flb_input_instance *ins, void *context);
 int flb_input_channel_init(struct flb_input_instance *ins);
+
 
 int flb_input_collector_start(int coll_id, struct flb_input_instance *ins);
 int flb_input_collectors_start(struct flb_config *config);
@@ -568,6 +529,9 @@ int flb_input_set_collector_socket(struct flb_input_instance *ins,
                                    flb_pipefd_t fd,
                                    struct flb_config *config);
 int flb_input_collector_running(int coll_id, struct flb_input_instance *ins);
+int flb_input_coro_id_get(struct flb_input_instance *ins);
+int flb_input_coro_finished(struct flb_config *config, int ins_id);
+
 int flb_input_instance_init(struct flb_input_instance *ins,
                             struct flb_config *config);
 void flb_input_instance_exit(struct flb_input_instance *ins,

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -204,10 +204,10 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->routable = FLB_TRUE;
         instance->context  = NULL;
         instance->data     = data;
-        instance->threaded = FLB_FALSE;
         instance->storage  = NULL;
         instance->storage_type = -1;
         instance->log_level = -1;
+        instance->runs_in_coroutine = FLB_FALSE;
 
         /* net */
         instance->host.name    = NULL;
@@ -222,7 +222,8 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         mk_list_init(&instance->tasks);
         mk_list_init(&instance->chunks);
         mk_list_init(&instance->collectors);
-        mk_list_init(&instance->coros);
+        mk_list_init(&instance->input_coro_list);
+        mk_list_init(&instance->input_coro_list_destroy);
 
         /* Initialize properties list */
         flb_kv_init(&instance->properties);
@@ -238,7 +239,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
 
         /* Plugin requires a Thread context */
         if (plugin->flags & FLB_INPUT_CORO) {
-            instance->threaded = FLB_TRUE;
+            instance->runs_in_coroutine = FLB_TRUE;
         }
 
         instance->mp_total_buf_size = 0;
@@ -263,6 +264,67 @@ static inline int prop_key_check(const char *key, const char *kv, int k_len)
     }
 
     return -1;
+}
+
+struct flb_input_instance *flb_input_get_instance(struct flb_config *config,
+                                                  int ins_id)
+{
+    struct mk_list *head;
+    struct flb_input_instance *ins;
+
+    mk_list_foreach(head, &config->inputs) {
+        ins = mk_list_entry(head, struct flb_input_instance, _head);
+        if (ins->id == ins_id) {
+            break;
+        }
+        ins = NULL;
+    }
+
+    if (!ins) {
+        return NULL;
+    }
+
+    return ins;
+}
+
+static void flb_input_coro_destroy(struct flb_input_coro *input_coro)
+{
+    flb_debug("[input coro] destroy coro_id=%i", input_coro->id);
+
+    mk_list_del(&input_coro->_head);
+    flb_coro_destroy(input_coro->coro);
+    flb_free(input_coro);
+}
+
+int flb_input_coro_finished(struct flb_config *config, int ins_id)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_input_instance *ins;
+    struct flb_input_coro *input_coro;
+
+    ins = flb_input_get_instance(config, ins_id);
+    if (!ins) {
+        return -1;
+    }
+
+    /* Look for input coroutines that needs to be destroyed */
+    mk_list_foreach_safe(head, tmp, &ins->input_coro_list_destroy) {
+        input_coro = mk_list_entry(head, struct flb_input_coro, _head);
+        printf("coro destroy!: coro_id=%i\n", input_coro->id);
+        flb_input_coro_destroy(input_coro);
+    }
+
+    return 0;
+}
+
+void flb_input_coro_prepare_destroy(struct flb_input_coro *input_coro)
+{
+    struct flb_input_instance *ins = input_coro->ins;
+
+    /* move flb_input_coro from 'input_coro_list' to 'input_coro_list_destroy' */
+    mk_list_del(&input_coro->_head);
+    mk_list_add(&input_coro->_head, &ins->input_coro_list_destroy);
 }
 
 int flb_input_name_exists(const char *name, struct flb_config *config)
@@ -471,6 +533,22 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
     flb_free(ins);
 }
 
+int flb_input_coro_id_get(struct flb_input_instance *ins)
+{
+    int id;
+    int max = (2 << 13) - 1; /* max for 14 bits */
+
+    id = ins->input_coro_id;
+    ins->input_coro_id++;
+
+    /* reset once it reach the maximum allowed */
+    if (ins->input_coro_id > max) {
+        ins->input_coro_id = 0;
+    }
+
+    return id;
+}
+
 int flb_input_instance_init(struct flb_input_instance *ins,
                             struct flb_config *config)
 {
@@ -486,6 +564,28 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     if (!p) {
         return 0;
     }
+
+    /* Input event channel */
+    ret = mk_event_channel_create(config->evl,
+                                  &ins->ch_events[0],
+                                  &ins->ch_events[1],
+                                  ins);
+    if (ret != 0) {
+        flb_error("could not create events channels for '%s'",
+                  flb_input_name(ins));
+        return -1;
+    }
+
+    flb_debug("[%s:%s] created event channels: read=%i write=%i",
+              ins->p->name, flb_input_name(ins),
+              ins->ch_events[0], ins->ch_events[1]);
+
+    /*
+     * Note: mk_event_channel_create() sets a type = MK_EVENT_NOTIFICATION by
+     * default, we need to overwrite this value so we can do a clean check
+     * into the Engine when the event is triggered.
+     */
+    ins->event.type = FLB_ENGINE_EV_INPUT;
 
 #ifdef FLB_HAVE_METRICS
     uint64_t ts;
@@ -1068,7 +1168,7 @@ int flb_input_collector_fd(flb_pipefd_t fd, struct flb_config *config)
 {
     struct mk_list *head;
     struct flb_input_collector *collector = NULL;
-    struct flb_coro *co;
+    struct flb_input_coro *input_coro;
 
     mk_list_foreach(head, &config->collectors) {
         collector = mk_list_entry(head, struct flb_input_collector, _head);
@@ -1092,12 +1192,12 @@ int flb_input_collector_fd(flb_pipefd_t fd, struct flb_config *config)
     }
 
     /* Trigger the collector callback */
-    if (collector->instance->threaded == FLB_TRUE) {
-        co = flb_input_coro_collect(collector, config);
-        if (!co) {
+    if (collector->instance->runs_in_coroutine) {
+        input_coro = flb_input_coro_collect(collector, config);
+        if (!input_coro) {
             return -1;
         }
-        flb_coro_resume(co);
+        flb_input_coro_resume(input_coro);
     }
     else {
         collector->cb_collect(collector->instance, config,

--- a/src/flb_sosreport.c
+++ b/src/flb_sosreport.c
@@ -249,7 +249,7 @@ int flb_sosreport(struct flb_config *config)
         printf("    Name\t\t%s (%s, id=%i)\n", ins_in->name, ins_in->p->name,
                ins_in->id);
         printf("    Flags\t\t"); input_flags(ins_in->flags);
-        printf("    Threaded\t\t%s\n", ins_in->threaded ? "Yes": "No");
+        printf("    Coroutines\t\t%s\n", ins_in->runs_in_coroutine ? "Yes": "No");
         if (ins_in->tag) {
             printf("    Tag\t\t\t%s\n", ins_in->tag);
         }

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -407,8 +407,14 @@ void flb_test_input_chunk_fs_chunks_size_real()
     struct cio_ctx *cio;
     msgpack_sbuffer mp_sbuf;
     char buf[262144];
+    struct mk_event_loop *evl;
 
     cfg = flb_config_init();
+    evl = mk_event_loop_create(256);
+
+    TEST_CHECK(evl != NULL);
+    cfg->evl = evl;
+
     flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, NULL);
 
     i_ins = flb_input_new(cfg, "dummy", NULL, FLB_TRUE);


### PR DESCRIPTION
The following PR re-implements the logic behind the coroutines for a clean exit. It uses the same (new) strategy implemented by output coroutines where the plugin instance now contains its own `event` channel to message the event loop. 

Now for input plugins using coroutines like `nginx_metrics` or `prometheus_scrape` we have a clean exit.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
