### PR TITLE
workflows: remove Win container build for PRs

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -60,6 +60,8 @@ jobs:
         if-no-files-found: error
 
   windows-build-container:
+    # Only build on push as takes a long time and not needed for PRs
+    if: github.event_name != 'pull_request'
     # Need to match the container base image
     runs-on: windows-2019
     steps:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Windows container builds take a looonnnnggg time and produce a large image so no need for them on PRs.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
