### PR TITLE
build: macos: Split macOS specific cmake rules into cmake/macos-setup.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,37 +311,8 @@ if(FLB_SYSTEM_WINDOWS)
 endif()
 
 # Tweak build targets for macOS
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    execute_process(
-    COMMAND brew --prefix
-    RESULT_VARIABLE HOMEBREW
-    OUTPUT_VARIABLE HOMEBREW_PREFIX
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if (HOMEBREW EQUAL 0 AND EXISTS "${HOMEBREW_PREFIX}")
-    message(STATUS "Found Homebrew at ${HOMEBREW_PREFIX}")
-    include(cmake/homebrew.cmake)
-  endif()
-
-  # Create rootcert on macOS
-  set(MACOS_ROOT_CERT ${CMAKE_CURRENT_BINARY_DIR}/certs/rootcert.pem)
-  execute_process(
-    COMMAND security find-certificate -a -p /Library/Keychains/System.keychain
-    RESULT_VARIABLE SECURITY_SYSTEM_RESULT
-    OUTPUT_VARIABLE SECURITY_SYSTEM_CERTS
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  file(WRITE ${MACOS_ROOT_CERT} ${SECURITY_SYSTEM_CERTS})
-
-  execute_process(
-    COMMAND security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain
-    RESULT_VARIABLE SECURITY_ROOT_RESULT
-    OUTPUT_VARIABLE SECURITY_ROOT_CERTS
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  file(APPEND ${MACOS_ROOT_CERT} ${SECURITY_ROOT_CERTS})
-
-  install(FILES ${MACOS_ROOT_CERT} COMPONENT binary DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/certs)
+if (FLB_SYSTEM_MACOS)
+  include(cmake/macos-setup.cmake)
 endif()
 
 # Extract Git commit information for debug output.

--- a/cmake/macos-setup.cmake
+++ b/cmake/macos-setup.cmake
@@ -1,0 +1,30 @@
+execute_process(
+  COMMAND brew --prefix
+  RESULT_VARIABLE HOMEBREW
+  OUTPUT_VARIABLE HOMEBREW_PREFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if (HOMEBREW EQUAL 0 AND EXISTS "${HOMEBREW_PREFIX}")
+  message(STATUS "Found Homebrew at ${HOMEBREW_PREFIX}")
+  include(cmake/homebrew.cmake)
+endif()
+
+# Create rootcert on macOS
+set(MACOS_ROOT_CERT ${CMAKE_CURRENT_BINARY_DIR}/certs/rootcert.pem)
+execute_process(
+  COMMAND security find-certificate -a -p /Library/Keychains/System.keychain
+  RESULT_VARIABLE SECURITY_SYSTEM_RESULT
+  OUTPUT_VARIABLE SECURITY_SYSTEM_CERTS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+file(WRITE ${MACOS_ROOT_CERT} ${SECURITY_SYSTEM_CERTS})
+
+execute_process(
+  COMMAND security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain
+  RESULT_VARIABLE SECURITY_ROOT_RESULT
+  OUTPUT_VARIABLE SECURITY_ROOT_CERTS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+file(APPEND ${MACOS_ROOT_CERT} ${SECURITY_ROOT_CERTS})
+
+install(FILES ${MACOS_ROOT_CERT} COMPONENT binary DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/certs)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, macOS specific building rules are growing and growing.
We should put macOS specific building rules into `cmake/macos-setup.cmake` for simplifying cmake files.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
