### PR TITLE
filter_modify: add error check for flb_strndup(#5103)

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -161,7 +161,25 @@ static int setup(struct filter_modify_ctx *ctx,
             condition->b_is_regex = false;
             condition->ra_a = NULL;
             condition->raw_k = flb_strndup(kv->key, flb_sds_len(kv->key));
+            if (condition->raw_k == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for "
+                              "condition->raw_k");
+                teardown(ctx);
+                condition_free(condition);
+                flb_utils_split_free(split);
+                return -1;
+            }
             condition->raw_v = flb_strndup(kv->val, flb_sds_len(kv->val));
+            if (condition->raw_v == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for "
+                              "condition->raw_v");
+                teardown(ctx);
+                condition_free(condition);
+                flb_utils_split_free(split);
+                return -1;
+            }
 
             sentry =
                 mk_list_entry_first(split, struct flb_split_entry, _head);
@@ -230,6 +248,15 @@ static int setup(struct filter_modify_ctx *ctx,
                 sentry =
                     mk_list_entry_last(split, struct flb_split_entry, _head);
                 condition->b = flb_strndup(sentry->value, sentry->len);
+                if (condition->b == NULL) {
+                    flb_errno();
+                    flb_plg_error(ctx->ins, "Unable to allocate memory for "
+                                  "condition->b");
+                    teardown(ctx);
+                    condition_free(condition);
+                    flb_utils_split_free(split);
+                    return -1;
+                }
                 condition->b_len = sentry->len;
             }
             else {
@@ -296,15 +323,53 @@ static int setup(struct filter_modify_ctx *ctx,
             rule->key_is_regex = false;
             rule->val_is_regex = false;
             rule->raw_k = flb_strndup(kv->key, flb_sds_len(kv->key));
+            if (rule->raw_k == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for rule->raw_k");
+                teardown(ctx);
+                flb_free(rule);
+                flb_utils_split_free(split);
+                return -1;
+            }
             rule->raw_v = flb_strndup(kv->val, flb_sds_len(kv->val));
+            if (rule->raw_v == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for rule->raw_v");
+                teardown(ctx);
+                flb_free(rule->raw_k);
+                flb_free(rule);
+                flb_utils_split_free(split);
+                return -1;
+            }
 
             sentry =
                 mk_list_entry_first(split, struct flb_split_entry, _head);
             rule->key = flb_strndup(sentry->value, sentry->len);
+            if (rule->key == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for rule->key");
+                teardown(ctx);
+                flb_free(rule->raw_v);
+                flb_free(rule->raw_k);
+                flb_free(rule);
+                flb_utils_split_free(split);
+                return -1;
+            }
             rule->key_len = sentry->len;
 
             sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
             rule->val = flb_strndup(sentry->value, sentry->len);
+            if (rule->val == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "Unable to allocate memory for rule->val");
+                teardown(ctx);
+                flb_free(rule->key);
+                flb_free(rule->raw_v);
+                flb_free(rule->raw_k);
+                flb_free(rule);
+                flb_utils_split_free(split);
+                return -1;
+            }
             rule->val_len = sentry->len;
 
             flb_utils_split_free(split);


### PR DESCRIPTION
This is to add error check for `flb_strndup`.
See also https://github.com/fluent/fluent-bit/issues/5103

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log

```
$ bin/flb-rt-filter_modify 
Test op_set_append...                           [2022/03/20 08:32:11] [ info] [engine] started (pid=5683)
[2022/03/20 08:32:11] [ info] [storage] version=1.1.6, initializing...
[2022/03/20 08:32:11] [ info] [storage] in-memory
[2022/03/20 08:32:11] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/20 08:32:11] [ info] [cmetrics] version=0.3.0
[2022/03/20 08:32:11] [ info] [sp] stream processor started
[2022/03/20 08:32:12] [ warn] [engine] service will shutdown in max 1 seconds
[2022/03/20 08:32:12] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]

(snip)
Test cond_key_value_does_not_matches and key does not exist... [2022/03/20 08:33:16] [ info] [engine] started (pid=5780)
[2022/03/20 08:33:16] [ info] [storage] version=1.1.6, initializing...
[2022/03/20 08:33:16] [ info] [storage] in-memory
[2022/03/20 08:33:16] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/20 08:33:16] [ info] [cmetrics] version=0.3.0
[2022/03/20 08:33:16] [ info] [sp] stream processor started
[2022/03/20 08:33:18] [ warn] [engine] service will shutdown in max 1 seconds
[2022/03/20 08:33:19] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

I think below error doesn't relate this patch since same error is reported using v1.9.0.
```
$ valgrind --leak-check=full bin/flb-rt-filter_modify 
==5854== Memcheck, a memory error detector
==5854== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5854== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5854== Command: bin/flb-rt-filter_modify
==5854== 
Test op_set_append...                           [2022/03/20 08:36:30] [ info] [engine] started (pid=5854)
[2022/03/20 08:36:30] [ info] [storage] version=1.1.6, initializing...
[2022/03/20 08:36:30] [ info] [storage] in-memory
[2022/03/20 08:36:30] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/20 08:36:30] [ info] [cmetrics] version=0.3.0
[2022/03/20 08:36:30] [ info] [sp] stream processor started
[2022/03/20 08:36:31] [ warn] [engine] service will shutdown in max 1 seconds
[2022/03/20 08:36:31] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
(snip)
[ OK ]
SUCCESS: All unit tests have passed.
==5854== 
==5854== HEAP SUMMARY:
==5854==     in use at exit: 185 bytes in 3 blocks
==5854==   total heap usage: 37,329 allocs, 37,326 frees, 20,896,145 bytes allocated
==5854== 
==5854== 185 bytes in 3 blocks are definitely lost in loss record 1 of 1
==5854==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5854==    by 0x2BAC86: flb_malloc (flb_mem.h:79)
==5854==    by 0x2BB58C: out_lib_flush (out_lib.c:164)
==5854==    by 0x1ADF3A: output_pre_cb_flush (flb_output.h:517)
==5854==    by 0x7737CA: co_init (amd64.c:117)
==5854== 
==5854== LEAK SUMMARY:
==5854==    definitely lost: 185 bytes in 3 blocks
==5854==    indirectly lost: 0 bytes in 0 blocks
==5854==      possibly lost: 0 bytes in 0 blocks
==5854==    still reachable: 0 bytes in 0 blocks
==5854==         suppressed: 0 bytes in 0 blocks
==5854== 
==5854== For lists of detected and suppressed errors, rerun with: -s
==5854== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
