### PR TITLE
out_stackdriver: add static labels defined in configuration

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -947,13 +947,19 @@ static void pack_labels(struct flb_stackdriver *ctx,
 {
     int i;
     int ret;
-    int labels_size;
+    int labels_size = 0;
     char *val;
     struct mk_list *head;
     struct flb_kv *list_kv;
     msgpack_object_kv *obj_kv = NULL;
 
-    labels_size = mk_list_size(&ctx->config_labels) + payload_labels_ptr->via.map.size;
+    /* Determine size of labels map */
+    labels_size = mk_list_size(&ctx->config_labels);
+    if (payload_labels_ptr != NULL &&
+        payload_labels_ptr->type == MSGPACK_OBJECT_MAP) {
+        labels_size += payload_labels_ptr->via.map.size;
+    }
+
     msgpack_pack_map(mp_pck, labels_size);
 
     /* pack labels from the payload */
@@ -2030,7 +2036,13 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             return -1;
         }
 
-        labels_size = mk_list_size(&ctx->config_labels) + payload_labels_ptr->via.map.size;
+        /* Number of parsed labels */
+        labels_size = mk_list_size(&ctx->config_labels);
+        if (payload_labels_ptr != NULL &&
+            payload_labels_ptr->type == MSGPACK_OBJECT_MAP) {
+            labels_size += payload_labels_ptr->via.map.size;
+        }
+
         if (labels_size > 0) {
             entry_size += 1;
         }

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -19,6 +19,7 @@
 
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
@@ -911,12 +912,12 @@ static int process_local_resource_id(struct flb_stackdriver *ctx,
 }
 
 /*
- * parse_labels
+ * get_payload_labels
  * - Iterate throught the original payload (obj) and find out the entry that matches
  *   the labels_key
  * - Used to convert all labels under labels_key to root-level `labels` field
  */
-static msgpack_object *parse_labels(struct flb_stackdriver *ctx, msgpack_object *obj)
+static msgpack_object *get_payload_labels(struct flb_stackdriver *ctx, msgpack_object *obj)
 {
     int i;
     int len;
@@ -938,6 +939,100 @@ static msgpack_object *parse_labels(struct flb_stackdriver *ctx, msgpack_object 
     //flb_plg_debug(ctx->ins, "labels_key [%s] not found in the payload",
     //              ctx->labels_key);
     return NULL;
+}
+
+/*
+ * parse_labels
+ * - Parse labels set in configuration
+ * - Construct root-level `labels` field using configuration and payload labels
+ */
+
+static int parse_labels(struct flb_stackdriver *ctx,
+                        msgpack_object *payload_labels_ptr,
+                        struct mk_list *labels_list)
+{
+    int i;
+    int ret;
+    int len;
+    char *p;
+    flb_sds_t key;
+    flb_sds_t val;
+    struct mk_list *head;
+    struct flb_slist_entry *entry;
+    msgpack_object_kv *kv = NULL;
+
+    /* add payload labels */
+    if (payload_labels_ptr != NULL &&
+        payload_labels_ptr->type == MSGPACK_OBJECT_MAP) {
+
+        for (i = 0; i < payload_labels_ptr->via.map.size; i++) {
+            kv = &payload_labels_ptr->via.map.ptr[i];
+            flb_kv_item_create_len(labels_list,
+                                   kv->key.via.str.ptr,
+                                   kv->key.via.str.size,
+                                   kv->val.via.str.ptr,
+                                   kv->val.via.str.size);
+        }
+    }
+
+    /* parse configuration labels */
+    if (ctx->labels) {
+        mk_list_foreach(head, ctx->labels) {
+            entry = mk_list_entry(head, struct flb_slist_entry, _head);
+
+            p = strchr(entry->str, '=');
+            if (!p) {
+                flb_plg_error(ctx->ins, "invalid key value pair on '%s'",
+                              entry->str);
+                return -1;
+            }
+
+            key = flb_sds_create_size((p - entry->str) + 1);
+            flb_sds_cat(key, entry->str, p - entry->str);
+            val = flb_sds_create(p + 1);
+            if (!key) {
+                flb_plg_error(ctx->ins,
+                              "invalid key value pair on '%s'",
+                              entry->str);
+                return -1;
+            }
+            if (!val || flb_sds_len(val) == 0) {
+                flb_plg_error(ctx->ins,
+                              "invalid key value pair on '%s'",
+                              entry->str);
+                flb_sds_destroy(key);
+                return -1;
+            }
+
+            ret = flb_kv_item_create(labels_list, key, val);
+            flb_sds_destroy(key);
+            flb_sds_destroy(val);
+
+            if (ret == -1) {
+                return -1;
+            }
+        }
+    }
+
+    return mk_list_size(labels_list);
+}
+
+static void pack_labels(struct flb_stackdriver *ctx,
+                        msgpack_packer *mp_pck,
+                        struct mk_list *labels_list)
+{
+    struct mk_list *head;
+    struct flb_kv *kv;
+
+    msgpack_pack_map(mp_pck, mk_list_size(labels_list));
+
+    mk_list_foreach(head, labels_list){
+        kv = mk_list_entry(head, struct flb_kv, _head);
+        msgpack_pack_str(mp_pck, flb_sds_len(kv->key));
+        msgpack_pack_str_body(mp_pck, kv->key, flb_sds_len(kv->key));
+        msgpack_pack_str(mp_pck, flb_sds_len(kv->val));
+        msgpack_pack_str_body(mp_pck, kv->val, flb_sds_len(kv->val));
+    }
 }
 
 static void cb_results(const char *name, const char *value,
@@ -1496,6 +1591,11 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     /* Count number of records */
     array_size = total_records;
 
+    /* Parameters for labels */
+    msgpack_object *payload_labels_ptr;
+    int labels_parsed_size = 0;
+    struct mk_list labels_list;
+
     /*
      * Search each entry and validate insertId.
      * Reject the entry if insertId is invalid.
@@ -1975,18 +2075,26 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             entry_size += 1;
         }
 
-        /* Extract labels */
-        labels_ptr = parse_labels(ctx, obj);
-        if (labels_ptr != NULL) {
-            if (labels_ptr->type != MSGPACK_OBJECT_MAP) {
-                flb_plg_error(ctx->ins, "the type of labels should be map");
-                flb_sds_destroy(operation_id);
-                flb_sds_destroy(operation_producer);
-                msgpack_unpacked_destroy(&result);
-                msgpack_sbuffer_destroy(&mp_sbuf);
-                return NULL;
-            }
+        /* Extract payload labels */
+        payload_labels_ptr = get_payload_labels(ctx, obj);
+        if (payload_labels_ptr != NULL &&
+            payload_labels_ptr->type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "the type of labels should be map");
+            flb_sds_destroy(operation_id);
+            flb_sds_destroy(operation_producer);
+            msgpack_unpacked_destroy(&result);
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            return -1;
+        }
+
+        /* Parse labels */
+        flb_kv_init(&labels_list);
+        labels_parsed_size = parse_labels(ctx, payload_labels_ptr, &labels_list);
+        if (labels_parsed_size > 0) {
             entry_size += 1;
+        }
+        else {
+            flb_kv_release(&labels_list);
         }
 
         msgpack_pack_map(&mp_pck, entry_size);
@@ -2043,10 +2151,11 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         }
 
         /* labels */
-        if (labels_ptr != NULL) {
+        if (labels_parsed_size > 0) {
             msgpack_pack_str(&mp_pck, 6);
             msgpack_pack_str_body(&mp_pck, "labels", 6);
-            msgpack_pack_object(&mp_pck, *labels_ptr);
+            pack_labels(ctx, &mp_pck, &labels_list);
+            flb_kv_release(&labels_list);
         }
 
         /* Clean up id and producer if operation extracted */
@@ -2452,6 +2561,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "task_id", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, task_id),
       "Set the resource task id"
+    },
+    {
+      FLB_CONFIG_MAP_CLIST, "labels", NULL,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, labels),
+      "Set the labels"
     },
     {
       FLB_CONFIG_MAP_STR, "labels_key", DEFAULT_LABELS_KEY,

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -131,14 +131,15 @@ struct flb_stackdriver {
     flb_sds_t node_name;
     bool is_k8s_resource_type;
 
-    flb_sds_t labels_key;
     flb_sds_t local_resource_id;
     flb_sds_t tag_prefix;
     /* shadow tag_prefix for safe deallocation */
     flb_sds_t tag_prefix_k8s;
 
     /* labels */
+    flb_sds_t labels_key;
     struct mk_list *labels;
+    struct mk_list config_labels; 
 
     /* generic resources */
     flb_sds_t location;

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -137,6 +137,9 @@ struct flb_stackdriver {
     /* shadow tag_prefix for safe deallocation */
     flb_sds_t tag_prefix_k8s;
 
+    /* labels */
+    struct mk_list *labels;
+
     /* generic resources */
     flb_sds_t location;
     flb_sds_t namespace_id;

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -3450,7 +3450,7 @@ void flb_test_custom_labels()
 void flb_test_config_labels_conflict()
 {
     int ret;
-    int size = sizeof(CUSTOM_LABELS) - 1;
+    int size = sizeof(DEFAULT_LABELS) - 1;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -3492,7 +3492,7 @@ void flb_test_config_labels_conflict()
 void flb_test_config_labels_no_conflict()
 {
     int ret;
-    int size = sizeof(CUSTOM_LABELS) - 1;
+    int size = sizeof(DEFAULT_LABELS) - 1;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -4906,6 +4906,8 @@ TEST_LIST = {
     {"resource_k8s_pod_no_local_resource_id", flb_test_resource_k8s_pod_no_local_resource_id },
     {"default_labels", flb_test_default_labels },
     {"custom_labels", flb_test_custom_labels },
+    {"config_labels_conflict", flb_test_config_labels_conflict },
+    {"config_labels_no_conflict", flb_test_config_labels_no_conflict },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
 


### PR DESCRIPTION
This change mirrors the [out_loki](https://docs.fluentbit.io/manual/pipeline/outputs/loki#using-the-label_keys-property) exporter functionality to set static `labels` during configuration. This as a list of comma separate `key=value` pairs, e.g. `label_a=value_a,label_b=value_b`. The `record_accesor` wasn't implemented since the functionality can be recreated using `label_keys`.

The expected behavior is that elements set with `labels` and `label_keys` are combined to set the LogEntry Labels in the LogExplorer. When duplicated keys appear, we would give preference to values set in `labels` over `label_keys`.

This PR is one approach to add the feature in #4912 .

### Configuration

This configuration implements the functionality by setting `labels` using `key=value` pairs and using a `modify` + `nest` to set a label in the payload to show the output combines the result.

```
[INPUT]
    Buffer_Chunk_Size 512k
    Buffer_Max_Size   5M
    Key               message
    Mem_Buf_Limit     10M
    Name              tail
    Path              /var/log/messages,/var/log/syslog
    Read_from_Head    True
    Rotate_Wait       30
    Skip_Long_Lines   On
    Tag               default_pipeline.syslog

[FILTER]
    Add   labelA valueA
    Match *
    Name  modify

[FILTER]
    Match      *
    Name       nest
    Nest_under logging.googleapis.com/labels
    Operation  nest
    Wildcard   labelA*

[OUTPUT]
    Match_Regex                   ^(default_pipeline\.syslog)$
    Name                          stackdriver
    Retry_Limit                   3
    net.connect_timeout_log_error False
    resource                      gce_instance
    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/2.11.0 (BuildDistro=buster;Platform=linux;ShortName=debian;ShortVersion=10.11)
    tls                           On
    tls.verify                    Off
    workers                       8
    labels                        compute.googleapis.com/resource_name=testing_vm_syslog,labelQ=valueQ
```

This is one output `LogEntry` :

![Screen Shot 2022-03-28 at 13 00 41](https://user-images.githubusercontent.com/1435136/160468154-23e1f5e9-45f4-43d0-99f7-2737bc2b65b9.png)



### Output Log and Valgrind result
The result of the following `valgrind` execution is shown below :
```
valgrind --leak-check=yes fluent-bit/build/bin/fluent-bit   --config ./fluent_bit_main.conf
```

This is the output log of the execution : 

```
==18343== Memcheck, a memory error detector
==18343== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18343== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==18343== Command: fluent-bit/build/bin/fluent-bit --config ./fluent_bit_main.conf
==18343== 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/11 16:39:41] [ info] [fluent bit] version=1.9.3, commit=3d5d754ffa, pid=18343
[2022/04/11 16:39:41] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/11 16:39:41] [ info] [cmetrics] version=0.3.0
[2022/04/11 16:39:44] [ info] [output:stackdriver:stackdriver.0] metadata_server set to http://metadata.google.internal
[2022/04/11 16:39:44] [ warn] [output:stackdriver:stackdriver.0] client_email is not defined, using a default one
[2022/04/11 16:39:44] [ warn] [output:stackdriver:stackdriver.0] private_key is not defined, fetching it from metadata server
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #0 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #1 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #2 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #3 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #4 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #5 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #6 started
[2022/04/11 16:39:46] [ info] [output:stackdriver:stackdriver.0] worker #7 started
[2022/04/11 16:39:46] [ info] [sp] stream processor started
[2022/04/11 16:39:47] [ info] [input:tail:tail.0] inotify_fs_add(): inode=410658 watch_fd=1 name=/var/log/messages
[2022/04/11 16:39:47] [ info] [input:tail:tail.0] inotify_fs_add(): inode=407396 watch_fd=2 name=/var/log/syslog
^C[2022/04/11 16:40:13] [engine] caught signal (SIGINT)
[2022/04/11 16:40:13] [ info] [input] pausing tail.0
[2022/04/11 16:40:13] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/11 16:40:13] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/11 16:40:13] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=410658 watch_fd=1
[2022/04/11 16:40:13] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=407396 watch_fd=2
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #0 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #0 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #1 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #1 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #2 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #2 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #3 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #3 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #4 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #4 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #5 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #5 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #6 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #6 stopped
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #7 stopping...
[2022/04/11 16:40:13] [ info] [output:stackdriver:stackdriver.0] thread worker #7 stopped
==18343== 
==18343== HEAP SUMMARY:
==18343==     in use at exit: 0 bytes in 0 blocks
==18343==   total heap usage: 69,777 allocs, 69,777 frees, 116,382,573 bytes allocated
==18343== 
==18343== All heap blocks were freed -- no leaks are possible
==18343== 
==18343== For counts of detected and suppressed errors, rerun with: -v
==18343== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Signed-off-by: Francisco Valente <fcovalente@google.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
Documentation PR #https://github.com/fluent/fluent-bit-docs/pull/768.

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

The PR for the backport into `1.8` branch #5095.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
