### PR TITLE
io: add connection backoff

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -45,6 +45,12 @@ struct flb_net_setup {
     /* connect timeout log error (default: true) */
     int connect_timeout_log_error;
 
+    /* backoff time in seconds after the first connection failure */
+    int backoff_init;
+
+    /* maximum connection backoff time in seconds */
+    int backoff_max;
+
     /* network interface to bind and use to send data */
     flb_sds_t source_address;
 

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -83,6 +83,10 @@ struct flb_upstream {
 
     struct flb_config *config;
     struct mk_list _head;
+
+    /* Backoff state. */
+    time_t backoff_next_attempt_time;
+    int backoff_last_duration;
 };
 
 

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -62,9 +62,56 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
 
+/* Increase backoff time of an upstream */
+static void flb_io_backoff_upstream(struct flb_upstream *u)
+{
+    time_t now = time(NULL);
+    int max_jitter, jitter = 0;
+
+    if (u->net.backoff_max < 1 || u->backoff_next_attempt_time > now) {
+        return;
+    }
+
+    if (u->backoff_last_duration > 0) {
+        u->backoff_last_duration = 2 * u->backoff_last_duration;
+    } else {
+        srand(now);
+        u->backoff_last_duration = u->net.backoff_init;
+    }
+    if (u->backoff_last_duration > u->net.backoff_max) {
+        u->backoff_last_duration = u->net.backoff_max;
+    }
+
+    if (u->backoff_last_duration > 2) {
+        /* Add plus/minus 10% jitter */
+        max_jitter = u->backoff_last_duration % 10 + 1;
+        /* Random int from -max_jitter to +max_jitter */
+        jitter = rand() % (2*max_jitter) - max_jitter;
+    }
+
+    u->backoff_next_attempt_time = now + u->backoff_last_duration + jitter;
+    flb_debug("[io] backoff connecting to %s:%i for %i seconds with jitter %i seconds",
+        u->tcp_host, u->tcp_port, u->backoff_last_duration, jitter);
+}
+
+/* Returns true if upstream should be skipped. */
+static int flb_io_in_backoff(struct flb_upstream *u)
+{
+    if (u->backoff_next_attempt_time > time(NULL)) {
+        flb_debug("[io] skipping connection to %s:%i because of backoff for another %i seconds",
+                    u->tcp_host, u->tcp_port, u->backoff_next_attempt_time - time(NULL));
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
 int flb_io_net_connect(struct flb_upstream_conn *u_conn,
                        struct flb_coro *coro)
 {
+    if (flb_io_in_backoff(u_conn->u) == FLB_TRUE) {
+        return -1;
+    }
+
     int ret;
     int async = FLB_FALSE;
     flb_sockfd_t fd = -1;
@@ -88,16 +135,18 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     fd = flb_net_tcp_connect(u->tcp_host, u->tcp_port, u->net.source_address,
                              u->net.connect_timeout, async, coro, u_conn);
     if (fd == -1) {
+        flb_io_backoff_upstream(u);
         return -1;
     }
 
     if (u->proxied_host) {
         ret = flb_http_client_proxy_connect(u_conn);
         if (ret == -1) {
+            flb_io_backoff_upstream(u);
             flb_debug("[http_client] flb_http_client_proxy_connect connection #%i failed to %s:%i.",
                       u_conn->fd, u->tcp_host, u->tcp_port);
-          flb_socket_close(fd);
-          return -1;
+            flb_socket_close(fd);
+            return -1;
         }
         flb_debug("[http_client] flb_http_client_proxy_connect connection #%i connected to %s:%i.",
                   u_conn->fd, u->tcp_host, u->tcp_port);
@@ -108,6 +157,9 @@ int flb_io_net_connect(struct flb_upstream_conn *u_conn,
     if (u->flags & FLB_IO_TLS) {
         ret = flb_tls_session_create(u->tls, u_conn, coro);
         if (ret != 0) {
+            flb_io_backoff_upstream(u);
+            flb_debug("[io] flb_tls_session_create failed on connection #%i", u_conn->fd);
+            flb_socket_close(fd);
             return -1;
         }
     }
@@ -399,6 +451,10 @@ int flb_io_fd_write(int fd, const void *data, size_t len, size_t *out_len)
 int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
                      size_t len, size_t *out_len)
 {
+    if (flb_io_in_backoff(u_conn->u) == FLB_TRUE) {
+        return -1;
+    }
+
     int ret = -1;
     struct flb_upstream *u = u_conn->u;
     struct flb_coro *coro = flb_coro_get();
@@ -423,6 +479,15 @@ int flb_io_net_write(struct flb_upstream_conn *u_conn, const void *data,
         }
     }
 #endif
+
+    if (ret == -1) {
+        flb_io_backoff_upstream(u);
+        flb_debug("[io] cannot write data to connection #%i at %s:%i",
+            u_conn->fd, u->tcp_host, u->tcp_port);
+    } else if (u->backoff_next_attempt_time < time(NULL) && u->backoff_last_duration > 0) {
+        flb_debug("[io] connection #%i was successful, reset backoff duration", u_conn->fd);
+        u->backoff_last_duration = 0;
+    }
 
     if (ret == -1 && u_conn->fd > 0) {
         flb_socket_close(u_conn->fd);

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -110,6 +110,8 @@ void flb_net_setup_init(struct flb_net_setup *net)
     net->connect_timeout = 10;
     net->io_timeout = 0; /* Infinite time */
     net->source_address = NULL;
+    net->backoff_init = 0;
+    net->backoff_max = 0;
 }
 
 int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address)


### PR DESCRIPTION
Fixes #3103.

This PR is the rebased version of https://github.com/fluent/fluent-bit/pull/3191.

I've lost write access to the source branch of the [original PR](https://github.com/fluent/fluent-bit/pull/3191), hence this new PR.
All info in the #3191 description is valid.

Additionally, I repeated the tests shown with a figure in #3191, results didn't change.
The Valgrind mem leak detection was performed again, see the link below.

The docs PR 491 will have to be replaced too, as it contains the outdated config parameter names.
Again, I've lost access to `c445` organisation and GitHub does not support changing the original PR branch, therefore a separate new PR will be published soon.

----

For testing info, see the [original PR](https://github.com/fluent/fluent-bit/pull/3191).

- [x] [Fresh Valgrind log](https://gist.github.com/kabakaev/323b417bf3b1433d7969dff20badfb45#file-valgrind-2022-02-17-log).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature is not ready yet. PR will follow.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
