### PR TITLE
workflows: add regular unstable triggering staging

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -1,0 +1,37 @@
+name: Composite action to generate the matrix of targets to build packages for.
+description: Remove any duplication of this information so we only have to update in one place.
+
+inputs:
+  target:
+    description: Override to build a single target for debug/test only.
+    required: false
+outputs:
+  build-matrix:
+    description: The build matrix we have created.
+    value: ${{ steps.set-matrix.outputs.matrix }}
+runs:
+  using: "composite"
+  steps:
+    - id: set-matrix
+      run: |
+        matrix=$((
+          echo '{ "distro" : ['
+          echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
+          echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8",'
+          echo '"debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
+          echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
+          echo '"raspbian/buster", "raspbian/bullseye"'
+          echo ']}'
+        ) | jq -c .)
+        if [ -n "${{ inputs.target || '' }}" ]; then
+          echo "Overriding matrix to build: ${{ inputs.target }}"
+          matrix=$((
+            echo '{ "distro" : ['
+            echo '"${{ inputs.target }}"'
+            echo ']}'
+          ) | jq -c .)
+        fi
+        echo $matrix
+        echo $matrix| jq .
+        echo "::set-output name=matrix::$matrix"
+      shell: bash

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -7,6 +7,16 @@ on:
         description: The Github environment to run this workflow on.
         type: string
         required: false
+      ref:
+        description: The commit, tag or branch to checkout for testing scripts.
+        type: string
+        default: master
+        required: false
+      release-name:
+        description: The URL of where to pull packages from.
+        required: false
+        type: string
+        default: ''
     secrets:
       token:
         description: The Github token or similar to authenticate with.
@@ -24,6 +34,18 @@ jobs:
     name: ${{ matrix.distro }} package tests
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    # Run a local Minio service for non-staging tests to use
+    services:
+      minio:
+        image: lazybit/minio
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+        volumes:
+          - ${{ github.workspace }}/data:/data
+        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
     env:
         AWS_URL: https://${{ secrets.bucket }}.s3.amazonaws.com
     strategy:
@@ -31,20 +53,40 @@ jobs:
       matrix:
         distro: [ amazonlinux2, centos7, centos8, debian10, debian11, ubuntu1804, ubuntu2004 ]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || 'master' }}
 
-    - name: Get the version
-      id: get_version
-      run: |
-        curl --fail -LO "$AWS_URL/latest-version.txt"
-        VERSION=$(cat latest-version.txt)
-        echo ::set-output name=VERSION::$VERSION
-      shell: bash
+      - name: Run package installation tests from Minio
+        if: inputs.release-name != ''
+        run: |
+          gh release download ${{ inputs.release-name }}
+          if [[ ! -f "packages-${{ inputs.release-name }}.tar.gz" ]] ; then
+            echo "Unable to find packages for release: "
+            exit 1
+          fi
+          mkdir -p $LOCAL_RELEASE_DIR
+          tar -xzvf packages-${{ inputs.release-name }}.tar.gz -C $LOCAL_RELEASE_DIR
 
-    - name: Run package installation tests
-      run: |
-        packaging/testing/smoke/packages/run-package-tests.sh
-      env:
-        PACKAGE_TEST: ${{ matrix.distro }}
-        RELEASE_URL: https://packages.fluentbit.io
+          export AWS_ACCESS_KEY_ID=minioadmin
+          export AWS_SECRET_ACCESS_KEY=minioadmin
+          export AWS_EC2_METADATA_DISABLED=true
+
+          aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://${{ secrets.bucket }}
+          aws --endpoint-url http://127.0.0.1:9000/ s3 sync "$LOCAL_RELEASE_DIR" "s3://${{ secrets.bucket }} --follow-symlinks --no-progress
+
+          export AWS_URL=http://127.0.0.1:9000
+          packaging/testing/smoke/packages/run-package-tests.sh
+        shell: bash
+        env:
+          LOCAL_RELEASE_DIR: local-release
+
+      - name: Run package installation tests from AWS
+        if: inputs.release-name != ''
+        run: |
+          packaging/testing/smoke/packages/run-package-tests.sh
+        env:
+          AWS_URL: https://${{ secrets.bucket }}.s3.amazonaws.com
+          PACKAGE_TEST: ${{ matrix.distro }}
+          RELEASE_URL: https://packages.fluentbit.io

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -1,0 +1,122 @@
+---
+name: Unstable build
+
+on:
+  workflow_dispatch:
+
+  # Run nightly build at this time, bit of trial and error but this seems good.
+  schedule:
+  - cron: "0 6 * * *"
+
+# We do not want a new unstable build to run whilst we are releasing the current unstable build.
+concurrency: unstable-build-release
+
+jobs:
+
+  # This job strips off the `v` at the start of any tag provided.
+  # It then provides this metadata for the other jobs to use.
+  unstable-build-get-meta:
+    name: Get metadata to add to build
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.date.outputs.date }}
+    steps:
+      # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"
+
+  unstable-build-images-master:
+    needs: unstable-build-get-meta
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    with:
+      ref: master
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      image: ${{ github.repository }}/unstable
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  unstable-build-generate-matrix:
+    name: unstable build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      # Set up the list of target to build so we can pass the JSON to the reusable job
+      - uses: ./.github/actions/release-server-sync
+        id: set-matrix
+
+  unstable-build-packages-master:
+    needs: [ unstable-build-get-meta, unstable-build-generate-matrix ]
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    with:
+      version: master
+      ref: master
+      build_matrix: ${{ needs.unstable-build-generate-matrix.outputs.build-matrix }}
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  # We already detain all artefacts as build output so just capture for an unstable release
+  unstable-release-master:
+    runs-on: ubuntu-latest
+    needs:
+      - unstable-build-get-meta
+      - unstable-build-images-master
+      - unstable-build-packages-master
+    environment: unstable
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artefacts
+        continue-on-error: true
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts/
+
+      - name: Single packages tar
+        run: |
+          mkdir -p release-upload
+          tar -czvf release-upload/packages-unstable-master.tar.gz -C artifacts/ .
+        shell: bash
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull containers as well (single arch only)
+        # May not be any/valid so ignore errors
+        continue-on-error: true
+        run: |
+          docker pull ghcr.io/${{ github.repository }}/unstable:master
+          docker save --output container-master.tar ghcr.io/${{ github.repository }}/unstable:master
+          docker pull ghcr.io/${{ github.repository }}/unstable:master-debug
+          docker save --output container-master-debug.tar ghcr.io/${{ github.repository }}/unstable:master-debug
+        shell: bash
+        working-directory: release-upload
+
+      - name: Display structure of files to upload
+        run: ls -R
+        working-directory: release-upload
+        shell: bash
+
+      - name: Remove any existing release
+        continue-on-error: true
+        run: gh release delete unstable-master --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Create Release
+        run: gh release create unstable-master *.tar* --generate-notes --prerelease --target master --title "Nightly unstable master build"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        working-directory: release-upload

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -46,7 +46,7 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
-      - uses: ./.github/actions/release-server-sync
+      - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
 
   unstable-build-packages-master:

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -43,7 +43,7 @@ jobs:
     name: unstable build matrix
     runs-on: ubuntu-latest
     outputs:
-      build-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
       - uses: ./.github/actions/generate-package-build-matrix

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -2,10 +2,6 @@
 name: Deploy to staging
 
 on:
-  push:
-    tags:
-      - '*'
-
   # When unstable passes, we can then trigger staging
   workflow_run:
     workflows: ['Unstable test']
@@ -39,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.formatted_version.outputs.replaced }}
-      date: ${{ steps.date.outputs.date }}
     steps:
 
       - run: |
@@ -74,11 +69,6 @@ jobs:
           replace-with: '$1'
           flags: 'g'
 
-      # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"
-
   staging-build-images:
     needs: staging-build-get-meta
     uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
@@ -101,7 +91,7 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
-      - uses: ./.github/actions/release-server-sync
+      - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
         with:
           target: ${{ github.event.inputs.target || '' }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -36,11 +36,6 @@ jobs:
     outputs:
       version: ${{ steps.formatted_version.outputs.replaced }}
     steps:
-
-      - run: |
-          echo "Version: ${{ github.event.inputs.version || github.ref_name }}"
-        shell: bash
-
       # This step is to consolidate the three different triggers into a single "version"
       # 1. If manual dispatch - use the version provided.
       # 2. If cron/regular build - use master.
@@ -59,15 +54,6 @@ jobs:
           # Use the dispatch variable in preference, if empty use the context ref_name which should
           # only ever be a tag or the master branch.
           INPUT_VERSION: ${{ github.event.inputs.version || github.ref_name }}
-
-      # String the 'v' prefix for tags.
-      - uses: frabert/replace-string-action@v2.0
-        id: formatted_version
-        with:
-          pattern: '[v]*(.*)$'
-          string: "${{ steps.get_version.outputs.VERSION }}"
-          replace-with: '$1'
-          flags: 'g'
 
   staging-build-images:
     needs: staging-build-get-meta

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -6,6 +6,12 @@ on:
     tags:
       - '*'
 
+  # When unstable passes, we can then trigger staging
+  workflow_run:
+    workflows: ['Unstable test']
+    types:
+      - completed
+
   workflow_dispatch:
     inputs:
       version:
@@ -17,10 +23,6 @@ on:
         required: false
         default: ""
 
-  # Run nightly build - disable until after 1.9 release
-  # schedule:
-  # - cron: "0 6 * * *"
-
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.
 concurrency: staging-build-release
@@ -30,6 +32,9 @@ jobs:
   # This job strips off the `v` at the start of any tag provided.
   # It then provides this metadata for the other jobs to use.
   staging-build-get-meta:
+    # Workflow run always triggers on completion regardless of status
+    # This prevents us from running if build fails.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Get metadata to build
     runs-on: ubuntu-latest
     outputs:
@@ -57,7 +62,7 @@ jobs:
         shell: bash
         env:
           # Use the dispatch variable in preference, if empty use the context ref_name which should
-          # only ever be a tag or the master branch for cron builds.
+          # only ever be a tag or the master branch.
           INPUT_VERSION: ${{ github.event.inputs.version || github.ref_name }}
 
       # String the 'v' prefix for tags.
@@ -84,7 +89,6 @@ jobs:
       username: ${{ github.actor }}
       image: ${{ github.repository }}/staging
       environment: staging
-      unstable: ${{ github.event_name == 'schedule' && needs.staging-build-get-meta.outputs.date || '' }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       cosign_private_key: ${{ secrets.COSIGN_PRIVATE_KEY }}
@@ -97,29 +101,10 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
-      - id: set-matrix
-        run: |
-          matrix=$((
-            echo '{ "distro" : ['
-            echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
-            echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8",'
-            echo '"debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
-            echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
-            echo '"raspbian/buster", "raspbian/bullseye"'
-            echo ']}'
-          ) | jq -c .)
-          if [ -n "${{ github.event.inputs.target || '' }}" ]; then
-            echo "Overriding matrix to build: ${{ github.event.inputs.target }}"
-            matrix=$((
-              echo '{ "distro" : ['
-              echo '"${{ github.event.inputs.target }}"'
-              echo ']}'
-            ) | jq -c .)
-          fi
-          echo $matrix
-          echo $matrix| jq .
-          echo "::set-output name=matrix::$matrix"
-        shell: bash
+      - uses: ./.github/actions/release-server-sync
+        id: set-matrix
+        with:
+          target: ${{ github.event.inputs.target || '' }}
 
   staging-build-packages:
     needs: [ staging-build-get-meta, staging-build-generate-matrix ]
@@ -129,7 +114,6 @@ jobs:
       ref: ${{ github.event.inputs.version || github.ref_name }}
       build_matrix: ${{ needs.staging-build-generate-matrix.outputs.build-matrix }}
       environment: staging
-      unstable: ${{ github.event_name == 'schedule' && needs.staging-build-get-meta.outputs.date || '' }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
@@ -137,59 +121,3 @@ jobs:
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg_private_key_passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-
-  # We already detain all artefacts as build output so just capture for an unstable release
-  staging-unstable-release:
-    runs-on: ubuntu-latest
-    needs:
-      - staging-build-get-meta
-      - staging-build-images
-      - staging-build-packages
-    environment: staging
-    permissions:
-      contents: write
-    steps:
-      - name: Download all artefacts
-        continue-on-error: true
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts/
-
-      - name: Single packages tar
-        run: |
-          mkdir -p release-upload
-          tar -czvf release-upload/packages-unstable-${{ needs.staging-build-get-meta.outputs.version }}.tar.gz -C artifacts/ .
-        shell: bash
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull containers as well (single arch only)
-        # May not be any/valid so ignore errors
-        continue-on-error: true
-        run: |
-          docker pull ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}
-          docker save --output container-${{ needs.staging-build-get-meta.outputs.version }}.tar ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}
-          docker pull ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}-debug
-          docker save --output container-${{ needs.staging-build-get-meta.outputs.version }}-debug.tar ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}-debug
-        shell: bash
-        working-directory: release-upload
-
-      - name: Display structure of files to upload
-        run: ls -R
-        working-directory: release-upload
-        shell: bash
-
-      - name: Unstable release on push to master to make it easier to download
-        # Ignore failures here as we still want to trigger testing
-        continue-on-error: true
-        uses: pyTooling/Actions/releaser@r0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: 'unstable'
-          files: |
-            release-upload/**/*

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -88,7 +88,7 @@ jobs:
     name: Staging build matrix
     runs-on: ubuntu-latest
     outputs:
-      build-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
       - uses: ./.github/actions/generate-package-build-matrix

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -12,11 +12,20 @@ on:
 concurrency: integration-test
 
 jobs:
-  staging-test-images:
-    name: Container images staging tests
+  staging-test-preflight-checks:
     # Workflow run always triggers on completion regardless of status
     # This prevents us from running if build fails.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Staging build completed"
+        if: github.event_name != 'workflow_dispatch'
+      - run: echo "Staging test manually initiated"
+        if: github.event_name == 'workflow_dispatch'
+
+  staging-test-images:
+    name: Container images staging tests
+    needs: staging-test-preflight-checks
     uses: fluent/fluent-bit/.github/workflows/call-test-images.yaml@master
     with:
       registry: ghcr.io
@@ -45,12 +54,10 @@ jobs:
 
   staging-test-packages:
     name: Binary packages staging test
-    # Workflow run always triggers on completion regardless of status
-    # This prevents us from running if build fails.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    needs: staging-test-preflight-checks
     uses: fluent/fluent-bit/.github/workflows/call-test-packages.yaml@master
     with:
       environment: staging
     secrets:
-      bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
+      url: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unstable-test.yaml
+++ b/.github/workflows/unstable-test.yaml
@@ -12,11 +12,20 @@ on:
 concurrency: integration-test
 
 jobs:
-  unstable-test-images:
-    name: Unstable - test container images
+  unstable-test-preflight-checks:
     # Workflow run always triggers on completion regardless of status
     # This prevents us from running if build fails.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Unstable build completed"
+        if: github.event_name != 'workflow_dispatch'
+      - run: echo "Unstable test manually initiated"
+        if: github.event_name == 'workflow_dispatch'
+
+  unstable-test-images:
+    name: Unstable - test container images
+    needs: unstable-test-preflight-checks
     uses: fluent/fluent-bit/.github/workflows/call-test-images.yaml@master
     with:
       registry: ghcr.io
@@ -43,16 +52,12 @@ jobs:
       grafana_password: ${{ secrets.GRAFANA_PASSWORD }}
 
   # Now need to reconstruct our release into a repo to use.
-  # TODO:
-
-  # unstable-test-packages:
-  #   name: Binary packages unstable test
-  #   # Workflow run always triggers on completion regardless of status
-  #   # This prevents us from running if build fails.
-  #   if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-  #   uses: fluent/fluent-bit/.github/workflows/call-test-packages.yaml@master
-  #   with:
-  #     environment: unstable
-  #   secrets:
-  #     bucket: ${{ secrets.AWS_S3_BUCKET_unstable }}
-  #     token: ${{ secrets.GITHUB_TOKEN }}
+  unstable-test-packages:
+    name: Binary packages unstable test
+    needs: unstable-test-preflight-checks
+    uses: fluent/fluent-bit/.github/workflows/call-test-packages.yaml@master
+    with:
+      environment: unstable
+    secrets:
+      url: https://github.com/fluent/fluent-bit/releases/download/unstable-master
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unstable-test.yaml
+++ b/.github/workflows/unstable-test.yaml
@@ -1,0 +1,58 @@
+---
+name: Unstable test
+# The intention is this workflow is triggered either manually or
+# after build has completed.
+on:
+  workflow_run:
+    workflows: ['Unstable build']
+    types:
+      - completed
+  workflow_dispatch:
+
+concurrency: integration-test
+
+jobs:
+  unstable-test-images:
+    name: Unstable - test container images
+    # Workflow run always triggers on completion regardless of status
+    # This prevents us from running if build fails.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    uses: fluent/fluent-bit/.github/workflows/call-test-images.yaml@master
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      image: ${{ github.repository }}/unstable
+      image-tag: latest
+      environment: unstable
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Called workflows cannot be nested
+  unstable-test-images-integration-gcp:
+    name: Unstable - run integration tests on GCP
+    # Wait for other tests to succeed
+    needs: unstable-test-images
+    uses: calyptia/fluent-bit-ci/.github/workflows/reusable-integration-test-gcp.yaml@main
+    with:
+      image_name: ghcr.io/${{ github.repository }}/unstable
+      image_tag: latest
+    secrets:
+      grafana_username: ${{ secrets.GRAFANA_USERNAME }}
+      terraform_api_token: ${{ secrets.TF_API_TOKEN }}
+      gcp_service_account_key: ${{ secrets.GCP_SA_KEY }}
+      grafana_password: ${{ secrets.GRAFANA_PASSWORD }}
+
+  # Now need to reconstruct our release into a repo to use.
+  # TODO:
+
+  # unstable-test-packages:
+  #   name: Binary packages unstable test
+  #   # Workflow run always triggers on completion regardless of status
+  #   # This prevents us from running if build fails.
+  #   if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+  #   uses: fluent/fluent-bit/.github/workflows/call-test-packages.yaml@master
+  #   with:
+  #     environment: unstable
+  #   secrets:
+  #     bucket: ${{ secrets.AWS_S3_BUCKET_unstable }}
+  #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/packaging/testing/smoke/packages/run-packages-tests-from-release.sh
+++ b/packaging/testing/smoke/packages/run-packages-tests-from-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2021 Calyptia, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file  except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the  License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eux
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RELEASE_NAME=${RELEASE_NAME:-unstable-master}
+RELEASE_PACKAGES=${RELEASE_PACKAGES:-packages-$RELEASE_NAME.tar.gz}
+RELEASE_PACKAGES_URL=${RELEASE_PACKAGES_URL:-https://github.com/fluent/fluent-bit/releases/download/$RELEASE_NAME/$RELEASE_PACKAGES}
+OUTPUT_DIR=${OUTPUT_DIR:-$SCRIPT_DIR/$RELEASE_NAME}
+
+# Download tarball locally
+rm -rf "${OUTPUT_DIR:?}/"
+mkdir -p "$OUTPUT_DIR"
+wget -O "$OUTPUT_DIR/$RELEASE_PACKAGES" "$RELEASE_PACKAGES_URL"
+tar -xzvf "$OUTPUT_DIR/$RELEASE_PACKAGES" -C "$OUTPUT_DIR"
+
+# Set up repo info
+"$SCRIPT_DIR/../update-repos.sh" "master" "$OUTPUT_DIR"

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -45,7 +45,8 @@ DEB_REPO_PATHS=( "debian/bullseye"
                  "ubuntu/xenial"
                  "ubuntu/bionic"
                  "ubuntu/focal"
-                 "raspbian/buster" )
+                 "raspbian/buster"
+                 "raspbian/bullseye" )
 
 for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do
     REPO_DIR=$(realpath -sm "$BASE_PATH/$DEB_REPO" )


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Trigger regular unstable build that makes a Github release then triggers existing staging pipeline as part of #4875.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
