### PR TITLE
filter_nest: fix wildcard config to allow multiple entries

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -640,7 +640,7 @@ static struct flb_config_map config_map[] = {
    },
    {
     FLB_CONFIG_MAP_STR, "Wildcard", NULL,
-    0, FLB_FALSE, 0,
+    FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
     "Nest records which field matches the wildcard"
    },
    {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Patch for PR #4936, which added config map support to filter_nest, but omitted to configure the key `Wildcard` as a multi-entry config.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

### Configuration

https://docs.fluentbit.io/manual/pipeline/filters/nest#example-1-nest-and-lift-undo
```
[INPUT]
    Name mem
    Tag  mem.local

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard Mem.*
    Wildcard Swap.*
    Nest_under Stats
    Add_prefix NESTED

[FILTER]
    Name nest
    Match *
    Operation lift
    Nested_under Stats
    Remove_prefix NESTED
```

### Repro bug
```
$ docker run -it --rm -v `pwd`/b.conf:/fluent-bit/etc/fluent-bit.conf fluent/fluent-bit:1.9.1
Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/07 21:35:14] [ info] [fluent bit] version=1.9.1, commit=67b144340b, pid=1
[2022/04/07 21:35:14] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/07 21:35:14] [ info] [cmetrics] version=0.3.0
[2022/04/07 21:35:14] [error] [config] nest: configuration property 'Wildcard' is set 2 times
[2022/04/07 21:35:14] [ help] try the command: /fluent-bit/bin/fluent-bit -F nest -h

[2022/04/07 21:35:14] [error] [lib] backend failed
```

### Debug log
```
$ bin/fluent-bit -c b.conf -v
Fluent Bit v1.9.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/07 21:35:25] [ info] Configuration:
[2022/04/07 21:35:25] [ info]  flush time     | 1.000000 seconds
[2022/04/07 21:35:25] [ info]  grace          | 5 seconds
[2022/04/07 21:35:25] [ info]  daemon         | 0
[2022/04/07 21:35:25] [ info] ___________
[2022/04/07 21:35:25] [ info]  inputs:
[2022/04/07 21:35:25] [ info]      mem
[2022/04/07 21:35:25] [ info] ___________
[2022/04/07 21:35:25] [ info]  filters:
[2022/04/07 21:35:25] [ info]      nest.0
[2022/04/07 21:35:25] [ info]      nest.1
[2022/04/07 21:35:25] [ info] ___________
[2022/04/07 21:35:25] [ info]  outputs:
[2022/04/07 21:35:25] [ info]      stdout.0
[2022/04/07 21:35:25] [ info] ___________
[2022/04/07 21:35:25] [ info]  collectors:
[2022/04/07 21:35:25] [ info] [fluent bit] version=1.9.2, commit=6deef11930, pid=354813
[2022/04/07 21:35:25] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/04/07 21:35:25] [debug] [storage] [cio stream] new stream registered: mem.0
[2022/04/07 21:35:25] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/07 21:35:25] [ info] [cmetrics] version=0.3.0
[2022/04/07 21:35:25] [debug] [mem:mem.0] created event channels: read=21 write=22
[2022/04/07 21:35:25] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2022/04/07 21:35:25] [debug] [router] match rule mem.0:stdout.0
[2022/04/07 21:35:25] [ info] [sp] stream processor started
[2022/04/07 21:35:25] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/07 21:35:26] [debug] [filter:nest:nest.1] Lift : Outer map size is 1, will be 6, lifting 1 record(s)
[2022/04/07 21:35:26] [debug] [input chunk] update output instances with new chunk size diff=89
[2022/04/07 21:35:27] [debug] [task] created task=0x7fa7f400dc10 id=0 OK
[2022/04/07 21:35:27] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/04/07 21:35:27] [debug] [filter:nest:nest.1] Lift : Outer map size is 1, will be 6, lifting 1 record(s)
[2022/04/07 21:35:27] [debug] [input chunk] update output instances with new chunk size diff=89
[0] mem.local: [1649367326.750038542, {"Mem.total"=>96684552, "Mem.used"=>16903896, "Mem.free"=>79780656, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:27] [debug] [out flush] cb_destroy coro_id=0
[2022/04/07 21:35:27] [debug] [task] destroy task=0x7fa7f400dc10 (task_id=0)
[2022/04/07 21:35:28] [debug] [task] created task=0x7fa7f400deb0 id=0 OK
[2022/04/07 21:35:28] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] mem.local: [1649367327.750076736, {"Mem.total"=>96684552, "Mem.used"=>16903896, "Mem.free"=>79780656, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:28] [debug] [filter:nest:nest.1] Lift : Outer map size is 1, will be 6, lifting 1 record(s)
[2022/04/07 21:35:28] [debug] [input chunk] update output instances with new chunk size diff=89
[2022/04/07 21:35:28] [debug] [out flush] cb_destroy coro_id=1
[2022/04/07 21:35:28] [debug] [task] destroy task=0x7fa7f400deb0 (task_id=0)
[0] mem.local: [1649367328.750072520, {"Mem.total"=>96684552, "Mem.used"=>16903896, "Mem.free"=>79780656, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:29] [debug] [task] created task=0x7fa7f400e030 id=0 OK
[2022/04/07 21:35:29] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/04/07 21:35:29] [debug] [out flush] cb_destroy coro_id=2
[2022/04/07 21:35:29] [debug] [filter:nest:nest.1] Lift : Outer map size is 1, will be 6, lifting 1 record(s)
[2022/04/07 21:35:29] [debug] [input chunk] update output instances with new chunk size diff=89
[2022/04/07 21:35:29] [debug] [task] destroy task=0x7fa7f400e030 (task_id=0)
[2022/04/07 21:35:30] [debug] [task] created task=0x7fa7f400e1b0 id=0 OK
[2022/04/07 21:35:30] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/04/07 21:35:30] [debug] [filter:nest:nest.1] Lift : Outer map size is 1, will be 6, lifting 1 record(s)
[2022/04/07 21:35:30] [debug] [input chunk] update output instances with new chunk size diff=89
[0] mem.local: [1649367329.750080265, {"Mem.total"=>96684552, "Mem.used"=>16903896, "Mem.free"=>79780656, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:30] [debug] [out flush] cb_destroy coro_id=3
[2022/04/07 21:35:30] [debug] [task] destroy task=0x7fa7f400e1b0 (task_id=0)
^C[2022/04/07 21:35:30] [engine] caught signal (SIGINT)
[2022/04/07 21:35:30] [debug] [task] created task=0x7fa7f400e330 id=0 OK
[2022/04/07 21:35:30] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/04/07 21:35:30] [ warn] [engine] service will shutdown in max 5 seconds
[0] mem.local: [1649367330.750070982, {"Mem.total"=>96684552, "Mem.used"=>16903896, "Mem.free"=>79780656, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:30] [debug] [out flush] cb_destroy coro_id=4
[2022/04/07 21:35:30] [debug] [task] destroy task=0x7fa7f400e330 (task_id=0)
[2022/04/07 21:35:31] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/07 21:35:31] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/07 21:35:31] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### Valgrind output
```
valgrind --leak-check=full bin/fluent-bit -c b.conf
==354818== Memcheck, a memory error detector
==354818== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==354818== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==354818== Command: bin/fluent-bit -c b.conf
==354818==
Fluent Bit v1.9.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/07 21:35:45] [ info] [fluent bit] version=1.9.2, commit=6deef11930, pid=354818
[2022/04/07 21:35:45] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/07 21:35:45] [ info] [cmetrics] version=0.3.0
[2022/04/07 21:35:45] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/07 21:35:45] [ info] [sp] stream processor started
[0] mem.local: [1649367346.764630863, {"Mem.total"=>96684552, "Mem.used"=>16968204, "Mem.free"=>79716348, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[0] mem.local: [1649367347.771442820, {"Mem.total"=>96684552, "Mem.used"=>16968960, "Mem.free"=>79715592, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[0] mem.local: [1649367348.750696742, {"Mem.total"=>96684552, "Mem.used"=>16968952, "Mem.free"=>79715600, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[0] mem.local: [1649367349.750879775, {"Mem.total"=>96684552, "Mem.used"=>16969204, "Mem.free"=>79715348, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
^C[2022/04/07 21:35:51] [engine] caught signal (SIGINT)
[0] mem.local: [1649367350.750283294, {"Mem.total"=>96684552, "Mem.used"=>16969204, "Mem.free"=>79715348, "Swap.total"=>0, "Swap.used"=>0, "Swap.free"=>0}]
[2022/04/07 21:35:51] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/07 21:35:51] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/07 21:35:51] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/07 21:35:51] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==354818==
==354818== HEAP SUMMARY:
==354818==     in use at exit: 0 bytes in 0 blocks
==354818==   total heap usage: 1,375 allocs, 1,375 frees, 2,085,351 bytes allocated
==354818==
==354818== All heap blocks were freed -- no leaks are possible
==354818==
==354818== For lists of detected and suppressed errors, rerun with: -s
==354818== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
