### PR TITLE
codeowners: update to include packaging directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,7 @@
 /.github/                @niedbalski
 /appveyor.yml            @niedbalski
 /dockerfiles/            @niedbalski
+/packaging/              @niedbalski
 
 # Core: Signv4
 # ------------


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Add the new `packaging` directory as CI to code owners to simplify PR management.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
