### PR TITLE
output_thread: sig 0xdeadbeef write 4 bytes, not 8 on 32bit machine

### DIFF
--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -509,7 +509,7 @@ int flb_output_thread_pool_coros_size(struct flb_output_instance *ins)
 void flb_output_thread_pool_destroy(struct flb_output_instance *ins)
 {
     int n;
-    uint64_t stop = 0xdeadbeef;
+    struct flb_task *stop = 0xdeadbeef;
     struct flb_tp *tp = ins->tp;
     struct mk_list *head;
     struct flb_out_thread_instance *th_ins;


### PR DESCRIPTION
Previously, 0xdeadbeef 00000000 written to worker task pipe causing
segfault on worker shutdown. Task of 0x00000000 address is invalid.

0xdeadbeef 00000000 was being written to the worker taskpipe because 0xdeadbeef is defined in a uint64_t which is 8 bytes (https://github.com/fluent/fluent-bit/blob/eef4cc0924ef26190b4d034e6dfc59b762d730f1/src/flb_output_thread.c#L512), and read as a (struct flb_task *) which is 4 bytes (https://github.com/fluent/fluent-bit/blob/eef4cc0924ef26190b4d034e6dfc59b762d730f1/src/flb_output_thread.c#L278) on 32 bit machines. This gets processed by the worker thread as two separate tasks, 1. 0xdeadbeef and 2. 0x00000000. The latter creates a segfault on engine shutdown causing issues.

Resolve by writing sizeof(ptr) which should evaluate to 4 bytes on 32 bit machines.

Signed-off-by: falamatt@amazon.com <falamatt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
