### PR TITLE
security: add filter in discussions link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ Thank you in advance for helping to keep Fluent-bit secure.
 
 ## Announcements
 
-For related CVEs that may or not affect Fluent Bit we'll be doing the corresponding announcement through [discussions](https://github.com/fluent/fluent-bit/discussions).
+For related CVEs that may or not affect Fluent Bit we'll be doing the corresponding announcement through [discussions](https://github.com/fluent/fluent-bit/discussions?discussions_q=label%3Asecurity).


### PR DESCRIPTION
Improve link to discussions adding a filter by security tag
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
