### PR TITLE
time: support timestamp extension type for msgpack functions

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -35,12 +35,16 @@ struct flb_time {
    see also
    https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v0#eventtime-ext-format
    https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
+
+   Timestamp extension type
+   https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
  */
 enum flb_time_eventtime_fmt {
     FLB_TIME_ETFMT_INT = 1,   /* second(integer) only */
     FLB_TIME_ETFMT_V0,        /* EventTime (v0) */
     FLB_TIME_ETFMT_V1_EXT,    /* EventTime (v1 ext) */
     FLB_TIME_ETFMT_V1_FIXEXT, /* EventTime (v1 fixext) */
+    FLB_TIME_EXTENSION,       /* Timestamp extension type */
     FLB_TIME_ETFMT_OTHER,
 };
 

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -271,6 +271,10 @@ int flb_time_msgpack_to_time(struct flb_time *time, msgpack_object *obj)
     case MSGPACK_OBJECT_EXT:
         if (obj->via.ext.type == 0) {
             /* EventTime Ext Format */
+            if (obj->via.ext.size != 8) {
+                flb_warn("invalid ext size=%d", obj->via.ext.size);
+                return -1;
+            }
             memcpy(&tmp, &obj->via.ext.ptr[0], 4);
             time->tm.tv_sec = (uint32_t) ntohl(tmp);
             memcpy(&tmp, &obj->via.ext.ptr[4], 4);


### PR DESCRIPTION
MessagePack supports `Timestamp extension type`.
https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
This patch is to support the type for msgpack family functions. (mpack doesn't support. next patch)

The type supports 64bit integer format.
(The current data type `EventTime` only supports 32bit integer.)
https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format




- Decode
  - Fluent-bit can decode if the timestamp type is  `Timestamp extension type`.
- Encode
  - Default type is `EventTime` to prevent breaking change.
  - Encode `Timestamp extension type` if user sets `FLB_TIME_EXTENSION`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug Log

```
$ bin/flb-it-flb_time 
Test flb_time_to_nanosec...                     [ OK ]
Test msgpack_to_time_int...                     [ OK ]
Test msgpack_to_time_double...                  [ OK ]
Test msgpack_to_time_eventtime...               [ OK ]
Test msgpack_to_time_timestamp_32...            [ OK ]
Test msgpack_to_time_timestamp_64...            [ OK ]
Test msgpack_to_time_timestamp_96...            [ OK ]
Test append_to_msgpack_eventtime...             [ OK ]
Test append_to_msgpack_timestamp_96...          [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-flb_time 
==94633== Memcheck, a memory error detector
==94633== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==94633== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==94633== Command: bin/flb-it-flb_time
==94633== 
Test flb_time_to_nanosec...                     [ OK ]
Test msgpack_to_time_int...                     [ OK ]
Test msgpack_to_time_double...                  [ OK ]
Test msgpack_to_time_eventtime...               [ OK ]
Test msgpack_to_time_timestamp_32...            [ OK ]
Test msgpack_to_time_timestamp_64...            [ OK ]
Test msgpack_to_time_timestamp_96...            [ OK ]
Test append_to_msgpack_eventtime...             [ OK ]
Test append_to_msgpack_timestamp_96...          [ OK ]
SUCCESS: All unit tests have passed.
==94633== 
==94633== HEAP SUMMARY:
==94633==     in use at exit: 0 bytes in 0 blocks
==94633==   total heap usage: 22 allocs, 22 frees, 116,240 bytes allocated
==94633== 
==94633== All heap blocks were freed -- no leaks are possible
==94633== 
==94633== For lists of detected and suppressed errors, rerun with: -s
==94633== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
