### PR TITLE
in_tcp: refactor to use config_map.

### DIFF
--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -117,6 +117,31 @@ static int in_tcp_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "format", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_tcp_config, format_name),
+     "Set the format: json or none"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "separator", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_tcp_config, raw_separator),
+     "Set separator"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "chunk_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_in_tcp_config, chunk_size_str),
+      "Set the chunk size"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "buffer_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_in_tcp_config, buffer_size_str),
+      "Set the buffer size"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_tcp_plugin = {
     .name         = "tcp",
@@ -126,5 +151,6 @@ struct flb_input_plugin in_tcp_plugin = {
     .cb_collect   = in_tcp_collect,
     .cb_flush_buf = NULL,
     .cb_exit      = in_tcp_exit,
+    .config_map   = config_map,
     .flags        = FLB_INPUT_NET,
 };

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -29,11 +29,15 @@
 
 struct flb_in_tcp_config {
     int server_fd;                  /* TCP server file descriptor  */
+    flb_sds_t format_name;          /* Data format name */
     int format;                     /* Data format */
     size_t buffer_size;             /* Buffer size for each reader */
+    flb_sds_t buffer_size_str;      /* Buffer size in string form  */
     size_t chunk_size;              /* Chunk allocation size       */
+    flb_sds_t chunk_size_str;       /* Chunk size in string form   */
     char *listen;                   /* Listen interface            */
     char *tcp_port;                 /* TCP Port                    */
+    flb_sds_t raw_separator;        /* Unescaped string delimiterr */
     flb_sds_t separator;            /* String delimiter            */
     struct mk_list connections;     /* List of active connections  */
     struct mk_event_loop *evl;      /* Event loop file descriptor  */

--- a/plugins/in_tcp/tcp_conn.h
+++ b/plugins/in_tcp/tcp_conn.h
@@ -22,7 +22,7 @@
 
 #include <fluent-bit/flb_pack.h>
 
-#define FLB_IN_TCP_CHUNK 32768
+#define FLB_IN_TCP_CHUNK "32768"
 
 enum {
     TCP_NEW        = 1,  /* it's a new connection                */


### PR DESCRIPTION
Add configmap support for the in_tcp plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
