### PR TITLE
out_stackdriver: add labels support and handling of 502 network error

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -181,6 +181,8 @@ struct flb_stackdriver {
     struct cmt_counter *cmt_successful_requests;
     struct cmt_counter *cmt_failed_requests;
     struct cmt_counter *cmt_requests_total;
+    struct cmt_counter *cmt_proc_records_total;
+    struct cmt_counter *cmt_retried_records_total;
 #endif
 
     /* plugin instance */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -46,7 +46,6 @@
 
 /* Default Resource type */
 #define FLB_SDS_RESOURCE_TYPE "global"
-
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define MONITORED_RESOURCE_KEY "logging.googleapis.com/monitored_resource"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
@@ -62,6 +61,14 @@
 #define OPERATION_KEY_SIZE 32
 #define SOURCE_LOCATION_SIZE 37
 #define HTTP_REQUEST_KEY_SIZE 35
+
+/*
+ * Stackdriver implements a specific HTTP status code that is used internally in clients to keep
+ * track of networking errors that could happen before a successful HTTP request/response. For
+ * metrics counting purposes, every failed networking connection will use a 502 HTTP status code
+ * that can be used later to query the metrics by using labels with that value.
+ */
+#define STACKDRIVER_NET_ERROR  502
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -431,6 +431,20 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                                                  "Total number of requests.",
                                                   1, (char *[]) {"status"});
 
+    ctx->cmt_proc_records_total = cmt_counter_create(ins->cmt,
+                                                     "fluentbit",
+                                                     "stackdriver",
+                                                     "proc_records_total",
+                                                     "Total number of processed records.",
+                                                     1, (char *[]) {"status"});
+
+    ctx->cmt_retried_records_total = cmt_counter_create(ins->cmt,
+                                                        "fluentbit",
+                                                        "stackdriver",
+                                                        "retried_records_total",
+                                                        "Total number of retried records.",
+                                                        1, (char *[]) {"status"});
+
     /* OLD api */
     flb_metrics_add(FLB_STACKDRIVER_SUCCESSFUL_REQUESTS,
                     "stackdriver_successful_requests", ctx->ins->metrics);


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
