### PR TITLE
Add basic support for avro serialization to out_http

### DIFF
--- a/include/fluent-bit/flb_file.h
+++ b/include/fluent-bit/flb_file.h
@@ -23,6 +23,7 @@
 
 #include <fluent-bit/flb_sds.h>
 
+int flb_file_resolve_path(const char *path, const char *relative_to);
 flb_sds_t flb_file_read(const char *path);
 // TODO int flb_file_write(const char *path, flb_sds_t contents);
 

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -550,9 +550,9 @@ static struct flb_config_map config_map[] = {
      "Specify the key to use for the 'level' in gelf format"
     },
     {
-     FLB_CONFIG_MAP_STR, "avro_schema", NULL,
-     0, FLB_TRUE, offsetof(struct flb_out_http, avro_schema),
-     "Specify the AVRO schema for use in the avro format"
+     FLB_CONFIG_MAP_STR, "avro_schema_path", NULL,
+     0, FLB_TRUE, 0,
+     "Specify path to file containing AVRO schema for use in the avro format"
     },
     /* EOF */
     {0}

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -322,7 +322,7 @@ static int msgpack_to_avro(struct flb_out_http *ctx,
         return -1;
     }
 
-    if (flb_msgpack_to_avro(&aobject, root) != FLB_TRUE) {
+    if (flb_msgpack_to_avro(&aobject, root)) {
         flb_errno();
         flb_error("Failed msgpack to avro\n");
         avro_value_decref(&aobject);

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -16,12 +16,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 #ifndef FLB_OUT_HTTP_H
 #define FLB_OUT_HTTP_H
 
+#ifdef FLB_HAVE_AVRO_ENCODER
+#include <fluent-bit/flb_avro.h>
+#endif
+
 #define FLB_HTTP_OUT_MSGPACK        FLB_PACK_JSON_FORMAT_NONE
 #define FLB_HTTP_OUT_GELF           20
+#ifdef FLB_HAVE_AVRO_ENCODER
+# define FLB_HTTP_OUT_AVRO          21
+#endif
 
 #define FLB_HTTP_CONTENT_TYPE   "Content-Type"
 #define FLB_HTTP_MIME_MSGPACK   "application/msgpack"
@@ -72,6 +78,10 @@ struct flb_out_http {
 
     /* Plugin instance */
     struct flb_output_instance *ins;
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+    flb_sds_t avro_schema;
+#endif
 };
 
 #endif

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -166,14 +166,17 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     }
 
 #ifdef FLB_HAVE_AVRO_ENCODER
-    /* Config AVRO */
-    tmp = flb_output_get_property("avro_schema_path", ins);
-    if (ctx->out_format == FLB_HTTP_OUT_AVRO && tmp) {
-        ctx->avro_schema = flb_file_read(tmp);
-        if (!ctx->avro_schema) {
-            flb_plg_error(ctx->ins, "cannot read '%s'", tmp);
-            flb_free(ctx);
-            return NULL;
+    /* Configure AVRO, if necessary */
+    if (ctx->out_format == FLB_HTTP_OUT_AVRO) {
+        if ((tmp = flb_output_get_property("avro_schema", ins))) {
+            ctx->avro_schema = flb_sds_create(tmp);
+        } else if ((tmp = flb_output_get_property("avro_schema_path", ins))) {
+            ctx->avro_schema = flb_file_read(tmp);
+            if (!ctx->avro_schema) {
+                flb_plg_error(ctx->ins, "cannot read '%s'", tmp);
+                flb_free(ctx);
+                return NULL;
+            }
         }
     }
 #endif

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_file.h>
 
 #include "http.h"
 #include "http_conf.h"
@@ -166,9 +167,14 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
 
 #ifdef FLB_HAVE_AVRO_ENCODER
     /* Config AVRO */
-    tmp = flb_output_get_property("avro_schema", ins);
-    if (tmp) {
-        ctx->avro_schema = flb_sds_create(tmp);
+    tmp = flb_output_get_property("avro_schema_path", ins);
+    if (ctx->out_format == FLB_HTTP_OUT_AVRO && tmp) {
+        ctx->avro_schema = flb_file_read(tmp);
+        if (!ctx->avro_schema) {
+            flb_plg_error(ctx->ins, "cannot read '%s'", tmp);
+            flb_free(ctx);
+            return NULL;
+        }
     }
 #endif
 

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -147,6 +147,11 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         if (strcasecmp(tmp, "gelf") == 0) {
             ctx->out_format = FLB_HTTP_OUT_GELF;
         }
+#ifdef FLB_HAVE_AVRO_ENCODER
+        else if (strcasecmp(tmp, "avro") == 0) {
+            ctx->out_format = FLB_HTTP_OUT_AVRO;
+        }
+#endif
         else {
             ret = flb_pack_to_json_format_type(tmp);
             if (ret == -1) {
@@ -158,6 +163,14 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
             }
         }
     }
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+    /* Config AVRO */
+    tmp = flb_output_get_property("avro_schema", ins);
+    if (tmp) {
+        ctx->avro_schema = flb_sds_create(tmp);
+    }
+#endif
 
     /* Date key */
     ctx->date_key = ctx->json_date_key;
@@ -212,6 +225,11 @@ void flb_http_conf_destroy(struct flb_out_http *ctx)
     if (ctx->u) {
         flb_upstream_destroy(ctx->u);
     }
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+    // avro
+    flb_sds_destroy(ctx->avro_schema);
+#endif
 
     flb_free(ctx->proxy_host);
     flb_free(ctx->uri);

--- a/src/flb_file.c
+++ b/src/flb_file.c
@@ -24,6 +24,12 @@
 #include <fluent-bit/flb_sds.h>
 
 #include <stdio.h>
+#include <sys/stat.h>
+
+int flb_file_read_config(const char *path, const char *conf_path)
+{
+    return -1;
+}
 
 flb_sds_t flb_file_read(const char *path)
 {


### PR DESCRIPTION
Example config file:

```
[SERVICE]
    flush      0.1
    grace      2
    log_level  info

[INPUT]
    name dummy
    dummy {"string_field": "some string value", "number_field": -7.5}

[OUTPUT]
    name http
    host 127.0.0.1
    port 8443
    format avro
    tls on
    tls.verify off 
    avro_schema_path avro-schema.json
```

Example schema:

```
{
    "name": "dummy",
    "type": "record",
    "fields" : [
        {"name":"string_field","type":"string"},
        {"name":"number_field","type":"float"}
    ]
}
```
