### PR TITLE
install: support Rocky and Alma Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ EOF
 yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
-    centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora)
+    centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
         sudo sh <<'SCRIPT'
 rpm --import https://packages.fluentbit.io/fluentbit.key
 cat > /etc/yum.repos.d/fluent-bit.repo <<EOF


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Updated to support Alma and Rocky Linux as a CentOS equivalent.

----
**Testing**

Failing commands before now pass:
```
$ docker run --rm -it almalinux:8 sh -c "yum install -y curl sudo; curl https://raw.githubusercontent.com/fluent/fluent-bit/349478fa95e57496aabf341b6054dc2ee639d0ac/install.sh| sh"
$ docker run --rm -it rockylinux:8 sh -c "yum install -y curl sudo; curl https://raw.githubusercontent.com/fluent/fluent-bit/349478fa95e57496aabf341b6054dc2ee639d0ac/install.sh| sh"
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
