### PR TITLE
packaging: update smoke tests to verify inline LUA

### DIFF
--- a/packaging/testing/smoke/container/fluent-bit.conf
+++ b/packaging/testing/smoke/container/fluent-bit.conf
@@ -6,10 +6,26 @@
     HC_Errors_Count 5
     HC_Retry_Failure_Count 5
     HC_Period 5
+    Log_level debug
 
 [INPUT]
-    Name  cpu
+    Name random
+    Tag test
+    Samples 10
+
+[FILTER]
+    Name Lua
+    Match *
+    call append_tag
+    code function append_tag(tag, timestamp, record) new_record = record new_record["tag"] = tag return 1, timestamp, new_record end
+
+[FILTER]
+    Name Expect
+    Match *
+    key_exists tag
+    key_val_eq tag test
+    action exit
 
 [OUTPUT]
-    Name  stdout
+    Name stdout
     Match *

--- a/packaging/testing/smoke/container/fluent-bit.yaml
+++ b/packaging/testing/smoke/container/fluent-bit.yaml
@@ -3,11 +3,31 @@
 service:
     http_server: "on"
     Health_Check: "on"
+    log_level: debug
 
 pipeline:
     inputs:
-        - cpu:
-              tag: input
+        - random:
+            tag: test
+            samples: 10
+
+    filters:
+        - lua:
+            match: test
+            call: append_tag
+            code: |
+                function append_tag(tag, timestamp, record)
+                   new_record = record
+                   new_record["tag"] = tag
+                   return 1, timestamp, new_record
+                end
+
+        - expect:
+            match: test
+            key_exists: tag
+            key_val_eq: tag test
+            action: exit
+
     outputs:
         - stdout:
-              match: '*'
+              match: test


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Verifies changes in #5302 for #4634 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
```
$ cd packaging/testing/smoke/container/
$ docker run --rm --pull=always -it -v $PWD/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro ghcr.io/fluent/fluent-bit/master:x86_64
$ docker run --rm --pull=always -it -v $PWD/fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml:ro ghcr.io/fluent/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/789

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
