### PR TITLE
packaging: add repo signing check to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
 name = Fluent Bit
 baseurl = https://packages.fluentbit.io/amazonlinux/\$releasever/\$basearch/
 gpgcheck=1
+repo_gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
 EOF
@@ -51,6 +52,7 @@ cat > /etc/yum.repos.d/fluent-bit.repo <<EOF
 name = Fluent Bit
 baseurl = https://packages.fluentbit.io/centos/\$releasever/\$basearch/
 gpgcheck=1
+repo_gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
 EOF

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -16,12 +16,12 @@ FROM official-install as staging-upgrade-prep
 RUN rm -f /etc/yum.repos.d/td-agent-bit.repo
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
 # hadolint ignore=DL3032
-RUN rpm --import "$AWS_URL/fluentbit.key" && \
-    wget -q "$AWS_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo && \
+RUN rpm --import "$STAGING_URL/fluentbit.key" && \
+    wget -q "$STAGING_URL/amazonlinux-2.repo" -O /etc/yum.repos.d/staging.repo && \
     yum update -y && yum install -y fluent-bit && \
     systemctl enable fluent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -5,11 +5,9 @@ FROM dokken/amazonlinux-2 as official-install
 ARG RELEASE_URL
 # For echo flags
 SHELL ["/bin/bash", "-c"]
-# hadolint ignore=DL3032
-RUN rpm --import $RELEASE_URL/fluentbit.key && \
-    echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/amazonlinux/2/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo && \
-    yum update -y && yum install -y td-agent-bit && \
-    systemctl enable td-agent-bit
+
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -3,9 +3,8 @@ ARG STAGING_BASE=dokken/amazonlinux-2
 
 FROM dokken/amazonlinux-2 as official-install
 ARG RELEASE_URL
-# For echo flags
-SHELL ["/bin/bash", "-c"]
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -14,11 +14,11 @@ FROM official-install as staging-upgrade-prep
 RUN rm -f /etc/yum.repos.d/*-bit.repo
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/centos-7.repo" -O /etc/yum.repos.d/staging.repo
+RUN rpm --import "$STAGING_URL/fluentbit.key"
+RUN wget "$STAGING_URL/centos-7.repo" -O /etc/yum.repos.d/staging.repo
 # hadolint ignore=DL3032
 RUN yum update -y && yum install -y fluent-bit
 RUN systemctl enable fluent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -17,11 +17,11 @@ FROM ${STAGING_BASE} as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN rpm --import "$STAGING_URL/fluentbit.key"
-RUN wget "$STAGING_URL/centos-7.repo" -O /etc/yum.repos.d/staging.repo
+RUN rpm --import "$STAGING_URL/fluentbit.key" && \
+    wget -nv "$STAGING_URL/centos-7.repo" -O /etc/yum.repos.d/staging.repo
 # hadolint ignore=DL3032
-RUN yum update -y && yum install -y fluent-bit
-RUN systemctl enable fluent-bit
+RUN yum update -y && yum install -y fluent-bit && \
+    systemctl enable fluent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -9,6 +9,7 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
 ARG RELEASE_URL
 RUN rpm --import $RELEASE_URL/fluentbit.key
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -23,16 +23,15 @@ FROM ${STAGING_BASE} as staging-install
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN rpm --import "$AWS_URL/fluentbit.key"
-RUN wget "$AWS_URL/centos-8.repo" -O /etc/yum.repos.d/staging.repo
+RUN rpm --import "$STAGING_URL/fluentbit.key"
+RUN wget "$STAGING_URL/centos-8.repo" -O /etc/yum.repos.d/staging.repo
 # hadolint ignore=DL3032
 RUN yum update -y && yum install -y fluent-bit
 RUN systemctl enable fluent-bit
 
-ENV SKIP_TEST=no
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -27,11 +27,11 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN rpm --import "$STAGING_URL/fluentbit.key"
-RUN wget "$STAGING_URL/centos-8.repo" -O /etc/yum.repos.d/staging.repo
+RUN rpm --import "$STAGING_URL/fluentbit.key" && \
+    wget -nv "$STAGING_URL/centos-8.repo" -O /etc/yum.repos.d/staging.repo
 # hadolint ignore=DL3032
-RUN yum update -y && yum install -y fluent-bit
-RUN systemctl enable fluent-bit
+RUN yum update -y && yum install -y fluent-bit && \
+    systemctl enable fluent-bit
 
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -9,13 +9,9 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
 ARG RELEASE_URL
 RUN rpm --import $RELEASE_URL/fluentbit.key
 
-# No official packages available yet
-# RUN echo -e "[td-agent-bit]\nname = Ttd-agent-bit\nbaseurl = $RELEASE_URL/centos/\$releasever/\$basearch/\ngpgcheck=1\ngpgkey=$RELEASE_URL/fluentbit.key\nenabled=1" > /etc/yum.repos.d/td-agent-bit.repo
-# hadolint ignore=DL3032
-# RUN yum update -y && yum install -y td-agent-bit
-# RUN systemctl enable td-agent-bit
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
-ENV SKIP_TEST=yes
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 

--- a/packaging/testing/smoke/packages/Dockerfile.debian10
+++ b/packaging/testing/smoke/packages/Dockerfile.debian10
@@ -15,11 +15,11 @@ FROM official-install as staging-upgrade-prep
 RUN head -n -1 /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN wget -qO - $AWS_URL/fluentbit.key | apt-key add -
-RUN echo "deb $AWS_URL/debian/buster buster main" >> /etc/apt/sources.list
+RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
+RUN echo "deb $STAGING_URL/debian/buster buster main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.debian10
+++ b/packaging/testing/smoke/packages/Dockerfile.debian10
@@ -18,6 +18,7 @@ FROM ${STAGING_BASE} as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
 RUN echo "deb $STAGING_URL/debian/buster buster main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.debian11
+++ b/packaging/testing/smoke/packages/Dockerfile.debian11
@@ -3,8 +3,7 @@ ARG STAGING_BASE=dokken/debian-11
 
 FROM dokken/debian-11 as official-install
 ARG RELEASE_URL
-RUN wget -qO - $RELEASE_URL/fluentbit.key | apt-key add -
-
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
@@ -18,6 +17,7 @@ FROM ${STAGING_BASE} as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
 RUN echo "deb $STAGING_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.debian11
+++ b/packaging/testing/smoke/packages/Dockerfile.debian11
@@ -15,15 +15,14 @@ FROM official-install as staging-upgrade-prep
 RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN wget -qO - $AWS_URL/fluentbit.key | apt-key add -
-RUN echo "deb $AWS_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
+RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
+RUN echo "deb $STAGING_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 
-ENV SKIP_TEST=no
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 

--- a/packaging/testing/smoke/packages/Dockerfile.debian11
+++ b/packaging/testing/smoke/packages/Dockerfile.debian11
@@ -5,17 +5,14 @@ FROM dokken/debian-11 as official-install
 ARG RELEASE_URL
 RUN wget -qO - $RELEASE_URL/fluentbit.key | apt-key add -
 
-# No official packages yet
-# RUN echo "deb $RELEASE_URL/debian/bullseye bullseye main" >> /etc/apt/sources.list
-# RUN apt-get update && apt-get install -y td-agent-bit
-# RUN systemctl enable td-agent-bit
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit || systemctl enable td-agent-bit
 
-ENV SKIP_TEST=yes
 COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 
 FROM official-install as staging-upgrade-prep
-RUN head -n -1 /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
+RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
 
 FROM ${STAGING_BASE} as staging-install
 ARG AWS_URL

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
@@ -15,11 +15,11 @@ FROM official-install as staging-upgrade-prep
 RUN head -n -1 /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN wget -qO - $AWS_URL/fluentbit.key | apt-key add -
-RUN echo "deb $AWS_URL/ubuntu/bionic bionic main" >> /etc/apt/sources.list
+RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
+RUN echo "deb $STAGING_URL/ubuntu/bionic bionic main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
@@ -18,6 +18,7 @@ FROM ${STAGING_BASE} as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
 RUN echo "deb $STAGING_URL/ubuntu/bionic bionic main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -14,11 +14,11 @@ FROM official-install as staging-upgrade-prep
 RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
 
 FROM ${STAGING_BASE} as staging-install
-ARG AWS_URL
+ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
-RUN wget -qO - $AWS_URL/fluentbit.key | apt-key add -
-RUN echo "deb $AWS_URL/ubuntu/focal focal main" >> /etc/apt/sources.list
+RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
+RUN echo "deb $STAGING_URL/ubuntu/focal focal main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit
 RUN systemctl enable td-agent-bit
 

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -17,6 +17,7 @@ FROM ${STAGING_BASE} as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
 RUN echo "deb $STAGING_URL/ubuntu/focal focal main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y td-agent-bit

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -11,7 +11,7 @@ COPY ./test.sh /test.sh
 RUN chmod a+x /test.sh
 
 FROM official-install as staging-upgrade-prep
-RUN head -n -1 /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
+RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
 
 FROM ${STAGING_BASE} as staging-install
 ARG AWS_URL

--- a/packaging/testing/smoke/packages/local-test-all.sh
+++ b/packaging/testing/smoke/packages/local-test-all.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Simple script to test all supported targets easily.
 
 RELEASE_URL=${RELEASE_URL:-https://packages.fluentbit.io}
-AWS_URL=${AWS_URL:-https://fluentbit-staging.s3.amazonaws.com}
+STAGING_URL=${STAGING_URL:-https://fluentbit-staging.s3.amazonaws.com}
 
 for DOCKERFILE in "$SCRIPT_DIR"/Dockerfile.*; do
     DISTRO=${DOCKERFILE##*.}
     echo "Testing $DISTRO"
-    PACKAGE_TEST="$DISTRO" RELEASE_URL="$RELEASE_URL" AWS_URL="$AWS_URL" "$SCRIPT_DIR"/run-package-tests.sh
+    PACKAGE_TEST="$DISTRO" RELEASE_URL="$RELEASE_URL" STAGING_URL="$STAGING_URL" "$SCRIPT_DIR"/run-package-tests.sh
 done

--- a/packaging/testing/smoke/packages/run-package-tests.sh
+++ b/packaging/testing/smoke/packages/run-package-tests.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 PACKAGE_TEST=${PACKAGE_TEST:-centos7}
 RELEASE_URL=${RELEASE_URL:-https://packages.fluentbit.io}
-AWS_URL=${AWS_URL:-https://fluentbit-staging.s3.amazonaws.com}
+STAGING_URL=${STAGING_URL:-https://fluentbit-staging.s3.amazonaws.com}
 
 if [[ ! -f "$SCRIPT_DIR/Dockerfile.$PACKAGE_TEST" ]]; then
     echo "No definition for $SCRIPT_DIR/Dockerfile.$PACKAGE_TEST"
@@ -41,7 +41,7 @@ do
     # We do want splitting for build args
     # shellcheck disable=SC2086
     docker build \
-                --build-arg AWS_URL=$AWS_URL \
+                --build-arg STAGING_URL=$STAGING_URL \
                 --build-arg RELEASE_URL=$RELEASE_URL $BUILD_ARGS \
                 --target "$TARGET" \
                 -t "$CONTAINER_NAME" \


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #3618 by ensuring we use the signed repo metadata for the one line install script: this is best practice anyway and will ensure it is used during testing then as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

```
$ docker run --rm -v $PWD/install.sh:/install.sh:ro centos:7 sh -c "yum install -y sudo curl;/install.sh"
$ docker run --rm -v $PWD/install.sh:/install.sh:ro amazonlinux:2 sh -c "yum install -y sudo curl;/install.sh"
$ ./packaging/testing/smoke/packages/local-test-all.sh 
```
All work as expected.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
