### PR TITLE
config_format: yaml: fix plugins definitions, use an array

### DIFF
--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -24,7 +24,7 @@ void test_basic()
     }
 
     /* Total number of sections */
-    TEST_CHECK(mk_list_size(&cf->sections) == 8);
+    TEST_CHECK(mk_list_size(&cf->sections) == 9);
 
 	/* SERVICE check */
     TEST_CHECK(cf->service != NULL);
@@ -36,7 +36,7 @@ void test_basic()
     TEST_CHECK(mk_list_size(&cf->parsers) == 0);
     TEST_CHECK(mk_list_size(&cf->multiline_parsers) == 0);
     TEST_CHECK(mk_list_size(&cf->customs) == 1);
-    TEST_CHECK(mk_list_size(&cf->inputs) == 2);
+    TEST_CHECK(mk_list_size(&cf->inputs) == 3);
     TEST_CHECK(mk_list_size(&cf->filters) == 1);
     TEST_CHECK(mk_list_size(&cf->outputs) == 2);
     TEST_CHECK(mk_list_size(&cf->others) == 1);

--- a/tests/internal/data/config_format/yaml/fluent-bit.yaml
+++ b/tests/internal/data/config_format/yaml/fluent-bit.yaml
@@ -5,20 +5,25 @@ includes:
     - service.yaml
 
 customs:
-    ${observability}:
+    - ${observability}:
         api_key: zyJUb2tlbklEItoiY2ZlMTcx
 
 pipeline:
     inputs:
-        tail:
+        - tail:
             path: ./test.log
             parser: json
             read_from_head: true
+        - tail:
+            path: ./test.log
+            parser: json
+            read_from_head: true
+
     filters:
-        record_modifier:
+        - record_modifier:
             match: "*"
             record: powered_by calyptia
 
     outputs:
-        stdout:
+        - stdout:
             match: "*"

--- a/tests/internal/data/config_format/yaml/test/dummy_pipeline.yaml
+++ b/tests/internal/data/config_format/yaml/test/dummy_pipeline.yaml
@@ -1,12 +1,12 @@
 pipeline:
     inputs:
-        dummy:
+        - dummy:
             tag: success
             group1:
                 a: b
                 c: d
     outputs:
-        stdout:
+        - stdout:
             match: "*"
 
 unknown:


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
