### PR TITLE
workflows: switch to SHA rather than ref

### DIFF
--- a/.github/workflows/pr-integration-test.yaml
+++ b/.github/workflows/pr-integration-test.yaml
@@ -23,7 +23,7 @@ jobs:
       registry: ghcr.io
       username: ${{ github.actor }}
       image: ${{ github.repository }}/pr-${{ github.event.number }}
-      image-tag: ${{ github.event.pull_request.head.ref }}
+      image-tag: ${{ github.sha }}
       environment: integration
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
     uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
     with:
       image_name: ghcr.io/${{ github.repository }}/pr-${{ github.event.pull_request.number }}
-      image_tag: ${{ github.event.pull_request.head.ref }}
+      image-tag: ${{ github.sha }}
     secrets:
       grafana_username: ${{ secrets.GRAFANA_USERNAME }}
       terraform_api_token: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Fixes #4999 by using the SHA as the tag name.
This allows us to identify the specific image used in each integration test run rather than a floating `latest` one with its inherent race conditions between build & provision+test.

Unfortunately as this is `pull_request_target` it will run with the base workflow.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
