### PR TITLE
in_disk: configmap support.

### DIFF
--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -221,6 +221,7 @@ static int configure(struct flb_in_disk_config *disk_config,
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *)disk_config);
     if (ret == -1) {
+        flb_plg_error(in, "unable to load configuration.");
         return -1;
     }
 

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -232,13 +232,6 @@ static int configure(struct flb_in_disk_config *disk_config,
         disk_config->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
-    if (disk_config->dev_name != NULL) {
-        disk_config->dev_name = flb_strdup(disk_config->dev_name);
-    }
-    else {
-        disk_config->dev_name = NULL;
-    }
-
     entry = get_diskstats_entries();
     if (entry == 0) {
         /* no entry to count */
@@ -281,7 +274,7 @@ static int in_disk_init(struct flb_input_instance *in,
     int ret = -1;
 
     /* Allocate space for the configuration */
-    disk_config = flb_malloc(sizeof(struct flb_in_disk_config));
+    disk_config = flb_calloc(1, sizeof(struct flb_in_disk_config));
     if (disk_config == NULL) {
         return -1;
     }
@@ -327,7 +320,6 @@ static int in_disk_exit(void *data, struct flb_config *config)
     flb_free(disk_config->write_total);
     flb_free(disk_config->prev_read_total);
     flb_free(disk_config->prev_write_total);
-    flb_free(disk_config->dev_name);
     flb_free(disk_config);
     return 0;
 }

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -346,7 +346,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_STR, "dev_name", "",
       0, FLB_TRUE, offsetof(struct flb_in_disk_config, dev_name),
-      "Set the collector interval (sub seconds)"
+      "Set the device name"
     },
     /* EOF */
     {0}

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -344,7 +344,7 @@ static struct flb_config_map config_map[] = {
       "Set the collector interval (nanoseconds)"
     },
     {
-      FLB_CONFIG_MAP_STR, "dev_name", "",
+      FLB_CONFIG_MAP_STR, "dev_name", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_in_disk_config, dev_name),
       "Set the device name"
     },

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -216,6 +216,13 @@ static int configure(struct flb_in_disk_config *disk_config,
     (void) *in;
     int entry = 0;
     int i;
+    int ret;
+
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)disk_config);
+    if (ret == -1) {
+        return -1;
+    }
 
     /* interval settings */
     if (disk_config->interval_sec <= 0 && disk_config->interval_nsec <= 0) {

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -341,7 +341,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
       0, FLB_TRUE, offsetof(struct flb_in_disk_config, interval_nsec),
-      "Set the collector interval (sub seconds)"
+      "Set the collector interval (nanoseconds)"
     },
     {
       FLB_CONFIG_MAP_STR, "dev_name", "",

--- a/plugins/in_disk/in_disk.c
+++ b/plugins/in_disk/in_disk.c
@@ -214,36 +214,18 @@ static int configure(struct flb_in_disk_config *disk_config,
                      struct flb_input_instance *in)
 {
     (void) *in;
-    const char *pval = NULL;
     int entry = 0;
     int i;
 
     /* interval settings */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        disk_config->interval_sec = atoi(pval);
-    }
-    else {
-        disk_config->interval_sec = DEFAULT_INTERVAL_SEC;
-    }
-
-    pval = flb_input_get_property("interval_nsec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        disk_config->interval_nsec = atoi(pval);
-    }
-    else {
-        disk_config->interval_nsec = DEFAULT_INTERVAL_NSEC;
-    }
-
     if (disk_config->interval_sec <= 0 && disk_config->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
-        disk_config->interval_sec = DEFAULT_INTERVAL_SEC;
-        disk_config->interval_nsec = DEFAULT_INTERVAL_NSEC;
+        disk_config->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        disk_config->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
-    pval = flb_input_get_property("dev_name", in);
-    if (pval != NULL) {
-        disk_config->dev_name = flb_strdup(pval);
+    if (disk_config->dev_name != NULL) {
+        disk_config->dev_name = flb_strdup(disk_config->dev_name);
     }
     else {
         disk_config->dev_name = NULL;
@@ -342,6 +324,26 @@ static int in_disk_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_in_disk_config, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_in_disk_config, interval_nsec),
+      "Set the collector interval (sub seconds)"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "dev_name", "",
+      0, FLB_TRUE, offsetof(struct flb_in_disk_config, dev_name),
+      "Set the collector interval (sub seconds)"
+    },
+    /* EOF */
+    {0}
+};
 
 struct flb_input_plugin in_disk_plugin = {
     .name         = "disk",
@@ -350,5 +352,6 @@ struct flb_input_plugin in_disk_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_disk_collect,
     .cb_flush_buf = NULL,
-    .cb_exit      = in_disk_exit
+    .cb_exit      = in_disk_exit,
+    .config_map   = config_map
 };

--- a/plugins/in_disk/in_disk.h
+++ b/plugins/in_disk/in_disk.h
@@ -23,8 +23,8 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
 
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 #define STR_KEY_WRITE "write_size"
 #define STR_KEY_READ  "read_size"

--- a/plugins/in_disk/in_disk.h
+++ b/plugins/in_disk/in_disk.h
@@ -30,15 +30,15 @@
 #define STR_KEY_READ  "read_size"
 
 struct flb_in_disk_config {
-    uint64_t *read_total;
-    uint64_t *write_total;
-    uint64_t *prev_read_total;
-    uint64_t *prev_write_total;
-    char     *dev_name;
-    int      entry;
-    int      interval_sec;
-    int      interval_nsec;
-    int      first_snapshot;   /* a feild to indicate whethor or not this is the first collect*/
+    uint64_t  *read_total;
+    uint64_t  *write_total;
+    uint64_t  *prev_read_total;
+    uint64_t  *prev_write_total;
+    flb_sds_t dev_name;
+    int       entry;
+    int       interval_sec;
+    int       interval_nsec;
+    int       first_snapshot;   /* a feild to indicate whethor or not this is the first collect*/
 };
 
 extern struct flb_input_plugin in_disk_plugin;


### PR DESCRIPTION
Add configmap support for the in_disk plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
