### PR TITLE
packaging: use SHA256 for RPM signing to satisfy FIPS

### DIFF
--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -34,6 +34,7 @@ RUN yum update -y && yum install -y fluent-bit && \
     systemctl enable fluent-bit
 
 COPY ./test.sh /test.sh
-RUN chmod a+x /test.sh
+COPY ./centos8 /extra-tests
+RUN chmod a+x /*.sh
 
 FROM staging-install as staging-upgrade

--- a/packaging/testing/smoke/packages/centos8/additional-tests.sh
+++ b/packaging/testing/smoke/packages/centos8/additional-tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Additional target-specific tests
+exitCode=0
+
+# Test for FIPS
+# https://github.com/fluent/fluent-bit/issues/3617#issuecomment-1071518859
+yumdownloader fluent-bit
+if rpm --checksig -v ./*-bit-*.rpm | grep "SHA256 digest" | grep -vq "OK" ; then
+    echo "Failed check for SHA256 digest"
+    rpm --checksig -v ./*-bit*.rpm
+    exitCode=1
+fi
+
+exit $exitCode

--- a/packaging/testing/smoke/packages/test.sh
+++ b/packaging/testing/smoke/packages/test.sh
@@ -18,3 +18,8 @@ done
 
 echo "Check service running"
 systemctl status -q --no-pager fluent-bit || systemctl status -q --no-pager td-agent-bit
+
+# Allow for per-target extra tests
+if [ -d "/extra-tests" ]; then
+    /extra-tests/additional-tests.sh
+fi

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -24,7 +24,7 @@ for RPM_REPO in "${RPM_REPO_PATHS[@]}"; do
 
     if [[ "$DISABLE_SIGNING" != "true" ]]; then
         # Sign all RPMs created for this target, cover both fluent-bit and td-agent-bit packages
-        find "$REPO_DIR" -name "*-bit-*.rpm" -exec rpm --define "_gpg_name $GPG_KEY" --addsign {} \;
+        find "$REPO_DIR" -name "*-bit-*.rpm" -exec rpm --define "_gpg_name $GPG_KEY" --define "_gpg_digest_algo sha256" --addsign {} \;
     fi
     # Create full metadata for all RPMs in the directory
     createrepo -dvp "$REPO_DIR"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #3617 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
