### PR TITLE
workflows: add support to trigger a package build for a specific target

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -3,6 +3,15 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version of Fluent Bit to build
+        required: false
+        default: master
+      target:
+        description: Only build a specific target, intended for debug/test builds only.
+        required: false
+        default: ""
 
 name: Build packages for master
 jobs:
@@ -18,6 +27,14 @@ jobs:
           matrix=$((
             echo '{ "distro" : [ "debian/bullseye", "ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04" ]}'
           ) | jq -c .)
+          if [ -n "${{ github.event.inputs.target || '' }}" ]; then
+            echo "Overriding matrix to build: ${{ github.event.inputs.target }}"
+            matrix=$((
+              echo '{ "distro" : ['
+              echo '"${{ github.event.inputs.target }}"'
+              echo ']}'
+            ) | jq -c .)
+          fi
           echo $matrix
           echo $matrix| jq .
           echo "::set-output name=matrix::$matrix"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Support package testing of issues by manually triggering for targets.
Intended to help verify #4270 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Changes taken from staging build solution but this means we do not mess with the bucket.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
