### PR TITLE
in_forward: check return status of flb_input_chunk_append_raw before ACK

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -174,6 +174,7 @@ static int fw_process_array(struct flb_input_instance *in,
                             msgpack_object *root, msgpack_object *arr, int chunk_id)
 {
     int i;
+    int ret;
     msgpack_object entry;
     msgpack_object options;
     msgpack_object chunk;
@@ -195,8 +196,13 @@ static int fw_process_array(struct flb_input_instance *in,
         msgpack_pack_object(&mp_pck, entry);
     }
 
-    flb_input_chunk_append_raw(in, tag, tag_len, mp_sbuf.data, mp_sbuf.size);
+    ret = flb_input_chunk_append_raw(in, tag, tag_len, mp_sbuf.data, mp_sbuf.size);
     msgpack_sbuffer_destroy(&mp_sbuf);
+
+    if (ret == -1) {
+        flb_warn("[in_forward] Failed to append raw input chunk.");
+        return -1;
+    }
 
     if (chunk_id != -1) {
         options = root->via.array.ptr[2];
@@ -445,11 +451,19 @@ int fw_prot_process(struct fw_conn *conn)
                 msgpack_pack_object(&mp_pck, map);
 
                 /* Register data object */
-                flb_input_chunk_append_raw(conn->in,
+                ret = flb_input_chunk_append_raw(conn->in,
                                            out_tag, flb_sds_len(out_tag),
                                            mp_sbuf.data, mp_sbuf.size);
                 msgpack_sbuffer_destroy(&mp_sbuf);
                 c++;
+
+                if (ret == -1) {
+                    flb_plg_debug(ctx->ins, "failed to append raw input chunk");
+                    msgpack_unpacked_destroy(&result);
+                    msgpack_unpacker_free(unp);
+                    flb_sds_destroy(out_tag);
+                    return -1;
+                }
 
                 /* Handle ACK response */
                 if (chunk_id != -1) {
@@ -505,15 +519,23 @@ int fw_prot_process(struct fw_conn *conn)
                         }
 
                         /* Append uncompressed data */
-                        flb_input_chunk_append_raw(conn->in,
+                        ret = flb_input_chunk_append_raw(conn->in,
                                                    out_tag, flb_sds_len(out_tag),
                                                    gz_data, gz_size);
                         flb_free(gz_data);
                     }
                     else {
-                        flb_input_chunk_append_raw(conn->in,
+                        ret = flb_input_chunk_append_raw(conn->in,
                                                    out_tag, flb_sds_len(out_tag),
                                                    data, len);
+                    }
+
+                    if (ret == -1) {
+                        flb_plg_debug(ctx->ins, "failed to append raw input chunk");
+                        msgpack_unpacked_destroy(&result);
+                        msgpack_unpacker_free(unp);
+                        flb_sds_destroy(out_tag);
+                        return -1;
                     }
 
                     /* Handle ACK response */


### PR DESCRIPTION
Signed-off-by: Aaron Epstein <a.epstein7ae@gmail.com>

<!-- Provide summary of changes -->
Forward input plugin would send an acknowledgement back even if the data could not be appended to a chunk. This changes in_forward to not send an ACK if there was a failure in flb_input_chunk_append_raw.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
