### PR TITLE
tests: internal: fuzzer: add filter_stdout fuzzer

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UNIT_TESTS_FILES
   config_random_fuzzer.c
   signv4_fuzzer.c
   flb_json_fuzzer.c
+  filter_stdout_fuzzer.c
   parser_fuzzer.c
   parse_json_fuzzer.c
   parse_logfmt_fuzzer.c

--- a/tests/internal/fuzzers/filter_stdout_fuzzer.c
+++ b/tests/internal/fuzzers/filter_stdout_fuzzer.c
@@ -1,0 +1,57 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdint.h>
+#include <fluent-bit.h>
+#include "flb_fuzz_header.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    if (in_ffd >= 0) {
+        flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+        out_ffd = flb_output(ctx, (char *) "stdout", NULL);
+        if (out_ffd >= 0) {
+            flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+            ret = flb_start(ctx);
+            if (ret == 0) {
+                char *p = get_null_terminated(size, &data, &size);
+                for (int i = 0; i < strlen(p); i++) {
+                    flb_lib_push(ctx, in_ffd, p+i, 1);
+                }
+                free(p);
+
+                sleep(1); /* waiting flush */
+            }
+        }
+    }
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    return 0;
+}


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
