### PR TITLE
filter_throttle: set default value if config value is invalid

### DIFF
--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -114,6 +114,12 @@ static int configure(struct flb_filter_throttle_ctx *ctx, struct flb_filter_inst
         flb_plg_error(f_ins, "unable to load configuration");
         return -1;
     }
+    if (ctx->max_rate <= 1.0) {
+        ctx->max_rate = strtod(THROTTLE_DEFAULT_RATE, NULL);
+    }
+    if (ctx->window_size <= 1) {
+        ctx->window_size = strtoul(THROTTLE_DEFAULT_WINDOW, NULL, 10);
+    }
 
     return 0;
 }

--- a/tests/runtime/filter_throttle.c
+++ b/tests/runtime/filter_throttle.c
@@ -10,10 +10,12 @@ pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Test functions */
 void flb_test_filter_throttle(void);
+void flb_test_filter_window_0(void);
 
 /* Test list */
 TEST_LIST = {
     {"throttle",   flb_test_filter_throttle   },
+    {"window_0",   flb_test_filter_window_0   },
     {NULL, NULL}
 };
 
@@ -62,6 +64,39 @@ void flb_test_filter_throttle(void)
         bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
         TEST_CHECK(bytes == strlen(p));
     }
+
+    sleep(1); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_filter_window_0(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "stdout", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "throttle", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*",
+                         "window", "0",
+                         NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
 
     sleep(1); /* waiting flush */
 


### PR DESCRIPTION
This patch is to set default value if the config value is invalid.
https://github.com/fluent/fluent-bit/blob/v1.8.15/plugins/filter_throttle/throttle.c#L118-L122
https://github.com/fluent/fluent-bit/blob/v1.8.15/plugins/filter_throttle/throttle.c#L125-L130

If user set `window=0`, it will cause SIGSEGV on v1.9.0-v1.9.2.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name cpu

[FILTER]
    Name throttle
    Match *
    Rate -10
    Window 0
    print_status true

[OUTPUT]
    Name stdout
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/10 09:49:20] [ info] [fluent bit] version=1.9.3, commit=3e3747c588, pid=33589
[2022/04/10 09:49:20] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/10 09:49:20] [ info] [cmetrics] version=0.3.0
[2022/04/10 09:49:20] [ info] [sp] stream processor started
[2022/04/10 09:49:20] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/10 09:49:20] [ info] [filter:throttle:throttle.0] 1649551760: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[2022/04/10 09:49:21] [ info] [filter:throttle:throttle.0] 1649551761: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[0] cpu.0: [1649551761.316361308, {"cpu_p"=>3.000000, "user_p"=>3.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>0.000000}]
[2022/04/10 09:49:22] [ info] [filter:throttle:throttle.0] 1649551762: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[0] cpu.0: [1649551762.316429619, {"cpu_p"=>3.000000, "user_p"=>3.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>3.000000, "cpu0.p_system"=>0.000000}]
[2022/04/10 09:49:23] [ info] [filter:throttle:throttle.0] 1649551763: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
^C[2022/04/10 09:49:23] [engine] caught signal (SIGINT)
[2022/04/10 09:49:23] [ info] [input] pausing cpu.0
[0] cpu.0: [1649551763.316827658, {"cpu_p"=>5.000000, "user_p"=>4.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>5.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>1.000000}]
[2022/04/10 09:49:23] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/10 09:49:24] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/10 09:49:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/10 09:49:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

v1.9.2:
```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/10 09:45:06] [ info] [fluent bit] version=1.9.2, commit=27a63c11d3, pid=30675
[2022/04/10 09:45:06] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/10 09:45:06] [ info] [cmetrics] version=0.3.0
[2022/04/10 09:45:06] [ info] [sp] stream processor started
[2022/04/10 09:45:06] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/10 09:45:06] [engine] caught signal (SIGSEGV)
#0  0x5629dcb72ed8      in  window_add() at plugins/filter_throttle/window.c:72
#1  0x5629dcb722ae      in  time_ticker() at plugins/filter_throttle/throttle.c:78
#2  0x7f3fb2558608      in  start_thread() at 2.31/nptl/pthread_create.c:477
#3  0x7f3fb225e162      in  ???() at ???:0
#4  0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)
```

## Valgrind output

Valgrind reported error.
It should be fixed by https://github.com/fluent/fluent-bit/pull/4792
```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==33594== Memcheck, a memory error detector
==33594== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33594== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==33594== Command: bin/fluent-bit -c a.conf
==33594== 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/10 09:49:50] [ info] [fluent bit] version=1.9.3, commit=3e3747c588, pid=33594
[2022/04/10 09:49:50] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/10 09:49:50] [ info] [cmetrics] version=0.3.0
[2022/04/10 09:49:50] [ info] [filter:throttle:throttle.0] 1649551790: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[2022/04/10 09:49:50] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/10 09:49:50] [ info] [sp] stream processor started
[2022/04/10 09:49:51] [ info] [filter:throttle:throttle.0] 1649551791: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[0] cpu.0: [1649551791.335881487, {"cpu_p"=>13.000000, "user_p"=>12.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>13.000000, "cpu0.p_user"=>12.000000, "cpu0.p_system"=>1.000000}]
[2022/04/10 09:49:52] [ info] [filter:throttle:throttle.0] 1649551792: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[0] cpu.0: [1649551792.344875498, {"cpu_p"=>10.000000, "user_p"=>10.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>10.000000, "cpu0.p_user"=>10.000000, "cpu0.p_system"=>0.000000}]
^C[2022/04/10 09:49:53] [engine] caught signal (SIGINT)
[2022/04/10 09:49:53] [ info] [input] pausing cpu.0
[2022/04/10 09:49:53] [ warn] [engine] service will shutdown in max 5 seconds
[0] cpu.0: [1649551793.317891838, {"cpu_p"=>4.000000, "user_p"=>4.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>4.000000, "cpu0.p_user"=>4.000000, "cpu0.p_system"=>0.000000}]
[2022/04/10 09:49:53] [ info] [filter:throttle:throttle.0] 1649551793: limit is 1.00 per 1 with window size of 5, current rate is: 0 per interval
[2022/04/10 09:49:54] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/10 09:49:54] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/10 09:49:54] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==33594== 
==33594== HEAP SUMMARY:
==33594==     in use at exit: 328 bytes in 2 blocks
==33594==   total heap usage: 1,217 allocs, 1,215 frees, 1,257,978 bytes allocated
==33594== 
==33594== 304 bytes in 1 blocks are possibly lost in loss record 2 of 2
==33594==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33594==    by 0x40149CA: allocate_dtv (dl-tls.c:286)
==33594==    by 0x40149CA: _dl_allocate_tls (dl-tls.c:532)
==33594==    by 0x4865322: allocate_stack (allocatestack.c:622)
==33594==    by 0x4865322: pthread_create@@GLIBC_2.2.5 (pthread_create.c:660)
==33594==    by 0x2F5815: cb_throttle_init (throttle.c:190)
==33594==    by 0x1C06F5: flb_filter_init_all (flb_filter.c:478)
==33594==    by 0x1D506D: flb_engine_start (flb_engine.c:659)
==33594==    by 0x1B1284: flb_lib_worker (flb_lib.c:626)
==33594==    by 0x4864608: start_thread (pthread_create.c:477)
==33594==    by 0x4BBF162: clone (clone.S:95)
==33594== 
==33594== LEAK SUMMARY:
==33594==    definitely lost: 0 bytes in 0 blocks
==33594==    indirectly lost: 0 bytes in 0 blocks
==33594==      possibly lost: 304 bytes in 1 blocks
==33594==    still reachable: 24 bytes in 1 blocks
==33594==         suppressed: 0 bytes in 0 blocks
==33594== Reachable blocks (those to which a pointer was found) are not shown.
==33594== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==33594== 
==33594== For lists of detected and suppressed errors, rerun with: -s
==33594== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
