### PR TITLE
out_counter: add empty configmap.

### DIFF
--- a/plugins/out_counter/counter.c
+++ b/plugins/out_counter/counter.c
@@ -45,6 +45,11 @@ static int cb_counter_init(struct flb_output_instance *ins,
     }
     ctx->total = 0;
     flb_output_set_context(ins, ctx);
+    if (flb_output_config_map_set(ins, (void *)ctx) == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        flb_free(ctx);
+        return -1;
+    }
 
     return 0;
 }

--- a/plugins/out_counter/counter.c
+++ b/plugins/out_counter/counter.c
@@ -85,11 +85,17 @@ static int cb_counter_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+   /* EOF */
+   {0}
+};
+
 struct flb_output_plugin out_counter_plugin = {
     .name         = "counter",
     .description  = "Records counter",
     .cb_init      = cb_counter_init,
     .cb_flush     = cb_counter_flush,
     .cb_exit      = cb_counter_exit,
+    .config_map   = config_map,
     .flags        = 0,
 };


### PR DESCRIPTION
Add configmap support for the out_counter plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
