### PR TITLE
out_s3: add storage_class support in multipart upload mode

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -107,6 +107,7 @@ struct flb_s3 {
     char *sts_endpoint;
     char *canned_acl;
     char *content_type;
+    char *storage_class;
     char *log_key;
     char *external_id;
     int free_endpoint;

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -189,4 +189,8 @@ int s3_plugin_under_test();
 
 int get_md5_base64(char *buf, size_t buf_size, char *md5_str, size_t md5_str_size);
 
+int create_headers(struct flb_s3 *ctx, char *body_md5,
+                   struct flb_aws_header **headers, int *num_headers,
+                   int multipart_upload);
+
 #endif

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -36,24 +36,6 @@
 
 flb_sds_t get_etag(char *response, size_t size);
 
-static struct flb_aws_header *create_canned_acl_header(char *canned_acl)
-{
-    struct flb_aws_header *acl_header = NULL;
-    
-    acl_header = flb_malloc(sizeof(struct flb_aws_header));
-    if (acl_header == NULL) {
-        flb_errno();
-        return NULL;
-    } 
-   
-    acl_header->key = "x-amz-acl";
-    acl_header->key_len = 9;
-    acl_header->val = canned_acl;
-    acl_header->val_len = strlen(canned_acl);
-
-    return acl_header;
-};
-
 static inline int try_to_write(char *buf, int *off, size_t left,
                                const char *str, size_t str_len)
 {
@@ -501,7 +483,9 @@ int create_multipart_upload(struct flb_s3 *ctx,
     flb_sds_t tmp;
     struct flb_http_client *c = NULL;
     struct flb_aws_client *s3_client;
-    struct flb_aws_header *canned_acl_header;
+    struct flb_aws_header *headers = NULL;
+    int num_headers = 0;
+    int ret;
 
     uri = flb_sds_create_size(flb_sds_len(m_upload->s3_key) + 8);
     if (!uri) {
@@ -521,20 +505,16 @@ int create_multipart_upload(struct flb_s3 *ctx,
         c = mock_s3_call("TEST_CREATE_MULTIPART_UPLOAD_ERROR", "CreateMultipartUpload");
     }
     else {
-        if (ctx->canned_acl == NULL) {
-            c = s3_client->client_vtable->request(s3_client, FLB_HTTP_POST,
-                                                  uri, NULL, 0, NULL, 0);
+        ret = create_headers(ctx, NULL, &headers, &num_headers, FLB_TRUE);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "Failed to create headers");
+            flb_sds_destroy(uri);
+            return -1;
         }
-        else {
-            canned_acl_header = create_canned_acl_header(ctx->canned_acl);
-            if (canned_acl_header == NULL) {
-                flb_sds_destroy(uri);
-                flb_plg_error(ctx->ins, "Failed to create canned ACL header");
-                return -1;
-            }
-            c = s3_client->client_vtable->request(s3_client, FLB_HTTP_POST,
-                                                  uri, NULL, 0, canned_acl_header, 1);
-            flb_free(canned_acl_header);
+        c = s3_client->client_vtable->request(s3_client, FLB_HTTP_POST,
+                                              uri, NULL, 0, headers, num_headers);
+        if (headers) {
+           flb_free(headers);
         }
     }
     flb_sds_destroy(uri);


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch is related to https://github.com/fluent/fluent-bit/pull/5009

In that patch(#5009), `storage_class` option requires S3 PutObject API mode (`use_put_object On`).
It means that `storage_class` option cannot be used in S3 multipart upload mode.

This patch allows `storage_class` option to be used in both multipart upload mode and PutObject mode.

In addition, `content_type` option, which could not be used in multipart upload mode, can now be used when multipart upload mode.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
* https://github.com/fluent/fluent-bit-docs/pull/778

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
