### PR TITLE
filter_modify: support config_map

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -120,6 +120,12 @@ static int setup(struct filter_modify_ctx *ctx,
     //   - Malloc Rule
     //   - Switch list size
 
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_errno();
+        flb_plg_error(f_ins, "configuration error");
+        return -1;
+    }
+
     mk_list_foreach(head, &f_ins->properties) {
         kv = mk_list_entry(head, struct flb_kv, _head);
 
@@ -1346,11 +1352,74 @@ static int cb_modify_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "Set", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Add a key/value pair with key KEY and value VALUE. "
+     "If KEY already exists, this field is overwritten."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Add", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Add a key/value pair with key KEY and value VALUE if KEY does not exist"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Remove", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Remove a key/value pair with key KEY if it exists"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Remove_wildcard", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Remove all key/value pairs with key matching wildcard KEY"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Remove_regex", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Remove all key/value pairs with key matching regexp KEY"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Rename", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Rename a key/value pair with key KEY to RENAMED_KEY "
+     "if KEY exists AND RENAMED_KEY does not exist"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Hard_Rename", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. "
+     "If RENAMED_KEY already exists, this field is overwritten"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Copy", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Copy a key/value pair with key KEY to COPIED_KEY "
+     "if KEY exists AND COPIED_KEY does not exist"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Hard_copy", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists. "
+     "If COPIED_KEY already exists, this field is overwritten"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Condition", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Set the condition to modify. Key_exists, Key_does_not_exist, A_key_matches, "
+     "No_key_matches, Key_value_equals, Key_value_does_not_equal, Key_value_matches, "
+     "Key_value_does_not_match, Matching_keys_have_matching_values "
+     "and Matching_keys_do_not_have_matching_values are supported."
+    },
+    {0}
+};
+
 struct flb_filter_plugin filter_modify_plugin = {
     .name = "modify",
     .description = "modify records by applying rules",
     .cb_init = cb_modify_init,
     .cb_filter = cb_modify_filter,
     .cb_exit = cb_modify_exit,
+    .config_map = config_map,
     .flags = 0
 };


### PR DESCRIPTION
This patch is to support config map for filter_modify.
#4863

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name mem
    Tag  mem.local

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name modify
    Match *
    Add Service1 SOMEVALUE
    Add Service3 SOMEVALUE3
    Add Mem.total2 TOTALMEM2
    Rename Mem.free MEMFREE
    Rename Mem.used MEMUSED
    Rename Swap.total SWAPTOTAL
    Add Mem.total TOTALMEM
```

## Debug log

```
$ bin/fluent-bit -c b.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/23 20:45:29] [ info] [engine] started (pid=13595)
[2022/02/23 20:45:29] [ info] [storage] version=1.1.6, initializing...
[2022/02/23 20:45:29] [ info] [storage] in-memory
[2022/02/23 20:45:29] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/23 20:45:29] [ info] [cmetrics] version=0.3.0
[2022/02/23 20:45:29] [ info] [sp] stream processor started
[2022/02/23 20:45:29] [ info] [output:stdout:stdout.0] worker #0 started
[0] mem.local: [1645616730.045022358, {"Mem.total"=>8143088, "MEMUSED"=>7940624, "MEMFREE"=>202464, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[1] mem.local: [1645616731.045664926, {"Mem.total"=>8143088, "MEMUSED"=>7940624, "MEMFREE"=>202464, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[2] mem.local: [1645616732.045168279, {"Mem.total"=>8143088, "MEMUSED"=>7940624, "MEMFREE"=>202464, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[3] mem.local: [1645616733.045079103, {"Mem.total"=>8143088, "MEMUSED"=>7940624, "MEMFREE"=>202464, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
^C[2022/02/23 20:45:34] [engine] caught signal (SIGINT)
[0] mem.local: [1645616734.045334976, {"Mem.total"=>8143088, "MEMUSED"=>7940624, "MEMFREE"=>202464, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[2022/02/23 20:45:34] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/23 20:45:35] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/23 20:45:35] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/23 20:45:35] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c b.conf 
==13600== Memcheck, a memory error detector
==13600== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13600== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==13600== Command: bin/fluent-bit -c b.conf
==13600== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/23 20:46:06] [ info] [engine] started (pid=13600)
[2022/02/23 20:46:06] [ info] [storage] version=1.1.6, initializing...
[2022/02/23 20:46:06] [ info] [storage] in-memory
[2022/02/23 20:46:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/23 20:46:06] [ info] [cmetrics] version=0.3.0
[2022/02/23 20:46:06] [ info] [output:stdout:stdout.0] worker #0 started
[2022/02/23 20:46:06] [ info] [sp] stream processor started
[0] mem.local: [1645616767.063311074, {"Mem.total"=>8143088, "MEMUSED"=>8003136, "MEMFREE"=>139952, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[1] mem.local: [1645616768.045779773, {"Mem.total"=>8143088, "MEMUSED"=>8003640, "MEMFREE"=>139448, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[2] mem.local: [1645616769.045261533, {"Mem.total"=>8143088, "MEMUSED"=>8003892, "MEMFREE"=>139196, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[3] mem.local: [1645616770.045175018, {"Mem.total"=>8143088, "MEMUSED"=>8003892, "MEMFREE"=>139196, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
^C[2022/02/23 20:46:11] [engine] caught signal (SIGINT)
[0] mem.local: [1645616771.112856389, {"Mem.total"=>8143088, "MEMUSED"=>8004144, "MEMFREE"=>138944, "SWAPTOTAL"=>1918356, "Swap.used"=>1548, "Swap.free"=>1916808, "Service1"=>"SOMEVALUE", "Service3"=>"SOMEVALUE3", "Mem.total2"=>"TOTALMEM2"}]
[2022/02/23 20:46:11] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/23 20:46:12] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/23 20:46:12] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/23 20:46:12] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==13600== 
==13600== HEAP SUMMARY:
==13600==     in use at exit: 0 bytes in 0 blocks
==13600==   total heap usage: 1,498 allocs, 1,498 frees, 1,471,776 bytes allocated
==13600== 
==13600== All heap blocks were freed -- no leaks are possible
==13600== 
==13600== For lists of detected and suppressed errors, rerun with: -s
==13600== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
