### PR TITLE
in_syslog: use FLB_CONFIG_MAP_SIZE for the buffer size parameter.

### DIFF
--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -153,6 +153,40 @@ static int in_syslog_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "mode", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, mode_str),
+     "Set the socket mode: unix_tcp, unix_udp, tcp or udp"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "path", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, unix_path),
+     "Set the path for the UNIX socket"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "unix_perm", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, unix_perm_str),
+     "Set the permissions for the UNIX socket"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "buffer_chunk_size", FLB_SYSLOG_CHUNK,
+      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_chunk_size_str),
+      "Set the buffer chunk size"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "buffer_max_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_max_size_str),
+      "Set the buffer chunk size"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "parser", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, parser_name),
+     "Set the parser"
+    },
+    /* EOF */
+    {0}
+};
 
 struct flb_input_plugin in_syslog_plugin = {
     .name         = "syslog",
@@ -162,5 +196,6 @@ struct flb_input_plugin in_syslog_plugin = {
     .cb_collect   = NULL,
     .cb_flush_buf = NULL,
     .cb_exit      = in_syslog_exit,
+    .config_map   = config_map,
     .flags        = FLB_INPUT_NET
 };

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -170,13 +170,13 @@ static struct flb_config_map config_map[] = {
      "Set the permissions for the UNIX socket"
     },
     {
-      FLB_CONFIG_MAP_INT, "buffer_chunk_size", FLB_SYSLOG_CHUNK,
-      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_chunk_size_str),
+      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", FLB_SYSLOG_CHUNK,
+      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_chunk_size),
       "Set the buffer chunk size"
     },
     {
-      FLB_CONFIG_MAP_INT, "buffer_max_size", (char *)NULL,
-      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_max_size_str),
+      FLB_CONFIG_MAP_SIZE, "buffer_max_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_max_size),
       "Set the buffer chunk size"
     },
     {

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -30,11 +30,12 @@
 #define FLB_SYSLOG_UDP       4
 
 /* 32KB chunk size */
-#define FLB_SYSLOG_CHUNK   32768
+#define FLB_SYSLOG_CHUNK   "32768"
 
 /* Context / Config*/
 struct flb_syslog {
     /* Listening mode: unix udp, unix tcp or normal tcp */
+    flb_sds_t mode_str;
     int mode;
 
     /* Network mode */
@@ -43,7 +44,8 @@ struct flb_syslog {
 
     /* Unix socket (UDP/TCP)*/
     int server_fd;
-    char *unix_path;
+    flb_sds_t unix_path;
+    flb_sds_t unix_perm_str;
     unsigned int unix_perm;
 
     /* UDP buffer, data length and buffer size */
@@ -52,10 +54,13 @@ struct flb_syslog {
     size_t buffer_size;
 
     /* Buffers setup */
+    flb_sds_t buffer_max_size_str;
+    flb_sds_t buffer_chunk_size_str;
     size_t buffer_max_size;
     size_t buffer_chunk_size;
 
     /* Configuration */
+    flb_sds_t parser_name;
     struct flb_parser *parser;
 
     /* List for connections and event loop */

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -54,8 +54,6 @@ struct flb_syslog {
     size_t buffer_size;
 
     /* Buffers setup */
-    flb_sds_t buffer_max_size_str;
-    flb_sds_t buffer_chunk_size_str;
     size_t buffer_max_size;
     size_t buffer_chunk_size;
 

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -20,6 +20,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_str.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_parser.h>
@@ -32,7 +33,7 @@
 struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
                                       struct flb_config *config)
 {
-    const char *tmp;
+    int ret;
     char port[16];
     struct flb_syslog *ctx;
 
@@ -46,23 +47,29 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
     ctx->buffer_data = NULL;
     mk_list_init(&ctx->connections);
 
+    ret = flb_input_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        flb_free(ctx);
+        return NULL;
+    }
+
     /* Syslog mode: unix_udp, unix_tcp, tcp or udp */
-    tmp = flb_input_get_property("mode", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "unix_tcp") == 0) {
+    if (ctx->mode_str) {
+        if (strcasecmp(ctx->mode_str, "unix_tcp") == 0) {
             ctx->mode = FLB_SYSLOG_UNIX_TCP;
         }
-        else if (strcasecmp(tmp, "unix_udp") == 0) {
+        else if (strcasecmp(ctx->mode_str, "unix_udp") == 0) {
             ctx->mode = FLB_SYSLOG_UNIX_UDP;
         }
-        else if (strcasecmp(tmp, "tcp") == 0) {
+        else if (strcasecmp(ctx->mode_str, "tcp") == 0) {
             ctx->mode = FLB_SYSLOG_TCP;
         }
-        else if (strcasecmp(tmp, "udp") == 0) {
+        else if (strcasecmp(ctx->mode_str, "udp") == 0) {
             ctx->mode = FLB_SYSLOG_UDP;
         }
         else {
-            flb_error("[in_syslog] Unknown syslog mode %s", tmp);
+            flb_error("[in_syslog] Unknown syslog mode %s", ctx->mode_str);
             flb_free(ctx);
             return NULL;
         }
@@ -82,41 +89,26 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
 
     /* Unix socket path and permission */
     if (ctx->mode == FLB_SYSLOG_UNIX_UDP || ctx->mode == FLB_SYSLOG_UNIX_TCP) {
-        tmp = flb_input_get_property("path", ins);
-        if (tmp) {
-            ctx->unix_path = flb_strdup(tmp);
-        }
-
-        tmp = flb_input_get_property("unix_perm", ins);
-        if (tmp) {
-            ctx->unix_perm = strtol(tmp, NULL, 8) & 07777;
+        if (ctx->unix_perm_str) {
+            ctx->unix_perm = strtol(ctx->unix_perm_str, NULL, 8) & 07777;
         } else {
             ctx->unix_perm = 0644;
         }
     }
 
     /* Buffer Chunk Size */
-    tmp = flb_input_get_property("buffer_chunk_size", ins);
-    if (!tmp) {
-        ctx->buffer_chunk_size = FLB_SYSLOG_CHUNK; /* 32KB */
-    }
-    else {
-        ctx->buffer_chunk_size = flb_utils_size_to_bytes(tmp);
-    }
+    ctx->buffer_chunk_size = flb_utils_size_to_bytes(ctx->buffer_chunk_size_str);
 
     /* Buffer Max Size */
-    tmp = flb_input_get_property("buffer_max_size", ins);
-    if (!tmp) {
+    if (ctx->buffer_max_size_str) {
+        ctx->buffer_max_size = flb_utils_size_to_bytes(ctx->buffer_max_size_str);
+    } else {
         ctx->buffer_max_size = ctx->buffer_chunk_size;
-    }
-    else {
-        ctx->buffer_max_size  = flb_utils_size_to_bytes(tmp);
     }
 
     /* Parser */
-    tmp = flb_input_get_property("parser", ins);
-    if (tmp) {
-        ctx->parser = flb_parser_get(tmp, config);
+    if (ctx->parser_name) {
+        ctx->parser = flb_parser_get(ctx->parser_name, config);
     }
     else {
         if (ctx->mode == FLB_SYSLOG_TCP || ctx->mode == FLB_SYSLOG_UDP) {

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -97,12 +97,19 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
     }
 
     /* Buffer Chunk Size */
-    ctx->buffer_chunk_size = flb_utils_size_to_bytes(ctx->buffer_chunk_size_str);
+    if (ctx->buffer_chunk_size == -1) {
+        flb_plg_error(ins, "invalid buffer_chunk_size");
+        flb_free(ctx);
+        return NULL; 
+    }
 
     /* Buffer Max Size */
-    if (ctx->buffer_max_size_str) {
-        ctx->buffer_max_size = flb_utils_size_to_bytes(ctx->buffer_max_size_str);
-    } else {
+    if (ctx->buffer_max_size == -1) {
+        flb_plg_error(ins, "invalid buffer_max_size");
+        flb_free(ctx);
+        return NULL;
+    }
+    else if (ctx->buffer_max_size == 0) {
         ctx->buffer_max_size = ctx->buffer_chunk_size;
     }
 


### PR DESCRIPTION
use FLB_CONFIG_MAP_SIZE for the buffer size parameter. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
