### PR TITLE
record_accessor: fix possible null-deref

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -422,6 +422,11 @@ static flb_sds_t ra_translate_keymap(struct flb_ra_parser *rp, flb_sds_t buf,
     struct flb_ra_value *v;
 
     /* Lookup key or subkey value */
+    if (rp->key == NULL) {
+      *found = FLB_FALSE;
+      return buf;
+    }
+
     v = flb_ra_key_to_value(rp->key->name, map, rp->key->subkeys);
     if (!v) {
         *found = FLB_FALSE;


### PR DESCRIPTION
Check rp->key is set before dereferencing. This fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45642

Signed-off-by: David Korczynski <david@adalogics.com>

Note that `rp->key` is not ensured to be non-null by design: https://github.com/fluent/fluent-bit/blob/1e49a77bd3098c970ce445bb99f8e07557a4f2ab/src/flb_record_accessor.c#L320-L328

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
