### PR TITLE
in_exec: use FLB_CONFIG_MAP_SIZE for the buffer size parameter.

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -158,19 +158,19 @@ static int in_exec_config_read(struct flb_exec *ctx,
    
     /* filepath setting */
     if (ctx->cmd == NULL) {
-        flb_error("[in_exec] no input 'command' was given");
+        flb_plg_error(in, "no input 'command' was given");
         return -1;
     }
 
     if (ctx->parser_name != NULL) {
         ctx->parser = flb_parser_get(ctx->parser_name, config);
         if (ctx->parser == NULL) {
-            flb_error("[in_exec] requested parser '%s' not found", ctx->parser_name);
+            flb_plg_error(in, "requested parser '%s' not found", ctx->parser_name);
         }
     }
 
     if (ctx->buf_size == -1) {
-        flb_error("[in_exec] buffer size '%s' is invalid", ctx->buf_size_str);
+        flb_plg_error(in, "buffer size is invalid");
         return -1;
     }
 
@@ -237,7 +237,7 @@ static int in_exec_init(struct flb_input_instance *in,
 
     ctx->buf = flb_malloc(ctx->buf_size);
     if (ctx->buf == NULL) {
-        flb_error("could not allocate exec buffer");
+        flb_plg_error(in, "could not allocate exec buffer");
         goto init_error;
     }
 
@@ -248,7 +248,7 @@ static int in_exec_init(struct flb_input_instance *in,
 
     if (ctx->oneshot == FLB_TRUE) {
         if (flb_pipe_create(ctx->ch_manager)) {
-            flb_error("could not create pipe for oneshot command");
+            flb_plg_error(in, "could not create pipe for oneshot command");
             goto init_error;
         }
 
@@ -263,7 +263,7 @@ static int in_exec_init(struct flb_input_instance *in,
                                            interval_nsec, config);
     }
     if (ret < 0) {
-        flb_error("could not set collector for exec input plugin");
+        flb_plg_error(in, "could not set collector for exec input plugin");
         goto init_error;
     }
 

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -169,7 +169,6 @@ static int in_exec_config_read(struct flb_exec *ctx,
         }
     }
 
-    ctx->buf_size = (size_t) flb_utils_size_to_bytes(ctx->buf_size_str);
     if (ctx->buf_size == -1) {
         flb_error("[in_exec] buffer size '%s' is invalid", ctx->buf_size_str);
         return -1;
@@ -186,8 +185,8 @@ static int in_exec_config_read(struct flb_exec *ctx,
         ctx->interval_nsec = -1;
     }
 
-    flb_debug("[in_exec] interval_sec=%d interval_nsec=%d oneshot=%i",
-              ctx->interval_sec, ctx->interval_nsec, ctx->oneshot);
+    flb_plg_debug(in, "interval_sec=%d interval_nsec=%d oneshot=%i buf_size=%d",
+              ctx->interval_sec, ctx->interval_nsec, ctx->oneshot, ctx->buf_size);
 
     return 0;
 }
@@ -329,8 +328,8 @@ static struct flb_config_map config_map[] = {
       "Set the collector interval (nanoseconds)"
     },
     {
-      FLB_CONFIG_MAP_STR, "buf_size", DEFAULT_BUF_SIZE,
-      0, FLB_TRUE, offsetof(struct flb_exec, buf_size_str),
+      FLB_CONFIG_MAP_SIZE, "buf_size", DEFAULT_BUF_SIZE,
+      0, FLB_TRUE, offsetof(struct flb_exec, buf_size),
       "Set the buffer size"
     },
     {

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -38,7 +38,6 @@ struct flb_exec {
     struct flb_parser  *parser;
     char *buf;
     size_t buf_size;
-    flb_sds_t buf_size_str;
     struct flb_input_instance *ins;
     int oneshot;
     flb_pipefd_t ch_manager[2];


### PR DESCRIPTION
in_exec: use FLB_CONFIG_MAP_SIZE for the buffer size parameter. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
