### PR TITLE
io: prevent recycled keepalive sockets from stalling

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -262,8 +262,7 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
     /* Update counters */
     total += bytes;
     if (total < len) {
-        if (u_conn->event.status == MK_EVENT_NONE) {
-            u_conn->event.mask = MK_EVENT_EMPTY;
+        if ((u_conn->event.mask & MK_EVENT_WRITE) == 0) {
             u_conn->coro = co;
             ret = mk_event_add(u_conn->evl,
                                u_conn->fd,

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -780,7 +780,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
             flb_debug("[upstream] KA count %i exceeded configured limit "
                       "of %i: closing.",
                       conn->ka_count, conn->u->net.keepalive_max_recycle);
-            return prepare_destroy_conn(conn);
+            return prepare_destroy_conn_safe(conn);
         }
 
         return 0;


### PR DESCRIPTION
This PR fixes the conditional in `net_io_write_async` that's meant to start monitoring for WRITE events after a partial write. This conditional worked fine for new connections but not so well for connections that had been released and thus set to only wait for CLOSE events.

Additionally this PR changes the `prepare_destroy_conn` call with `prepare_destroy_conn_safe` in `flb_upstream_conn_release` when a socket exceeds its usage limit.