### PR TITLE
csv: Implement CSV support library

### DIFF
--- a/include/fluent-bit/flb_csv.h
+++ b/include/fluent-bit/flb_csv.h
@@ -1,0 +1,64 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CSV_H
+#define FLB_CSV_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+
+enum {
+    FLB_CSV_SUCCESS = 0,
+    FLB_CSV_ALLOC_FAILED = -1,
+    FLB_CSV_INVALID_STATE = -2,
+    FLB_CSV_EOF = -3,
+};
+
+typedef void (*flb_csv_field_parsed_callback)(void *data,
+                                              const char *field,
+                                              size_t field_len);
+
+struct flb_csv_state {
+    flb_csv_field_parsed_callback field_callback;
+    flb_sds_t buffered_data;
+    flb_sds_t escape_buffer;
+    size_t offset;
+    size_t start;
+    size_t length;
+    size_t field_count;
+    int state;
+    bool field_parsed;
+    bool has_dquote;
+    void *data;
+};
+
+void flb_csv_init(struct flb_csv_state *state,
+                  flb_csv_field_parsed_callback field_callback,
+                  void *data);
+
+int flb_csv_parse_record(struct flb_csv_state *state,
+                         char **bufptr,
+                         size_t *buflen,
+                         size_t *field_count);
+
+void flb_csv_destroy(struct flb_csv_state *state);
+
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(src
   flb_mp.c
   flb_kv.c
   flb_api.c
+  flb_csv.c
   flb_lib.c
   flb_log.c
   flb_env.c

--- a/src/flb_csv.c
+++ b/src/flb_csv.c
@@ -1,0 +1,313 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#define _GNU_SOURCE
+#include <time.h>
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_str.h>
+
+#include <fluent-bit/flb_csv.h>
+
+
+enum {
+    FLB_CSV_STATE_INITIAL = 0,
+    FLB_CSV_STATE_STARTED_SIMPLE,
+    FLB_CSV_STATE_STARTED_DQUOTE,
+    FLB_CSV_STATE_FOUND_DQUOTE,
+    FLB_CSV_STATE_FOUND_CR
+};
+
+static void reset_state(struct flb_csv_state *state)
+{
+    state->start = 0;
+    state->length = 0;
+    state->has_dquote = false;
+    state->field_parsed = false;
+    state->state = FLB_CSV_STATE_INITIAL;
+    flb_sds_len_set(state->escape_buffer, 0);
+    flb_sds_len_set(state->buffered_data, 0);
+    state->offset = 0;
+}
+
+static int invoke_field_callback(struct flb_csv_state *state, const char *buf, size_t bufsize)
+{
+    size_t escpos;
+    size_t bufpos;
+    size_t bufend;
+
+    if (!state->has_dquote) {
+        /* simple case, since there's no double quotes, no escaping needs
+         * to be done */
+        state->field_callback(state->data, buf + state->start, state->length);
+        return 0;
+    }
+    /* ensure there's enough space in the escape buffer */
+    if (flb_sds_alloc(state->escape_buffer) < state->length) {
+        state->escape_buffer = flb_sds_increase(
+                state->escape_buffer, state->length);
+        if (!state->escape_buffer) {
+            return FLB_CSV_ALLOC_FAILED;
+        }
+    }
+
+    escpos = 0;
+    bufpos = state->start;
+    bufend = bufpos + state->length;
+    while (bufpos < bufend) {
+        if (buf[bufpos] == '"') {
+            /* escape double quote */
+            bufpos++;
+        }
+        state->escape_buffer[escpos++] = buf[bufpos++];
+    }
+    state->escape_buffer[escpos] = 0;
+    flb_sds_len_set(state->escape_buffer, escpos);
+    state->field_callback(state->data, state->escape_buffer, escpos);
+    return 0;
+}
+
+static int parse_simple(struct flb_csv_state *state, const char *buf, size_t bufsize)
+{
+    char c;
+
+    for (;;) {
+        if (state->offset >= bufsize) {
+            return FLB_CSV_EOF;
+        }
+        c = buf[state->offset];
+        if (c == ',' || c == '\n' || c == '\r') {
+            /* end of field */
+            break;
+        }
+        state->offset++;
+    }
+
+    state->length = state->offset - state->start;
+    return 0;
+}
+
+static int parse_quoted(struct flb_csv_state *state, const char *buf, size_t bufsize)
+{
+    char c;
+
+    for (;;) {
+        if (state->offset >= bufsize) {
+            return FLB_CSV_EOF;
+        }
+        c = buf[state->offset];
+        if (state->state == FLB_CSV_STATE_FOUND_DQUOTE) {
+            state->state = FLB_CSV_STATE_STARTED_DQUOTE;
+            if (c == '"') {
+                /* dquote inside field, skip but set flag so we can properly escape later */
+                state->has_dquote = true;
+            }
+            else {
+                /* end of field */
+                break;
+            }
+        }
+        else if (c == '"') {
+            state->state = FLB_CSV_STATE_FOUND_DQUOTE;
+        }
+        state->offset++;
+    }
+
+    /* subtract 1 to remove ending double quote */
+    state->length = state->offset - state->start - 1;
+    return 0;
+}
+
+static int parse_csv_field(struct flb_csv_state *state, const char *data, size_t len)
+{
+    int ret;
+    const char *buf;
+    size_t bufsize;
+    bool buffered = false;
+
+    buf = data;
+    bufsize = len;
+
+    if (state->state == FLB_CSV_STATE_INITIAL) {
+        if (data[state->offset] == '"') {
+            /* advance past opening quote */
+            state->offset++;
+            state->state = FLB_CSV_STATE_STARTED_DQUOTE;
+        }
+        else {
+            state->state = FLB_CSV_STATE_STARTED_SIMPLE;
+        }
+        state->start = state->offset;
+    }
+    else if (state->field_callback) {
+        state->buffered_data = flb_sds_cat(state->buffered_data, data, len);
+        if (!state->buffered_data) {
+            return FLB_CSV_ALLOC_FAILED;
+        }
+        buf = state->buffered_data;
+        bufsize = flb_sds_len(state->buffered_data);
+        buffered = true;
+    }
+
+    switch (state->state) {
+        case FLB_CSV_STATE_STARTED_SIMPLE:
+            ret = parse_simple(state, buf, bufsize);
+            break;
+        case FLB_CSV_STATE_STARTED_DQUOTE:
+        case FLB_CSV_STATE_FOUND_DQUOTE:
+            ret = parse_quoted(state, buf, bufsize);
+            break;
+        default:
+            return FLB_CSV_INVALID_STATE;
+    }
+
+    if (ret) {
+        if (!buffered && ret == FLB_CSV_EOF) {
+            /* not finished, we need to save data in the buffer */
+            state->buffered_data = flb_sds_cat(state->buffered_data, data, len);
+            if (!state->buffered_data) {
+                return FLB_CSV_ALLOC_FAILED;
+            }
+        }
+        return ret;
+    }
+
+    if (state->field_callback) {
+        ret = invoke_field_callback(state, buf, bufsize);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    return ret;
+}
+
+void flb_csv_init(struct flb_csv_state *state,
+                  flb_csv_field_parsed_callback field_callback,
+                  void *data)
+{
+    state->buffered_data = flb_sds_create("");
+    state->escape_buffer = flb_sds_create("");
+    state->field_callback = field_callback;
+    state->data = data;
+    state->field_count = 0;
+    reset_state(state);
+}
+
+int flb_csv_parse_record(struct flb_csv_state *state,
+                         char **bufptr,
+                         size_t *buflen,
+                         size_t *field_count)
+{
+    char c;
+    int ret;
+    size_t initial_offset;
+    size_t advanced;
+
+    for (;;) {
+        if (!(*buflen)) {
+            return FLB_CSV_EOF;
+        }
+        c = **bufptr;
+        if (state->state == FLB_CSV_STATE_INITIAL) {
+            if (c == '\r') {
+                state->state = FLB_CSV_STATE_FOUND_CR;
+                (*bufptr)++;
+                (*buflen)--;
+                continue;
+            }
+            else if (c == '\n') {
+                /* accept single linefeed as record terminator, even
+                 * though the spec says to look for \r\n */
+                (*bufptr)++;
+                (*buflen)--;
+                break;
+            }
+            else if (c == ',') {
+                (*bufptr)++;
+                (*buflen)--;
+                if (!state->field_parsed) {
+                    state->field_count++;
+                    if (state->field_callback) {
+                        /* empty field, but we need to invoke the callback anyway */
+                        state->field_callback(state->data, "", 0);
+                    }
+                }
+                state->field_parsed = false;
+                continue;
+            }
+        }
+        else if (state->state == FLB_CSV_STATE_FOUND_CR) {
+            state->state = FLB_CSV_STATE_INITIAL;
+            if (c == '\n') {
+                /* if the character following \r is \n, consume it */
+                (*bufptr)++;
+                (*buflen)--;
+            }
+            /* in any case, accept lone \r as record separator */
+            break;
+        }
+
+        initial_offset = state->offset;
+
+        ret = parse_csv_field(state, *bufptr, *buflen);
+
+        advanced = state->offset - initial_offset;
+        *bufptr += advanced;
+        *buflen -= advanced;
+
+        if (ret) {
+            if (!state->field_callback) {
+                /* when no field callback is set, we shouldn't keep
+                 * offset state between calls since no data will be buffered */
+                state->offset = 0;
+            }
+            return ret;
+        }
+
+        /* when a field is fully parsed, we can reset state */
+        reset_state(state);
+        /* set this flag so we can properly handle empty fields at the start
+         * of the loop */
+        state->field_parsed = true;
+        state->field_count++;
+    }
+
+    if (!state->field_parsed) {
+        state->field_count++;
+        if (state->field_callback) {
+            /* empty field, but we need to invoke the callback anyway */
+            state->field_callback(state->data, "", 0);
+        }
+    }
+    state->field_parsed = false;
+    *field_count = state->field_count;
+    state->field_count = 0;
+    return FLB_CSV_SUCCESS;
+}
+
+void flb_csv_destroy(struct flb_csv_state *state)
+{
+    flb_sds_destroy(state->buffered_data);
+    flb_sds_destroy(state->escape_buffer);
+}

--- a/src/flb_file.c
+++ b/src/flb_file.c
@@ -58,6 +58,7 @@ flb_sds_t flb_file_read(const char *path)
         goto err;
     }
 
+    result[flen] = 0;
     flb_sds_len_set(result, flen);
     fclose(f);
     return result;

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UNIT_TESTS_FILES
   input_chunk.c
   flb_time.c
   file.c
+  csv.c
   multiline.c
   typecast.c
   timeout.c

--- a/tests/internal/csv.c
+++ b/tests/internal/csv.c
@@ -1,0 +1,167 @@
+#include <fluent-bit/flb_csv.h>
+#include <fluent-bit/flb_sds.h>
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+#define row_count 3
+#define col_count 4
+
+char data[] =
+    "r0c1,,,\r"
+    ",r1c2,\"\",\"r1three\nlines\nfield\"\r\n"
+    "r2c1,r2c2,\"\"\"r2c\n3\n\",\"r2three\nlines\nfield\"\"\"\n";
+
+char *parse_expected[row_count][col_count] = {
+    { "r0c1", "", "", "" },
+    { "", "r1c2", "", "r1three\nlines\nfield" },
+    { "r2c1", "r2c2", "\"r2c\n3\n", "r2three\nlines\nfield\"" },
+};
+
+char *split_expected[row_count] = {
+    "r0c1,,,\r",
+    ",r1c2,\"\",\"r1three\nlines\nfield\"\r\n",
+    "r2c1,r2c2,\"\"\"r2c\n3\n\",\"r2three\nlines\nfield\"\"\"\n",
+};
+
+struct parse_state {
+    char **parsed;
+    size_t current_row;
+    size_t current_col;
+};
+
+static void field_parsed(void *data, const char *field, size_t field_len)
+{
+    struct parse_state *state = data;
+    size_t col = state->current_col;
+    size_t row = state->current_row;
+    char *fdup = strndup(field, field_len);
+    state->parsed[row * col_count + col] = fdup;
+    state->current_col++;
+}
+
+static char **parse_data_step(int step)
+{
+    int i;
+    size_t len = sizeof(data);
+    struct parse_state state;
+    char *bufptr;
+    struct flb_csv_state csv_state;
+    size_t field_count;
+    state.parsed = malloc(sizeof *state.parsed * row_count * col_count);
+    state.current_row = 0;
+    state.current_col = 0;
+    flb_csv_init(&csv_state, field_parsed, &state);
+    bufptr = data;
+    for (i = 0; i < sizeof(data);) {
+        int ret;
+        size_t bl = MIN(len - i, step);
+        ret = flb_csv_parse_record(&csv_state, &bufptr, &bl, &field_count);
+        i = bufptr - data;
+        if (ret == FLB_CSV_SUCCESS) {
+            TEST_CHECK(field_count == 4);
+            state.current_row++;
+            state.current_col = 0;
+        }
+        else if (ret == FLB_CSV_EOF) {
+            continue;
+        }
+        else {
+            abort();
+        };
+    }
+    flb_csv_destroy(&csv_state);
+    return state.parsed;
+}
+
+static void check_parse_result(char **result)
+{
+    int row, col;
+
+    for (row = 0; row < row_count; row++) {
+        for (col = 0; col < col_count; col++) {
+            char *res = result[row * col_count + col];
+            TEST_CHECK(strcmp(res, parse_expected[row][col]) == 0);
+            TEST_MSG("Mismatch on row %d, col %d", row, col);
+            TEST_MSG("Expected: %s", parse_expected[row][col]);
+            TEST_MSG("Result:   %s", result[row * col_count + col]);
+            free(res);
+        }
+    }
+
+    free(result);
+}
+
+static void check_split_result(char **result)
+{
+    int row;
+
+    for (row = 0; row < row_count; row++) {
+        char *res = result[row];
+        TEST_CHECK(strcmp(res, split_expected[row]) == 0);
+        TEST_MSG("Mismatch on row %d", row);
+        TEST_MSG("Expected: %s", split_expected[row]);
+        TEST_MSG("Result:   %s", result[row]);
+        free(res);
+    }
+
+    free(result);
+}
+
+static char **split_rows_step(int step)
+{
+    int i;
+    size_t len = sizeof(data);
+    char *bufptr;
+    char *row_start;
+    size_t current_row = 0;
+    char **result = malloc(sizeof *result * row_count);
+    struct flb_csv_state csv_state;
+    flb_csv_init(&csv_state, NULL, NULL);
+    bufptr = data;
+    row_start = data;
+    size_t field_count;
+    for (i = 0; i < len;) {
+        int ret;
+        size_t bl = MIN(len - i, step);
+        ret = flb_csv_parse_record(&csv_state, &bufptr, &bl, &field_count);
+        i = bufptr - data;
+        if (ret == FLB_CSV_SUCCESS) {
+            TEST_CHECK(field_count == 4);
+            result[current_row] = strndup(row_start, bufptr - row_start);
+            row_start = bufptr;
+            current_row++;
+        }
+        else if (ret == FLB_CSV_EOF) {
+            continue;
+        } else {
+            abort();
+        };
+    }
+    flb_csv_destroy(&csv_state);
+    return result;
+}
+
+static void test_basic()
+{
+    int step;
+    for (step = 1; step <= sizeof(data); step++) {
+        check_parse_result(parse_data_step(step));
+    }
+}
+
+static void test_split_lines()
+{
+    int step;
+    for (step = 1; step <= sizeof(data); step++) {
+        check_split_result(split_rows_step(step));
+    }
+}
+
+TEST_LIST = {
+    { "basic" , test_basic},
+    { "split_lines" , test_split_lines},
+    { 0 }
+};


### PR DESCRIPTION
This implements a CSV library that can be used as the basis of implementing CSV plugins/parsers on fluent-bit.

The library is designed with a simple re-entrant API where you feed bytes, and the parse function tells you if it needs more data to complete a full CSV record. 

It can optionally receive a callback that will be invoked whenever a CSV column is fully parsed (idea similar to a SAX parser). If no callback is passed, then the library can only be used for splitting CSV records (which may span across multiple lines).

A note about the tests: It may seem complex, but I've tested the same inputs multiple times, with each time having a different chunk size (from 1 to the full data). The reason for doing this is that we can't predict where CSV data will be split when reading from a file descriptor, so it is important to test every possible way the input can be fed.

Also did some fixes for the flb_file.c module, which was not properly creating a NUL terminated `flb_sds_t` instance.




