### PR TITLE
core: change old default flush interval time from 5 to 1 second

### DIFF
--- a/conf/fluent-bit-win32.conf
+++ b/conf/fluent-bit-win32.conf
@@ -2,7 +2,7 @@
     # Flush
     # =====
     # set an interval of seconds before to flush records to a destination
-    flush        5
+    flush        1
 
     # Daemon
     # ======

--- a/conf/fluent-bit.conf
+++ b/conf/fluent-bit.conf
@@ -2,7 +2,7 @@
     # Flush
     # =====
     # set an interval of seconds before to flush records to a destination
-    flush        5
+    flush        1
 
     # Daemon
     # ======

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -30,7 +30,7 @@
 
 #include <monkey/mk_core.h>
 
-#define FLB_CONFIG_FLUSH_SECS   5
+#define FLB_CONFIG_FLUSH_SECS   1
 #define FLB_CONFIG_HTTP_LISTEN  "0.0.0.0"
 #define FLB_CONFIG_HTTP_PORT    "2020"
 #define HC_ERRORS_COUNT_DEFAULT 5


### PR DESCRIPTION
There is no longer a reason for `5` seconds as a flush interval as a default, it used to make sense for old use cases but 95% users now set '1' second

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
