### PR TITLE
out_kafka: fix broken configuration

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -517,7 +517,7 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_STR, "format", (char *)NULL,
     0, FLB_TRUE, offsetof(struct flb_out_kafka, format_str),
-    "Set the rcord output format."
+    "Set the record output format."
    },
    {
     FLB_CONFIG_MAP_STR, "message_key", (char *)NULL,
@@ -582,7 +582,7 @@ static struct flb_config_map config_map[] = {
    },
 #endif
    {
-    FLB_CONFIG_MAP_STR, "topic", (char *)NULL,
+    FLB_CONFIG_MAP_STR, "topics", (char *)NULL,
     0, FLB_FALSE, 0,
     "Set the kafka topics, delimited by commas."
    },


### PR DESCRIPTION
<!-- Provide summary of changes -->
Commit https://github.com/fluent/fluent-bit/commit/57c814fde3ed2ac6304a66729cf03eb1cb375ebb breaks the out_kafka configuration. Option __topics__ was renamed to __topic__.

example configuration:
```
[OUTPUT]
    name kafka
    match *
    brokers   kafka:9092
    topics    test
```
produces:
```
 [2022/03/05 17:46:15] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/05 17:46:15] [ info] [cmetrics] version=0.3.0
[2022/03/05 17:46:15] [error] [config] kafka: unknown configuration property 'topics'. The following properties are allowed: topic_key, dynamic_topic, format, message_key, message_key_field, timestamp_key, timestamp_format, queue_full_retries, gelf_timestamp_key, gelf_host_key, gelf_short_message_key, gelf_full_message_key, gelf_level_key, hash, hash_key, topic, brokers, client_id, group_id, and rdkafka..
[2022/03/05 17:46:15] [ help] try the command: /fluent-bit/bin/fluent-bit -o kafka -h
```

Using __topic__ instead of __topics__ prints:
```
[2022/03/05 17:50:11] [ info] [output:kafka:kafka.1] brokers='kafka:9092' topics='(null)'
```

This PR renames option 'topic' back to 'topics', so configuration works again: 
```
[2022/03/06 09:29:22] [ info] [output:kafka:kafka.1] brokers='kafka:9092' topics='test'
[2022/03/06 09:29:22] [ info] [sp] stream processor started
```
Signed-off-by: Michael Voelker <novecento@gmx.de>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
