### PR TITLE
filter_tensorflow: fixes and removal of string-type input field

### DIFF
--- a/plugins/filter_tensorflow/tensorflow.c
+++ b/plugins/filter_tensorflow/tensorflow.c
@@ -20,15 +20,13 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_filter_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_config_map.h>
 
-#include <fluent-bit/flb_base64.h>
-
 #include "tensorflow/lite/c/c_api.h"
+#include "tensorflow/lite/c/common.h"
 
 #include <msgpack.h>
 #include <time.h>
@@ -40,23 +38,23 @@
                           x == MSGPACK_OBJECT_FLOAT32)
 #define MSGPACK_NUMBER(x) (MSGPACK_INTEGER(x) || MSGPACK_FLOAT(x))
 
-#define TFLITE_INTEGER(x) (x == kTfLiteInt16 || x == kTfLiteInt32 || x == kTfLiteInt64)
-#define TFLITE_FLOAT(x) (x == kTfLiteFloat16 || x == kTfLiteFloat32)
-
 void print_tensor_info(struct flb_tensorflow *ctx, const TfLiteTensor* tensor)
 {
     int i;
     TfLiteType type;
-    char dims[100] = "";
+    char tensor_info[128] = "";
+    char tensor_dim[8];
 
     type = TfLiteTensorType(tensor);
-    sprintf(dims, "[tensorflow] type: %s  dimensions: {", TfLiteTypeGetName(type));
+    sprintf(tensor_info, "type: %s dimensions: {", TfLiteTypeGetName(type));
     for (i = 0; i < TfLiteTensorNumDims(tensor) - 1; i++) {
-        sprintf(dims, "%s%d, ", dims, TfLiteTensorDim(tensor, i));
+        sprintf(tensor_dim, "%d, ", TfLiteTensorDim(tensor, i));
+        strcat(tensor_info, tensor_dim);
     }
-    sprintf(dims, "%s%d}", dims, TfLiteTensorDim(tensor, i));
+    sprintf(tensor_dim, "%d}", TfLiteTensorDim(tensor, i));
+    strcat(tensor_info, tensor_dim);
 
-    flb_plg_debug(ctx->ins, "%s", dims);
+    flb_plg_info(ctx->ins, "%s", tensor_info);
 }
 
 void print_model_io(struct flb_tensorflow *ctx)
@@ -64,13 +62,12 @@ void print_model_io(struct flb_tensorflow *ctx)
     int i;
     int num;
     const TfLiteTensor* tensor;
-    char dims[100] = "";
 
     /* Input information */
     num = TfLiteInterpreterGetInputTensorCount(ctx->interpreter);
     for (i = 0; i < num; i++) {
         tensor = TfLiteInterpreterGetInputTensor(ctx->interpreter, i);
-        flb_plg_debug(ctx->ins, "[tensorflow] ===== input #%d =====", i + 1);
+        flb_plg_info(ctx->ins, "===== input #%d =====", i + 1);
         print_tensor_info(ctx, tensor);
     }
 
@@ -78,7 +75,7 @@ void print_model_io(struct flb_tensorflow *ctx)
     num = TfLiteInterpreterGetOutputTensorCount(ctx->interpreter);
     for (i = 0; i < num; i++) {
         tensor = TfLiteInterpreterGetOutputTensor(ctx->interpreter, i);
-        flb_plg_debug(ctx->ins, "[tensorflow] ===== output #%d ====", i + 1);
+        flb_plg_info(ctx->ins, "===== output #%d ====", i + 1);
         print_tensor_info(ctx, tensor);
     }
 }
@@ -91,7 +88,7 @@ void build_interpreter(struct flb_tensorflow *ctx, char* model_path)
     ctx->interpreter = TfLiteInterpreterCreate(ctx->model, ctx->interpreter_options);
     TfLiteInterpreterAllocateTensors(ctx->interpreter);
 
-    flb_info("Tensorflow Lite interpreter created!");
+    flb_info("TensorFlow Lite interpreter created!");
     print_model_io(ctx);
 }
 
@@ -106,25 +103,49 @@ void inference(TfLiteInterpreter* interpreter, void* input_data, void* output_da
     TfLiteTensorCopyToBuffer(output_tensor, output_data, output_buf_size);
 }
 
-int allocateIOBuffer(void** buf, TfLiteType type, int size)
+int allocateIOBuffer(struct flb_tensorflow *ctx, void** buf, TfLiteType type, int size)
 {
-    if (TFLITE_FLOAT(type)) {
+    if (type == kTfLiteFloat32) {
         *buf = (void*) flb_malloc(size * sizeof(float));
     }
-    else if (TFLITE_INTEGER(type)) {
-        *buf = (void*) flb_malloc(size * sizeof(int));
-    }
     else {
-        flb_error("[tensorflow] tensor type (%d) is not currently supported!", type);
+        flb_plg_error(ctx->ins, "Tensor type (%d) is not currently supported!", type);
         return -1;
     }
 
     return 0;
 }
 
-static int cb_tf_init(struct flb_filter_instance *f_ins,
-                      struct flb_config *config,
-                      void *data)
+void flb_tensorflow_conf_destroy(struct flb_tensorflow *ctx)
+{
+    flb_sds_destroy(ctx->input_field);
+
+    if (ctx->input) {
+        flb_free(ctx->input);
+    }
+
+    if (ctx->output) {
+        flb_free(ctx->output);
+    }
+
+    if (ctx->normalization_value) {
+        flb_free(ctx->normalization_value);
+    }
+
+    /* delete TensorFlow model and interpreter */
+    if (ctx->model) {
+        TfLiteModelDelete(ctx->model);
+    }
+
+    TfLiteInterpreterOptionsDelete(ctx->interpreter_options);
+    TfLiteInterpreterDelete(ctx->interpreter);
+
+    flb_free(ctx);
+}
+
+static int cb_tensorflow_init(struct flb_filter_instance *f_ins,
+                              struct flb_config *config,
+                              void *data)
 {
     int i;
     int ret;
@@ -138,10 +159,18 @@ static int cb_tf_init(struct flb_filter_instance *f_ins,
         return -1;
     }
 
+    ret = flb_filter_config_map_set(f_ins, (void *) ctx);
+    if (ret == -1) {
+        flb_tensorflow_conf_destroy(ctx);
+        return -1;
+    }
+
+    ctx->ins = f_ins;
+
     tmp = flb_filter_get_property("input_field", f_ins);
     if (!tmp) {
-        flb_error("[tensorflow] inuput field is not defined!");
-        flb_free(ctx);
+        flb_plg_error(ctx->ins, "input field is not defined!");
+        flb_tensorflow_conf_destroy(ctx);
         return -1;
     }
 
@@ -149,22 +178,22 @@ static int cb_tf_init(struct flb_filter_instance *f_ins,
 
     tmp = flb_filter_get_property("model_file", f_ins);
     if (!tmp) {
-        flb_error("[tensorflow] Tensorflow Lite model file is not provided!");
-        flb_free(ctx);
+        flb_plg_error(ctx->ins, "TensorFlow Lite model file is not provided!");
+        flb_tensorflow_conf_destroy(ctx);
         return -1;
     }
 
     if(access(tmp, F_OK) == -1) {
-        flb_error("[tensorflow] Tensorflow Lite model file %s not found!", tmp);
-        flb_free(ctx);
+        flb_plg_error(ctx->ins, "TensorFlow Lite model file %s not found!", tmp);
+        flb_tensorflow_conf_destroy(ctx);
         return -1;
     }
 
     build_interpreter(ctx, (char *) tmp);
 
     if (!ctx->interpreter) {
-        flb_error("[tensorflow] error creating interpreter");
-        flb_free(ctx);
+        flb_plg_error(ctx->ins, "Error creating the interpreter");
+        flb_tensorflow_conf_destroy(ctx);
         return -1;
     }
 
@@ -175,9 +204,9 @@ static int cb_tf_init(struct flb_filter_instance *f_ins,
         ctx->input_size *= TfLiteTensorDim(tensor, i);
     }
     ctx->input_tensor_type = TfLiteTensorType(tensor);
-    if (allocateIOBuffer(&ctx->input, ctx->input_tensor_type, ctx->input_size) == -1) {
-      flb_free(ctx);
-      return -1;
+    if (allocateIOBuffer(ctx, &ctx->input, ctx->input_tensor_type, ctx->input_size) == -1) {
+        flb_tensorflow_conf_destroy(ctx);
+        return -1;
     }
     ctx->input_byte_size = TfLiteTensorByteSize(tensor);
 
@@ -188,9 +217,9 @@ static int cb_tf_init(struct flb_filter_instance *f_ins,
         ctx->output_size *= TfLiteTensorDim(tensor, i);
     }
     ctx->output_tensor_type = TfLiteTensorType(tensor);
-    if (allocateIOBuffer(&ctx->output, ctx->output_tensor_type, ctx->output_size) == -1) {
-      flb_free(ctx);
-      return -1;
+    if (allocateIOBuffer(ctx, &ctx->output, ctx->output_tensor_type, ctx->output_size) == -1) {
+        flb_tensorflow_conf_destroy(ctx);
+        return -1;
     }
     ctx->output_byte_size = TfLiteTensorByteSize(tensor);
 
@@ -208,25 +237,17 @@ static int cb_tf_init(struct flb_filter_instance *f_ins,
         *ctx->normalization_value = atof(tmp);
     }
 
-    ctx->ins = f_ins;
-
-    ret = flb_filter_config_map_set(f_ins, (void *) ctx);
-    if (ret == -1) {
-        flb_free(ctx);
-        return -1;
-    }
-
     flb_filter_set_context(f_ins, ctx);
     return 0;
 }
 
-static int cb_tf_filter(const void *data, size_t bytes,
-                        const char *tag, int tag_len,
-                        void **out_buf, size_t *out_bytes,
-                        struct flb_filter_instance *f_ins,
-                        struct flb_input_instance *i_ins,
-                        void *filter_context,
-                        struct flb_config *config)
+static int cb_tensorflow_filter(const void *data, size_t bytes,
+                                const char *tag, int tag_len,
+                                void **out_buf, size_t *out_bytes,
+                                struct flb_filter_instance *f_ins,
+                                struct flb_input_instance *i_ins,
+                                void *filter_context,
+                                struct flb_config *config)
 {
     size_t off = 0;
     int i;
@@ -249,18 +270,18 @@ static int cb_tf_filter(const void *data, size_t bytes,
     msgpack_sbuffer tmp_sbuf;
     msgpack_packer tmp_pck;
 
-    struct flb_tensorflow* ctx = filter_context;
+    struct flb_tensorflow* ctx;
 
     /* data pointers */
-    int* dint;
     float* dfloat;
-
-    size_t b64_out_len;
 
     /* calculate inference time */
     clock_t start, end;
-    double elapsed_time;
+    double inference_time;
 
+    /* initializations */
+    ctx = filter_context;
+    inference_time = 0;
     start = clock();
 
     msgpack_sbuffer_init(&tmp_sbuf);
@@ -284,86 +305,94 @@ static int cb_tf_filter(const void *data, size_t bytes,
                 continue;
             }
 
-            /* convention: value has to be of primitive types, or array of
-               primitive types i.e. unrolled data (like unrolled image) */
             value = map.via.map.ptr[i].val;
             if (value.type == MSGPACK_OBJECT_ARRAY)
             {
                 int size = value.via.array.size;
                 if (size == 0) {
-                    flb_error("[tensorflow] input data size has to be non-zero!");
+                    flb_plg_error(ctx->ins, "input data size has to be non-zero!");
                     break;
                 }
 
                 if (size != ctx->input_size) {
-                    flb_error("[tensorflow] input data size doesn't match model's input size!");
+                    flb_plg_error(ctx->ins, "input data size doesn't match model's input size!");
                     break;
                 }
 
-                /* we only accept numbers as in */
+                /* we only accept numbers inside input array */
                 input_data_type = value.via.array.ptr[0].type;
                 if (!MSGPACK_NUMBER(input_data_type)) {
-                    flb_error("[tensorflow] input data has to be of numerical type!");
+                    flb_plg_error(ctx->ins, "input data has to be of numerical type!");
                     break;
                 }
 
-                /* copy data from messagepack into input buffer */
-                if (TFLITE_FLOAT(ctx->input_tensor_type)) {
-                    dfloat = (float*) ctx->input;
+                /* copy data from messagepack into the input buffer */
+                /* tensor type: kTfLiteFloat32 */
+                if (ctx->input_tensor_type == kTfLiteFloat32) {
+                    if (sizeof(float) != sizeof(kTfLiteFloat32)) {
+                        flb_plg_error(ctx->ins, "input tensor type (kTfLiteFloat32) doesn't match float size!");
+                        break;
+                    }
+
+                    dfloat = (float *) ctx->input;
+
                     if (MSGPACK_FLOAT(input_data_type)) {
                         for (i = 0; i < value.via.array.size; i++) {
-                            if (ctx->normalization_value) {
-                                dfloat[i] = value.via.array.ptr[i].via.f64 / *ctx->normalization_value;
-                            }
-                            else {
-                                dfloat[i] = value.via.array.ptr[i].via.f64;
-                            }
+                            dfloat[i] = value.via.array.ptr[i].via.f64;
                         }
                     }
-                    else { /* MSGPACK_INTEGER */
+                    else if (MSGPACK_INTEGER(input_data_type)) {
                         for (i = 0; i < value.via.array.size; i++) {
-                            if (ctx->normalization_value) {
-                                dfloat[i] = ((float) value.via.array.ptr[i].via.i64) / *ctx->normalization_value;
-                            }
-                            else {
-                                dfloat[i] = ((float) value.via.array.ptr[i].via.i64);
-                            }
+                            dfloat[i] = ((float) value.via.array.ptr[i].via.i64);
                         }
                     }
-                }
-                else if (TFLITE_INTEGER(ctx->input_tensor_type)) {
-                    dint = (int*) ctx->input;
-                    if (MSGPACK_INTEGER(input_data_type)) {
-                        for (i = 0; i < value.via.array.size; i++) {
-                            dint[i] = value.via.array.ptr[i].via.i64;
-                        }
+                    else {
+                        flb_plg_error(ctx->ins, "input record type is not supported for a float32 input tensor!");
+                        break;
                     }
-                    else { /* MSGPACK_FLOAT */
+
+                    if (ctx->normalization_value) {
                         for (i = 0; i < value.via.array.size; i++) {
-                            dint[i] = (int) value.via.array.ptr[i].via.f64;
+                            dfloat[i] /= *ctx->normalization_value;
                         }
                     }
                 }
                 else {
-                    flb_error("[tensorflow] input tensor type is not currently not supported!");
+                    flb_plg_error(ctx->ins, "input tensor type is not currently not supported!");
                     break;
                 }
             }
-            else if (value.type == MSGPACK_OBJECT_STR) {
-                if(flb_base64_encode(ctx->input, ctx->input_byte_size, &b64_out_len, (const unsigned char *) value.via.str.ptr, value.via.str.size) != 0) {
-                  flb_error("[tensorflow] can't base64 decode the field!");
-                  break;
-                }
+            else if (value.type == MSGPACK_OBJECT_BIN) {
+                 if (ctx->input_tensor_type == kTfLiteFloat32) {
+                     dfloat = (float *) ctx->input;
 
-                if (b64_out_len != ctx->input_byte_size) {
-                    flb_error("[tensorflow] input data size (%d bytes) doesn't"
-                              "match model's input size (%d bytes)!",
-                              b64_out_len, ctx->input_byte_size);
-                    break;
+                     /*
+                      * re:IEEE754 float size is 32 bits
+                      * TODO: currently, the following assumes that the binrary
+                      * string is the serialization of a string of characters (uint8_t).
+                      * It is required to add other primitive data type encodings such as
+                      * floating point numbers.
+                      */
+                     if (ctx->input_byte_size != (value.via.bin.size << 2)) {
+                       flb_plg_error(ctx->ins, "input data size (%d bytes * 4) doesn't"
+                                 "match model's input size (%d bytes)!",
+                                 value.via.bin.size, ctx->input_byte_size);
+                       break;
+                     }
+
+                     for (i = 0; i < value.via.bin.size; i++) {
+                         dfloat[i] = ((float) value.via.bin.ptr[i]);
+                     }
+
+                     if (ctx->normalization_value) {
+                         for (i = 0; i < value.via.bin.size; i++) {
+                             dfloat[i] /= *ctx->normalization_value;
+                         }
+                     }
                 }
             }
             else {
-                flb_error("[tensorflow] input data format is not currently supported!");
+                flb_plg_error(ctx->ins, "input data format is not currently supported!");
                 break;
             }
 
@@ -372,7 +401,7 @@ static int cb_tf_filter(const void *data, size_t bytes,
 
             /* create output messagepack */
             end = clock();
-            elapsed_time = ((double) (end - start)) / CLOCKS_PER_SEC;
+            inference_time = ((double) (end - start)) / CLOCKS_PER_SEC;
 
             msgpack_pack_array(&tmp_pck, 2);
             flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
@@ -393,19 +422,17 @@ static int cb_tf_filter(const void *data, size_t bytes,
 
             msgpack_pack_str(&tmp_pck, strlen("inference_time"));
             msgpack_pack_str_body(&tmp_pck, "inference_time", strlen("inference_time"));
-            msgpack_pack_float(&tmp_pck, elapsed_time);
+            msgpack_pack_float(&tmp_pck, inference_time);
 
-            msgpack_pack_str(&tmp_pck, strlen("tf_out"));
-            msgpack_pack_str_body(&tmp_pck, "tf_out", strlen("tf_out"));
+            msgpack_pack_str(&tmp_pck, strlen("output"));
+            msgpack_pack_str_body(&tmp_pck, "output", 6);
 
             msgpack_pack_array(&tmp_pck, ctx->output_size);
             for (i=0; i < ctx->output_size; i++) {
-                if (TFLITE_FLOAT(ctx->output_tensor_type)) {
+                if (ctx->output_tensor_type == kTfLiteFloat32) {
                     msgpack_pack_float(&tmp_pck, ((float*) ctx->output)[i]);
                 }
-                else if (TFLITE_INTEGER(ctx->output_tensor_type)) {
-                    msgpack_pack_int64(&tmp_pck, ((int*)ctx->output)[i]);
-                }
+                /* TODO: work out other types */
             }
             break;
         }
@@ -417,28 +444,11 @@ static int cb_tf_filter(const void *data, size_t bytes,
     return FLB_FILTER_MODIFIED;
 }
 
-void flb_tf_conf_destroy(struct flb_tensorflow *ctx)
-{
-    flb_sds_destroy(ctx->input_field);
-    flb_free(ctx->input);
-    flb_free(ctx->output);
-    if (ctx->normalization_value) {
-        flb_free(ctx->normalization_value);
-    }
-
-    /* delete Tensorflow model and interpreter */
-    TfLiteInterpreterDelete(ctx->interpreter);
-    TfLiteInterpreterOptionsDelete(ctx->interpreter_options);
-    TfLiteModelDelete(ctx->model);
-
-    flb_free(ctx);
-}
-
-static int cb_tf_exit(void *data, struct flb_config *config)
+static int cb_tensorflow_exit(void *data, struct flb_config *config)
 {
     struct flb_tensorflow *ctx = data;
 
-    flb_tf_conf_destroy(ctx);
+    flb_tensorflow_conf_destroy(ctx);
     return 0;
 }
 
@@ -446,7 +456,7 @@ static struct flb_config_map config_map[] = {
     {
         FLB_CONFIG_MAP_STR, "model_file", NULL,
         0, FLB_FALSE, 0,
-        "Address of the Tensorflow Lite model file (.tflite)"
+        "Address of the TensorFlow Lite model file (.tflite)"
     },
     {
         FLB_CONFIG_MAP_STR, "input_field", NULL,
@@ -456,12 +466,12 @@ static struct flb_config_map config_map[] = {
     {
         FLB_CONFIG_MAP_BOOL, "include_input_fields", "true",
         0, FLB_TRUE, offsetof(struct flb_tensorflow, include_input_fields),
-        NULL
+        "Include input field in the output of the filter."
     },
     {
         FLB_CONFIG_MAP_DOUBLE, "normalization_value", NULL,
         0, FLB_FALSE, 0,
-        NULL
+        "Divide input feature values to this value (e.g. divide image pixles by 255)."
     },
     /* EOF */
     {0}
@@ -469,10 +479,10 @@ static struct flb_config_map config_map[] = {
 
 struct flb_filter_plugin filter_tensorflow_plugin = {
     .name         = "tensorflow",
-    .description  = "Tensorflow Lite inference engine",
-    .cb_init      = cb_tf_init,
-    .cb_filter    = cb_tf_filter,
-    .cb_exit      = cb_tf_exit,
+    .description  = "TensorFlow Lite inference engine",
+    .cb_init      = cb_tensorflow_init,
+    .cb_filter    = cb_tensorflow_filter,
+    .cb_exit      = cb_tensorflow_exit,
     .config_map   = config_map,
     .flags        = 0
 };

--- a/plugins/filter_tensorflow/tensorflow.c
+++ b/plugins/filter_tensorflow/tensorflow.c
@@ -43,7 +43,7 @@
 #define TFLITE_INTEGER(x) (x == kTfLiteInt16 || x == kTfLiteInt32 || x == kTfLiteInt64)
 #define TFLITE_FLOAT(x) (x == kTfLiteFloat16 || x == kTfLiteFloat32)
 
-void print_tensor_info(const TfLiteTensor* tensor)
+void print_tensor_info(struct flb_tensorflow *ctx, const TfLiteTensor* tensor)
 {
     int i;
     TfLiteType type;
@@ -56,30 +56,30 @@ void print_tensor_info(const TfLiteTensor* tensor)
     }
     sprintf(dims, "%s%d}", dims, TfLiteTensorDim(tensor, i));
 
-    flb_info("%s", dims);
+    flb_plg_debug(ctx->ins, "%s", dims);
 }
 
-void print_model_io(TfLiteInterpreter* interpreter)
+void print_model_io(struct flb_tensorflow *ctx)
 {
     int i;
     int num;
     const TfLiteTensor* tensor;
     char dims[100] = "";
 
-    // Input information
-    num = TfLiteInterpreterGetInputTensorCount(interpreter);
+    /* Input information */
+    num = TfLiteInterpreterGetInputTensorCount(ctx->interpreter);
     for (i = 0; i < num; i++) {
-        tensor = TfLiteInterpreterGetInputTensor(interpreter, i);
-        flb_info("[tensorflow] ===== input #%d =====", i + 1);
-        print_tensor_info(tensor);
+        tensor = TfLiteInterpreterGetInputTensor(ctx->interpreter, i);
+        flb_plg_debug(ctx->ins, "[tensorflow] ===== input #%d =====", i + 1);
+        print_tensor_info(ctx, tensor);
     }
 
-    // Output information
-    num = TfLiteInterpreterGetOutputTensorCount(interpreter);
+    /* Output information */
+    num = TfLiteInterpreterGetOutputTensorCount(ctx->interpreter);
     for (i = 0; i < num; i++) {
-        tensor = TfLiteInterpreterGetOutputTensor(interpreter, i);
-        flb_info("[tensorflow] ===== output #%d ====", i + 1);
-        print_tensor_info(tensor);
+        tensor = TfLiteInterpreterGetOutputTensor(ctx->interpreter, i);
+        flb_plg_debug(ctx->ins, "[tensorflow] ===== output #%d ====", i + 1);
+        print_tensor_info(ctx, tensor);
     }
 }
 
@@ -92,7 +92,7 @@ void build_interpreter(struct flb_tensorflow *ctx, char* model_path)
     TfLiteInterpreterAllocateTensors(ctx->interpreter);
 
     flb_info("Tensorflow Lite interpreter created!");
-    print_model_io(ctx->interpreter);
+    print_model_io(ctx);
 }
 
 void inference(TfLiteInterpreter* interpreter, void* input_data, void* output_data, int input_buf_size, int output_buf_size) {

--- a/plugins/filter_tensorflow/tensorflow.c
+++ b/plugins/filter_tensorflow/tensorflow.c
@@ -43,7 +43,7 @@
 #define TFLITE_INTEGER(x) (x == kTfLiteInt16 || x == kTfLiteInt32 || x == kTfLiteInt64)
 #define TFLITE_FLOAT(x) (x == kTfLiteFloat16 || x == kTfLiteFloat32)
 
-void print_tensor_info(struct flb_tensorflow *ctx, const TfLiteTensor* tensor)
+void print_tensor_info(const TfLiteTensor* tensor)
 {
     int i;
     TfLiteType type;
@@ -56,30 +56,30 @@ void print_tensor_info(struct flb_tensorflow *ctx, const TfLiteTensor* tensor)
     }
     sprintf(dims, "%s%d}", dims, TfLiteTensorDim(tensor, i));
 
-    flb_plg_debug(ctx->ins, "%s", dims);
+    flb_info("%s", dims);
 }
 
-void print_model_io(struct flb_tensorflow *ctx)
+void print_model_io(TfLiteInterpreter* interpreter)
 {
     int i;
     int num;
     const TfLiteTensor* tensor;
     char dims[100] = "";
 
-    /* Input information */
-    num = TfLiteInterpreterGetInputTensorCount(ctx->interpreter);
+    // Input information
+    num = TfLiteInterpreterGetInputTensorCount(interpreter);
     for (i = 0; i < num; i++) {
-        tensor = TfLiteInterpreterGetInputTensor(ctx->interpreter, i);
-        flb_plg_debug(ctx->ins, "[tensorflow] ===== input #%d =====", i + 1);
-        print_tensor_info(ctx, tensor);
+        tensor = TfLiteInterpreterGetInputTensor(interpreter, i);
+        flb_info("[tensorflow] ===== input #%d =====", i + 1);
+        print_tensor_info(tensor);
     }
 
-    /* Output information */
-    num = TfLiteInterpreterGetOutputTensorCount(ctx->interpreter);
+    // Output information
+    num = TfLiteInterpreterGetOutputTensorCount(interpreter);
     for (i = 0; i < num; i++) {
-        tensor = TfLiteInterpreterGetOutputTensor(ctx->interpreter, i);
-        flb_plg_debug(ctx->ins, "[tensorflow] ===== output #%d ====", i + 1);
-        print_tensor_info(ctx, tensor);
+        tensor = TfLiteInterpreterGetOutputTensor(interpreter, i);
+        flb_info("[tensorflow] ===== output #%d ====", i + 1);
+        print_tensor_info(tensor);
     }
 }
 
@@ -92,7 +92,7 @@ void build_interpreter(struct flb_tensorflow *ctx, char* model_path)
     TfLiteInterpreterAllocateTensors(ctx->interpreter);
 
     flb_info("Tensorflow Lite interpreter created!");
-    print_model_io(ctx);
+    print_model_io(ctx->interpreter);
 }
 
 void inference(TfLiteInterpreter* interpreter, void* input_data, void* output_data, int input_buf_size, int output_buf_size) {

--- a/plugins/filter_tensorflow/tensorflow.h
+++ b/plugins/filter_tensorflow/tensorflow.h
@@ -28,7 +28,7 @@ struct flb_tensorflow {
     TfLiteType input_tensor_type;
     TfLiteType output_tensor_type;
 
-    // IO buffer
+    /* IO buffer */
     void* input;
     void* output;
     int input_size;
@@ -36,7 +36,7 @@ struct flb_tensorflow {
     int output_size;
     int output_byte_size;
 
-    // feature scaling/normalization
+    /* feature scaling/normalization */
     bool include_input_fields;
     float* normalization_value;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Several fixes and modifications in the TensorFlow plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind --leak-check=full ./build/bin/fluent-bit -c conf/filter_tensorflow.conf                                                                                                         
==33454== Memcheck, a memory error detector                                                                                                                                                                                  
==33454== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.                                                                                                                                                    
==33454== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info                                                                                                                                                 
==33454== Command: ./build/bin/fluent-bit -c conf/filter_tensorflow.conf                                                                                                                                                     
==33454==                                                                                                                                                                                                                    
Fluent Bit v2.0.0                                                                                                                                                                                                            
* Copyright (C) 2015-2022 The Fluent Bit Authors                                                                                                                                                                             
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd                                                                                                                                                             
* https://fluentbit.io                                                                                                                                                                                                       
                                                                                                                                                                                                                             
[2022/08/19 21:27:33] [ info] [fluent bit] version=2.0.0, commit=2dc5ab4b25, pid=33454                                                                                                                                       
[2022/08/19 21:27:33] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128                                                                                                   
[2022/08/19 21:27:33] [ info] [cmetrics] version=0.3.5                                                                                                                                                                       
[2022/08/19 21:27:33] [ info] [input:mqtt:mqtt.0] listening on 0.0.0.0:1883                                                                                                                                                  
[2022/08/19 21:27:33] [ info] TensorFlow Lite interpreter created!                                                                                                                                                           
[2022/08/19 21:27:33] [ info] [filter:tensorflow:tensorflow.0] ===== input #1 =====                                                                                                                                          
[2022/08/19 21:27:33] [ info] [filter:tensorflow:tensorflow.0] type: FLOAT32 dimensions: {1, 224, 224, 3}                                                                                                                    
[2022/08/19 21:27:33] [ info] [filter:tensorflow:tensorflow.0] ===== output #1 ====                                                                                                                                          
[2022/08/19 21:27:33] [ info] [filter:tensorflow:tensorflow.0] type: FLOAT32 dimensions: {1, 2}                                                                                                                              
[2022/08/19 21:27:33] [ info] [sp] stream processor started
[2022/08/19 21:27:33] [ info] [output:stdout:stdout.0] worker #0 started
==33454== Thread 2 flb-pipeline:
==33454== Source and destination overlap in memcpy_chk(0x61356f0, 0x61356f0, 4)
==33454==    at 0x4843BF0: __memcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33454==    by 0x50B1EBB: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B23AC: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B29C0: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x48634DE: __pthread_once_slow (pthread_once.c:116)
==33454==    by 0x50AE29A: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AC5D: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500ADD8: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AE2C: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008B37: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008D04: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x4DAA96E: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454== 
==33454== Source and destination overlap in memcpy_chk(0x61356f0, 0x61356f0, 4)
==33454==    at 0x4843BF0: __memcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33454==    by 0x50B1EBB: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B23FC: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B29CC: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x48634DE: __pthread_once_slow (pthread_once.c:116)
==33454==    by 0x50AE29A: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AC5D: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500ADD8: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AE2C: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008B37: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008D04: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x4DAA96E: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454== 
==33454== Source and destination overlap in memcpy_chk(0x61356f0, 0x61356f0, 4)
==33454==    at 0x4843BF0: __memcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33454==    by 0x50B1EBB: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B244F: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B2A44: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x48634DE: __pthread_once_slow (pthread_once.c:116)
==33454==    by 0x50AE29A: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AC5D: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500ADD8: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AE2C: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008B37: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008D04: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x4DAA96E: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454== 
==33454== Source and destination overlap in memcpy_chk(0x61356f0, 0x61356f0, 4)
==33454==    at 0x4843BF0: __memcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33454==    by 0x50B1EBB: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B248F: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x50B2A69: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x48634DE: __pthread_once_slow (pthread_once.c:116)
==33454==    by 0x50AE29A: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AC5D: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500ADD8: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x500AE2C: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008B37: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x5008D04: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454==    by 0x4DAA96E: ??? (in /usr/lib/libtensorflowlite_c.so)
==33454== 
==33454== Warning: client switching stacks?  SP change: 0x77f39d8 --> 0x560a4b0
==33454==          to suppress, use: --max-stackframe=35558696 or greater
==33454== Warning: client switching stacks?  SP change: 0x560a408 --> 0x77f39d8
==33454==          to suppress, use: --max-stackframe=35558864 or greater
==33454== Warning: client switching stacks?  SP change: 0x77f39d8 --> 0x560a408
==33454==          to suppress, use: --max-stackframe=35558864 or greater
==33454==          further instances of this message will not be shown.
[0] mqtt.local: [1660944471.140997268, {"inference_time"=>2.261195, "output"=>[0.878906, 0.121094]}]
^C[2022/08/19 21:27:56] [engine] caught signal (SIGINT)
[2022/08/19 21:27:56] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/19 21:27:56] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/19 21:27:56] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/08/19 21:27:56] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==33454== 
==33454== HEAP SUMMARY:
==33454==     in use at exit: 107,298 bytes in 3,661 blocks
==33454==   total heap usage: 8,706 allocs, 5,045 frees, 907,508,073 bytes allocated
==33454== 
==33454== LEAK SUMMARY:
==33454==    definitely lost: 0 bytes in 0 blocks
==33454==    indirectly lost: 0 bytes in 0 blocks
==33454==      possibly lost: 0 bytes in 0 blocks
==33454==    still reachable: 107,298 bytes in 3,661 blocks
==33454==         suppressed: 0 bytes in 0 blocks
==33454== Reachable blocks (those to which a pointer was found) are not shown.
==33454== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==33454== 
==33454== For lists of detected and suppressed errors, rerun with: -s
==33454== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
