### PR TITLE
record_accessor: revert record_accessor: allow dot 

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -181,7 +181,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
                 /* ignore '.' if it is inside a string/subkey */
                 continue;
             }
-            else if (buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
+            else if (buf[end] == '.' || buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
                 break;
             }
         }

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -692,7 +692,10 @@ void cb_issue_4917()
 TEST_LIST = {
     { "keys"            , cb_keys},
     { "dash_key"        , cb_dash_key},
+    /*
+     * If #4370 is fixed, this testcase should be enabled.
     { "dot_slash_key"   , cb_dot_and_slash_key},
+    */
     { "translate"       , cb_translate},
     { "translate_tag"   , cb_translate_tag},
     { "dots_subkeys"    , cb_dots_subkeys},


### PR DESCRIPTION
Fixes #4917 

This patch is to revert https://github.com/fluent/fluent-bit/commit/9dd1cbc6527b0f5cd162c0885d36e3dbfd44de76.
The commit is one of #4619 and it causes regression #4917.
The commit is to fix #4370 so if this PR is merged #4370 will be re-opened.

We need to take care #4616 or other way to fix #4370.

## Commit 

1. Add a test case for #4917 
2. Revert https://github.com/fluent/fluent-bit/commit/9dd1cbc6527b0f5cd162c0885d36e3dbfd44de76
3. Disable a test case for #4370 since above commit is reverted

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Flush 1
    Log_Level info

[INPUT]
    NAME dummy
    Dummy {"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}
    Tag test_tag

[FILTER]
    Name rewrite_tag
    Match test_tag
    Rule $tool ^(fluent)$ from.$TAG.new.$tool.$sub['s1']['s2'].out false
    Emitter_Name re_emitted

[OUTPUT]
    Name stdout
    Match from.*
```

## Debug log

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/26 20:51:32] [ info] [engine] started (pid=53088)
[2022/02/26 20:51:32] [ info] [storage] version=1.1.6, initializing...
[2022/02/26 20:51:32] [ info] [storage] in-memory
[2022/02/26 20:51:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/26 20:51:32] [ info] [cmetrics] version=0.3.0
[2022/02/26 20:51:32] [ info] [sp] stream processor started
[2022/02/26 20:51:32] [ info] [output:stdout:stdout.0] worker #0 started
[0] from.test_tag.new.fluent.bit.out: [1645876292.646750770, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[0] from.test_tag.new.fluent.bit.out: [1645876293.646765584, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[0] from.test_tag.new.fluent.bit.out: [1645876294.646735221, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
^C[2022/02/26 20:51:36] [engine] caught signal (SIGINT)
[0] from.test_tag.new.fluent.bit.out: [1645876295.646805356, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[2022/02/26 20:51:36] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/26 20:51:36] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/26 20:51:36] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/26 20:51:36] [ info] [output:stdout:stdout.0] thread worker #0 stopped
taka@locals:~/git/fluent-bit/build/4917$ 
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==53092== Memcheck, a memory error detector
==53092== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==53092== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==53092== Command: ../bin/fluent-bit -c a.conf
==53092== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/26 20:52:06] [ info] [engine] started (pid=53092)
[2022/02/26 20:52:06] [ info] [storage] version=1.1.6, initializing...
[2022/02/26 20:52:06] [ info] [storage] in-memory
[2022/02/26 20:52:06] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/26 20:52:06] [ info] [cmetrics] version=0.3.0
[2022/02/26 20:52:07] [ info] [sp] stream processor started
[2022/02/26 20:52:07] [ info] [output:stdout:stdout.0] worker #0 started
[0] from.test_tag.new.fluent.bit.out: [1645876327.680672520, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
^C[2022/02/26 20:52:09] [engine] caught signal (SIGINT)
[0] from.test_tag.new.fluent.bit.out: [1645876328.702395522, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[2022/02/26 20:52:09] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/26 20:52:09] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/26 20:52:09] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/26 20:52:09] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==53092== 
==53092== HEAP SUMMARY:
==53092==     in use at exit: 0 bytes in 0 blocks
==53092==   total heap usage: 1,388 allocs, 1,388 frees, 1,547,490 bytes allocated
==53092== 
==53092== All heap blocks were freed -- no leaks are possible
==53092== 
==53092== For lists of detected and suppressed errors, rerun with: -s
==53092== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
