### PR TITLE
time: set ext type 0 as event time(#5215)

### DIFF
--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -183,7 +183,9 @@ int flb_time_append_to_mpack(mpack_writer_t *writer, struct flb_time *tm, int fm
         memcpy(&ext_data, &tmp, 4);
         tmp = htonl((uint32_t)tm->tm.tv_nsec);/* nanosecond */
         memcpy(&ext_data[4], &tmp, 4);
-        mpack_write_ext(writer, 8/*fixext8*/, ext_data, sizeof(ext_data));
+
+        /* https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format */
+        mpack_write_ext(writer, 0 /*ext type=0 */, ext_data, sizeof(ext_data));
         break;
 
     default:

--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -20,6 +20,7 @@
 
 #include <fluent-bit.h>
 #include <fluent-bit/flb_time.h>
+#include <mpack/mpack.h>
 #include "flb_tests_internal.h"
 
 
@@ -38,7 +39,57 @@ void test_to_nanosec()
     }
 }
 
+/* https://github.com/fluent/fluent-bit/issues/5215 */
+void test_append_to_mpack_v1() {
+    mpack_writer_t writer;
+    char *data;
+    size_t size;
+    struct flb_time tm;
+    int ret;
+
+    msgpack_zone mempool;
+    msgpack_object ret_obj;
+    size_t off = 0;
+
+    flb_time_set(&tm, 123, 456);
+    mpack_writer_init_growable(&writer, &data, &size);
+
+    ret = flb_time_append_to_mpack(&writer, &tm, FLB_TIME_ETFMT_V1_FIXEXT);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_time_append_to_mpack failed");
+        mpack_writer_destroy(&writer);
+        flb_free(data);
+        exit(EXIT_FAILURE);
+    }
+    mpack_writer_destroy(&writer);
+
+    msgpack_zone_init(&mempool, 1024);
+    ret = msgpack_unpack(data, size, &off, &mempool, &ret_obj);
+    if (!TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("unpack failed ret = %d", ret);
+        msgpack_zone_destroy(&mempool);
+        flb_free(data);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(ret_obj.type == MSGPACK_OBJECT_EXT)) {
+        TEST_MSG("data type is not ext. type=%d", ret_obj.type);
+        msgpack_zone_destroy(&mempool);
+        flb_free(data);
+        exit(EXIT_FAILURE);
+    }
+    if (!TEST_CHECK(ret_obj.via.ext.type == 0)) {
+        TEST_MSG("ext type is not 0. ext type=%d", ret_obj.via.ext.type);
+        msgpack_zone_destroy(&mempool);
+        flb_free(data);
+        exit(EXIT_FAILURE);
+    }
+    msgpack_zone_destroy(&mempool);
+    flb_free(data);
+}
+
 TEST_LIST = {
     { "flb_time_to_nanosec"           , test_to_nanosec},
+    { "flb_time_append_to_mpack_v1"   , test_append_to_mpack_v1},
     { NULL, NULL }
 };


### PR DESCRIPTION
Fixes #5215 

filter_lua uses mpack as backend from v1.9.0
Then it uses `flb_time_append_to_mpack` to write flb_time.

However `flb_time_append_to_mpack` uses ext type and its type is 8.
The type of event time should be 0.
https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug output

```
$ ../bin/flb-it-flb_time 
Test flb_time_to_nanosec...                     [ OK ]
Test flb_time_append_to_mpack_v1...             [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/flb-it-flb_time 
==74081== Memcheck, a memory error detector
==74081== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==74081== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==74081== Command: ../bin/flb-it-flb_time
==74081== 
Test flb_time_to_nanosec...                     [ OK ]
Test flb_time_append_to_mpack_v1...             [ OK ]
SUCCESS: All unit tests have passed.
==74081== 
==74081== HEAP SUMMARY:
==74081==     in use at exit: 0 bytes in 0 blocks
==74081==   total heap usage: 5 allocs, 5 frees, 6,194 bytes allocated
==74081== 
==74081== All heap blocks were freed -- no leaks are possible
==74081== 
==74081== For lists of detected and suppressed errors, rerun with: -s
==74081== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
