### PR TITLE
tests: runtime: in_forward: add test for in_forward

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ if(FLB_OUT_LIB)
   FLB_RT_TEST(FLB_IN_DUMMY_THREAD  "in_dummy_thread.c")
   FLB_RT_TEST(FLB_IN_RANDOM        "in_random.c")
   FLB_RT_TEST(FLB_IN_TAIL          "in_tail.c")
+  FLB_RT_TEST(FLB_IN_FORWARD       "in_forward.c")
 endif()
 
 # Filter Plugins

--- a/tests/runtime/in_forward.c
+++ b/tests/runtime/in_forward.c
@@ -1,0 +1,473 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef FLB_HAVE_UNIX_SOCKET
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+#include <fcntl.h>
+#include "flb_tests_runtime.h"
+
+struct test_ctx {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd (unused) */
+    int o_ffd;         /* Output fd */
+};
+
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+static int create_simple_json(char **out_buf, size_t *size)
+{
+    int root_type;
+    int ret;
+    char json[] = "[\"test\", 1234567890,{\"test\":\"msg\"} ]";
+
+    ret = flb_pack_json(&json[0], strlen(json), out_buf, size, &root_type);
+    TEST_CHECK(ret==0);
+
+    return ret;
+}
+
+
+/* Callback to check expected results */
+static int cb_check_result_json(void *record, size_t size, void *data)
+{
+    char *p;
+    char *expected;
+    char *result;
+    int num = get_output_num();
+
+    set_output_num(num+1);
+
+    expected = (char *) data;
+    result = (char *) record;
+
+    p = strstr(result, expected);
+    TEST_CHECK(p != NULL);
+
+    if (p==NULL) {
+        flb_error("Expected to find: '%s' in result '%s'",
+                  expected, result);
+    }
+    /*
+     * If you want to debug your test
+     *
+     * printf("Expect: '%s' in result '%s'", expected, result);
+     */
+    flb_free(record);
+    return 0;
+}
+
+static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int o_ffd;
+    struct test_ctx *ctx = NULL;
+
+    ctx = flb_malloc(sizeof(struct test_ctx));
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("malloc failed");
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "forward", NULL);
+    TEST_CHECK(i_ffd >= 0);
+    ctx->i_ffd = i_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    ctx->o_ffd = o_ffd;
+
+    return ctx;
+}
+
+static void test_ctx_destroy(struct test_ctx *ctx)
+{
+    TEST_CHECK(ctx != NULL);
+
+    sleep(1);
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_PORT 24224
+static int connect_tcp(char *in_host, int in_port)
+{
+    int port = in_port;
+    char *host = in_host;
+    int fd;
+    int ret;
+    struct sockaddr_in addr;
+
+    if (host == NULL) {
+        host = DEFAULT_HOST;
+    }
+    if (port < 0) {
+        port = DEFAULT_PORT;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    fd = socket(PF_INET, SOCK_STREAM, 0);
+    if (!TEST_CHECK(fd >= 0)) {
+        TEST_MSG("failed to socket. host=%s port=%d errno=%d", host, port, errno);
+        return -1;
+    }
+
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr(host);
+    addr.sin_port = htons(port);
+
+    ret = connect(fd, (const struct sockaddr *)&addr, sizeof(addr));
+    if (!TEST_CHECK(ret >= 0)) {
+        TEST_MSG("failed to connect. host=%s port=%d errno=%d", host, port, errno);
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+void flb_test_forward()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+
+    char *buf;
+    size_t size;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "test",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* use default host/port */
+    fd = connect_tcp(NULL, -1);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+    create_simple_json(&buf, &size);
+    w_size = send(fd, buf, size, 0);
+    flb_free(buf);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    close(fd);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_forward_port()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+
+    int fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+    char *port = "24000";
+
+    char *buf;
+    size_t size;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "port", port,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "test",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* use default host */
+    fd = connect_tcp(NULL, atoi(port));
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    create_simple_json(&buf, &size);
+    w_size = send(fd, buf, size, 0);
+    flb_free(buf);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    close(fd);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_tag_prefix()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    char *tag_prefix = "tag_";
+    int fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+
+    char *buf;
+    size_t size;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "tag_prefix", tag_prefix,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "tag_test", /*tag_prefix + "test"*/
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* use default host/port */
+    fd = connect_tcp(NULL, -1);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    create_simple_json(&buf, &size);
+    w_size = send(fd, buf, size, 0);
+    flb_free(buf);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    close(fd);
+    test_ctx_destroy(ctx);
+}
+
+#ifdef FLB_HAVE_UNIX_SOCKET
+void flb_test_unix_path()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct sockaddr_un sun;
+    int fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+    char *unix_path = "in_forward_unix";
+
+    char *buf;
+    size_t size;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "unix_path", unix_path,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "test",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* waiting to create socket */
+    flb_time_msleep(200); 
+
+    memset(&sun, 0, sizeof(sun));
+    fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+    if (!TEST_CHECK(fd >= 0)) {
+        TEST_MSG("failed to socket %s, errno=%d", unix_path, errno);
+        unlink(unix_path);
+        exit(EXIT_FAILURE);
+    }
+
+    sun.sun_family = AF_LOCAL;
+    strcpy(sun.sun_path, unix_path);
+    ret = connect(fd, (const struct sockaddr *)&sun, sizeof(sun));
+    if (!TEST_CHECK(ret >= 0)) {
+        TEST_MSG("failed to connect, errno=%d", errno);
+        close(fd);
+        unlink(unix_path);
+        exit(EXIT_FAILURE);
+    }
+    create_simple_json(&buf, &size);
+    w_size = send(fd, buf, size, 0);
+    flb_free(buf);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to write to %s", unix_path);
+        close(fd);
+        unlink(unix_path);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    close(fd);
+    test_ctx_destroy(ctx);
+}
+#endif /* FLB_HAVE_UNIX_SOCKET */
+
+
+TEST_LIST = {
+    {"forward", flb_test_forward},
+    {"forward_port", flb_test_forward_port},
+    {"tag_prefix", flb_test_tag_prefix},
+#ifdef FLB_HAVE_UNIX_SOCKET
+    {"unix_path", flb_test_unix_path},
+#endif
+    {NULL, NULL}
+};
+


### PR DESCRIPTION
This patch is to add test code for in_forward.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-in_forward 
Test forward...                                 [2022/04/16 20:41:00] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/04/16 20:41:03] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/04/16 20:41:06] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/04/16 20:41:09] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_forward 
==61108== Memcheck, a memory error detector
==61108== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==61108== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==61108== Command: bin/flb-rt-in_forward
==61108== 
Test forward...                                 [2022/04/16 20:41:34] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/04/16 20:41:38] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/04/16 20:41:40] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/04/16 20:41:44] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
==61108== 
==61108== HEAP SUMMARY:
==61108==     in use at exit: 0 bytes in 0 blocks
==61108==   total heap usage: 4,141 allocs, 4,141 frees, 6,278,409 bytes allocated
==61108== 
==61108== All heap blocks were freed -- no leaks are possible
==61108== 
==61108== For lists of detected and suppressed errors, rerun with: -s
==61108== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
