### PR TITLE
filter_nest: support config map

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -71,6 +71,11 @@ static int configure(struct filter_nest_ctx *ctx,
     ctx->remove_prefix = false;
     ctx->add_prefix = false;
 
+    if (flb_filter_config_map_set(f_ins, ctx) < 0) {
+        flb_plg_error(f_ins, "unable to load configuration");
+        return -1;
+    }
+
     mk_list_foreach(head, &f_ins->properties) {
         kv = mk_list_entry(head, struct flb_kv, _head);
 
@@ -626,11 +631,47 @@ static int cb_nest_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_STR, "Operation", NULL,
+    0, FLB_FALSE, 0,
+    "Select the operation nest or lift"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "Wildcard", NULL,
+    0, FLB_FALSE, 0,
+    "Nest records which field matches the wildcard"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "Nest_under", NULL,
+    0, FLB_FALSE, 0,
+    "Nest records matching the Wildcard under this key"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "Nested_under", NULL,
+    0, FLB_FALSE, 0,
+    "Lift records nested under the Nested_under key"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "Add_prefix", NULL,
+    0, FLB_FALSE, 0,
+    "Prefix affected keys with this string"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "Remove_prefix", NULL,
+    0, FLB_FALSE, 0,
+    "Remove prefix from affected keys if it matches this string"
+   },
+   {0}
+};
+
 struct flb_filter_plugin filter_nest_plugin = {
     .name = "nest",
     .description = "nest events by specified field values",
     .cb_init = cb_nest_init,
     .cb_filter = cb_nest_filter,
     .cb_exit = cb_nest_exit,
+    .config_map = config_map,
     .flags = 0
 };


### PR DESCRIPTION
This patch is to support config map for filter_nest.
See also #4863 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

https://docs.fluentbit.io/manual/pipeline/filters/nest#example-3-multiple-nest-and-lift-filters-with-prefix
```
[INPUT]
    Name mem
    Tag  mem.local

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard Mem.*
    Nest_under LAYER1

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard LAYER1*
    Nest_under LAYER2

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard LAYER2*
    Nest_under LAYER3

[FILTER]
    Name nest
    Match *
    Operation lift
    Nested_under LAYER3
    Add_prefix Lifted3_

[FILTER]
    Name nest
    Match *
    Operation lift
    Nested_under Lifted3_LAYER2
    Add_prefix Lifted3_Lifted2_

[FILTER]
    Name nest
    Match *
    Operation lift
    Nested_under Lifted3_Lifted2_LAYER1
    Add_prefix Lifted3_Lifted2_Lifted1_
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/27 07:59:20] [ info] [engine] started (pid=7230)
[2022/02/27 07:59:20] [ info] [storage] version=1.1.6, initializing...
[2022/02/27 07:59:20] [ info] [storage] in-memory
[2022/02/27 07:59:20] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/27 07:59:20] [ info] [cmetrics] version=0.3.0
[2022/02/27 07:59:20] [ info] [sp] stream processor started
[2022/02/27 07:59:20] [ info] [output:stdout:stdout.0] worker #0 started
[0] mem.local: [1645916361.154962911, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3806524, "Lifted3_Lifted2_Lifted1_Mem.free"=>4336564}]
[1] mem.local: [1645916362.155333085, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3806524, "Lifted3_Lifted2_Lifted1_Mem.free"=>4336564}]
[2] mem.local: [1645916363.155369219, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3806524, "Lifted3_Lifted2_Lifted1_Mem.free"=>4336564}]
[3] mem.local: [1645916364.154986805, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3809052, "Lifted3_Lifted2_Lifted1_Mem.free"=>4334036}]
^C[2022/02/27 07:59:25] [engine] caught signal (SIGINT)
[2022/02/27 07:59:25] [ warn] [engine] service will shutdown in max 5 seconds
[0] mem.local: [1645916365.154994510, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3814352, "Lifted3_Lifted2_Lifted1_Mem.free"=>4328736}]
[2022/02/27 07:59:26] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/27 07:59:26] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/27 07:59:26] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==7234== Memcheck, a memory error detector
==7234== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==7234== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==7234== Command: bin/fluent-bit -c a.conf
==7234== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/27 08:00:03] [ info] [engine] started (pid=7234)
[2022/02/27 08:00:03] [ info] [storage] version=1.1.6, initializing...
[2022/02/27 08:00:03] [ info] [storage] in-memory
[2022/02/27 08:00:03] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/27 08:00:03] [ info] [cmetrics] version=0.3.0
[2022/02/27 08:00:03] [ info] [output:stdout:stdout.0] worker #0 started
[2022/02/27 08:00:03] [ info] [sp] stream processor started
[0] mem.local: [1645916404.171235859, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3875100, "Lifted3_Lifted2_Lifted1_Mem.free"=>4267988}]
[1] mem.local: [1645916405.155112032, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3875604, "Lifted3_Lifted2_Lifted1_Mem.free"=>4267484}]
[2] mem.local: [1645916406.155212908, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3875856, "Lifted3_Lifted2_Lifted1_Mem.free"=>4267232}]
[3] mem.local: [1645916407.155165951, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3875856, "Lifted3_Lifted2_Lifted1_Mem.free"=>4267232}]
^C[2022/02/27 08:00:08] [engine] caught signal (SIGINT)
[0] mem.local: [1645916408.183572668, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Lifted3_Lifted2_Lifted1_Mem.total"=>8143088, "Lifted3_Lifted2_Lifted1_Mem.used"=>3876360, "Lifted3_Lifted2_Lifted1_Mem.free"=>4266728}]
[2022/02/27 08:00:08] [ warn] [engine] service will shutdown in max 5 seconds
[2022/02/27 08:00:09] [ info] [engine] service has stopped (0 pending tasks)
[2022/02/27 08:00:09] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/02/27 08:00:09] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==7234== 
==7234== HEAP SUMMARY:
==7234==     in use at exit: 0 bytes in 0 blocks
==7234==   total heap usage: 1,726 allocs, 1,726 frees, 1,793,218 bytes allocated
==7234== 
==7234== All heap blocks were freed -- no leaks are possible
==7234== 
==7234== For lists of detected and suppressed errors, rerun with: -s
==7234== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
