### PR TITLE
task: fixed wrong assumed type for data in flb_task_retry_count

### DIFF
--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -193,12 +193,9 @@ int flb_task_retry_count(struct flb_task *task, void *data)
     struct mk_list *head;
     struct flb_task_retry *retry;
     struct flb_output_instance *o_ins;
-    struct flb_output_coro *out_coro;
 
-    out_coro = (struct flb_output_coro *) FLB_CORO_DATA(data);
-    o_ins = out_coro->o_ins;
+    o_ins = (struct flb_output_instance *) data;
 
-    /* Delete 'retries' only associated with the output instance */
     mk_list_foreach(head, &task->retries) {
         retry = mk_list_entry(head, struct flb_task_retry, _head);
         if (retry->o_ins == o_ins) {


### PR DESCRIPTION
This PR fixes an issue that originated in commit 4eff2c60ba after a refactor in which `handle_output_event` stopped sending an `flb_coro *` and started directly providing the `flb_output_instance *` related to the event that caused its invocation.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>