### PR TITLE
filter_kubernetes: fix leak on journal mode when excluding records

### DIFF
--- a/plugins/filter_kubernetes/kube_property.c
+++ b/plugins/filter_kubernetes/kube_property.c
@@ -351,8 +351,10 @@ void flb_kube_prop_destroy(struct flb_kube_props *props)
 {
     if (props->stdout_parser) {
         flb_sds_destroy(props->stdout_parser);
+        props->stdout_parser = NULL;
     }
     if (props->stderr_parser) {
         flb_sds_destroy(props->stderr_parser);
+        props->stderr_parser = NULL;
     }
 }

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -520,6 +520,7 @@ static int cb_kube_filter(const void *data, size_t bytes,
                     /* Skip this record */
                     if (ctx->use_journal == FLB_TRUE) {
                         flb_kube_meta_release(&meta);
+                        flb_kube_prop_destroy(&props);
                     }
                     continue;
                 }
@@ -531,6 +532,11 @@ static int cb_kube_filter(const void *data, size_t bytes,
         case FLB_KUBE_PROP_STREAM_STDERR:
             {
                 if (props.stderr_exclude == FLB_TRUE) {
+                    /* Skip this record */
+                    if (ctx->use_journal == FLB_TRUE) {
+                        flb_kube_meta_release(&meta);
+                        flb_kube_prop_destroy(&props);
+                    }
                     continue;
                 }
                 if (props.stderr_parser != NULL) {


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
