### PR TITLE
in_docker: update to use config_map.

### DIFF
--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -620,8 +620,6 @@ static int cb_docker_init(struct flb_input_instance *in,
 {
     int ret;
     struct flb_docker *ctx;
-    const char *pval = NULL;
-    (void) data;
 
     /* Allocate space for the configuration */
     ctx = flb_calloc(1, sizeof(struct flb_docker));
@@ -631,20 +629,23 @@ static int cb_docker_init(struct flb_input_instance *in,
     }
     ctx->ins = in;
 
-    /* Collection time setting */
-    pval = flb_input_get_property("interval_sec", in);
-    if (pval != NULL && atoi(pval) > 0) {
-        ctx->interval_sec = atoi(pval);
-    }
-    else {
-        ctx->interval_sec = DEFAULT_INTERVAL_SEC;
-    }
-    ctx->interval_nsec = DEFAULT_INTERVAL_NSEC;
-
     init_filter_lists(in, ctx);
 
     /* Set the context */
     flb_input_set_context(in, ctx);
+    
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        flb_plg_error(in, "unable to load configuration.");
+        return -1;
+    }    
+    
+    if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
+    }
 
     /* Set our collector based on time, CPU usage every 1 second */
     ret = flb_input_set_collector_time(in,
@@ -831,6 +832,21 @@ static int cb_docker_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_docker, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_docker, interval_nsec),
+      "Set the collector interval (nanoseconds)"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_docker_plugin = {
     .name         = "docker",
@@ -841,5 +857,6 @@ struct flb_input_plugin in_docker_plugin = {
     .cb_flush_buf  = NULL,
     .cb_pause     = cb_docker_pause,
     .cb_resume    = cb_docker_resume,
-    .cb_exit      = cb_docker_exit
+    .cb_exit      = cb_docker_exit,
+    .config_map   = config_map
 };

--- a/plugins/in_docker/docker.h
+++ b/plugins/in_docker/docker.h
@@ -39,8 +39,8 @@
 #define DOCKER_LIB_ROOT       "/var/lib/docker/containers"
 #define DOCKER_CONFIG_JSON    "config.v2.json"
 #define DOCKER_NAME_ARG       "\"Name\""
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 typedef struct docker_info {
     char *id;


### PR DESCRIPTION
Add configmap support for the in_docker plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
