### PR TITLE
tests: internal: fuzzers: fix malloc denial

### DIFF
--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -54,7 +54,7 @@ int flb_malloc_p;
 
 static inline int flb_fuzz_get_probability(int val) {
   flb_malloc_p += 1;
-  flb_malloc_p = flb_malloc_p % 2500;
+  flb_malloc_p = flb_malloc_p % 25000;
   if (val > flb_malloc_p) {
     return 1;
   }

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -54,7 +54,7 @@ int flb_malloc_p;
 
 static inline int flb_fuzz_get_probability(int val) {
   flb_malloc_p += 1;
-  flb_malloc_p = flb_malloc_p % 100;
+  flb_malloc_p = flb_malloc_p % 1000;
   if (val > flb_malloc_p) {
     return 1;
   }

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -54,7 +54,7 @@ int flb_malloc_p;
 
 static inline int flb_fuzz_get_probability(int val) {
   flb_malloc_p += 1;
-  flb_malloc_p = flb_malloc_p % 1000;
+  flb_malloc_p = flb_malloc_p % 1500;
   if (val > flb_malloc_p) {
     return 1;
   }

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -54,7 +54,7 @@ int flb_malloc_p;
 
 static inline int flb_fuzz_get_probability(int val) {
   flb_malloc_p += 1;
-  flb_malloc_p = flb_malloc_p % 1500;
+  flb_malloc_p = flb_malloc_p % 2500;
   if (val > flb_malloc_p) {
     return 1;
   }

--- a/tests/internal/fuzzers/config_fuzzer.c
+++ b/tests/internal/fuzzers/config_fuzzer.c
@@ -320,6 +320,7 @@ char conf_file[] = "# Parser: no_year\n"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    flb_malloc_p = 0;
     /* Limit the size of the config files to 32KB. */
     if (size > 32768) {
         return 0;

--- a/tests/internal/fuzzers/config_map_fuzzer.c
+++ b/tests/internal/fuzzers/config_map_fuzzer.c
@@ -155,6 +155,7 @@ struct flb_config_map *configs[] = {config_map_mult, config_map};
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    flb_malloc_p = 0;
     if (size < 40) {
         return 0;
     }

--- a/tests/internal/fuzzers/config_random_fuzzer.c
+++ b/tests/internal/fuzzers/config_random_fuzzer.c
@@ -24,6 +24,8 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    flb_malloc_p = 0;
+
     /* Limit the size of the config files to 32KB. */
     if (size > 32768) {
         return 0;

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -121,7 +121,7 @@ struct flb_lib_out_cb cb;
 
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
-
+    flb_malloc_p = 0;
     ctx = flb_create();
     flb_service_set(ctx, "Flush", "0", "Grace", 
                     "0", "Log_Level", "debug", NULL);

--- a/tests/internal/fuzzers/filter_stdout_fuzzer.c
+++ b/tests/internal/fuzzers/filter_stdout_fuzzer.c
@@ -27,7 +27,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
-
+    flb_malloc_p = 0;
     ctx = flb_create();
     flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
     in_ffd = flb_input(ctx, (char *) "lib", NULL);

--- a/tests/internal/fuzzers/flb_json_fuzzer.c
+++ b/tests/internal/fuzzers/flb_json_fuzzer.c
@@ -24,7 +24,7 @@
 int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
 {
     TIMEOUT_GUARD
-
+    flb_malloc_p = 0;
     if (size < 1) {
         return 0;
     }

--- a/tests/internal/fuzzers/http_fuzzer.c
+++ b/tests/internal/fuzzers/http_fuzzer.c
@@ -14,6 +14,7 @@ extern int fuzz_check_connection(struct flb_http_client *c);
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    flb_malloc_p = 0;
     struct flb_upstream *u;
     struct flb_upstream_conn *u_conn = NULL;
     struct flb_http_client *c;

--- a/tests/internal/fuzzers/msgpack_parse_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_parse_fuzzer.c
@@ -4,6 +4,7 @@
 #include <fluent-bit/flb_pack.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    flb_malloc_p = 0;
     if (size != 512)
         return 0;
 

--- a/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
@@ -4,6 +4,7 @@
 #include <fluent-bit/flb_pack.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    flb_malloc_p = 0;
     if (size != 512)
         return 0;
 

--- a/tests/internal/fuzzers/multiline_fuzzer.c
+++ b/tests/internal/fuzzers/multiline_fuzzer.c
@@ -132,7 +132,7 @@ void test_multiline_parser(msgpack_object *root2, int rand_val) {
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     TIMEOUT_GUARD
-
+    flb_malloc_p = 0;
     /* Ensure there's enough data */
     if (size < 250) {
         return 0;

--- a/tests/internal/fuzzers/pack_json_state_fuzzer.c
+++ b/tests/internal/fuzzers/pack_json_state_fuzzer.c
@@ -6,6 +6,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     int out_size= 0;
     char *out_buf = NULL;
     struct flb_pack_state state;
+    flb_malloc_p = 0;
 
     /* Target json packer */
     flb_pack_state_init(&state);

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -24,12 +24,12 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     TIMEOUT_GUARD
-
     void *out_buf = NULL;
     size_t out_size = 0;
     struct flb_time out_time;
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
+    flb_malloc_p = 0;
 
     /* json parser */
     fuzz_config = flb_config_init();

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -11,6 +11,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
 
+    flb_malloc_p = 0;
+
     /* logfmt parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, FLB_TRUE,

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -11,6 +11,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
 
+    flb_malloc_p = 0;
+
     /* ltsvc parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, FLB_TRUE,

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -42,6 +42,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     int time_keep = 0;
     int types_len = 0;
 
+    flb_malloc_p = 0;
+
     if (size < 100) {
         return 0;
     }

--- a/tests/internal/fuzzers/record_ac_fuzzer.c
+++ b/tests/internal/fuzzers/record_ac_fuzzer.c
@@ -22,6 +22,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     size_t off = 0;
     msgpack_object map;
 
+    flb_malloc_p = 0;
+
     if (size < 100) {
        return 0;
     }

--- a/tests/internal/fuzzers/signv4_fuzzer.c
+++ b/tests/internal/fuzzers/signv4_fuzzer.c
@@ -19,6 +19,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
+    flb_malloc_p = 0;
+
     char s3_mode = data[0];
     MOVE_INPUT(1)
     int method = (int)data[0];

--- a/tests/internal/fuzzers/strp_fuzzer.c
+++ b/tests/internal/fuzzers/strp_fuzzer.c
@@ -19,6 +19,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
+    flb_malloc_p = 0;
+
     char *fmt = get_null_terminated(size - 30, &data, &size);
     char *buf = get_null_terminated(size, &data, &size);
 


### PR DESCRIPTION
Ensure all fuzzers set flb_malloc_p to 0 and decrease the chance of a
malloc failing. We need to do this as otherwise the impact of denying
malloc is too large.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
