### PR TITLE
workflows: fix integration tests secrets vars

### DIFF
--- a/.github/workflows/master-integration-test.yaml
+++ b/.github/workflows/master-integration-test.yaml
@@ -27,6 +27,6 @@ jobs:
       image_tag: x86_64
     secrets:
       opensearch_aws_access_id: ${{ secrets.OPENSEARCH_AWS_ACCESS_ID }}
-      opensearch_aws_access_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
+      opensearch_aws_secret_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
       opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
       terraform_api_password: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/pr-integration-test.yaml
+++ b/.github/workflows/pr-integration-test.yaml
@@ -49,7 +49,7 @@ jobs:
       image_tag: ${{ github.sha }}
     secrets:
       opensearch_aws_access_id: ${{ secrets.OPENSEARCH_AWS_ACCESS_ID }}
-      opensearch_aws_access_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
+      opensearch_aws_secret_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
       opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
       terraform_api_password: ${{ secrets.TF_API_TOKEN }}
 

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -39,7 +39,7 @@ jobs:
       image_tag: latest
     secrets:
       opensearch_aws_access_id: ${{ secrets.OPENSEARCH_AWS_ACCESS_ID }}
-      opensearch_aws_access_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
+      opensearch_aws_secret_key: ${{ secrets.OPENSEARCH_AWS_SECRET_KEY }}
       opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
       terraform_api_password: ${{ secrets.TF_API_TOKEN }}
 


### PR DESCRIPTION
Fix typo secret variable passed to the workflow from _access_key to secret_key.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
