### PR TITLE
workflows: unstable builds for supported branches

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -6,6 +6,10 @@ inputs:
   target:
     description: Override to build a single target for debug/test only.
     required: false
+  fluent-bit-version:
+    description: The version of Fluent Bit to build.
+    required: false
+    default: 'master'
 outputs:
   build-matrix:
     description: The build matrix we have created.
@@ -13,7 +17,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: set-matrix
+    - name: master/1.9 targets
+      if: fluent-bit-version != '1.8'
       run: |
         matrix=$((
           echo '{ "distro" : ['
@@ -32,7 +37,35 @@ runs:
             echo ']}'
           ) | jq -c .)
         fi
-        echo $matrix
-        echo $matrix| jq .
-        echo "::set-output name=matrix::$matrix"
+        echo "MATRIX=$matrix" >> $GITHUB_ENV
+      shell: bash
+
+    - name: 1.8 targets
+      if: fluent-bit-version == '1.8'
+      run: |
+        matrix=$((
+          echo '{ "distro" : ['
+          echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
+          echo '"centos/7", "centos/7.arm64v8",'
+          echo '"debian/stretch", "debian/stretch.arm64v8", "debian/buster", "debian/buster.arm64v8",'
+          echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/18.04.arm64v8", "ubuntu/20.04.arm64v8",'
+          echo '"raspbian/buster"'
+          echo ']}'
+        ) | jq -c .)
+        if [ -n "${{ inputs.target || '' }}" ]; then
+          echo "Overriding matrix to build: ${{ inputs.target }}"
+          matrix=$((
+            echo '{ "distro" : ['
+            echo '"${{ inputs.target }}"'
+            echo ']}'
+          ) | jq -c .)
+        fi
+        echo "MATRIX=$matrix" >> $GITHUB_ENV
+      shell: bash
+
+    - id: set-matrix
+      run: |
+        echo $MATRIX
+        echo $MATRIX| jq .
+        echo "::set-output name=matrix::$MATRIX"
       shell: bash

--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: master/1.9 targets
-      if: fluent-bit-version != '1.8'
+      if: inputs.fluent-bit-version != '1.8'
       run: |
         matrix=$((
           echo '{ "distro" : ['
@@ -41,7 +41,7 @@ runs:
       shell: bash
 
     - name: 1.8 targets
-      if: fluent-bit-version == '1.8'
+      if: inputs.fluent-bit-version == '1.8'
       run: |
         matrix=$((
           echo '{ "distro" : ['

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,6 +3,7 @@
 | Workflow file                                         | Description               | Run event                                         |
 | :---------------------------------------------------- | ------------------------  | ------------------------------------------------- |
 | [build-master-packages](./build-master-packages.yaml) | Builds packages using `master` for certain targets | on new commit/push on master / manual |
+| [cron-unstable-build](./cron-unstable-build.yaml) | Automated nightly builds of each supported branch | Scheduled/manual trigger |
 | [master-integration-test](./master-integration-test.yaml)     | Runs the integration testing suite on master | on new commit/push on master |
 | [staging-build](./staging-build.yaml)            | Builds the distro packages and docker images from a tagged release into staging (S3 and GHCR) | on new release/tag |
 | [staging-test](./staging-test.yaml)            | Test the staging distro packages and docker images| manually or when `staging-build` completes successfully |
@@ -42,7 +43,8 @@ These are only required for Cosign of the container images, will be skipped if n
 
 ## Environments
 
-Two environments are used:
+These environments are used:
+* `unstable` for all nightly builds
 * `staging` for all staging builds
 * `release` for running the promotion of staging to release, this can have additional approvals added
 

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -139,6 +139,35 @@ jobs:
           build-args: |
             FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
 
+  call-build-images-generate-schema:
+    if: inputs.ref != '1.8'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: call-build-images
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.username }}
+          password: ${{ secrets.token }}
+
+      - name: Generate schema
+        run: |
+          docker run --rm -t ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }} -J > fluent-bit-schema.json
+          cat fluent-bit-schema.json | jq -M > fluent-bit-schema-pretty.json
+        shell: bash
+
+      - name: Upload the schema
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./
+          name: fluent-bit-schema*.json
+          if-no-files-found: error
+
   call-build-images-scan:
     name: Trivy + Dockle image scan
     runs-on: ubuntu-latest

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -134,7 +134,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          target: production
           push: true
           load: false
           build-args: |

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -46,16 +46,24 @@ on:
 jobs:
   call-build-images:
     name: Multiarch container images to GHCR
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout code
+        if: inputs.ref != '1.8'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Checkout the docker build repo
+        if: inputs.ref == '1.8'
+        uses: actions/checkout@v3
+        with:
+          repository: fluent/fluent-bit-docker-image
+          ref: '1.8'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -80,6 +88,7 @@ jobs:
             raw,latest
 
       - name: Build the production images
+        if: inputs.ref != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -102,6 +111,7 @@ jobs:
             raw,latest-debug
 
       - name: Build the debug multi-arch images
+        if: inputs.ref != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -115,9 +125,24 @@ jobs:
           build-args: |
             FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
 
+      - name: Build the legacy image
+        if: inputs.ref == '1.8'
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/Dockerfile.x86_64
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          target: production
+          push: true
+          load: false
+          build-args: |
+            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
+
   call-build-images-scan:
     name: Trivy + Dockle image scan
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     needs: call-build-images
     permissions:
@@ -156,7 +181,7 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     needs: call-build-images
     steps:

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -129,7 +129,7 @@ jobs:
         if: inputs.ref == '1.8'
         uses: docker/build-push-action@v2
         with:
-          file: ./dockerfiles/Dockerfile.x86_64
+          file: Dockerfile.x86_64
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -179,7 +179,6 @@ jobs:
     environment: ${{ inputs.environment }}
     needs:
       - call-build-packages
-      - call-build-packages-legacy
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -46,6 +46,9 @@ on:
         required: false
 
 jobs:
+
+  # We build both master/1.9 and 1.8 style packages in a single job as it is simpler to keep all the custom
+  # code and workflow together. We need to run the dependent job after this as well.
   call-build-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}

--- a/.github/workflows/call-build-packages.yaml
+++ b/.github/workflows/call-build-packages.yaml
@@ -55,9 +55,17 @@ jobs:
       matrix: ${{ fromJSON(inputs.build_matrix) }}
     steps:
       - name: Checkout code
+        if: inputs.ref != '1.8'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Checkout packaging code
+        if: inputs.ref == '1.8'
+        uses: actions/checkout@v3
+        with:
+          repository: fluent/fluent-bit-packaging
+          path: packaging
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -74,6 +82,7 @@ jobs:
           flags: 'g'
 
       - name: fluent-bit - ${{ matrix.distro }} artifacts
+        if: inputs.ref != '1.8'
         run: |
           ./build.sh
         env:
@@ -85,6 +94,7 @@ jobs:
         working-directory: packaging
 
       - name: td-agent-bit - ${{ matrix.distro }} artifacts
+        if: inputs.ref != '1.8'
         run: |
           ./build.sh
         env:
@@ -93,6 +103,17 @@ jobs:
           FLB_TD: "On"
           FLB_NIGHTLY_BUILD: ${{ inputs.unstable }}
           CMAKE_INSTALL_PREFIX: /opt/td-agent-bit/
+        working-directory: packaging
+
+      - name: Legacy td-agent-bit - ${{ matrix.distro }} artifacts
+        if: inputs.ref == '1.8'
+        run: |
+          ./build.sh -v $FLB_VERSION -b $FLB_BRANCH -d $FLB_DISTRO
+        env:
+          FLB_VERSION: ${{ inputs.ref }}
+          FLB_BRANCH: ${{ inputs.ref }}
+          FLB_DISTRO: ${{ matrix.distro }}
+          FLB_OUT_DIR: staging
         working-directory: packaging
 
       - name: Upload the ${{ matrix.distro }} artifacts
@@ -153,14 +174,16 @@ jobs:
     # Need to use 18.04 as 20.04 has no createrepo available
     runs-on: ubuntu-18.04
     environment: ${{ inputs.environment }}
-    needs: call-build-packages
+    needs:
+      - call-build-packages
+      - call-build-packages-legacy
     steps:
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y createrepo aptly
 
-      - name: Checkout code
+      - name: Checkout code for repo metadata construction - always latest
         uses: actions/checkout@v3
 
       - name: Import GPG key for signing

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -127,6 +127,8 @@ jobs:
       # Set up the list of target to build so we can pass the JSON to the reusable job
       - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
+        with:
+          fluent-bit-version: ${{ needs.unstable-build-get-meta.outputs.branch }}
 
   unstable-build-packages:
     needs:

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -118,6 +118,8 @@ jobs:
 
   unstable-build-generate-matrix:
     name: unstable build matrix
+    needs:
+      - unstable-build-get-meta
     runs-on: ubuntu-latest
     outputs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -77,7 +77,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_support_version_in_ci_parameter
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -136,7 +136,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@4875_support_version_in_ci_parameter
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -78,7 +78,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_support_version_in_ci_parameter
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -111,7 +111,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@4875_support_version_in_ci_parameter
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -13,9 +13,9 @@ on:
   # Run nightly build at this time, bit of trial and error but this seems good.
   schedule:
   - cron: "0 6 * * *"   # master build
-  # - cron: "0 12 * * *"  # 1.9 build
-  # Not available currently
-  # - cron: "0 18 * * *"  # 1.8 build
+  - cron: "0 12 * * *"  # 1.9 build
+  # Not available currently so will fail until it is
+  - cron: "0 18 * * *"  # 1.8 build
   # A 1.8 build requires merging all the changes from master to handle packaging from local
 
 # We do not want a new unstable build to run whilst we are releasing the current unstable build.

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -27,6 +27,7 @@ jobs:
   unstable-build-get-meta:
     name: Get metadata to add to build
     runs-on: ubuntu-latest
+    environment: unstable
     outputs:
       date: ${{ steps.date.outputs.date }}
       branch: ${{ steps.branch.outputs.branch }}
@@ -97,6 +98,7 @@ jobs:
       - unstable-build-get-meta
       - unstable-build-images
     runs-on: ubuntu-latest
+    environment: unstable
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v1
@@ -124,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+    environment: unstable
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -151,6 +154,7 @@ jobs:
     needs:
       - unstable-build-get-meta
     runs-on: windows-latest
+    environment: unstable
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -127,42 +127,42 @@ jobs:
     runs-on: windows-latest
     environment: unstable
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
 
-    - name: Get dependencies
-      run: |
-        Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
-        Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
-        Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
-        Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
-        echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
-      env:
-        WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
-      shell: pwsh
+      - name: Get dependencies
+        run: |
+          Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
+          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
+          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
+          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
+          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
+        env:
+          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
+        shell: pwsh
 
-    - name: Set up Visual Studio shell
-      uses: egor-tensin/vs-shell@v2
-      with:
-        arch: x64
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+        with:
+          arch: x64
 
-    - name: Build Fluent Bit packages
-      run: |
-        cmake -G "NMake Makefiles" ../
-        cmake --build .
-        cpack
-      working-directory: build
+      - name: Build Fluent Bit packages
+        run: |
+          cmake -G "NMake Makefiles" ../
+          cmake --build .
+          cpack
+        working-directory: build
 
-    - name: Upload build packages
-      uses: actions/upload-artifact@v2
-      with:
-        name: windows-packages
-        path: |
-          build/fluent-bit-*.exe
-          build/fluent-bit-*.zip
-        if-no-files-found: error
+      - name: Upload build packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-packages
+          path: |
+            build/fluent-bit-*.exe
+            build/fluent-bit-*.zip
+          if-no-files-found: error
 
   # We already detain all artefacts as build output so just capture for an unstable release
   unstable-release:
@@ -176,6 +176,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Required to make a release later
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Download all artefacts
         continue-on-error: true
         uses: actions/download-artifact@v2

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -91,7 +91,8 @@ jobs:
 
   unstable-build-generate-schema:
     # Not available for 1.8
-    if: github.event.schedule != '*18 * * * *'
+    # Handle manually initiated
+    if: needs.unstable-build-get-meta.outputs.branch != '1.8'
     needs:
       - unstable-build-get-meta
       - unstable-build-images
@@ -105,7 +106,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: |
-          docker run --rm -it ${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }} -J > fluent-bit-schema.json
+          docker run --rm -t ${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }} -J > fluent-bit-schema.json
           cat fluent-bit-schema.json | jq -M > fluent-bit-schema-pretty.json
         shell: bash
 
@@ -209,7 +210,8 @@ jobs:
       - name: Single packages tar
         run: |
           mkdir -p release-upload
-          mv -f artifacts/*.json release-upload/
+          # Optional JSON schema so ignore failure
+          mv -f artifacts/*.json release-upload/ || true
           tar -czvf release-upload/packages-unstable-${{ needs.unstable-build-get-meta.outputs.branch }}.tar.gz -C artifacts/ .
         shell: bash
 

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -13,8 +13,10 @@ on:
   # Run nightly build at this time, bit of trial and error but this seems good.
   schedule:
   - cron: "0 6 * * *"   # master build
-  - cron: "0 12 * * *"  # 1.9 build
-  - cron: "0 18 * * *"  # 1.8 build
+  # - cron: "0 12 * * *"  # 1.9 build
+  # Not available currently
+  # - cron: "0 18 * * *"  # 1.8 build
+  # A 1.8 build requires merging all the changes from master to handle packaging from local
 
 # We do not want a new unstable build to run whilst we are releasing the current unstable build.
 concurrency: unstable-build-release
@@ -45,19 +47,19 @@ jobs:
         shell: bash
 
       - name: master run
-        if:  github.event_name == 'schedule' && github.event.schedule=='0 6 * * *'         # set-env value
+        if:  github.event_name == 'schedule' && github.event.schedule=='0 6 * * *'
         run: |
           echo "cron_branch=master" >> $GITHUB_ENV
         shell: bash
 
       - name: 1.9 run
-        if:  github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'   # set env value
+        if:  github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'
         run: |
           echo "cron_branch=1.9" >> $GITHUB_ENV
         shell: bash
 
       - name: 1.8 run
-        if:  github.event_name == 'schedule' && github.event.schedule=='0 18 * * *'   # set env value
+        if:  github.event_name == 'schedule' && github.event.schedule=='0 18 * * *'
         run: |
           echo "cron_branch=1.8" >> $GITHUB_ENV
         shell: bash
@@ -89,7 +91,7 @@ jobs:
 
   unstable-build-generate-schema:
     # Not available for 1.8
-    if: github.event.schedule != '*/18 * * * *'
+    if: github.event.schedule != '*18 * * * *'
     needs:
       - unstable-build-get-meta
       - unstable-build-images

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -90,35 +90,6 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 
-  unstable-build-generate-schema:
-    # Not available for 1.8
-    # Handle manually initiated
-    if: needs.unstable-build-get-meta.outputs.branch != '1.8'
-    needs:
-      - unstable-build-get-meta
-      - unstable-build-images
-    runs-on: ubuntu-latest
-    environment: unstable
-    steps:
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: |
-          docker run --rm -t ${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }} -J > fluent-bit-schema.json
-          cat fluent-bit-schema.json | jq -M > fluent-bit-schema-pretty.json
-        shell: bash
-
-      - name: Upload the schema
-        uses: actions/upload-artifact@v2
-        with:
-          path: ./
-          name: fluent-bit-schema*.json
-          if-no-files-found: error
-
   unstable-build-generate-matrix:
     name: unstable build matrix
     needs:
@@ -230,12 +201,14 @@ jobs:
         # May not be any/valid so ignore errors
         continue-on-error: true
         run: |
-          docker pull ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}
-          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}.tar ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}
-          docker pull ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}-debug
-          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}-debug.tar ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}-debug
+          docker pull $IMAGE
+          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}.tar $IMAGE
+          docker pull $IMAGE-debug
+          docker save --output container-${{ needs.unstable-build-get-meta.outputs.branch }}-debug.tar $IMAGE-debug
         shell: bash
         working-directory: release-upload
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/unstable:${{ needs.unstable-build-get-meta.outputs.branch }}
 
       - name: Display structure of files to upload
         run: ls -R

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -77,7 +77,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_support_version_in_ci_parameter
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -137,7 +137,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@4875_support_version_in_ci_parameter
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -77,7 +77,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_support_version_in_ci_parameter
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -132,7 +132,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@4875_support_version_in_ci_parameter
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -5,6 +5,9 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - master
+      - '1.9'
 
   workflow_dispatch:
     inputs:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -18,12 +18,6 @@ FROM debian:bullseye-slim as builder
 COPY --from=qemu-arm32 /usr/bin/qemu-arm-static /usr/bin/
 COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 
-# Fluent Bit version
-ENV FLB_MAJOR 1
-ENV FLB_MINOR 9
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.9.0
-
 ARG FLB_NIGHTLY_BUILD
 ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
 

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -43,6 +43,7 @@ baseurl=https://$AWS_S3_BUCKET.s3.amazonaws.com/$RPM_REPO/
 enabled=1
 gpgkey=https://$AWS_S3_BUCKET.s3.amazonaws.com/fluentbit.key
 gpgcheck=1
+repo_gpgcheck=1
 EOF
     fi
 done
@@ -101,10 +102,10 @@ done
 # Ensure we sign the Yum repo meta-data
 if [[ "$DISABLE_SIGNING" != "true" ]]; then
     GPG_PARAMS="--batch --armor --yes -u $GPG_KEY"
-    if [[ -n "$GPG_KEY_PASSPHRASE" ]]; then
+    if [[ -n "${GPG_KEY_PASSPHRASE:-}" ]]; then
         GPG_PARAMS="$GPG_PARAMS --passphrase $GPG_KEY_PASSPHRASE"
     fi
     # We do want splitting here for parameters
     # shellcheck disable=SC2086
-    find "/var/www/apt.fluentbit.io" -name repomd.xml -exec gpg --detach-sign $GPG_PARAMS {} \;
+    find "$BASE_PATH" -name repomd.xml -exec gpg --detach-sign $GPG_PARAMS {} \;
 fi


### PR DESCRIPTION
Supporting #4875 by building for 1.8 as well: https://github.com/fluent/fluent-bit/runs/5606239586
The intention here is just to make these available to enable further updates to test and trigger staging builds then.

An example created from this branch: https://github.com/fluent/fluent-bit/releases/tag/unstable-1.8

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Due to the restrictions on reusable workflows, we have to specify this branch to use as a temporary change then revert it prior to merge:

- 1.8 build: https://github.com/fluent/fluent-bit/actions/runs/2012030356
- `master` build (fails due to #5119) : https://github.com/fluent/fluent-bit/actions/runs/2012035350

**Documentation**
Updated README.

**Backporting**
No need to backport.

[ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
