### PR TITLE
input: close event channel on destroy

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -526,6 +526,14 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
         flb_hash_destroy(ins->ht_metric_chunks);
     }
 
+    if (ins->ch_events[0] > 0) {
+        mk_event_closesocket(ins->ch_events[0]);
+    }
+
+    if (ins->ch_events[1] > 0) {
+        mk_event_closesocket(ins->ch_events[1]);
+    }
+
     /* Unlink and release */
     mk_list_del(&ins->_head);
 


### PR DESCRIPTION
This patch is to close event channels of input instance.
(I found this when I created the patch https://github.com/fluent/fluent-bit/pull/5350) 

Note: The event channels of output instance are closed on destroy handler.
https://github.com/fluent/fluent-bit/blob/v1.9.2/src/flb_output.c#L277-L283

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

I tested in_tcp since in_tcp created event channels.
```
fluent-bit -i tcp -o stdout
```


## Debug log

I sent JSON using `echo '{"aa":"hoge", "bb":"moge"}' | nc localhost 5170`.

```
$ bin/fluent-bit -i tcp -o stdout
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/23 10:34:07] [ info] [fluent bit] version=1.9.3, commit=9ca777d10f, pid=48244
[2022/04/23 10:34:07] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/23 10:34:07] [ info] [cmetrics] version=0.3.1
[2022/04/23 10:34:07] [ info] [input:tcp:tcp.0] listening on 0.0.0.0:5170
[2022/04/23 10:34:07] [ info] [sp] stream processor started
[2022/04/23 10:34:07] [ info] [output:stdout:stdout.0] worker #0 started
[0] tcp.0: [1650677659.719383936, {"aa"=>"hoge", "bb"=>"moge"}]
^C[2022/04/23 10:34:21] [engine] caught signal (SIGINT)
[2022/04/23 10:34:21] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/23 10:34:21] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/23 10:34:21] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/23 10:34:21] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i tcp -o stdout
==48255== Memcheck, a memory error detector
==48255== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==48255== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==48255== Command: bin/fluent-bit -i tcp -o stdout
==48255== 
Fluent Bit v1.9.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/04/23 10:35:46] [ info] [fluent bit] version=1.9.3, commit=9ca777d10f, pid=48255
[2022/04/23 10:35:46] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/23 10:35:46] [ info] [cmetrics] version=0.3.1
[2022/04/23 10:35:46] [ info] [input:tcp:tcp.0] listening on 0.0.0.0:5170
[2022/04/23 10:35:46] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/23 10:35:46] [ info] [sp] stream processor started
[0] tcp.0: [1650677749.023532051, {"aa"=>"hoge", "bb"=>"moge"}]
^C[2022/04/23 10:35:52] [engine] caught signal (SIGINT)
[2022/04/23 10:35:52] [ warn] [engine] service will shutdown in max 5 seconds
[2022/04/23 10:35:52] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/23 10:35:52] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/23 10:35:52] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==48255== 
==48255== HEAP SUMMARY:
==48255==     in use at exit: 0 bytes in 0 blocks
==48255==   total heap usage: 1,080 allocs, 1,080 frees, 685,538 bytes allocated
==48255== 
==48255== All heap blocks were freed -- no leaks are possible
==48255== 
==48255== For lists of detected and suppressed errors, rerun with: -s
==48255== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
