### PR TITLE
record_accessor: add append API, flb_ra_append_kv_pair

### DIFF
--- a/include/fluent-bit/flb_ra_key.h
+++ b/include/fluent-bit/flb_ra_key.h
@@ -65,6 +65,8 @@ int flb_ra_key_strcmp(flb_sds_t ckey, msgpack_object map,
 int flb_ra_key_regex_match(flb_sds_t ckey, msgpack_object map,
                            struct mk_list *subkeys, struct flb_regex *regex,
                            struct flb_regex_search *result);
+int flb_ra_key_value_append(struct flb_ra_parser *rp, msgpack_object obj,
+                            msgpack_object *in_val, msgpack_packer *mp_pck);
 int flb_ra_key_value_update(struct flb_ra_parser *rp, msgpack_object obj,
                             msgpack_object *in_key, msgpack_object *in_val,
                             msgpack_packer *mp_pck);

--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -51,6 +51,8 @@ int flb_ra_get_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
 
 struct flb_ra_value *flb_ra_get_value_object(struct flb_record_accessor *ra,
                                              msgpack_object map);
+int flb_ra_append_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
+                          void **out_map, size_t *out_size, msgpack_object *in_val);
 int flb_ra_update_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
                           void **out_map, size_t *out_size,
                           msgpack_object *in_key, msgpack_object *in_val);

--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -547,6 +547,32 @@ int flb_ra_key_value_update(struct flb_ra_parser *rp, msgpack_object map,
     map_size = map.via.map.size;
 
     msgpack_pack_map(mp_pck, map_size);
+    if (levels == 0) {
+        /* no subkeys */
+        for (i=0; i<map_size; i++) {
+            if (i != kv_id) {
+                /* pack original key/val */
+                msgpack_pack_object(mp_pck, map.via.map.ptr[i].key);
+                msgpack_pack_object(mp_pck, map.via.map.ptr[i].val);
+                continue;
+            }
+
+            /* update key/val */
+            if (in_key != NULL) {
+                msgpack_pack_object(mp_pck, *in_key);
+            }
+            else {
+                msgpack_pack_object(mp_pck, map.via.map.ptr[i].key);
+            }
+            if (in_val != NULL) {
+                msgpack_pack_object(mp_pck, *in_val);
+            }
+            else {
+                msgpack_pack_object(mp_pck, map.via.map.ptr[i].val);
+            }
+        }
+        return 0;
+    }
 
     for (i=0; i<map_size; i++) {
         msgpack_pack_object(mp_pck, map.via.map.ptr[i].key);

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -679,7 +679,7 @@ int flb_ra_update_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
         flb_error("%s: no inputs", __FUNCTION__);
         return -1;
     }
-    else if (ra == NULL || out_map == NULL) {
+    else if (ra == NULL || out_map == NULL || out_size == NULL) {
         /* invalid input */
         flb_error("%s: invalid input", __FUNCTION__);
         return -1;

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -708,3 +708,66 @@ int flb_ra_update_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
 
     return 0;
 }
+
+/**
+ *  Add key and/or value of the map using record accessor.
+ *  If key already exists, the API fails.
+ *
+ *  @param ra   the record accessor to specify key.
+ *  @param map  the original map.
+ *  @param in_val   the pointer to add val.
+ *  @param out_map  the updated map. If the API fails, out_map will be NULL.
+ *
+ *  @return result of the API. 0:success, -1:fail
+ */
+
+int flb_ra_append_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
+                          void **out_map, size_t *out_size,
+                          msgpack_object *in_val)
+{
+    struct flb_ra_parser *rp;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    int ret;
+
+    msgpack_object *s_key = NULL;
+    msgpack_object *o_key = NULL;
+    msgpack_object *o_val = NULL;
+
+    if (in_val == NULL) {
+        /* no key and value. nothing to do */
+        flb_error("%s: no value", __FUNCTION__);
+        return -1;
+    }
+    else if (ra == NULL || out_map == NULL|| out_size == NULL) {
+        /* invalid input */
+        flb_error("%s: invalid input", __FUNCTION__);
+        return -1;
+    }
+
+    flb_ra_get_kv_pair(ra, map, &s_key, &o_key, &o_val);
+    if (o_key != NULL && o_val != NULL) {
+        /* key and value already exist */
+        flb_error("%s: already exist", __FUNCTION__);
+        return -1;
+    }
+
+    rp = get_ra_parser(ra);
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    ret = flb_ra_key_value_append(rp, map, in_val, &mp_pck);
+    if (ret < 0) {
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        return -1;
+    }
+
+    *out_map  = mp_sbuf.data;
+    *out_size = mp_sbuf.size;
+
+    return 0;
+}

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -1021,6 +1021,214 @@ void cb_issue_4917()
     msgpack_unpacked_destroy(&result);
 }
 
+void cb_update_root_key()
+{
+    int ret;
+    size_t off = 0;
+    char *json;
+    flb_sds_t fmt;
+    flb_sds_t updated_fmt;
+    char *fmt_out = "updated_key";
+
+
+    char *out_buf = NULL;
+    size_t out_size = 0;
+
+    msgpack_unpacked result;
+    msgpack_unpacked out_result;
+
+    msgpack_object map;
+    msgpack_object *start_key = NULL;
+    msgpack_object *out_key = NULL;
+    msgpack_object *out_val = NULL;
+    void *updated_map;
+    msgpack_object in_key;
+
+    struct flb_record_accessor *ra;
+    struct flb_record_accessor *updated_ra;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\""
+        "}}]}";
+    ret = create_map(json, &map, &out_buf, &result);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed create map");
+        if (out_buf != NULL) {
+            flb_free(out_buf);
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key1");
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$updated_key");
+    updated_ra = flb_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    ret = set_str_to_msgpack_object(fmt_out, &in_key);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to set object");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_ra_update_kv_pair(ra, map, (void**)&updated_map, &out_size, &in_key, NULL);
+    TEST_CHECK(ret == 0);
+    off = 0;
+    msgpack_unpacked_init(&out_result);
+    if (msgpack_unpack_next(&out_result, updated_map, out_size, &off)
+        != MSGPACK_UNPACK_SUCCESS) {
+        TEST_MSG("failed to unpack");
+        exit(EXIT_FAILURE);
+    }
+    ret = flb_ra_get_kv_pair(updated_ra, out_result.data, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        msgpack_object_print(stdout, out_result.data);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(out_key->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_key->via.str.size == strlen(fmt_out));
+    TEST_CHECK(memcmp(out_key->via.str.ptr, fmt_out, strlen(fmt_out)) == 0);
+
+    msgpack_unpacked_destroy(&out_result);
+    msgpack_unpacked_destroy(&result);
+    flb_free(updated_map);
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(updated_ra);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+}
+
+void cb_update_root_key_val()
+{
+    int ret;
+    size_t off = 0;
+    char *json;
+    flb_sds_t fmt;
+    flb_sds_t updated_fmt;
+    char *fmt_out_key = "updated_key";
+    char *fmt_out_val = "updated_val";
+
+    char *out_buf = NULL;
+    size_t out_size = 0;
+
+    msgpack_unpacked result;
+    msgpack_unpacked out_result;
+
+    msgpack_object map;
+    msgpack_object *start_key = NULL;
+    msgpack_object *out_key = NULL;
+    msgpack_object *out_val = NULL;
+    void *updated_map;
+    msgpack_object in_key;
+    msgpack_object in_val;
+
+    struct flb_record_accessor *ra;
+    struct flb_record_accessor *updated_ra;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\""
+        "}}]}";
+    ret = create_map(json, &map, &out_buf, &result);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed create map");
+        if (out_buf != NULL) {
+            flb_free(out_buf);
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key1");
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$updated_key");
+    updated_ra = flb_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    ret = set_str_to_msgpack_object(fmt_out_key, &in_key);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to set object");
+        exit(EXIT_FAILURE);
+    }
+    /* create value object to overwrite */
+    ret = set_str_to_msgpack_object(fmt_out_val, &in_val);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to set object");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_ra_update_kv_pair(ra, map, (void**)&updated_map, &out_size, &in_key, &in_val);
+    TEST_CHECK(ret == 0);
+    off = 0;
+    msgpack_unpacked_init(&out_result);
+    if (msgpack_unpack_next(&out_result, updated_map, out_size, &off)
+        != MSGPACK_UNPACK_SUCCESS) {
+        TEST_MSG("failed to unpack");
+        exit(EXIT_FAILURE);
+    }
+    ret = flb_ra_get_kv_pair(updated_ra, out_result.data, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        msgpack_object_print(stdout, out_result.data);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(out_key->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_key->via.str.size == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key->via.str.ptr, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_val->via.str.size == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->via.str.ptr, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    msgpack_unpacked_destroy(&out_result);
+    msgpack_unpacked_destroy(&result);
+    flb_free(updated_map);
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(updated_ra);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+}
+
 TEST_LIST = {
     { "keys"            , cb_keys},
     { "dash_key"        , cb_dash_key},
@@ -1037,6 +1245,8 @@ TEST_LIST = {
     { "update_key_val", cb_update_key_val},
     { "update_key", cb_update_key},
     { "update_val", cb_update_val},
+    { "update_root_key", cb_update_root_key},
+    { "update_root_key_val", cb_update_root_key_val},
     { "issue_4917"      , cb_issue_4917},
     { NULL }
 };

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -1229,6 +1229,214 @@ void cb_update_root_key_val()
     flb_free(out_buf);
 }
 
+void cb_add_key_val()
+{
+    int ret;
+    size_t off = 0;
+    char *json;
+    flb_sds_t fmt;
+    flb_sds_t updated_fmt;
+    char *fmt_out_key = "add_key";
+    char *fmt_out_val = "add_val";
+
+    char *out_buf = NULL;
+    size_t out_size = 0;
+
+    msgpack_unpacked result;
+    msgpack_unpacked out_result;
+
+    msgpack_object map;
+    msgpack_object *start_key = NULL;
+    msgpack_object *out_key = NULL;
+    msgpack_object *out_val = NULL;
+    void *updated_map;
+    msgpack_object in_val;
+
+    struct flb_record_accessor *ra;
+    struct flb_record_accessor *updated_ra;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\""
+        "}}]}";
+    ret = create_map(json, &map, &out_buf, &result);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed create map");
+        if (out_buf != NULL) {
+            flb_free(out_buf);
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['add_key']");
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$kubernetes[2]['annotations']['add_key']");
+    updated_ra = flb_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create value object to overwrite */
+    ret = set_str_to_msgpack_object(fmt_out_val, &in_val);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to set object");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Add key/value */
+    ret = flb_ra_append_kv_pair(ra, map, (void**)&updated_map, &out_size, &in_val);
+    TEST_CHECK(ret == 0);
+
+    off = 0;
+    msgpack_unpacked_init(&out_result);
+    ret = msgpack_unpack_next(&out_result, updated_map, out_size, &off);
+    if (!TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("failed to unpack");
+        exit(EXIT_FAILURE);
+    }
+    ret = flb_ra_get_kv_pair(updated_ra, out_result.data, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("print out_result\n");
+        msgpack_object_print(stdout, out_result.data);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(out_key->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_key->via.str.size == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key->via.str.ptr, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_val->via.str.size == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->via.str.ptr, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    msgpack_unpacked_destroy(&out_result);
+    msgpack_unpacked_destroy(&result);
+    flb_free(updated_map);
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(updated_ra);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+}
+
+void cb_add_root_key_val()
+{
+    int ret;
+    size_t off = 0;
+    char *json;
+    flb_sds_t fmt;
+    flb_sds_t updated_fmt;
+    char *fmt_out_key = "add_key";
+    char *fmt_out_val = "add_val";
+
+    char *out_buf = NULL;
+    size_t out_size = 0;
+
+    msgpack_unpacked result;
+    msgpack_unpacked out_result;
+
+    msgpack_object map;
+    msgpack_object *start_key = NULL;
+    msgpack_object *out_key = NULL;
+    msgpack_object *out_val = NULL;
+    void *updated_map;
+    msgpack_object in_val;
+
+    struct flb_record_accessor *ra;
+    struct flb_record_accessor *updated_ra;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\""
+        "}}]}";
+    ret = create_map(json, &map, &out_buf, &result);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed create map");
+        if (out_buf != NULL) {
+            flb_free(out_buf);
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$add_key");
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$add_key");
+    updated_ra = flb_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_ra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create value object to overwrite */
+    ret = set_str_to_msgpack_object(fmt_out_val, &in_val);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to set object");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Add key/value */
+    ret = flb_ra_append_kv_pair(ra, map, (void**)&updated_map, &out_size, &in_val);
+    TEST_CHECK(ret == 0);
+
+    off = 0;
+    msgpack_unpacked_init(&out_result);
+    ret = msgpack_unpack_next(&out_result, updated_map, out_size, &off);
+    if (!TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("failed to unpack");
+        exit(EXIT_FAILURE);
+    }
+    ret = flb_ra_get_kv_pair(updated_ra, out_result.data, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("print out_result\n");
+        msgpack_object_print(stdout, out_result.data);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(out_key->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_key->via.str.size == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key->via.str.ptr, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == MSGPACK_OBJECT_STR);
+    TEST_CHECK(out_val->via.str.size == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->via.str.ptr, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    msgpack_unpacked_destroy(&out_result);
+    msgpack_unpacked_destroy(&result);
+    flb_free(updated_map);
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(updated_ra);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+}
+
 TEST_LIST = {
     { "keys"            , cb_keys},
     { "dash_key"        , cb_dash_key},
@@ -1247,6 +1455,8 @@ TEST_LIST = {
     { "update_val", cb_update_val},
     { "update_root_key", cb_update_root_key},
     { "update_root_key_val", cb_update_root_key_val},
+    { "add_key_val", cb_add_key_val},
+    { "add_root_key_val", cb_add_root_key_val},
     { "issue_4917"      , cb_issue_4917},
     { NULL }
 };


### PR DESCRIPTION
I added an API to append key/value of map using record accessor and the API is only used by test code.
It is useful for filter plugin.
I'll update `filter_modify` to support record accessor when the patch will be merged.

This patch is to 
- Fix update APIs which is added by #3835 .  https://github.com/fluent/fluent-bit/commit/6bf9b74aad21b81229a4bafab8f9211c098a604b https://github.com/fluent/fluent-bit/commit/dfa7163f603e882f0795cd5afb4391d04a4af0d4
- Add new append API. https://github.com/fluent/fluent-bit/commit/2b2cbe1a64f55758641b77def9e943b92de60ba5
- Add test codes.

See also : https://github.com/fluent/fluent-bit/pull/3835

```c
int flb_ra_append_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
                          void **out_map, size_t *out_size, msgpack_object *in_val);
```

|Arg|Description|
|----|-------------|
|ra| record accessor to indicate key/value pair|
|map| the original map to update |
|out_map| overwritten map. The value should be free via flb_free after using.|
|out_size| the size of out_map.|
|in_val| The val to append.  |

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log

```
$ bin/flb-it-record_accessor 
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a
(snip)
Test update_root_key...                         [ OK ]
Test update_root_key_val...                     [ OK ]
Test add_key_val...                             [ OK ]
Test add_root_key_val...                        [ OK ]
(snip)
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-record_accessor 
==26077== Memcheck, a memory error detector
==26077== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26077== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==26077== Command: bin/flb-it-record_accessor
==26077== 
Test keys...                                    
=== test ===
type       : KEYMAP
key name   : aaa
 - subkey  : a

type       : STRING
string     : ' extra '

type       : KEYMAP
key name   : bbb
 - subkey  : b

type       : STRING
string     : ' final access'

=== test ===
type       : KEYMAP
key name   : b
 - subkey  : x
 - subkey  : y

=== test ===
type       : KEYMAP
key name   : z

=== test ===
type       : STRING
string     : 'abc'
[2022/05/02 08:28:27] [error] [record accessor] syntax error, unexpected $end, expecting ']' at '$abc['a''
[ OK ]
Test dash_key...                                == input ==
something
== output ==
something
[ OK ]
Test translate...                               == input ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
== output ==
START k1 => "string", k2 => true (bool), k3 => false (bool), k4 => 0.123457 (float), k5 => 123456789 (int),k6 => nested (nested), k8 =>  (nothing), translated END
[ OK ]
Test translate_tag...                           [ OK ]
Test dots_subkeys...                            == input ==
thetag
== output ==
thetag
[ OK ]
Test array_id...                                == input ==
thetag
== output ==
thetag
[ OK ]
Test get_kv_pair...                             [ OK ]
Test key_order_lookup...                        
-- record --
[0] {"key"=>"abc", "bool"=>false, "bool"=>true, "str"=>"bad", "str"=>"good", "num"=>0, "num"=>1}
[ OK ]
Test update_key_val...                          [ OK ]
Test update_key...                              [ OK ]
Test update_val...                              [ OK ]
Test update_root_key...                         [ OK ]
Test update_root_key_val...                     [ OK ]
Test add_key_val...                             [ OK ]
Test add_root_key_val...                        [ OK ]
Test issue_4917...                              
-- record --
[0] {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}
== input ==
from.new.fluent.bit.out
== output ==
from.new.fluent.bit.out
[ OK ]
SUCCESS: All unit tests have passed.
==26077== 
==26077== HEAP SUMMARY:
==26077==     in use at exit: 0 bytes in 0 blocks
==26077==   total heap usage: 774 allocs, 774 frees, 591,618 bytes allocated
==26077== 
==26077== All heap blocks were freed -- no leaks are possible
==26077== 
==26077== For lists of detected and suppressed errors, rerun with: -s
==26077== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
