### PR TITLE
workflows: resolve 1.8 container build issue

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Build the legacy ${{ matrix.arch }} image
         uses: docker/build-push-action@v2
         with:
-          file: ./dockerfiles/Dockerfile.${{ matrix.suffix }}
+          file: ./Dockerfile.${{ matrix.suffix }}
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -208,7 +208,7 @@ jobs:
       - name: Build the legacy x86_64 debug image
         uses: docker/build-push-action@v2
         with:
-          file: ./dockerfiles/Dockerfile.x86_64-debug
+          file: ./Dockerfile.x86_64-debug
           context: .
           tags: ${{ steps.debug-meta.outputs.tags }}
           labels: ${{ steps.debug-meta.outputs.labels }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Fixes #5405 to provide 1.8 container image build

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
