### PR TITLE
in_thermal: configmap support.

### DIFF
--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -159,6 +159,7 @@ static int in_thermal_init(struct flb_input_instance *in,
     ret = flb_input_config_map_set(in, (void *)ctx);
     if (ret == -1) {
         flb_free(ctx);
+        flb_plg_error(in, "unable to load configuration");
         return -1;
     }
 

--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -309,12 +309,12 @@ static struct flb_config_map config_map[] = {
     },
 #ifdef FLB_HAVE_REGEX
     {
-      FLB_CONFIG_MAP_STR, "name_regex", "",
+      FLB_CONFIG_MAP_STR, "name_regex", NULL,
       0, FLB_TRUE, offsetof(struct flb_in_thermal_config, name_rgx),
       "Set thermal name regular expression filter"
     },
     {
-      FLB_CONFIG_MAP_STR, "type_regex", "",
+      FLB_CONFIG_MAP_STR, "type_regex", NULL,
       0, FLB_TRUE, offsetof(struct flb_in_thermal_config, type_rgx),
       "Set thermal type regular expression filter"
     },

--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -76,7 +76,7 @@ static inline int proc_temperature(struct flb_in_thermal_config *ctx,
         }
 
 #ifdef FLB_HAVE_REGEX
-        if (ctx->name_rgx && !flb_regex_match(ctx->name_rgx,
+        if (ctx->name_regex && !flb_regex_match(ctx->name_regex,
                                                 (unsigned char *) e->d_name,
                                                 strlen(e->d_name))) {
             continue;
@@ -109,8 +109,8 @@ static inline int proc_temperature(struct flb_in_thermal_config *ctx,
                 fclose(f);
 
 #ifdef FLB_HAVE_REGEX
-                if (ctx->type_rgx &&
-                    !flb_regex_match(ctx->type_rgx,
+                if (ctx->type_regex &&
+                    !flb_regex_match(ctx->type_regex,
                                      (unsigned char *) info[i].type,
                                      strlen(info[i].type))) {
                     continue;
@@ -170,18 +170,16 @@ static int in_thermal_init(struct flb_input_instance *in,
     }
 
 #ifdef FLB_HAVE_REGEX
-    ctx->name_rgx = NULL;
-    if (ctx->name_regex && strcmp(ctx->name_regex, "") != 0) {
-        ctx->name_rgx = flb_regex_create(ctx->name_regex);
-        if (!ctx->name_rgx) {
+    if (ctx->name_rgx && strcmp(ctx->name_rgx, "") != 0) {
+        ctx->name_regex = flb_regex_create(ctx->name_rgx);
+        if (!ctx->name_regex) {
             flb_plg_error(ctx->ins, "invalid 'name_regex' config value");
         }
     }
 
-    ctx->type_rgx = NULL;
-    if (ctx->type_regex && strcmp(ctx->type_regex, "") != 0) {
-        ctx->type_rgx = flb_regex_create(ctx->type_regex);
-        if (!ctx->type_rgx) {
+    if (ctx->type_rgx && strcmp(ctx->type_rgx, "") != 0) {
+        ctx->type_regex = flb_regex_create(ctx->type_rgx);
+        if (!ctx->type_regex) {
             flb_plg_error(ctx->ins, "invalid 'type_regex' config value");
         }
     }
@@ -286,11 +284,11 @@ static int in_thermal_exit(void *data, struct flb_config *config)
     (void) *config;
     struct flb_in_thermal_config *ctx = data;
 #ifdef FLB_HAVE_REGEX
-    if (ctx && ctx->name_rgx) {
-        flb_regex_destroy(ctx->name_rgx);
+    if (ctx && ctx->name_regex) {
+        flb_regex_destroy(ctx->name_regex);
     }
-    if (ctx && ctx->type_rgx) {
-        flb_regex_destroy(ctx->type_rgx);
+    if (ctx && ctx->type_regex) {
+        flb_regex_destroy(ctx->type_regex);
     }
 #endif
     flb_free(ctx);
@@ -306,17 +304,17 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
       0, FLB_TRUE, offsetof(struct flb_in_thermal_config, interval_nsec),
-      "Set the collector interval (sub seconds)"
+      "Set the collector interval (nanoseconds)"
     },
 #ifdef FLB_HAVE_REGEX
     {
       FLB_CONFIG_MAP_STR, "name_regex", "",
-      0, FLB_TRUE, offsetof(struct flb_in_thermal_config, name_regex),
+      0, FLB_TRUE, offsetof(struct flb_in_thermal_config, name_rgx),
       "Set thermal name regular expression filter"
     },
     {
       FLB_CONFIG_MAP_STR, "type_regex", "",
-      0, FLB_TRUE, offsetof(struct flb_in_thermal_config, type_regex),
+      0, FLB_TRUE, offsetof(struct flb_in_thermal_config, type_rgx),
       "Set thermal type regular expression filter"
     },
 #endif // FLB_HAVE_REGEX

--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -155,6 +155,13 @@ static int in_thermal_init(struct flb_input_instance *in,
     }
     ctx->ins = in;
 
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
     /* Collection time setting */
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */

--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -318,7 +318,7 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct flb_in_thermal_config, type_rgx),
       "Set thermal type regular expression filter"
     },
-#endif // FLB_HAVE_REGEX
+#endif /* FLB_HAVE_REGEX */
     /* EOF */
     {0}
 };

--- a/plugins/in_thermal/in_thermal.h
+++ b/plugins/in_thermal/in_thermal.h
@@ -35,10 +35,10 @@ struct flb_in_thermal_config {
     int interval_nsec;            /* interval collection time (Nanosecond) */
     int prev_device_num;          /* number of thermal devices             */
 #ifdef FLB_HAVE_REGEX
-    struct flb_regex *name_rgx;   /* compiled filter by name */
-    struct flb_regex *type_rgx;   /* compiled filter by type */
-    char *name_regex; /* optional filter by name */
-    char *type_regex; /* optional filter by type */
+    struct    flb_regex *name_regex;   /* compiled filter by name */
+    struct    flb_regex *type_regex;   /* compiled filter by type */
+    flb_sds_t name_rgx; /* optional filter by name */
+    flb_sds_t type_rgx; /* optional filter by type */
 #endif
     struct flb_input_instance *ins;
 };

--- a/plugins/in_thermal/in_thermal.h
+++ b/plugins/in_thermal/in_thermal.h
@@ -35,8 +35,10 @@ struct flb_in_thermal_config {
     int interval_nsec;            /* interval collection time (Nanosecond) */
     int prev_device_num;          /* number of thermal devices             */
 #ifdef FLB_HAVE_REGEX
-    struct flb_regex *name_regex; /* optional filter by name */
-    struct flb_regex *type_regex; /* optional filter by type */
+    struct flb_regex *name_rgx;   /* compiled filter by name */
+    struct flb_regex *type_rgx;   /* compiled filter by type */
+    char *name_regex; /* optional filter by name */
+    char *type_regex; /* optional filter by type */
 #endif
     struct flb_input_instance *ins;
 };


### PR DESCRIPTION
Add configmap support for the in_thermal plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.
----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
