### PR TITLE
dockerfiles: ensure certificates included

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -158,6 +158,10 @@ LABEL description="Fluent Bit multi-architecture container image" \
 # Copy the libraries from the extractor stage into root
 COPY --from=deb-extractor /dpkg /
 
+# Copy certificates
+COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
+COPY --from=builder /etc/ssl/ /etc/ssl/
+
 COPY --from=builder /fluent-bit /fluent-bit
 
 EXPOSE 2020

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -160,6 +160,8 @@ COPY --from=deb-extractor /dpkg /
 
 # Copy certificates
 COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
+# Workaround for https://github.com/moby/moby/issues/37965 in classic mode
+RUN true
 COPY --from=builder /etc/ssl/ /etc/ssl/
 
 COPY --from=builder /fluent-bit /fluent-bit

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -159,11 +159,10 @@ LABEL description="Fluent Bit multi-architecture container image" \
 COPY --from=deb-extractor /dpkg /
 
 # Copy certificates
-COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
-# Workaround for https://github.com/moby/moby/issues/37965 in classic mode
-COPY --from=builder /fluent-bit /fluent-bit
-COPY --from=builder /etc/ssl/ /etc/ssl/
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Finally the binaries as most likely to change
+COPY --from=builder /fluent-bit /fluent-bit
 
 EXPOSE 2020
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -161,10 +161,9 @@ COPY --from=deb-extractor /dpkg /
 # Copy certificates
 COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
 # Workaround for https://github.com/moby/moby/issues/37965 in classic mode
-RUN true
+COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=builder /etc/ssl/ /etc/ssl/
 
-COPY --from=builder /fluent-bit /fluent-bit
 
 EXPOSE 2020
 


### PR DESCRIPTION
Missed out certificate updates for distroless after transition to single definition.
This was failing the integration tests then but now passes.

Classic mode test was failing due to https://github.com/moby/moby/issues/37965, removed the copy of the /usr/share directory just for certs as unnecessary.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Integration tests run and pass along with all other image tests.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
