### PR TITLE
in_exec: refactor to use config_map.

### DIFF
--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -28,18 +28,22 @@
 
 #include <msgpack.h>
 
-#define DEFAULT_BUF_SIZE      4096
-#define DEFAULT_INTERVAL_SEC  1
-#define DEFAULT_INTERVAL_NSEC 0
+#define DEFAULT_BUF_SIZE      "4096"
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 struct flb_exec {
-    const char  *cmd;
+    flb_sds_t cmd;
+    flb_sds_t parser_name;
     struct flb_parser  *parser;
     char *buf;
     size_t buf_size;
+    flb_sds_t buf_size_str;
     struct flb_input_instance *ins;
     int oneshot;
     flb_pipefd_t ch_manager[2];
+    int interval_sec;
+    int interval_nsec;
 };
 
 #endif /* FLB_IN_EXEC_H */


### PR DESCRIPTION
Add configmap support for the in_exec plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
