### PR TITLE
build: macos: Create certfiticates from keychain on configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ init/fluent-bit.service
 lib/chunkio/include/chunkio/cio_version.h
 lib/monkey/monkey.service
 lib/monkey/include/monkey/mk_core/mk_core_info.h
+src/tls/mbedtls.c
 
 packaging/packages
 packaging/distros/**/sources/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   add_definitions(-DFLB_SYSTEM_WINDOWS)
 endif()
 
+# Define macro to identify macOS system
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(FLB_SYSTEM_MACOS On)
+  add_definitions(-DFLB_SYSTEM_MACOS)
+endif()
+
 # Update CFLAGS
 if (MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -315,6 +321,26 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     message(STATUS "Found Homebrew at ${HOMEBREW_PREFIX}")
     include(cmake/homebrew.cmake)
   endif()
+
+  # Create rootcert on macOS
+  set(MACOS_ROOT_CERT ${CMAKE_CURRENT_BINARY_DIR}/certs/rootcert.pem)
+  execute_process(
+    COMMAND security find-certificate -a -p /Library/Keychains/System.keychain
+    RESULT_VARIABLE SECURITY_SYSTEM_RESULT
+    OUTPUT_VARIABLE SECURITY_SYSTEM_CERTS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  file(WRITE ${MACOS_ROOT_CERT} ${SECURITY_SYSTEM_CERTS})
+
+  execute_process(
+    COMMAND security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain
+    RESULT_VARIABLE SECURITY_ROOT_RESULT
+    OUTPUT_VARIABLE SECURITY_ROOT_CERTS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  file(APPEND ${MACOS_ROOT_CERT} ${SECURITY_ROOT_CERTS})
+
+  install(FILES ${MACOS_ROOT_CERT} COMPONENT binary DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/certs)
 endif()
 
 # Extract Git commit information for debug output.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,11 @@ endif()
 
 # Fluent Bit have TLS support
 if(FLB_TLS)
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/src/tls/mbedtls.c.in"
+    "${PROJECT_SOURCE_DIR}/src/tls/mbedtls.c"
+    )
+
   # Register the TLS interface and functions
   set(src
     ${src}

--- a/src/tls/mbedtls.c
+++ b/src/tls/mbedtls.c
@@ -106,7 +106,11 @@ static int windows_load_system_certificates(struct tls_context *ctx)
 static int load_system_certificates(struct tls_context *ctx)
 {
     int ret;
+#ifdef FLB_SYSTEM_MACOS
+    const char ca_path[] = "/usr/local/etc/certs/";
+#else
     const char ca_path[] = "/etc/ssl/certs/";
+#endif
 
     /* For Windows use specific API to read the certs store */
 #ifdef _MSC_VER

--- a/src/tls/mbedtls.c.in
+++ b/src/tls/mbedtls.c.in
@@ -107,7 +107,7 @@ static int load_system_certificates(struct tls_context *ctx)
 {
     int ret;
 #ifdef FLB_SYSTEM_MACOS
-    const char ca_path[] = "/usr/local/etc/certs/";
+    const char ca_path[] = "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SYSCONFDIR@/certs/";
 #else
     const char ca_path[] = "/etc/ssl/certs/";
 #endif


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
After `make install`, generated certificates is put in /usr/local/etc/certs/ (macOS default location on Fluent Bit).
Fluent Bit will refer the default installation location on macOS.

```ini
[SERVICE]
    Log_Level trace

[INPUT]
    Name  dummy
    Tag   dummy

[OUTPUT]
    Name        stackdriver
    Match       *
    tls         On
```

- [x] Debug log output from testing the change
This change can be workable on generated certificates from keychain.
```log
luent Bit v1.9.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/05 17:02:20] [ info] Configuration:
[2022/04/05 17:02:20] [ info]  flush time     | 1.000000 seconds
[2022/04/05 17:02:20] [ info]  grace          | 5 seconds
[2022/04/05 17:02:20] [ info]  daemon         | 0
[2022/04/05 17:02:20] [ info] ___________
[2022/04/05 17:02:20] [ info]  inputs:
[2022/04/05 17:02:20] [ info]      dummy
[2022/04/05 17:02:20] [ info] ___________
[2022/04/05 17:02:20] [ info]  filters:
[2022/04/05 17:02:20] [ info] ___________
[2022/04/05 17:02:20] [ info]  outputs:
[2022/04/05 17:02:20] [ info]      stackdriver.0
[2022/04/05 17:02:20] [ info] ___________
[2022/04/05 17:02:20] [ info]  collectors:
[2022/04/05 17:02:20] [ info] [fluent bit] version=1.9.2, commit=6133d7fa2d, pid=88341
[2022/04/05 17:02:20] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/04/05 17:02:20] [debug] [storage] [cio stream] new stream registered: dummy.0
[2022/04/05 17:02:20] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/05 17:02:20] [ info] [cmetrics] version=0.3.0
[2022/04/05 17:02:20] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2022/04/05 17:02:20] [debug] [stackdriver:stackdriver.0] created event channels: read=23 write=24
[2022/04/05 17:02:20] [ info] [output:stackdriver:stackdriver.0] metadata_server set to http://metadata.google.internal
[2022/04/05 17:02:20] [debug] [output:stackdriver:stackdriver.0] JWT signature:
<<snip>>
[2022/04/05 17:02:20] [debug] [http_client] not using http_proxy for header
[2022/04/05 17:02:20] [ info] [oauth2] HTTP Status=200
[2022/04/05 17:02:20] [debug] [oauth2] payload:
{"access_token":"<snip>","expires_in":3599,"token_type":"Bearer"}
[2022/04/05 17:02:20] [ info] [oauth2] access token from 'www.googleapis.com:443' retrieved
[2022/04/05 17:02:20] [debug] [upstream] KA connection #27 to www.googleapis.com:443 is now available
[2022/04/05 17:02:20] [debug] [router] match rule dummy.0:stackdriver.0
[2022/04/05 17:02:20] [ info] [output:stackdriver:stackdriver.0] worker #0 started
[2022/04/05 17:02:20] [ info] [output:stackdriver:stackdriver.0] worker #1 started
[2022/04/05 17:02:20] [ info] [sp] stream processor started
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
