### PR TITLE
go: proxy: plugin: Implement multi-threaded Golang input plugin mechanism

### DIFF
--- a/include/fluent-bit/flb_api.h
+++ b/include/fluent-bit/flb_api.h
@@ -25,6 +25,14 @@
 
 struct flb_api {
     const char *(*output_get_property) (const char *, struct flb_output_instance *);
+    const char *(*input_get_property) (const char *, struct flb_input_instance *);
+
+    void *(*output_get_cmt_instance) (struct flb_output_instance *);
+    void *(*input_get_cmt_instance) (struct flb_input_instance *);
+
+    void (*log_print) (int, const char*, int, const char*, ...);
+    int (*input_log_check) (struct flb_input_instance *, int);
+    int (*output_log_check) (struct flb_output_instance *, int);
 };
 
 #ifdef FLB_CORE

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -51,6 +51,8 @@
 
 /* Input plugin flag masks */
 #define FLB_INPUT_NET          4   /* input address may set host and port   */
+#define FLB_INPUT_PLUGIN_CORE  0
+#define FLB_INPUT_PLUGIN_PROXY 1
 #define FLB_INPUT_CORO       128   /* plugin requires a thread on callbacks */
 #define FLB_INPUT_PRIVATE    256   /* plugin is not published/exposed       */
 #define FLB_INPUT_NOTAG      512   /* plugin might don't have tags          */
@@ -67,6 +69,13 @@
 struct flb_input_instance;
 
 struct flb_input_plugin {
+    /*
+     * The type defines if this is a core-based plugin or it's handled by
+     * some specific proxy.
+     */
+    int type;
+    void *proxy;
+
     int flags;                /* plugin flags */
     int event_type;           /* event type to be generated: logs ?, metrics ? */
 
@@ -522,6 +531,9 @@ int flb_input_set_property(struct flb_input_instance *ins,
                            const char *k, const char *v);
 const char *flb_input_get_property(const char *key,
                                    struct flb_input_instance *ins);
+#ifdef FLB_HAVE_METRICS
+void *flb_input_get_cmt_instance(struct flb_input_instance *ins);
+#endif
 
 int flb_input_check(struct flb_config *config);
 void flb_input_set_context(struct flb_input_instance *ins, void *context);
@@ -581,6 +593,7 @@ void flb_input_net_default_listener(const char *listen, int port,
 
 int flb_input_event_type_is_metric(struct flb_input_instance *ins);
 int flb_input_event_type_is_log(struct flb_input_instance *ins);
+int flb_input_log_check(struct flb_input_instance *ins, int l);
 
 struct mk_event_loop *flb_input_event_loop_get(struct flb_input_instance *ins);
 int flb_input_upstream_set(struct flb_upstream *u, struct flb_input_instance *ins);

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -728,6 +728,9 @@ const char *flb_output_name(struct flb_output_instance *in);
 int flb_output_set_property(struct flb_output_instance *out,
                             const char *k, const char *v);
 const char *flb_output_get_property(const char *key, struct flb_output_instance *ins);
+#ifdef FLB_HAVE_METRICS
+void *flb_output_get_cmt_instance(struct flb_output_instance *ins);
+#endif
 void flb_output_net_default(const char *host, int port,
                             struct flb_output_instance *ins);
 const char *flb_output_name(struct flb_output_instance *ins);
@@ -737,6 +740,7 @@ void flb_output_set_context(struct flb_output_instance *ins, void *context);
 int flb_output_instance_destroy(struct flb_output_instance *ins);
 int flb_output_init_all(struct flb_config *config);
 int flb_output_check(struct flb_config *config);
+int flb_output_log_check(struct flb_output_instance *ins, int l);
 
 int flb_output_upstream_set(struct flb_upstream *u, struct flb_output_instance *ins);
 int flb_output_upstream_ha_set(void *ha, struct flb_output_instance *ins);

--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -23,6 +23,7 @@
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_input_thread.h>
 
 /* Plugin Types */
 #define FLB_PROXY_INPUT_PLUGIN     1
@@ -61,12 +62,18 @@ struct flb_plugin_proxy_context {
     struct flb_plugin_proxy *proxy;
 };
 
+struct flb_plugin_input_proxy_context {
+    int coll_fd;
+    /* A proxy ptr is needed to store the proxy type/lang (OUTPUT/GOLANG) */
+    struct flb_plugin_proxy *proxy;
+};
+
 void *flb_plugin_proxy_symbol(struct flb_plugin_proxy *proxy,
                               const char *symbol);
 
-int flb_plugin_proxy_init(struct flb_plugin_proxy *proxy,
-                          struct flb_output_instance *o_ins,
-                          struct flb_config *config);
+int flb_plugin_proxy_output_init(struct flb_plugin_proxy *proxy,
+                                 struct flb_output_instance *o_ins,
+                                 struct flb_config *config);
 
 int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
                               struct flb_config *config);

--- a/src/flb_api.c
+++ b/src/flb_api.c
@@ -20,7 +20,9 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_api.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
 
+#include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 
 struct flb_api *flb_api_create()
@@ -34,6 +36,17 @@ struct flb_api *flb_api_create()
     }
 
     api->output_get_property = flb_output_get_property;
+    api->input_get_property = flb_input_get_property;
+
+#ifdef FLB_HAVE_METRICS
+    api->output_get_cmt_instance = flb_output_get_cmt_instance;
+    api->input_get_cmt_instance = flb_input_get_cmt_instance;
+#endif
+
+    api->log_print = flb_log_print;
+    api->input_log_check = flb_input_log_check;
+    api->output_log_check = flb_output_log_check;
+
     return api;
 }
 

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -775,6 +775,10 @@ int flb_input_thread_destroy(struct flb_input_thread *it, struct flb_input_insta
 {
     int ret;
     flb_input_thread_exit(it, ins);
+    /* On Darwin, we must call pthread_cancel here to ensure worker
+     * thread termination. Otherwise, worker thread termination will
+     * be blocked. */
+    pthread_cancel(it->thread);
     ret = pthread_join(it->thread, NULL);
     mpack_writer_destroy(&it->writer);
     pthread_mutex_destroy(&it->mutex);

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -36,6 +36,8 @@
 /* Proxies */
 #include "proxy/go/go.h"
 
+#define PROXY_CALLBACK_TIME    1 /* 1 seconds */
+
 static void proxy_cb_flush(struct flb_event_chunk *event_chunk,
                            struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
@@ -51,11 +53,11 @@ static void proxy_cb_flush(struct flb_event_chunk *event_chunk,
 #ifdef FLB_HAVE_PROXY_GO
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         flb_trace("[GO] entering go_flush()");
-        ret = proxy_go_flush(ctx,
-                             event_chunk->data,
-                             event_chunk->size,
-                             event_chunk->tag,
-                             flb_sds_len(event_chunk->tag));
+        ret = proxy_go_output_flush(ctx,
+                                    event_chunk->data,
+                                    event_chunk->size,
+                                    event_chunk->tag,
+                                    flb_sds_len(event_chunk->tag));
     }
 #else
     (void) ctx;
@@ -68,16 +70,147 @@ static void proxy_cb_flush(struct flb_event_chunk *event_chunk,
     FLB_OUTPUT_RETURN(ret);
 }
 
+static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    int ret = FLB_OK;
+    size_t len = 0;
+    void *data = NULL;
+    struct flb_plugin_input_proxy_context *ctx = (struct flb_plugin_input_proxy_context *) in_context;
+
+#ifdef FLB_HAVE_PROXY_GO
+    if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
+        flb_trace("[GO] entering go_collect()");
+        ret = proxy_go_input_collect(ctx->proxy, &data, &len);
+
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
+
+        flb_input_chunk_append_raw(ins, NULL, 0, data, len);
+
+        if (!data) {
+            free(data);
+        }
+
+        ret = proxy_go_input_cleanup(ctx->proxy, data);
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
+    }
+#endif
+
+    return 0;
+}
+
+static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
+                                   struct flb_config *config, void *data)
+{
+    int ret = -1;
+    struct flb_plugin_input_proxy_context *ctx;
+    struct flb_plugin_proxy_context *pc;
+
+    /* Allocate space for the configuration context */
+    ctx = flb_malloc(sizeof(struct flb_plugin_input_proxy_context));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+
+    /* Before to initialize for proxy, set the proxy instance reference */
+    pc = (struct flb_plugin_proxy_context *)(ins->context);
+    ctx->proxy = pc->proxy;
+
+    /* Before to initialize, set the instance reference */
+    pc->proxy->instance = ins;
+
+    /* Based on 'proxy', use the proper handler */
+    if (pc->proxy->def->proxy == FLB_PROXY_GOLANG) {
+#ifdef FLB_HAVE_PROXY_GO
+        ret = proxy_go_input_init(pc->proxy);
+
+        if (ret == -1) {
+            flb_error("Could not initialize proxy for threaded input plugin");
+            goto init_error;
+        }
+#else
+        flb_error("Could not find initializing function on proxy for threaded input plugin");
+        goto init_error;
+#endif
+    }
+    else {
+        fprintf(stderr, "[proxy] unrecognized input proxy handler %i\n",
+                pc->proxy->def->proxy);
+    }
+
+    /* Set the context */
+    flb_input_set_context(ins, ctx);
+
+    /* Collect upon data available on timer */
+    ret = flb_input_set_collector_time(ins,
+                                       flb_proxy_input_cb_collect,
+                                       PROXY_CALLBACK_TIME, 0,
+                                       config);
+
+    if (ret == -1) {
+        flb_error("Could not set collector for threaded proxy input plugin");
+        goto init_error;
+    }
+    ctx->coll_fd = ret;
+
+    return ret;
+
+init_error:
+    flb_free(ctx);
+
+    return -1;
+}
+
+static void flb_proxy_input_cb_pause(void *data, struct flb_config *config)
+{
+    struct flb_plugin_input_proxy_context *ctx = data;
+
+    flb_input_collector_pause(ctx->coll_fd, ctx->proxy->instance);
+}
+
+static void flb_proxy_input_cb_resume(void *data, struct flb_config *config)
+{
+    struct flb_plugin_input_proxy_context *ctx = data;
+
+    flb_input_collector_resume(ctx->coll_fd, ctx->proxy->instance);
+}
+
 static void flb_plugin_proxy_destroy(struct flb_plugin_proxy *proxy);
-static int flb_proxy_cb_exit(void *data, struct flb_config *config)
+static int flb_proxy_output_cb_exit(void *data, struct flb_config *config)
 {
     struct flb_output_plugin *instance = data;
     struct flb_plugin_proxy *proxy = (instance->proxy);
 
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
-        proxy_go_destroy(proxy->data);
+        proxy_go_output_destroy(proxy->data);
     }
     flb_plugin_proxy_destroy(proxy);
+    return 0;
+}
+
+static int flb_proxy_input_cb_exit(void *in_context, struct flb_config *config)
+{
+    struct flb_plugin_input_proxy_context *ctx = in_context;
+
+    if (!in_context) {
+        return 0;
+    }
+
+    if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
+        proxy_go_input_destroy(ctx->proxy->data);
+    }
+
+    flb_plugin_proxy_destroy(ctx->proxy);
+
+    flb_free(ctx);
+
     return 0;
 }
 
@@ -107,7 +240,41 @@ static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
      * we put our proxy-middle callbacks to do the translation properly.
      */
     out->cb_flush = proxy_cb_flush;
-    out->cb_exit = flb_proxy_cb_exit;
+    out->cb_exit = flb_proxy_output_cb_exit;
+    return 0;
+}
+
+static int flb_proxy_register_input(struct flb_plugin_proxy *proxy,
+                                    struct flb_plugin_proxy_def *def,
+                                    struct flb_config *config)
+{
+    struct flb_input_plugin *in;
+
+    in = flb_calloc(1, sizeof(struct flb_input_plugin));
+    if (!in) {
+        flb_errno();
+        return -1;
+    }
+
+    /* Plugin registration */
+    in->type  = FLB_INPUT_PLUGIN_PROXY;
+    in->proxy = proxy;
+    in->flags = def->flags | FLB_INPUT_THREADED;
+    in->name  = flb_strdup(def->name);
+    in->description = def->description;
+    mk_list_add(&in->_head, &config->in_plugins);
+
+    /*
+     * Set proxy callbacks: external plugins which are not following
+     * the core plugins specs, have a different callback approach, so
+     * we put our proxy-middle callbacks to do the translation properly.
+     */
+    in->cb_init = flb_proxy_input_cb_init;
+    in->cb_collect = flb_proxy_input_cb_collect;
+    in->cb_flush_buf = NULL;
+    in->cb_exit = flb_proxy_input_cb_exit;
+    in->cb_pause = flb_proxy_input_cb_pause;
+    in->cb_resume = flb_proxy_input_cb_resume;
     return 0;
 }
 
@@ -160,7 +327,12 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
     ret = -1;
     if (def->proxy == FLB_PROXY_GOLANG) {
 #ifdef FLB_HAVE_PROXY_GO
-        ret = proxy_go_register(proxy, def);
+        if (def->type == FLB_PROXY_OUTPUT_PLUGIN) {
+            ret = proxy_go_output_register(proxy, def);
+        }
+        else if (def->type == FLB_PROXY_INPUT_PLUGIN) {
+            ret = proxy_go_input_register(proxy, def);
+        }
 #endif
     }
     if (ret == 0) {
@@ -171,14 +343,17 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
         if (def->type == FLB_PROXY_OUTPUT_PLUGIN) {
             flb_proxy_register_output(proxy, def, config);
         }
+        else if (def->type == FLB_PROXY_INPUT_PLUGIN) {
+            flb_proxy_register_input(proxy, def, config);
+        }
     }
 
     return 0;
 }
 
-int flb_plugin_proxy_init(struct flb_plugin_proxy *proxy,
-                          struct flb_output_instance *o_ins,
-                          struct flb_config *config)
+int flb_plugin_proxy_output_init(struct flb_plugin_proxy *proxy,
+                                 struct flb_output_instance *o_ins,
+                                 struct flb_config *config)
 {
     int ret = -1;
 
@@ -188,7 +363,7 @@ int flb_plugin_proxy_init(struct flb_plugin_proxy *proxy,
     /* Based on 'proxy', use the proper handler */
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
 #ifdef FLB_HAVE_PROXY_GO
-        ret = proxy_go_init(proxy);
+        ret = proxy_go_output_init(proxy);
 #endif
     }
     else {

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -36,13 +36,35 @@ struct flbgo_output_plugin {
     int (*cb_exit_ctx)(void *);
 };
 
-int proxy_go_register(struct flb_plugin_proxy *proxy,
-                      struct flb_plugin_proxy_def *def);
+struct flbgo_input_plugin {
+    char *name;
+    void *api;
+    void *i_ins;
+    struct flb_plugin_proxy_context *context;
 
-int proxy_go_init(struct flb_plugin_proxy *proxy);
+    int (*cb_init)();
+    int (*cb_collect)(void **, size_t *);
+    int (*cb_cleanup)(void *);
+    int (*cb_exit)();
+};
 
-int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
-                   const void *data, size_t size,
-                   const char *tag, int tag_len);
-int proxy_go_destroy(void *data);
+int proxy_go_output_register(struct flb_plugin_proxy *proxy,
+                             struct flb_plugin_proxy_def *def);
+
+int proxy_go_output_init(struct flb_plugin_proxy *proxy);
+
+int proxy_go_output_flush(struct flb_plugin_proxy_context *ctx,
+                          const void *data, size_t size,
+                          const char *tag, int tag_len);
+int proxy_go_output_destroy(void *data);
+
+int proxy_go_input_register(struct flb_plugin_proxy *proxy,
+                            struct flb_plugin_proxy_def *def);
+
+int proxy_go_input_init(struct flb_plugin_proxy *proxy);
+int proxy_go_input_collect(struct flb_plugin_proxy *ctx,
+                           void **collected_data, size_t *len);
+int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
+                           void *allocated_data);
+int proxy_go_input_destroy(void *data);
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR provides Golang input plugin mechanism on Fluent Bit core.
This work is based on multi-threaded input plugin mechanism that is implemented on https://github.com/fluent/fluent-bit/pull/4586.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

The related issue is None.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

### fluent-bit.conf

```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    trace
    Plugins_File plugins.conf
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name gdummy
    Tag  gdummy.local

[OUTPUT]
    Name  stdout
    Match gdummy*
```

### plugins.conf

```ini
[PLUGINS]
  Path /path/to/workdir/fluent-bit/build/in_gdummy.so
```

- [x] Debug log output from testing the change
This patch works with fluent-bit-go and corresponds a shared object that is built with Golang input plugin interface.
This is also sent a PR there: https://github.com/fluent/fluent-bit-go/pull/52

```log
$  bin/fluent-bit -c fluent-bit.conf
Fluent Bit v1.9.0
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/14 10:36:55] [ info] Configuration:
[2022/03/14 10:36:55] [ info]  flush time     | 5.000000 seconds
[2022/03/14 10:36:55] [ info]  grace          | 5 seconds
[2022/03/14 10:36:55] [ info]  daemon         | 0
[2022/03/14 10:36:55] [ info] ___________
[2022/03/14 10:36:55] [ info]  inputs:
[2022/03/14 10:36:55] [ info]      gdummy
[2022/03/14 10:36:55] [ info] ___________
[2022/03/14 10:36:55] [ info]  filters:
[2022/03/14 10:36:55] [ info] ___________
[2022/03/14 10:36:55] [ info]  outputs:
[2022/03/14 10:36:55] [ info]      stdout.0
[2022/03/14 10:36:55] [ info] ___________
[2022/03/14 10:36:55] [ info]  collectors:
[2022/03/14 10:36:55] [ info] [engine] started (pid=1062825)
[2022/03/14 10:36:55] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/03/14 10:36:55] [debug] [storage] [cio stream] new stream registered: gdummy.0
[2022/03/14 10:36:55] [ info] [storage] version=1.1.6, initializing...
[2022/03/14 10:36:55] [ info] [storage] in-memory
[2022/03/14 10:36:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/14 10:36:55] [ info] [cmetrics] version=0.3.0
[2022/03/14 10:36:55] [debug] [gdummy:gdummy.0] created event channels: read=21 write=22
[flb-go] plugin parameter = ''
[2022/03/14 10:36:55] [debug] [stdout:stdout.0] created event channels: read=25 write=26
[2022/03/14 10:36:55] [debug] [router] match rule gdummy.0:stdout.0
[2022/03/14 10:36:55] [ info] [sp] stream processor started
[2022/03/14 10:36:55] [ info] [output:stdout:stdout.0] worker #0 started
[2022/03/14 10:36:56] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:36:56] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:36:57] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:36:57] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:36:58] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:36:58] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:36:59] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:36:59] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:00] [debug] [task] created task=0x7f94d401d5d0 id=0 OK
[2022/03/14 10:37:00] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] gdummy.local: [1647221815.557805574, {"message"=>"dummy"}]
[1] gdummy.local: [1647221816.558982897, {"message"=>"dummy"}]
[2] gdummy.local: [1647221817.559238836, {"message"=>"dummy"}]
[3] gdummy.local: [1647221818.559523525, {"message"=>"dummy"}]
[2022/03/14 10:37:00] [debug] [out flush] cb_destroy coro_id=0
[2022/03/14 10:37:00] [debug] [task] destroy task=0x7f94d401d5d0 (task_id=0)
[2022/03/14 10:37:00] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:00] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:01] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:01] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:02] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:02] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:03] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:03] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:04] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:04] [debug] [input chunk] update output instances with new chunk size diff=26
[2022/03/14 10:37:05] [debug] [task] created task=0x7f94d405d830 id=0 OK
[2022/03/14 10:37:05] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] gdummy.local: [1647221819.560334706, {"message"=>"dummy"}]
[1] gdummy.local: [1647221820.560606884, {"message"=>"dummy"}]
[2] gdummy.local: [1647221821.561860932, {"message"=>"dummy"}]
[3] gdummy.local: [1647221822.562044770, {"message"=>"dummy"}]
[4] gdummy.local: [1647221823.562335594, {"message"=>"dummy"}]
[2022/03/14 10:37:05] [debug] [out flush] cb_destroy coro_id=1
[2022/03/14 10:37:05] [debug] [task] destroy task=0x7f94d405d830 (task_id=0)
[2022/03/14 10:37:05] [trace] [input:gdummy:gdummy.0 at build/src/CMakeFiles/fluent-bit-static.dir/compiler_depend.ts:93] input thread read() = 26
[2022/03/14 10:37:05] [debug] [input chunk] update output instances with new chunk size diff=26
^C[2022/03/14 10:37:06] [engine] caught signal (SIGINT)
[2022/03/14 10:37:06] [debug] [task] created task=0x7f94d401d870 id=0 OK
[2022/03/14 10:37:06] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/03/14 10:37:06] [ warn] [engine] service will shutdown in max 5 seconds
[0] gdummy.local: [1647221824.562711972, {"message"=>"dummy"}]
[2022/03/14 10:37:06] [debug] [out flush] cb_destroy coro_id=2
[2022/03/14 10:37:06] [debug] [task] destroy task=0x7f94d401d870 (task_id=0)
[2022/03/14 10:37:06] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/14 10:37:06] [debug] [GO] running exit callback
[2022/03/14 10:37:06] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/14 10:37:06] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
