### PR TITLE
tiger: 1.8.12 20220323

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -262,8 +262,7 @@ static FLB_INLINE int net_io_write_async(struct flb_coro *co,
     /* Update counters */
     total += bytes;
     if (total < len) {
-        if (u_conn->event.status == MK_EVENT_NONE) {
-            u_conn->event.mask = MK_EVENT_EMPTY;
+        if ((u_conn->event.mask & MK_EVENT_WRITE) == 0) {
             u_conn->coro = co;
             ret = mk_event_add(u_conn->evl,
                                u_conn->fd,

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -193,12 +193,9 @@ int flb_task_retry_count(struct flb_task *task, void *data)
     struct mk_list *head;
     struct flb_task_retry *retry;
     struct flb_output_instance *o_ins;
-    struct flb_output_coro *out_coro;
 
-    out_coro = (struct flb_output_coro *) FLB_CORO_DATA(data);
-    o_ins = out_coro->o_ins;
+    o_ins = (struct flb_output_instance *) data;
 
-    /* Delete 'retries' only associated with the output instance */
     mk_list_foreach(head, &task->retries) {
         retry = mk_list_entry(head, struct flb_task_retry, _head);
         if (retry->o_ins == o_ins) {

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -780,7 +780,7 @@ int flb_upstream_conn_release(struct flb_upstream_conn *conn)
             flb_debug("[upstream] KA count %i exceeded configured limit "
                       "of %i: closing.",
                       conn->ka_count, conn->u->net.keepalive_max_recycle);
-            return prepare_destroy_conn(conn);
+            return prepare_destroy_conn_safe(conn);
         }
 
         return 0;


### PR DESCRIPTION
Backport fixes that landed in v1.8.15

- 411822bef  task: fixed wrong assumed type for data in flb_task_retry_count
- cc7820e4a upstream: replaced non thread safe release call in flb_upstream_conn_release
- 08226b791 io: fixed write event monitoring for recycled keep_alive connections

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
