### PR TITLE
multiline: cri: Use non-greedy parsing for parsing time

### DIFF
--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -22,7 +22,7 @@
 #include <fluent-bit/multiline/flb_ml_parser.h>
 
 #define FLB_ML_CRI_REGEX                                                \
-  "^(?<time>.+) (?<stream>stdout|stderr) (?<_p>F|P) (?<log>.*)$"
+  "^(?<time>.+?) (?<stream>stdout|stderr) (?<_p>F|P) (?<log>.*)$"
 #define FLB_ML_CRI_TIME                         \
   "%Y-%m-%dT%H:%M:%S.%L%z"
 


### PR DESCRIPTION
Fixes #4377 and #5010

If a pod logs in cri format, you potentially have fluent-bit parsing this

```<time> <stream> <_p> <log_a>```
where log_a is also in cri format 
```<time> <stream> <_p> <log_b>```

This causes time regex to be greedy and you run into issues of invalid time format and time string length is too long.

This also causes fluent-bit to go into an infinite loop of rejecting its own logs 
```
./fluent-bit-containerd-7dfm9_logging_fluent-bit-7faa06256bcf2ec5b526ce780d77c60f1fe10e92649679891ecb9c5b3f1f8efc.log:2022-03-14T16:24:20.770455995-06:00 stderr F [2022/03/14 22:24:20] [ warn] [parser:_ml_cri] invalid time format %Y-%m-%dT%H:%M:%S.%L%z for '2022-03-14T16:24:18.778252457-06:00 stderr F [2022/03/14 22:24:18] [ warn] [parser:_ml_cri] invalid time format %Y-%m-%dT%H:%M:%S.%L%z for '2022-03-14T16:24:16.798195119-06:00'
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
