### PR TITLE
packaging: add raspbian/bullseye and option to skip signing

### DIFF
--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -185,7 +185,7 @@ jobs:
           gpg --export -a "${{ steps.import_gpg.outputs.name }}" > ./latest/fluentbit.key
           rpm --import ./latest/fluentbit.key
 
-          ./update-repos.sh "${{ inputs.version }}" "./latest/"
+          ./update-repos.sh "./latest/"
           echo "${{ inputs.version }}" > "./latest/latest-version.txt"
           aws s3 sync "./latest/" "s3://$AWS_S3_BUCKET" --delete --follow-symlinks --no-progress ${ENDPOINT}
         env:

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -96,7 +96,7 @@ jobs:
       run: |
         rm -f packaging/releases/*.repo
         LATEST_VERSION=$(cat packaging/releases/latest-version.txt)
-        packaging/update-repos.sh "$VERSION" packaging/releases/
+        packaging/update-repos.sh packaging/releases/
         rm -f packaging/releases/latest-version.txt
       env:
         GPG_KEY: ${{ steps.import_gpg.outputs.name }}

--- a/packaging/remove-version.sh
+++ b/packaging/remove-version.sh
@@ -12,4 +12,4 @@ find "$BASE_PATH" -type f \( -iname "*-bit-${VERSION}*.rpm" -o -iname "*-bit-${V
 
 # Update the repo metadata now
 # VERSION is only used to find the RPM to sign so without it will skip signing
-"$SCRIPT_DIR/update-repos.sh" "$VERSION" "$BASE_PATH"
+"$SCRIPT_DIR/update-repos.sh" "$BASE_PATH"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Part of #5098 to support migration to S3 bucket
Resolves missing `raspbian/bullseye` repo handling as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
