### PR TITLE
4875 unstable regular build

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -1,0 +1,38 @@
+
+name: Composite action to generate the matrix of targets to build packages for.
+description: Remove any duplication of this information so we only have to update in one place.
+
+inputs:
+  target:
+    description: Override to build a single target for debug/test only.
+    required: false
+outputs:
+  build-matrix:
+    description: The build matrix we have created.
+    value: ${{ steps.set-matrix.outputs.matrix }}
+runs:
+  using: "composite"
+  steps:
+    - id: set-matrix
+      run: |
+        matrix=$((
+          echo '{ "distro" : ['
+          echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
+          echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8",'
+          echo '"debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
+          echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
+          echo '"raspbian/buster", "raspbian/bullseye"'
+          echo ']}'
+        ) | jq -c .)
+        if [ -n "${{ inputs.target || '' }}" ]; then
+          echo "Overriding matrix to build: ${{ inputs.target }}"
+          matrix=$((
+            echo '{ "distro" : ['
+            echo '"${{ inputs.target }}"'
+            echo ']}'
+          ) | jq -c .)
+        fi
+        echo $matrix
+        echo $matrix| jq .
+        echo "::set-output name=matrix::$matrix"
+      shell: bash

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -7,6 +7,11 @@ on:
         description: The Github environment to run this workflow on.
         type: string
         required: false
+      ref:
+        description: The commit, tag or branch to checkout for testing scripts.
+        type: string
+        default: master
+        required: false
     secrets:
       token:
         description: The Github token or similar to authenticate with.

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -1,0 +1,190 @@
+---
+name: Unstable build
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to create an unstable release for/from.
+        type: string
+        default: master
+        required: true
+
+  # Run nightly build at this time, bit of trial and error but this seems good.
+  schedule:
+  - cron: "0 6 * * *"   # master build
+  - cron: "0 12 * * *"  # 1.9 build
+  - cron: "0 18 * * *"  # 1.8 build
+
+# We do not want a new unstable build to run whilst we are releasing the current unstable build.
+concurrency: unstable-build-release
+
+jobs:
+
+  # This job provides this metadata for the other jobs to use.
+  unstable-build-get-meta:
+    name: Get metadata to add to build
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.date.outputs.date }}
+      branch: ${{ steps.branch.outputs.branch }}
+    steps:
+      # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"
+
+      # Now we need to determine which branch to build
+      - name: Manual run - get branch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "::set-env name=cron_branch::${{ github.event.inputs.branch }}"
+        shell: bash
+
+      - name: master run
+        if:  github.event_name == 'schedule' && github.event.schedule=='*/6 * * * *'         # set-env value
+        run: |
+          echo "::set-env name=cron_branch::master"
+        shell: bash
+
+      - name: 1.9 run
+        if:  github.event_name == 'schedule' && github.event.schedule=='*/12 * * * *'   # set env value
+        run: |
+          echo "::set-env name=cron_branch::1.9"
+        shell: bash
+
+      - name: 1.8 run
+        if:  github.event_name == 'schedule' && github.event.schedule=='*/18 * * * *'   # set env value
+        run: |
+          echo "::set-env name=cron_branch::1.8"
+        shell: bash
+
+      - name: Output the branch to use
+        id: branch
+        run: |
+          echo "$cron_branch"
+          echo "::set-output name=branch::$cron_branch"
+        shell: bash
+
+  unstable-build-images:
+    needs: unstable-build-get-meta
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    with:
+      ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      image: ${{ github.repository }}/unstable
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  unstable-build-generate-schema:
+    # Not available for 1.8
+    if: github.event.schedule != '*/18 * * * *'
+    needs:
+      - unstable-build-get-meta
+      - unstable-build-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: |
+          docker run --rm -it ${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }} -J > fluent-bit-schema.json
+          cat fluent-bit-schema.json | jq -M > fluent-bit-schema-pretty.json
+        shell: bash
+
+      - name: Upload the schema
+        uses: actions/upload-artifact@v2
+        with:
+          name: fluent-bit-schema*.json
+          if-no-files-found: error
+
+  unstable-build-generate-matrix:
+    name: unstable build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+    steps:
+      # Set up the list of target to build so we can pass the JSON to the reusable job
+      - uses: ./.github/actions/generate-package-build-matrix
+        id: set-matrix
+
+  unstable-build-packages:
+    needs:
+      - unstable-build-get-meta
+      - unstable-build-generate-matrix
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    with:
+      version: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      build_matrix: ${{ needs.unstable-build-generate-matrix.outputs.build-matrix }}
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  # We already detain all artefacts as build output so just capture for an unstable release
+  unstable-release:
+    runs-on: ubuntu-latest
+    needs:
+      - unstable-build-get-meta
+      - unstable-build-images
+      - unstable-build-packages
+    environment: unstable
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artefacts
+        continue-on-error: true
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts/
+
+      - name: Single packages tar
+        run: |
+          mkdir -p release-upload
+          mv -f artifacts/*.json release-upload/
+          tar -czvf release-upload/packages-unstable-${{ needs.unstable-build-get-meta.outputs.branch }}.tar.gz -C artifacts/ .
+        shell: bash
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull containers as well (single arch only)
+        # May not be any/valid so ignore errors
+        continue-on-error: true
+        run: |
+          docker pull ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}
+          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}.tar ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}
+          docker pull ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}-debug
+          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}-debug.tar ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}-debug
+        shell: bash
+        working-directory: release-upload
+
+      - name: Display structure of files to upload
+        run: ls -R
+        working-directory: release-upload
+        shell: bash
+
+      - name: Remove any existing release
+        continue-on-error: true
+        run: gh release delete unstable-${{ needs.unstable-build-get-meta.outputs.branch }} --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Create Release
+        run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -17,10 +17,6 @@ on:
         required: false
         default: ""
 
-  # Run nightly build - disable until after 1.9 release
-  # schedule:
-  # - cron: "0 6 * * *"
-
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.
 concurrency: staging-build-release
@@ -69,11 +65,6 @@ jobs:
           replace-with: '$1'
           flags: 'g'
 
-      # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date '+%Y-%m-%d-%H_%M_%S')"
-
   staging-build-images:
     needs: staging-build-get-meta
     uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
@@ -84,7 +75,6 @@ jobs:
       username: ${{ github.actor }}
       image: ${{ github.repository }}/staging
       environment: staging
-      unstable: ${{ github.event_name == 'schedule' && needs.staging-build-get-meta.outputs.date || '' }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       cosign_private_key: ${{ secrets.COSIGN_PRIVATE_KEY }}
@@ -94,32 +84,13 @@ jobs:
     name: Staging build matrix
     runs-on: ubuntu-latest
     outputs:
-      build-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
     steps:
       # Set up the list of target to build so we can pass the JSON to the reusable job
-      - id: set-matrix
-        run: |
-          matrix=$((
-            echo '{ "distro" : ['
-            echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
-            echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8",'
-            echo '"debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
-            echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
-            echo '"raspbian/buster", "raspbian/bullseye"'
-            echo ']}'
-          ) | jq -c .)
-          if [ -n "${{ github.event.inputs.target || '' }}" ]; then
-            echo "Overriding matrix to build: ${{ github.event.inputs.target }}"
-            matrix=$((
-              echo '{ "distro" : ['
-              echo '"${{ github.event.inputs.target }}"'
-              echo ']}'
-            ) | jq -c .)
-          fi
-          echo $matrix
-          echo $matrix| jq .
-          echo "::set-output name=matrix::$matrix"
-        shell: bash
+      - uses: ./.github/actions/generate-package-build-matrix
+        id: set-matrix
+        with:
+          target: ${{ github.event.inputs.target || '' }}
 
   staging-build-packages:
     needs: [ staging-build-get-meta, staging-build-generate-matrix ]
@@ -129,7 +100,6 @@ jobs:
       ref: ${{ github.event.inputs.version || github.ref_name }}
       build_matrix: ${{ needs.staging-build-generate-matrix.outputs.build-matrix }}
       environment: staging
-      unstable: ${{ github.event_name == 'schedule' && needs.staging-build-get-meta.outputs.date || '' }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
@@ -137,59 +107,3 @@ jobs:
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg_private_key_passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-
-  # We already detain all artefacts as build output so just capture for an unstable release
-  staging-unstable-release:
-    runs-on: ubuntu-latest
-    needs:
-      - staging-build-get-meta
-      - staging-build-images
-      - staging-build-packages
-    environment: staging
-    permissions:
-      contents: write
-    steps:
-      - name: Download all artefacts
-        continue-on-error: true
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts/
-
-      - name: Single packages tar
-        run: |
-          mkdir -p release-upload
-          tar -czvf release-upload/packages-unstable-${{ needs.staging-build-get-meta.outputs.version }}.tar.gz -C artifacts/ .
-        shell: bash
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull containers as well (single arch only)
-        # May not be any/valid so ignore errors
-        continue-on-error: true
-        run: |
-          docker pull ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}
-          docker save --output container-${{ needs.staging-build-get-meta.outputs.version }}.tar ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}
-          docker pull ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}-debug
-          docker save --output container-${{ needs.staging-build-get-meta.outputs.version }}-debug.tar ghcr.io/${{ github.repository }}/staging:${{ needs.staging-build-get-meta.outputs.version }}-debug
-        shell: bash
-        working-directory: release-upload
-
-      - name: Display structure of files to upload
-        run: ls -R
-        working-directory: release-upload
-        shell: bash
-
-      - name: Unstable release on push to master to make it easier to download
-        # Ignore failures here as we still want to trigger testing
-        continue-on-error: true
-        uses: pyTooling/Actions/releaser@r0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: 'unstable'
-          files: |
-            release-upload/**/*

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -65,8 +65,7 @@ for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do
 
     cat << EOF > "$APTLY_CONFIG"
 {
-    "rootDir": "$APTLY_ROOTDIR/",
-    "gpgDisableSign": $DISABLE_SIGNING,
+    "rootDir": "$APTLY_ROOTDIR/"
 }
 EOF
     cat "$APTLY_CONFIG"
@@ -78,7 +77,11 @@ EOF
 
     aptly -config="$APTLY_CONFIG" repo add "$APTLY_REPO_NAME" "$REPO_DIR/"
     aptly -config="$APTLY_CONFIG" repo show "$APTLY_REPO_NAME"
-    aptly -config="$APTLY_CONFIG" publish repo -gpg-key="$GPG_KEY" "$APTLY_REPO_NAME"
+    if [[ "$DISABLE_SIGNING" != "true" ]]; then
+        aptly -config="$APTLY_CONFIG" publish repo -gpg-key="$GPG_KEY" "$APTLY_REPO_NAME"
+    else
+        aptly -config="$APTLY_CONFIG" publish repo --skip-signing "$APTLY_REPO_NAME"
+    fi
     rsync -av "$APTLY_ROOTDIR"/public/* "$REPO_DIR"
     # Remove unnecessary files
     rm -rf "$REPO_DIR/conf/" "$REPO_DIR/db/" "$APTLY_ROOTDIR" "$APTLY_CONFIG"


### PR DESCRIPTION
Part of work for #4875 to provide automated builds nightly of all three supported branches:

- 1.8
- 1.9
- master

Special `unstable-<branch>` pre-release will be created with all artefacts including JSON schema to satisfy #5083

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
