### PR TITLE
workflows: sync releases to bucket

### DIFF
--- a/.github/actions/release-bucket-sync/action.yaml
+++ b/.github/actions/release-bucket-sync/action.yaml
@@ -63,7 +63,7 @@ runs:
     shell: bash
 
   - name: Upload artefacts
-    if: mode != '' || failure()
+    if: inputs.mode != '' || failure()
     uses: actions/upload-artifact
     with:
       path: packaging/aws-release-sync

--- a/.github/actions/release-bucket-sync/action.yaml
+++ b/.github/actions/release-bucket-sync/action.yaml
@@ -1,0 +1,67 @@
+name: Composite action to sync releases from server to bucket
+
+inputs:
+  bucket:
+    description: The name of the S3 (US-East) bucket to use.
+    required: true
+  access_key_id:
+    description: The S3 access key id for the bucket.
+    required: true
+  secret_access_key:
+    description: The S3 secret access key for the bucket.
+    required: true
+  server_hostname:
+    description: The server hostname to sync from.
+    required: true
+  server_username:
+    description: The username to authenticate with on the server.
+    required: true
+  server_key:
+    description: The SSH key to use for authentication.
+    required: true
+  ref:
+    description: The Git commit, branch or tag to checkout for the packaging code.
+    required: false
+    default: "master"
+  version:
+    description: A single version to sync rather than everything from the server.
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+  - name: Setup runner (Ubuntu 18.04 required for now)
+    run: |
+      sudo apt-get install debsigs createrepo aptly rsync
+    shell: bash
+
+  - name: Hashed known hosts value
+    id: known_hosts
+    run: |
+      OUTPUT=$(ssh-keyscan -H ${{ inputs.server_hostname }})
+      echo ::set-output name=OUTPUT::$OUTPUT
+    shell: bash
+
+  - name: Install SSH Key
+    uses: shimataro/ssh-key-action@v2
+    with:
+      key: ${{ inputs.server_key }}
+      known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
+
+  - name: Checkout code
+    uses: actions/checkout@v3
+    with:
+      ref: ${{ inputs.ref }}
+
+  - name: Sync packages from release bucket on S3
+    run: packaging/sync-releases-to-bucket.sh
+    env:
+      AWS_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
+      AWS_SECRET_ACCESS_KEY: ${{ inputs.secret_access_key }}
+      INPUT_BUCKET: ${{ inputs.bucket }}
+      GPG_KEY: ${{ steps.import_gpg.outputs.name }}
+      RELEASE_SERVER: ${{ inputs.server_hostname }}
+      RELEASE_SERVER_USERNAME: ${{ inputs.server_username }}
+      SYNC_VERSION: ${{ inputs.version }}
+    shell: bash

--- a/.github/actions/release-bucket-sync/action.yaml
+++ b/.github/actions/release-bucket-sync/action.yaml
@@ -19,12 +19,12 @@ inputs:
   server_key:
     description: The SSH key to use for authentication.
     required: true
-  ref:
-    description: The Git commit, branch or tag to checkout for the packaging code.
-    required: false
-    default: "master"
   version:
     description: A single version to sync rather than everything from the server.
+    required: false
+    default: ''
+  mode:
+    description: Optionally run in various modes to exercise the download but not upload, etc.
     required: false
     default: ''
 
@@ -49,11 +49,6 @@ runs:
       key: ${{ inputs.server_key }}
       known_hosts: ${{ steps.known_hosts.outputs.OUTPUT }}
 
-  - name: Checkout code
-    uses: actions/checkout@v3
-    with:
-      ref: ${{ inputs.ref }}
-
   - name: Sync packages from release bucket on S3
     run: packaging/sync-releases-to-bucket.sh
     env:
@@ -64,4 +59,11 @@ runs:
       RELEASE_SERVER: ${{ inputs.server_hostname }}
       RELEASE_SERVER_USERNAME: ${{ inputs.server_username }}
       SYNC_VERSION: ${{ inputs.version }}
+      MODE: ${{ inputs.mode }}
     shell: bash
+
+  - name: Upload artefacts
+    if: mode != '' || failure()
+    uses: actions/upload-artifact
+    with:
+      path: packaging/aws-release-sync

--- a/.github/workflows/release-sync.yaml
+++ b/.github/workflows/release-sync.yaml
@@ -1,0 +1,27 @@
+---
+name: Release sync from server to bucket
+
+# This is only expected to be invoked on-demand.
+on:
+  workflow_dispatch:
+
+concurrency: release-sync
+
+jobs:
+  release-sync-s3:
+    name: Sync to release bucket
+    runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
+    environment: release
+    steps:
+      - name: Checkout code for action at least
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/release-server-sync
+        with:
+          bucket: ${{ secrets.AWS_S3_BUCKET_RELEASE }}
+          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          server_hostname: ${{ secrets.FLUENTBITIO_HOST }}
+          server_username: ${{ secrets.FLUENTBITIO_USERNAME }}
+          server_key: ${{ secrets.FLUENTBITIO_SSHKEY }}
+          ref: ${{ github.ref_name }}

--- a/.github/workflows/release-sync.yaml
+++ b/.github/workflows/release-sync.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code for action at least
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/release-server-sync
+      - uses: ./.github/actions/release-bucket-sync
         with:
           bucket: ${{ secrets.AWS_S3_BUCKET_RELEASE }}
           access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release-sync.yaml
+++ b/.github/workflows/release-sync.yaml
@@ -4,6 +4,10 @@ name: Release sync from server to bucket
 # This is only expected to be invoked on-demand.
 on:
   workflow_dispatch:
+    mode:
+      description: Optionally run in various modes to exercise the download but not upload, etc.
+      required: false
+      default: ''
 
 concurrency: release-sync
 
@@ -24,4 +28,4 @@ jobs:
           server_hostname: ${{ secrets.FLUENTBITIO_HOST }}
           server_username: ${{ secrets.FLUENTBITIO_USERNAME }}
           server_key: ${{ secrets.FLUENTBITIO_SSHKEY }}
-          ref: ${{ github.ref_name }}
+          mode: ${{ github.event.inputs.mode }}

--- a/.github/workflows/release-sync.yaml
+++ b/.github/workflows/release-sync.yaml
@@ -4,10 +4,11 @@ name: Release sync from server to bucket
 # This is only expected to be invoked on-demand.
 on:
   workflow_dispatch:
-    mode:
-      description: Optionally run in various modes to exercise the download but not upload, etc.
-      required: false
-      default: ''
+    inputs:
+      mode:
+        description: Optionally run in various modes to exercise the download but not upload, etc.
+        required: false
+        default: ''
 
 concurrency: release-sync
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ packaging/packages
 packaging/distros/**/sources/
 packaging/releases
 packaging/latest/
+packaging/aws-release-sync/
 workflow/
 *.key
 *.log

--- a/packaging/sync-releases-to-bucket.sh
+++ b/packaging/sync-releases-to-bucket.sh
@@ -25,6 +25,10 @@ RSYNC_CMD=${RSYNC_CMD:-rsync -chavzP --prune-empty-dirs}
 # Used to speed up rsync from server by specifying a particular release you want only downloaded.
 # We still have to grab all of AWS to reconstruct.
 SYNC_VERSION=${SYNC_VERSION:-}
+# Run only segments of this script before exiting
+# DOWNLOAD_ONLY - download from AWS and the server only
+# DISABLE_UPLOAD - run everything except the final sync to $OUTPUT_BUCKET
+MODE=${MODE:-}
 
 # We download everything from AWS but only artefacts from the server.
 # We then massage them into a common format ready to recreate the repository metadata from.
@@ -68,7 +72,7 @@ for LEGACY_REPO in "${LEGACY_REPOS[@]}"; do
 done
 echo "Legacy APT repository download complete"
 
-if [[ -n "${DISABLE_METADATA_CONSTRUCTION:-}" ]]; then
+if [[ "$MODE" == "DOWNLOAD_ONLY" ]]; then
     echo "Download only specified so skipping metadata construction and upload"
     exit 0
 fi
@@ -114,7 +118,7 @@ fi
 "$SCRIPT_DIR/update-repos.sh" "$BASE_PATH"
 echo "Repository metadata construction complete"
 
-if [[ -n "${DISABLE_UPLOAD:-}" ]]; then
+if [[ "$MODE" == "DISABLE_UPLOAD" ]]; then
     echo "Skipping upload as requested"
     exit 0
 fi

--- a/packaging/sync-releases-to-bucket.sh
+++ b/packaging/sync-releases-to-bucket.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Simple script to "sync" releases from the legacy server to the release bucket.
+# Can be run manually or scripted via CI - make sure to set up GPG & SSH keys if so.
+
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.env"
+fi
+
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?}
+INPUT_BUCKET=${INPUT_BUCKET:-?}
+OUTPUT_BUCKET=${OUTPUT_BUCKET:-$INPUT_BUCKET}
+RELEASE_SERVER=${RELEASE_SERVER:-packages.fluentbit.io}
+RELEASE_SERVER_PATH=${RELEASE_SERVER_PATH:-/var/www/apt.fluentbit.io}
+RELEASE_SERVER_WINDOWS_PATH=${RELEASE_SERVER_WINDOWS_PATH:-/var/www/releases.fluentbit.io/releases}
+RELEASE_SERVER_USERNAME=${RELEASE_SERVER_USERNAME:-$USER}
+GPG_KEY=${GPG_KEY:?}
+BASE_PATH=${BASE_PATH:-$SCRIPT_DIR/aws-release-sync}
+# Rsync command info: https://explainshell.com/explain?cmd=rsync+-chavzP+--prune-empty-dirs
+RSYNC_CMD=${RSYNC_CMD:-rsync -chavzP --prune-empty-dirs}
+
+# We download everything from AWS but only artefacts from the server.
+# We then massage them into a common format ready to recreate the repository metadata from.
+mkdir -p "$BASE_PATH"
+
+# Download from S3 bucket
+aws-cli s3 sync "s3://$BUCKET" "$BASE_PATH"
+echo "AWS download complete"
+
+# Grab Linux packages from the release server
+$RSYNC_CMD --include='*.rpm' --include='*.deb' --include='*.key' --include='*/' --exclude '*' \
+    "$RELEASE_SERVER_USERNAME"@"$RELEASE_SERVER":"$RELEASE_SERVER_PATH"/ "$BASE_PATH"
+echo "Server artefact download complete"
+
+# Remove duplicates for Yum repos and generally consolidate everything so RPMs are at
+# the root of the repo rather than in architecture-specific subdirectories.
+RPM_REPO_PATHS=("amazonlinux/2" "centos/7" "centos/8")
+for RPM_REPO in "${RPM_REPO_PATHS[@]}"; do
+    echo "Updating $RPM_REPO"
+    REPO_DIR=$( realpath -sm "$BASE_PATH/$RPM_REPO" )
+    [[ ! -d "$REPO_DIR" ]] && continue
+    find "$REPO_DIR" -name "*.rpm" -exec cp -fv {} "$REPO_DIR/" \;
+    rm -rf "$REPO_DIR"/aarch64 "$REPO_DIR"/x86_64 "$REPO_DIR"/repodata
+done
+echo "YUM repository construction complete"
+
+# For Aptly we need everything at the top-level to then add it.
+# We only cover repos we have started managing from 1.9 onwards.
+DEB_REPO_PATHS=( "debian/bullseye"
+                    "debian/buster"
+                    "ubuntu/xenial"
+                    "ubuntu/bionic"
+                    "ubuntu/focal"
+                    "raspbian/buster"
+                    "raspbian/bullseye" )
+for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do
+    REPO_DIR=$(realpath -sm "$BASE_PATH/$DEB_REPO" )
+    [[ ! -d "$REPO_DIR" ]] && continue
+    CODENAME=${DEB_REPO##*/}
+
+    find "$REPO_DIR" -name "*.deb" -exec cp -fv {} "$REPO_DIR/" \;
+    rm -rf "$REPO_DIR"/pool "$REPO_DIR"/dists "${REPO_DIR:?}/$CODENAME"
+done
+echo "APT repository construction complete"
+
+# Now grab the repos we do not process to leave as-is
+LEGACY_REPOS=( "debian/jessie"
+                "debian/stretch" )
+for LEGACY_REPO in "${LEGACY_REPOS[@]}"; do
+    $RSYNC_CMD "$RELEASE_SERVER_USERNAME"@"$RELEASE_SERVER":"$RELEASE_SERVER_PATH"/"$LEGACY_REPO" "$BASE_PATH/$LEGACY_REPO"
+done
+echo "Legacy APT repository download complete"
+
+# Grab Windows packages
+mkdir -p "$BASE_PATH"/windows
+$RSYNC_CMD --include='*win32.*' --include='*win64.*' --include='*/' --exclude '*' \
+    "$RELEASE_SERVER_USERNAME"@"$RELEASE_SERVER":"$RELEASE_SERVER_WINDOWS_PATH"/ "$BASE_PATH"/windows
+echo "Windows package download complete"
+
+# Generate checksums for all Windows releases
+find "$BASE_PATH"/windows -type f -name "*win*.*" -exec sh -c 'cd "${1%/*}";sha256sum "${1##*/}" > "$1".sha256' _ {} \;
+echo "Windows checksum creation complete"
+
+if [[ -n "${DISABLE_METADATA_CONSTRUCTION:-}" ]]; then
+    echo "Download only specified so skipping metadata construction and upload"
+    exit 0
+fi
+
+# Update metadata now - have to use Ubuntu 18.04 for 'createrepo' to be available
+if ! command -v createrepo ; then
+    echo "Unable to find createrepo"
+    exit 1
+fi
+
+# This will overwrite all the metadata to then push back up to the bucket
+"$SCRIPT_DIR/update-repos.sh" "$BASE_PATH"
+echo "Repository metadata construction complete"
+
+if [[ -n "${DISABLE_UPLOAD:-}" ]]; then
+    echo "Skipping upload as requested"
+    exit 0
+fi
+
+# Now sync back up
+aws-cli s3 sync "$BASE_PATH" "s3://$BUCKET"
+echo "Release sync complete"

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -43,6 +43,7 @@ baseurl=https://$AWS_S3_BUCKET.s3.amazonaws.com/$RPM_REPO/
 enabled=1
 gpgkey=https://$AWS_S3_BUCKET.s3.amazonaws.com/fluentbit.key
 gpgcheck=1
+repo_gpgcheck=1
 EOF
     fi
 done


### PR DESCRIPTION
Provides a script and automation to run a sync from server to release bucket as requested by #5098 .
Also adds signing check to repo config file creation for staging et al.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
