### PR TITLE
out_file: new property to control output file append at the end line

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -643,7 +643,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "line_append", "false",
      0, FLB_TRUE, offsetof(struct flb_file_conf, line_append),
-     "Append new data to the end of log in same line. Default value is false"
+     "Append data to the existing line rather than start a new line. Default value is false, use embedded new line characters '\n' to create new lines if true otherwise all output will be on a single line."
     },
 
     /* EOF */

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -53,6 +53,7 @@ struct flb_file_conf {
     int format;
     int csv_column_names;
     int mkdir;
+    int line_append;
     struct flb_output_instance *ins;
 };
 
@@ -97,6 +98,7 @@ static int cb_file_init(struct flb_output_instance *ins,
     ctx->delimiter = NULL;
     ctx->label_delimiter = NULL;
     ctx->template = NULL;
+    ctx->line_append = FLB_FALSE;
 
     ret = flb_output_config_map_set(ins, (void *) ctx);
     if (ret == -1) {
@@ -316,7 +318,9 @@ static int template_output(FILE *fp, struct flb_time *tm, msgpack_object *obj,
     if (inbrace) {
         fputs(inbrace, fp);
     }
-    fputs(NEWLINE, fp);
+    if (ctx->line_append == FLB_FALSE){
+         fputs(NEWLINE, fp);
+    }
     return 0;
 }
 
@@ -634,6 +638,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "mkdir", "false",
      0, FLB_TRUE, offsetof(struct flb_file_conf, mkdir),
      "Recursively create output directory if it does not exist. Permissions set to 0755"
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "line_append", "false",
+     0, FLB_TRUE, offsetof(struct flb_file_conf, line_append),
+     "Append new data to the end of log in same line. Default value is false"
     },
 
     /* EOF */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Feature #5170
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
Doc PR is [here770](https://github.com/fluent/fluent-bit-docs/pull/770)

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

**Test Part 1**
when add new property `line_append         true` in service conf output item

Example configuration file as below:

```bash
[service]
    flush               5
    grace               10
    daemon              on
    log_file            /tmp/ekwongchum/flb.log
    log_level           debug

[input]
    Name                 tail
    Tag                  syslog
    Path                 /var/log/syslog
    DB                   /tmp/ekwongchum/syslog.db

[output]
    Name                 file
    Match                syslog
    Path                 /tmp/ekwongchum/
    File                 record.file
    Mkdir                true
    Format               template
    Template             {log}
    line_append          true
```

debug log output as below:

```bash
./fluent-bit -c flb.conf
Fluent Bit v2.0.0
* Git commit: 8efde37ad077f32611ad52f9ce831da413985f57
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/25 10:12:41] [ info] Configuration:
[2022/03/25 10:12:41] [ info]  flush time     | 5.000000 seconds
[2022/03/25 10:12:41] [ info]  grace          | 10 seconds
[2022/03/25 10:12:41] [ info]  daemon         | 1
[2022/03/25 10:12:41] [ info] ___________
[2022/03/25 10:12:41] [ info]  inputs:
[2022/03/25 10:12:41] [ info]      tail
[2022/03/25 10:12:41] [ info] ___________
[2022/03/25 10:12:41] [ info]  filters:
[2022/03/25 10:12:41] [ info] ___________
[2022/03/25 10:12:41] [ info]  outputs:
[2022/03/25 10:12:41] [ info]      file.0
[2022/03/25 10:12:41] [ info] ___________
[2022/03/25 10:12:41] [ info]  collectors:
[2022/03/25 10:12:41] [ info] switching to background mode (PID=216399)
```

and log file show here:
```bash
[2022/03/25 10:12:41] [ info] [engine] started (pid=216399)
[2022/03/25 10:12:41] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/03/25 10:12:41] [debug] [storage] [cio stream] new stream registered: tail.0
[2022/03/25 10:12:41] [ info] [storage] version=1.1.6, initializing...
[2022/03/25 10:12:41] [ info] [storage] in-memory
[2022/03/25 10:12:41] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/25 10:12:41] [ info] [cmetrics] version=0.3.0
[2022/03/25 10:12:41] [debug] [tail:tail.0] created event channels: read=20 write=21
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] inotify watch fd=26
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] scanning path /var/log/syslog
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] inode=36177971 with offset=121979 appended as /var/log/syslog
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] scan_glob add(): /var/log/syslog, inode 36177971
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] 1 new files found on path '/var/log/syslog'
[2022/03/25 10:12:41] [debug] [file:file.0] created event channels: read=31 write=32
[2022/03/25 10:12:41] [debug] [router] match rule tail.0:file.0
[2022/03/25 10:12:41] [ info] [sp] stream processor started
[2022/03/25 10:12:41] [ info] [output:file:file.0] worker #0 started
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] inode=36177971 file=/var/log/syslog promote to TAIL_EVENT
[2022/03/25 10:12:41] [ info] [input:tail:tail.0] inotify_fs_add(): inode=36177971 watch_fd=1 name=/var/log/syslog
[2022/03/25 10:12:41] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2022/03/25 10:13:40] [debug] [input:tail:tail.0] scanning path /var/log/syslog
[2022/03/25 10:13:40] [debug] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/syslog, inode 36177971
[2022/03/25 10:13:40] [debug] [input:tail:tail.0] 0 new files found on path '/var/log/syslog'
```

and record file is here
```bash
Mar 25 10:15:32 ekwong-NUC10 dbus-daemon[748]: [system] Activating via systemd: service name='org.freedesktop.PackageKit' unit='packagekit.service' requested by ':1.1757' (uid=0 pid=217147 comm="/usr/bin/gdbus call --system --dest org.freedeskto" label="unconfined")Mar 25 10:15:32 ekwong-NUC10 systemd[1]: Starting PackageKit Daemon...Mar 25 10:15:32 ekwong-NUC10 PackageKit: daemon startMar 25 10:15:32 ekwong-NUC10 dbus-daemon[748]: [system] Successfully activated service 'org.freedesktop.PackageKit'Mar 25 10:15:32 ekwong-NUC10 systemd[1]: Started PackageKit Daemon.Mar 25 10:16:39 ekwong-NUC10 dbus-daemon[2999]: [session uid=1000 pid=2999] Activating via systemd: service name='org.freedesktop.Tracker1' unit='tracker-store.service' requested by ':1.1' (uid=1000 pid=2992 comm="/usr/libexec/tracker-miner-fs " label="unconfined")Mar 25 10:16:39 ekwong-NUC10 systemd[2981]: Starting Tracker metadata database store and lookup manager...Mar 25 10:16:39 ekwong-NUC10 dbus-daemon[2999]: [session uid=1000 pid=2999] Successfully activated service 'org.freedesktop.Tracker1'Mar 25 10:16:39 ekwong-NUC10 systemd[2981]: Started Tracker metadata database store and lookup manager.%
```


**Test Part 2**
when add new property `line_append         false` in service conf output item

Example configuration file as below:

```bash
[service]
    flush               5
    grace               10
    daemon              on
    log_file            /tmp/ekwongchum/flb.log
    log_level           debug

[input]
    Name                 tail
    Tag                  syslog
    Path                 /var/log/syslog
    DB                   /tmp/ekwongchum/syslog.db

[output]
    Name                 file
    Match                syslog
    Path                 /tmp/ekwongchum/
    File                 record.file
    Mkdir                true
    Format               template
    Template             {log}
    line_append          false
```

debug log output as below:

```bash
./fluent-bit -c flb.conf
Fluent Bit v2.0.0
* Git commit: 8efde37ad077f32611ad52f9ce831da413985f57
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/25 10:23:18] [ info] Configuration:
[2022/03/25 10:23:18] [ info]  flush time     | 5.000000 seconds
[2022/03/25 10:23:18] [ info]  grace          | 10 seconds
[2022/03/25 10:23:18] [ info]  daemon         | 1
[2022/03/25 10:23:18] [ info] ___________
[2022/03/25 10:23:18] [ info]  inputs:
[2022/03/25 10:23:18] [ info]      tail
[2022/03/25 10:23:18] [ info] ___________
[2022/03/25 10:23:18] [ info]  filters:
[2022/03/25 10:23:18] [ info] ___________
[2022/03/25 10:23:18] [ info]  outputs:
[2022/03/25 10:23:18] [ info]      file.0
[2022/03/25 10:23:18] [ info] ___________
[2022/03/25 10:23:18] [ info]  collectors:
[2022/03/25 10:23:18] [ info] switching to background mode (PID=217435)
```

and log file show here:

```bash
[2022/03/25 10:23:18] [ info] [engine] started (pid=217435)
[2022/03/25 10:23:18] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/03/25 10:23:18] [debug] [storage] [cio stream] new stream registered: tail.0
[2022/03/25 10:23:18] [ info] [storage] version=1.1.6, initializing...
[2022/03/25 10:23:18] [ info] [storage] in-memory
[2022/03/25 10:23:18] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/25 10:23:18] [ info] [cmetrics] version=0.3.0
[2022/03/25 10:23:18] [debug] [tail:tail.0] created event channels: read=19 write=20
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] inotify watch fd=26
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] scanning path /var/log/syslog
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] inode=36177971 with offset=124138 appended as /var/log/syslog
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] scan_glob add(): /var/log/syslog, inode 36177971
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] 1 new files found on path '/var/log/syslog'
[2022/03/25 10:23:18] [debug] [file:file.0] created event channels: read=30 write=31
[2022/03/25 10:23:18] [debug] [router] match rule tail.0:file.0
[2022/03/25 10:23:18] [ info] [sp] stream processor started
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] inode=36177971 file=/var/log/syslog promote to TAIL_EVENT
[2022/03/25 10:23:18] [ info] [output:file:file.0] worker #0 started
[2022/03/25 10:23:18] [ info] [input:tail:tail.0] inotify_fs_add(): inode=36177971 watch_fd=1 name=/var/log/syslog
[2022/03/25 10:23:18] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2022/03/25 10:23:20] [debug] [input:tail:tail.0] inode=36177971 events: IN_MODIFY
[2022/03/25 10:23:20] [debug] [input chunk] update output instances with new chunk size diff=72
[2022/03/25 10:23:20] [debug] [input:tail:tail.0] inode=36177971 events: IN_MODIFY
[2022/03/25 10:23:20] [debug] [input chunk] update output instances with new chunk size diff=95
[2022/03/25 10:23:22] [debug] [task] created task=0x7fac6804a6c0 id=0 OK
[2022/03/25 10:23:22] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2022/03/25 10:23:22] [debug] [out flush] cb_destroy coro_id=0
[2022/03/25 10:23:22] [debug] [task] destroy task=0x7fac6804a6c0 (task_id=0)
```

and record file is here
```bash
Mar 25 10:23:20 ekwong-NUC10 systemd[2981]: tracker-store.service: Succeeded.
Mar 25 10:28:53 ekwong-NUC10 dbus-daemon[748]: [system] Activating via systemd: service name='org.freedesktop.PackageKit' unit='packagekit.service' requested by ':1.1761' (uid=0 pid=218217 comm="/usr/bin/gdbus call --system --dest org.freedeskto" label="unconfined")
Mar 25 10:28:53 ekwong-NUC10 systemd[1]: Starting PackageKit Daemon...
Mar 25 10:28:53 ekwong-NUC10 PackageKit: daemon start
Mar 25 10:28:53 ekwong-NUC10 dbus-daemon[748]: [system] Successfully activated service 'org.freedesktop.PackageKit'
Mar 25 10:28:53 ekwong-NUC10 systemd[1]: Started PackageKit Daemon.
```

**Test Part 3**
when no  property `line_append` in service conf output item

Example configuration file as below:

```bash
[service]
    flush               5
    grace               10
    daemon              on
    log_file            /tmp/ekwongchum/flb.log
    log_level           debug

[input]
    Name                 tail
    Tag                  syslog
    Path                 /var/log/syslog
    DB                   /tmp/ekwongchum/syslog.db

[output]
    Name                 file
    Match                syslog
    Path                 /tmp/ekwongchum/
    File                 record.file
    Mkdir                true
    Format               template
    Template             {log}
```

debug log output as below:

```bash
./fluent-bit -c flb.conf
Fluent Bit v2.0.0
* Git commit: 8efde37ad077f32611ad52f9ce831da413985f57
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/25 10:31:26] [ info] Configuration:
[2022/03/25 10:31:26] [ info]  flush time     | 5.000000 seconds
[2022/03/25 10:31:26] [ info]  grace          | 10 seconds
[2022/03/25 10:31:26] [ info]  daemon         | 1
[2022/03/25 10:31:26] [ info] ___________
[2022/03/25 10:31:26] [ info]  inputs:
[2022/03/25 10:31:26] [ info]      tail
[2022/03/25 10:31:26] [ info] ___________
[2022/03/25 10:31:26] [ info]  filters:
[2022/03/25 10:31:26] [ info] ___________
[2022/03/25 10:31:26] [ info]  outputs:
[2022/03/25 10:31:26] [ info]      file.0
[2022/03/25 10:31:26] [ info] ___________
[2022/03/25 10:31:26] [ info]  collectors:
[2022/03/25 10:31:26] [ info] switching to background mode (PID=218374)
```

and log file show here:

```bash
[2022/03/25 10:31:26] [ info] [engine] started (pid=218374)
[2022/03/25 10:31:26] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/03/25 10:31:26] [debug] [storage] [cio stream] new stream registered: tail.0
[2022/03/25 10:31:26] [ info] [storage] version=1.1.6, initializing...
[2022/03/25 10:31:26] [ info] [storage] in-memory
[2022/03/25 10:31:26] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/25 10:31:26] [ info] [cmetrics] version=0.3.0
[2022/03/25 10:31:26] [debug] [tail:tail.0] created event channels: read=20 write=21
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] inotify watch fd=28
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] scanning path /var/log/syslog
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] inode=36177971 with offset=124847 appended as /var/log/syslog
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] scan_glob add(): /var/log/syslog, inode 36177971
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] 1 new files found on path '/var/log/syslog'
[2022/03/25 10:31:26] [debug] [file:file.0] created event channels: read=30 write=31
[2022/03/25 10:31:26] [debug] [router] match rule tail.0:file.0
[2022/03/25 10:31:26] [ info] [sp] stream processor started
[2022/03/25 10:31:26] [ info] [output:file:file.0] worker #0 started
[2022/03/25 10:31:26] [debug] [input chunk] update output instances with new chunk size diff=977
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] [static files] processed 874b
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] inode=36177971 file=/var/log/syslog promote to TAIL_EVENT
[2022/03/25 10:31:26] [ info] [input:tail:tail.0] inotify_fs_add(): inode=36177971 watch_fd=1 name=/var/log/syslog
[2022/03/25 10:31:26] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2022/03/25 10:31:30] [debug] [task] created task=0x7f2e00049b40 id=0 OK
[2022/03/25 10:31:30] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2022/03/25 10:31:30] [debug] [out flush] cb_destroy coro_id=0
[2022/03/25 10:31:30] [debug] [task] destroy task=0x7f2e00049b40 (task_id=0)
[2022/03/25 10:31:43] [debug] [input:tail:tail.0] inode=36177971 events: IN_MODIFY
[2022/03/25 10:31:43] [debug] [input chunk] update output instances with new chunk size diff=72
[2022/03/25 10:31:43] [debug] [input:tail:tail.0] inode=36177971 events: IN_MODIFY
[2022/03/25 10:31:43] [debug] [input chunk] update output instances with new chunk size diff=95
[2022/03/25 10:31:45] [debug] [task] created task=0x7f2e00049e80 id=0 OK
[2022/03/25 10:31:45] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2022/03/25 10:31:45] [debug] [out flush] cb_destroy coro_id=1
[2022/03/25 10:31:45] [debug] [task] destroy task=0x7f2e00049e80 (task_id=0)
```

and record file is here
```bash
Mar 25 10:31:43 ekwong-NUC10 tracker-store[218363]: OK
Mar 25 10:31:43 ekwong-NUC10 systemd[2981]: tracker-store.service: Succeeded.
Mar 25 10:32:29 ekwong-NUC10 rtkit-daemon[1276]: Supervising 3 threads of 1 processes of 1 users.
Mar 25 10:32:29 ekwong-NUC10 rtkit-daemon[1276]: Successfully made thread 218394 of process 2990 owned by '1000' RT at priority 5.
Mar 25 10:32:29 ekwong-NUC10 rtkit-daemon[1276]: Supervising 4 threads of 1 processes of 1 users.
Mar 25 10:32:29 ekwong-NUC10 gsd-media-keys[3398]: Unable to get default sink
Mar 25 10:32:29 ekwong-NUC10 gsd-media-keys[3398]: gvc_mixer_card_get_index: assertion 'GVC_IS_MIXER_CARD (card)' failed
Mar 25 10:32:29 ekwong-NUC10 gsd-media-keys[3398]: message repeated 4 times: [ gvc_mixer_card_get_index: assertion 'GVC_IS_MIXER_CARD (card)' failed]
Mar 25 10:32:29 ekwong-NUC10 gnome-shell[3246]: gvc_mixer_card_get_index: assertion 'GVC_IS_MIXER_CARD (card)' failed
Mar 25 10:32:29 ekwong-NUC10 gnome-shell[3246]: message repeated 4 times: [ gvc_mixer_card_get_index: assertion 'GVC_IS_MIXER_CARD (card)' failed]
Mar 25 10:32:29 ekwong-NUC10 dbus-daemon[748]: [system] Activating via systemd: service name='net.reactivated.Fprint' unit='fprintd.service' requested by ':1.91' (uid=1000 pid=3246 comm="/usr/bin/gnome-shell " label="unconfined")
Mar 25 10:32:29 ekwong-NUC10 systemd[1]: Starting Fingerprint Authentication Daemon...
Mar 25 10:32:29 ekwong-NUC10 dbus-daemon[748]: [system] Successfully activated service 'net.reactivated.Fprint'
Mar 25 10:32:29 ekwong-NUC10 systemd[1]: Started Fingerprint Authentication Daemon.
```
