### PR TITLE
in_systemd: update to use config_map.

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -392,6 +392,14 @@ static int in_systemd_init(struct flb_input_instance *ins,
     /* Set the context */
     flb_input_set_context(ins, ctx);
 
+    /* Load the config_map */
+    ret = flb_input_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        flb_free(config);
+        return -1;
+    }
+
     /* Events collector: archive */
     ret = flb_input_set_collector_event(ins, in_systemd_collect_archive,
                                         ctx->ch_manager[0], config);
@@ -462,6 +470,53 @@ static int in_systemd_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_STR, "path", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, path),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "max_fields", FLB_SYSTEMD_MAX_FIELDS,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, max_fields),
+      "Set the maximum fields per notification"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "max_entries", FLB_SYSTEMD_MAX_ENTRIES,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, max_entries),
+      "Set the maximum entries per notification"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "systemd_filter_type", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, filter_type),
+      "Set the systemd filter type to either 'and' or 'or'"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "read_from_tail", "false",
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, read_from_tail),
+      "Read the journal from the end (tail)"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "strip_underscores", "false",
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, strip_underscores),
+      "Strip undersecores from fields"
+    },
+#ifdef FLB_HAVE_SQLDB
+    {
+      FLB_CONFIG_MAP_STR, "db_sync", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, db_sync_mode),
+      "Set the database sync mode: extra, full, normal or off"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "db", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, db_path),
+      "Set the database path"
+    },
+#endif /* FLB_HAVE_SQLDB */
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_systemd_plugin = {
     .name         = "systemd",
@@ -472,5 +527,6 @@ struct flb_input_plugin in_systemd_plugin = {
     .cb_pause     = in_systemd_pause,
     .cb_resume    = in_systemd_resume,
     .cb_exit      = in_systemd_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -392,14 +392,6 @@ static int in_systemd_init(struct flb_input_instance *ins,
     /* Set the context */
     flb_input_set_context(ins, ctx);
 
-    /* Load the config_map */
-    ret = flb_input_config_map_set(ins, (void *)ctx);
-    if (ret == -1) {
-        flb_plg_error(ins, "unable to load configuration");
-        flb_free(config);
-        return -1;
-    }
-
     /* Events collector: archive */
     ret = flb_input_set_collector_event(ins, in_systemd_collect_archive,
                                         ctx->ch_manager[0], config);
@@ -490,6 +482,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "systemd_filter_type", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_systemd_config, filter_type),
       "Set the systemd filter type to either 'and' or 'or'"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "systemd_filter", (char *)NULL,
+      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_systemd_config, systemd_filters),
+      "Add a systemd filter, can be set multiple times"
     },
     {
       FLB_CONFIG_MAP_BOOL, "read_from_tail", "false",

--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -474,7 +474,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_STR, "path", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_systemd_config, path),
-      "Set the collector interval"
+      "Set the systemd journal path"
     },
     {
       FLB_CONFIG_MAP_INT, "max_fields", FLB_SYSTEMD_MAX_FIELDS,

--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -58,6 +58,14 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     ctx->db_sync = -1;
 #endif
 
+    /* Load the config_map */
+    ret = flb_input_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        flb_free(config);
+        return NULL;
+    }
+
     /* Create the channel manager */
     ret = pipe(ctx->ch_manager);
     if (ret == -1) {
@@ -241,10 +249,6 @@ int flb_systemd_config_destroy(struct flb_systemd_config *ctx)
     /* Close context */
     if (ctx->j) {
         sd_journal_close(ctx->j);
-    }
-
-    if (ctx->path) {
-        flb_free(ctx->path);
     }
 
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -37,8 +37,8 @@
 /* constants */
 #define FLB_SYSTEMD_UNIT     "_SYSTEMD_UNIT"
 #define FLB_SYSTEMD_UNKNOWN  "unknown"
-#define FLB_SYSTEMD_MAX_FIELDS   8000
-#define FLB_SYSTEMD_MAX_ENTRIES  5000
+#define FLB_SYSTEMD_MAX_FIELDS   "8000"
+#define FLB_SYSTEMD_MAX_ENTRIES  "5000"
 
 /* Input configuration & context */
 struct flb_systemd_config {
@@ -46,7 +46,9 @@ struct flb_systemd_config {
     int fd;              /* Journal file descriptor */
     sd_journal *j;       /* Journal context */
     char *cursor;
-    char *path;
+    flb_sds_t path;
+    flb_sds_t filter_type; /* sysytemd filter type: and|or */
+    struct mk_list *systemd_filters;
     int pending_records;
     int read_from_tail;  /* read_from_tail option */
 
@@ -61,7 +63,9 @@ struct flb_systemd_config {
     int strip_underscores;
 
 #ifdef FLB_HAVE_SQLDB
+    flb_sds_t db_path;
     struct flb_sqldb *db;
+    flb_sds_t db_sync_mode;
     int db_sync;
     sqlite3_stmt *stmt_cursor;
 #endif

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -51,6 +51,7 @@ struct flb_systemd_config {
     struct mk_list *systemd_filters;
     int pending_records;
     int read_from_tail;  /* read_from_tail option */
+    int strip_underscores;
 
     /* Internal */
     int ch_manager[2];         /* pipe: channel manager    */
@@ -60,7 +61,6 @@ struct flb_systemd_config {
     int dynamic_tag;
     int max_fields;            /* max number of fields per record */
     int max_entries;           /* max number of records per iteration */
-    int strip_underscores;
 
 #ifdef FLB_HAVE_SQLDB
     flb_sds_t db_path;


### PR DESCRIPTION
Add configmap support for the in_systemd plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
