### PR TITLE
Prevent multiline filter from losing logs on shutdown

### DIFF
--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -26,6 +26,20 @@
 #define FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT  "10M"
 #define FLB_MULTILINE_METRIC_EMITTED    200
 
+/* Register external function to emit records, check 'plugins/in_emitter' */
+int in_emitter_add_record(const char *tag, int tag_len,
+                          const char *buf_data, size_t buf_size,
+                          struct flb_input_instance *in);
+
+/* Register optional pause callback for in_emitter, check 'plugins/in_emitter' */
+typedef void(flb_in_emitter_pause_cb)(void *data, struct flb_config *config);
+
+struct flb_emitter_callbacks {
+    flb_in_emitter_pause_cb *pause;
+
+    void *data;
+};
+
 /* 
  * input instance + tag is the unique identifier
  * for a multiline stream
@@ -58,6 +72,8 @@ struct ml_ctx {
 
     struct flb_filter_instance *ins;
 
+    struct flb_emitter_callbacks emitter_cb;
+
     /* emitter */
     flb_sds_t emitter_name;                 /* emitter input plugin name */
     flb_sds_t emitter_storage_type;         /* emitter storage type */
@@ -69,10 +85,5 @@ struct ml_ctx {
     struct cmt_counter *cmt_emitted;
 #endif
 };
-
-/* Register external function to emit records, check 'plugins/in_emitter' */
-int in_emitter_add_record(const char *tag, int tag_len,
-                          const char *buf_data, size_t buf_size,
-                          struct flb_input_instance *in);
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

https://github.com/fluent/fluent-bit/issues/4918

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
