### PR TITLE
packaging: add updates for server publishing

### DIFF
--- a/packaging/server/README.md
+++ b/packaging/server/README.md
@@ -1,0 +1,1 @@
+This directory contains the necessary files to support publishing release packages.

--- a/packaging/server/aptly.conf
+++ b/packaging/server/aptly.conf
@@ -1,0 +1,76 @@
+{
+  "rootDir": "/var/www/apt.fluentbit.io",
+  "downloadConcurrency": 4,
+  "downloadSpeedLimit": 0,
+  "architectures": ["i386", "amd64", "arm64", "armhf"],
+  "dependencyFollowSuggests": false,
+  "dependencyFollowRecommends": false,
+  "dependencyFollowAllVariants": false,
+  "dependencyFollowSource": false,
+  "dependencyVerboseResolve": false,
+  "gpgDisableSign": false,
+  "gpgDisableVerify": false,
+  "gpgProvider": "gpg2",
+  "downloadSourcePackages": false,
+  "skipLegacyPool": true,
+  "ppaDistributorID": "ubuntu",
+  "ppaCodename": "",
+  "skipContentsPublishing": false,
+  "FileSystemPublishEndpoints": {
+    "debian/jessie": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/jessie",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "debian/stretch": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/stretch",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "debian/buster": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/buster",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "debian/bullseye": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/bullseye",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "ubuntu/xenial": {
+      "rootDir": "/var/www/apt.fluentbit.io/ubuntu/xenial",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "ubuntu/bionic": {
+      "rootDir": "/var/www/apt.fluentbit.io/ubuntu/bionic",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "ubuntu/focal": {
+      "rootDir": "/var/www/apt.fluentbit.io/ubuntu/focal",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "raspbian/jessie": {
+      "rootDir": "/var/www/apt.fluentbit.io/raspbian/jessie",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "raspbian/stretch": {
+      "rootDir": "/var/www/apt.fluentbit.io/raspbian/stretch",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "raspbian/buster": {
+      "rootDir": "/var/www/apt.fluentbit.io/raspbian/buster",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "raspbian/bullseye": {
+      "rootDir": "/var/www/apt.fluentbit.io/raspbian/bullseye",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    }
+  }
+}

--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -2,7 +2,7 @@
 set -eux
 
 SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
-APTLY_CONFIG=${APTLY_CONFIG:-$HOME/.aptly.conf}
+APTLY_CONFIG=${APTLY_CONFIG:-/etc/aptly.conf}
 
 if [ -z "$1" ]; then
     echo "Usage: ./publish_all  new_version"
@@ -47,40 +47,68 @@ echo "Publishing Debian 10 Buster"
 # Conflicts otherwise with existing
 find "$SOURCE_DIR/debian/buster/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-debian-buster {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-debian-buster-${VERSION}" from repo flb-debian-buster
-aptly -config="$APTLY_CONFIG" publish switch buster filesystem:debian/buster: "fluent-bit-debian-buster-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch buster filesystem:debian/buster: "fluent-bit-debian-buster-${VERSION}" ; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-debian-buster-${VERSION}"
+    exit 1
+fi
 
 # Debian 11 Bullseye
 echo "Publishing Debian 11 Bullseye"
 find "$SOURCE_DIR/debian/bullseye/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-debian-bullseye {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-debian-bullseye-${VERSION}" from repo flb-debian-bullseye
-aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:debian/bullseye: "fluent-bit-debian-bullseye-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:debian/bullseye: "fluent-bit-debian-bullseye-${VERSION}"; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-debian-bullseye-${VERSION}"
+    exit 1
+fi
 
 # Raspbian 10 Buster
 echo "Publishing Raspbian 10 Buster"
 find "$SOURCE_DIR/raspbian/buster/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-raspbian-buster {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-raspbian-buster-${VERSION}" from repo flb-raspbian-buster
-aptly -config="$APTLY_CONFIG" publish switch buster filesystem:raspbian/buster: "fluent-bit-raspbian-buster-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch buster filesystem:raspbian/buster: "fluent-bit-raspbian-buster-${VERSION}" ; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-raspbian-buster-${VERSION}"
+    exit 1
+fi
 
 # Raspbian 11 Bullseye
 echo "Publishing Raspbian 11 Bullseye"
 find "$SOURCE_DIR/raspbian/bullseye/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-raspbian-bullseye {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-raspbian-bullseye-${VERSION}" from repo flb-raspbian-bullseye
-aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:raspbian/bullseye: "fluent-bit-raspbian-bullseye-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch bullseye filesystem:raspbian/bullseye: "fluent-bit-raspbian-bullseye-${VERSION}" ; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-raspbian-bullseye-${VERSION}"
+    exit 1
+fi
 
 # Ubuntu 16.04 Xenial
 echo "Publishing Ubuntu 16.04 Xenial"
 find "$SOURCE_DIR/ubuntu/xenial/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-xenial {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-xenial-${VERSION}" from repo flb-ubuntu-xenial
-aptly -config="$APTLY_CONFIG" publish switch xenial filesystem:ubuntu/xenial: "fluent-bit-ubuntu-xenial-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch xenial filesystem:ubuntu/xenial: "fluent-bit-ubuntu-xenial-${VERSION}" ; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-ubuntu-xenial-${VERSION}"
+    exit 1
+fi
 
 # Ubuntu 18.04 Bionic
 echo "Publishing Ubuntu 18.04 Bionic"
 find "$SOURCE_DIR/ubuntu/bionic/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-bionic {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-bionic-${VERSION}" from repo flb-ubuntu-bionic
-aptly -config="$APTLY_CONFIG" publish switch bionic filesystem:ubuntu/bionic: "fluent-bit-ubuntu-bionic-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch bionic filesystem:ubuntu/bionic: "fluent-bit-ubuntu-bionic-${VERSION}" ; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-ubuntu-bionic-${VERSION}"
+    exit 1
+fi
 
 # Ubuntu 20.04 Focal
 echo "Publishing Ubuntu 20.04 Focal"
 find "$SOURCE_DIR/ubuntu/focal/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-ubuntu-focal {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-ubuntu-focal-${VERSION}" from repo flb-ubuntu-focal
-aptly -config="$APTLY_CONFIG" publish switch focal filesystem:ubuntu/focal: "fluent-bit-ubuntu-focal-${VERSION}"
+if ! aptly -config="$APTLY_CONFIG" publish switch focal filesystem:ubuntu/focal: "fluent-bit-ubuntu-focal-${VERSION}"; then
+    # Cleanup snapshot in case we want to retry later
+    aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-ubuntu-focal-${VERSION}"
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Updates to capture anything required for server-side publishing.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
