### PR TITLE
filter_nest: check if flb_strndup returns NULL

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -103,6 +103,11 @@ static int configure(struct filter_nest_ctx *ctx,
             }
 
             wildcard->key = flb_strndup(kv->val, flb_sds_len(kv->val));
+            if (wildcard->key == NULL) {
+                flb_errno();
+                flb_free(wildcard);
+                return -1;
+            }
             wildcard->key_len = flb_sds_len(kv->val);
 
             if (wildcard->key[wildcard->key_len - 1] == '*') {


### PR DESCRIPTION
See also: https://github.com/fluent/fluent-bit/issues/5103

This patch is to check if flb_strndup returns NULL.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    Name mem
    Tag  mem.local

[OUTPUT]
    Name  stdout
    Match *

[FILTER]
    Name nest
    Match *
    Operation nest
    Wildcard Mem.*
    Nest_under Memstats
    Remove_prefix Mem.
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/15 20:22:40] [ info] [fluent bit] version=1.9.3, commit=7a03451b38, pid=3791
[2022/04/15 20:22:40] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/15 20:22:40] [ info] [cmetrics] version=0.3.0
[2022/04/15 20:22:40] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/15 20:22:40] [ info] [sp] stream processor started
[0] mem.local: [1650021760.284527961, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8143076, "used"=>2485640, "free"=>5657436}}]
[0] mem.local: [1650021761.284461265, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8143076, "used"=>2485640, "free"=>5657436}}]
^C[2022/04/15 20:22:42] [engine] caught signal (SIGINT)
[0] mem.local: [1650021762.284671575, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8143076, "used"=>2485640, "free"=>5657436}}]
[2022/04/15 20:22:42] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/15 20:22:43] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/15 20:22:43] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/15 20:22:43] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==3795== Memcheck, a memory error detector
==3795== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3795== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==3795== Command: bin/fluent-bit -c a.conf
==3795== 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/15 20:23:15] [ info] [fluent bit] version=1.9.3, commit=7a03451b38, pid=3795
[2022/04/15 20:23:15] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/15 20:23:15] [ info] [cmetrics] version=0.3.0
[2022/04/15 20:23:15] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/15 20:23:15] [ info] [sp] stream processor started
[0] mem.local: [1650021796.308272085, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8143076, "used"=>2587844, "free"=>5555232}}]
^C[2022/04/15 20:23:17] [engine] caught signal (SIGINT)
[0] mem.local: [1650021797.307386694, {"Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Memstats"=>{"total"=>8143076, "used"=>2588600, "free"=>5554476}}]
[2022/04/15 20:23:17] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/15 20:23:18] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/15 20:23:18] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/15 20:23:18] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==3795== 
==3795== HEAP SUMMARY:
==3795==     in use at exit: 0 bytes in 0 blocks
==3795==   total heap usage: 1,192 allocs, 1,192 frees, 897,876 bytes allocated
==3795== 
==3795== All heap blocks were freed -- no leaks are possible
==3795== 
==3795== For lists of detected and suppressed errors, rerun with: -s
==3795== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
