### PR TITLE
tests: runtime: in_forward: use socket wrapper

### DIFF
--- a/tests/runtime/in_forward.c
+++ b/tests/runtime/in_forward.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_socket.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef FLB_HAVE_UNIX_SOCKET
@@ -150,11 +151,11 @@ static void test_ctx_destroy(struct test_ctx *ctx)
 
 #define DEFAULT_HOST "127.0.0.1"
 #define DEFAULT_PORT 24224
-static int connect_tcp(char *in_host, int in_port)
+static flb_sockfd_t connect_tcp(char *in_host, int in_port)
 {
     int port = in_port;
     char *host = in_host;
-    int fd;
+    flb_sockfd_t fd;
     int ret;
     struct sockaddr_in addr;
 
@@ -179,7 +180,7 @@ static int connect_tcp(char *in_host, int in_port)
     ret = connect(fd, (const struct sockaddr *)&addr, sizeof(addr));
     if (!TEST_CHECK(ret >= 0)) {
         TEST_MSG("failed to connect. host=%s port=%d errno=%d", host, port, errno);
-        close(fd);
+        flb_socket_close(fd);
         return -1;
     }
     return fd;
@@ -189,7 +190,7 @@ void flb_test_forward()
 {
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
-    int fd;
+    flb_sockfd_t fd;
     int ret;
     int num;
     ssize_t w_size;
@@ -228,7 +229,7 @@ void flb_test_forward()
     flb_free(buf);
     if (!TEST_CHECK(w_size == size)) {
         TEST_MSG("failed to send, errno=%d", errno);
-        close(fd);
+        flb_socket_close(fd);
         exit(EXIT_FAILURE);
     }
 
@@ -240,7 +241,7 @@ void flb_test_forward()
         TEST_MSG("no outputs");
     }
 
-    close(fd);
+    flb_socket_close(fd);
     test_ctx_destroy(ctx);
 }
 
@@ -249,7 +250,7 @@ void flb_test_forward_port()
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
 
-    int fd;
+    flb_sockfd_t fd;
     int ret;
     int num;
     ssize_t w_size;
@@ -295,7 +296,7 @@ void flb_test_forward_port()
     flb_free(buf);
     if (!TEST_CHECK(w_size == size)) {
         TEST_MSG("failed to send, errno=%d", errno);
-        close(fd);
+        flb_socket_close(fd);
         exit(EXIT_FAILURE);
     }
 
@@ -307,7 +308,7 @@ void flb_test_forward_port()
         TEST_MSG("no outputs");
     }
 
-    close(fd);
+    flb_socket_close(fd);
     test_ctx_destroy(ctx);
 }
 
@@ -316,7 +317,7 @@ void flb_test_tag_prefix()
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     char *tag_prefix = "tag_";
-    int fd;
+    flb_sockfd_t fd;
     int ret;
     int num;
     ssize_t w_size;
@@ -360,7 +361,7 @@ void flb_test_tag_prefix()
     flb_free(buf);
     if (!TEST_CHECK(w_size == size)) {
         TEST_MSG("failed to send, errno=%d", errno);
-        close(fd);
+        flb_socket_close(fd);
         exit(EXIT_FAILURE);
     }
 
@@ -372,7 +373,7 @@ void flb_test_tag_prefix()
         TEST_MSG("no outputs");
     }
 
-    close(fd);
+    flb_socket_close(fd);
     test_ctx_destroy(ctx);
 }
 
@@ -382,7 +383,7 @@ void flb_test_unix_path()
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     struct sockaddr_un sun;
-    int fd;
+    flb_sockfd_t fd;
     int ret;
     int num;
     ssize_t w_size;
@@ -433,7 +434,7 @@ void flb_test_unix_path()
     ret = connect(fd, (const struct sockaddr *)&sun, sizeof(sun));
     if (!TEST_CHECK(ret >= 0)) {
         TEST_MSG("failed to connect, errno=%d", errno);
-        close(fd);
+        flb_socket_close(fd);
         unlink(unix_path);
         exit(EXIT_FAILURE);
     }
@@ -442,7 +443,7 @@ void flb_test_unix_path()
     flb_free(buf);
     if (!TEST_CHECK(w_size == size)) {
         TEST_MSG("failed to write to %s", unix_path);
-        close(fd);
+        flb_socket_close(fd);
         unlink(unix_path);
         exit(EXIT_FAILURE);
     }
@@ -455,7 +456,7 @@ void flb_test_unix_path()
         TEST_MSG("no outputs");
     }
 
-    close(fd);
+    flb_socket_close(fd);
     test_ctx_destroy(ctx);
 }
 #endif /* FLB_HAVE_UNIX_SOCKET */


### PR DESCRIPTION
We should use `flb_sockfd_t` and `flb_socket_close` for compatibility.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-in_forward 
Test forward...                                 [2022/04/24 07:33:59] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/04/24 07:34:02] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/04/24 07:34:05] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/04/24 07:34:08] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_forward 
==6265== Memcheck, a memory error detector
==6265== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==6265== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==6265== Command: bin/flb-rt-in_forward
==6265== 
Test forward...                                 [2022/04/24 07:34:35] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/04/24 07:34:38] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/04/24 07:34:41] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/04/24 07:34:44] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
==6265== 
==6265== HEAP SUMMARY:
==6265==     in use at exit: 0 bytes in 0 blocks
==6265==   total heap usage: 4,145 allocs, 4,145 frees, 6,279,205 bytes allocated
==6265== 
==6265== All heap blocks were freed -- no leaks are possible
==6265== 
==6265== For lists of detected and suppressed errors, rerun with: -s
==6265== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
