### PR TITLE
parser: do not pass cached config format context (#5141)

### DIFF
--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -102,6 +102,10 @@ struct flb_cf {
 
     /* set the last error found */
     char *error_str;
+
+
+    /* a list head entry in case the caller want's to link contexts */
+    struct mk_list _head;
 };
 
 

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -72,7 +72,7 @@ struct flb_config {
 
     /* main configuration */
     struct flb_cf *cf_main;
-    struct flb_cf *cf_parsers;
+    struct mk_list cf_parsers_list;
 
     flb_sds_t program_name;      /* argv[0] */
 

--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -742,6 +742,7 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
 
     if (ret == -1 && created) {
         flb_cf_destroy(cf);
+        return NULL;
     }
 
     return cf;


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
