### PR TITLE
packaging: retry for transient failures

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -36,7 +36,7 @@ fi
 
 if [ -z "$FLB_BRANCH" ]; then
     # The standard tags have a v prefix but we may want to build others
-    if curl -sL --output /dev/null --head --fail "http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" ; then
+    if curl -sL --output /dev/null --head --fail --retry 3 "http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip" ; then
         FLB_PREFIX="v"
     fi
 fi
@@ -99,7 +99,7 @@ if [ -n "$FLB_TARGZ" ]; then
 else
     # Check we have a valid remote source URL
     FLB_SOURCE_URL="http://github.com/fluent/fluent-bit/archive/$FLB_PREFIX$FLB_VERSION.zip"
-    if ! curl -sL --output /dev/null --head --fail "$FLB_SOURCE_URL" ; then
+    if ! curl -sL --output /dev/null --head --fail --retry 3 "$FLB_SOURCE_URL" ; then
         echo "Unable to download source from URL:$FLB_SOURCE_URL "
         exit 1
     fi


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Try to improve resilience to Github transient failures, e.g. https://github.com/fluent/fluent-bit/runs/5450126593?check_suite_focus=true#step:6:18

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
