### PR TITLE
filter_parser: mark 'unescape_key' as a deprecated property

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -375,6 +375,11 @@ static struct flb_config_map config_map[] = {
      "Keep all other original fields in the parsed result. "
      "If false, all other original fields will be removed."
     },
+    {
+     FLB_CONFIG_MAP_DEPRECATED, "Unescape_key", NULL,
+     0, FLB_FALSE, 0,
+     "(deprecated)"
+    },
     {0}
 };
 


### PR DESCRIPTION
`Unescape_Key` of filter_parser has not been supported yet, but it is documented on v1.8. (It is removed from v1.9)
https://docs.fluentbit.io/manual/v/1.8/pipeline/filters/parser

This PR is to mark as a deprecated.

See also 
https://github.com/fluent/fluent-bit/pull/4874#issuecomment-1046161504
https://github.com/fluent/fluent-bit/issues/453
https://github.com/fluent/fluent-bit/issues/5210

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

parsers.conf:
```
[PARSER]
    Name dummy_test
    Format regex
    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
```

a.conf:
```
[SERVICE]
    Parsers_File /path/to/parsers.conf

[INPUT]
    Name dummy
    Tag  dummy.data
    Dummy {"data":"100 0.5 true This is example"}

[FILTER]
    Name parser
    Match dummy.*
    Key_Name data
    Parser dummy_test
    Unescape_key data

[OUTPUT]
    Name stdout
    Match *
```

## Debug log

`[2022/03/30 18:28:56] [ warn] [config] parser: 'Unescape_key' is deprecated`

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.2
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/30 18:23:29] [ info] [fluent bit] version=1.9.2, commit=84c94ccc03, pid=17105
[2022/03/30 18:23:29] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/30 18:23:29] [ info] [cmetrics] version=0.3.0
[2022/03/30 18:23:29] [ warn] [config] parser: 'Unescape_key' is deprecated
[2022/03/30 18:23:29] [ info] [sp] stream processor started
[2022/03/30 18:23:29] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.data: [1648632209.998375684, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
[0] dummy.data: [1648632210.998355610, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
[0] dummy.data: [1648632211.998387661, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
[0] dummy.data: [1648632212.998465755, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
^C[2022/03/30 18:23:34] [engine] caught signal (SIGINT)
[0] dummy.data: [1648632213.998385376, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
[2022/03/30 18:23:34] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/30 18:23:34] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/30 18:23:34] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/30 18:23:34] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==17209== Memcheck, a memory error detector
==17209== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17209== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==17209== Command: ../bin/fluent-bit -c a.conf
==17209== 
Fluent Bit v1.9.2
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/03/30 18:28:56] [ info] [fluent bit] version=1.9.2, commit=84c94ccc03, pid=17209
[2022/03/30 18:28:56] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/03/30 18:28:56] [ info] [cmetrics] version=0.3.0
[2022/03/30 18:28:56] [ warn] [config] parser: 'Unescape_key' is deprecated
[2022/03/30 18:28:56] [ info] [output:stdout:stdout.0] worker #0 started
[2022/03/30 18:28:56] [ info] [sp] stream processor started
[0] dummy.data: [1648632537.021028930, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
^C[2022/03/30 18:28:58] [engine] caught signal (SIGINT)
[0] dummy.data: [1648632538.019783064, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
[2022/03/30 18:28:58] [ warn] [engine] service will shutdown in max 5 seconds
[2022/03/30 18:28:58] [ info] [engine] service has stopped (0 pending tasks)
[2022/03/30 18:28:59] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/03/30 18:28:59] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17209== 
==17209== HEAP SUMMARY:
==17209==     in use at exit: 0 bytes in 0 blocks
==17209==   total heap usage: 1,293 allocs, 1,293 frees, 963,560 bytes allocated
==17209== 
==17209== All heap blocks were freed -- no leaks are possible
==17209== 
==17209== For lists of detected and suppressed errors, rerun with: -s
==17209== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
