### PR TITLE
core: add compile flag to disable control chars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,11 @@ if(FLB_TRACE)
   FLB_DEFINITION(FLB_HAVE_TRACE)
 endif()
 
+# Disable colors and any other control characters in the output
+if (FLB_LOG_NO_CONTROL_CHARS)
+  FLB_DEFINITION(FLB_LOG_NO_CONTROL_CHARS)
+endif()
+
 if(FLB_HTTP_SERVER)
   FLB_OPTION(FLB_METRICS ON)
   FLB_DEFINITION(FLB_HAVE_METRICS)

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -71,6 +71,7 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_OUT_KAFKA=On \
           -DFLB_OUT_PGSQL=On \
           -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          -DFLB_LOG_NO_CONTROL_CHARS=On \
           ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -339,11 +339,6 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
 
     va_start(args, fmt);
 
-    #ifdef FLB_LOG_NO_CONTROL_CHARS
-        header_color = "";
-        bold_color = "";
-        reset_color = "";
-    #else
     switch (type) {
     case FLB_LOG_HELP:
         header_title = "help";
@@ -375,6 +370,11 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
         break;
     }
 
+    #ifdef FLB_LOG_NO_CONTROL_CHARS
+    header_color = "";
+    bold_color = "";
+    reset_color = "";
+    #else
     /* Only print colors to a terminal */
     if (!isatty(STDOUT_FILENO)) {
         header_color = "";

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -339,6 +339,11 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
 
     va_start(args, fmt);
 
+    #ifdef FLB_LOG_NO_CONTROL_CHARS
+        header_color = "";
+        bold_color = "";
+        reset_color = "";
+    #else
     switch (type) {
     case FLB_LOG_HELP:
         header_title = "help";
@@ -376,6 +381,7 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
         bold_color = "";
         reset_color = "";
     }
+    #endif // FLB_LOG_NO_CONTROL_CHARS
 
     now = time(NULL);
     current = localtime_r(&now, &result);

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -89,6 +89,30 @@ struct flb_stacktrace flb_st;
 #define n_get_key(a, b, c)   (intptr_t) get_key(a, b, c)
 #define s_get_key(a, b, c)   (char *) get_key(a, b, c)
 
+#ifdef FLB_LOG_NO_CONTROL_CHARS
+
+#undef ANSI_RESET
+#undef ANSI_BOLD
+#undef ANSI_CYAN
+#undef ANSI_MAGENTA
+#undef ANSI_RED
+#undef ANSI_YELLOW
+#undef ANSI_BLUE
+#undef ANSI_GREEN
+#undef ANSI_WHITE
+
+#define ANSI_RESET    ""
+#define ANSI_BOLD     ""
+#define ANSI_CYAN     ""
+#define ANSI_MAGENTA  ""
+#define ANSI_RED      ""
+#define ANSI_YELLOW   ""
+#define ANSI_BLUE     ""
+#define ANSI_GREEN    ""
+#define ANSI_WHITE    ""
+
+#endif // FLB_LOG_NO_CONTROL_CHARS
+
 static void flb_version()
 {
 #ifdef FLB_NIGHTLY_BUILD


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #5002 by allowing us to compile out the control codes and then use this for containers.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
