### PR TITLE
workflows: move unstable releases to separate repo

### DIFF
--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -151,7 +151,7 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
 
   # We already detain all artefacts as build output so just capture for an unstable release.
-  # We make all of these on https://github.com/fluent/fluent-bit-release-notifications to prevent notification spam.
+  # We make all of these on a separate repo to prevent notification spam.
   unstable-release:
     runs-on: ubuntu-latest
     needs:
@@ -209,13 +209,13 @@ jobs:
 
       - name: Remove any existing release
         continue-on-error: true
-        run: gh release delete unstable-${{ needs.unstable-build-get-meta.outputs.branch }} --yes --repo fluent/fluent-bit-release-notifications
+        run: gh release delete unstable-${{ needs.unstable-build-get-meta.outputs.branch }} --yes --repo ${{ secrets.RELEASE_REPO }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash
 
       - name: Create Release
-        run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --repo fluent/fluent-bit-release-notifications --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
+        run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --repo ${{ secrets.RELEASE_REPO }} --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -31,6 +31,8 @@ jobs:
     outputs:
       date: ${{ steps.date.outputs.date }}
       branch: ${{ steps.branch.outputs.branch }}
+    permissions:
+      contents: none
     steps:
       # For cron builds, i.e. nightly, we provide date and time as extra parameter to distinguish them.
       - name: Get current date
@@ -98,6 +100,8 @@ jobs:
     outputs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
     environment: unstable
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository, always latest for action
         uses: actions/checkout@v3
@@ -146,7 +150,8 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 
-  # We already detain all artefacts as build output so just capture for an unstable release
+  # We already detain all artefacts as build output so just capture for an unstable release.
+  # We make all of these on https://github.com/fluent/fluent-bit-release-notifications to prevent notification spam.
   unstable-release:
     runs-on: ubuntu-latest
     needs:
@@ -157,7 +162,7 @@ jobs:
       - unstable-build-macos-package
     environment: unstable
     permissions:
-      contents: write
+      contents: read
     steps:
       # Required to make a release later
       - name: Checkout repository
@@ -204,13 +209,13 @@ jobs:
 
       - name: Remove any existing release
         continue-on-error: true
-        run: gh release delete unstable-${{ needs.unstable-build-get-meta.outputs.branch }} --yes
+        run: gh release delete unstable-${{ needs.unstable-build-get-meta.outputs.branch }} --yes --repo fluent/fluent-bit-release-notifications
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash
 
       - name: Create Release
-        run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
+        run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --repo fluent/fluent-bit-release-notifications --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         shell: bash


### PR DESCRIPTION
Resolves #5259 by making sure pre-releases are on a separate repo.
Needs https://github.com/calyptia/fluent-bit-infra/pull/105 to run.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
