### PR TITLE
out_kafka: fix broken config map(#5097)

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -541,8 +541,8 @@ static struct flb_config_map config_map[] = {
    },
    {
     FLB_CONFIG_MAP_INT, "queue_full_retries", FLB_KAFKA_QUEUE_FULL_RETRIES,
-    0, FLB_TRUE, offsetof(struct flb_out_kafka, timestamp_format_str),
-    "Set the format the timestamp is in."
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, queue_full_retries),
+    "Set the number of local retries to enqueue the data."
    },
    {
     FLB_CONFIG_MAP_STR, "gelf_timestamp_key", (char *)NULL,

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -30,6 +30,7 @@
 struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
                                            struct flb_config *config)
 {
+    int ret;
     const char *tmp;
     char errstr[512];
     struct mk_list *head;
@@ -45,6 +46,13 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     }
     ctx->ins = ins;
     ctx->blocked = FLB_FALSE;
+
+    ret = flb_output_config_map_set(ins, (void*) ctx);
+    if (ret == -1) {
+        flb_plg_error(ins, "unable to load configuration.");
+        flb_free(ctx);
+        return -1;
+    }
 
     /* rdkafka config context */
     ctx->conf = flb_kafka_conf_create(&ctx->kafka, &ins->properties, 0);


### PR DESCRIPTION
Fixes #5097 

This patch is to fix config map of out_kafka.
- Add missing `flb_output_config_map_set`
- Fix `"queue_full_retries"` property not to set other property

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
fluent-bit -i mem -o kafka -p brokers=localhost:9092
```

## Debug log

Output of kafka. 
There is no name keys e.g. `"":1647457453.307707`.
```
$ bin/kafka-console-consumer.sh --topic fluent-bit --from-beginning --bootstrap-server localhost:9092
{"@timestamp":1647666307.639214,"Mem.total":8143088,"Mem.used":6951272,"Mem.free":1191816,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666308.61863,"Mem.total":8143088,"Mem.used":6951776,"Mem.free":1191312,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666309.603657,"Mem.total":8143088,"Mem.used":6952564,"Mem.free":1190524,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666310.603667,"Mem.total":8143088,"Mem.used":6952816,"Mem.free":1190272,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666311.604255,"Mem.total":8143088,"Mem.used":6952816,"Mem.free":1190272,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666312.603574,"Mem.total":8143088,"Mem.used":6953068,"Mem.free":1190020,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666313.603609,"Mem.total":8143088,"Mem.used":6953068,"Mem.free":1190020,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666314.60448,"Mem.total":8143088,"Mem.used":6953320,"Mem.free":1189768,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}
{"@timestamp":1647666315.603548,"Mem.total":8143088,"Mem.used":6953320,"Mem.free":1189768,"Swap.total":1918356,"Swap.used":1292,"Swap.free":1917064}

```

```
$ bin/fluent-bit -i mem -o kafka -p brokers=localhost:9092
Fluent Bit v1.9.1
* Git commit: 619277847c6343dea9e4215deacd36cf61caf0a3
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/19 13:52:39] [ info] [engine] started (pid=104223)
[2022/03/19 13:52:39] [ info] [storage] version=1.1.6, initializing...
[2022/03/19 13:52:39] [ info] [storage] in-memory
[2022/03/19 13:52:39] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/19 13:52:39] [ info] [cmetrics] version=0.3.0
[2022/03/19 13:52:39] [ info] [output:kafka:kafka.0] brokers='localhost:9092' topics='(null)'
[2022/03/19 13:52:39] [ info] [sp] stream processor started
^C[2022/03/19 13:52:50] [engine] caught signal (SIGINT)
[2022/03/19 13:52:50] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/19 13:52:50] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/19 13:52:50] [ warn] [output:kafka:kafka.0] fluent-bit#producer-1: [thrd:app]: Producer terminating with 1 message (146 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

## Valgrind output

```
$ valgrind --leak-check=full  bin/fluent-bit -i mem -o kafka -p brokers=localhost:9092
==114166== Memcheck, a memory error detector
==114166== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==114166== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==114166== Command: bin/fluent-bit -i mem -o kafka -p brokers=localhost:9092
==114166== 
Fluent Bit v1.9.1
* Git commit: aadfed0d1d7337ab29ba476b06f46b50195908ff
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/19 14:05:07] [ info] [engine] started (pid=114166)
[2022/03/19 14:05:07] [ info] [storage] version=1.1.6, initializing...
[2022/03/19 14:05:07] [ info] [storage] in-memory
[2022/03/19 14:05:07] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/19 14:05:07] [ info] [cmetrics] version=0.3.0
[2022/03/19 14:05:07] [ info] [output:kafka:kafka.0] brokers='localhost:9092' topics='(null)'
[2022/03/19 14:05:07] [ info] [sp] stream processor started
^C[2022/03/19 14:05:15] [engine] caught signal (SIGINT)
[2022/03/19 14:05:15] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/19 14:05:16] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/19 14:05:16] [ warn] [output:kafka:kafka.0] fluent-bit#producer-1: [thrd:app]: Producer terminating with 1 message (148 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
==114166== 
==114166== HEAP SUMMARY:
==114166==     in use at exit: 0 bytes in 0 blocks
==114166==   total heap usage: 1,546 allocs, 1,546 frees, 3,363,906 bytes allocated
==114166== 
==114166== All heap blocks were freed -- no leaks are possible
==114166== 
==114166== For lists of detected and suppressed errors, rerun with: -s
==114166== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
