### PR TITLE
packaging: add publish script

### DIFF
--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -eux
+
+SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
+APTLY_CONFIG=${APTLY_CONFIG:-$HOME/.aptly.conf}
+
+if [ -z "$1" ]; then
+    echo "Usage: ./publish_all  new_version"
+    echo "                          |      "
+    echo "                        -----    "
+    echo "                        1.9.1    "
+    echo
+    exit 1
+fi
+VERSION="$1"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Missing source directory: $SOURCE_DIR"
+fi
+
+# Amazon Linux 2
+echo "Publishing AmazonLinux 2"
+find "$SOURCE_DIR/amazonlinux/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64"
+
+find "$SOURCE_DIR/amazonlinux/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64"
+
+# Centos 7
+echo "Publishing Centos 7"
+find "$SOURCE_DIR/centos/7/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/7/aarch64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/centos/7/aarch64"
+
+find "$SOURCE_DIR/centos/7/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/7/x86_64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/centos/7/x86_64"
+
+# Centos 8
+echo "Publishing Centos 8"
+find "$SOURCE_DIR/centos/8/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/8/aarch64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/centos/8/aarch64"
+
+find "$SOURCE_DIR/centos/8/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/8/x86_64" \;
+createrepo -dvp "/var/www/apt.fluentbit.io/centos/8/x86_64"
+
+# Debian 10 Buster
+echo "Publishing Debian 10 Buster"
+# Conflicts otherwise with existing
+find "$SOURCE_DIR/debian/buster/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-debian-buster {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-debian-buster-${VERSION}" from repo flb-debian-buster
+aptly -config="$APTLY_CONFIG" publish switch buster filesystem:debian/buster: "fluent-bit-debian-buster-${VERSION}"
+
+# Debian 11 Bullseye
+echo "Publishing Debian 11 Bullseye"
+find "$SOURCE_DIR/debian/bullseye/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-debian-bullseye {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-debian-bullseye-${VERSION}" from repo flb-debian-bullseye
+aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:debian/bullseye: "fluent-bit-debian-bullseye-${VERSION}"
+
+# Raspbian 10 Buster
+echo "Publishing Raspbian 10 Buster"
+find "$SOURCE_DIR/raspbian/buster/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-raspbian-buster {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-raspbian-buster-${VERSION}" from repo flb-raspbian-buster
+aptly -config="$APTLY_CONFIG" publish switch buster filesystem:raspbian/buster: "fluent-bit-raspbian-buster-${VERSION}"
+
+# Raspbian 11 Bullseye
+echo "Publishing Raspbian 11 Bullseye"
+find "$SOURCE_DIR/raspbian/bullseye/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-raspbian-bullseye {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-raspbian-bullseye-${VERSION}" from repo flb-raspbian-bullseye
+aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:raspbian/bullseye: "fluent-bit-raspbian-bullseye-${VERSION}"
+
+# Ubuntu 16.04 Xenial
+echo "Publishing Ubuntu 16.04 Xenial"
+find "$SOURCE_DIR/ubuntu/xenial/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-xenial {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-xenial-${VERSION}" from repo flb-ubuntu-xenial
+aptly -config="$APTLY_CONFIG" publish switch xenial filesystem:ubuntu/xenial: "fluent-bit-ubuntu-xenial-${VERSION}"
+
+# Ubuntu 18.04 Bionic
+echo "Publishing Ubuntu 18.04 Bionic"
+find "$SOURCE_DIR/ubuntu/bionic/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-bionic {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-bionic-${VERSION}" from repo flb-ubuntu-bionic
+aptly -config="$APTLY_CONFIG" publish switch bionic filesystem:ubuntu/bionic: "fluent-bit-ubuntu-bionic-${VERSION}"
+
+# Ubuntu 20.04 Focal
+echo "Publishing Ubuntu 20.04 Focal"
+find "$SOURCE_DIR/ubuntu/focal/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-focal {} \;
+aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-focal-${VERSION}" from repo flb-ubuntu-focal
+aptly -config="$APTLY_CONFIG" publish switch focal filesystem:ubuntu/focal: "fluent-bit-ubuntu-focal-${VERSION}"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Add the packaging server publish script so we can automate the full process.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
