### PR TITLE
in_proc: fix possible free before allocation.

### DIFF
--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -471,7 +471,6 @@ static int in_proc_exit(void *data, struct flb_config *config)
     }
 
     /* Destroy context */
-    flb_free(ctx->proc_name);
     flb_free(ctx);
 
     return 0;


### PR DESCRIPTION
in_proc: fix possible free before allocation.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
