### PR TITLE
in_exec: fix using interval from config map

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -140,9 +140,7 @@ static int in_exec_collect(struct flb_input_instance *ins,
 /* read config file and*/
 static int in_exec_config_read(struct flb_exec *ctx,
                                struct flb_input_instance *in,
-                               struct flb_config *config,
-                               int *interval_sec,
-                               int *interval_nsec
+                               struct flb_config *config
 )
 {
     int ret;
@@ -219,8 +217,6 @@ static int in_exec_init(struct flb_input_instance *in,
 {
     struct flb_exec *ctx = NULL;
     int ret = -1;
-    int interval_sec = 0;
-    int interval_nsec = 0;
 
     /* Allocate space for the configuration */
     ctx = flb_malloc(sizeof(struct flb_exec));
@@ -230,7 +226,7 @@ static int in_exec_init(struct flb_input_instance *in,
     ctx->parser = NULL;
 
     /* Initialize exec config */
-    ret = in_exec_config_read(ctx, in, config, &interval_sec, &interval_nsec);
+    ret = in_exec_config_read(ctx, in, config);
     if (ret < 0) {
         goto init_error;
     }
@@ -259,8 +255,8 @@ static int in_exec_init(struct flb_input_instance *in,
     else {
         ret = flb_input_set_collector_time(in,
                                            in_exec_collect,
-                                           interval_sec,
-                                           interval_nsec, config);
+                                           ctx->interval_sec,
+                                           ctx->interval_nsec, config);
     }
     if (ret < 0) {
         flb_plg_error(in, "could not set collector for exec input plugin");


### PR DESCRIPTION
<!-- Provide summary of changes -->
In commit [in_exec: refactor to use config_map.](https://github.com/fluent/fluent-bit/commit/7196b273404131a2080db40ab8a9d30d0db45927) the in_exec plugin was refactored to use a config_map. The interval config settings were now loaded into the `flb_exec` context (`ctx->interval_sec`), but `in_exec_init` was still using the prior local variables instead of the new location of these settings.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #5221