### PR TITLE
in_systemd: Don't insert rows if flb_sqldb_query fails

### DIFF
--- a/plugins/in_systemd/systemd_db.c
+++ b/plugins/in_systemd/systemd_db.c
@@ -137,6 +137,10 @@ int flb_systemd_db_init_cursor(struct flb_systemd_config *ctx, const char *curso
     ret = flb_sqldb_query(ctx->db,
                           SQL_GET_CURSOR, cb_cursor_check, &qs);
 
+    if (ret != FLB_OK) {
+        return -1;
+    }
+
     if (qs.rows == 0) {
         /* Register the cursor */
         snprintf(query, sizeof(query) - 1,


### PR DESCRIPTION
This can potentially cause an issue where a new row is
inserted into in_systemd_cursor table and in_systemd_cursor
table can now have more than one row. Once multiple rows
exist in the table, this then causes a memory leak as
strdup will be called for each row to set qs.cursor in
cb_cursor_check, however qs.cursor will only be freed once.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
