### PR TITLE
in_docker: add missing include/exclude property

### DIFF
--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -843,6 +843,16 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct flb_docker, interval_nsec),
       "Set the collector interval (nanoseconds)"
     },
+    {
+      FLB_CONFIG_MAP_STR, "include", NULL,
+      0, FLB_FALSE, 0,
+      "A space-separated list of containers to include"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "exclude", NULL,
+      0, FLB_FALSE, 0,
+      "A space-separated list of containers to exclude"
+    },
     /* EOF */
     {0}
 };


### PR DESCRIPTION
This patch is to add missing properties `include` and `exclude` to config map.
The issue was caused by https://github.com/fluent/fluent-bit/pull/4923 .

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

Run containers.
```
$ sudo docker ps -a
CONTAINER ID   IMAGE     COMMAND   CREATED             STATUS             PORTS     NAMES
dc6d5a1660f2   ubuntu    "bash"    13 minutes ago      Up 13 minutes                stoic_brattain
2cd8433f36eb   ubuntu    "bash"    14 minutes ago      Up 14 minutes                blissful_almeida
58c33a47212e   ubuntu    "bash"    About an hour ago   Up About an hour             charming_darwin
```

```
$ sudo bin/fluent-bit -i docker -p 'exclude=58c33a47212e 2cd8433f36eb' -o stdout
```

## Debug log

Include case:
`"id"=>"58c33a47212e"` and `"id"=>"2cd8433f36eb"` are reported.
```
$ sudo bin/fluent-bit -i docker -p 'include=58c33a47212e 2cd8433f36eb' -o stdout
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 09:55:47] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=43764
[2022/03/26 09:55:47] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 09:55:47] [ info] [cmetrics] version=0.3.0
[2022/03/26 09:55:47] [ info] [sp] stream processor started
[2022/03/26 09:55:47] [ info] [output:stdout:stdout.0] worker #0 started
[0] docker.0: [1648256148.186714283, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256148.186801369, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1648256149.186312822, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256149.186386663, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
^C[2022/03/26 09:55:50] [engine] caught signal (SIGINT)
[2022/03/26 09:55:50] [ info] [input] pausing docker.0
[0] docker.0: [1648256150.185958158, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:55:50] [ warn] [engine] service will shutdown in max 5 seconds
[1] docker.0: [1648256150.186022861, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:55:51] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 09:55:51] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 09:55:51] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

Exclude case:
Only `"id"=>"dc6d5a1660f2"` is gathered.
```
$ sudo bin/fluent-bit -i docker -p 'exclude=58c33a47212e 2cd8433f36eb' -o stdout
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 09:54:47] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=43758
[2022/03/26 09:54:47] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 09:54:47] [ info] [cmetrics] version=0.3.0
[2022/03/26 09:54:47] [ info] [sp] stream processor started
[2022/03/26 09:54:47] [ info] [output:stdout:stdout.0] worker #0 started
[0] docker.0: [1648256088.186581277, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1648256089.185850111, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
^C[2022/03/26 09:54:50] [engine] caught signal (SIGINT)
[2022/03/26 09:54:50] [ info] [input] pausing docker.0
[0] docker.0: [1648256090.186302359, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:54:50] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 09:54:51] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 09:54:51] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 09:54:51] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

Include case:
```
$ sudo valgrind --leak-check=full bin/fluent-bit -i docker -p 'include=58c33a47212e 2cd8433f36eb' -o stdout
==43775== Memcheck, a memory error detector
==43775== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43775== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43775== Command: bin/fluent-bit -i docker -p include=58c33a47212e\ 2cd8433f36eb -o stdout
==43775== 
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 09:57:07] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=43775
[2022/03/26 09:57:07] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 09:57:07] [ info] [cmetrics] version=0.3.0
[2022/03/26 09:57:07] [ info] [sp] stream processor started
[2022/03/26 09:57:07] [ info] [output:stdout:stdout.0] worker #0 started
[0] docker.0: [1648256228.258658493, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256228.306689695, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
^C[2022/03/26 09:57:09] [engine] caught signal (SIGINT)
[2022/03/26 09:57:09] [ info] [input] pausing docker.0
[0] docker.0: [1648256229.242684210, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256229.243622412, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:57:09] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 09:57:10] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 09:57:10] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 09:57:10] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==43775== 
==43775== HEAP SUMMARY:
==43775==     in use at exit: 0 bytes in 0 blocks
==43775==   total heap usage: 1,223 allocs, 1,223 frees, 1,041,540 bytes allocated
==43775== 
==43775== All heap blocks were freed -- no leaks are possible
==43775== 
==43775== For lists of detected and suppressed errors, rerun with: -s
==43775== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Exclude case:
```
$ sudo valgrind --leak-check=full bin/fluent-bit -i docker -p 'exclude=58c33a47212e 2cd8433f36eb' -o stdout
==43782== Memcheck, a memory error detector
==43782== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43782== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43782== Command: bin/fluent-bit -i docker -p exclude=58c33a47212e\ 2cd8433f36eb -o stdout
==43782== 
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 09:57:46] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=43782
[2022/03/26 09:57:46] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 09:57:46] [ info] [cmetrics] version=0.3.0
[2022/03/26 09:57:46] [ info] [sp] stream processor started
[2022/03/26 09:57:46] [ info] [output:stdout:stdout.0] worker #0 started
[0] docker.0: [1648256267.259870467, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
^C[2022/03/26 09:57:48] [engine] caught signal (SIGINT)
[2022/03/26 09:57:48] [ info] [input] pausing docker.0
[0] docker.0: [1648256268.255317395, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:57:48] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 09:57:49] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 09:57:49] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 09:57:49] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==43782== 
==43782== HEAP SUMMARY:
==43782==     in use at exit: 0 bytes in 0 blocks
==43782==   total heap usage: 1,179 allocs, 1,179 frees, 954,052 bytes allocated
==43782== 
==43782== All heap blocks were freed -- no leaks are possible
==43782== 
==43782== For lists of detected and suppressed errors, rerun with: -s
==43782== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

No option:
```
$ sudo valgrind --leak-check=full bin/fluent-bit -i docker -o stdout
==43787== Memcheck, a memory error detector
==43787== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43787== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43787== Command: bin/fluent-bit -i docker -o stdout
==43787== 
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 09:58:21] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=43787
[2022/03/26 09:58:21] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 09:58:21] [ info] [cmetrics] version=0.3.0
[2022/03/26 09:58:21] [ info] [sp] stream processor started
[2022/03/26 09:58:21] [ info] [output:stdout:stdout.0] worker #0 started
[0] docker.0: [1648256302.264342562, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256302.312289312, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
[2] docker.0: [1648256302.314522135, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
^C[2022/03/26 09:58:24] [engine] caught signal (SIGINT)
[2022/03/26 09:58:24] [ info] [input] pausing docker.0
[0] docker.0: [1648256303.274564864, {"id"=>"58c33a47212e", "name"=>"charming_darwin", "cpu_used"=>36291828, "mem_used"=>5750784, "mem_limit"=>9223372036854771712}]
[1] docker.0: [1648256303.276464369, {"id"=>"dc6d5a1660f2", "name"=>"stoic_brattain", "cpu_used"=>44329282, "mem_used"=>831488, "mem_limit"=>9223372036854771712}]
[2] docker.0: [1648256303.276800141, {"id"=>"2cd8433f36eb", "name"=>"blissful_almeida", "cpu_used"=>44178417, "mem_used"=>806912, "mem_limit"=>9223372036854771712}]
[2022/03/26 09:58:24] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 09:58:24] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/26 09:58:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/26 09:58:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==43787== 
==43787== HEAP SUMMARY:
==43787==     in use at exit: 0 bytes in 0 blocks
==43787==   total heap usage: 1,232 allocs, 1,232 frees, 1,128,240 bytes allocated
==43787== 
==43787== All heap blocks were freed -- no leaks are possible
==43787== 
==43787== For lists of detected and suppressed errors, rerun with: -s
==43787== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
