### PR TITLE
1.8: multiline: java: modify start_state to ignore 'Exception:' at the beginning of line.

### DIFF
--- a/src/multiline/flb_ml_parser_java.c
+++ b/src/multiline/flb_ml_parser_java.c
@@ -59,7 +59,7 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key)
 
     ret = rule(mlp,
                "start_state, java_start_exception",
-               "/(?:Exception|Error|Throwable|V8 errors stack trace)[:\\r\\n]/",
+               "/(.)(?:Exception|Error|Throwable|V8 errors stack trace)[:\\r\\n]/",
                "java_after_exception", NULL);
     if (ret != 0) {
         rule_error(mlp);


### PR DESCRIPTION
This patch is for v1.8 branch.
Original PR is https://github.com/fluent/fluent-bit/pull/4990
Issue is https://github.com/fluent/fluent-bit/issues/4949

====

This patch is to ignore 'Exception:' at the beginning of line.
I'm not familiar with java exception logs.
If it outputs 'Exception:' at the begging of line, this patch makes ignoring such java real exception log.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    flush                 1
    log_level             info

[INPUT]
    name                  tail
    path                  java-python.log
    read_from_head        true
    multiline.parser      java,python

[OUTPUT]
    name                  stdout
    match                 *
```

java-python.log
```
Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
```

## Debug log

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.8.15
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 07:47:08] [ info] [engine] started (pid=17200)
[2022/03/26 07:47:08] [ info] [storage] version=1.1.6, initializing...
[2022/03/26 07:47:08] [ info] [storage] in-memory
[2022/03/26 07:47:08] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/26 07:47:08] [ info] [cmetrics] version=0.2.2
[2022/03/26 07:47:08] [ info] [input:tail:tail.0] multiline core started
[2022/03/26 07:47:08] [ info] [sp] stream processor started
[2022/03/26 07:47:08] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1451493 watch_fd=1 name=java-python.log
[2022/03/26 07:47:08] [ info] [output:stdout:stdout.0] worker #0 started
[0] tail.0: [1648248428.366684021, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
^C[2022/03/26 07:47:14] [engine] caught signal (SIGINT)
[2022/03/26 07:47:14] [ info] [input] pausing tail.0
[2022/03/26 07:47:14] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 07:47:15] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 07:47:15] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1451493 watch_fd=1
[2022/03/26 07:47:15] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 07:47:15] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

All unit tests are succeed .
```
$ ../bin/flb-it-multiline 
Test parser_docker...                           
----- MULTILINE FLUSH -----
[0] [1612197903.012310000, {"log"=>"aa
", "stream"=>"stdout", "time"=>"2021-02-01T16:45:03.01231z"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [1612197903.012310000, {"log"=>"aa
", "stream"=>"stderr", "time"=>"2021-02-01T16:45:03.01231z"}]
----------- EOF -----------

(snip)
Test issue_4949...                              

----- MULTILINE FLUSH -----
[0] [1648248471.527723569, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [1648248471.527723569, {"log"=>"hello world, not multiline
"}]
----------- EOF -----------
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output


Valgrind reported error.
I think it doesn't releted this PR since it wasn't reported on original PR.

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==17222== Memcheck, a memory error detector
==17222== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17222== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==17222== Command: ../bin/fluent-bit -c a.conf
==17222== 
Fluent Bit v1.8.15
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 07:48:55] [ info] [engine] started (pid=17222)
[2022/03/26 07:48:55] [ info] [storage] version=1.1.6, initializing...
[2022/03/26 07:48:55] [ info] [storage] in-memory
[2022/03/26 07:48:55] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/03/26 07:48:55] [ info] [cmetrics] version=0.2.2
[2022/03/26 07:48:55] [ info] [input:tail:tail.0] multiline core started
[2022/03/26 07:48:55] [ info] [output:stdout:stdout.0] worker #0 started
[2022/03/26 07:48:55] [ info] [sp] stream processor started
[2022/03/26 07:48:55] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1451493 watch_fd=1 name=java-python.log
[0] tail.0: [1648248535.809076552, {"log"=>"Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py", line 1535, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 17, in start
    return get()
  File "/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py", line 5, in get
    raise Exception('spam', 'eggs')
Exception: ('spam', 'eggs')
"}]
^C[2022/03/26 07:48:59] [engine] caught signal (SIGINT)
[2022/03/26 07:48:59] [ info] [input] pausing tail.0
[2022/03/26 07:48:59] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 07:49:00] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 07:49:00] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1451493 watch_fd=1
==17222== Thread 4 flb-out-stdout.0:
==17222== Invalid read of size 8
==17222==    at 0x72FD54: mk_event_timeout_destroy (mk_event.c:165)
==17222==    by 0x1C80F6: flb_sched_timer_destroy (flb_scheduler.c:649)
==17222==    by 0x1C7F16: flb_sched_destroy (flb_scheduler.c:596)
==17222==    by 0x1B4D62: output_thread (flb_output_thread.c:361)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Address 0x4e8bd70 is 16 bytes inside a block of size 24 free'd
==17222==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2DA: mk_mem_free (mk_memory.h:102)
==17222==    by 0x72FBB0: mk_event_loop_destroy (mk_event.c:82)
==17222==    by 0x1B4D53: output_thread (flb_output_thread.c:359)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Block was alloc'd at
==17222==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2A1: mk_mem_alloc_z (mk_memory.h:70)
==17222==    by 0x72FAEC: mk_event_loop_create (mk_event.c:58)
==17222==    by 0x1B507B: flb_output_thread_pool_create (flb_output_thread.c:443)
==17222==    by 0x1B25DB: flb_output_enable_multi_threading (flb_output.c:784)
==17222==    by 0x1B3392: flb_output_init_all (flb_output.c:1070)
==17222==    by 0x1C34CD: flb_engine_start (flb_engine.c:602)
==17222==    by 0x1A1A98: flb_lib_worker (flb_lib.c:627)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222== 
==17222== Invalid read of size 4
==17222==    at 0x72F653: _mk_event_del (mk_event_epoll.c:153)
==17222==    by 0x72F888: _mk_event_timeout_destroy (mk_event_epoll.c:325)
==17222==    by 0x72FD6E: mk_event_timeout_destroy (mk_event.c:166)
==17222==    by 0x1C80F6: flb_sched_timer_destroy (flb_scheduler.c:649)
==17222==    by 0x1C7F16: flb_sched_destroy (flb_scheduler.c:596)
==17222==    by 0x1B4D62: output_thread (flb_output_thread.c:361)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Address 0x4e8b9d0 is 0 bytes inside a block of size 16 free'd
==17222==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2DA: mk_mem_free (mk_memory.h:102)
==17222==    by 0x72F50F: _mk_event_loop_destroy (mk_event_epoll.c:94)
==17222==    by 0x72FB94: mk_event_loop_destroy (mk_event.c:80)
==17222==    by 0x1B4D53: output_thread (flb_output_thread.c:359)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Block was alloc'd at
==17222==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2A1: mk_mem_alloc_z (mk_memory.h:70)
==17222==    by 0x72F41E: _mk_event_loop_create (mk_event_epoll.c:54)
==17222==    by 0x72FACD: mk_event_loop_create (mk_event.c:53)
==17222==    by 0x1B507B: flb_output_thread_pool_create (flb_output_thread.c:443)
==17222==    by 0x1B25DB: flb_output_enable_multi_threading (flb_output.c:784)
==17222==    by 0x1B3392: flb_output_init_all (flb_output.c:1070)
==17222==    by 0x1C34CD: flb_engine_start (flb_engine.c:602)
==17222==    by 0x1A1A98: flb_lib_worker (flb_lib.c:627)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222== 
==17222== Invalid read of size 8
==17222==    at 0x72FC7A: mk_event_del (mk_event.c:126)
==17222==    by 0x72FD39: mk_event_timeout_disable (mk_event.c:157)
==17222==    by 0x1C7C4C: flb_sched_timer_cb_disable (flb_scheduler.c:494)
==17222==    by 0x1C810D: flb_sched_timer_destroy (flb_scheduler.c:652)
==17222==    by 0x1C7F16: flb_sched_destroy (flb_scheduler.c:596)
==17222==    by 0x1B4D62: output_thread (flb_output_thread.c:361)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Address 0x4e8bd70 is 16 bytes inside a block of size 24 free'd
==17222==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2DA: mk_mem_free (mk_memory.h:102)
==17222==    by 0x72FBB0: mk_event_loop_destroy (mk_event.c:82)
==17222==    by 0x1B4D53: output_thread (flb_output_thread.c:359)
==17222==    by 0x1CD05B: step_callback (flb_worker.c:44)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222==  Block was alloc'd at
==17222==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==17222==    by 0x72F2A1: mk_mem_alloc_z (mk_memory.h:70)
==17222==    by 0x72FAEC: mk_event_loop_create (mk_event.c:58)
==17222==    by 0x1B507B: flb_output_thread_pool_create (flb_output_thread.c:443)
==17222==    by 0x1B25DB: flb_output_enable_multi_threading (flb_output.c:784)
==17222==    by 0x1B3392: flb_output_init_all (flb_output.c:1070)
==17222==    by 0x1C34CD: flb_engine_start (flb_engine.c:602)
==17222==    by 0x1A1A98: flb_lib_worker (flb_lib.c:627)
==17222==    by 0x4864608: start_thread (pthread_create.c:477)
==17222==    by 0x4BBF162: clone (clone.S:95)
==17222== 
[2022/03/26 07:49:00] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 07:49:00] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17222== 
==17222== HEAP SUMMARY:
==17222==     in use at exit: 0 bytes in 0 blocks
==17222==   total heap usage: 1,288 allocs, 1,288 frees, 706,871 bytes allocated
==17222== 
==17222== All heap blocks were freed -- no leaks are possible
==17222== 
==17222== For lists of detected and suppressed errors, rerun with: -s
==17222== ERROR SUMMARY: 5 errors from 3 contexts (suppressed: 0 from 0)
taka@locals:~/git/fluent-bit/build/4949$ 

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
