### PR TITLE
in_netif: update to use config_map.

### DIFF
--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -94,45 +94,23 @@ static int init_entry_linux(struct flb_in_netif_config *ctx)
 }
 
 static int configure(struct flb_in_netif_config *ctx,
-                     struct flb_input_instance *in,
-                     int *interval_sec,
-                     int *interval_nsec)
+                     struct flb_input_instance *in)
 {
-    const char *pval = NULL;
+    int ret;
     ctx->map_num = 0;
 
-    /* interval settings */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        *interval_sec = atoi(pval);
-    }
-    else {
-        *interval_sec = DEFAULT_INTERVAL_SEC;
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        return -1;
     }
 
-    pval = flb_input_get_property("interval_nsec", in);
-    if (pval != NULL && atoi(pval) >= 0) {
-        *interval_nsec = atoi(pval);
-    }
-    else {
-        *interval_nsec = DEFAULT_INTERVAL_NSEC;
-    }
-
-    if (*interval_sec <= 0 && *interval_nsec <= 0) {
+    if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
-        *interval_sec = DEFAULT_INTERVAL_SEC;
-        *interval_nsec = DEFAULT_INTERVAL_NSEC;
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
     }
 
-    pval = flb_input_get_property("verbose", in);
-    if (pval != NULL && flb_utils_bool(pval)) {
-        ctx->verbose = FLB_TRUE;
-    }
-    else {
-        ctx->verbose = FLB_FALSE;
-    }
-
-    ctx->interface = flb_input_get_property("interface", in);
     if (ctx->interface == NULL) {
         flb_plg_error(ctx->ins, "'interface' is not set");
         return -1;
@@ -280,8 +258,6 @@ static int in_netif_init(struct flb_input_instance *in,
                          struct flb_config *config, void *data)
 {
     int ret;
-    int interval_sec = 0;
-    int interval_nsec = 0;
 
     struct flb_in_netif_config *ctx = NULL;
     (void) data;
@@ -294,7 +270,7 @@ static int in_netif_init(struct flb_input_instance *in,
     }
     ctx->ins = in;
 
-    if (configure(ctx, in, &interval_sec, &interval_nsec) < 0) {
+    if (configure(ctx, in) < 0) {
         config_destroy(ctx);
         return -1;
     }
@@ -305,8 +281,8 @@ static int in_netif_init(struct flb_input_instance *in,
     /* Set our collector based on time */
     ret = flb_input_set_collector_time(in,
                                        in_netif_collect,
-                                       interval_sec,
-                                       interval_nsec,
+                                       ctx->interval_sec,
+                                       ctx->interval_nsec,
                                        config);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "Could not set collector for Proc input plugin");
@@ -317,6 +293,31 @@ static int in_netif_init(struct flb_input_instance *in,
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_STR, "interface", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_in_netif_config, interface),
+      "Set the interface"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_in_netif_config, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_in_netif_config, interval_nsec),
+      "Set the collector interval (sub seconds)"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "verbose", "false",
+      0, FLB_TRUE, offsetof(struct flb_in_netif_config, verbose),
+      "Enable verbosity"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_netif_plugin = {
     .name         = "netif",
@@ -326,5 +327,6 @@ struct flb_input_plugin in_netif_plugin = {
     .cb_collect   = in_netif_collect,
     .cb_flush_buf = NULL,
     .cb_exit      = in_netif_exit,
+    .config_map   = config_map,
     .flags        = 0,
 };

--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -308,7 +308,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
       0, FLB_TRUE, offsetof(struct flb_in_netif_config, interval_nsec),
-      "Set the collector interval (sub seconds)"
+      "Set the collector interval (nanoseconds)"
     },
     {
       FLB_CONFIG_MAP_BOOL, "verbose", "false",

--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -102,6 +102,7 @@ static int configure(struct flb_in_netif_config *ctx,
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *)ctx);
     if (ret == -1) {
+        flb_plg_error(in, "unable to load configuration");
         return -1;
     }
 

--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -298,7 +298,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_STR, "interface", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_in_netif_config, interface),
-      "Set the interface"
+      "Set the interface, eg: eth0 or enp1s0"
     },
     {
       FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,

--- a/plugins/in_netif/in_netif.h
+++ b/plugins/in_netif/in_netif.h
@@ -26,8 +26,8 @@
 #include <fluent-bit/flb_input.h>
 #include <msgpack.h>
 
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 #define FLB_IN_NETIF_NAME "in_netif"
 
@@ -48,6 +48,9 @@ struct netif_entry {
 };
 
 struct flb_in_netif_config {
+    int interval_sec;
+    int interval_nsec;
+
     const char *interface;
     int  interface_len;
 

--- a/plugins/in_netif/in_netif.h
+++ b/plugins/in_netif/in_netif.h
@@ -51,8 +51,8 @@ struct flb_in_netif_config {
     int interval_sec;
     int interval_nsec;
 
-    const char *interface;
-    int  interface_len;
+    flb_sds_t interface;
+    int       interface_len;
 
     int  verbose;
     int  first_snapshot;   /* a feild to indicate whethor or not this is the first collect */


### PR DESCRIPTION
Add configmap support for the in_netif plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.
----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
