### PR TITLE
workflows: prevent re-trigger of generation workflow on its own changes

### DIFF
--- a/.github/workflows/docs-generate.yaml
+++ b/.github/workflows/docs-generate.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+    # Do not re-trigger when our own PRs are merged
+    paths-ignore:
+      - codebase-structure.svg
 jobs:
   update_diagram:
     name: Update the codebase structure diagram
@@ -17,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Update diagram
-        # TODO: still not "official" enough for a proper semantic release version
+        # Not "official" enough for a proper semantic release version
         uses: githubocto/repo-visualizer@main
         with:
           excluded_paths: "ignore,.github"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolve a loop of running every time it commits a change it made.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
