### PR TITLE
out_retry: refactor to use configmap.

### DIFF
--- a/plugins/out_retry/retry.c
+++ b/plugins/out_retry/retry.c
@@ -98,7 +98,7 @@ static int cb_retry_exit(void *data, struct flb_config *config)
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
    {
-    FLB_CONFIG_MAP_INT, "retries", "3",
+    FLB_CONFIG_MAP_INT, "retry", "3",
     0, FLB_TRUE, offsetof(struct retry_ctx, n_retry),
     "Number of retries."
    },

--- a/plugins/out_retry/retry.c
+++ b/plugins/out_retry/retry.c
@@ -39,8 +39,8 @@ static int cb_retry_init(struct flb_output_instance *ins,
 {
     (void) config;
     (void) data;
-    const char *tmp;
     struct retry_ctx *ctx;
+    int ret;
 
     ctx = flb_calloc(1, sizeof(struct retry_ctx));
     if (!ctx) {
@@ -49,12 +49,10 @@ static int cb_retry_init(struct flb_output_instance *ins,
     ctx->ins = ins;
     ctx->count = 0;
 
-    tmp = flb_output_get_property("retries", ins);
-    if (!tmp) {
-        ctx->n_retry = 3;
-    }
-    else {
-        ctx->n_retry = atoi(tmp);
+    ret = flb_output_config_map_set(ins, ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        return -1;
     }
 
     flb_output_set_context(ins, ctx);
@@ -97,11 +95,22 @@ static int cb_retry_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_INT, "retries", "3",
+    0, FLB_TRUE, offsetof(struct retry_ctx, n_retry),
+    "Number of retries."
+   },
+   {0}
+};
+
 struct flb_output_plugin out_retry_plugin = {
     .name         = "retry",
     .description  = "Issue a retry upon flush request",
     .cb_init      = cb_retry_init,
     .cb_flush     = cb_retry_flush,
     .cb_exit      = cb_retry_exit,
+    .config_map   = config_map,
     .flags        = 0,
 };


### PR DESCRIPTION
Add configmap support for the out_retry plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
