### PR TITLE
http_client: add 'flb_http_get_header' to get the value of request header

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -148,6 +148,8 @@ struct flb_http_client *flb_http_client(struct flb_upstream_conn *u_conn,
 int flb_http_add_header(struct flb_http_client *c,
                         const char *key, size_t key_len,
                         const char *val, size_t val_len);
+flb_sds_t flb_http_get_header(struct flb_http_client *c,
+                              const char *key, size_t key_len);
 int flb_http_basic_auth(struct flb_http_client *c,
                         const char *user, const char *passwd);
 int flb_http_proxy_auth(struct flb_http_client *c,

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -915,6 +915,30 @@ int flb_http_add_header(struct flb_http_client *c,
     return 0;
 }
 
+/*
+ * flb_http_get_header looks up a first value of request header.
+ * The return value should be destroyed after using.
+ * The return value is NULL, if the value is not found.
+ */
+flb_sds_t flb_http_get_header(struct flb_http_client *c,
+                              const char *key, size_t key_len)
+{
+    flb_sds_t ret_str;
+    struct flb_kv *kv;
+    struct mk_list *head = NULL;
+    struct mk_list *tmp  = NULL;
+
+    mk_list_foreach_safe(head, tmp, &c->headers) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+        if (flb_sds_casecmp(kv->key, key, key_len) == 0) {
+            ret_str = flb_sds_create(kv->val);
+            return ret_str;
+        }
+    }
+
+    return NULL;
+}
+
 static int http_header_push(struct flb_http_client *c, struct flb_kv *header)
 {
     char *tmp;

--- a/tests/internal/http_client.c
+++ b/tests/internal/http_client.c
@@ -8,28 +8,88 @@
 
 #include "flb_tests_internal.h"
 
+struct test_ctx {
+    struct flb_upstream      *u;
+    struct flb_upstream_conn *u_conn;
+    struct flb_config        *config;
+};
+
+struct test_ctx* test_ctx_create()
+{
+    struct test_ctx *ret_ctx = NULL;
+
+    ret_ctx = flb_malloc(sizeof(struct test_ctx));
+    if (!TEST_CHECK(ret_ctx != NULL)) {
+        flb_errno();
+        TEST_MSG("flb_malloc(test_ctx) failed");
+        return NULL;
+    }
+    ret_ctx->u = NULL;
+    ret_ctx->u_conn = NULL;
+
+    ret_ctx->config = flb_config_init();
+    if(!TEST_CHECK(ret_ctx->config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        flb_free(ret_ctx);
+        return NULL;
+    }
+
+    ret_ctx->u = flb_upstream_create(ret_ctx->config, "127.0.0.1", 80, 0, NULL);
+    if (!TEST_CHECK(ret_ctx->u != NULL)) {
+        TEST_MSG("flb_upstream_create failed");
+        flb_config_exit(ret_ctx->config);
+        flb_free(ret_ctx);
+        return NULL;
+    }
+
+    ret_ctx->u_conn = flb_malloc(sizeof(struct flb_upstream_conn));
+    if(!TEST_CHECK(ret_ctx->u_conn != NULL)) {
+        flb_errno();
+        TEST_MSG("flb_malloc(flb_upstream_conn) failed");
+        flb_upstream_destroy(ret_ctx->u);
+        flb_config_exit(ret_ctx->config);
+        flb_free(ret_ctx);
+        return NULL;
+    }
+    ret_ctx->u_conn->u = ret_ctx->u;
+
+    return ret_ctx;
+}
+
+int test_ctx_destroy(struct test_ctx* ctx)
+{
+    if (!TEST_CHECK(ctx != NULL)) {
+        return -1;
+    }
+    if (ctx->u_conn) {
+        flb_free(ctx->u_conn);
+    }
+    if (ctx->u) {
+        flb_upstream_destroy(ctx->u);
+    }
+    if (ctx->config) {
+        flb_config_exit(ctx->config);
+    }
+
+    flb_free(ctx);
+    return 0;
+}
+
 void test_http_buffer_increase()
 {
     int ret;
     size_t s;
+    struct test_ctx *ctx;
     struct flb_http_client *c;
     struct flb_http_response *resp;
-    struct flb_upstream *u;
-    struct flb_upstream_conn *u_conn;
-    struct flb_config *config;
 
-    config = flb_config_init();
-    TEST_CHECK(config != NULL);
-
-    u = flb_upstream_create(config, "127.0.0.1", 80, 0, NULL);
-    TEST_CHECK(u != NULL);
-
-    u_conn = flb_malloc(sizeof(struct flb_upstream_conn));
-    TEST_CHECK(u_conn != NULL);
-    u_conn->u = u;
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
 
     /* Create HTTP client instance */
-    c = flb_http_client(u_conn, FLB_HTTP_GET, "/", NULL, 0,
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
                         "127.0.0.1", 80, NULL, 0);
     TEST_CHECK(c != NULL);
 
@@ -73,13 +133,345 @@ void test_http_buffer_increase()
     ret = strncmp(c->resp.payload, "__PAYLOAD__", 11);
     TEST_CHECK(ret == 0);
 
-    flb_free(u_conn);
     flb_http_client_destroy(c);
-    flb_upstream_destroy(u);
-    flb_config_exit(config);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_add_get_header()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    char *ua = "Fluent-Bit";
+    char *host = "127.0.0.1:80";
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check User-Agent */
+    ret = flb_http_add_header(c, "User-Agent", 10, ua, strlen(ua));
+    TEST_CHECK(ret == 0);
+
+    ret_str = flb_http_get_header(c, "User-Agent", 10);
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, ua, strlen(ua)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, ua);
+    }
+    flb_sds_destroy(ret_str);
+
+
+    /* Check Host */
+    ret_str = flb_http_get_header(c, "Host", 4);
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, host, strlen(host)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, host);
+    }
+
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_set_keepalive()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Set keepalive header */
+    ret = flb_http_set_keepalive(c);
+    TEST_CHECK(ret == 0);
+
+    ret_str = flb_http_get_header(c, FLB_HTTP_HEADER_CONNECTION,
+                                  strlen(FLB_HTTP_HEADER_CONNECTION));
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Compare */
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, FLB_HTTP_HEADER_KA, strlen(FLB_HTTP_HEADER_KA)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, FLB_HTTP_HEADER_KA);
+    }
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_strip_port_from_host()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    char *host_port = "127.0.0.1:80";
+    char *host = "127.0.0.1";
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check Host. It should contain port number */
+    ret_str = flb_http_get_header(c, "Host", 4);
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, host_port, strlen(host_port)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, host_port);
+    }
+    flb_sds_destroy(ret_str);
+
+
+    ret = flb_http_strip_port_from_host(c);
+    TEST_CHECK(ret == 0);
+
+    /* Check Host. Port number should be removed. */
+    ret_str = flb_http_get_header(c, "Host", 4);
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, host, strlen(host)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, host);
+    }
+
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_encoding_gzip()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    char *gzip = "gzip";
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check encoding. It should be error */
+    ret_str = flb_http_get_header(c, FLB_HTTP_HEADER_CONTENT_ENCODING,
+                                  strlen(FLB_HTTP_HEADER_CONTENT_ENCODING));
+    if (!TEST_CHECK(ret_str == NULL)) {
+        TEST_MSG("Got encoding? Header:%s", ret_str);
+        flb_sds_destroy(ret_str);
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_set_content_encoding_gzip(c);
+    TEST_CHECK(ret == 0);
+
+    /* Check Encoding */
+    ret_str = flb_http_get_header(c, FLB_HTTP_HEADER_CONTENT_ENCODING,
+                                  strlen(FLB_HTTP_HEADER_CONTENT_ENCODING));
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, gzip, strlen(gzip)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, gzip);
+    }
+
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_add_basic_auth_header()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    char *expect = "Basic dXNlcjpwYXNzd29yZA=="; /* user:password in base64 */
+    char *auth = FLB_HTTP_HEADER_AUTH;
+    const char *user = "user";
+    char *passwd = "password";
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check Autholization. It should be error. */
+    ret_str = flb_http_get_header(c, auth, strlen(auth));
+    if (!TEST_CHECK(ret_str == NULL)) {
+        TEST_MSG("Got auth? Header:%s", ret_str);
+        flb_sds_destroy(ret_str);
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_basic_auth(c, user, passwd);
+    TEST_CHECK(ret == 0);
+
+    /* Check Autholization. */
+    ret_str = flb_http_get_header(c, auth, strlen(auth));
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, expect, strlen(expect)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, expect);
+    }
+
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
+void test_http_add_proxy_auth_header()
+{
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    flb_sds_t ret_str;
+    char *expect = "Basic dXNlcjpwYXNzd29yZA=="; /* user:password in base64 */
+    char *auth = FLB_HTTP_HEADER_PROXY_AUTH;
+    const char *user = "user";
+    char *passwd = "password";
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Create HTTP client instance */
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    if(!TEST_CHECK(c != NULL)) {
+        TEST_MSG("flb_http_client failed");
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check autholization header. It should be error. */
+    ret_str = flb_http_get_header(c, auth, strlen(auth));
+    if (!TEST_CHECK(ret_str == NULL)) {
+        TEST_MSG("Got auth? Header:%s", ret_str);
+        flb_sds_destroy(ret_str);
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_proxy_auth(c, user, passwd);
+    TEST_CHECK(ret == 0);
+
+    /* Check autholization header. */
+    ret_str = flb_http_get_header(c, auth, strlen(auth));
+    if (!TEST_CHECK(ret_str != NULL)) {
+        TEST_MSG("flb_http_get_header failed");
+        flb_http_client_destroy(c);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(flb_sds_cmp(ret_str, expect, strlen(expect)) == 0)) {
+        TEST_MSG("strcmp failed. got=%s expect=%s", ret_str, expect);
+    }
+
+    flb_sds_destroy(ret_str);
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
 }
 
 TEST_LIST = {
-    { "http_buffer_increase", test_http_buffer_increase},
+    { "http_buffer_increase"  , test_http_buffer_increase},
+    { "add_get_header"        , test_http_add_get_header},
+    { "set_keepalive"         , test_http_set_keepalive},
+    { "strip_port_from_host"  , test_http_strip_port_from_host},
+    { "encoding_gzip"         , test_http_encoding_gzip},
+    { "add_basic_auth_header" , test_http_add_basic_auth_header},
+    { "add_proxy_auth_header" , test_http_add_proxy_auth_header},
     { 0 }
 };


### PR DESCRIPTION
This PR is to
* Add `flb_http_get_header` to get the value of request header
* Add test cases for http request header 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-it-http_client 
Test http_buffer_increase...                    [2022/03/12 08:27:17] [error] [http] requested buffer size 1 (bytes) needs to be greater than minimum size allowed 4096 (bytes)
[ OK ]
Test add_get_header...                          [ OK ]
Test set_keepalive...                           [ OK ]
Test strip_port_from_host...                    [ OK ]
Test encoding_gzip...                           [ OK ]
Test add_basic_auth_header...                   [ OK ]
Test add_proxy_auth_header...                   [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-http_client 
==8633== Memcheck, a memory error detector
==8633== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8633== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==8633== Command: bin/flb-it-http_client
==8633== 
Test http_buffer_increase...                    [2022/03/12 08:27:44] [error] [http] requested buffer size 1 (bytes) needs to be greater than minimum size allowed 4096 (bytes)
==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_get_header...                          ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test set_keepalive...                           ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test strip_port_from_host...                    ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test encoding_gzip...                           ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_basic_auth_header...                   ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_proxy_auth_header...                   ==8633== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==8633== 
==8633== HEAP SUMMARY:
==8633==     in use at exit: 0 bytes in 0 blocks
==8633==   total heap usage: 5,142 allocs, 5,142 frees, 1,411,898 bytes allocated
==8633== 
==8633== All heap blocks were freed -- no leaks are possible
==8633== 
==8633== For lists of detected and suppressed errors, rerun with: -s
==8633== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
