### PR TITLE
filter_stdout: add and parse empty config_map.

### DIFF
--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 
 #include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_filter_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
 
@@ -33,6 +34,10 @@ static int cb_stdout_init(struct flb_filter_instance *f_ins,
     (void) config;
     (void) data;
 
+    if (flb_filter_config_map_set(f_ins, (void *)config) == -1) {
+        flb_plg_error(f_ins, "unable to load configuration");
+        return -1;
+    }
     return 0;
 }
 
@@ -66,11 +71,17 @@ static int cb_stdout_filter(const void *data, size_t bytes,
     return FLB_FILTER_NOTOUCH;
 }
 
+static struct flb_config_map config_map[] = {
+    /* EOF */
+    {0}
+};
+
 struct flb_filter_plugin filter_stdout_plugin = {
     .name         = "stdout",
     .description  = "Filter events to STDOUT",
     .cb_init      = cb_stdout_init,
     .cb_filter    = cb_stdout_filter,
     .cb_exit      = NULL,
+    .config_map   = config_map,
     .flags        = 0
 };


### PR DESCRIPTION
Add configmap support for the filter_stdout plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----

**Testing**
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
