### PR TITLE
codeowners: update in_docker owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@
 /appveyor.yml            @niedbalski @patrick-stephens
 /dockerfiles/            @niedbalski @patrick-stephens
 /packaging/              @niedbalski @patrick-stephens
+/codebase-structure.svg  @niedbalski @patrick-stephens
 
 # Core: Signv4
 # ------------
@@ -39,7 +40,7 @@
 # Input Plugins
 # -------------
 /plugins/in_collectd     @fujimotos
-/plugins/in_docker       @ashutoshdhundhara
+/plugins/in_docker       @nokute78 @edsiper
 /plugins/in_dummy        @nokute78
 /plugins/in_netif        @nokute78
 /plugins/in_statsd       @fujimotos


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Fixes #5347 as that referenced a username that no longer seems to exist.
Picked @nokute78 and @edsiper mostly because they have commits to it recently.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
