### PR TITLE
workflows: handle 1.8 container builds and image tagging by major version

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -45,10 +45,10 @@ on:
         required: false
 jobs:
   call-build-images-meta:
-    # Determine if this is a 1.8 type of build which is different
     name: Extract any supporting metadata
     outputs:
       build-type: ${{ steps.determine-build-type.outputs.BUILD_TYPE }}
+      major-version: ${{ steps.determine-major-version.outputs.replaced }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -59,6 +59,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # Determine if this is a 1.8 type of build which is different
       - name: Determine build type
         id: determine-build-type
         run: |
@@ -69,6 +70,17 @@ jobs:
           echo "Detected type: $BUILD_TYPE"
           echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
         shell: bash
+
+      # For main branch/releases we want to also tag with the major version.
+      # E.g. if we build version 1.9.2 we want to tag with 1.9.2 and 1.9.
+      - name: Determine major version tag
+        id: determine-major-version
+        uses: frabert/replace-string-action@v2.0
+        with:
+          pattern: '^(\d+\.\d+).*$'
+          string: ${{ inputs.version }}
+          replace-with: '$1'
+          flags: 'g'
 
   # For 1.8 builds it is a little more complex so we have this build matrix to handle it.
   # This creates separate images for each architecture.
@@ -166,6 +178,7 @@ jobs:
           docker pull --platform=linux/arm/v7  ${{ inputs.registry }}/${{ inputs.image }}:arm32v7-${{ inputs.version }}
 
       - name: Create manifests for images
+        # Latest is 1.9, not 1.8 now
         run: |
           docker manifest create ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }} \
             --amend ${{ inputs.registry }}/${{ inputs.image }}:x86_64-${{ inputs.version }} \
@@ -174,6 +187,15 @@ jobs:
           docker manifest push --purge ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
+        shell: bash
+
+      - name: Create major version manifest
+        if: needs.call-build-images-meta.outputs.major-version != inputs.version
+        run: |
+          docker manifest push --purge ${{ inputs.registry }}/${{ inputs.image }}:${{ needs.call-build-images-meta.outputs.major-version }}
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        shell: bash
 
       - id: debug-meta
         uses: docker/metadata-action@v3
@@ -181,6 +203,7 @@ jobs:
           images: ${{ inputs.registry }}/${{ inputs.image }}
           tags: |
             raw,${{ inputs.version }}-debug
+            raw,${{ needs.call-build-images-meta.outputs.major-version }}-debug
 
       - name: Build the legacy x86_64 debug image
         uses: docker/build-push-action@v2
@@ -234,6 +257,7 @@ jobs:
           images: ${{ inputs.registry }}/${{ inputs.image }}
           tags: |
             raw,${{ inputs.version }}
+            raw,${{ needs.call-build-images-meta.outputs.major-version }}
             raw,latest
 
       - name: Build the production images
@@ -256,6 +280,7 @@ jobs:
           images: ${{ inputs.registry }}/${{ inputs.image }}
           tags: |
             raw,${{ inputs.version }}-debug
+            raw,${{ needs.call-build-images-meta.outputs.major-version }}-debug
             raw,latest-debug
 
       - name: Build the debug multi-arch images
@@ -370,6 +395,7 @@ jobs:
             -a "ref=${{ github.sha }}" \
             -a "release=${{ inputs.version }}" \
             "${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}" \
+            "${{ inputs.registry }}/${{ inputs.image }}:${{ needs.call-build-images-meta.outputs.major-version }}" \
             "${{ inputs.registry }}/${{ inputs.image }}:latest"
         shell: bash
         # Ensure we move on to key-based signing as well
@@ -389,6 +415,7 @@ jobs:
             -a "ref=${{ github.sha }}" \
             -a "release=${{ inputs.version }}" \
             "${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}" \
+            "${{ inputs.registry }}/${{ inputs.image }}:${{ needs.call-build-images-meta.outputs.major-version }}" \
             "${{ inputs.registry }}/${{ inputs.image }}:latest"
           rm -f /tmp/my_cosign.key
         shell: bash

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -210,8 +210,8 @@ jobs:
         with:
           file: ./dockerfiles/Dockerfile.x86_64-debug
           context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.debug-meta.outputs.tags }}
+          labels: ${{ steps.debug-meta.outputs.labels }}
           platforms: linux/amd64
           push: true
           load: false

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -44,7 +44,7 @@ on:
         description: If the Cosign key requires a password then specify here, otherwise not required.
         required: false
 jobs:
-  call-build-legacy-check:
+  call-build-images-meta:
     # Determine if this is a 1.8 type of build which is different
     name: Extract any supporting metadata
     outputs:
@@ -74,12 +74,12 @@ jobs:
   # This creates separate images for each architecture.
   # The later step then creates a multi-arch manifest for all of these.
   call-build-legacy-images-matrix:
-    if: needs.call-build-legacy-check.outputs.build-type == '1.8'
+    if: needs.call-build-images-meta.outputs.build-type == '1.8'
     name: Build single arch legacy images
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +137,7 @@ jobs:
 
   # Create a multi-arch manifest for the separate 1.8 images.
   call-build-legacy-image-manifests:
-    if: needs.call-build-legacy-check.outputs.build-type == '1.8'
+    if: needs.call-build-images-meta.outputs.build-type == '1.8'
     name: Deploy multi-arch container image manifests
     permissions:
       contents: read
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
       - call-build-legacy-images-matrix
     steps:
       - name: Set up Docker Buildx
@@ -199,9 +199,9 @@ jobs:
   # signing, etc only trigger from this.
   # 1.8 images are legacy and were not scanned or signed previously so this keeps it simple.
   call-build-images:
-    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    if: needs.call-build-images-meta.outputs.build-type != '1.8'
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
     name: Multiarch container images to GHCR
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
@@ -274,9 +274,9 @@ jobs:
 
   call-build-images-generate-schema:
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
       - call-build-images
-    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    if: needs.call-build-images-meta.outputs.build-type != '1.8'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -304,9 +304,9 @@ jobs:
           if-no-files-found: error
 
   call-build-images-scan:
-    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    if: needs.call-build-images-meta.outputs.build-type != '1.8'
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
       - call-build-images
     name: Trivy + Dockle image scan
     runs-on: ubuntu-latest
@@ -340,9 +340,9 @@ jobs:
           exit-level: WARN
 
   call-build-images-sign:
-    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    if: needs.call-build-images-meta.outputs.build-type != '1.8'
     needs:
-      - call-build-legacy-check
+      - call-build-images-meta
       - call-build-images
     name: Deploy and sign multi-arch container image manifests
     permissions:

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -70,24 +70,32 @@ jobs:
           echo ::set-output name=BUILD_TYPE::$BUILD_TYPE
         shell: bash
 
-  call-build-images:
-    name: Multiarch container images to GHCR
+  # For 1.8 builds it is a little more complex so we have this build matrix to handle it.
+  # This creates separate images for each architecture.
+  # The later step then creates a multi-arch manifest for all of these.
+  call-build-legacy-images-matrix:
+    if: needs.call-build-legacy-check.outputs.build-type == '1.8'
+    name: Build single arch legacy images
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     needs:
       - call-build-legacy-check
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64, arm/v7 ]
+        include:
+          - arch: amd64
+            suffix: x86_64
+          - arch: arm/v7
+            suffix: arm32v7
+          - arch: arm64
+            suffix: arm64v8
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Checkout code for modern style builds
-        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-
       - name: Checkout the docker build repo for legacy builds
-        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
         uses: actions/checkout@v3
         with:
           repository: fluent/fluent-bit-docker-image
@@ -112,11 +120,123 @@ jobs:
         with:
           images: ${{ inputs.registry }}/${{ inputs.image }}
           tags: |
+            raw,${{ matrix.suffix }}-${{ inputs.version }}
+
+      - name: Build the legacy ${{ matrix.arch }} image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/Dockerfile.${{ matrix.suffix }}
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          load: false
+          build-args: |
+            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
+
+  # Create a multi-arch manifest for the separate 1.8 images.
+  call-build-legacy-image-manifests:
+    if: needs.call-build-legacy-check.outputs.build-type == '1.8'
+    name: Deploy multi-arch container image manifests
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs:
+      - call-build-legacy-check
+      - call-build-legacy-images-matrix
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.username }}
+          password: ${{ secrets.token }}
+
+      - name: Pull all the images
+        # Use platform to trigger warnings on invalid image metadata
+        run: |
+          docker pull --platform=linux/amd64 ${{ inputs.registry }}/${{ inputs.image }}:x86_64-${{ inputs.version }}
+          docker pull --platform=linux/arm64 ${{ inputs.registry }}/${{ inputs.image }}:arm64v8-${{ inputs.version }}
+          docker pull --platform=linux/arm/v7  ${{ inputs.registry }}/${{ inputs.image }}:arm32v7-${{ inputs.version }}
+
+      - name: Create manifests for images
+        run: |
+          docker manifest create ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }} \
+            --amend ${{ inputs.registry }}/${{ inputs.image }}:x86_64-${{ inputs.version }} \
+            --amend ${{ inputs.registry }}/${{ inputs.image }}:arm64v8-${{ inputs.version }} \
+            --amend ${{ inputs.registry }}/${{ inputs.image }}:arm32v7-${{ inputs.version }}
+          docker manifest push --purge ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+
+      - id: debug-meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image }}
+          tags: |
+            raw,${{ inputs.version }}-debug
+
+      - name: Build the legacy x86_64 debug image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/Dockerfile.x86_64-debug
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          load: false
+          build-args: |
+            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
+
+  # This is the intended approach to multi-arch image and all the other checks scanning,
+  # signing, etc only trigger from this.
+  # 1.8 images are legacy and were not scanned or signed previously so this keeps it simple.
+  call-build-images:
+    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    needs:
+      - call-build-legacy-check
+    name: Multiarch container images to GHCR
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code for modern style builds
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.username }}
+          password: ${{ secrets.token }}
+
+      - name: Extract metadata from Github
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image }}
+          tags: |
             raw,${{ inputs.version }}
             raw,latest
 
       - name: Build the production images
-        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -139,7 +259,6 @@ jobs:
             raw,latest-debug
 
       - name: Build the debug multi-arch images
-        if: needs.call-build-legacy-check.outputs.build-type != '1.8'
         uses: docker/build-push-action@v2
         with:
           file: ./dockerfiles/Dockerfile
@@ -152,20 +271,6 @@ jobs:
           load: false
           build-args: |
             FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
-
-      - name: Build the legacy image
-        if: needs.call-build-legacy-check.outputs.build-type == '1.8'
-        uses: docker/build-push-action@v2
-        with:
-          file: Dockerfile.x86_64
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          push: true
-          load: false
-          build-args: |
-            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
 
   call-build-images-generate-schema:
     needs:
@@ -199,10 +304,13 @@ jobs:
           if-no-files-found: error
 
   call-build-images-scan:
+    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    needs:
+      - call-build-legacy-check
+      - call-build-images
     name: Trivy + Dockle image scan
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: call-build-images
     permissions:
       contents: read
       packages: read
@@ -232,6 +340,10 @@ jobs:
           exit-level: WARN
 
   call-build-images-sign:
+    if: needs.call-build-legacy-check.outputs.build-type != '1.8'
+    needs:
+      - call-build-legacy-check
+      - call-build-images
     name: Deploy and sign multi-arch container image manifests
     permissions:
       contents: read
@@ -241,7 +353,6 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: call-build-images
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -78,7 +78,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_1_8_container_builds
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -78,7 +78,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@4875_1_8_container_builds
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}


### PR DESCRIPTION
Part of work for #4875, this now supports building 1.8 based container images (all of the architectures) via the same workflows.
Resolves #5254 by determining major tag to use for images as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Verified by testing on an unstable release: https://github.com/fluent/fluent-bit/actions/runs/2150327416

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
