### PR TITLE
workflows: increase stale ops limit

### DIFF
--- a/.github/workflows/cron-stale.yaml
+++ b/.github/workflows/cron-stale.yaml
@@ -23,4 +23,4 @@ jobs:
           # start with the oldest
           ascending: true
           # keep an eye on this
-          operations-per-run: 100
+          operations-per-run: 250


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Increase ops per run for stale check to allow it to cover more issues & PRs.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
