### PR TITLE
out_td: refactor to use config_map.

### DIFF
--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -274,6 +274,26 @@ static int cb_td_exit(void *data, struct flb_config *config)
 }
 
 static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_STR, "API", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_td, api),
+      "Set the API key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "Database", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_td, db_name),
+      "Set the Database file"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "Table", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_td, db_table),
+      "Set the Database Table"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "Region", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_td, region_str),
+      "Set the Region: us or jp"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -273,6 +273,11 @@ static int cb_td_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    /* EOF */
+    {0}
+};
+
 /* Plugin reference */
 struct flb_output_plugin out_td_plugin = {
     .name           = "td",
@@ -281,5 +286,6 @@ struct flb_output_plugin out_td_plugin = {
     .cb_pre_run     = NULL,
     .cb_flush       = cb_td_flush,
     .cb_exit        = cb_td_exit,
+    .config_map     = config_map,
     .flags          = FLB_IO_TLS,
 };

--- a/plugins/out_td/td_config.c
+++ b/plugins/out_td/td_config.c
@@ -23,32 +23,10 @@
 
 struct flb_td *td_config_init(struct flb_output_instance *ins)
 {
-    const char *tmp;
-    const char *api;
-    const char *db_name;
-    const char *db_table;
+    int ret;
     struct flb_td *ctx;
 
-    /* Validate TD section keys */
-    api = flb_output_get_property("API", ins);
-    db_name = flb_output_get_property("Database", ins);
-    db_table = flb_output_get_property("Table", ins);
-
-    if (!api) {
-        flb_plg_error(ins, "error reading API key value");
-        return NULL;
-    }
-
-    if (!db_name) {
-        flb_plg_error(ins, "error reading Database name");
-        return NULL;
-    }
-
-    if (!db_table) {
-        flb_plg_error(ins, "error reading Table name");
-        return NULL;
-    }
-
+    
     /* Allocate context */
     ctx = flb_calloc(1, sizeof(struct flb_td));
     if (!ctx) {
@@ -57,17 +35,38 @@ struct flb_td *td_config_init(struct flb_output_instance *ins)
     }
     ctx->ins      = ins;
     ctx->fd       = -1;
-    ctx->api      = api;
-    ctx->db_name  = db_name;
-    ctx->db_table = db_table;
+    
+    ret = flb_output_config_map_set(ins, (void *)ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration");
+        flb_free(ctx);
+        return NULL;
+    }
+    
+    if (ctx->api == NULL) {
+        flb_plg_error(ins, "error reading API key value");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    if (ctx->db_name == NULL) {
+        flb_plg_error(ins, "error reading Database name");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    if (ctx->db_table == NULL) {
+        flb_plg_error(ins, "error reading Table name");
+        flb_free(ctx);
+        return NULL;
+    }
 
     /* Lookup desired region */
-    tmp = flb_output_get_property("region", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "us") == 0) {
+    if (ctx->region_str) {
+        if (strcasecmp(ctx->region_str, "us") == 0) {
             ctx->region = FLB_TD_REGION_US;
         }
-        else if (strcasecmp(tmp, "jp") == 0) {
+        else if (strcasecmp(ctx->region_str, "jp") == 0) {
             ctx->region = FLB_TD_REGION_JP;
         }
         else {

--- a/plugins/out_td/td_config.h
+++ b/plugins/out_td/td_config.h
@@ -28,6 +28,7 @@
 struct flb_td {
     int fd;           /* Socket to destination/backend */
     int region;       /* TD Region end-point */
+    flb_sds_t region_str;
     const char *api;
     const char *db_name;
     const char *db_table;


### PR DESCRIPTION
out_td: add empty config_map. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----

**Testing**
- [ ] Example configuration file for the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
