### PR TITLE
in_systemd: add 'lowercase' option

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -25,6 +25,8 @@
 #include "systemd_config.h"
 #include "systemd_db.h"
 
+#include <ctype.h>
+
 /* msgpack helpers to pack unsigned ints (it takes care of endianness */
 #define pack_uint16(buf, d) _msgpack_store16(buf, (uint16_t) d)
 #define pack_uint32(buf, d) _msgpack_store32(buf, (uint32_t) d)
@@ -73,6 +75,7 @@ static int in_systemd_collect(struct flb_input_instance *ins,
 {
     int ret;
     int ret_j;
+    int i;
     int len;
     int entries = 0;
     int skip_entries = 0;
@@ -82,10 +85,12 @@ static int in_systemd_collect(struct flb_input_instance *ins,
     uint8_t h;
     uint64_t usec;
     size_t length;
+    size_t threshold;
     const char *sep;
     const char *key;
     const char *val;
     char *tmp;
+    char *buf = NULL;
 #ifdef FLB_HAVE_SQLDB
     char *cursor = NULL;
 #endif
@@ -122,6 +127,17 @@ static int in_systemd_collect(struct flb_input_instance *ins,
         }
         if (ret != SD_JOURNAL_APPEND && ret != SD_JOURNAL_NOP) {
             return FLB_SYSTEMD_NONE;
+        }
+    }
+
+    if (ctx->lowercase == FLB_TRUE) {
+        ret = sd_journal_get_data_threshold(ctx->j, &threshold);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "error setting up systemd data. "
+                          "sd_journal_get_data_threshold() return value '%i'",
+                          ret);
+            return FLB_SYSTEMD_ERROR;
         }
     }
 
@@ -211,14 +227,36 @@ static int in_systemd_collect(struct flb_input_instance *ins,
                 key++;
                 length--;
             }
+
             sep = strchr(key, '=');
             if (sep == NULL) {
                 skip_entries++;
                 continue;
             }
+
             len = (sep - key);
             msgpack_pack_str(&mp_pck, len);
-            msgpack_pack_str_body(&mp_pck, key, len);
+
+            if (ctx->lowercase == FLB_TRUE) {
+                /*
+                 * Ensure buf to have enough space for the key because the libsystemd
+                 * might return larger data than the threshold.
+                 */
+                if (buf == NULL) {
+                    buf = flb_sds_create_len(NULL, threshold);
+                }
+                if (flb_sds_alloc(buf) < len) {
+                    buf = flb_sds_increase(buf, len - flb_sds_alloc(buf));
+                }
+                for (i = 0; i < len; i++) {
+                    buf[i] = tolower(key[i]);
+                }
+
+                msgpack_pack_str_body(&mp_pck, buf, len);
+            }
+            else {
+                msgpack_pack_str_body(&mp_pck, key, len);
+            }
 
             val = sep + 1;
             len = length - (sep - key) - 1;
@@ -275,6 +313,8 @@ static int in_systemd_collect(struct flb_input_instance *ins,
             break;
         }
     }
+
+    flb_sds_destroy(buf);
 
 #ifdef FLB_HAVE_SQLDB
     /* Save cursor */
@@ -492,6 +532,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_BOOL, "read_from_tail", "false",
       0, FLB_TRUE, offsetof(struct flb_systemd_config, read_from_tail),
       "Read the journal from the end (tail)"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "lowercase", "false",
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, lowercase),
+      "Lowercase the fields"
     },
     {
       FLB_CONFIG_MAP_BOOL, "strip_underscores", "false",

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -151,16 +151,19 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     if (ctx->filter_type) {
         if (strcasecmp(ctx->filter_type, "and") == 0) {
             journal_filter_is_and = FLB_TRUE;
-        } else if (strcasecmp(ctx->filter_type, "or") == 0) {
+        }
+        else if (strcasecmp(ctx->filter_type, "or") == 0) {
             journal_filter_is_and = FLB_FALSE;
-        } else {
+        }
+        else {
             flb_plg_error(ctx->ins,
                           "systemd_filter_type must be 'and' or 'or'. Got %s",
                           ctx->filter_type);
             flb_free(ctx);
             return NULL;
         }
-    } else {
+    }
+    else {
         journal_filter_is_and = FLB_FALSE;
     }
 
@@ -172,7 +175,8 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
             sd_journal_add_match(ctx->j, mv->val.str, 0);
             if (journal_filter_is_and) {
                 sd_journal_add_conjunction(ctx->j);
-            } else {
+            }
+            else {
                 sd_journal_add_disjunction(ctx->j);
             }
         }

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -51,6 +51,7 @@ struct flb_systemd_config {
     struct mk_list *systemd_filters;
     int pending_records;
     int read_from_tail;  /* read_from_tail option */
+    int lowercase;
     int strip_underscores;
 
     /* Internal */


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch adds support of lowercase option for the systemd input plugin. The name of option is aligned to 
https://github.com/fluent-plugin-systemd/fluent-plugin-systemd.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #1543

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
- https://github.com/fluent/fluent-bit-docs/pull/724

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.