### PR TITLE
in_exec: fix oneshot config property

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -333,7 +333,7 @@ static struct flb_config_map config_map[] = {
       "Set the buffer size"
     },
     {
-      FLB_CONFIG_MAP_BOOL, "bool", "false",
+      FLB_CONFIG_MAP_BOOL, "oneshot", "false",
       0, FLB_TRUE, offsetof(struct flb_exec, oneshot),
       "execute the command only once"
     },


### PR DESCRIPTION
With the refactor of plugins to use config_map (PR #4932, it seems that
the `oneshot` property (introduced in PR #2789) accidentially got
renamed to ` bool`.
Because ` bool` isn't a very descriptive name and this rename also
breaks existing configs, this patch changes the name of the property
back to `oneshot`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
v1.7 docs: fluent/fluent-bit-docs#775
v1.8 docs: fluent/fluent-bit-docs#774
v1.9+ docs: fluent/fluent-bit-docs#776
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release. (1.9 branch doesn't yet exist)

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
