### PR TITLE
dockerfile: remove missing package ltrace for other architectures

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -188,16 +188,13 @@ RUN apt-get update && \
         libatomic1 \
         libgcrypt20 \
         libyaml-0-2 \
-        # build/code
         bash gdb valgrind build-essential  \
         git bash-completion vim tmux jq \
-        # network
         dnsutils iputils-ping iputils-arping iputils-tracepath iputils-clockdiff \
         tcpdump curl nmap tcpflow iftop \
         net-tools mtr netcat-openbsd bridge-utils iperf ngrep \
         openssl \
-        # processes/io
-        htop atop strace iotop sysstat ltrace ncdu logrotate hdparm pciutils psmisc tree pv \
+        htop atop strace iotop sysstat ncdu logrotate hdparm pciutils psmisc tree pv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #5150 to allow staging builds to complete now.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
