### PR TITLE
out_kafka: refactor to use configmap.

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -503,11 +503,120 @@ static int cb_kafka_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_STR, "topic_key", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, topic_key),
+    "Which record to use as the kafka topic."
+   },
+   {
+    FLB_CONFIG_MAP_BOOL, "dynamic_topic", "false",
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, dynamic_topic),
+    "Activate dynamic topics."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "format", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, format_str),
+    "Set the rcord output format."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "message_key", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, message_key),
+    "Which record key to use as the message data."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "message_key_field", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, message_key_field),
+    "Which record key field to use as the message data."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "timestamp_key", FLB_KAFKA_TS_KEY,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, timestamp_key),
+    "Set the key for the the timestamp."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "timestamp_format", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, timestamp_format_str),
+    "Set the format the timestamp is in."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "queue_full_retries", FLB_KAFKA_QUEUE_FULL_RETRIES,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, timestamp_format_str),
+    "Set the format the timestamp is in."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "gelf_timestamp_key", (char *)NULL,
+    0, FLB_FALSE,  0,
+    "Set the timestamp key for gelf  output."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "gelf_host_key", (char *)NULL,
+    0, FLB_FALSE,  0,
+    "Set the host key for gelf  output."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "gelf_short_message_key", (char *)NULL,
+    0, FLB_FALSE,  0,
+    "Set the short message key for gelf  output."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "gelf_full_message_key", (char *)NULL,
+    0, FLB_FALSE,  0,
+    "Set the full message key for gelf  output."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "gelf_level_key", (char *)NULL,
+    0, FLB_FALSE,  0,
+    "Set the level key for gelf  output."
+   },
+#ifdef FLB_HAVE_AVRO_ENCODER
+   {
+    FLB_CONFIG_MAP_STR, "schema_str", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set AVRO schema."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_id", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set AVRO schema ID."
+   },
+#endif
+   {
+    FLB_CONFIG_MAP_STR, "topic", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set the kafka topics, delimited by commas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "brokers", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set the kafka brokers, delimited by commas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "client_id", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set the kafka client_id."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "group_id", (char *)NULL,
+    0, FLB_FALSE, 0,
+    "Set the kafka group_id."
+   },
+   {
+    FLB_CONFIG_MAP_STR_PREFIX, "rdkafka.", NULL,
+    //FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_out_kafka, rdkafka_opts),
+    0,  FLB_FALSE, 0,
+    "Set the kafka group_id."
+   },
+   /* EOF */
+   {0}
+};
+
 struct flb_output_plugin out_kafka_plugin = {
     .name         = "kafka",
     .description  = "Kafka",
     .cb_init      = cb_kafka_init,
     .cb_flush     = cb_kafka_flush,
     .cb_exit      = cb_kafka_exit,
+    .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -64,38 +64,23 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     rd_kafka_conf_set_log_cb(ctx->conf, cb_kafka_logger);
 
     /* Config: Topic_Key */
-    tmp = flb_output_get_property("topic_key", ins);
-    if (tmp) {
-        ctx->topic_key = flb_strdup(tmp);
-        ctx->topic_key_len = strlen(tmp);
-    }
-    else {
-        ctx->topic_key = NULL;
-    }
-
-    /* Config: dynamic_topic */
-    tmp = flb_output_get_property("dynamic_topic", ins);
-    if (tmp) {
-        ctx->dynamic_topic = flb_utils_bool(tmp);
-    }
-    else {
-        ctx->dynamic_topic = FLB_FALSE;
+    if (ctx->topic_key) {
+        ctx->topic_key_len = strlen(ctx->topic_key);
     }
 
     /* Config: Format */
-    tmp = flb_output_get_property("format", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "json") == 0) {
+    if (ctx->format_str) {
+        if (strcasecmp(ctx->format_str, "json") == 0) {
             ctx->format = FLB_KAFKA_FMT_JSON;
         }
-        else if (strcasecmp(tmp, "msgpack") == 0) {
+        else if (strcasecmp(ctx->format_str, "msgpack") == 0) {
             ctx->format = FLB_KAFKA_FMT_MSGP;
         }
-        else if (strcasecmp(tmp, "gelf") == 0) {
+        else if (strcasecmp(ctx->format_str, "gelf") == 0) {
             ctx->format = FLB_KAFKA_FMT_GELF;
         }
 #ifdef FLB_HAVE_AVRO_ENCODER
-        else if (strcasecmp(tmp, "avro") == 0) {
+        else if (strcasecmp(ctx->format_str, "avro") == 0) {
             ctx->format = FLB_KAFKA_FMT_AVRO;
         }
 #endif
@@ -105,70 +90,37 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     }
 
     /* Config: Message_Key */
-    tmp = flb_output_get_property("message_key", ins);
-    if (tmp) {
-        ctx->message_key = flb_strdup(tmp);
-        ctx->message_key_len = strlen(tmp);
+    if (ctx->message_key) {
+        ctx->message_key_len = strlen(ctx->message_key);
     }
     else {
-        ctx->message_key = NULL;
         ctx->message_key_len = 0;
     }
 
     /* Config: Message_Key_Field */
-    tmp = flb_output_get_property("message_key_field", ins);
-    if (tmp) {
-        ctx->message_key_field = flb_strdup(tmp);
-        ctx->message_key_field_len = strlen(tmp);
+    if (ctx->message_key_field) {
+        ctx->message_key_field_len = strlen(ctx->message_key_field);
     }
     else {
-        ctx->message_key_field = NULL;
         ctx->message_key_field_len = 0;
     }
 
     /* Config: Timestamp_Key */
-    tmp = flb_output_get_property("timestamp_key", ins);
-    if (tmp) {
-        ctx->timestamp_key = flb_strdup(tmp);
-        ctx->timestamp_key_len = strlen(tmp);
-    }
-    else {
-        ctx->timestamp_key = FLB_KAFKA_TS_KEY;
-        ctx->timestamp_key_len = strlen(FLB_KAFKA_TS_KEY);
+    if (ctx->timestamp_key) {
+        ctx->timestamp_key_len = strlen(ctx->timestamp_key);
     }
 
     /* Config: Timestamp_Format */
     ctx->timestamp_format = FLB_JSON_DATE_DOUBLE;
-    tmp = flb_output_get_property("timestamp_format", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "iso8601") == 0) {
+    if (ctx->timestamp_format_str) {
+        if (strcasecmp(ctx->timestamp_format_str, "iso8601") == 0) {
             ctx->timestamp_format = FLB_JSON_DATE_ISO8601;
         }
     }
 
-    /* Config: queue_full_retries */
-    tmp = flb_output_get_property("queue_full_retries", ins);
-    if (!tmp) {
-        ctx->queue_full_retries = FLB_KAFKA_QUEUE_FULL_RETRIES;
-    }
-    else {
-        /* set number of retries: note that if the number is zero, means forever */
-        ctx->queue_full_retries = atoi(tmp);
-        if (ctx->queue_full_retries < 0) {
-            ctx->queue_full_retries = 0;
-        }
-    }
-
-    /* Config Gelf_Timestamp_Key */
-    tmp = flb_output_get_property("gelf_timestamp_key", ins);
-    if (tmp) {
-        ctx->gelf_fields.timestamp_key = flb_sds_create(tmp);
-    }
-
-    /* Config Gelf_Host_Key */
-    tmp = flb_output_get_property("gelf_host_key", ins);
-    if (tmp) {
-        ctx->gelf_fields.host_key = flb_sds_create(tmp);
+    /* set number of retries: note that if the number is zero, means forever */
+    if (ctx->queue_full_retries < 0) {
+        ctx->queue_full_retries = 0;
     }
 
     /* Config Gelf_Short_Message_Key */

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -35,7 +35,7 @@
 #define FLB_KAFKA_FMT_AVRO            3
 #endif
 #define FLB_KAFKA_TS_KEY              "@timestamp"
-#define FLB_KAFKA_QUEUE_FULL_RETRIES  10
+#define FLB_KAFKA_QUEUE_FULL_RETRIES  "10"
 
 /* rdkafka log levels based on syslog(3) */
 #define FLB_KAFKA_LOG_EMERG   0
@@ -62,6 +62,7 @@ struct flb_out_kafka {
     struct flb_kafka kafka;
     /* Config Parameters */
     int format;
+    flb_sds_t format_str;
 
     /* Optional topic key for routing */
     int topic_key_len;
@@ -70,6 +71,7 @@ struct flb_out_kafka {
     int timestamp_key_len;
     char *timestamp_key;
     int timestamp_format;
+    flb_sds_t timestamp_format_str;
 
     int message_key_len;
     char *message_key;


### PR DESCRIPTION
Add configmap support for the out_kafka plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863. The biggest challenge was simply allowing rdkafka.* options. I also had to hunt down the options that were retrieved inside of src/flb_kafka.c.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
