### PR TITLE
workflows: fix 1.8 integration test

### DIFF
--- a/.github/workflows/1.8.yaml
+++ b/.github/workflows/1.8.yaml
@@ -2,17 +2,18 @@ on:
   push:
     branches:
       - 1.8
+  workflow_dispatch:
 
 name: Build and publish for branch 1.8
 jobs:
   docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - name: Checkout the docker build repo
+        uses: actions/checkout@v3
         with:
-          repository: calyptia/fluent-bit-ci
-          path: ci
+          repository: fluent/fluent-bit-docker-image
+          ref: '1.8'
 
       - name: Setup environment
         run: |
@@ -26,19 +27,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build a docker image for master branch
+      - name: Build a docker image for 1.8 branch
         run: |
-          DOCKER_BUILDKIT=1 docker build --no-cache -f ./dockerfiles/Dockerfile.${{ env.arch }}-1_8 -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-1_8 .
+          docker build --no-cache -f ./Dockerfile.${{ env.arch }} -t ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-1_8 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/1.8 .
         env:
+          DOCKER_BUILDKIT: 1
           arch: x86_64
           dockerhub_organization: fluentbitdev
 
       - name: Push image to Docker Hub
         run: |
-          DOCKER_BUILDKIT=1 docker push ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-1_8
+          docker push ${{ env.dockerhub_organization }}/fluent-bit:${{ env.arch }}-1_8
         env:
+          DOCKER_BUILDKIT: 1
           arch: x86_64
           dockerhub_organization: fluentbitdev
+
   run-integration-tests:
     name: run integration tests on GCP - k8s ${{ matrix.k8s-release }} for 1.8 branch
     needs: docker_build
@@ -46,7 +50,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        k8s-release: [ '1.19' ] #, '1.20' ] #, 1.19/stable, 1.18/stable ]
+        k8s-release: [ '1.19' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/1.8.yaml
+++ b/.github/workflows/1.8.yaml
@@ -3,8 +3,6 @@ on:
     branches:
       - 1.8
   workflow_dispatch:
-  # DO NOT MERGE THIS - added for testing
-  pull_request:
 
 name: Build and publish for branch 1.8
 jobs:

--- a/.github/workflows/1.8.yaml
+++ b/.github/workflows/1.8.yaml
@@ -3,6 +3,8 @@ on:
     branches:
       - 1.8
   workflow_dispatch:
+  # DO NOT MERGE THIS - added for testing
+  pull_request:
 
 name: Build and publish for branch 1.8
 jobs:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

The workflow to run 1.8 integration tests relied on local container images, it should be using those from the separate repo.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested by adding a trigger to run on `pull_request`: https://github.com/fluent/fluent-bit/runs/5406458352?check_suite_focus=true
This was removed for the final change to merge.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
