### PR TITLE
filter_lua: allow to load Lua code from the config

### DIFF
--- a/include/fluent-bit/flb_luajit.h
+++ b/include/fluent-bit/flb_luajit.h
@@ -36,6 +36,8 @@ struct flb_luajit {
 
 struct flb_luajit *flb_luajit_create();
 int flb_luajit_load_script(struct flb_luajit *lj, char *script);
+int flb_luajit_load_buffer(struct flb_luajit *lj, char *string, size_t len, char *name);
+
 void flb_luajit_destroy(struct flb_luajit *lj);
 int flb_luajit_destroy_all(struct flb_config *ctx);
 

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -29,6 +29,7 @@
 #define LUA_BUFFER_CHUNK    1024 * 8  /* 8K should be enough to get started */
 
 struct lua_filter {
+    flb_sds_t code;                   /* lua script source code */
     flb_sds_t script;                 /* lua script path */
     flb_sds_t call;                   /* function name   */
     flb_sds_t buffer;                 /* json dec buffer */

--- a/src/flb_luajit.c
+++ b/src/flb_luajit.c
@@ -59,6 +59,20 @@ int flb_luajit_load_script(struct flb_luajit *lj, char *script)
     return 0;
 }
 
+int flb_luajit_load_buffer(struct flb_luajit *lj, char *string, size_t len, char *name)
+{
+    int ret;
+
+    ret = luaL_loadbuffer(lj->state, string, len, name);
+    if (ret != 0) {
+        flb_error("[luajit] error loading buffer: %s",
+                  lua_tostring(lj->state, -1));
+        return -1;
+    }
+
+    return 0;
+}
+
 void flb_luajit_destroy(struct flb_luajit *lj)
 {
     lua_close(lj->state);


### PR DESCRIPTION
The following PR adds a new option called `code` that allows loading the Lua code from a text from the configuration instead of an existing file.
    
note: 'code' and 'script' cannot be used at the same time.

config usage example:

```yaml
service:
    flush:           1
    daemon:          off
    log_level:       info

pipeline:
    inputs:
        - random:
            tag:           test
            samples:       10

    filters:
        - lua:
            match:         "*"
            call:          append_tag
            code:          |
                function append_tag(tag, timestamp, record)
                   new_record = record
                   new_record["tag"] = tag
                   return 1, timestamp, new_record
                end

    outputs:
        - stdout:
            match:         "*"
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
