### PR TITLE
dockerfiles: add extra debug tools

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -194,7 +194,16 @@ RUN apt-get update && \
         libatomic1 \
         libgcrypt20 \
         libyaml-0-2 \
-        bash gdb valgrind build-essential \
+        # build/code
+        bash gdb valgrind build-essential  \
+        git bash-completion vim tmux jq \
+        # network
+        dnsutils iputils-ping iputils-arping iputils-tracepath iputils-clockdiff \
+        tcpdump curl nmap tcpflow iftop \
+        net-tools mtr netcat-openbsd bridge-utils iperf ngrep \
+        openssl \
+        # processes/io
+        htop atop strace iotop sysstat ltrace ncdu logrotate hdparm pciutils psmisc tree pv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Adds requested tools plus a lot of others from #5074.
Debug image should be very complete now hopefully!

Size increase:
```
$ docker build -t test --target=debug -f ./dockerfiles/Dockerfile .
$ docker images
REPOSITORY                                                             TAG              IMAGE ID       CREATED         SIZE
test                                                                   latest           9e6a7eb23439   4 seconds ago   717MB
fluent/fluent-bit                                                      1.9.0-debug      75c1ff776cb6   2 days ago      545MB
...
$ docker run --rm -it test
Fluent Bit v1.9.0
* Git commit: 1f3c282168ec0b8a6229b30f695730d6cb3771c7
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/14 19:23:30] [ info] [engine] started (pid=1)
[2022/03/14 19:23:30] [ info] [storage] version=1.1.6, initializing...
[2022/03/14 19:23:30] [ info] [storage] in-memory
[2022/03/14 19:23:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/14 19:23:30] [ info] [cmetrics] version=0.3.0
[2022/03/14 19:23:30] [ info] [sp] stream processor started
[2022/03/14 19:23:30] [ info] [output:stdout:stdout.0] worker #0 started
[0] cpu.local: [1647285810.472079302, {"cpu_p"=>0.062500, "user_p"=>0.062500, "system_p"=>0.000000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>0.000000, "cpu2.p_user"=>0.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>1.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>1.000000, "cpu4.p_cpu"=>0.000000, "cpu4.p_user"=>0.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>0.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>0.000000, "cpu6.p_cpu"=>0.000000, "cpu6.p_user"=>0.000000, "cpu6.p_system"=>0.000000, "cpu7.p_cpu"=>0.000000, "cpu7.p_user"=>0.000000, "cpu7.p_system"=>0.000000, "cpu8.p_cpu"=>0.000000, "cpu8.p_user"=>0.000000, "cpu8.p_system"=>0.000000, "cpu9.p_cpu"=>0.000000, "cpu9.p_user"=>0.000000, "cpu9.p_system"=>0.000000, "cpu10.p_cpu"=>0.000000, "cpu10.p_user"=>0.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>0.000000, "cpu11.p_user"=>0.000000, "cpu11.p_system"=>0.000000, "cpu12.p_cpu"=>0.000000, "cpu12.p_user"=>0.000000, "cpu12.p_system"=>0.000000, "cpu13.p_cpu"=>0.000000, "cpu13.p_user"=>0.000000, "cpu13.p_system"=>0.000000, "cpu14.p_cpu"=>0.000000, "cpu14.p_user"=>0.000000, "cpu14.p_system"=>0.000000, "cpu15.p_cpu"=>0.000000, "cpu15.p_user"=>0.000000, "cpu15.p_system"=>0.000000}]
...
$  docker run --rm -it test bash
root@8179d92c4865:/# netstat
Active Internet connections (w/o servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State      
Active UNIX domain sockets (w/o servers)
Proto RefCnt Flags       Type       State         I-Node   Path
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
