### PR TITLE
in_kmsg: add empty config_map.

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -281,6 +281,13 @@ static int in_kmsg_init(struct flb_input_instance *ins,
     ctx->buf_len = 0;
     ctx->buf_size = FLB_KMSG_BUF_SIZE;
 
+    /* Load the config map */
+    ret = flb_input_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
     /* set context */
     flb_input_set_context(ins, ctx);
 
@@ -331,6 +338,10 @@ static int in_kmsg_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    /* EOF */
+    {0}
+};
 
 /* Plugin reference */
 struct flb_input_plugin in_kmsg_plugin = {
@@ -340,5 +351,6 @@ struct flb_input_plugin in_kmsg_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_kmsg_collect,
     .cb_flush_buf = NULL,
-    .cb_exit      = in_kmsg_exit
+    .cb_exit      = in_kmsg_exit,
+    .config_map   = config_map
 };


### PR DESCRIPTION
Add an empty configmap to work as configmap support for the in_kmsg plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

the in_kmsg plugin has no configuration so nothing to do here.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
