### PR TITLE
out_stackdriver: refactor to use config_map

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2353,6 +2353,123 @@ static int cb_stackdriver_exit(void *data, struct flb_config *config)
     return 0;
 }
 
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "google_service_credentials", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_stackdriver, credentials_file),
+     "Set the path for the google service credentials file"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "metadata_server", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_stackdriver, metadata_server),
+     "Set the metadata server"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "service_account_email", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, client_email),
+      "Set the service account email"
+    },
+    // set in flb_bigquery_oauth_credentials
+    {
+      FLB_CONFIG_MAP_STR, "service_account_secret", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, private_key),
+      "Set the service account secret"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "export_to_project_id", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, export_to_project_id),
+      "Export to project id"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "resource", FLB_SDS_RESOURCE_TYPE,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, resource),
+      "Set the resource"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "severity_key", DEFAULT_SEVERITY_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, severity_key),
+      "Set the severity key"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "autoformat_stackdriver_trace", "false",
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, autoformat_stackdriver_trace),
+      "Autoformat the stacrdriver trace"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "trace_key", DEFAULT_TRACE_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, trace_key),
+      "Set the trace key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "log_name_key", DEFAULT_LOG_NAME_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, log_name_key),
+      "Set the logname key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "http_request_key", HTTPREQUEST_FIELD_IN_JSON,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, http_request_key),
+      "Set the http request key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "k8s_cluster_name", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, cluster_name),
+      "Set the kubernetes cluster name"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "k8s_cluster_location", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, cluster_location),
+      "Set the kubernetes cluster location"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "location", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, location),
+      "Set the resource location"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "namespace", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, namespace_id),
+      "Set the resource namespace"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "node_id", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, node_id),
+      "Set the resource node id"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "job", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, job),
+      "Set the resource job"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "task_id", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, task_id),
+      "Set the resource task id"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "labels_key", DEFAULT_LABELS_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, labels_key),
+      "Set the labels key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "tag_prefix", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, tag_prefix),
+      "Set the tag prefix"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "stackdriver_agent", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, stackdriver_agent),
+      "Set the stackdriver agent"
+    },
+    /* Custom Regex */
+    {
+      FLB_CONFIG_MAP_STR, "custom_k8s_regex", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, custom_k8s_regex),
+      "Set a custom kubernetes regex filter"
+    },
+    /* EOF */
+    {0}
+};
+
 struct flb_output_plugin out_stackdriver_plugin = {
     .name         = "stackdriver",
     .description  = "Send events to Google Stackdriver Logging",
@@ -2360,6 +2477,7 @@ struct flb_output_plugin out_stackdriver_plugin = {
     .cb_flush     = cb_stackdriver_flush,
     .cb_exit      = cb_stackdriver_exit,
     .workers      = 2,
+    .config_map   = config_map,
 
     /* Test */
     .test_formatter.callback = stackdriver_format_test,

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1093,7 +1093,7 @@ static int cb_stackdriver_init(struct flb_output_instance *ins,
     }
 
     if (!ctx->export_to_project_id) {
-        ctx->export_to_project_id = flb_sds_create(ctx->project_id);
+        ctx->export_to_project_id = ctx->project_id;
     }
 
     ret = flb_stackdriver_regex_init(ctx);

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -980,13 +980,6 @@ static void cb_results(const char *name, const char *value,
 int flb_stackdriver_regex_init(struct flb_stackdriver *ctx)
 {
     /* If a custom regex is not set, use the defaults */
-    if (!ctx->custom_k8s_regex) {
-        ctx->custom_k8s_regex = flb_sds_create(DEFAULT_TAG_REGEX);
-        if (!ctx->custom_k8s_regex) {
-            return -1;
-        }
-    }
-
     ctx->regex = flb_regex_create(ctx->custom_k8s_regex);
     if (!ctx->regex) {
         return -1;
@@ -2360,7 +2353,7 @@ static struct flb_config_map config_map[] = {
      "Set the path for the google service credentials file"
     },
     {
-     FLB_CONFIG_MAP_STR, "metadata_server", (char *)NULL,
+     FLB_CONFIG_MAP_STR, "metadata_server", FLB_STD_METADATA_SERVER,
      0, FLB_TRUE, offsetof(struct flb_stackdriver, metadata_server),
      "Set the metadata server"
     },
@@ -2462,7 +2455,7 @@ static struct flb_config_map config_map[] = {
     },
     /* Custom Regex */
     {
-      FLB_CONFIG_MAP_STR, "custom_k8s_regex", (char *)NULL,
+      FLB_CONFIG_MAP_STR, "custom_k8s_regex", DEFAULT_TAG_REGEX,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, custom_k8s_regex),
       "Set a custom kubernetes regex filter"
     },

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -127,6 +127,8 @@ struct flb_stackdriver {
     flb_sds_t labels_key;
     flb_sds_t local_resource_id;
     flb_sds_t tag_prefix;
+    /* shadow tag_prefix for safe deallocation */
+    flb_sds_t tag_prefix_k8s;
 
     /* generic resources */
     flb_sds_t location;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -78,6 +78,23 @@
 #define FLB_STACKDRIVER_FAILED_REQUESTS      1001   /* failed requests */
 #endif
 
+struct flb_stackdriver_oauth_credentials {
+    /* parsed credentials file */
+    flb_sds_t type;
+    flb_sds_t project_id;
+    flb_sds_t private_key_id;
+    flb_sds_t private_key;
+    flb_sds_t client_email;
+    flb_sds_t client_id;
+    flb_sds_t auth_uri;
+    flb_sds_t token_uri;
+};
+
+struct flb_stackdriver_env {
+    flb_sds_t creds_file;
+    flb_sds_t metadata_server;
+};
+
 struct flb_stackdriver {
     /* credentials */
     flb_sds_t credentials_file;
@@ -142,6 +159,12 @@ struct flb_stackdriver {
 
     /* oauth2 context */
     struct flb_oauth2 *o;
+
+    /* parsed oauth2 credentials */
+    struct flb_stackdriver_oauth_credentials *creds;
+
+    /* environment variable settings */
+    struct flb_stackdriver_env *env;
 
     /* mutex for acquiring oauth tokens */
     pthread_mutex_t token_mutex;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -81,7 +81,6 @@
 struct flb_stackdriver_oauth_credentials {
     /* parsed credentials file */
     flb_sds_t type;
-    flb_sds_t project_id;
     flb_sds_t private_key_id;
     flb_sds_t private_key;
     flb_sds_t client_email;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -41,7 +41,7 @@ static inline int key_cmp(const char *str, int len, const char *cmp) {
     return strncasecmp(str, cmp, len);
 }
 
-static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
+static int read_credentials_file(const char *cred_file, struct flb_stackdriver *ctx)
 {
     int i;
     int ret;
@@ -58,25 +58,25 @@ static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
     jsmntok_t *tokens;
 
     /* Validate credentials path */
-    ret = stat(creds, &st);
+    ret = stat(cred_file, &st);
     if (ret == -1) {
         flb_errno();
         flb_plg_error(ctx->ins, "cannot open credentials file: %s",
-                      creds);
+                      cred_file);
         return -1;
     }
 
     if (!S_ISREG(st.st_mode) && !S_ISLNK(st.st_mode)) {
         flb_plg_error(ctx->ins, "credentials file "
-                      "is not a valid file: %s", creds);
+                      "is not a valid file: %s", cred_file);
         return -1;
     }
 
     /* Read file content */
-    buf = mk_file_to_buffer(creds);
+    buf = mk_file_to_buffer(cred_file);
     if (!buf) {
         flb_plg_error(ctx->ins, "error reading credentials file: %s",
-                      creds);
+                      cred_file);
         return -1;
     }
 
@@ -92,7 +92,7 @@ static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
     ret = jsmn_parse(&parser, buf, st.st_size, tokens, tok_size);
     if (ret <= 0) {
         flb_plg_error(ctx->ins, "invalid JSON credentials file: %s",
-                  creds);
+                  cred_file);
         flb_free(buf);
         flb_free(tokens);
         return -1;
@@ -101,7 +101,7 @@ static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
     t = &tokens[0];
     if (t->type != JSMN_OBJECT) {
         flb_plg_error(ctx->ins, "invalid JSON map on file: %s",
-                  creds);
+                  cred_file);
         flb_free(buf);
         flb_free(tokens);
         return -1;
@@ -129,35 +129,35 @@ static int read_credentials_file(const char *creds, struct flb_stackdriver *ctx)
         val_len = (t->end - t->start);
 
         if (key_cmp(key, key_len, "type") == 0) {
-            ctx->type = flb_sds_create_len(val, val_len);
+            ctx->creds->type = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "project_id") == 0) {
-            ctx->project_id = flb_sds_create_len(val, val_len);
+            ctx->creds->project_id = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "private_key_id") == 0) {
-            ctx->private_key_id = flb_sds_create_len(val, val_len);
+            ctx->creds->private_key_id = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "private_key") == 0) {
             tmp = flb_sds_create_len(val, val_len);
             if (tmp) {
                 /* Unescape private key */
-                ctx->private_key = flb_sds_create_size(val_len);
+                ctx->creds->private_key = flb_sds_create_size(val_len);
                 flb_unescape_string(tmp, flb_sds_len(tmp),
-                                    &ctx->private_key);
+                                    &ctx->creds->private_key);
                 flb_sds_destroy(tmp);
             }
         }
         else if (key_cmp(key, key_len, "client_email") == 0) {
-            ctx->client_email = flb_sds_create_len(val, val_len);
+            ctx->creds->client_email = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "client_id") == 0) {
-            ctx->client_id = flb_sds_create_len(val, val_len);
+            ctx->creds->client_id = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "auth_uri") == 0) {
-            ctx->auth_uri = flb_sds_create_len(val, val_len);
+            ctx->creds->auth_uri = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "token_uri") == 0) {
-            ctx->token_uri = flb_sds_create_len(val, val_len);
+            ctx->creds->token_uri = flb_sds_create_len(val, val_len);
         }
     }
 
@@ -196,10 +196,16 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     if (ctx->metadata_server == NULL) {
         tmp = getenv("METADATA_SERVER");
         if(tmp) {
-            ctx->metadata_server = flb_sds_create(tmp);
-        }
-        else {
-            ctx->metadata_server = flb_sds_create(FLB_STD_METADATA_SERVER);
+            if (ctx->env == NULL) {
+                ctx->env = flb_calloc(1, sizeof(struct flb_stackdriver_env));
+                if (ctx->env == NULL) {
+                    flb_plg_error(ins, "unable to allocate env variables");
+                    flb_free(ctx);
+                    return NULL;
+                }
+            }
+            ctx->env->metadata_server = flb_sds_create(tmp);
+            ctx->metadata_server = ctx->env->metadata_server;
         }
     }
     flb_plg_info(ctx->ins, "metadata_server set to %s", ctx->metadata_server);
@@ -217,32 +223,62 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                 "GOOGLE_SERVICE_CREDENTIALS are both defined. "
                 "Defaulting to GOOGLE_APPLICATION_CREDENTIALS");
         }
+        if ((tmp || backwards_compatible_env_var) && (ctx->env == NULL)) {
+            ctx->env = flb_calloc(1, sizeof(struct flb_stackdriver_env));
+            if (ctx->env == NULL) {
+                flb_plg_error(ins, "unable to allocate env variables");
+                flb_free(ctx);
+                return NULL;
+            }
+        }
         if (tmp) {
-            ctx->credentials_file = flb_sds_create(tmp);
+            ctx->env->creds_file = flb_sds_create(tmp);
+            ctx->credentials_file = ctx->env->creds_file;
         }
         else if (backwards_compatible_env_var) {
-            ctx->credentials_file = flb_sds_create(backwards_compatible_env_var);
+            ctx->env->creds_file = flb_sds_create(backwards_compatible_env_var);
+            ctx->credentials_file = ctx->env->creds_file;
         }
     }
 
     if (ctx->credentials_file) {
+        ctx->creds = flb_calloc(1, sizeof(struct flb_stackdriver_oauth_credentials));
+        if (ctx->creds == NULL) {
+            flb_plg_error(ctx->ins, "unable to allocate credentials");
+            flb_stackdriver_conf_destroy(ctx);
+            return NULL;
+        }
         ret = read_credentials_file(ctx->credentials_file, ctx);
         if (ret != 0) {
             flb_stackdriver_conf_destroy(ctx);
             return NULL;
         }
+        ctx->type = ctx->creds->type;
+        ctx->project_id = ctx->creds->project_id;
+        ctx->private_key_id = ctx->creds->private_key_id;
+        ctx->private_key = ctx->creds->private_key;
+        ctx->client_email = ctx->creds->client_email;
+        ctx->client_id = ctx->creds->client_id;
+        ctx->auth_uri = ctx->creds->auth_uri;
+        ctx->token_uri = ctx->creds->token_uri;
     }
     else {
         /*
          * If no credentials file has been defined, do manual lookup of the
          * client email and the private key
          */
-
+        ctx->creds = flb_calloc(1, sizeof(struct flb_stackdriver_oauth_credentials));
+        if (ctx->creds == NULL) {
+            flb_plg_error(ctx->ins, "unable to allocate credentials");
+            flb_stackdriver_conf_destroy(ctx);
+            return NULL;
+        }
+        
         /* Service Account Email */
         if (ctx->client_email == NULL) {
             tmp = getenv("SERVICE_ACCOUNT_EMAIL");
             if (tmp) {
-                ctx->client_email = flb_sds_create(tmp);
+                ctx->creds->client_email = flb_sds_create(tmp);
             }
         }
 
@@ -250,9 +286,12 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         if (ctx->private_key == NULL) {
             tmp = getenv("SERVICE_ACCOUNT_SECRET");
             if (tmp) {
-                ctx->private_key = flb_sds_create(tmp);
+                ctx->creds->private_key = flb_sds_create(tmp);
             }
         }
+
+        ctx->private_key = ctx->creds->private_key;
+        ctx->client_email = ctx->creds->client_email;
     }
 
     /*
@@ -396,6 +435,44 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         return -1;
     }
 
+    if (ctx->creds) {
+        if (ctx->creds->type) {
+            flb_sds_destroy(ctx->creds->type);
+        }
+        if (ctx->creds->project_id) {
+            flb_sds_destroy(ctx->creds->project_id);
+        }
+        if (ctx->creds->private_key_id) {
+            flb_sds_destroy(ctx->creds->private_key_id);
+        }
+        if (ctx->creds->private_key) {
+            flb_sds_destroy(ctx->creds->private_key);
+        }
+        if (ctx->creds->client_email) {
+            flb_sds_destroy(ctx->creds->client_email);
+        }
+        if (ctx->creds->client_id) {
+            flb_sds_destroy(ctx->creds->client_id);
+        }
+        if (ctx->creds->auth_uri) {
+            flb_sds_destroy(ctx->creds->auth_uri);
+        }
+        if (ctx->creds->token_uri) {
+            flb_sds_destroy(ctx->creds->token_uri);
+        }
+        flb_free(ctx->creds);
+    }
+    
+    if (ctx->env) {
+        if (ctx->env->creds_file) {
+            flb_sds_destroy(ctx->env->creds_file);
+        }
+        if (ctx->env->metadata_server) {
+            flb_sds_destroy(ctx->env->metadata_server);
+        }
+        flb_free(ctx->env);
+    }
+    
     if (ctx->is_k8s_resource_type){
         flb_sds_destroy(ctx->namespace_name);
         flb_sds_destroy(ctx->pod_name);
@@ -403,13 +480,6 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         flb_sds_destroy(ctx->node_name);
         flb_sds_destroy(ctx->local_resource_id);
     }
-
-    flb_sds_destroy(ctx->type);
-    flb_sds_destroy(ctx->project_id);
-    flb_sds_destroy(ctx->private_key_id);
-    flb_sds_destroy(ctx->client_id);
-    flb_sds_destroy(ctx->auth_uri);
-    flb_sds_destroy(ctx->token_uri);
     
     if (ctx->metadata_server_auth) {
         flb_sds_destroy(ctx->zone);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -333,6 +333,8 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             flb_sds_destroy(ctx->http_request_key);
             ctx->http_request_key = NULL;
             ctx->http_request_key_size = 0;
+        } else {
+            ctx->http_request_key_size = http_request_key_size;
         }
     }
 

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -132,7 +132,7 @@ static int read_credentials_file(const char *cred_file, struct flb_stackdriver *
             ctx->creds->type = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "project_id") == 0) {
-            ctx->creds->project_id = flb_sds_create_len(val, val_len);
+            ctx->project_id = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "private_key_id") == 0) {
             ctx->creds->private_key_id = flb_sds_create_len(val, val_len);
@@ -254,7 +254,6 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             return NULL;
         }
         ctx->type = ctx->creds->type;
-        ctx->project_id = ctx->creds->project_id;
         ctx->private_key_id = ctx->creds->private_key_id;
         ctx->private_key = ctx->creds->private_key;
         ctx->client_email = ctx->creds->client_email;
@@ -439,9 +438,6 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         if (ctx->creds->type) {
             flb_sds_destroy(ctx->creds->type);
         }
-        if (ctx->creds->project_id) {
-            flb_sds_destroy(ctx->creds->project_id);
-        }
         if (ctx->creds->private_key_id) {
             flb_sds_destroy(ctx->creds->private_key_id);
         }
@@ -500,6 +496,10 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
 
     if (ctx->regex) {
         flb_regex_destroy(ctx->regex);
+    }
+    
+    if (ctx->project_id) {
+        flb_sds_destroy(ctx->project_id);
     }
 
     flb_free(ctx);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -283,7 +283,9 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         http_request_key_size = flb_sds_len(ctx->http_request_key);
         if (http_request_key_size >= INT_MAX) {
             flb_plg_error(ctx->ins, "http_request_key is too long");
-            return NULL;
+            flb_sds_destroy(ctx->http_request_key);
+            ctx->http_request_key = NULL;
+            ctx->http_request_key_size = 0;
         }
     }
 
@@ -399,8 +401,6 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         flb_sds_destroy(ctx->pod_name);
         flb_sds_destroy(ctx->container_name);
         flb_sds_destroy(ctx->node_name);
-        flb_sds_destroy(ctx->cluster_name);
-        flb_sds_destroy(ctx->cluster_location);
         flb_sds_destroy(ctx->local_resource_id);
     }
 

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -389,8 +389,10 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     }
 
     if (ctx->tag_prefix == NULL && ctx->is_k8s_resource_type == FLB_TRUE) {
-        ctx->tag_prefix = flb_sds_create(ctx->resource);
-        ctx->tag_prefix = flb_sds_cat(ctx->tag_prefix, ".", 1);
+        /* allocate the flb_sds_t to tag_prefix_k8s so we can safely deallocate it */
+        ctx->tag_prefix_k8s = flb_sds_create(ctx->resource);
+        ctx->tag_prefix_k8s = flb_sds_cat(ctx->tag_prefix_k8s, ".", 1);
+        ctx->tag_prefix = ctx->tag_prefix_k8s;
     }
 
     /* Register metrics */
@@ -500,6 +502,10 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     
     if (ctx->project_id) {
         flb_sds_destroy(ctx->project_id);
+    }
+    
+    if (ctx->tag_prefix_k8s) {
+        flb_sds_destroy(ctx->tag_prefix_k8s);
     }
 
     flb_free(ctx);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -309,7 +309,16 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     if (!ctx->client_email) {
         flb_plg_warn(ctx->ins, "client_email is not defined, using "
                      "a default one");
-        ctx->client_email = flb_sds_create("default");
+        if (ctx->creds == NULL) {
+            ctx->creds = flb_calloc(1, sizeof(struct flb_stackdriver_oauth_credentials));
+            if (ctx->creds == NULL) {
+                flb_plg_error(ctx->ins, "unable to allocate credentials");
+                flb_stackdriver_conf_destroy(ctx);
+                return NULL;
+            }
+        }
+        ctx->creds->client_email = flb_sds_create("default");
+        ctx->client_email = ctx->creds->client_email;
     }
     if (!ctx->private_key) {
         flb_plg_warn(ctx->ins, "private_key is not defined, fetching "


### PR DESCRIPTION
Add configmap support for the out_stackdriver plugin. This is related to https://github.com/fluent/fluent-bit/issues/4863.

----
**Testing**
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
