### PR TITLE
filter_nightfall: add input instance to filter callback

### DIFF
--- a/plugins/filter_nightfall/nightfall.c
+++ b/plugins/filter_nightfall/nightfall.c
@@ -456,11 +456,13 @@ static int cb_nightfall_filter(const void *data, size_t bytes,
                                const char *tag, int tag_len,
                                void **out_buf, size_t *out_size,
                                struct flb_filter_instance *f_ins,
+                               struct flb_input_instance *i_ins,
                                void *context,
                                struct flb_config *config)
 {
     struct flb_filter_nightfall *ctx = context;
     (void) f_ins;
+    (void) i_ins;
     (void) config;
     int ret;
     char is_modified = FLB_FALSE;


### PR DESCRIPTION
A patch https://github.com/fluent/fluent-bit/pull/4671 modified filter callback api.
This patch is to modify filter callback for filter_nightfall.

Cc @PettitWesley 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
