### PR TITLE
packaging: add auto-call publish-all

### DIFF
--- a/.github/actions/release-server-sync/action.yaml
+++ b/.github/actions/release-server-sync/action.yaml
@@ -20,6 +20,10 @@ inputs:
   server_key:
     description: The SSH key to use for authentication.
     required: true
+  server_aptly_config:
+    description: The Aptly config file to use for all repositories.
+    required: false
+    default: "/etc/aptly.conf"
 
 runs:
   using: "composite"
@@ -61,10 +65,14 @@ runs:
       USERNAME: ${{ inputs.server_username }}
     shell: bash
 
-  # We could also automate the final step here eventually to get the packages "live"
-  # - name: Publish on build server
-  #   run: |
-  #     ssh $USERNAME@$HOST /bin/bash /home/$USERNAME/publish_all.sh "$VERSION"
-  #   env:
-  #     VERSION: ${{ inputs.version }}
-  #   shell: bash
+  # Automate the final step here to get the packages "live"
+  - name: Publish on build server
+    run: |
+      scp ./packaging/server/publish-all.sh $USERNAME@$HOST:/home/$USERNAME/publish-all.sh
+      ssh $USERNAME@$HOST APTLY_CONFIG="$APTLY_CONFIG" /bin/bash /home/$USERNAME/publish-all.sh "$VERSION"
+    env:
+      VERSION: ${{ inputs.version }}
+      HOST: ${{ inputs.server_hostname }}
+      USERNAME: ${{ inputs.server_username }}
+      APTLY_CONFIG: ${{ inputs.server_aptly_config || '/etc/aptly.conf' }}
+    shell: bash

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -137,6 +137,7 @@ jobs:
         server_hostname: ${{ secrets.FLUENTBITIO_HOST }}
         server_username: ${{ secrets.FLUENTBITIO_USERNAME }}
         server_key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+        server_aptly_config: ${{ secrets.FLUENTBITIO_APTLY_CONFIG }}
 
   # Simple skopeo copy jobs to transfer image from staging to release registry with optional GPG key signing.
   # Unfortunately skopeo currently does not support Cosign: https://github.com/containers/skopeo/issues/1533


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Related to #4875 but to provide auto publishing of packages on the appropriate server.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
