### PR TITLE
in_serial: refactor to use config_map.

### DIFF
--- a/plugins/in_serial/in_serial.c
+++ b/plugins/in_serial/in_serial.c
@@ -339,6 +339,36 @@ static int cb_serial_init(struct flb_input_instance *in,
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "file", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_serial_config, file),
+     "Set the serial character device file name"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "bitrate", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_serial_config, bitrate),
+     "Set the serial bitrate (baudrate)"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "separator", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_serial_config, separator),
+     "Set the record separator"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "format", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_serial_config, format_str),
+     "Set the serial format: json or none"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "min_bytes", "0",
+     0, FLB_TRUE, offsetof(struct flb_in_serial_config, min_bytes),
+     "Set the serial minimum bytes"
+    },
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_input_plugin in_serial_plugin = {
     .name         = "serial",
@@ -347,5 +377,6 @@ struct flb_input_plugin in_serial_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = cb_serial_collect,
     .cb_flush_buf = NULL,
-    .cb_exit      = cb_serial_exit
+    .cb_exit      = cb_serial_exit,
+    .config_map   = config_map,
 };

--- a/plugins/in_serial/in_serial_config.h
+++ b/plugins/in_serial/in_serial_config.h
@@ -38,15 +38,16 @@ struct flb_in_serial_config {
 
     /* config */
     int min_bytes;
-    const char *file;
-    const char *bitrate;
+    flb_sds_t file;
+    flb_sds_t bitrate;
 
     /* separator */
     int sep_len;
-    const char *separator;
+    flb_sds_t separator;
 
     /* Incoming format: JSON only for now */
     int format;
+    flb_sds_t format_str;
 
     struct termios tio;
     struct termios tio_orig;


### PR DESCRIPTION
Add configmap support for the in_serial plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.
----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
