### PR TITLE
exec: fix name of oneshot parameter

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -333,7 +333,7 @@ static struct flb_config_map config_map[] = {
       "Set the buffer size"
     },
     {
-      FLB_CONFIG_MAP_BOOL, "bool", "false",
+      FLB_CONFIG_MAP_BOOL, "oneshot", "false",
       0, FLB_TRUE, offsetof(struct flb_exec, oneshot),
       "execute the command only once"
     },


### PR DESCRIPTION
I think there was a typo in https://github.com/fluent/fluent-bit/pull/4932/ as the `oneshot` parameter was renamed to `bool`:

```
bin/fluent-bit -f 1 -i exec -p "command=exec 2>&1; ls /var/log" -p 'oneshot=true' -o stdout
Fluent Bit v1.9.1
* Git commit: 619277847c6343dea9e4215deacd36cf61caf0a3
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/19 08:55:47] [ info] [engine] started (pid=2451199)
[2022/03/19 08:55:47] [ info] [storage] version=1.1.6, initializing...
[2022/03/19 08:55:47] [ info] [storage] in-memory
[2022/03/19 08:55:47] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/19 08:55:47] [ info] [cmetrics] version=0.3.0
[2022/03/19 08:55:47] [error] [config] exec: unknown configuration property 'oneshot'. The following properties are allowed: command, parser, interval_sec, interval_nsec, buf_size, and bool.
[2022/03/19 08:55:47] [error] [lib] backend failed
[2022/03/19 08:55:47] [ help] try the command: bin/fluent-bit -i exec -h
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
