### PR TITLE
workflows: Install building dependencies on macOS

### DIFF
--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -75,7 +75,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install bison flex || true
       - name: Build Fluent Bit packages
         run: |
           cmake -DCPACK_GENERATOR=productbuild -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

Currently, nightly building on macOS failed.
We need to install `bison` and `flex` dependencies on macOS in nightly build workflow.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

No issue is related but this PR should fix macOS nightly building failure on our workflow.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
