### PR TITLE
in_mem: configmap support.

### DIFF
--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -119,10 +119,8 @@ static int in_mem_init(struct flb_input_instance *in,
                        struct flb_config *config, void *data)
 {
     int ret;
-    const char *tmp;
     struct flb_in_mem_config *ctx;
     (void) data;
-    const char *pval = NULL;
 
     /* Initialize context */
     ctx = flb_malloc(sizeof(struct flb_in_mem_config));
@@ -133,6 +131,13 @@ static int in_mem_init(struct flb_input_instance *in,
     ctx->pid = 0;
     ctx->page_size = sysconf(_SC_PAGESIZE);
     ctx->ins = in;
+    
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
 
     /* Collection time setting */
     if (ctx->interval_sec <= 0) {
@@ -153,6 +158,7 @@ static int in_mem_init(struct flb_input_instance *in,
                                        config);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not set collector for memory input plugin");
+        return -1;
     }
 
     return 0;

--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -135,19 +135,11 @@ static int in_mem_init(struct flb_input_instance *in,
     ctx->ins = in;
 
     /* Collection time setting */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) > 0) {
-        ctx->interval_sec = atoi(pval);
+    if (ctx->interval_sec <= 0) {
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
     }
-    else {
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-    }
-    ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
-
-    /* Check if the caller want's to trace a specific Process ID */
-    tmp = flb_input_get_property("pid", in);
-    if (tmp) {
-        ctx->pid = atoi(tmp);
+    if (ctx->interval_nsec <= 0) {
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
     /* Set the context */
@@ -276,6 +268,26 @@ static int in_mem_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_in_mem_config, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_in_mem_config, interval_nsec),
+      "Set the collector interval (subseconds)"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "pid", "0",
+      0, FLB_TRUE, offsetof(struct flb_in_mem_config, pid),
+      "Set the PID of the process to measure"
+    },
+    /* EOF */
+    {0}
+};
+
 struct flb_input_plugin in_mem_plugin = {
     .name         = "mem",
     .description  = "Memory Usage",
@@ -283,5 +295,6 @@ struct flb_input_plugin in_mem_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_mem_collect,
     .cb_flush_buf = NULL,
-    .cb_exit      = in_mem_exit
+    .cb_exit      = in_mem_exit,
+    .config_map   = config_map
 };

--- a/plugins/in_mem/mem.h
+++ b/plugins/in_mem/mem.h
@@ -25,8 +25,8 @@
 #include <fluent-bit/flb_utils.h>
 #include <msgpack.h>
 
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 struct flb_in_mem_info {
     uint64_t mem_total;


### PR DESCRIPTION
Add configmap support for the in_disk plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
