### PR TITLE
dockerfiles: Add a dockerfile for windows for 1.8

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -1,0 +1,90 @@
+# escape=`
+
+ARG WINDOWS_VERSION=ltsc2019
+
+# Builder Image - Windows Server Core
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
+
+RUN setx /M PATH "%PATH%;C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\WinFlexBison"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+WORKDIR /local
+
+# Install Visual Studio 2019
+ADD https://aka.ms/vs/16/release/vs_buildtools.exe /local/vs_buildtools.exe
+ADD https://aka.ms/vs/16/release/channel /local/VisualStudio.chman
+
+RUN Start-Process /local/vs_buildtools.exe `
+    -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
+    '--installPath C:\BuildTools', `
+    '--channelUri C:\local\VisualStudio.chman', `
+    '--installChannelUri C:\local\VisualStudio.chman', `
+    '--add Microsoft.VisualStudio.Workload.VCTools', `
+    '--includeRecommended'  -NoNewWindow -Wait;
+
+ADD https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip /local/win_flex_bison.zip
+
+RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
+    Copy-Item -Path /WinFlexBison/win_bison.exe /WinFlexBison/bison.exe; `
+    Copy-Item -Path /WinFlexBison/win_flex.exe /WinFlexBison/flex.exe;
+
+# Technique from https://github.com/StefanScherer/dockerfiles-windows/blob/master/mongo/3.6/Dockerfile
+WORKDIR /local
+ADD https://aka.ms/vs/15/release/vc_redist.x64.exe /local/vc_redist.x64.exe
+
+WORKDIR /fluent-bit/bin/
+RUN Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+    Copy-Item -Path /Windows/System32/msvcp140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
+
+# Build Fluent Bit from source - context must be the root of the Git repo
+WORKDIR /src/build
+COPY . /src/
+
+RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=Release ../; `
+    cmake --build . --config Release;
+
+# Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
+RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
+    Copy-Item -Path /src/conf/fluent-bit-win32.conf /fluent-bit/etc/fluent-bit.conf; `
+    Copy-Item -Path /src/conf/parsers.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_ambassador.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_java.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_extra.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_openstack.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
+    Copy-Item -Path /src/build/bin/Release/fluent-bit.dll /fluent-bit/bin/;
+#
+# Runtime Image - Windows Server Core
+#
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as runtime
+
+ARG FLUENTBIT_VERSION=1.8
+ARG IMAGE_CREATE_DATE
+ARG IMAGE_SOURCE_REVISION
+
+# Metadata as defined in OCI image spec annotations
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="Fluent Bit" `
+      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+      org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+      org.opencontainers.image.version=$FLUENTBIT_VERSION `
+      org.opencontainers.image.authors="Eduardo Silva <eduardo@calyptia.com>" `
+      org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+      org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+      org.opencontainers.image.vendor="Fluent Organization" `
+      org.opencontainers.image.licenses="Apache-2.0" `
+      org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+
+COPY --from=builder /fluent-bit /fluent-bit
+
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
+
+ENTRYPOINT [ "C:\fluent-bit\bin\fluent-bit.exe" ]
+# Hadolint gets confused by Windows it seems
+# hadolint ignore=DL3025
+CMD [ "C:\fluent-bit\bin\fluent-bit.exe", "-c", "C:\fluent-bit\etc\fluent-bit.conf" ]

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -13,3 +13,31 @@ For a detailed list of installation, usage and versions available, please refer 
 ## Building
 
 All container images for the `1.8` branch are built from the separate `fluent/fluent-bit-docker-image` repository on the `1.8` branch: https://github.com/fluent/fluent-bit-docker-image/tree/1.8
+
+## Windows
+
+**The minimum version of fluent-bit supported is `1.3.7`.**
+
+The Windows version can be specified when building the Windows image. The instructions below leverage the **Windows Server Core 2019 - 1809/ltsc2019** base image. The large Windows Server Core base image is leveraged as the builder, while the smaller Windows Nano base image is leveraged for the final runtime image.
+
+More information is available at:
+
+- [Windows Container Base Images](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images)
+- [Windows Container Version Compatibility](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2019%2Cwindows-10-1909#tabpanel_CeZOj-G++Q_windows-server-2019)
+
+In addition, metadata as defined in OCI image spec annotations, is leveraged in the generated image. This is the reason for the additional `--build-arg` parameters.
+
+### Minimum set of build-args
+```powershell
+docker build --no-cache `
+  --build-arg WINDOWS_VERSION=1809 --build-arg FLUENTBIT_VERSION=1.8.11 `
+  -t fluent/fluent-bit:1.8.11-nanoserver -f ./dockerfiles/Dockerfile.windows ./dockerfiles/
+```
+### Full set of build-args
+```powershell
+docker build --no-cache `
+  --build-arg WINDOWS_VERSION=1809 --build-arg FLUENTBIT_VERSION=1.8.11 `
+  --build-arg IMAGE_CREATE_DATE="$(Get-Date((Get-Date).ToUniversalTime()) -UFormat '%Y-%m-%dT%H:%M:%SZ')" `
+  --build-arg IMAGE_SOURCE_REVISION="$(git rev-parse HEAD)" `
+  -t fluent/fluent-bit:1.8.11-nanoserver -f ./dockerfiles/Dockerfile.windows ./dockerfiles/
+```


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is needed for Anthos pipeline to build the windows image.

More information here:
https://github.com/fluent/fluent-bit/discussions/5007#discussioncomment-2524868

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
