### PR TITLE
out_stackdriver: fix wrong check of connection

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2215,7 +2215,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
-    if (u_conn) {
+    if (!u_conn) {
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
                         ts, 1, (char *[]) {name});


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
