### PR TITLE
cmake: add support for jemalloc page size config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,13 +714,13 @@ if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
   # Add support for options like page size
-  set(FLB_JEMALLOC_OPTIONS "" CACHE string "Extra options to configure jemalloc")
+  set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3" CACHE string "Extra options to configure jemalloc")
   message(STATUS "jemalloc configuration: \"${FLB_JEMALLOC_OPTIONS}\"")
 
   # Link to Jemalloc as an external dependency
   ExternalProject_Add(jemalloc
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} ${FLB_JEMALLOC_OPTIONS} --with-lg-quantum=3 --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} ${FLB_JEMALLOC_OPTIONS} --prefix=<INSTALL_DIR>
     CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
     BUILD_COMMAND $(MAKE)
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,10 +713,14 @@ if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   FLB_DEFINITION(FLB_HAVE_JEMALLOC)
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
+  # Add support for options like page size
+  set(FLB_JEMALLOC_OPTIONS "" CACHE string "Extra options to configure jemalloc")
+  message(STATUS "jemalloc configuration: \"${FLB_JEMALLOC_OPTIONS}\"")
+
   # Link to Jemalloc as an external dependency
   ExternalProject_Add(jemalloc
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} --with-lg-quantum=3 --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} ${FLB_JEMALLOC_OPTIONS} --with-lg-quantum=3 --prefix=<INSTALL_DIR>
     CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
     BUILD_COMMAND $(MAKE)
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -47,7 +47,7 @@ ARG FLB_OUT_PGSQL=Off
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
 
 # Need larger page size
-ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16"
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
 ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
 # centos/8 base image
@@ -95,7 +95,7 @@ ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
 
 # Need larger page size
-ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16"
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
 ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
 # Common build for all distributions now

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -46,6 +46,10 @@ RUN yum -y update && \
 ARG FLB_OUT_PGSQL=Off
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
 
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
 # centos/8 base image
 FROM centos:8 as centos-8-base
 
@@ -89,6 +93,10 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
 # Common build for all distributions now
 # hadolint ignore=DL3006
@@ -134,6 +142,7 @@ RUN cmake3 -DCMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
            -DFLB_OUT_KAFKA="$FLB_OUT_KAFKA" \
            -DFLB_OUT_PGSQL="$FLB_OUT_PGSQL" \
            -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+           -DFLB_JEMALLOC_OPTIONS="$FLB_JEMALLOC_OPTIONS" \
            ../
 
 VOLUME [ "/output" ]


### PR DESCRIPTION
Fixes #4270 by specifying the page size explicitly for CentOS 7/8 ARM 64 builds.
This only covers the build changes, I still want to resolve the testing side but best to get a fix in now.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
