### PR TITLE
staging: resolve S3 bucket usage for Mac & Windows

### DIFF
--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -118,7 +118,7 @@ jobs:
         # Only upload for staging
         if: inputs.environment == 'staging'
         run: |
-          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress --delete
+          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress
         env:
           SOURCE_DIR: "artifacts"
           DEST_DIR: "${{ inputs.version }}/macos/"

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -118,10 +118,11 @@ jobs:
         # Only upload for staging
         if: inputs.environment == 'staging'
         run: |
-          aws s3 sync "$SOURCE_DIR" "s3://$DEST_DIR" --follow-symlinks --no-progress
+          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress --delete
         env:
           SOURCE_DIR: "artifacts"
-          DEST_DIR: "${{ secrets.bucket }}/${{ inputs.version }}/macos/"
+          DEST_DIR: "${{ inputs.version }}/macos/"
+          AWS_S3_BUCKET: ${{ secrets.bucket }}
           AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -114,7 +114,7 @@ jobs:
           name: macos-packages
           path: artifacts/
 
-      - name: Push Windows packages to S3
+      - name: Push MacOS packages to S3
         # Only upload for staging
         if: inputs.environment == 'staging'
         run: |

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -109,10 +109,11 @@ jobs:
         # Only upload for staging
         if: inputs.environment == 'staging'
         run: |
-          aws s3 sync "$SOURCE_DIR" "s3://$DEST_DIR" --follow-symlinks --no-progress
+          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress --delete
         env:
           SOURCE_DIR: "artifacts/"
-          DEST_DIR: "${{ secrets.bucket }}/${{ inputs.version }}/windows/"
+          DEST_DIR: "${{ inputs.version }}/windows/"
+          AWS_S3_BUCKET: ${{ secrets.bucket }}
           AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_access_key }}

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -109,7 +109,7 @@ jobs:
         # Only upload for staging
         if: inputs.environment == 'staging'
         run: |
-          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress --delete
+          aws s3 sync "$SOURCE_DIR" "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --follow-symlinks --no-progress
         env:
           SOURCE_DIR: "artifacts/"
           DEST_DIR: "${{ inputs.version }}/windows/"


### PR DESCRIPTION
Resolves failures seen uploading to S3 for Mac/Windows packages.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
