### PR TITLE
ci: add codebase visualisation

### DIFF
--- a/.github/workflows/docs-generate.yaml
+++ b/.github/workflows/docs-generate.yaml
@@ -26,6 +26,7 @@ jobs:
           should_push: false
 
       - name: Generate PR for updates
+        uses: peter-evans/create-pull-request@v4
         with:
           commit_message: 'ci: update repo-visualizer diagram'
           signoff: true

--- a/.github/workflows/docs-generate.yaml
+++ b/.github/workflows/docs-generate.yaml
@@ -1,0 +1,37 @@
+
+name: Documentation and diagram generation
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - '1.9'
+jobs:
+  update_diagram:
+    name: Update the codebase structure diagram
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Update diagram
+        # TODO: still not "official" enough for a proper semantic release version
+        uses: githubocto/repo-visualizer@main
+        with:
+          excluded_paths: "ignore,.github"
+          output_file: codebase-structure.svg
+          should_push: false
+
+      - name: Generate PR for updates
+        with:
+          commit_message: 'ci: update repo-visualizer diagram'
+          signoff: true
+          branch-suffix: random
+          delete-branch: true
+          title: 'ci: update repo-visualizer diagram'
+          reviewers: 'patrick-stephens,niedbalski'
+          add-paths: |
+            codebase-structure.svg

--- a/.github/workflows/docs-generate.yaml
+++ b/.github/workflows/docs-generate.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Generate PR for updates
         uses: peter-evans/create-pull-request@v4
         with:
-          commit_message: 'ci: update repo-visualizer diagram'
+          commit-message: 'ci: update repo-visualizer diagram'
           signoff: true
           branch: ci_update_diagram
           delete-branch: true

--- a/.github/workflows/docs-generate.yaml
+++ b/.github/workflows/docs-generate.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - '1.9'
 jobs:
   update_diagram:
     name: Update the codebase structure diagram
@@ -30,7 +29,7 @@ jobs:
         with:
           commit_message: 'ci: update repo-visualizer diagram'
           signoff: true
-          branch-suffix: random
+          branch: ci_update_diagram
           delete-branch: true
           title: 'ci: update repo-visualizer diagram'
           reviewers: 'patrick-stephens,niedbalski'

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Fluent Bit is fully supported on Windows environments, get started with [these i
 
 If you are interested in contributing to Fluent bit with bug fixes, new features or coding in general, please refer to the code [CONTRIBUTING](CONTRIBUTING.md) guidelines. You can also refer the Beginners Guide to contributing to Fluent Bit [here.](DEVELOPER_GUIDE.md)
 
+![Visualization of the codebase](./codebase-structure.svg)
 ## Community & Contact
 
 Feel free to join us on our Slack channel, Mailing List or IRC:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addition of basic diagram generation showing codebase structure.
* https://next.github.com/projects/repo-visualization/#integrate-into-your-own-projects

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
