### PR TITLE
filter_grep: check if flb_strndup returns NULL

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -113,6 +113,13 @@ static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
         /* Get remaining content (regular expression) */
         sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
         rule->regex_pattern = flb_strndup(sentry->value, sentry->len);
+        if (rule->regex_pattern == NULL) {
+            flb_errno();
+            delete_rules(ctx);
+            flb_free(rule);
+            flb_utils_split_free(split);
+            return -1;
+        }
 
         /* Release split */
         flb_utils_split_free(split);


### PR DESCRIPTION
See also: https://github.com/fluent/fluent-bit/issues/5103

This patch is to check if flb_strndup returns NULL.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"log":"\"protocol\":\"HTTP2\""}
#    Dummy {"log":"\"path\":\"-\""}

[FILTER]
    Name    grep
    Match   *
#    Exclude log \"path\"\s*:\s*\"-\"
    Regex   log \"protocol\"\s*:\s*\"HTTP

[OUTPUT]
    Name stdout
    Match *
```

## Debug output

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/15 21:25:11] [ info] [fluent bit] version=1.9.3, commit=7a03451b38, pid=4009
[2022/04/15 21:25:11] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/15 21:25:11] [ info] [cmetrics] version=0.3.0
[2022/04/15 21:25:11] [ info] [sp] stream processor started
[2022/04/15 21:25:11] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1650025512.284942543, {"log"=>""protocol":"HTTP2""}]
^C[2022/04/15 21:25:13] [engine] caught signal (SIGINT)
[0] dummy.0: [1650025513.285857235, {"log"=>""protocol":"HTTP2""}]
[2022/04/15 21:25:13] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/15 21:25:14] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/15 21:25:14] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/15 21:25:14] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==4013== Memcheck, a memory error detector
==4013== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4013== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4013== Command: bin/fluent-bit -c a.conf
==4013== 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/15 21:25:38] [ info] [fluent bit] version=1.9.3, commit=7a03451b38, pid=4013
[2022/04/15 21:25:38] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/15 21:25:38] [ info] [cmetrics] version=0.3.0
[2022/04/15 21:25:38] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/15 21:25:38] [ info] [sp] stream processor started
[0] dummy.0: [1650025539.312438299, {"log"=>""protocol":"HTTP2""}]
^C[2022/04/15 21:25:40] [engine] caught signal (SIGINT)
[0] dummy.0: [1650025540.307504140, {"log"=>""protocol":"HTTP2""}]
[2022/04/15 21:25:40] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/15 21:25:41] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/15 21:25:41] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/15 21:25:41] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==4013== 
==4013== HEAP SUMMARY:
==4013==     in use at exit: 0 bytes in 0 blocks
==4013==   total heap usage: 1,230 allocs, 1,230 frees, 935,001 bytes allocated
==4013== 
==4013== All heap blocks were freed -- no leaks are possible
==4013== 
==4013== For lists of detected and suppressed errors, rerun with: -s
==4013== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
