### PR TITLE
in_cpu: configmap support.

### DIFF
--- a/plugins/in_cpu/cpu.c
+++ b/plugins/in_cpu/cpu.c
@@ -495,8 +495,7 @@ static int cb_cpu_init(struct flb_input_instance *in,
     int ret;
     struct flb_cpu *ctx;
     (void) data;
-    const char *pval = NULL;
-
+    
     /* Allocate space for the configuration */
     ctx = flb_calloc(1, sizeof(struct flb_cpu));
     if (!ctx) {
@@ -504,6 +503,12 @@ static int cb_cpu_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->ins = in;
+    
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
 
     /* Gather number of processors and CPU ticks */
     ctx->n_processors = sysconf(_SC_NPROCESSORS_ONLN);
@@ -512,8 +517,8 @@ static int cb_cpu_init(struct flb_input_instance *in,
     /* Collection time setting */
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
     /* Initialize buffers for CPU stats */

--- a/plugins/in_cpu/cpu.c
+++ b/plugins/in_cpu/cpu.c
@@ -509,32 +509,7 @@ static int cb_cpu_init(struct flb_input_instance *in,
     ctx->n_processors = sysconf(_SC_NPROCESSORS_ONLN);
     ctx->cpu_ticks    = sysconf(_SC_CLK_TCK);
 
-    /* Process ID */
-    pval = flb_input_get_property("pid", in);
-    if (pval) {
-        ctx->pid = atoi(pval);
-    }
-    else {
-        ctx->pid = -1;
-    }
-
     /* Collection time setting */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        ctx->interval_sec = atoi(pval);
-    }
-    else {
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-    }
-
-    pval = flb_input_get_property("interval_nsec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        ctx->interval_nsec = atoi(pval);
-    }
-    else {
-        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
-    }
-
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
         ctx->interval_sec = DEFAULT_INTERVAL_SEC;
@@ -610,6 +585,27 @@ static int cb_cpu_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_INT, "pid", "-1",
+     0, FLB_TRUE, offsetof(struct flb_cpu, pid),
+     "Configure a single process to measure usage via their PID"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_cpu, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_cpu, interval_nsec),
+      "Set the collector interval (sub seconds)"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_cpu_plugin = {
     .name         = "cpu",
@@ -618,6 +614,7 @@ struct flb_input_plugin in_cpu_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = cb_cpu_collect,
     .cb_flush_buf = NULL,
+    .config_map   = config_map,
     .cb_pause     = cb_cpu_pause,
     .cb_resume    = cb_cpu_resume,
     .cb_exit      = cb_cpu_exit

--- a/plugins/in_cpu/cpu.h
+++ b/plugins/in_cpu/cpu.h
@@ -25,8 +25,8 @@
 #include <fluent-bit/flb_utils.h>
 
 /* Default collection time: every 1 second (0 nanoseconds) */
-#define DEFAULT_INTERVAL_SEC    1
-#define DEFAULT_INTERVAL_NSEC   0
+#define DEFAULT_INTERVAL_SEC    "1"
+#define DEFAULT_INTERVAL_NSEC   "0"
 #define IN_CPU_KEY_LEN       16
 
 struct cpu_key {


### PR DESCRIPTION
Add configmap support for the in_cpu plugin. This is related to #4863.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
