### PR TITLE
tests: runtime: remove warnings

### DIFF
--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/tests/runtime/filter_rewrite_tag.c
+++ b/tests/runtime/filter_rewrite_tag.c
@@ -38,52 +38,6 @@ struct expect_str {
 pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 int  num_output = 0;
 
-/* Callback to check expected results */
-static int cb_check_result(void *record, size_t size, void *data)
-{
-    char *p;
-    char *result;
-    struct expect_str *expected;
-
-    expected = (struct expect_str*)data;
-    result = (char *) record;
-
-    if (!TEST_CHECK(expected != NULL)) {
-        flb_error("expected is NULL");
-    }
-    if (!TEST_CHECK(result != NULL)) {
-        flb_error("result is NULL");
-    }
-
-    while(expected != NULL && expected->str != NULL) {
-        if (expected->found == FLB_TRUE) {
-            p = strstr(result, expected->str);
-            if(!TEST_CHECK(p != NULL)) {
-                flb_error("Expected to find: '%s' in result '%s'",
-                          expected->str, result);
-            }
-        }
-        else {
-            p = strstr(result, expected->str);
-            if(!TEST_CHECK(p == NULL)) {
-                flb_error("'%s' should be removed in result '%s'",
-                          expected->str, result);
-            }
-        }
-
-        /*
-         * If you want to debug your test
-         *
-         * printf("Expect: '%s' in result '%s'", expected, result);
-         */
-
-        expected++;
-    }
-
-    flb_free(record);
-    return 0;
-}
-
 static int cb_count_msgpack(void *record, size_t size, void *data)
 {
     msgpack_unpacked result;


### PR DESCRIPTION
This patch is to suppress below warnings.
#5171 

filter_lua:
```
[ 87%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_lua.dir/filter_lua.c.o
/home/taka/git/fluent-bit/tests/runtime/filter_lua.c: In function ‘flb_test_drop_all_records’:
/home/taka/git/fluent-bit/tests/runtime/filter_lua.c:608:5: warning: implicit declaration of function ‘flb_time_msleep’ [-Wimplicit-function-declaration]
  608 |     flb_time_msleep(1500); /* waiting flush */
```

filter_rewrite_tag:
```
[ 97%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_rewrite_tag.dir/filter_rewrite_tag.c.o
/home/taka/git/WORKTREE/test_in_syslog/tests/runtime/filter_rewrite_tag.c:42:12: warning: ‘cb_check_result’ defined but not used [-Wunused-function]
   42 | static int cb_check_result(void *record, size_t size, void *data)
      |            ^~~~~~~~~~~~~~~
[ 97%] Linking C executable ../../bin/flb-rt-filter_rewrite_tag
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log

```
d$ bin/flb-rt-filter_lua 
Test hello_world...                             [2022/04/29 08:15:25] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21660
[2022/04/29 08:15:25] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:25] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:25] [ info] [sp] stream processor started
[2022/04/29 08:15:25] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:25] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/29 08:15:26] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/29 08:15:26] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/29 08:15:26] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2022/04/29 08:15:26] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21664
[2022/04/29 08:15:26] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:26] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:26] [ info] [sp] stream processor started
[2022/04/29 08:15:27] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:28] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key...                            [2022/04/29 08:15:28] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21667
[2022/04/29 08:15:28] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:28] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:28] [ info] [sp] stream processor started
[2022/04/29 08:15:29] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:30] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key_multi...                      [2022/04/29 08:15:30] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21670
[2022/04/29 08:15:30] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:30] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:30] [ info] [sp] stream processor started
[2022/04/29 08:15:31] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:32] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_array_key...                          [2022/04/29 08:15:32] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21673
[2022/04/29 08:15:32] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:32] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:32] [ info] [sp] stream processor started
[2022/04/29 08:15:33] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:34] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2022/04/29 08:15:34] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21676
[2022/04/29 08:15:34] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:34] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:34] [ info] [sp] stream processor started
[2022/04/29 08:15:35] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:36] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2022/04/29 08:15:36] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21679
[2022/04/29 08:15:36] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:15:36] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:15:36] [ info] [sp] stream processor started
[2022/04/29 08:15:38] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:15:38] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
```

```
$ bin/flb-rt-filter_rewrite_tag 
Test matched...                                 [ OK ]
Test not_matched...                             [ OK ]
Test keep_true...                               [ OK ]
Test heavy_input_pause_emitter...               [ OK ]
Test issue_4518...                              [ OK ]
Test issue_4793...                              [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_lua 
==21682== Memcheck, a memory error detector
==21682== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==21682== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==21682== Command: bin/flb-rt-filter_lua
==21682== 
Test hello_world...                             [2022/04/29 08:16:31] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:31] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:31] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:31] [ info] [output:stdout:stdout.0] worker #0 started
[2022/04/29 08:16:31] [ info] [sp] stream processor started
[2022/04/29 08:16:31] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:32] [ info] [engine] service has stopped (0 pending tasks)
[2022/04/29 08:16:32] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/04/29 08:16:32] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2022/04/29 08:16:33] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:33] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:33] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:33] [ info] [sp] stream processor started
[2022/04/29 08:16:34] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:34] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key...                            [2022/04/29 08:16:34] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:34] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:34] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:34] [ info] [sp] stream processor started
[2022/04/29 08:16:35] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:36] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key_multi...                      [2022/04/29 08:16:36] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:36] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:36] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:36] [ info] [sp] stream processor started
[2022/04/29 08:16:37] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:38] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_array_key...                          [2022/04/29 08:16:38] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:38] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:38] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:38] [ info] [sp] stream processor started
[2022/04/29 08:16:39] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:40] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2022/04/29 08:16:40] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:40] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:40] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:40] [ info] [sp] stream processor started
[2022/04/29 08:16:41] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:42] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2022/04/29 08:16:42] [ info] [fluent bit] version=1.9.4, commit=b687c7e8f8, pid=21682
[2022/04/29 08:16:42] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/04/29 08:16:42] [ info] [cmetrics] version=0.3.1
[2022/04/29 08:16:42] [ info] [sp] stream processor started
[2022/04/29 08:16:44] [ warn] [engine] service will shutdown in max 1 seconds
[2022/04/29 08:16:44] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==21682== 
==21682== HEAP SUMMARY:
==21682==     in use at exit: 0 bytes in 0 blocks
==21682==   total heap usage: 7,619 allocs, 7,619 frees, 3,804,473 bytes allocated
==21682== 
==21682== All heap blocks were freed -- no leaks are possible
==21682== 
==21682== For lists of detected and suppressed errors, rerun with: -s
==21682== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/flb-rt-filter_rewrite_tag 
==21723== Memcheck, a memory error detector
==21723== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==21723== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==21723== Command: bin/flb-rt-filter_rewrite_tag
==21723== 
Test matched...                                 [ OK ]
Test not_matched...                             [ OK ]
Test keep_true...                               [ OK ]
Test heavy_input_pause_emitter...               [ OK ]
Test issue_4518...                              [ OK ]
Test issue_4793...                              [ OK ]
SUCCESS: All unit tests have passed.
==21723== 
==21723== HEAP SUMMARY:
==21723==     in use at exit: 0 bytes in 0 blocks
==21723==   total heap usage: 916,510 allocs, 916,510 frees, 2,049,335,370 bytes allocated
==21723== 
==21723== All heap blocks were freed -- no leaks are possible
==21723== 
==21723== For lists of detected and suppressed errors, rerun with: -s
==21723== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
