### PR TITLE
in_storage_backlog: skip corrupted chunks

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -349,7 +349,10 @@ int sb_segregate_chunks(struct flb_config *config)
             chunk = mk_list_entry(chunk_iterator, struct cio_chunk, _head);
 
             if (!cio_chunk_is_up(chunk)) {
-                cio_chunk_up_force(chunk);
+                ret = cio_chunk_up_force(chunk);
+                if (ret == CIO_CORRUPTED) {
+                    continue;
+                }
             }
 
             if (!cio_chunk_is_up(chunk)) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently if a single chunk is corrupted, the whole fluent-bit process stops. Skip corrupted chunks instead.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #5265. Relevant to #4278

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [n/a ] Example configuration file for the change
- [n/a ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ n/a] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ n/a] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ n/a] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
