### PR TITLE
filter_multiline: implement Docker partial_message support

### DIFF
--- a/plugins/filter_multiline/CMakeLists.txt
+++ b/plugins/filter_multiline/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(src
-  ml.c)
+    ml.c
+    ml_concat.c)
 
 FLB_PLUGIN(filter_multiline "${src}" "")

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -503,7 +503,7 @@ static void partial_timer_cb(struct flb_config *config, void *data)
     unsigned long long diff;
     int ret; 
 
-    now = current_timestamp();
+    now = ml_current_timestamp();
 
     mk_list_foreach_safe(head, tmp, &ctx->split_message_packers) {
         packer = mk_list_entry(head, struct split_message_packer, _head);
@@ -514,7 +514,7 @@ static void partial_timer_cb(struct flb_config *config, void *data)
         }
         
         mk_list_del(&packer->_head);
-        split_message_packer_complete(packer);
+        ml_split_message_packer_complete(packer);
         /* re-emit record with original tag */
         flb_plg_trace(ctx->ins, "emitting from %s to %s", packer->input_name, packer->tag);
         ret = in_emitter_add_record(packer->tag, flb_sds_len(packer->tag), 
@@ -525,7 +525,7 @@ static void partial_timer_cb(struct flb_config *config, void *data)
             flb_plg_warn(ctx->ins, "Couldn't send concatenated record of size %zu bytes to in_emitter %s",
                          packer->mp_sbuf.size, ctx->ins_emitter->name);
         }
-        split_message_packer_destroy(packer);
+        ml_split_message_packer_destroy(packer);
     }
 
 }
@@ -572,7 +572,8 @@ static int ml_filter_partial(const void *data, size_t bytes,
         sched = flb_sched_ctx_get();
 
         ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
-                                        ctx->flush_ms, partial_timer_cb, ctx, NULL);
+                                        ctx->flush_ms / 2, partial_timer_cb, 
+                                        ctx, NULL);
         if (ret < 0) {
             flb_plg_error(ctx->ins, "Failed to create flush timer");
         } else {
@@ -592,22 +593,22 @@ static int ml_filter_partial(const void *data, size_t bytes,
         total_records++;
         flb_time_pop_from_msgpack(&tm, &result, &obj);
         
-        partial = is_partial(obj);
+        partial = ml_is_partial(obj);
         if (partial == FLB_TRUE) {
             partial_records++;
-            ret = get_partial_id(obj, &partial_id_str, &partial_id_size);
+            ret = ml_get_partial_id(obj, &partial_id_str, &partial_id_size);
             if (ret == -1) {
                 flb_plg_warn(ctx->ins, "Could not find partial_id but partial_message key is FLB_TRUE for record with tag %s", tag);
                 /* handle this record as non-partial */
                 partial_records--;
                 goto pack_non_partial;
             }
-            packer = get_packer(&ctx->split_message_packers, tag, 
-                                i_ins->name, partial_id_str, partial_id_size);
+            packer = ml_get_packer(&ctx->split_message_packers, tag, 
+                                   i_ins->name, partial_id_str, partial_id_size);
             if (packer == NULL) {
                 flb_plg_trace(ctx->ins, "Found new partial record with tag %s", tag);
-                packer = create_packer(tag, i_ins->name, partial_id_str, partial_id_size,
-                                       obj, "log", &tm);
+                packer = ml_create_packer(tag, i_ins->name, partial_id_str, partial_id_size,
+                                          obj, ctx->key_content, &tm);
                 if (packer == NULL) {
                     flb_plg_warn(ctx->ins, "Could not create packer for partial record with tag %s", tag);
                     /* handle this record as non-partial */
@@ -616,21 +617,21 @@ static int ml_filter_partial(const void *data, size_t bytes,
                 }
                 mk_list_add(&packer->_head, &ctx->split_message_packers);
             }
-            ret = split_message_packer_write(packer, obj, "log");
+            ret = ml_split_message_packer_write(packer, obj, ctx->key_content);
             if (ret < 0) {
                 flb_plg_warn(ctx->ins, "Could not append content for partial record with tag %s", tag);
                 /* handle this record as non-partial */
                 partial_records--;
                 goto pack_non_partial;
             }
-            is_last_partial = is_partial_last(obj);
+            is_last_partial = ml_is_partial_last(obj);
             if (is_last_partial == FLB_TRUE) {
                 /* emit the record in this filter invocation */
                 return_records++;
-                split_message_packer_complete(packer);
-                append_complete_record(packer->mp_sbuf.data, packer->mp_sbuf.size, &tmp_pck);
+                ml_split_message_packer_complete(packer);
+                ml_append_complete_record(packer->mp_sbuf.data, packer->mp_sbuf.size, &tmp_pck);
                 mk_list_del(&packer->_head);
-                split_message_packer_destroy(packer);
+                ml_split_message_packer_destroy(packer);
             }
         } else {
 

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -26,8 +26,10 @@
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/multiline/flb_ml.h>
 #include <fluent-bit/multiline/flb_ml_parser.h>
+#include <fluent-bit/flb_scheduler.h>
 
 #include "ml.h"
+#include "ml_concat.h"
 
 static struct ml_stream *get_by_id(struct ml_ctx *ctx, uint64_t stream_id);
 
@@ -197,6 +199,7 @@ static int cb_ml_init(struct flb_filter_instance *ins,
     ctx->ins = ins;
     ctx->debug_flush = FLB_FALSE;
     ctx->config = config;
+    ctx->timer_created = FLB_FALSE;
 
     /* 
      * Config map is not yet set at this point in the code
@@ -207,6 +210,26 @@ static int cb_ml_init(struct flb_filter_instance *ins,
     if (tmp) {
         ctx->use_buffer = flb_utils_bool(tmp);
     }
+    ctx->partial_mode = FLB_FALSE;
+    tmp = (char *) flb_filter_get_property("mode", ins);
+    if (tmp != NULL) {
+        if (strcasecmp(tmp, FLB_MULTILINE_MODE_PARTIAL_MESSAGE) == 0) {
+            ctx->partial_mode = FLB_TRUE;
+        } else if (strcasecmp(tmp, FLB_MULTILINE_MODE_PARSER) == 0) {
+            ctx->partial_mode = FLB_FALSE;
+        } else {
+            flb_plg_error(ins, "'Mode' must be '%s' or '%s'", 
+                          FLB_MULTILINE_MODE_PARTIAL_MESSAGE,
+                          FLB_MULTILINE_MODE_PARSER);
+            return -1;
+        }
+    }
+
+    if (ctx->partial_mode == FLB_TRUE && ctx->use_buffer == FLB_FALSE) {
+        flb_plg_error(ins, "'%s' 'Mode' requires 'Buffer' to be 'On'",
+                      FLB_MULTILINE_MODE_PARTIAL_MESSAGE);
+    }
+
     if (ctx->use_buffer == FLB_FALSE) {
             /* Init buffers */
             msgpack_sbuffer_init(&ctx->mp_sbuf);
@@ -252,9 +275,24 @@ static int cb_ml_init(struct flb_filter_instance *ins,
         flb_free(ctx);
         return -1;
     }
-
+    
     /* Set plugin context */
     flb_filter_set_context(ins, ctx);
+
+    if (ctx->key_content == NULL && ctx->partial_mode == FLB_TRUE) {
+        flb_plg_error(ins, "'Mode' '%s' requires 'multiline.key_content'",
+                      FLB_MULTILINE_MODE_PARTIAL_MESSAGE);
+        flb_free(ctx);
+        return -1;
+    }
+
+    if (ctx->partial_mode == FLB_FALSE && mk_list_size(ctx->multiline_parsers) == 0) {
+        flb_plg_error(ins, "The default 'Mode' '%s' requires at least one 'multiline.parser'",
+                      FLB_MULTILINE_MODE_PARSER);
+        flb_free(ctx);
+        return -1;
+    }
+
 
     if (ctx->use_buffer == FLB_TRUE) {
         /*
@@ -293,43 +331,46 @@ static int cb_ml_init(struct flb_filter_instance *ins,
 #endif
     }
 
-    /* Create multiline context */
-    ctx->m = flb_ml_create(config, ctx->ins->name);
-    if (!ctx->m) {
-        /*
-        * we don't free the context since upon init failure, the exit
-         * callback will be triggered with our context set above.
-         */
-        return -1;
-    }
-
-    /* Load the parsers/config */
-    ret = multiline_load_parsers(ctx);
-    if (ret == -1) {
-        return -1;
-    }
-
     mk_list_init(&ctx->ml_streams);
+    mk_list_init(&ctx->split_message_packers);
 
-    if (ctx->use_buffer == FLB_TRUE) {
+    if (ctx->partial_mode == FLB_FALSE) {
+        /* Create multiline context */
+        ctx->m = flb_ml_create(config, ctx->ins->name);
+        if (!ctx->m) {
+            /*
+            * we don't free the context since upon init failure, the exit
+            * callback will be triggered with our context set above.
+            */
+            return -1;
+        }
 
-        ctx->m->flush_ms = ctx->flush_ms;
-        ret = flb_ml_auto_flush_init(ctx->m);
+        /* Load the parsers/config */
+        ret = multiline_load_parsers(ctx);
         if (ret == -1) {
             return -1;
         }
-    } else {
-        /* Create a stream for this file */
-        len = strlen(ins->name);
-        ret = flb_ml_stream_create(ctx->m,
-                                ins->name, len,
-                                flush_callback, ctx,
-                                &stream_id);
-        if (ret != 0) {
-            flb_plg_error(ctx->ins, "could not create multiline stream");
-            return -1;
+
+        if (ctx->use_buffer == FLB_TRUE) {
+
+            ctx->m->flush_ms = ctx->flush_ms;
+            ret = flb_ml_auto_flush_init(ctx->m);
+            if (ret == -1) {
+                return -1;
+            }
+        } else {
+            /* Create a stream for this file */
+            len = strlen(ins->name);
+            ret = flb_ml_stream_create(ctx->m,
+                                    ins->name, len,
+                                    flush_callback, ctx,
+                                    &stream_id);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "could not create multiline stream");
+                return -1;
+            }
+            ctx->stream_id = stream_id;
         }
-        ctx->stream_id = stream_id;
     }
 
     return 0;
@@ -451,6 +492,175 @@ static struct ml_stream *get_or_create_stream(struct ml_ctx *ctx,
     return stream;
 }
 
+static void partial_timer_cb(struct flb_config *config, void *data)
+{
+    struct ml_ctx *ctx = data;
+    (void) config;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct split_message_packer *packer;
+    unsigned long long now;
+    unsigned long long diff;
+    int ret; 
+
+    now = current_timestamp();
+
+    mk_list_foreach_safe(head, tmp, &ctx->split_message_packers) {
+        packer = mk_list_entry(head, struct split_message_packer, _head);
+        
+        diff = now - packer->last_write_time;
+        if (diff <= ctx->flush_ms) {
+            continue;
+        }
+        
+        mk_list_del(&packer->_head);
+        split_message_packer_complete(packer);
+        /* re-emit record with original tag */
+        flb_plg_trace(ctx->ins, "emitting from %s to %s", packer->input_name, packer->tag);
+        ret = in_emitter_add_record(packer->tag, flb_sds_len(packer->tag), 
+                                    packer->mp_sbuf.data, packer->mp_sbuf.size,
+                                    ctx->ins_emitter);
+        if (ret < 0) {
+            /* this shouldn't happen in normal execution */
+            flb_plg_warn(ctx->ins, "Couldn't send concatenated record of size %zu bytes to in_emitter %s",
+                         packer->mp_sbuf.size, ctx->ins_emitter->name);
+        }
+        split_message_packer_destroy(packer);
+    }
+
+}
+
+static int ml_filter_partial(const void *data, size_t bytes,
+                             const char *tag, int tag_len,
+                             void **out_buf, size_t *out_bytes,
+                             struct flb_filter_instance *f_ins,
+                             struct flb_input_instance *i_ins,
+                             void *filter_context,
+                             struct flb_config *config)
+{
+    int ret;
+    int ok = MSGPACK_UNPACK_SUCCESS;
+    size_t off = 0;
+    (void) f_ins;
+    (void) config;
+    msgpack_unpacked result;
+    msgpack_object *obj;
+    struct ml_ctx *ctx = filter_context;
+    struct flb_time tm;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    int partial_records = 0;
+    int total_records = 0;
+    int return_records = 0;
+    int partial = FLB_FALSE;
+    int is_last_partial = FLB_FALSE;
+    struct split_message_packer *packer;
+    char *partial_id_str = NULL;
+    size_t partial_id_size = 0;
+    struct flb_sched *sched;
+
+    /*
+     * create a timer that will run periodically and check if pending buffers
+     * have expired
+     * this is created once on the first flush
+     */
+    if (ctx->timer_created == FLB_FALSE) {
+        flb_plg_debug(ctx->ins,
+                      "Creating flush timer with frequency %dms",
+                      ctx->flush_ms);
+
+        sched = flb_sched_ctx_get();
+
+        ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
+                                        ctx->flush_ms, partial_timer_cb, ctx, NULL);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to create flush timer");
+        } else {
+            ctx->timer_created = FLB_TRUE;
+        }
+    }
+
+    /* 
+     * Create temporary msgpack buffer
+     * for non-partial messages which are passed on as-is
+     */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+        total_records++;
+        flb_time_pop_from_msgpack(&tm, &result, &obj);
+        
+        partial = is_partial(obj);
+        if (partial == FLB_TRUE) {
+            partial_records++;
+            ret = get_partial_id(obj, &partial_id_str, &partial_id_size);
+            if (ret == -1) {
+                flb_plg_warn(ctx->ins, "Could not find partial_id but partial_message key is FLB_TRUE for record with tag %s", tag);
+                /* handle this record as non-partial */
+                partial_records--;
+                goto pack_non_partial;
+            }
+            packer = get_packer(&ctx->split_message_packers, tag, 
+                                i_ins->name, partial_id_str, partial_id_size);
+            if (packer == NULL) {
+                flb_plg_trace(ctx->ins, "Found new partial record with tag %s", tag);
+                packer = create_packer(tag, i_ins->name, partial_id_str, partial_id_size,
+                                       obj, "log", &tm);
+                if (packer == NULL) {
+                    flb_plg_warn(ctx->ins, "Could not create packer for partial record with tag %s", tag);
+                    /* handle this record as non-partial */
+                    partial_records--;
+                    goto pack_non_partial;
+                }
+                mk_list_add(&packer->_head, &ctx->split_message_packers);
+            }
+            ret = split_message_packer_write(packer, obj, "log");
+            if (ret < 0) {
+                flb_plg_warn(ctx->ins, "Could not append content for partial record with tag %s", tag);
+                /* handle this record as non-partial */
+                partial_records--;
+                goto pack_non_partial;
+            }
+            is_last_partial = is_partial_last(obj);
+            if (is_last_partial == FLB_TRUE) {
+                /* emit the record in this filter invocation */
+                return_records++;
+                split_message_packer_complete(packer);
+                append_complete_record(packer->mp_sbuf.data, packer->mp_sbuf.size, &tmp_pck);
+                mk_list_del(&packer->_head);
+                split_message_packer_destroy(packer);
+            }
+        } else {
+
+pack_non_partial:
+            return_records++;
+            /* record passed from filter as-is */
+            msgpack_pack_array(&tmp_pck, 2);
+            flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
+            msgpack_pack_object(&tmp_pck, *obj);
+        }
+
+    }
+
+    msgpack_unpacked_destroy(&result);
+
+    if (partial_records == 0) {
+        /* if no records were partial, we didn't modify the chunk */
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return FLB_FILTER_NOTOUCH;
+    } else if (return_records > 0) {
+        /* some new records can be returned now, return a new buffer */
+        *out_buf  = tmp_sbuf.data;
+        *out_bytes = tmp_sbuf.size;
+    } else {
+        /* no records to return right now, free buffer */
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+    }
+    return FLB_FILTER_MODIFIED;
+}
+
 static int cb_ml_filter(const void *data, size_t bytes,
                         const char *tag, int tag_len,
                         void **out_buf, size_t *out_bytes,
@@ -462,8 +672,6 @@ static int cb_ml_filter(const void *data, size_t bytes,
     int ret;
     int ok = MSGPACK_UNPACK_SUCCESS;
     size_t off = 0;
-    (void) out_buf;
-    (void) out_bytes;
     (void) f_ins;
     (void) config;
     msgpack_unpacked result;
@@ -474,6 +682,20 @@ static int cb_ml_filter(const void *data, size_t bytes,
     struct flb_time tm;
     struct ml_stream *stream;
 
+    if (i_ins == ctx->ins_emitter) {
+        flb_plg_trace(ctx->ins, "not processing records from the emitter");
+        return FLB_FILTER_NOTOUCH;
+    }
+
+    /* 'partial_message' mode */
+    if (ctx->partial_mode == FLB_TRUE) {
+        return ml_filter_partial(data, bytes, tag, tag_len,
+                                 out_buf, out_bytes,
+                                 f_ins, i_ins,
+                                 filter_context, config);
+    }
+
+    /* 'parser' mode */
     if (ctx->use_buffer == FLB_FALSE) {
         /* reset mspgack size content */
         ctx->mp_sbuf.size = 0;
@@ -519,10 +741,6 @@ static int cb_ml_filter(const void *data, size_t bytes,
         return FLB_FILTER_NOTOUCH;
     
     } else { /* buffered mode */
-        if (i_ins == ctx->ins_emitter) {
-            flb_plg_trace(ctx->ins, "not processing record from the emitter");
-            return FLB_FILTER_NOTOUCH;
-        }
         
         stream = get_or_create_stream(ctx, i_ins, tag, tag_len);
 
@@ -594,6 +812,13 @@ static struct flb_config_map config_map[] = {
      "rather than in chunks, re-emitting them into the beggining of the "
      "pipeline using the in_emitter instance. "
      "With buffer off, this filter will not work with most inputs, except tail."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "mode", "parser",
+     0, FLB_TRUE, offsetof(struct ml_ctx, mode),
+     "Mode can be 'parser' for regex concat, or 'partial_message' to "
+     "concat split docker logs."
     },
 
     {

--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -22,9 +22,12 @@
 #define FLB_FILTER_MULTILINE_H
 
 #include <fluent-bit/flb_filter_plugin.h>
+#include "ml_concat.h"
 
 #define FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT  "10M"
-#define FLB_MULTILINE_METRIC_EMITTED    200
+#define FLB_MULTILINE_METRIC_EMITTED         200
+#define FLB_MULTILINE_MODE_PARTIAL_MESSAGE   "partial_message"
+#define FLB_MULTILINE_MODE_PARSER            "parser"
 
 /* 
  * input instance + tag is the unique identifier
@@ -43,6 +46,7 @@ struct ml_ctx {
     int debug_flush;
     int use_buffer;
     flb_sds_t key_content;
+    flb_sds_t mode;
 
     /* packaging buffers */
     msgpack_sbuffer mp_sbuf;  /* temporary msgpack buffer */
@@ -54,7 +58,13 @@ struct ml_ctx {
     struct mk_list *multiline_parsers;
     int flush_ms;
 
+    int timer_created;
+
+    int partial_mode;
+
     struct mk_list ml_streams;
+
+    struct mk_list split_message_packers;
 
     struct flb_filter_instance *ins;
 

--- a/plugins/filter_multiline/ml_concat.c
+++ b/plugins/filter_multiline/ml_concat.c
@@ -31,7 +31,7 @@
 
 #include "ml_concat.h"
 
-msgpack_object_kv *get_key(msgpack_object *map, char *check_for_key)
+msgpack_object_kv *ml_get_key(msgpack_object *map, char *check_for_key)
 {
     int i;
     char *key_str = NULL;
@@ -66,13 +66,13 @@ msgpack_object_kv *get_key(msgpack_object *map, char *check_for_key)
     return NULL;
 }
 
-int is_partial(msgpack_object *map)
+int ml_is_partial(msgpack_object *map)
 {
     char *val_str = NULL;
     msgpack_object_kv *kv;
     msgpack_object  val;
     
-    kv = get_key(map, FLB_MULTILINE_PARTIAL_MESSAGE_KEY);
+    kv = ml_get_key(map, FLB_MULTILINE_PARTIAL_MESSAGE_KEY);
 
     if (kv == NULL) {
         return FLB_FALSE;
@@ -92,13 +92,13 @@ int is_partial(msgpack_object *map)
     return FLB_FALSE;
 }
 
-int is_partial_last(msgpack_object *map)
+int ml_is_partial_last(msgpack_object *map)
 {
     char *val_str = NULL;
     msgpack_object_kv *kv;
     msgpack_object  val;
     
-    kv = get_key(map, FLB_MULTILINE_PARTIAL_LAST_KEY);
+    kv = ml_get_key(map, FLB_MULTILINE_PARTIAL_LAST_KEY);
 
     if (kv == NULL) {
         return FLB_FALSE;
@@ -118,7 +118,7 @@ int is_partial_last(msgpack_object *map)
     return FLB_FALSE;
 }
 
-int get_partial_id(msgpack_object *map, 
+int ml_get_partial_id(msgpack_object *map, 
                      char **partial_id_str,
                      size_t *partial_id_size)
 {
@@ -127,7 +127,7 @@ int get_partial_id(msgpack_object *map,
     msgpack_object_kv *kv;
     msgpack_object  val;
     
-    kv = get_key(map, FLB_MULTILINE_PARTIAL_ID_KEY);
+    kv = ml_get_key(map, FLB_MULTILINE_PARTIAL_ID_KEY);
 
     if (kv == NULL) {
         return -1;
@@ -149,9 +149,9 @@ int get_partial_id(msgpack_object *map,
     return 0;
 }
 
-struct split_message_packer *get_packer(struct mk_list *packers, const char *tag, 
-                                        char *input_name, 
-                                        char *partial_id_str, size_t partial_id_size)
+struct split_message_packer *ml_get_packer(struct mk_list *packers, const char *tag, 
+                                           char *input_name, 
+                                           char *partial_id_str, size_t partial_id_size)
 {
     struct mk_list *tmp;
     struct mk_list *head;
@@ -180,10 +180,10 @@ struct split_message_packer *get_packer(struct mk_list *packers, const char *tag
     return NULL;
 }
 
-struct split_message_packer *create_packer(const char *tag, char *input_name, 
-                                           char *partial_id_str, size_t partial_id_size,
-                                           msgpack_object *map, char *multiline_key_content,
-                                           struct flb_time *tm)
+struct split_message_packer *ml_create_packer(const char *tag, char *input_name, 
+                                              char *partial_id_str, size_t partial_id_size,
+                                              msgpack_object *map, char *multiline_key_content,
+                                              struct flb_time *tm)
 {
     struct split_message_packer *packer;
     msgpack_object_kv *kv;
@@ -214,7 +214,7 @@ struct split_message_packer *create_packer(const char *tag, char *input_name,
     tmp = flb_sds_create(tag);
     if (!tmp) {
         flb_errno();
-        split_message_packer_destroy(packer);
+        ml_split_message_packer_destroy(packer);
         return NULL;
     }
     packer->tag = tmp;
@@ -222,7 +222,7 @@ struct split_message_packer *create_packer(const char *tag, char *input_name,
     tmp = flb_sds_create_len(partial_id_str, partial_id_size);
     if (!tmp) {
         flb_errno();
-        split_message_packer_destroy(packer);
+        ml_split_message_packer_destroy(packer);
         return NULL;
     }
     packer->partial_id = tmp;
@@ -230,7 +230,7 @@ struct split_message_packer *create_packer(const char *tag, char *input_name,
     packer->buf = flb_sds_create_size(FLB_MULTILINE_PARTIAL_BUF_SIZE);
     if (!packer->buf) {
         flb_errno();
-        split_message_packer_destroy(packer);
+        ml_split_message_packer_destroy(packer);
         return NULL;
     }
 
@@ -238,10 +238,10 @@ struct split_message_packer *create_packer(const char *tag, char *input_name,
     msgpack_packer_init(&packer->mp_pck, &packer->mp_sbuf, msgpack_sbuffer_write);
 
     /* get the key that is split */
-    split_kv = get_key(map, multiline_key_content);
+    split_kv = ml_get_key(map, multiline_key_content);
     if (split_kv == NULL) {
         flb_error("[partial message concat] Could not find key %s in record", multiline_key_content);
-        split_message_packer_destroy(packer);
+        ml_split_message_packer_destroy(packer);
         return NULL;
     }
 
@@ -324,7 +324,7 @@ struct split_message_packer *create_packer(const char *tag, char *input_name,
     return packer;
 }
 
-unsigned long long current_timestamp() {
+unsigned long long ml_current_timestamp() {
     struct timeval te; 
     unsigned long long milliseconds;
     gettimeofday(&te, NULL); 
@@ -332,15 +332,15 @@ unsigned long long current_timestamp() {
     return milliseconds;
 }
 
-int split_message_packer_write(struct split_message_packer *packer, 
-                               msgpack_object *map, char *multiline_key_content)
+int ml_split_message_packer_write(struct split_message_packer *packer, 
+                                  msgpack_object *map, char *multiline_key_content)
 {   
     char *val_str = NULL;
     size_t val_str_size = 0;
     msgpack_object_kv *kv;
     msgpack_object  val;
     
-    kv = get_key(map, multiline_key_content);
+    kv = ml_get_key(map, multiline_key_content);
 
     if (kv == NULL) {
         flb_error("[partial message concat] Could not find key %s in record", multiline_key_content);
@@ -351,19 +351,22 @@ int split_message_packer_write(struct split_message_packer *packer,
     if (val.type == MSGPACK_OBJECT_BIN) {
         val_str  = (char *) val.via.bin.ptr;
         val_str_size = val.via.bin.size;
-    }
-    if (val.type == MSGPACK_OBJECT_STR) {
+    } else if (val.type == MSGPACK_OBJECT_STR) {
         val_str  = (char *) val.via.str.ptr;
         val_str_size = val.via.str.size;
+    } else {
+        return -1;
     }
 
+
+
     flb_sds_cat_safe(&packer->buf, val_str, val_str_size);
-    packer->last_write_time = current_timestamp();
+    packer->last_write_time = ml_current_timestamp();
 
     return 0;
 }
 
-void split_message_packer_complete(struct split_message_packer *packer)
+void ml_split_message_packer_complete(struct split_message_packer *packer)
 {
     int len;
     len = flb_sds_len(packer->buf);
@@ -371,7 +374,7 @@ void split_message_packer_complete(struct split_message_packer *packer)
     msgpack_pack_str_body(&packer->mp_pck, packer->buf, len);
 }
 
-void append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck)
+void ml_append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck)
 {
     int ok = MSGPACK_UNPACK_SUCCESS;
     size_t off = 0;
@@ -388,7 +391,7 @@ void append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck)
     }
 }
 
-void split_message_packer_destroy(struct split_message_packer *packer)
+void ml_split_message_packer_destroy(struct split_message_packer *packer)
 {
     if (!packer) {
         return;

--- a/plugins/filter_multiline/ml_concat.c
+++ b/plugins/filter_multiline/ml_concat.c
@@ -1,0 +1,415 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_filter_plugin.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_metrics.h>
+#include <fluent-bit/flb_storage.h>
+#include <fluent-bit/multiline/flb_ml.h>
+#include <fluent-bit/multiline/flb_ml_parser.h>
+#include <sys/time.h>
+#include <stdio.h>
+
+#include "ml_concat.h"
+
+msgpack_object_kv *get_key(msgpack_object *map, char *check_for_key)
+{
+    int i;
+    char *key_str = NULL;
+    size_t key_str_size = 0;
+    msgpack_object_kv *kv;
+    msgpack_object  key;
+    int check_key = FLB_FALSE;
+
+    kv = map->via.map.ptr;
+
+    for(i=0; i < map->via.map.size; i++) {
+        check_key = FLB_FALSE;
+
+        key = (kv+i)->key;
+        if (key.type == MSGPACK_OBJECT_BIN) {
+            key_str  = (char *) key.via.bin.ptr;
+            key_str_size = key.via.bin.size;
+            check_key = FLB_TRUE;
+        }
+        if (key.type == MSGPACK_OBJECT_STR) {
+            key_str  = (char *) key.via.str.ptr;
+            key_str_size = key.via.str.size;
+            check_key = FLB_TRUE;
+        }
+
+        if (check_key == FLB_TRUE) {
+            if (strncmp(check_for_key, key_str, key_str_size) == 0) {
+                return (kv+i);
+            }
+        }
+    }
+    return NULL;
+}
+
+int is_partial(msgpack_object *map)
+{
+    char *val_str = NULL;
+    msgpack_object_kv *kv;
+    msgpack_object  val;
+    
+    kv = get_key(map, FLB_MULTILINE_PARTIAL_MESSAGE_KEY);
+
+    if (kv == NULL) {
+        return FLB_FALSE;
+    }
+
+    val = kv->val;
+    if (val.type == MSGPACK_OBJECT_BIN) {
+        val_str  = (char *) val.via.bin.ptr;
+    }
+    if (val.type == MSGPACK_OBJECT_STR) {
+        val_str  = (char *) val.via.str.ptr;
+    }
+
+    if (strncasecmp("true", val_str, 4) == 0) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
+int is_partial_last(msgpack_object *map)
+{
+    char *val_str = NULL;
+    msgpack_object_kv *kv;
+    msgpack_object  val;
+    
+    kv = get_key(map, FLB_MULTILINE_PARTIAL_LAST_KEY);
+
+    if (kv == NULL) {
+        return FLB_FALSE;
+    }
+
+    val = kv->val;
+    if (val.type == MSGPACK_OBJECT_BIN) {
+        val_str  = (char *) val.via.bin.ptr;
+    }
+    if (val.type == MSGPACK_OBJECT_STR) {
+        val_str  = (char *) val.via.str.ptr;
+    }
+
+    if (strncasecmp("true", val_str, 4) == 0) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
+int get_partial_id(msgpack_object *map, 
+                     char **partial_id_str,
+                     size_t *partial_id_size)
+{
+    char *val_str = NULL;
+    size_t val_str_size = 0;
+    msgpack_object_kv *kv;
+    msgpack_object  val;
+    
+    kv = get_key(map, FLB_MULTILINE_PARTIAL_ID_KEY);
+
+    if (kv == NULL) {
+        return -1;
+    }
+
+    val = kv->val;
+    if (val.type == MSGPACK_OBJECT_BIN) {
+        val_str  = (char *) val.via.bin.ptr;
+        val_str_size  = val.via.bin.size;
+    }
+    if (val.type == MSGPACK_OBJECT_STR) {
+        val_str  = (char *) val.via.str.ptr;
+        val_str_size  = val.via.str.size;
+    }
+
+    *partial_id_str = val_str;
+    *partial_id_size = val_str_size;
+
+    return 0;
+}
+
+struct split_message_packer *get_packer(struct mk_list *packers, const char *tag, 
+                                        char *input_name, 
+                                        char *partial_id_str, size_t partial_id_size)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct split_message_packer *packer;
+    int name_check;
+    int tag_check;
+    int id_check;
+
+
+    mk_list_foreach_safe(head, tmp, packers) {
+        packer = mk_list_entry(head, struct split_message_packer, _head);
+        id_check = strncmp(packer->partial_id, partial_id_str, partial_id_size);
+        if (id_check != 0) {
+            continue;
+        }
+        name_check = strcmp(packer->input_name, input_name);
+        if (name_check != 0) {
+            continue;
+        }
+        tag_check = strcmp(packer->tag, tag);
+        if (tag_check == 0) {
+            return packer;
+        }
+    }
+
+    return NULL;
+}
+
+struct split_message_packer *create_packer(const char *tag, char *input_name, 
+                                           char *partial_id_str, size_t partial_id_size,
+                                           msgpack_object *map, char *multiline_key_content,
+                                           struct flb_time *tm)
+{
+    struct split_message_packer *packer;
+    msgpack_object_kv *kv;
+    msgpack_object_kv *split_kv;
+    flb_sds_t tmp;
+    int i;
+    char *key_str = NULL;
+    size_t key_str_size = 0;
+    msgpack_object  key;
+    int check_key = FLB_FALSE;
+    size_t len;
+    int map_size = 0;
+
+    packer = flb_calloc(1, sizeof(struct split_message_packer));
+    if (!packer) {
+        flb_errno();
+        return NULL;
+    }
+
+    tmp = flb_sds_create(input_name);
+    if (!tmp) {
+        flb_errno();
+        flb_free(packer);
+        return NULL;
+    }
+    packer->input_name = tmp;
+
+    tmp = flb_sds_create(tag);
+    if (!tmp) {
+        flb_errno();
+        split_message_packer_destroy(packer);
+        return NULL;
+    }
+    packer->tag = tmp;
+
+    tmp = flb_sds_create_len(partial_id_str, partial_id_size);
+    if (!tmp) {
+        flb_errno();
+        split_message_packer_destroy(packer);
+        return NULL;
+    }
+    packer->partial_id = tmp;
+
+    packer->buf = flb_sds_create_size(FLB_MULTILINE_PARTIAL_BUF_SIZE);
+    if (!packer->buf) {
+        flb_errno();
+        split_message_packer_destroy(packer);
+        return NULL;
+    }
+
+    msgpack_sbuffer_init(&packer->mp_sbuf);
+    msgpack_packer_init(&packer->mp_pck, &packer->mp_sbuf, msgpack_sbuffer_write);
+
+    /* get the key that is split */
+    split_kv = get_key(map, multiline_key_content);
+    if (split_kv == NULL) {
+        flb_error("[partial message concat] Could not find key %s in record", multiline_key_content);
+        split_message_packer_destroy(packer);
+        return NULL;
+    }
+
+    /* write all of the keys except the split one and the partial metadata */
+    msgpack_pack_array(&packer->mp_pck, 2);
+    flb_time_append_to_msgpack(tm, &packer->mp_pck, 0);
+
+    kv = map->via.map.ptr;
+
+    /* determine size of new map */
+    for(i=0; i < map->via.map.size; i++) {
+        if ((kv+i) == split_kv) {
+            continue;
+        }
+
+        key = (kv+i)->key;
+        if (key.type == MSGPACK_OBJECT_BIN) {
+            key_str  = (char *) key.via.bin.ptr;
+            key_str_size = key.via.bin.size;
+            check_key = FLB_TRUE;
+        }
+        if (key.type == MSGPACK_OBJECT_STR) {
+            key_str  = (char *) key.via.str.ptr;
+            key_str_size = key.via.str.size;
+            check_key = FLB_TRUE;
+        }
+
+        len = FLB_MULTILINE_PARTIAL_PREFIX_LEN;
+        if (key_str_size < len) {
+            len = key_str_size;
+        }
+
+        if (check_key == FLB_TRUE) {
+            if (strncmp(FLB_MULTILINE_PARTIAL_PREFIX, key_str, len) == 0) {
+                /* don't pack the partial keys */
+                continue;
+            }
+        }
+
+        map_size++;
+    }
+    map_size++; /* +1 for split key added later */
+    msgpack_pack_map(&packer->mp_pck, map_size);
+
+    for(i=0; i < map->via.map.size; i++) {
+        if ((kv+i) == split_kv) {
+            continue;
+        }
+
+        key = (kv+i)->key;
+        if (key.type == MSGPACK_OBJECT_BIN) {
+            key_str  = (char *) key.via.bin.ptr;
+            key_str_size = key.via.bin.size;
+            check_key = FLB_TRUE;
+        }
+        if (key.type == MSGPACK_OBJECT_STR) {
+            key_str  = (char *) key.via.str.ptr;
+            key_str_size = key.via.str.size;
+            check_key = FLB_TRUE;
+        }
+
+        len = FLB_MULTILINE_PARTIAL_PREFIX_LEN;
+        if (key_str_size < len) {
+            len = key_str_size;
+        }
+
+        if (check_key == FLB_TRUE) {
+            if (strncmp(FLB_MULTILINE_PARTIAL_PREFIX, key_str, len) == 0) {
+                /* don't pack the partial keys */
+                continue;
+            }
+        }
+        msgpack_pack_object(&packer->mp_pck, (kv+i)->key);
+        msgpack_pack_object(&packer->mp_pck, (kv+i)->val);
+    }
+
+    /* write split kv last, so we can append to it later as needed */
+    msgpack_pack_object(&packer->mp_pck, split_kv->key);
+
+    return packer;
+}
+
+unsigned long long current_timestamp() {
+    struct timeval te; 
+    unsigned long long milliseconds;
+    gettimeofday(&te, NULL); 
+    milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; 
+    return milliseconds;
+}
+
+int split_message_packer_write(struct split_message_packer *packer, 
+                               msgpack_object *map, char *multiline_key_content)
+{   
+    char *val_str = NULL;
+    size_t val_str_size = 0;
+    msgpack_object_kv *kv;
+    msgpack_object  val;
+    
+    kv = get_key(map, multiline_key_content);
+
+    if (kv == NULL) {
+        flb_error("[partial message concat] Could not find key %s in record", multiline_key_content);
+        return -1;
+    }
+
+    val = kv->val;
+    if (val.type == MSGPACK_OBJECT_BIN) {
+        val_str  = (char *) val.via.bin.ptr;
+        val_str_size = val.via.bin.size;
+    }
+    if (val.type == MSGPACK_OBJECT_STR) {
+        val_str  = (char *) val.via.str.ptr;
+        val_str_size = val.via.str.size;
+    }
+
+    flb_sds_cat_safe(&packer->buf, val_str, val_str_size);
+    packer->last_write_time = current_timestamp();
+
+    return 0;
+}
+
+void split_message_packer_complete(struct split_message_packer *packer)
+{
+    int len;
+    len = flb_sds_len(packer->buf);
+    msgpack_pack_str(&packer->mp_pck, len);
+    msgpack_pack_str_body(&packer->mp_pck, packer->buf, len);
+}
+
+void append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck)
+{
+    int ok = MSGPACK_UNPACK_SUCCESS;
+    size_t off = 0;
+    msgpack_unpacked result;
+    msgpack_object *obj;
+    struct flb_time tm;
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+        flb_time_pop_from_msgpack(&tm, &result, &obj);
+        msgpack_pack_array(tmp_pck, 2);
+        flb_time_append_to_msgpack(&tm, tmp_pck, 0);
+        msgpack_pack_object(tmp_pck, *obj);
+    }
+}
+
+void split_message_packer_destroy(struct split_message_packer *packer)
+{
+    if (!packer) {
+        return;
+    }
+
+    if (packer->tag) {
+        flb_sds_destroy(packer->tag);
+    }
+    if (packer->buf) {
+        flb_sds_destroy(packer->buf);
+    }
+    if (packer->input_name) {
+        flb_sds_destroy(packer->input_name);
+    }
+    if (packer->partial_id) {
+        flb_sds_destroy(packer->partial_id);
+    }
+    if (packer->mp_sbuf.data) {
+        msgpack_sbuffer_destroy(&packer->mp_sbuf);
+    }
+
+    flb_free(packer);
+}
+

--- a/plugins/filter_multiline/ml_concat.h
+++ b/plugins/filter_multiline/ml_concat.h
@@ -1,0 +1,80 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FILTER_MULTILINE_CONCAT_H
+#define FLB_FILTER_MULTILINE_CONCAT_H
+
+#include <fluent-bit/flb_filter_plugin.h>
+
+#define FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT  "10M"
+#define FLB_MULTILINE_METRIC_EMITTED         200
+/* docker logs are split at 16KB */
+#define FLB_MULTILINE_PARTIAL_BUF_SIZE       24000
+
+/* 
+ * Long term these keys could be made user configurable
+ * But everyone who's asking for this right now wants it for split
+ * Docker logs, which has a set series of keys
+ */
+#define FLB_MULTILINE_PARTIAL_PREFIX       "partial_"
+#define FLB_MULTILINE_PARTIAL_PREFIX_LEN   8
+#define FLB_MULTILINE_PARTIAL_MESSAGE_KEY  "partial_message"
+#define FLB_MULTILINE_PARTIAL_ID_KEY       "partial_id"
+#define FLB_MULTILINE_PARTIAL_LAST_KEY     "partial_last"
+
+struct split_message_packer {
+    flb_sds_t tag;
+    flb_sds_t input_name;
+    flb_sds_t partial_id;
+
+    /* packaging buffers */
+    msgpack_sbuffer mp_sbuf;  /* temporary msgpack buffer              */
+    msgpack_packer mp_pck;    /* temporary msgpack packer              */
+
+    flb_sds_t buf;
+
+    /* used to flush buffers that have been pending for more than flush_ms */
+    unsigned long long last_write_time;
+
+    struct mk_list _head;
+};
+
+msgpack_object_kv *get_key(msgpack_object *map, char *check_for_key);
+int is_partial(msgpack_object *map);
+int is_partial_last(msgpack_object *map);
+int get_partial_id(msgpack_object *map, 
+                   char **partial_id_str,
+                   size_t *partial_id_size);
+struct split_message_packer *get_packer(struct mk_list *packers, const char *tag, 
+                                        char *input_name, 
+                                        char *partial_id_str, size_t partial_id_size);
+struct split_message_packer *create_packer(const char *tag, char *input_name, 
+                                           char *partial_id_str, size_t partial_id_size,
+                                           msgpack_object *map, char *multiline_key_content,
+                                           struct flb_time *tm);
+int split_message_packer_write(struct split_message_packer *packer, 
+                               msgpack_object *map, char *multiline_key_content);
+void split_message_packer_complete(struct split_message_packer *packer);
+void split_message_packer_destroy(struct split_message_packer *packer);
+void append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck);
+unsigned long long current_timestamp();
+
+
+#endif

--- a/plugins/filter_multiline/ml_concat.h
+++ b/plugins/filter_multiline/ml_concat.h
@@ -56,25 +56,25 @@ struct split_message_packer {
     struct mk_list _head;
 };
 
-msgpack_object_kv *get_key(msgpack_object *map, char *check_for_key);
-int is_partial(msgpack_object *map);
-int is_partial_last(msgpack_object *map);
-int get_partial_id(msgpack_object *map, 
-                   char **partial_id_str,
-                   size_t *partial_id_size);
-struct split_message_packer *get_packer(struct mk_list *packers, const char *tag, 
-                                        char *input_name, 
-                                        char *partial_id_str, size_t partial_id_size);
-struct split_message_packer *create_packer(const char *tag, char *input_name, 
-                                           char *partial_id_str, size_t partial_id_size,
-                                           msgpack_object *map, char *multiline_key_content,
-                                           struct flb_time *tm);
-int split_message_packer_write(struct split_message_packer *packer, 
-                               msgpack_object *map, char *multiline_key_content);
-void split_message_packer_complete(struct split_message_packer *packer);
-void split_message_packer_destroy(struct split_message_packer *packer);
-void append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck);
-unsigned long long current_timestamp();
+msgpack_object_kv *ml_get_key(msgpack_object *map, char *check_for_key);
+int ml_is_partial(msgpack_object *map);
+int ml_is_partial_last(msgpack_object *map);
+int ml_get_partial_id(msgpack_object *map, 
+                      char **partial_id_str,
+                      size_t *partial_id_size);
+struct split_message_packer *ml_get_packer(struct mk_list *packers, const char *tag, 
+                                           char *input_name, 
+                                           char *partial_id_str, size_t partial_id_size);
+struct split_message_packer *ml_create_packer(const char *tag, char *input_name, 
+                                              char *partial_id_str, size_t partial_id_size,
+                                              msgpack_object *map, char *multiline_key_content,
+                                              struct flb_time *tm);
+int ml_split_message_packer_write(struct split_message_packer *packer, 
+                                  msgpack_object *map, char *multiline_key_content);
+void ml_split_message_packer_complete(struct split_message_packer *packer);
+void ml_split_message_packer_destroy(struct split_message_packer *packer);
+void ml_append_complete_record(char *data, size_t bytes, msgpack_packer *tmp_pck);
+unsigned long long ml_current_timestamp();
 
 
 #endif


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
