### PR TITLE
out_bigquery: Ensure URL encoding for the OAuth2 request, and send to the more modern endpoint.

### DIFF
--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -225,8 +225,8 @@ static int bigquery_get_oauth2_token(struct flb_bigquery *ctx)
 
     ret = flb_oauth2_payload_append(ctx->o,
                                     "grant_type", -1,
-                                    "urn:ietf:params:oauth:"
-                                    "grant-type:jwt-bearer", -1);
+                                    "urn%3Aietf%3Aparams%3Aoauth%3A"
+                                    "grant-type%3Ajwt-bearer", -1);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error appending oauth2 params");
         flb_sds_destroy(sig_data);

--- a/plugins/out_bigquery/bigquery.h
+++ b/plugins/out_bigquery/bigquery.h
@@ -32,7 +32,7 @@
 #define FLB_BIGQUERY_SCOPE     "https://www.googleapis.com/auth/bigquery.insertdata"
 
 /* BigQuery authorization URL */
-#define FLB_BIGQUERY_AUTH_URL  "https://www.googleapis.com/oauth2/v4/token"
+#define FLB_BIGQUERY_AUTH_URL  "https://oauth2.googleapis.com/token"
 
 #define FLB_BIGQUERY_RESOURCE_TEMPLATE  "/bigquery/v2/projects/%s/datasets/%s/tables/%s/insertAll"
 #define FLB_BIGQUERY_URL_BASE           "https://www.googleapis.com"


### PR DESCRIPTION
Ensure that the OAuth2 request body is URL-encoded, to match the [header value](https://github.com/fluent/fluent-bit/blob/master/include/fluent-bit/flb_oauth2.h#L29).
Also replace the old URL for retrieving OAuth2 tokens with the newer one. The new token URL is what's listed in the [well-known OAuth2 config](https://accounts.google.com/.well-known/openid-configuration).

Similar to #3198.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.