### PR TITLE
in_proc: add support for configmap.

### DIFF
--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -158,66 +158,29 @@ static pid_t get_pid_from_procname_linux(struct flb_in_proc_config *ctx,
 static int configure(struct flb_in_proc_config *ctx,
                      struct flb_input_instance *in)
 {
-    const char *pval = NULL;
+    char *proc_name = NULL;
+    int ret;
 
-    /* interval settings */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        ctx->interval_sec = atoi(pval);
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        return -1;
     }
-    else {
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-    }
-
-    pval = flb_input_get_property("interval_nsec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        ctx->interval_nsec = atoi(pval);
-    }
-    else {
-        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
-    }
-
+    
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-        ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
-    pval = flb_input_get_property("alert", in);
-    if (pval) {
-        if (strcasecmp(pval, "true") == 0 || strcasecmp(pval, "on") == 0) {
-            ctx->alert = FLB_TRUE;
-        }
-    }
-
-    pval = flb_input_get_property("mem", in);
-    if (pval) {
-        if (strcasecmp(pval, "true") == 0 || strcasecmp(pval, "on") == 0) {
-            ctx->mem = FLB_TRUE;
-        }
-        else if (strcasecmp(pval, "false") == 0 || strcasecmp(pval, "off") == 0) {
-            ctx->mem = FLB_FALSE;
-        }
-    }
-
-    pval = flb_input_get_property("fd", in);
-    if (pval) {
-        if (strcasecmp(pval, "true") == 0 || strcasecmp(pval, "on") == 0) {
-            ctx->fds = FLB_TRUE;
-        }
-        else if (strcasecmp(pval, "false") == 0 || strcasecmp(pval, "off") == 0) {
-            ctx->fds = FLB_FALSE;
-        }
-    }
-
-    pval = flb_input_get_property("proc_name", in);
-    if (pval) {
-        ctx->proc_name = (char*)flb_malloc(FLB_CMD_LEN);
+    if (ctx->proc_name != NULL && strcmp(ctx->proc_name, "") != 0) {
+        proc_name = (char*)flb_malloc(FLB_CMD_LEN);
         if (ctx->proc_name == NULL) {
             return -1;
         }
-        strncpy(ctx->proc_name, pval, FLB_CMD_LEN);
-        ctx->proc_name[FLB_CMD_LEN-1] = '\0';
+        strncpy(proc_name, ctx->proc_name, FLB_CMD_LEN);
+        proc_name[FLB_CMD_LEN-1] = '\0';
+        ctx->proc_name = proc_name;
         ctx->len_proc_name = strlen(ctx->proc_name);
     }
 
@@ -521,6 +484,41 @@ static int in_proc_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_in_proc_config, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_in_proc_config, interval_nsec),
+      "Set the collector interval (sub seconds)"
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "alert", "false",
+     0, FLB_TRUE, offsetof(struct flb_in_proc_config, alert),
+     "Only generate alerts if process is down"
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "mem", "true",
+     0, FLB_TRUE, offsetof(struct flb_in_proc_config, mem),
+     "Append memory usage to record"
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "fd", "true",
+     0, FLB_TRUE, offsetof(struct flb_in_proc_config, fds),
+     "Append fd count to record"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "proc_name", "",
+     0, FLB_TRUE, offsetof(struct flb_in_proc_config, proc_name),
+     "Define process name to health check"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_proc_plugin = {
     .name         = "proc",
@@ -530,5 +528,6 @@ struct flb_input_plugin in_proc_plugin = {
     .cb_collect   = in_proc_collect,
     .cb_flush_buf = NULL,
     .cb_exit      = in_proc_exit,
+    .config_map   = config_map,
     .flags        = 0,
 };

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -163,6 +163,7 @@ static int configure(struct flb_in_proc_config *ctx,
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *)ctx);
     if (ret == -1) {
+        flb_plg_error(in, "unable to load configuration");
         return -1;
     }
     

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -174,13 +174,6 @@ static int configure(struct flb_in_proc_config *ctx,
     }
 
     if (ctx->proc_name != NULL && strcmp(ctx->proc_name, "") != 0) {
-        proc_name = (char*)flb_malloc(FLB_CMD_LEN);
-        if (ctx->proc_name == NULL) {
-            return -1;
-        }
-        strncpy(proc_name, ctx->proc_name, FLB_CMD_LEN);
-        proc_name[FLB_CMD_LEN-1] = '\0';
-        ctx->proc_name = proc_name;
         ctx->len_proc_name = strlen(ctx->proc_name);
     }
 

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -158,7 +158,6 @@ static pid_t get_pid_from_procname_linux(struct flb_in_proc_config *ctx,
 static int configure(struct flb_in_proc_config *ctx,
                      struct flb_input_instance *in)
 {
-    char *proc_name = NULL;
     int ret;
 
     /* Load the config map */

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -511,7 +511,7 @@ static struct flb_config_map config_map[] = {
      "Append fd count to record"
     },
     {
-     FLB_CONFIG_MAP_STR, "proc_name", "",
+     FLB_CONFIG_MAP_STR, "proc_name", NULL,
      0, FLB_TRUE, offsetof(struct flb_in_proc_config, proc_name),
      "Define process name to health check"
     },

--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -486,7 +486,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
       0, FLB_TRUE, offsetof(struct flb_in_proc_config, interval_nsec),
-      "Set the collector interval (sub seconds)"
+      "Set the collector interval (nanoseconds)"
     },
     {
      FLB_CONFIG_MAP_BOOL, "alert", "false",

--- a/plugins/in_proc/in_proc.h
+++ b/plugins/in_proc/in_proc.h
@@ -25,8 +25,8 @@
 #include <fluent-bit/flb_input.h>
 #include <msgpack.h>
 
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 #define FLB_CMD_LEN 256
 #define FLB_IN_PROC_NAME "in_proc"

--- a/plugins/in_proc/in_proc.h
+++ b/plugins/in_proc/in_proc.h
@@ -56,9 +56,9 @@ struct flb_in_proc_config {
     uint8_t  alive;
 
     /* Checking process */
-    char*  proc_name;
-    pid_t  pid;
-    size_t len_proc_name;
+    flb_sds_t  proc_name;
+    pid_t      pid;
+    size_t     len_proc_name;
 
     /* Time interval check */
     int interval_sec;


### PR DESCRIPTION
Add configmap support for the in_proc plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
