### PR TITLE
out_http: Implement "body_key" and "content_type" options

### DIFF
--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -68,6 +68,12 @@ struct flb_out_http {
     /* GELF fields */
     struct flb_gelf_fields gelf_fields;
 
+    /* which record key to use as body */
+    flb_sds_t body_key;
+
+    /* override content-type */
+    flb_sds_t content_type;
+
     /* Include tag in header */
     flb_sds_t header_tag;
 


### PR DESCRIPTION
This PR adds two new options to out_http plugin:

- "body_key" allows specifying a record key which contains the http body. Specifying this key will result in the plugin adding the payload directly without doing any conversion
- "content_type" can be used together with "body_key" to specify what is the mime type of data contained in the body.


