### PR TITLE
multiline: java: modify start_state to ignore 'Exception:' at the beginning of line.

### DIFF
--- a/src/multiline/flb_ml_parser_java.c
+++ b/src/multiline/flb_ml_parser_java.c
@@ -58,7 +58,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
 
     ret = rule(mlp,
                "start_state, java_start_exception",
-               "/(?:Exception|Error|Throwable|V8 errors stack trace)[:\\r\\n]/",
+               "/(.)(?:Exception|Error|Throwable|V8 errors stack trace)[:\\r\\n]/",
                "java_after_exception", NULL);
     if (ret != 0) {
         rule_error(mlp);

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -728,6 +728,73 @@ static void test_parser_python()
     flb_config_exit(config);
 }
 
+static void test_issue_4949()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    /* Expected results context */
+    res.key = "log";
+    res.out_records = python_output;
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* Initialize environment */
+    config = flb_config_init();
+
+    /* Create docker multiline mode */
+    ml = flb_ml_create(config, "python-test");
+    TEST_CHECK(ml != NULL);
+
+    /* Generate an instance of multiline python parser */
+    mlp_i = flb_ml_parser_instance_create(ml, "python");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "python", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    /* Generate an instance of multiline java parser */
+    mlp_i = flb_ml_parser_instance_create(ml, "java");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "java", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&tm);
+
+    printf("\n");
+    entries = sizeof(python_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &python_input[i];
+        len = strlen(r->buf);
+
+        /* Package as msgpack */
+        flb_time_get(&tm);
+        flb_ml_append(ml, stream_id, FLB_ML_TYPE_TEXT, &tm, r->buf, len);
+    }
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    flb_config_exit(config);
+}
+
 static void test_parser_elastic()
 {
     int i;
@@ -1234,5 +1301,6 @@ TEST_LIST = {
     /* Issues reported on Github */
     { "issue_3817_1"  , test_issue_3817_1},
     { "issue_4034"    , test_issue_4034},
+    { "issue_4949"    , test_issue_4949},
     { 0 }
 };


### PR DESCRIPTION
Fixes #4949 

This patch is to ignore 'Exception:' at the beginning of line.
I'm not familiar with java exception logs.
If it outputs  'Exception:' at the begging of line, this patch makes ignoring such java real exception log.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    flush                 1
    log_level             info

[INPUT]
    name                  tail
    path                  java-python.log
    read_from_head        true
    multiline.parser      java,python

[OUTPUT]
    name                  stdout
    match                 *
```

java-python.log:
```
Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
```

## Debug log

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/05 11:59:55] [ info] [engine] started (pid=58741)
[2022/03/05 11:59:55] [ info] [storage] version=1.1.6, initializing...
[2022/03/05 11:59:55] [ info] [storage] in-memory
[2022/03/05 11:59:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/05 11:59:55] [ info] [cmetrics] version=0.3.0
[2022/03/05 11:59:55] [ info] [input:tail:tail.0] multiline core started
[2022/03/05 11:59:55] [ info] [sp] stream processor started
[2022/03/05 11:59:55] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1451493 watch_fd=1 name=java-python.log
[2022/03/05 11:59:55] [ info] [output:stdout:stdout.0] worker #0 started
[0] tail.0: [1646449195.151031155, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
^C[2022/03/05 12:00:01] [engine] caught signal (SIGINT)
[2022/03/05 12:00:01] [ info] [input] pausing tail.0
[2022/03/05 12:00:01] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/05 12:00:02] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/05 12:00:02] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1451493 watch_fd=1
[2022/03/05 12:00:02] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/05 12:00:02] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

All unit tests are succeed .

```
$ ../bin/flb-it-multiline 
Test parser_docker...                           
----- MULTILINE FLUSH -----
[0] [1612197903.012310000, {"log"=>"aa
", "stream"=>"stdout", "time"=>"2021-02-01T16:45:03.01231z"}]
----------- EOF -----------
(snip)
Test issue_4949...                              

----- MULTILINE FLUSH -----
[0] [1646449287.433943757, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [1646449287.433943757, {"log"=>"hello world, not multiline
"}]
----------- EOF -----------
[ OK ]
SUCCESS: All unit tests have passed.
taka@locals:~/git/fluent-bit/build/4949$ 
```

## Valgrind output

```
9$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==58745== Memcheck, a memory error detector
==58745== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==58745== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==58745== Command: ../bin/fluent-bit -c a.conf
==58745== 
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/05 12:00:32] [ info] [engine] started (pid=58745)
[2022/03/05 12:00:32] [ info] [storage] version=1.1.6, initializing...
[2022/03/05 12:00:32] [ info] [storage] in-memory
[2022/03/05 12:00:32] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/05 12:00:32] [ info] [cmetrics] version=0.3.0
[2022/03/05 12:00:32] [ info] [input:tail:tail.0] multiline core started
[2022/03/05 12:00:32] [ info] [output:stdout:stdout.0] worker #0 started
[2022/03/05 12:00:33] [ info] [sp] stream processor started
[2022/03/05 12:00:33] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1451493 watch_fd=1 name=java-python.log
[0] tail.0: [1646449233.017561801, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
^C[2022/03/05 12:00:37] [engine] caught signal (SIGINT)
[2022/03/05 12:00:37] [ info] [input] pausing tail.0
[2022/03/05 12:00:37] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/05 12:00:37] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/05 12:00:37] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1451493 watch_fd=1
[2022/03/05 12:00:37] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/05 12:00:37] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==58745== 
==58745== HEAP SUMMARY:
==58745==     in use at exit: 0 bytes in 0 blocks
==58745==   total heap usage: 1,275 allocs, 1,275 frees, 725,881 bytes allocated
==58745== 
==58745== All heap blocks were freed -- no leaks are possible
==58745== 
==58745== For lists of detected and suppressed errors, rerun with: -s
==58745== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
