### PR TITLE
config: enable YAML support by default

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.os == 'ubuntu-18.04'
         run: |
           sudo apt update
-          sudo apt install -yyq gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr
+          sudo apt install -yyq gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev
           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
       - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ option(FLB_PROXY_GO           "Enable Go plugins support"   Yes)
 # Built-in Custom Plugins
 option(FLB_CUSTOM_CALYPTIA    "Enable Calyptia Support"      Yes)
 
+# Config formats
+option(FLB_CONFIG_YAML        "Enable YAML config format"    Yes)
+
 # Built-in Plugins
 option(FLB_IN_CPU             "Enable CPU input plugin"             Yes)
 option(FLB_IN_THERMAL         "Enable Thermal plugin"               Yes)
@@ -654,14 +657,25 @@ if(FLB_HAVE_UNIX_SOCKET)
   FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
 endif()
 
-# libyaml support
+# Configuration file YAML format support
+if(FLB_CONFIG_YAML)
+# Requies libyaml support
 check_c_source_compiles("
   #include <yaml.h>
   int main() {
     yaml_parser_t parser;
     return 0;
   }" FLB_HAVE_LIBYAML)
-if(FLB_HAVE_LIBYAML)
+
+  if(NOT FLB_HAVE_LIBYAML)
+    message(FATAL_ERROR
+      "YAML development dependencies required for YAML configuration format handling.\n"
+      "This is a build time dependency, you can either install the "
+      "dependencies or disable the feature setting the CMake option "
+      "-DFLB_CONFIG_YAML=Off ."
+      )
+  endif()
+
   FLB_DEFINITION(FLB_HAVE_LIBYAML)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,8 @@ endif()
 
 if (FLB_TESTS_OSSFUZZ)
   FLB_DEFINITION(FLB_HAVE_TESTS_OSSFUZZ)
+  # Disable for fuzz testing
+  set(FLB_CONFIG_YAML Off)
 endif()
 
 # Set Fluent Bit dependency libraries path

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -14,6 +14,7 @@ if(FLB_WINDOWS_DEFAULTS)
   set(FLB_AWS                   Yes)
   set(FLB_HTTP_SERVER           Yes)
   set(FLB_METRICS               Yes)
+  set(FLB_CONFIG_YAML           No)
 
   # INPUT plugins
   # =============

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -7,7 +7,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
-                   postgresql-libs postgresql-devel postgresql-server postgresql && \
+                   postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3

--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -604,7 +604,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         key_len = i;
 
         if (!key || i < 0) {
-            config_error(cfg_file, line, "undefined key");
+            config_error(cfg_file, line, "undefined key - check config is in valid classic format");
             goto error;
         }
 


### PR DESCRIPTION
Addresses #5308 by adding a slight hint in the error message and also enabling YAML support by default.

Fuzzing will fail until we handle the dependency as a static one for https://github.com/fluent/fluent-bit/blob/master/tests/internal/fuzzers/CMakeLists.txt#L49. Therefore we disable YAML support explicitly for now to ensure fuzzing still passes.
Windows needs a solution for the lib-yaml dependency so is explicitly disabled: it is already disabled just implicitly so this makes it clear.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
