### PR TITLE
bin: add support for full config JSON schema (-J)

### DIFF
--- a/include/fluent-bit/flb_help.h
+++ b/include/fluent-bit/flb_help.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_output.h>
 
+int flb_help_custom(struct flb_custom_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_filter(struct flb_filter_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_output(struct flb_output_instance *ins, void **out_buf, size_t *out_size);

--- a/include/fluent-bit/flb_help.h
+++ b/include/fluent-bit/flb_help.h
@@ -21,13 +21,25 @@
 #define FLB_HELP_H
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_custom.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_output.h>
+
+/* JSON Helper version: current '1' */
+#define FLB_HELP_SCHEMA_VERSION "1"
+
+#define FLB_HELP_PLUGIN_CUSTOM   0
+#define FLB_HELP_PLUGIN_INPUT    1
+#define FLB_HELP_PLUGIN_OUTPUT   2
+#define FLB_HELP_PLUGIN_FILTER   3
 
 int flb_help_custom(struct flb_custom_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_filter(struct flb_filter_instance *ins, void **out_buf, size_t *out_size);
 int flb_help_output(struct flb_output_instance *ins, void **out_buf, size_t *out_size);
+
+flb_sds_t flb_help_build_json_schema(struct flb_config *config);
 
 #endif

--- a/include/fluent-bit/flb_utils.h
+++ b/include/fluent-bit/flb_utils.h
@@ -66,6 +66,7 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
                               char **out_username, char **out_password,
                               char **out_host, char **out_port);
 int flb_utils_read_file(char *path, char **out_buf, size_t *out_size);
+char *flb_utils_get_os_name();
 int flb_utils_uuid_v4_gen(char *buf);
 int flb_utils_get_machine_id(char **out_id, size_t *out_size);
 

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -75,8 +75,6 @@ struct flb_stacktrace flb_st;
 #define FLB_HELP_TEXT    0
 #define FLB_HELP_JSON    1
 
-/* JSON Helper version: current '1' */
-#define FLB_HELP_VERSION 1
 
 #define PLUGIN_CUSTOM   0
 #define PLUGIN_INPUT    1
@@ -896,6 +894,7 @@ int flb_main(int argc, char **argv)
 {
     int opt;
     int ret;
+    flb_sds_t json;
 
     /* handle plugin properties:  -1 = none, 0 = input, 1 = output */
     int last_plugin = -1;
@@ -1082,7 +1081,14 @@ int flb_main(int argc, char **argv)
             break;
         case 'J':
             if (last_plugin == -1) {
-                flb_help(EXIT_SUCCESS, config);
+                json = flb_help_build_json_schema(config);
+                if (!json) {
+                    exit(EXIT_FAILURE);
+                }
+
+                printf("%s\n", json);
+                flb_sds_destroy(json);
+                exit(0);
             }
             else {
                 flb_help_plugin(EXIT_SUCCESS, FLB_HELP_JSON, config,


### PR DESCRIPTION
The following patch introduces an extension to the config helper by providing a full JSON schema. It can be triggered as follows:

```bash
fluent-bit -J
```

This is the `pretty printed` version of the JSON output:

```json
{
  "fluent-bit": {
    "version": "1.9.0",
    "schema_version": "1",
    "os": "linux"
  },
  "customs": [
    {
      "type": "custom",
      "name": "calyptia",
      "description": "Calyptia Cloud",
      "properties": {
        "options": [
          {
            "name": "api_key",
            "description": "Calyptia Cloud API Key.",
            "default": null,
            "type": "string"
          },
          {
            "name": "store_path",
            "description": "",
            "default": null,
            "type": "string"
          },
          {
            "name": "calyptia_host",
            "description": "",
            "default": null,
            "type": "string"
          },
          {
            "name": "calyptia_port",
            "description": "",
            "default": null,
            "type": "string"
          },
          {
            "name": "calyptia_tls",
            "description": "",
            "default": "true",
            "type": "boolean"
          },
          {
            "name": "calyptia_tls.verify",
            "description": "",
            "default": "true",
            "type": "boolean"
          },
          {
            "name": "add_label",
            "description": "Label to append to the generated metric.",
            "default": null,
            "type": "space delimited strings (minimum 1)"
          },
          {
            "name": "machine_id",
            "description": "Custom machine_id to be used when registering agent",
            "default": null,
            "type": "string"
          }
        ]
      }
    }
  ],
  "inputs": [
    {
      "type": "input",
      "name": "cpu",
      "description": "CPU Usage",
      "properties": {
        "options": [
          {
            "name": "pid",
            "description": "Configure a single process to measure usage via their PID",
            "default": "-1",
            "type": "integer"
          },
          {
            "name": "interval_sec",
            "description": "Set the collector interval",
            "default": "1",
            "type": "integer"
          },
          {
            "name": "interval_nsec",
            "description": "Set the collector interval (sub seconds)",
            "default": "0",
            "type": "integer"
          }
        ]
      }
    },
    ......(redacted).......
            }
        ]
      }
    }
  ]
}
```

attached is tarball with the full  content: [1.9.0.schema.json.tar.gz](https://github.com/fluent/fluent-bit/files/8235244/1.9.0.schema.json.tar.gz)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
