### PR TITLE
workflows: support 1.8 branch builds plus MacOS (and Windows for staging)

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -2,6 +2,9 @@
 name: Composite action to generate the matrix of targets to build packages for.
 description: Remove any duplication of this information so we only have to update in one place.
 
+# Remember to add any new checks and target creation required.
+# For example, when 2.0 comes out we should detect it and add any target changes.
+
 inputs:
   target:
     description: Override to build a single target for debug/test only.
@@ -24,6 +27,7 @@ runs:
         path: version-check
 
     - name: Determine target type
+      # TODO: probably switch to a sentinel file with the version in rather than checking for specific changes, or git branch tests.
       id: determine-build-type
       run: |
         ls -l

--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -6,10 +6,10 @@ inputs:
   target:
     description: Override to build a single target for debug/test only.
     required: false
-  fluent-bit-version:
-    description: The version of Fluent Bit to build.
-    required: false
-    default: 'master'
+    default: ''
+  ref:
+    description: The commit, tag or branch of Fluent Bit to checkout for building we then use to determine version for.
+    required: true
 outputs:
   build-matrix:
     description: The build matrix we have created.
@@ -17,8 +17,27 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: master/1.9 targets
-      if: inputs.fluent-bit-version != '1.8'
+    - name: Checkout code for version check
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        path: version-check
+
+    - name: Determine target type
+      id: determine-build-type
+      run: |
+        ls -l
+        BUILD_TYPE="1.8"
+        if [[ -d "packaging" ]]; then
+          BUILD_TYPE="1.9"
+        fi
+        echo "Detected type: $BUILD_TYPE"
+        echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
+      shell: bash
+      working-directory: version-check
+
+    - name: 1.9 targets
+      if: steps.determine-build-type.outputs.BUILD_TYPE == '1.9'
       run: |
         matrix=$((
           echo '{ "distro" : ['
@@ -29,19 +48,11 @@ runs:
           echo '"raspbian/buster", "raspbian/bullseye"'
           echo ']}'
         ) | jq -c .)
-        if [ -n "${{ inputs.target || '' }}" ]; then
-          echo "Overriding matrix to build: ${{ inputs.target }}"
-          matrix=$((
-            echo '{ "distro" : ['
-            echo '"${{ inputs.target }}"'
-            echo ']}'
-          ) | jq -c .)
-        fi
         echo "MATRIX=$matrix" >> $GITHUB_ENV
       shell: bash
 
     - name: 1.8 targets
-      if: inputs.fluent-bit-version == '1.8'
+      if: steps.determine-build-type.outputs.BUILD_TYPE == '1.8'
       run: |
         matrix=$((
           echo '{ "distro" : ['
@@ -52,6 +63,12 @@ runs:
           echo '"raspbian/buster"'
           echo ']}'
         ) | jq -c .)
+        echo "MATRIX=$matrix" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Manual override of target
+      if: inputs.target != ''
+      run: |
         if [ -n "${{ inputs.target || '' }}" ]; then
           echo "Overriding matrix to build: ${{ inputs.target }}"
           matrix=$((

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,6 +58,13 @@ For some reason this is not automatically done via permission inheritance or sim
 2. Once this is working locally, you should then be able to set up action permissions for the repository. If you already have a package no need to push a test one.
 3. Go to `https://github.com/users/USER/packages/container/fluent-bit/settings` and ensure the repository has access to `Write`.
 
+## Version-specific targets
+
+Each major version (e.g. 1.8 & 1.9) supports different targets to build for, e.g. 1.9 includes a CentOS 8 target and 1.8 has some other legacy targets.
+
+This is all handled by the [build matrix generation composite action](../actions/generate-package-build-matrix/action.yaml) so make sure to update appropriately.
+The build matrix is then fed into the reusable job that builds packages which will then fire for the appropriate targets.
+
 ## Releases
 
 Currently the process is as follows:

--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -42,7 +42,7 @@ jobs:
 
   master-build-packages:
     needs: master-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
     with:
       version: master
       ref: master

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -44,26 +44,54 @@ on:
         description: If the Cosign key requires a password then specify here, otherwise not required.
         required: false
 jobs:
-  call-build-images:
-    name: Multiarch container images to GHCR
+  call-build-legacy-check:
+    # Determine if this is a 1.8 type of build which is different
+    name: Extract any supporting metadata
+    outputs:
+      build-type: ${{ steps.determine-build-type.outputs.BUILD_TYPE }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout code
-        if: inputs.ref != '1.8'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Checkout the docker build repo
-        if: inputs.ref == '1.8'
+      - name: Determine build type
+        id: determine_build_type
+        run: |
+          BUILD_TYPE="1.8"
+          if [[ -f "dockerfiles/Dockerfile" ]]; then
+            BUILD_TYPE="modern"
+          fi
+          echo "Detected type: $BUILD_TYPE"
+          echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
+        shell: bash
+
+  call-build-images:
+    name: Multiarch container images to GHCR
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs:
+      - call-build-legacy-check
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code for modern style builds
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Checkout the docker build repo for legacy builds
+        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
         uses: actions/checkout@v3
         with:
           repository: fluent/fluent-bit-docker-image
-          ref: '1.8'
+          ref: '1.8' # Fixed to this branch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -88,7 +116,7 @@ jobs:
             raw,latest
 
       - name: Build the production images
-        if: inputs.ref != '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -111,7 +139,7 @@ jobs:
             raw,latest-debug
 
       - name: Build the debug multi-arch images
-        if: inputs.ref != '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -126,7 +154,7 @@ jobs:
             FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
 
       - name: Build the legacy image
-        if: inputs.ref == '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile.x86_64
@@ -140,10 +168,12 @@ jobs:
             FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
 
   call-build-images-generate-schema:
-    if: inputs.ref != '1.8'
+    needs:
+      - call-build-legacy-check
+      - call-build-images
+    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: call-build-images
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -60,7 +60,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Determine build type
-        id: determine_build_type
+        id: determine-build-type
         run: |
           BUILD_TYPE="1.8"
           if [[ -f "dockerfiles/Dockerfile" ]]; then

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -46,6 +46,31 @@ on:
         required: false
 
 jobs:
+  call-build-legacy-check:
+    # Determine if this is a 1.8 type of build which is different
+    name: Extract any supporting metadata
+    outputs:
+      build-type: ${{ steps.determine-build-type.outputs.BUILD_TYPE }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Determine build type
+        id: determine-build-type
+        run: |
+          BUILD_TYPE="1.8"
+          if [[ -f "dockerfiles/Dockerfile" ]]; then
+            BUILD_TYPE="modern"
+          fi
+          echo "Detected type: $BUILD_TYPE"
+          echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
+        shell: bash
 
   # We build both master/1.9 and 1.8 style packages in a single job as it is simpler to keep all the custom
   # code and workflow together. We need to run the dependent job after this as well.
@@ -53,18 +78,22 @@ jobs:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    needs:
+      - call-build-legacy-check
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
     steps:
       - name: Checkout code
-        if: inputs.ref != '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Checkout packaging code
-        if: inputs.ref == '1.8'
+      - name: Checkout legacy packaging code
+        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
         uses: actions/checkout@v3
         with:
           repository: fluent/fluent-bit-packaging
@@ -85,7 +114,7 @@ jobs:
           flags: 'g'
 
       - name: fluent-bit - ${{ matrix.distro }} artifacts
-        if: inputs.ref != '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         run: |
           ./build.sh
         env:
@@ -98,7 +127,7 @@ jobs:
         working-directory: packaging
 
       - name: td-agent-bit - ${{ matrix.distro }} artifacts
-        if: inputs.ref != '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         run: |
           ./build.sh
         env:
@@ -111,7 +140,7 @@ jobs:
         working-directory: packaging
 
       - name: Legacy td-agent-bit - ${{ matrix.distro }} artifacts
-        if: inputs.ref == '1.8'
+        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
         run: |
           ./build.sh -v $FLB_VERSION -b $FLB_BRANCH -d $FLB_DISTRO
         env:
@@ -153,7 +182,7 @@ jobs:
 
       - name: Push packages to S3
         # Only upload for staging
-        if: ${{ inputs.environment == 'staging' }}
+        if: inputs.environment == 'staging'
         # Make sure not to do a --delete on sync as it will remove the other architecture
         run: |
           if [ -z "${{ steps.get-target-info.outputs.target }}" ]; then
@@ -175,7 +204,7 @@ jobs:
   call-build-linux-packages-repo:
     name: Create repo metadata in S3
     # Only upload for staging
-    if: ${{ inputs.environment == 'staging' }}
+    if: inputs.environment == 'staging'
     # Need to use 18.04 as 20.04 has no createrepo available
     runs-on: ubuntu-18.04
     environment: ${{ inputs.environment }}

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -49,7 +49,7 @@ jobs:
 
   # We build both master/1.9 and 1.8 style packages in a single job as it is simpler to keep all the custom
   # code and workflow together. We need to run the dependent job after this as well.
-  call-build-packages:
+  call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
@@ -172,7 +172,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}
           AWS_S3_BUCKET: ${{ secrets.bucket }}
 
-  call-build-packages-repo:
+  call-build-linux-packages-repo:
     name: Create repo metadata in S3
     # Only upload for staging
     if: ${{ inputs.environment == 'staging' }}
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: ${{ inputs.environment }}
     needs:
-      - call-build-packages
+      - call-build-linux-packages
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
 
   call-build-macos-package:
-    if: needs.call-build-legacy-check.outputs.build-type == 'modern'
+    if: needs.call-build-macos-legacy-check.outputs.build-type == 'modern'
     runs-on: macos-latest
     environment: ${{ inputs.environment }}
     needs:

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -68,6 +68,8 @@ jobs:
     environment: ${{ inputs.environment }}
     needs:
       - call-build-macos-legacy-check
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -52,7 +52,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Determine build type
-        id: determine_build_type
+        id: determine-build-type
         run: |
           BUILD_TYPE="legacy"
           if [[ -f "conf/fluent-bit-macos.conf" ]]; then
@@ -92,7 +92,7 @@ jobs:
 
       - name: Push packages to S3
         # Only upload for staging
-        if: ${{ inputs.environment == 'staging' }}
+        if: inputs.environment == 'staging'
         # Make sure not to do a --delete on sync as it will remove the other architecture
         run: |
           if [ -n "${AWS_S3_ENDPOINT}" ]; then

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "productbuild" -DCPACK_GENERATOR=productbuild -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
+          cmake -DCPACK_GENERATOR=productbuild -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
           cmake --build .
           cpack -G productbuild
         working-directory: build

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -36,45 +36,58 @@ on:
         required: false
 
 jobs:
-  call-build-windows-package:
-    runs-on: windows-latest
+  call-build-macos-legacy-check:
+    # Requires https://github.com/fluent/fluent-bit/pull/5247 so will not build for previous branches
+    name: Extract any supporting metadata
+    outputs:
+      build-type: ${{ steps.determine-build-type.outputs.BUILD_TYPE }}
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Determine build type
+        id: determine_build_type
+        run: |
+          BUILD_TYPE="legacy"
+          if [[ -f "conf/fluent-bit-macos.conf" ]]; then
+            BUILD_TYPE="modern"
+          fi
+          echo "Detected type: $BUILD_TYPE"
+          echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
+        shell: bash
+
+  call-build-macos-package:
+    if: needs.call-build-legacy-check.outputs.build-type == 'modern'
+    runs-on: macos-latest
+    environment: ${{ inputs.environment }}
+    needs:
+      - call-build-macos-legacy-check
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Get dependencies
-        run: |
-          Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
-          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
-          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
-          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
-          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
-        env:
-          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
-        shell: pwsh
-
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
-        with:
-          arch: x64
-
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
+          cmake -G "productbuild" -DCPACK_GENERATOR=productbuild -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
           cmake --build .
-          cpack
+          cpack -G productbuild
         working-directory: build
 
       - name: Upload build packages
         uses: actions/upload-artifact@v2
         with:
-          name: windows-packages
+          name: macos-packages
           path: |
-            build/fluent-bit-*.exe
-            build/fluent-bit-*.zip
+            build/fluent-bit-*-apple
+            build/fluent-bit-*-intel
           if-no-files-found: error
 
       - name: Push packages to S3
@@ -85,10 +98,10 @@ jobs:
           if [ -n "${AWS_S3_ENDPOINT}" ]; then
             ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
           fi
-          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*.exe" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
-          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*.zip" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
+          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*-apple" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
+          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*-intel" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
         env:
-          DEST_DIR: "${{ inputs.version }}/windows/"
+          DEST_DIR: "${{ inputs.version }}/macos/"
           AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -75,8 +75,8 @@ jobs:
         with:
           name: windows-packages
           path: |
-            build/fluent-bit-*.exe
-            build/fluent-bit-*.zip
+            build/*-bit-*.exe
+            build/*-bit-*.zip
           if-no-files-found: error
 
       - name: Push packages to S3
@@ -87,8 +87,8 @@ jobs:
           if [ -n "${AWS_S3_ENDPOINT}" ]; then
             ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
           fi
-          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*.exe" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
-          aws --region "$AWS_REGION" s3 sync "build/fluent-bit-*.zip" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
+          aws --region "$AWS_REGION" s3 sync "build/*-bit-*.exe" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
+          aws --region "$AWS_REGION" s3 sync "build/*-bit-*.zip" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
         env:
           DEST_DIR: "${{ inputs.version }}/windows/"
           AWS_REGION: "us-east-1"

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Push packages to S3
         # Only upload for staging
-        if: ${{ inputs.environment == 'staging' }}
+        if: inputs.environment == 'staging'
         # Make sure not to do a --delete on sync as it will remove the other architecture
         run: |
           if [ -n "${AWS_S3_ENDPOINT}" ]; then

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -1,0 +1,95 @@
+---
+name: Reusable workflow to build Windows packages optionally into S3 bucket
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of Fluent Bit to create.
+        type: string
+        required: true
+      ref:
+        description: The commit, tag or branch of Fluent Bit to checkout for building that creates the version above.
+        type: string
+        required: true
+      environment:
+        description: The Github environment to run this workflow on.
+        type: string
+        required: false
+      unstable:
+        description: Optionally add metadata to build to indicate an unstable build, set to the contents you want to add.
+        type: string
+        required: false
+        default: ''
+    secrets:
+      token:
+        description: The Github token or similar to authenticate with.
+        required: true
+      bucket:
+        description: The name of the S3 (US-East) bucket to push packages into.
+        required: false
+      access_key_id:
+        description: The S3 access key id for the bucket.
+        required: false
+      secret_access_key:
+        description: The S3 secret access key for the bucket.
+        required: false
+
+jobs:
+  cll-build-windows-package:
+    runs-on: windows-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Get dependencies
+        run: |
+          Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
+          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
+          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
+          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
+          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
+        env:
+          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
+        shell: pwsh
+
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+        with:
+          arch: x64
+
+      - name: Build Fluent Bit packages
+        run: |
+          cmake -G "NMake Makefiles" -D FLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
+          cmake --build .
+          cpack
+        working-directory: build
+
+      - name: Upload build packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-packages
+          path: |
+            build/fluent-bit-*.exe
+            build/fluent-bit-*.zip
+          if-no-files-found: error
+
+      - name: Push packages to S3
+        # Only upload for staging
+        if: ${{ inputs.environment == 'staging' }}
+        # Make sure not to do a --delete on sync as it will remove the other architecture
+        run: |
+          if [ -n "${AWS_S3_ENDPOINT}" ]; then
+            ENDPOINT="--endpoint-url ${AWS_S3_ENDPOINT}"
+          fi
+          aws --region "$AWS_REGION" s3 sync "${SOURCE_DIR}" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress ${ENDPOINT}
+        env:
+          SOURCE_DIR: "build/"
+          DEST_DIR: "${{ inputs.version }}/windows/"
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}
+          AWS_S3_BUCKET: ${{ secrets.bucket }}

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -39,6 +39,8 @@ jobs:
   call-build-windows-package:
     runs-on: windows-latest
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -124,7 +124,7 @@ jobs:
   unstable-build-windows-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -136,7 +136,7 @@ jobs:
   unstable-build-macos-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -78,7 +78,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -112,7 +112,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -125,7 +125,7 @@ jobs:
   unstable-build-windows-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -137,7 +137,7 @@ jobs:
   unstable-build-macos-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@5241_ci_updates_1_8_branch_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -111,7 +111,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -78,7 +78,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -111,7 +111,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -124,7 +124,7 @@ jobs:
   unstable-build-windows-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -136,7 +136,7 @@ jobs:
   unstable-build-macos-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@5241_ci_updates_1_8_branch_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -99,13 +99,14 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
     environment: unstable
     steps:
-      - name: Checkout repository
+      - name: Checkout repository, always latest for action
         uses: actions/checkout@v3
+
       # Set up the list of target to build so we can pass the JSON to the reusable job
       - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
         with:
-          fluent-bit-version: ${{ needs.unstable-build-get-meta.outputs.branch }}
+          ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
 
   unstable-build-packages:
     needs:

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -133,6 +133,18 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 
+  unstable-build-macos-package:
+    needs:
+      - unstable-build-get-meta
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@master
+    with:
+      version: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   # We already detain all artefacts as build output so just capture for an unstable release
   unstable-release:
     runs-on: ubuntu-latest
@@ -141,6 +153,7 @@ jobs:
       - unstable-build-images
       - unstable-build-packages
       - unstable-build-windows-package
+      - unstable-build-macos-package
     environment: unstable
     permissions:
       contents: write

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -124,45 +124,14 @@ jobs:
   unstable-build-windows-package:
     needs:
       - unstable-build-get-meta
-    runs-on: windows-latest
-    environment: unstable
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
-
-      - name: Get dependencies
-        run: |
-          Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
-          Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
-          Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
-          Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
-          echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
-        env:
-          WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
-        shell: pwsh
-
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
-        with:
-          arch: x64
-
-      - name: Build Fluent Bit packages
-        run: |
-          cmake -G "NMake Makefiles" ../
-          cmake --build .
-          cpack
-        working-directory: build
-
-      - name: Upload build packages
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows-packages
-          path: |
-            build/fluent-bit-*.exe
-            build/fluent-bit-*.zip
-          if-no-files-found: error
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
+    with:
+      version: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
+      environment: unstable
+      unstable: ${{ needs.unstable-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   # We already detain all artefacts as build output so just capture for an unstable release
   unstable-release:

--- a/.github/workflows/pr-windows-build.yaml
+++ b/.github/workflows/pr-windows-build.yaml
@@ -1,4 +1,4 @@
-name: Windows CI
+name: PR - Windows checks
 on:
   workflow_dispatch:
 
@@ -17,60 +17,11 @@ on:
       - synchronize
 
 jobs:
-  windows-build-package:
-    runs-on: windows-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Get dependencies
-      run: |
-        Invoke-WebRequest -O winflexbison.zip $env:WINFLEXBISON
-        Expand-Archive winflexbison.zip -Destination C:\WinFlexBison
-        Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
-        Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
-        echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
-      env:
-        WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
-      shell: pwsh
-
-    - name: Set up Visual Studio shell
-      uses: egor-tensin/vs-shell@v2
-      with:
-        arch: x64
-
-    - name: Build Fluent Bit packages
-      run: |
-        cmake -G "NMake Makefiles" ../
-        cmake --build .
-        cpack
-      working-directory: build
-
-    - name: Upload build packages
-      uses: actions/upload-artifact@v2
-      with:
-        name: windows-packages
-        path: |
-          build/fluent-bit-*.exe
-          build/fluent-bit-*.zip
-        if-no-files-found: error
-
-  windows-build-container:
-    # Only build on push as takes a long time and not needed for PRs
-    if: github.event_name != 'pull_request'
-    # Need to match the container base image
-    runs-on: windows-2019
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - run: |
-        docker build -t fluent/fluent-bit:windows-${{ github.sha }} -f ./dockerfiles/Dockerfile.windows .
-        docker save -o windows-${{ github.sha }}.tar fluent/fluent-bit:windows-${{ github.sha }}
-
-    - name: Upload containers
-      uses: actions/upload-artifact@v2
-      with:
-        name: windows-containers
-        path: windows-${{ github.sha }}.tar
-        if-no-files-found: error
+  pr-windows-build:
+    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
+    with:
+      version: ${{ github.sha }}
+      ref: ${{ github.sha }}
+      environment: pr
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -121,6 +121,7 @@ jobs:
       - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
         with:
+          ref: ${{ github.event.inputs.version || github.ref_name }}
           target: ${{ github.event.inputs.target || '' }}
 
   staging-build-packages:

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -125,7 +125,7 @@ jobs:
 
   staging-build-packages:
     needs: [ staging-build-get-meta, staging-build-generate-matrix ]
-    uses: fluent/fluent-bit/.github/workflows/call-build-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -152,3 +152,17 @@ jobs:
       bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
       access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  staging-build-macos-packages:
+    needs:
+      - staging-build-get-meta
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@master
+    with:
+      version: ${{ needs.staging-build-get-meta.outputs.version }}
+      ref: ${{ github.event.inputs.version || github.ref_name }}
+      environment: staging
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
+      access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: master
       target:
-        description: Only build a specific target, intended for debug/test/quick builds only.
+        description: Only build a specific Linux target, intended for debug/test/quick builds only.
         required: false
         default: ""
 
@@ -138,3 +138,17 @@ jobs:
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg_private_key_passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+
+  staging-build-windows-packages:
+    needs:
+      - staging-build-get-meta
+    uses: fluent/fluent-bit/.github/workflows/call-build-windows-packages.yaml@master
+    with:
+      version: ${{ needs.staging-build-get-meta.outputs.version }}
+      ref: ${{ github.event.inputs.version || github.ref_name }}
+      environment: staging
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
+      access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -142,7 +142,7 @@ jobs:
   staging-build-windows-packages:
     needs:
       - staging-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-windows-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}
@@ -156,7 +156,7 @@ jobs:
   staging-build-macos-packages:
     needs:
       - staging-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos-packages.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@master
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}


### PR DESCRIPTION
Resolves #5241 by determining the type of build to do for 1.8 container images vs more recent.
Refactors Windows job into common one for unstable and staging to reuse.
Provides MacOS job dependent on #5247 - it will skip if not present for older branches/versions.

This also lays groundwork for multiple staging builds of different versions - previously we could only do master/1.9.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested with a build modified to call this branch (reusable workflows currently have to be hardcoded): https://github.com/fluent/fluent-bit/actions/runs/2101759748
This is a build of the 1.8 branch attempted in the original #5241 issue that failed previously.

Also tested a `master` build: https://github.com/fluent/fluent-bit/actions/runs/2101771999
This was prior to MacOS PR being merged.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
