### PR TITLE
in_tail: on file rotation, remove entry from hash tables

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1144,6 +1144,10 @@ void flb_tail_file_remove(struct flb_tail_file *file)
         flb_free(file->tag_buf);
     }
 
+    /* remove any potential entry from the hash tables */
+    flb_hash_del(ctx->static_hash, file->hash_key);
+    flb_hash_del(ctx->event_hash, file->hash_key);
+
     flb_free(file->buf_data);
     flb_free(file->name);
     flb_free(file->real_name);
@@ -1170,14 +1174,12 @@ int flb_tail_file_remove_all(struct flb_tail_config *ctx)
 
     mk_list_foreach_safe(head, tmp, &ctx->files_static) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
-        flb_hash_del(ctx->static_hash, file->hash_key);
         flb_tail_file_remove(file);
         count++;
     }
 
     mk_list_foreach_safe(head, tmp, &ctx->files_event) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
-        flb_hash_del(ctx->event_hash, file->hash_key);
         flb_tail_file_remove(file);
         count++;
     }


### PR DESCRIPTION
When a file is rotated and removed from the monitored list, it's not
removing the entry from the hash table, so if a new file is discovered
which contains the same name and inode, it won't be added since it's
considered already registered.

The following patch fix the wrong behavior and now when a file is
removed (because of rotation or another cause), it properly remove the
entry from the hash tables.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
