### PR TITLE
filter_record_modifier: add error check for flb_strndup(#5103)

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -101,10 +101,21 @@ static int configure(struct record_modifier_ctx *ctx,
         sentry = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
         mod_record->key_len = flb_sds_len(sentry->str);
         mod_record->key = flb_strndup(sentry->str, mod_record->key_len);
+        if (mod_record->key == NULL) {
+            flb_errno();
+            flb_free(mod_record);
+            continue;
+        }
 
         sentry = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
         mod_record->val_len = flb_sds_len(sentry->str);
         mod_record->val = flb_strndup(sentry->str, mod_record->val_len);
+        if (mod_record->val == NULL) {
+            flb_errno();
+            flb_free(mod_record->key);
+            flb_free(mod_record);
+            continue;
+        }
 
         mk_list_add(&mod_record->_head, &ctx->records);
         ctx->records_num++;


### PR DESCRIPTION
This is to add error check for `flb_strndup`
See also https://github.com/fluent/fluent-bit/issues/5103

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-filter_record_modifier 
Test json_long...                               [ OK ]
Test remove_keys...                             [ OK ]
Test records...                                 [ OK ]
Test allowlist_keys...                          [ OK ]
Test multiple...                                [ OK ]
Test exclusive_setting...                       [2022/03/19 07:55:50] [error] [lib] backend failed
[2022/03/19 07:55:50] [error] [filter:record_modifier:record_modifier.0] remove_keys and allowlist_keys are exclusive with each other.
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_record_modifier 
==36375== Memcheck, a memory error detector
==36375== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==36375== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==36375== Command: bin/flb-rt-filter_record_modifier
==36375== 
Test json_long...                               [ OK ]
Test remove_keys...                             [ OK ]
Test records...                                 [ OK ]
Test allowlist_keys...                          [ OK ]
Test multiple...                                [ OK ]
Test exclusive_setting...                       [2022/03/19 07:56:25] [error] [filter:record_modifier:record_modifier.0] remove_keys and allowlist_keys are exclusive with each other.
[2022/03/19 07:56:25] [error] Failed initialize filter record_modifier.0
[2022/03/19 07:56:25] [error] [lib] backend failed
[ OK ]
SUCCESS: All unit tests have passed.
==36375== 
==36375== HEAP SUMMARY:
==36375==     in use at exit: 0 bytes in 0 blocks
==36375==   total heap usage: 6,311 allocs, 6,311 frees, 3,523,358 bytes allocated
==36375== 
==36375== All heap blocks were freed -- no leaks are possible
==36375== 
==36375== For lists of detected and suppressed errors, rerun with: -s
==36375== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
