### PR TITLE
in_stdin: refactor to use config_map.

### DIFF
--- a/plugins/in_stdin/in_stdin.h
+++ b/plugins/in_stdin/in_stdin.h
@@ -32,6 +32,8 @@ struct flb_in_stdin_config {
     size_t buf_size;          /* size of a buffer      */
     int    buf_len;           /* read buffer length    */
     char   *buf;              /* read buffer           */
+    flb_sds_t parser_name;    /* name of the parser    */
+    flb_sds_t buffer_size;    /* buffer size in string */
 
     /* Parser / Format */
     struct flb_parser *parser;


### PR DESCRIPTION
Add configmap support for the in_stdin plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
