### PR TITLE
tests: internal: fuzzers: extend json fuzzer

### DIFF
--- a/tests/internal/fuzzers/flb_json_fuzzer.c
+++ b/tests/internal/fuzzers/flb_json_fuzzer.c
@@ -25,6 +25,13 @@ int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
 {
     TIMEOUT_GUARD
 
+    if (size < 1) {
+        return 0;
+    }
+    unsigned char decider = *data;
+    data++;
+    size--;
+
     /* json packer */
     char *out_buf = NULL;
     size_t out_size;
@@ -45,14 +52,27 @@ int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
             }
         }
         msgpack_unpacked_destroy(&result);
-
-        flb_sds_t ret_s = flb_pack_msgpack_to_json_format(out_buf, out_size,
-                FLB_PACK_JSON_FORMAT_LINES,
-                FLB_PACK_JSON_DATE_EPOCH, NULL);
-        free(out_buf);
-        if (ret_s != NULL) {
-            flb_sds_destroy(ret_s);
+        flb_sds_t d;
+        d = flb_sds_create("date");
+        if (decider < 0x30) {
+            flb_sds_t ret_s = flb_pack_msgpack_to_json_format(out_buf, out_size,
+                    FLB_PACK_JSON_FORMAT_LINES,
+                    (int)decider, d);
+            free(out_buf);
+            if (ret_s != NULL) {
+                flb_sds_destroy(ret_s);
+            }
         }
+        else {
+            flb_sds_t ret_s = flb_pack_msgpack_to_json_format(out_buf, out_size,
+                    FLB_PACK_JSON_FORMAT_LINES,
+                    FLB_PACK_JSON_DATE_EPOCH, NULL);
+            free(out_buf);
+            if (ret_s != NULL) {
+                flb_sds_destroy(ret_s);
+            }
+        }
+        flb_sds_destroy(d);
     }
 
     return 0;


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] ] Example configuration file for the change
- [N/A]] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
