### PR TITLE
workflows: align compile check with fuzz triggers

### DIFF
--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**.c'
       - '**.h'
-      - '**/CMakeLists.txt'
+      - 'CMakeLists.txt'
       - 'cmake/*'
   workflow_dispatch:
 

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -1,15 +1,12 @@
 name: 'Pull requests compile checks'
 on:
   pull_request:
-    # Only trigger if there is a code change
+    # Only trigger if there is a code change or a CMake change that (could) affect code
     paths:
-      - '**.h'
       - '**.c'
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
+      - '**.h'
+      - '**/CMakeLists.txt'
+      - 'cmake/*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-fuzz.yaml
+++ b/.github/workflows/pr-fuzz.yaml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: 
+on:
   pull_request:
     # Only fuzz when C source files change
     paths:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 1.9
       - 1.8
   pull_request:
     paths-ignore:
@@ -15,6 +16,7 @@ on:
       - '**.sh'
     branches:
       - master
+      - 1.9
       - 1.8
     types: [opened, reopened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #5115 to align triggers for CentOS with fuzzing - fuzzing fired on #4791 but CentOS checks did not.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
