### PR TITLE
1.8: out_stackdriver: add static labels defined in configuration (#4912)

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -20,6 +20,7 @@
 
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
@@ -947,9 +948,9 @@ static msgpack_object *get_payload_labels(struct flb_stackdriver *ctx, msgpack_o
  * - Construct root-level `labels` field using configuration and payload labels
  */
 
-static int *parse_labels(struct flb_stackdriver *ctx,
-                         msgpack_object *payload_labels_ptr,
-                         struct mk_list *labels_list)
+static int parse_labels(struct flb_stackdriver *ctx,
+                        msgpack_object *payload_labels_ptr,
+                        struct mk_list *labels_list)
 {
     int i;
     int ret;
@@ -1022,7 +1023,6 @@ static void pack_labels(struct flb_stackdriver *ctx,
                         struct mk_list *labels_list)
 {
     struct mk_list *head;
-    struct mk_list *split;
     struct flb_kv *kv;
 
     msgpack_pack_map(mp_pck, mk_list_size(labels_list));
@@ -2096,7 +2096,7 @@ static int stackdriver_format(struct flb_config *config,
             flb_sds_destroy(operation_producer);
             msgpack_unpacked_destroy(&result);
             msgpack_sbuffer_destroy(&mp_sbuf);
-            return NULL;
+            return -1;
         }
 
         /* Parse labels */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -113,6 +113,10 @@ struct flb_stackdriver {
     flb_sds_t local_resource_id;
     flb_sds_t tag_prefix;
 
+    /* labels */
+    struct mk_list *labels;
+    struct mk_list labels_list;
+
     /* generic resources */
     flb_sds_t location;
     flb_sds_t namespace_id;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -115,7 +115,6 @@ struct flb_stackdriver {
 
     /* labels */
     struct mk_list *labels;
-    struct mk_list labels_list;
 
     /* generic resources */
     flb_sds_t location;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -337,13 +337,11 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     }
 
     tmp = flb_output_get_property("labels", ins);
-    flb_plg_info(ins, "input labels %s", tmp);
     if (tmp) {
         ctx->labels = flb_utils_split(tmp, ',', -1);
         if (!ctx->labels) {
             flb_plg_error(ins, "failed to allocate labels list");
         }
-        flb_plg_info(ins, "size %d", mk_list_size(ctx->labels));
     }
 
     tmp = flb_output_get_property("http_request_key", ins);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -336,6 +336,16 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->log_name_key = flb_sds_create(DEFAULT_LOG_NAME_KEY);
     }
 
+    tmp = flb_output_get_property("labels", ins);
+    flb_plg_info(ins, "input labels %s", tmp);
+    if (tmp) {
+        ctx->labels = flb_utils_split(tmp, ',', -1);
+        if (!ctx->labels) {
+            flb_plg_error(ins, "failed to allocate labels list");
+        }
+        flb_plg_info(ins, "size %d", mk_list_size(ctx->labels));
+    }
+
     tmp = flb_output_get_property("http_request_key", ins);
     if (tmp) {
         http_request_key = flb_sds_create(tmp);
@@ -551,6 +561,10 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
     flb_sds_destroy(ctx->labels_key);
     flb_sds_destroy(ctx->tag_prefix);
     flb_sds_destroy(ctx->custom_k8s_regex);
+
+    if (ctx->labels) {
+        flb_utils_split_free(ctx->labels);
+    }
 
     if (ctx->stackdriver_agent) {
         flb_sds_destroy(ctx->stackdriver_agent);


### PR DESCRIPTION
This change mirrors the [out_loki](https://docs.fluentbit.io/manual/pipeline/outputs/loki#using-the-label_keys-property) exporter functionality to set static `labels` during configuration. This as a list of comma separate `key=value` pairs, e.g. `label_a=value_a,label_b=value_b`. The `record_accesor` wasn't implemented since the functionality can be recreated using `label_keys`.

To add this feature in `master` would require effort only in using the `config map` feature, which won't be very different to what is presented in this PR. Let me know if there is a requirement for the steps add a new feature.

This PR is one approach to add the feature in #4912 .

### Configuration

This configuration implements the functionality by setting `labels` using `key=value` pairs and using a `modify` + `nest` to set a label in the payload to show the output combines the result.

```
[INPUT]
    Buffer_Chunk_Size 512k
    Buffer_Max_Size   5M
    Key               message
    Mem_Buf_Limit     10M
    Name              tail
    Path              /var/log/messages,/var/log/syslog
    Read_from_Head    True
    Rotate_Wait       30
    Skip_Long_Lines   On
    Tag               default_pipeline.syslog

[FILTER]
    Add   labela valuea
    Match *
    Name  modify

[FILTER]
    Match      *
    Name       nest
    Nest_under logging.googleapis.com/labels
    Operation  nest
    Wildcard   labela*

[OUTPUT]
    Match_Regex                   ^(default_pipeline\.syslog)$
    Name                          stackdriver
    Retry_Limit                   3
    net.connect_timeout_log_error False
    resource                      gce_instance
    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/2.11.0 (BuildDistro=buster;Platform=linux;ShortName=debian;ShortVersion=10.11)
    tls                           On
    tls.verify                    Off
    workers                       8
    labels                        compute.googleapis.com/resource_name=testing_vm_syslog,labelQ=valueQ
```

This is one output `LogEntry` :

![Screen Shot 2022-03-18 at 11 59 41](https://user-images.githubusercontent.com/1435136/159058121-4fbd0d91-e87c-4515-aa27-c4ac461ad9ed.png)


### Output Log and Valgrind result
The result of the following `valgrind` execution is shown below :
```
valgrind --leak-check=yes fluent-bit/build/bin/fluent-bit   --config ./fluent_bit_main.conf
```

This is the output log of the execution. Note : The errors of the form `Invalid read of size` also show in the current `1.8` branch, I'm not sure if they appear due to the configuration or some other issue : 

```
==15424== Memcheck, a memory error detector
==15424== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15424== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==15424== Command: fluent-bit/build/bin/fluent-bit --config ./fluent_bit_main.conf
==15424== 
Fluent Bit v1.8.143
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/18 18:48:02] [ info] [engine] started (pid=15424)
[2022/03/18 18:48:02] [ info] [storage] version=1.1.6, initializing...
[2022/03/18 18:48:02] [ info] [storage] in-memory
[2022/03/18 18:48:02] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/18 18:48:02] [ info] [cmetrics] version=0.2.2
[2022/03/18 18:48:05] [ info] [output:stackdriver:stackdriver.0] metadata_server set to http://metadata.google.internal
[2022/03/18 18:48:05] [ warn] [output:stackdriver:stackdriver.0] client_email is not defined, using a default one
[2022/03/18 18:48:05] [ warn] [output:stackdriver:stackdriver.0] private_key is not defined, fetching it from metadata server
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #0 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #2 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #3 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #4 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #1 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #5 started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #6 started
[2022/03/18 18:48:07] [ info] [sp] stream processor started
[2022/03/18 18:48:07] [ info] [output:stackdriver:stackdriver.0] worker #7 started
[2022/03/18 18:48:07] [ info] [input:tail:tail.0] inotify_fs_add(): inode=410914 watch_fd=1 name=/var/log/messages
[2022/03/18 18:48:07] [ info] [input:tail:tail.0] inotify_fs_add(): inode=407355 watch_fd=2 name=/var/log/syslog
^C[2022/03/18 18:48:37] [engine] caught signal (SIGINT)
[2022/03/18 18:48:37] [ info] [input] pausing tail.0
[2022/03/18 18:48:37] [ warn] [engine] service will shutdown in max 5 seconds
==15424== Thread 4 flb-out-stackdri:
==15424== Invalid read of size 8
==15424==    at 0x4FBB51: mk_event_timeout_destroy (mk_event.c:165)
==15424==    by 0x19761D: flb_sched_timer_destroy (flb_scheduler.c:649)
==15424==    by 0x197449: flb_sched_destroy (flb_scheduler.c:596)
==15424==    by 0x18519C: output_thread (flb_output_thread.c:361)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Address 0x64dccd0 is 16 bytes inside a block of size 24 free'd
==15424==    at 0x48369AB: free (vg_replace_malloc.c:530)
==15424==    by 0x4FB197: mk_mem_free (mk_memory.h:102)
==15424==    by 0x4FB9C5: mk_event_loop_destroy (mk_event.c:82)
==15424==    by 0x185190: output_thread (flb_output_thread.c:359)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Block was alloc'd at
==15424==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==15424==    by 0x4FB15E: mk_mem_alloc_z (mk_memory.h:70)
==15424==    by 0x4FB902: mk_event_loop_create (mk_event.c:58)
==15424==    by 0x185484: flb_output_thread_pool_create (flb_output_thread.c:443)
==15424==    by 0x182D7D: flb_output_enable_multi_threading (flb_output.c:784)
==15424==    by 0x1839D4: flb_output_init_all (flb_output.c:1070)
==15424==    by 0x192E21: flb_engine_start (flb_engine.c:602)
==15424==    by 0x1731CF: flb_lib_worker (flb_lib.c:627)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424== 
==15424== Invalid read of size 4
==15424==    at 0x4FB4B5: _mk_event_del (mk_event_epoll.c:153)
==15424==    by 0x4FB6C7: _mk_event_timeout_destroy (mk_event_epoll.c:325)
==15424==    by 0x4FBB6B: mk_event_timeout_destroy (mk_event.c:166)
==15424==    by 0x19761D: flb_sched_timer_destroy (flb_scheduler.c:649)
==15424==    by 0x197449: flb_sched_destroy (flb_scheduler.c:596)
==15424==    by 0x18519C: output_thread (flb_output_thread.c:361)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Address 0x64dc930 is 0 bytes inside a block of size 16 free'd
==15424==    at 0x48369AB: free (vg_replace_malloc.c:530)
==15424==    by 0x4FB197: mk_mem_free (mk_memory.h:102)
==15424==    by 0x4FB394: _mk_event_loop_destroy (mk_event_epoll.c:94)
==15424==    by 0x4FB9A9: mk_event_loop_destroy (mk_event.c:80)
==15424==    by 0x185190: output_thread (flb_output_thread.c:359)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Block was alloc'd at
==15424==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==15424==    by 0x4FB15E: mk_mem_alloc_z (mk_memory.h:70)
==15424==    by 0x4FB2A0: _mk_event_loop_create (mk_event_epoll.c:54)
==15424==    by 0x4FB8E3: mk_event_loop_create (mk_event.c:53)
==15424==    by 0x185484: flb_output_thread_pool_create (flb_output_thread.c:443)
==15424==    by 0x182D7D: flb_output_enable_multi_threading (flb_output.c:784)
==15424==    by 0x1839D4: flb_output_init_all (flb_output.c:1070)
==15424==    by 0x192E21: flb_engine_start (flb_engine.c:602)
==15424==    by 0x1731CF: flb_lib_worker (flb_lib.c:627)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424== 
==15424== Invalid read of size 8
==15424==    at 0x4FBA83: mk_event_del (mk_event.c:126)
==15424==    by 0x4FBB3A: mk_event_timeout_disable (mk_event.c:157)
==15424==    by 0x19718B: flb_sched_timer_cb_disable (flb_scheduler.c:494)
==15424==    by 0x197634: flb_sched_timer_destroy (flb_scheduler.c:652)
==15424==    by 0x197449: flb_sched_destroy (flb_scheduler.c:596)
==15424==    by 0x18519C: output_thread (flb_output_thread.c:361)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Address 0x64dccd0 is 16 bytes inside a block of size 24 free'd
==15424==    at 0x48369AB: free (vg_replace_malloc.c:530)
==15424==    by 0x4FB197: mk_mem_free (mk_memory.h:102)
==15424==    by 0x4FB9C5: mk_event_loop_destroy (mk_event.c:82)
==15424==    by 0x185190: output_thread (flb_output_thread.c:359)
==15424==    by 0x19C244: step_callback (flb_worker.c:44)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424==  Block was alloc'd at
==15424==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==15424==    by 0x4FB15E: mk_mem_alloc_z (mk_memory.h:70)
==15424==    by 0x4FB902: mk_event_loop_create (mk_event.c:58)
==15424==    by 0x185484: flb_output_thread_pool_create (flb_output_thread.c:443)
==15424==    by 0x182D7D: flb_output_enable_multi_threading (flb_output.c:784)
==15424==    by 0x1839D4: flb_output_init_all (flb_output.c:1070)
==15424==    by 0x192E21: flb_engine_start (flb_engine.c:602)
==15424==    by 0x1731CF: flb_lib_worker (flb_lib.c:627)
==15424==    by 0x4850FA2: start_thread (pthread_create.c:486)
==15424==    by 0x4B114CE: clone (clone.S:95)
==15424== 
[2022/03/18 18:48:38] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/18 18:48:38] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=410914 watch_fd=1
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #0 stopping...
[2022/03/18 18:48:38] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=407355 watch_fd=2
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #0 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #1 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #1 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #2 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #3 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #2 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #3 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #4 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #4 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #5 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #5 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #6 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #6 stopped
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #7 stopping...
[2022/03/18 18:48:38] [ info] [output:stackdriver:stackdriver.0] thread worker #7 stopped
==15424== 
==15424== HEAP SUMMARY:
==15424==     in use at exit: 0 bytes in 0 blocks
==15424==   total heap usage: 28,361 allocs, 28,361 frees, 20,596,116 bytes allocated
==15424== 
==15424== All heap blocks were freed -- no leaks are possible
==15424== 
==15424== For counts of detected and suppressed errors, rerun with: -v
==15424== ERROR SUMMARY: 40 errors from 3 contexts (suppressed: 0 from 0)
```

Signed-off-by: Francisco Valente <fcovalente@google.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature
Will add documentation in next iteration.

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

This update is for the `1.8` branch, but it can be added to `master` as described earlier if required.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
