### PR TITLE
out_plot: refactor to use config_map.

### DIFF
--- a/plugins/out_plot/plot.c
+++ b/plugins/out_plot/plot.c
@@ -37,7 +37,7 @@ static int cb_plot_init(struct flb_output_instance *ins,
                         struct flb_config *config,
                         void *data)
 {
-    const char *tmp;
+    int ret;
     (void) config;
     (void) data;
     struct flb_plot *ctx;
@@ -49,16 +49,10 @@ static int cb_plot_init(struct flb_output_instance *ins,
     }
     ctx->ins = ins;
 
-    /* Optional 'key' field to obtain the datapoint value */
-    tmp = flb_output_get_property("key", ins);
-    if (tmp) {
-        ctx->key = flb_sds_create(tmp);
-    }
-
-    /* Optional output file name/path */
-    tmp = flb_output_get_property("file", ins);
-    if (tmp) {
-        ctx->out_file = tmp;
+    ret = flb_output_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+    	flb_free(ctx);
+    	return -1;
     }
 
     /* Set the context */
@@ -197,11 +191,24 @@ static int cb_plot_exit(void *data, struct flb_config *config)
 {
     struct flb_plot *ctx = data;
 
-    flb_sds_destroy(ctx->key);
     flb_free(ctx);
-
     return 0;
 }
+
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "key", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_plot, key),
+     "set a number of times to generate event."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "file", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_plot, out_file),
+     "set a number of times to generate event."
+    },
+    /* EOF */
+    {0}
+};
 
 struct flb_output_plugin out_plot_plugin = {
     .name         = "plot",
@@ -209,5 +216,6 @@ struct flb_output_plugin out_plot_plugin = {
     .cb_init      = cb_plot_init,
     .cb_flush     = cb_plot_flush,
     .cb_exit      = cb_plot_exit,
+    .config_map   = config_map,
     .flags        = 0,
 };


### PR DESCRIPTION
Add configmap support for the in_tcp plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
