### PR TITLE
out_websocket: add missing json_date_ properties to config_map

### DIFF
--- a/plugins/out_websocket/websocket.c
+++ b/plugins/out_websocket/websocket.c
@@ -305,6 +305,16 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Set desired payload format: json, json_stream, json_lines, gelf or msgpack"
     },
+    {
+     FLB_CONFIG_MAP_STR, "json_date_format", "double",
+     0, FLB_FALSE, 0,
+     "Specify the format of the date"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "json_date_key", "date",
+     0, FLB_TRUE, offsetof(struct flb_out_ws, json_date_key),
+     "Specify the name of the date field in output"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/out_websocket/websocket_conf.c
+++ b/plugins/out_websocket/websocket_conf.c
@@ -53,7 +53,7 @@ struct flb_out_ws *flb_ws_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
-    //flb_output_net_default("127.0.0.1", 8080, ins);
+    flb_output_net_default("127.0.0.1", 80, ins);
 
     /* Check if SSL/TLS is enabled */
 #ifdef FLB_HAVE_TLS
@@ -97,15 +97,6 @@ struct flb_out_ws *flb_ws_conf_create(struct flb_output_instance *ins,
         else {
             ctx->json_date_format = ret;
         }
-    }
-
-    /* Date key for JSON output */
-    tmp = flb_output_get_property("json_date_key", ins);
-    if (tmp) {
-        ctx->json_date_key = flb_sds_create(tmp);
-    }
-    else {
-        ctx->json_date_key = flb_sds_create("date");
     }
 
     if (ins->host.uri) {
@@ -163,9 +154,6 @@ void flb_ws_conf_destroy(struct flb_out_ws *ctx)
         flb_upstream_destroy(ctx->u);
     }
 
-    if (ctx->json_date_key) {
-        flb_sds_destroy(ctx->json_date_key);
-    }
     flb_free(ctx->uri);
     flb_free(ctx);
 }


### PR DESCRIPTION
`json_date_key` and `json_date_format` are described in document.
https://docs.fluentbit.io/manual/pipeline/outputs/websocket
However, they are not supported by config_map.

This patch is to support them and set default network host and port.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
fluent-bit -i cpu -o websocket://localhost:8080 -p json_date_key=hoge -p json_date_format=hoge
```

## Debug log

```
$ bin/fluent-bit -i cpu -o websocket://localhost:8080 -p json_date_key=hoge -p json_date_format=hoge
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 14:23:24] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=70161
[2022/03/26 14:23:24] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 14:23:24] [ info] [cmetrics] version=0.3.0
[2022/03/26 14:23:24] [error] [out_ws] unrecognized 'json_date_format' option 'hoge'. Using 'double'
[2022/03/26 14:23:24] [ info] [out_ws] we have following parameter /, localhost, 8080, 25
[2022/03/26 14:23:24] [ info] [sp] stream processor started
[2022/03/26 14:23:26] [ info] [out_ws] handshake for ws
[2022/03/26 14:23:26] [ warn] [engine] failed to flush chunk '70161-1648272205.390668112.flb', retry in 11 seconds: task_id=0, input=cpu.0 > output=websocket.0 (out_id=0)
[2022/03/26 14:23:27] [ info] [out_ws] handshake for ws
[2022/03/26 14:23:27] [ warn] [engine] failed to flush chunk '70161-1648272206.390711738.flb', retry in 7 seconds: task_id=1, input=cpu.0 > output=websocket.0 (out_id=0)
^C[2022/03/26 14:23:27] [engine] caught signal (SIGINT)
[2022/03/26 14:23:27] [ info] [input] pausing cpu.0
[2022/03/26 14:23:27] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 14:23:27] [ info] [out_ws] handshake for ws
[2022/03/26 14:23:28] [ info] [task] cpu/cpu.0 has 3 pending task(s):
[2022/03/26 14:23:28] [ info] [task]   task_id=0 still running on route(s): websocket/websocket.0 
[2022/03/26 14:23:28] [ info] [task]   task_id=1 still running on route(s): websocket/websocket.0 
[2022/03/26 14:23:28] [ info] [task]   task_id=2 still running on route(s): websocket/websocket.0 
[2022/03/26 14:23:32] [ info] [task] cpu/cpu.0 has 3 pending task(s):
[2022/03/26 14:23:32] [ info] [task]   task_id=0 still running on route(s): websocket/websocket.0 
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o websocket://localhost:8080 -p json_date_key=hoge -p json_date_format=hoge
==70165== Memcheck, a memory error detector
==70165== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==70165== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==70165== Command: bin/fluent-bit -i cpu -o websocket://localhost:8080 -p json_date_key=hoge -p json_date_format=hoge
==70165== 
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/26 14:24:18] [ info] [fluent bit] version=1.9.1, commit=1b89b4711b, pid=70165
[2022/03/26 14:24:19] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/26 14:24:19] [ info] [cmetrics] version=0.3.0
[2022/03/26 14:24:19] [error] [out_ws] unrecognized 'json_date_format' option 'hoge'. Using 'double'
[2022/03/26 14:24:19] [ info] [out_ws] we have following parameter /, localhost, 8080, 25
[2022/03/26 14:24:19] [ info] [sp] stream processor started
[2022/03/26 14:24:20] [ info] [out_ws] handshake for ws
[2022/03/26 14:24:20] [ warn] [engine] failed to flush chunk '70165-1648272259.432765989.flb', retry in 9 seconds: task_id=0, input=cpu.0 > output=websocket.0 (out_id=0)
[2022/03/26 14:24:21] [ info] [out_ws] handshake for ws
[2022/03/26 14:24:21] [ warn] [engine] failed to flush chunk '70165-1648272260.421888804.flb', retry in 9 seconds: task_id=1, input=cpu.0 > output=websocket.0 (out_id=0)
^C[2022/03/26 14:24:22] [engine] caught signal (SIGINT)
[2022/03/26 14:24:22] [ info] [input] pausing cpu.0
[2022/03/26 14:24:22] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/26 14:24:22] [ info] [out_ws] handshake for ws
[2022/03/26 14:24:22] [ info] [task] cpu/cpu.0 has 3 pending task(s):
[2022/03/26 14:24:22] [ info] [task]   task_id=0 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:22] [ info] [task]   task_id=1 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:22] [ info] [task]   task_id=2 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:26] [ info] [task] cpu/cpu.0 has 3 pending task(s):
[2022/03/26 14:24:26] [ info] [task]   task_id=0 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:26] [ info] [task]   task_id=1 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:26] [ info] [task]   task_id=2 still running on route(s): websocket/websocket.0 
[2022/03/26 14:24:26] [ info] [engine] service has stopped (1 pending tasks)
[2022/03/26 14:24:26] [ info] [out_ws] flb_ws_conf_destroy 
==70165== 
==70165== HEAP SUMMARY:
==70165==     in use at exit: 0 bytes in 0 blocks
==70165==   total heap usage: 1,276 allocs, 1,276 frees, 1,357,333 bytes allocated
==70165== 
==70165== All heap blocks were freed -- no leaks are possible
==70165== 
==70165== For lists of detected and suppressed errors, rerun with: -s
==70165== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
