### PR TITLE
build: enforce for Flex 2 and Bison 3 as a minimum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,8 +317,8 @@ endif()
 
 # Optional features like Stream Processor and Record Accessor needs Flex
 # and Bison to generate it parsers.
-find_package(FLEX)
-find_package(BISON)
+find_package(FLEX 2)
+find_package(BISON 3)
 
 if(FLEX_FOUND AND BISON_FOUND)
   set(FLB_FLEX_BISON  1)


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
