### PR TITLE
upstream: avoid dns timeout null event injection

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -841,10 +841,11 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
             }
 
             if (drop == FLB_TRUE) {
-                mk_event_inject(u_conn->evl, &u_conn->event,
-                                MK_EVENT_READ | MK_EVENT_WRITE,
-                                FLB_TRUE);
-
+                if (u_conn->event.status != MK_EVENT_NONE) {
+                    mk_event_inject(u_conn->evl, &u_conn->event,
+                                    MK_EVENT_READ | MK_EVENT_WRITE,
+                                    FLB_TRUE);
+                }
                 u_conn->net_error = ETIMEDOUT;
                 prepare_destroy_conn(u_conn);
             }


### PR DESCRIPTION
Signed-off-by: Matthew Fala <falamatt@amazon.com>
Fluent Bit segfaults periodically due to dns timeout null event injection.

```
Fluent Bit v1.8.13
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/02 01:23:32] [ info] [engine] started (pid=15071)
[2022/03/02 01:23:32] [ info] [storage] version=1.1.6, initializing...
[2022/03/02 01:23:32] [ info] [storage] in-memory
[2022/03/02 01:23:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/02 01:23:32] [ info] [cmetrics] version=0.2.2
[2022/03/02 01:23:32] [ info] [output:kinesis_firehose:kinesis_firehose.0] worker #0 started
[2022/03/02 01:23:32] [ info] [sp] stream processor started
[2022/03/02 01:23:53] [error] [upstream] connection #-1 to firehose.us-west-2.amazonaws.com:443 timed out after 10 seconds
[2022/03/02 01:23:53] [error] [upstream] connection #-1 to firehose.us-west-2.amazonaws.com:443 timed out after 10 seconds
[2022/03/02 01:24:26] [engine] caught signal (SIGSEGV)
#0  0x0                 in  ???() at ???:0
```
For issue: https://github.com/fluent/fluent-bit/issues/4957
See issue for details.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
