### PR TITLE
out_http: Add AWS SigV4 Authentication Option to out_http

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -29,6 +29,13 @@
 #include <fluent-bit/flb_gzip.h>
 #include <msgpack.h>
 
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_signv4.h>
+#endif
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -79,6 +86,7 @@ static int http_post(struct flb_out_http *ctx,
     struct flb_config_map_val *mv;
     struct flb_slist_entry *key = NULL;
     struct flb_slist_entry *val = NULL;
+    flb_sds_t signature = NULL;
 
     /* Get upstream context and connection */
     u = ctx->u;
@@ -174,6 +182,30 @@ static int http_post(struct flb_out_http *ctx,
                             val->str, flb_sds_len(val->str));
     }
 
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    /* AWS SigV4 headers */
+    if (ctx->has_aws_auth == FLB_TRUE) {
+        flb_plg_debug(ctx->ins, "signing request with AWS Sigv4");        
+        signature = flb_signv4_do(c,
+                                  FLB_TRUE,  /* normalize URI ? */
+                                  FLB_TRUE,  /* add x-amz-date header ? */
+                                  time(NULL),
+                                  (char *) ctx->aws_region,
+                                  (char *) ctx->aws_service,
+                                  0,
+                                  ctx->aws_provider);
+
+        if (!signature) {
+            flb_plg_error(ctx->ins, "could not sign request with sigv4");
+            out_ret = FLB_RETRY;
+            goto cleanup;
+        }
+        flb_sds_destroy(signature);
+    }
+#endif
+#endif
+
     ret = flb_http_do(c, &b_sent);
     if (ret == 0) {
         /*
@@ -220,6 +252,7 @@ static int http_post(struct flb_out_http *ctx,
         out_ret = FLB_RETRY;
     }
 
+cleanup:
     /*
      * If the payload buffer is different than incoming records in body, means
      * we generated a different payload and must be freed.
@@ -377,6 +410,21 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_out_http, http_passwd),
      "Set HTTP auth password"
     },
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS 
+    {
+     FLB_CONFIG_MAP_BOOL, "aws_auth", "false",
+     0, FLB_TRUE, offsetof(struct flb_out_http, has_aws_auth),
+     "Enable AWS SigV4 authentication"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "aws_service", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_http, aws_service),
+     "AWS destination service code, used by SigV4 authentication"
+    },
+    FLB_AWS_CREDENTIAL_BASE_CONFIG_MAP(FLB_HTTP_AWS_CREDENTIAL_PREFIX),
+#endif
+#endif
     {
      FLB_CONFIG_MAP_STR, "header_tag", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_http, header_tag),

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -27,10 +27,26 @@
 #define FLB_HTTP_MIME_MSGPACK   "application/msgpack"
 #define FLB_HTTP_MIME_JSON      "application/json"
 
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#define FLB_HTTP_AWS_CREDENTIAL_PREFIX "aws_"
+#endif
+#endif
+
 struct flb_out_http {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+
+    /* AWS Auth */
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    int has_aws_auth;
+    struct flb_aws_provider *aws_provider;
+    const char *aws_region;
+    const char *aws_service;
+#endif
+#endif
 
     /* Proxy */
     const char *proxy;

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -22,7 +22,11 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
-
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#include <fluent-bit/flb_aws_credentials.h>
+#endif
+#endif
 #include "http.h"
 #include "http_conf.h"
 
@@ -80,6 +84,39 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     else {
         flb_output_net_default("127.0.0.1", 80, ins);
     }
+
+    /* Check if AWS SigV4 authentication is enabled */
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    if (ctx->has_aws_auth) {
+        ctx->aws_service = flb_output_get_property(FLB_HTTP_AWS_CREDENTIAL_PREFIX
+                                                   "service", ctx->ins);
+        if (!ctx->aws_service) {
+            flb_plg_error(ins, "aws_auth option requires " FLB_HTTP_AWS_CREDENTIAL_PREFIX
+                          "service to be set");
+            flb_free(ctx);
+            return NULL;
+        }
+
+        ctx->aws_provider = flb_managed_chain_provider_create(
+            ins,
+            config,
+            FLB_HTTP_AWS_CREDENTIAL_PREFIX,
+            NULL,
+            flb_aws_client_generator()
+        );
+        if (!ctx->aws_provider) {
+            flb_plg_error(ins, "failed to create aws credential provider for sigv4 auth");
+            flb_free(ctx);
+            return NULL;
+        }
+
+        /* If managed provider creation succeeds, then region key is present */
+        ctx->aws_region = flb_output_get_property(FLB_HTTP_AWS_CREDENTIAL_PREFIX
+                                                  "region", ctx->ins);
+    }
+#endif /* !FLB_HAVE_AWS */
+#endif /* !FLB_HAVE_SIGNV4 */
 
     /* Check if SSL/TLS is enabled */
 #ifdef FLB_HAVE_TLS
@@ -212,6 +249,14 @@ void flb_http_conf_destroy(struct flb_out_http *ctx)
     if (ctx->u) {
         flb_upstream_destroy(ctx->u);
     }
+
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    if (ctx->aws_provider) {
+        flb_aws_provider_destroy(ctx->aws_provider);
+    }
+#endif
+#endif
 
     flb_free(ctx->proxy_host);
     flb_free(ctx->uri);

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_aws_util.h>
 #include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_output_plugin.h>
 
 #include <stdlib.h>
 #include <time.h>
@@ -323,6 +324,186 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
     return provider;
 }
 
+struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_instance
+                                                           *ins,
+                                                           struct flb_config
+                                                           *config,
+                                                           char *config_key_prefix,
+                                                           char *proxy,
+                                                           struct
+                                                           flb_aws_client_generator
+                                                           *generator)
+{
+    flb_sds_t config_key_region;
+    flb_sds_t config_key_sts_endpoint;
+    flb_sds_t config_key_role_arn;
+    flb_sds_t config_key_external_id;
+    const char *region = NULL;
+    const char *sts_endpoint = NULL;
+    const char *role_arn = NULL;
+    const char *external_id = NULL;
+    char *session_name = NULL;
+    int key_prefix_len;
+    int key_max_len;
+
+    /* Provider managed dependencies */
+    struct flb_aws_provider *aws_provider = NULL;
+    struct flb_aws_provider *base_aws_provider = NULL;
+    struct flb_tls *cred_tls = NULL;
+    struct flb_tls *sts_tls = NULL;
+
+    /* Config keys */
+    key_prefix_len = strlen(config_key_prefix);
+    key_max_len = key_prefix_len + 12; /* max length of
+                                              "region", "sts_endpoint", "role_arn",
+                                              "external_id" */
+    
+    /* Evaluate full config keys */
+    config_key_region = flb_sds_create_len(config_key_prefix, key_max_len);
+    strcpy(config_key_region + key_prefix_len, "region");
+    config_key_sts_endpoint = flb_sds_create_len(config_key_prefix, key_max_len);
+    strcpy(config_key_sts_endpoint + key_prefix_len, "sts_endpoint");
+    config_key_role_arn = flb_sds_create_len(config_key_prefix, key_max_len);
+    strcpy(config_key_role_arn + key_prefix_len, "role_arn");
+    config_key_external_id = flb_sds_create_len(config_key_prefix, key_max_len);
+    strcpy(config_key_external_id + key_prefix_len, "external_id");
+
+    /* AWS provider needs a separate TLS instance */
+    cred_tls = flb_tls_create(FLB_TRUE,
+                              ins->tls_debug,
+                              ins->tls_vhost,
+                              ins->tls_ca_path,
+                              ins->tls_ca_file,
+                              ins->tls_crt_file,
+                              ins->tls_key_file,
+                              ins->tls_key_passwd);
+    if (!cred_tls) {
+        flb_plg_error(ins, "Failed to create TLS instance for AWS Provider");
+        flb_errno();
+        goto error;
+    }
+
+    region = flb_output_get_property(config_key_region, ins);
+    if (!region) {
+        flb_plg_error(ins, "aws_auth enabled but %s not set", config_key_region);
+        goto error;
+    }
+
+    /* Use null sts_endpoint if none provided */
+    sts_endpoint = flb_output_get_property(config_key_sts_endpoint, ins);
+
+    aws_provider = flb_standard_chain_provider_create(config,
+                                                      cred_tls,
+                                                      (char *) region,
+                                                      (char *) sts_endpoint,
+                                                      NULL,
+                                                      flb_aws_client_generator());
+    if (!aws_provider) {
+        flb_plg_error(ins, "Failed to create AWS Credential Provider");
+        goto error;
+    }
+
+    role_arn = flb_output_get_property(config_key_role_arn, ins);
+    if (role_arn) {
+        /* Use the STS Provider */
+        base_aws_provider = aws_provider;
+        external_id = flb_output_get_property(config_key_external_id, ins);
+
+        session_name = flb_sts_session_name();
+        if (!session_name) {
+            flb_plg_error(ins, "Failed to generate aws iam role "
+                        "session name");
+            goto error;
+        }
+
+        /* STS provider needs yet another separate TLS instance */
+        sts_tls = flb_tls_create(FLB_TRUE,
+                                 ins->tls_debug,
+                                 ins->tls_vhost,
+                                 ins->tls_ca_path,
+                                 ins->tls_ca_file,
+                                 ins->tls_crt_file,
+                                 ins->tls_key_file,
+                                 ins->tls_key_passwd);
+        if (!sts_tls) {
+            flb_plg_error(ins, "Failed to create TLS instance for AWS STS Credential "
+                          "Provider");
+            flb_errno();
+            goto error;
+        }
+
+        aws_provider = flb_sts_provider_create(config,
+                                               sts_tls,
+                                               base_aws_provider,
+                                               (char *) external_id,
+                                               (char *) role_arn,
+                                               session_name,
+                                               (char *) region,
+                                               (char *) sts_endpoint,
+                                               NULL,
+                                               flb_aws_client_generator());
+        if (!aws_provider) {
+            flb_plg_error(ins, "Failed to create AWS STS Credential "
+                        "Provider");
+            goto error;
+        }
+    }
+
+    /* initialize credentials in sync mode */
+    aws_provider->provider_vtable->sync(aws_provider);
+    aws_provider->provider_vtable->init(aws_provider);
+    
+    /* set back to async */
+    aws_provider->provider_vtable->async(aws_provider);
+    
+    /* store dependencies in aws_provider for managed cleanup */
+    aws_provider->base_aws_provider = base_aws_provider;
+    aws_provider->cred_tls = cred_tls;
+    aws_provider->sts_tls = sts_tls;
+
+    goto cleanup;
+
+error:
+    if (aws_provider) {
+        /* disconnect dependencies */
+        aws_provider->base_aws_provider = NULL;
+        aws_provider->cred_tls = NULL;
+        aws_provider->sts_tls = NULL;
+        /* destroy */
+        flb_aws_provider_destroy(aws_provider);
+    }
+    /* free dependencies */
+    if (base_aws_provider) {
+        flb_aws_provider_destroy(base_aws_provider);
+    }
+    if (cred_tls) {
+        flb_tls_destroy(cred_tls);
+    }
+    if (sts_tls) {
+        flb_tls_destroy(sts_tls);
+    }
+    aws_provider = NULL;
+
+cleanup:
+    if (config_key_region) {
+        flb_sds_destroy(config_key_region);
+    }
+    if (config_key_sts_endpoint) {
+        flb_sds_destroy(config_key_sts_endpoint);
+    }
+    if (config_key_role_arn) {
+        flb_sds_destroy(config_key_role_arn);
+    }
+    if (config_key_external_id) {
+        flb_sds_destroy(config_key_external_id);
+    }
+    if (session_name) {
+        flb_free(session_name);
+    }
+
+    return aws_provider;
+}
+
 static struct flb_aws_provider *standard_chain_create(struct flb_config
                                                       *config,
                                                       struct flb_tls *tls,
@@ -573,6 +754,17 @@ void flb_aws_provider_destroy(struct flb_aws_provider *provider)
     if (provider) {
         if (provider->implementation) {
             provider->provider_vtable->destroy(provider);
+        }
+
+        /* free managed dependencies */
+        if (provider->base_aws_provider) {
+            flb_aws_provider_destroy(provider->base_aws_provider);
+        }
+        if (provider->cred_tls) {
+            flb_tls_destroy(provider->cred_tls);
+        }
+        if (provider->sts_tls) {
+            flb_tls_destroy(provider->sts_tls);
         }
 
         flb_free(provider);


### PR DESCRIPTION
<!-- Provide summary of changes -->
# Documentation
Documentation PR in review.
See: https://github.com/fluent/fluent-bit-docs/pull/760

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
# SigV4 Results with Valgrind
### Config File
```
[SERVICE]
     Grace 30
     Log_Level info

[INPUT]
     Name        tcp
     Listen      127.0.0.1
     Port        4560
     Chunk_Size  80
     Buffer_Size 100
     Tag         me-tcp

[OUTPUT]
     Name http
     Match *
     Host 127.0.0.1
     Port 6435
     URI  /
     Format json
     aws_auth true
     aws_region us-west-2
     aws_service myservice
```
### Valgrind output
```
[[...] bin]$ valgrind --leak-check=full ./fluent-bit -c "[...]/fluent-bit/.vscode/fluent-bit-config/fluent-bit.conf"
==6323== Memcheck, a memory error detector
==6323== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==6323== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==6323== Command: ./fluent-bit -c /home/ec2-user/fala-forks/fluent-bit/.vscode/fluent-bit-config/fluent-bit.conf
==6323== 
Fluent Bit v1.9.1
* Git commit: 47671b467b02ac0e3d22835f9edeb3dfd2ecb44c
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/23 22:43:19] [ info] [engine] started (pid=6323)
[2022/03/23 22:43:19] [ info] [storage] version=1.1.6, initializing...
[2022/03/23 22:43:19] [ info] [storage] in-memory
[2022/03/23 22:43:19] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/23 22:43:19] [ info] [cmetrics] version=0.3.0
[2022/03/23 22:43:19] [ info] [input:tcp:tcp.0] listening on 127.0.0.1:4560
[2022/03/23 22:43:20] [ info] [sp] stream processor started
[2022/03/23 22:43:20] [ info] [output:http:http.0] worker #0 started
[2022/03/23 22:43:20] [ info] [output:http:http.0] worker #1 started
==6323== Warning: client switching stacks?  SP change: 0xa0578c8 --> 0x933cd90
==6323==          to suppress, use: --max-stackframe=13740856 or greater
==6323== Warning: client switching stacks?  SP change: 0x933cd08 --> 0xa0578c8
==6323==          to suppress, use: --max-stackframe=13740992 or greater
==6323== Warning: client switching stacks?  SP change: 0xa0578c8 --> 0x933cd08
==6323==          to suppress, use: --max-stackframe=13740992 or greater
==6323==          further instances of this message will not be shown.
[2022/03/23 22:43:39] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:40] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:41] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:42] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:43] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:44] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:45] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:46] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:47] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
[2022/03/23 22:43:48] [ info] [output:http:http.0] 127.0.0.1:6435, HTTP status=200
OK
^C[2022/03/23 22:44:14] [engine] caught signal (SIGINT)
[2022/03/23 22:44:14] [ warn] [engine] service will shutdown in max 30 seconds
[2022/03/23 22:44:15] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/23 22:44:15] [ info] [output:http:http.0] thread worker #0 stopping...
[2022/03/23 22:44:15] [ info] [output:http:http.0] thread worker #0 stopped
[2022/03/23 22:44:15] [ info] [output:http:http.0] thread worker #1 stopping...
[2022/03/23 22:44:15] [ info] [output:http:http.0] thread worker #1 stopped
==6323== 
==6323== HEAP SUMMARY:
==6323==     in use at exit: 101,728 bytes in 3,410 blocks
==6323==   total heap usage: 31,771 allocs, 28,361 frees, 8,704,474 bytes allocated
==6323== 
==6323== LEAK SUMMARY:
==6323==    definitely lost: 0 bytes in 0 blocks
==6323==    indirectly lost: 0 bytes in 0 blocks
==6323==      possibly lost: 0 bytes in 0 blocks
==6323==    still reachable: 101,728 bytes in 3,410 blocks
==6323==         suppressed: 0 bytes in 0 blocks
==6323== Reachable blocks (those to which a pointer was found) are not shown.
==6323== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

### Result Headers (from http server)
```
[
  "Host",
  "127.0.0.1:6435",
  "Content-Length",
  "491",
  "Content-Type",
  "application/json",
  "User-Agent",
  "Fluent-Bit",
  "x-amz-date",
  "20220323T224920Z",
  "Authorization",
  "AWS4-HMAC-SHA256 Credential=XXXXXXXX/20220323/us-west-2/myservice/aws4_request, SignedHeaders=content-length;content-type;host;user-agent;x-amz-date, Signature=8de8f8ec640f571d6313b67578d64505f9d464652b8f3f71c5479eb7a854fe62",
]
```

# Valgrind SigV4 Error Test

### Config File
```
[SERVICE]
     Grace 30
     Log_Level info

[INPUT]
     Name        tcp
     Listen      127.0.0.1
     Port        4560
     Chunk_Size  80
     Buffer_Size 100
     Tag         me-tcp

[OUTPUT]
     Name http
     Match *
     Host 127.0.0.1
     Port 6435
     URI  /
     Format json
     aws_auth true
     aws_region us-west-2
     aws_service myservice
     aws_role_arn bob
     aws_external_id ext_bob
     aws_sts_endpoint sts.fpaoeijfapeowijfpoaewijfapeowijfaepwoijfa
```
### Valgrind Output
```
[... bin]$ ./fluent-bit -c "[...]/fluent-bit/.vscode/fluent-bit-config/fluent-bit.conf"
Fluent Bit v1.9.1
* Git commit: 47671b467b02ac0e3d22835f9edeb3dfd2ecb44c
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/23 22:15:48] [ info] [engine] started (pid=17119)
[2022/03/23 22:15:48] [ info] [storage] version=1.1.6, initializing...
[2022/03/23 22:15:48] [ info] [storage] in-memory
[2022/03/23 22:15:48] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/23 22:15:48] [ info] [cmetrics] version=0.3.0
[2022/03/23 22:15:48] [ info] [input:tcp:tcp.0] listening on 127.0.0.1:4560
[2022/03/23 22:15:48] [ warn] [net] getaddrinfo(host='sts.fpaoeijfapeowijfpoaewijfapeowijfaepwoijfa', err=-2): Name or service not known
[2022/03/23 22:15:48] [ info] [sp] stream processor started
[2022/03/23 22:15:48] [ info] [output:http:http.0] worker #0 started
[2022/03/23 22:15:48] [ info] [output:http:http.0] worker #1 started
[2022/03/23 22:19:11] [ warn] [net] getaddrinfo(host='sts.fpaoeijfapeowijfpoaewijfapeowijfaepwoijfa', err=4): Domain name not found
[2022/03/23 22:19:11] [error] [aws_client] connection initialization error
[2022/03/23 22:19:11] [error] [aws_credentials] STS assume role request failed
[2022/03/23 22:19:11] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.

[...]


==14574== 
==14574== 
==14574== HEAP SUMMARY:
==14574==     in use at exit: 101,728 bytes in 3,410 blocks
==14574==   total heap usage: 58,098 allocs, 54,688 frees, 13,083,154 bytes allocated
==14574== 
==14574== LEAK SUMMARY:
==14574==    definitely lost: 0 bytes in 0 blocks
==14574==    indirectly lost: 0 bytes in 0 blocks
==14574==      possibly lost: 0 bytes in 0 blocks
==14574==    still reachable: 101,728 bytes in 3,410 blocks
==14574==         suppressed: 0 bytes in 0 blocks
==14574== Rerun with --leak-check=full to see details of leaked memory
==14574== 
==14574== For counts of detected and suppressed errors, rerun with: -v
==14574== Use --track-origins=yes to see where uninitialised values come from
==14574== ERROR SUMMARY: 1509411 errors from 997 contexts (suppressed: 169 from 56)
```

# One Click Replication Configuration
via Firelens Datajet
- Sets up a server
- Connects to fluent bit via tcp
- Sends 1 70,000 byte log per second 10 times
HTTP loopback validator featured only on the `http-validator` branch

Here's a link to the firelens-datajet project which aims to make replicating fluent bit end to end testing portable.
https://github.com/aws/firelens-datajet/tree/http-validator
```
{
	"component": "wrap",
	"comment": "validator currently under development. this test will yield incorrect results",
	"comment2": "validator currently used as HTTP loopback address for fluent bit logs",
	"library": [
		{
			"referenceId": "stageGenerator",
			"component": "generator",
			"generator": {
				"name": "increment",
				"config": {
					"payloadSize": 70000,
					"disableSignal": true
				}
			}
		},
		{
			"referenceId": "validationGenerator",
			"component": "generator",
			"generator": {
				"name": "http",
				"config": {
                    "port": 6435
				}
			}
		}
	],
	"config": {
		"wrapper": {
			"name": "comparator-validator",
			"config": {
				"validationGraceTimeout": 3,
				"validationIdleTimeout": 0.2,
				"stageGeneratorRef": "stageGenerator",
				"validationGeneratorRef": "validationGenerator"
			}
		}
	},
	"child": {
		"component": "synchronizer",
		"config": {
			"repeat": 1,
			"waitBefore": 0.5,
			"waitAfter": 0.5,
			"waitBetween": 0.01,
			"isAsync": false
		},
		"children": [
			{
				"generator": {
					"name": "reference",
					"config": {
						"ref": "stageGenerator"
					}
				},
				"datajet": {
					"name": "tcp",
					"config": {
						"port": 4560
					}
				},
				"stage": {
					"batchRate": 1,
					"maxBatches": 10
				}
			}
		]
	}
}
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
