### PR TITLE
tests: internal: fuzzers: fix compiler warnings

### DIFF
--- a/tests/internal/fuzzers/config_fuzzer.c
+++ b/tests/internal/fuzzers/config_fuzzer.c
@@ -314,8 +314,8 @@ char conf_file[] = "# Parser: no_year\n"
 "    name          exception_test\n"
 "    type          regex\n"
 "    flush_timeout 1000\n"
-"    rule          \"start_state\"  \"/(Dec \d+ \d+\:\d+\:\d+)(.*)/\" \"cont\"\n"
-"    rule          \"cont\" \"/^\s+at.*/\" \"cont\"\n";
+"    rule          \"start_state\"  \"/(Dec \\d+ \\d+\\:\\d+\\:\\d+)(.*)/\" \"cont\"\n"
+"    rule          \"cont\" \"/^\\s+at.*/\" \"cont\"\n";
 
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
@@ -348,7 +348,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             struct flb_parser *parser = NULL;
             struct flb_time out_time;
             parser = mk_list_entry(head, struct flb_parser, _head);
-            flb_parser_do(parser, data, size, &out_buf,
+            flb_parser_do(parser, (const char*)data, size, (void **)&out_buf,
                           &out_size, &out_time);
             if (out_buf != NULL) {
                 free(out_buf);
@@ -389,7 +389,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 struct flb_time out_time;
                 
                 parser = mk_list_entry(head, struct flb_parser, _head);
-                flb_parser_do(parser, data, size, &out_buf,
+                flb_parser_do(parser, (const char*)data, size, (void **)&out_buf,
                               &out_size, &out_time);
                 if (out_buf != NULL) {
                     free(out_buf);

--- a/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
@@ -12,7 +12,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_time tm = {0};
     struct flb_gelf_fields fields = {0};
     fields.short_message_key = flb_sds_create("AAAAAAAAAA");
-    record = flb_msgpack_raw_to_gelf(data, size, &tm, &fields);
+    record = flb_msgpack_raw_to_gelf((char*)data, size, &tm, &fields);
 
     /* cleanup */
     flb_sds_destroy(record);


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
