### PR TITLE
filter_kubernetes: Add ability to change kubelet_host

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -90,7 +90,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
         ctx->api_https = FLB_FALSE;
     }
     else if (ctx->use_kubelet) {
-        ctx->api_host = flb_strdup(FLB_KUBELET_HOST);
+        ctx->api_host = flb_strdup(ctx->kubelet_host);
         ctx->api_port = ctx->kubelet_port;
         ctx->api_https = FLB_TRUE;
 

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -54,9 +54,6 @@
 #define FLB_API_PORT  443
 #define FLB_API_TLS   FLB_TRUE
 
-/* Kubelet info */
-#define FLB_KUBELET_HOST  "127.0.0.1"
-
 /*
  * Default expected Kubernetes tag prefix, this is used mostly when source
  * data comes from in_tail with custom tags like: kube.service.*
@@ -156,6 +153,7 @@ struct flb_kube {
 
     int use_tag_for_meta;
     int use_kubelet;
+    char *kubelet_host;
     int kubelet_port;
 
     int kube_meta_cache_ttl;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -846,6 +846,15 @@ static struct flb_config_map config_map[] = {
      "use kubelet to get metadata instead of kube-server"
     },
     /*
+     * The kubelet host for /pods endpoint, default is 127.0.0.1
+     * Will only check when "use_kubelet" config is set to true
+     */
+    {
+     FLB_CONFIG_MAP_STR, "kubelet_host", "127.0.0.1",
+     0, FLB_TRUE, offsetof(struct flb_kube, kubelet_host),
+     "kubelet host to connect with when using kubelet"
+    },
+    /*
      * The kubelet port for /pods endpoint, default is 10250
      * Will only check when "use_kubelet" config is set to true
      */


### PR DESCRIPTION
Allow the user to set kubelet_host when use_kubelet is true.
Defaults to '127.0.0.1'.

Fixes #5143

Signed-off-by: Thomas Danielsson <thomas.danielsson@sharespine.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[INPUT]
  Name dummy
  Dummy {"top": {".dotted": "value"}}

[FILTER]
  Name          kubernetes
  Match         *
  Use_Kubelet   true
  Kubelet_Host  ${KUBELET_HOST}
  Kubelet_Port  10250


[OUTPUT]
  Name stdout
  Match *
```
- [x] Debug log output from testing the change
```
[2022/04/12 10:12:30] [ info] [filter:kubernetes:kubernetes.0] https=1 host=10.132.15.210 port=10250
[2022/04/12 10:12:30] [ info] [filter:kubernetes:kubernetes.0] local POD info OK
[2022/04/12 10:12:30] [ info] [filter:kubernetes:kubernetes.0] testing connectivity with Kubelet...
[2022/04/12 10:12:30] [debug] [filter:kubernetes:kubernetes.0] Send out request to Kubelet for pods information.
[2022/04/12 10:12:30] [debug] [http_client] not using http_proxy for header
[2022/04/12 10:12:30] [debug] [http_client] server 10.132.15.210:10250 will close connection #67
[2022/04/12 10:12:30] [debug] [filter:kubernetes:kubernetes.0] Request (ns=logging, pod=fluent-bit-kt7hc) http_do=0, HTTP Status: 200
[2022/04/12 10:12:30] [ info] [filter:kubernetes:kubernetes.0] connectivity OK
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/787
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
