### PR TITLE
1.8: ci: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,9 +18,9 @@
 
 # CI 
 # -------------------------
-/.github/                @niedbalski
-/appveyor.yml            @niedbalski
-/dockerfiles/            @niedbalski
+/.github/                @niedbalski @patrick-stephens
+/appveyor.yml            @niedbalski @patrick-stephens
+/dockerfiles/            @niedbalski @patrick-stephens
 
 # Core: Signv4
 # ------------


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Added myself to codeowners for 1.8 CI.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
