### PR TITLE
aws: check AWS EC2 IMDSv2 client error

### DIFF
--- a/src/aws/flb_aws_imds.c
+++ b/src/aws/flb_aws_imds.c
@@ -167,6 +167,11 @@ int flb_aws_imds_request_by_key(struct flb_aws_imds *ctx, const char *metadata_p
         flb_debug("[imds] refreshed IMDSv2 token");
         c = ec2_imds_client->client_vtable->request(
             ec2_imds_client, FLB_HTTP_GET, metadata_path, NULL, 0, &token_header, 1);
+        if (!c) {
+            /* Exit gracefully allowing for retries */
+            flb_warn("[imds] failed to retrieve metadata");
+            return -1;
+        }
     }
 
     if (c->resp.status != 200) {


### PR DESCRIPTION
Fluent Bit sometimes crashes with segfault when calling the AWS SigV4 code. Core dump shows that null pointer is accessed in the IMDSv2 function.

* Added a check for IMDSv2 EC2 client. The same check is done earlier in the same function.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #5084
----
See also PR #5085 to _master_ branch. Testing was done on _master_ branch.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
  This crash is rare, and I didn't want to enable _debug_ log output on all instances, so instead I temporarily changed _debug_ logging to _info_ inside the `flb_aws_imds_request_by_key` function. I also temporarily changed the message of the newly added check to _failed to retrieve metadata 2_ to see when it happens in logs.
  ```
  [2022/03/15 05:54:05] [ info] [imds] invalid token
  [2022/03/15 05:54:05] [ info] [imds] refreshed IMDSv2 token
  [2022/03/15 05:54:05] [ warn] [http_client] malformed HTTP response from 169.254.169.254:80 on connection #181
  [2022/03/15 05:54:05] [ warn] [imds] failed to retrieve metadata 2
  [2022/03/15 05:54:05] [error] [output:bigquery:bigquery_***] Google STS token response status: 400, payload:
  {"error":"invalid_grant","error_description":"Received invalid AWS response of type ExpiredToken with error message: The security token included in the request is expired"}
  [2022/03/15 05:54:05] [error] [output:bigquery:bigquery_***] cannot retrieve oauth2 token
  [2022/03/15 05:54:05] [ info] [imds] invalid token
  [2022/03/15 05:54:05] [ info] [imds] refreshed IMDSv2 token
  [2022/03/15 05:54:05] [ warn] [engine] failed to flush chunk '19644-1647348845.133732374.flb', retry in 7 seconds: task_id=0, input=tail_*** > output=bigquery_*** (out_id=7)
  [2022/03/15 05:54:12] [ info] [output:bigquery:bigquery_***] Retrieved Google service account OAuth token via Identity Federation
  ```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
  ```
  ==30827==
  Fluent Bit v1.9.0
  * Copyright (C) 2015-2021 The Fluent Bit Authors
  * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
  * https://fluentbit.io
  
  [2022/03/15 09:40:17] [error] [parser] parser named 'service.haproxy' already exists, skip.
  ==30827== Warning: client switching stacks?  SP change: 0x1781bad8 --> 0x18142c30
  ==30827==          to suppress, use: --max-stackframe=9597272 or greater
  ==30827== Warning: client switching stacks?  SP change: 0x18142b98 --> 0x1781bad8
  ==30827==          to suppress, use: --max-stackframe=9597120 or greater
  ==30827== Warning: client switching stacks?  SP change: 0x1781bb88 --> 0x18142b98
  ==30827==          to suppress, use: --max-stackframe=9596944 or greater
  ==30827==          further instances of this message will not be shown.
  ==30827== Thread 6 monkey: wrk/0:
  ==30827== Use of uninitialised value of size 8
  ==30827==    at 0x608C35B: _itoa_word (in /lib64/libc-2.17.so)
  ==30827==
  ==30827== Conditional jump or move depends on uninitialised value(s)
  ==30827==    at 0x608C365: _itoa_word (in /lib64/libc-2.17.so)
  ==30827==
  ==30827== Conditional jump or move depends on uninitialised value(s)
  ==30827==    at 0x609062F: vfprintf (in /lib64/libc-2.17.so)
  ==30827==
  ==30827== Conditional jump or move depends on uninitialised value(s)
  ==30827==    at 0x608ED5B: vfprintf (in /lib64/libc-2.17.so)
  ==30827==
  ==30827== Conditional jump or move depends on uninitialised value(s)
  ==30827==    at 0x608EDDE: vfprintf (in /lib64/libc-2.17.so)
  ==30827==
  ^C[2022/03/15 09:41:07] [engine] caught signal (SIGINT)
  ...
  ==30827== Thread 2 flb-pipeline:
  ==30827== Invalid read of size 4
  ==30827==    at 0x7F8B92: mk_stop (mk_lib.c:254)
  ==30827==    by 0x511CAC: flb_hs_destroy (flb_hs.c:125)
  ==30827==    by 0x4E405D: flb_engine_shutdown (flb_engine.c:930)
  ==30827==    by 0x4E3CF5: flb_engine_start (flb_engine.c:821)
  ==30827==    by 0x4C41A2: flb_lib_worker (flb_lib.c:626)
  ==30827==    by 0x4E3BE74: start_thread (in /lib64/libpthread-2.17.so)
  ==30827==    by 0x6142A2C: clone (in /lib64/libc-2.17.so)
  ==30827==  Address 0x12d1039c is 396 bytes inside a block of size 744 free'd
  ==30827==    at 0x4C29CDD: free (vg_replace_malloc.c:530)
  ==30827==    by 0x7FD38B: mk_mem_free (mk_memory.h:102)
  ==30827==    by 0x7FD709: mk_config_free_all (mk_config.c:106)
  ==30827==    by 0x80C088: mk_exit_all (monkey.c:218)
  ==30827==    by 0x7F89FB: mk_lib_worker (mk_lib.c:174)
  ==30827==    by 0x4E3BE74: start_thread (in /lib64/libpthread-2.17.so)
  ==30827==    by 0x6142A2C: clone (in /lib64/libc-2.17.so)
  ==30827==  Block was alloc'd at
  ==30827==    at 0x4C2A975: calloc (vg_replace_malloc.c:711)
  ==30827==    by 0x80BB8F: mk_mem_alloc_z (mk_memory.h:70)
  ==30827==    by 0x80BD7D: mk_server_create (monkey.c:89)
  ==30827==    by 0x7F8735: mk_create (mk_lib.c:61)
  ==30827==    by 0x511ACF: flb_hs_create (flb_hs.c:77)
  ==30827==    by 0x4E38A9: flb_engine_start (flb_engine.c:721)
  ==30827==    by 0x4C41A2: flb_lib_worker (flb_lib.c:626)
  ==30827==    by 0x4E3BE74: start_thread (in /lib64/libpthread-2.17.so)
  ==30827==    by 0x6142A2C: clone (in /lib64/libc-2.17.so)
  ==30827==
  ==30827==
  ==30827== HEAP SUMMARY:
  ==30827==     in use at exit: 102,248 bytes in 3,427 blocks
  ==30827==   total heap usage: 3,363,777 allocs, 3,360,350 frees, 2,002,289,099 bytes allocated
  ==30827==
  ==30827== LEAK SUMMARY:
  ==30827==    definitely lost: 56 bytes in 1 blocks
  ==30827==    indirectly lost: 0 bytes in 0 blocks
  ==30827==      possibly lost: 0 bytes in 0 blocks
  ==30827==    still reachable: 102,192 bytes in 3,426 blocks
  ==30827==         suppressed: 0 bytes in 0 blocks
  ==30827== Rerun with --leak-check=full to see details of leaked memory
  ==30827==
  ==30827== For counts of detected and suppressed errors, rerun with: -v
  ==30827== Use --track-origins=yes to see where uninitialised values come from
  ==30827== ERROR SUMMARY: 91 errors from 6 contexts (suppressed: 0 from 0)
  ```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
