### PR TITLE
cmake: backport jemalloc changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,10 +663,14 @@ if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   FLB_DEFINITION(FLB_HAVE_JEMALLOC)
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
+  # Add support for options like page size
+  set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3" CACHE string "Extra options to configure jemalloc")
+  message(STATUS "jemalloc configuration: \"${FLB_JEMALLOC_OPTIONS}\"")
+
   # Link to Jemalloc as an external dependency
   ExternalProject_Add(jemalloc
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} --host=${HOST} --with-lg-quantum=3 --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} --host=${HOST} ${FLB_JEMALLOC_OPTIONS} --prefix=<INSTALL_DIR>
     CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
     BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,14 +663,18 @@ if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   FLB_DEFINITION(FLB_HAVE_JEMALLOC)
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
-  # Add support for options like page size
-  set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3" CACHE string "Extra options to configure jemalloc")
-  message(STATUS "jemalloc configuration: \"${FLB_JEMALLOC_OPTIONS}\"")
+  # Add support for options like page size, if empty we default it
+  if(DEFINED FLB_JEMALLOC_OPTIONS AND "${FLB_JEMALLOC_OPTIONS}" STREQUAL "")
+    set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3")
+  endif()
+  # Split into a list so CMake handles it correctly when passing to configure command
+  separate_arguments(FLB_JEMALLOC_OPTIONS_LIST UNIX_COMMAND ${FLB_JEMALLOC_OPTIONS})
+  message(STATUS "jemalloc configure: ${FLB_JEMALLOC_OPTIONS_LIST}")
 
   # Link to Jemalloc as an external dependency
   ExternalProject_Add(jemalloc
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} --host=${HOST} ${FLB_JEMALLOC_OPTIONS} --prefix=<INSTALL_DIR>
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.2.1/configure ${AUTOCONF_HOST_OPT} --host=${HOST} "${FLB_JEMALLOC_OPTIONS_LIST}" --prefix=<INSTALL_DIR>
     CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
     BUILD_COMMAND $(MAKE) CC=${CMAKE_C_COMPILER}
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,7 +664,7 @@ if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
   # Add support for options like page size, if empty we default it
-  if(DEFINED FLB_JEMALLOC_OPTIONS AND "${FLB_JEMALLOC_OPTIONS}" STREQUAL "")
+  if(NOT DEFINED FLB_JEMALLOC_OPTIONS OR "${FLB_JEMALLOC_OPTIONS}" STREQUAL "")
     set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3")
   endif()
   # Split into a list so CMake handles it correctly when passing to configure command


### PR DESCRIPTION
Backport of #5020 to resolve #4270 .

On the `1.8` branch there is a slight change from `master` in that ` --host=${HOST}` is used in a few places for `configure`. 
This is from https://github.com/fluent/fluent-bit/pull/3152/ and has been left in here as well as it is unrelated to this specific change, however note that this change did affect Yocto builds so was reverted for `master`:
- https://github.com/fluent/fluent-bit/issues/4204
- https://github.com/fluent/fluent-bit/pull/4646

Note this also requires a change to the separate packaging repository for 1.8 - master does not require this: https://github.com/fluent/fluent-bit-packaging/pull/29

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

This is the backport of #5027.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
