### PR TITLE
pack: modify to determine how many JSON messages are OK(#5336)

### DIFF
--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -634,6 +634,154 @@ void test_json_pack_bug1278()
     }
 }
 
+static int check_msgpack_val(msgpack_object obj, int expected_type, char *expected_val)
+{
+    int len;
+
+    if (!TEST_CHECK(obj.type == expected_type)) {
+        TEST_MSG("type mismatch\nexpected=%d got=%d", expected_type, obj.type);
+        return -1;
+    }
+    switch(obj.type) {
+    case MSGPACK_OBJECT_MAP:
+        if(!TEST_CHECK(obj.via.map.size == atoi(expected_val))) {
+            TEST_MSG("map size mismatch\nexpected=%s got=%d", expected_val, obj.via.map.size);
+            return -1;
+        }
+        break;
+
+    case MSGPACK_OBJECT_ARRAY:
+        if(!TEST_CHECK(obj.via.array.size == atoi(expected_val))) {
+            TEST_MSG("array size mismatch\nexpected=%s got=%d", expected_val, obj.via.array.size);
+            return -1;
+        }
+        break;
+
+    case MSGPACK_OBJECT_STR:
+        len = strlen(expected_val);
+        if (!TEST_CHECK(obj.via.str.size == strlen(expected_val))) {
+            TEST_MSG("str size mismatch\nexpected=%d got=%d", len, obj.via.str.size);
+            return -1;
+        }
+        else if(!TEST_CHECK(strncmp(expected_val, obj.via.str.ptr ,len) == 0)) {
+            TEST_MSG("str mismatch\nexpected=%.*s got=%.*s", len, expected_val, len, obj.via.str.ptr);
+            return -1;
+        }
+        break;
+
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        if(!TEST_CHECK(obj.via.u64 == (uint64_t)atoi(expected_val))) {
+            TEST_MSG("int mismatch\nexpected=%s got=%"PRIu64, expected_val, obj.via.u64);
+            return -1;
+        }
+        break;
+
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            if(!TEST_CHECK(strncasecmp(expected_val, "true",4) == 0)) {
+                TEST_MSG("bool mismatch\nexpected=%s got=true", expected_val);
+                return -1;
+            }
+        }
+        else {
+            if(!TEST_CHECK(strncasecmp(expected_val, "false",5) == 0)) {
+                TEST_MSG("bool mismatch\nexpected=%s got=false", expected_val);
+                return -1;
+            }
+        }
+        break;
+
+    default:
+        TEST_MSG("unknown type %d", obj.type);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * https://github.com/fluent/fluent-bit/issues/5336
+ * Pack "valid JSON + partial JSON"
+ */
+#define JSON_BUG5336 "{\"int\":10, \"string\":\"hello\", \"bool\":true, \"array\":[0,1,2]}"
+void test_json_pack_bug5336()
+{
+    int ret;
+    char *json_valid = JSON_BUG5336;
+    size_t len = strlen(json_valid);
+
+    char *json_incomplete = JSON_BUG5336 JSON_BUG5336;
+    char *out = NULL;
+    int out_size;
+    struct flb_pack_state state;
+    int i;
+
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+
+    int loop_cnt = 0;
+
+    for (i=len; i<len*2; i++) {
+        loop_cnt++;
+
+        flb_pack_state_init(&state);
+
+        /* Pass small string size to create incomplete JSON */
+        ret = flb_pack_json_state(json_incomplete, i, &out, &out_size, &state);
+        if (!TEST_CHECK(ret != FLB_ERR_JSON_INVAL)) {
+            TEST_MSG("%ld: FLB_ERR_JSON_INVAL\njson=%.*s", i-len, i, json_incomplete);
+            exit(EXIT_FAILURE);
+        }
+        else if(!TEST_CHECK(ret != FLB_ERR_JSON_PART)) {
+            TEST_MSG("%ld: FLB_ERR_JSON_PART\njson=%.*s", i-len, i, json_incomplete);
+            exit(EXIT_FAILURE);
+        }
+
+        /* unpack parsed data */
+        msgpack_unpacked_init(&result);
+        off = 0;
+        TEST_CHECK(msgpack_unpack_next(&result, out, out_size, &off) == MSGPACK_UNPACK_SUCCESS);
+
+        TEST_CHECK(check_msgpack_val(result.data, MSGPACK_OBJECT_MAP, "4" /*map size*/) == 0);
+
+        /* "int":10 */
+        obj = result.data.via.map.ptr[0].key;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_STR, "int") == 0);
+        obj = result.data.via.map.ptr[0].val;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_POSITIVE_INTEGER, "10") == 0);
+
+        /* "string":"hello"*/
+        obj = result.data.via.map.ptr[1].key;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_STR, "string") == 0);
+        obj = result.data.via.map.ptr[1].val;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_STR, "hello") == 0);
+
+        /* "bool":true */
+        obj = result.data.via.map.ptr[2].key;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_STR, "bool") == 0);
+        obj = result.data.via.map.ptr[2].val;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_BOOLEAN, "true") == 0);
+
+        /* "array":[0,1,2] */
+        obj = result.data.via.map.ptr[3].key;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_STR, "array") == 0);
+        obj = result.data.via.map.ptr[3].val;
+        TEST_CHECK(check_msgpack_val(obj, MSGPACK_OBJECT_ARRAY, "3" /*array size*/) == 0);
+        TEST_CHECK(check_msgpack_val(obj.via.array.ptr[0], MSGPACK_OBJECT_POSITIVE_INTEGER, "0") == 0);
+        TEST_CHECK(check_msgpack_val(obj.via.array.ptr[1], MSGPACK_OBJECT_POSITIVE_INTEGER, "1") == 0);
+        TEST_CHECK(check_msgpack_val(obj.via.array.ptr[2], MSGPACK_OBJECT_POSITIVE_INTEGER, "2") == 0);
+
+        msgpack_unpacked_destroy(&result);
+        flb_free(out);
+        flb_pack_state_reset(&state);
+    }
+
+    if(!TEST_CHECK(loop_cnt == len)) {
+        TEST_MSG("loop_cnt expect=%ld got=%d", len, loop_cnt);
+    }
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "json_pack"          , test_json_pack },
@@ -644,6 +792,7 @@ TEST_LIST = {
     { "json_dup_keys"      , test_json_dup_keys},
     { "json_pack_bug342"   , test_json_pack_bug342},
     { "json_pack_bug1278"  , test_json_pack_bug1278},
+    { "json_pack_bug5336"  , test_json_pack_bug5336},
 
     /* Mixed bytes, check JSON encoding */
     { "utf8_to_json", test_utf8_to_json},


### PR DESCRIPTION
Fixes #5336 
Root cause: https://github.com/fluent/fluent-bit/issues/5336#issuecomment-1115513183

`jsmn_parse` updates `jsmn_parser` members even if a JSON is incomplete. (state->parser is updated)
In this case, a member `toknext` points next incomplete object token.

This patch is to use `toknext` as an index of last member of complete JSON.
This patch also changes a loop to descending.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

https://github.com/fluent/fluent-bit/issues/5336#issue-1211251079

```
for i in $(seq 1 65535); do echo '{"foo":"bar"}'; done > tcp.log
```

```
[SERVICE]
  Flush         10
  Log_Level     debug
  Daemon        off
[INPUT]
  Name          tcp
  Listen        0.0.0.0
  Port          5170
  Chunk_Size    32
  Buffer_Size   64
  Format        json
  Mem_Buf_Limit 30MB
[OUTPUT]
  Name stdout
  Match *
```

flb-rt-in_tcp:
```
$ bin/flb-rt-in_tcp 
Test tcp...                                     [ OK ]
Test format_none...                             [ OK ]
Test format_none_separator...                   [ OK ]
Test 65535_records_issue_5336...                [ OK ]
SUCCESS: All unit tests have passed.
```

flb-it-pack:
```
$ bin/flb-it-pack 
Test json_pack...                               [ OK ]
Test json_pack_iter...                          [ OK ]
Test json_pack_mult...                          [ OK ]
Test json_pack_mult_iter...                     [ OK ]
Test json_macros...                             [ OK ]
Test json_dup_keys...                           [ OK ]
Test json_pack_bug342...                        [ OK ]
Test json_pack_bug1278...                       
test 0 out => "one\u0007two"
test 1 out => "one\btwo"
test 2 out => "one\ttwo"
test 3 out => "one\ntwo"
test 4 out => "one\u000btwo"
test 5 out => "one\ftwo"
test 6 out => "one\rtwo"
test 7 out => "\\n"
[ OK ]
Test json_pack_bug5336...                       [ OK ]
Test utf8_to_json...                            [ OK ]
SUCCESS: All unit tests have passed.
```

## Debug log

```
6$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/05/05 21:09:28] [ info] Configuration:
[2022/05/05 21:09:28] [ info]  flush time     | 10.000000 seconds
[2022/05/05 21:09:28] [ info]  grace          | 5 seconds
[2022/05/05 21:09:28] [ info]  daemon         | 0
[2022/05/05 21:09:28] [ info] ___________
(snip)
[65531] tcp.0: [1651752589.579062568, {"foo"=>"bar"}]
[65532] tcp.0: [1651752589.579062909, {"foo"=>"bar"}]
[65533] tcp.0: [1651752589.579063209, {"foo"=>"bar"}]
[65534] tcp.0: [1651752589.579063540, {"foo"=>"bar"}]
[2022/05/05 21:09:58] [debug] [out flush] cb_destroy coro_id=0
[2022/05/05 21:09:58] [debug] [task] destroy task=0x7f9f9c014690 (task_id=0)
```

## Valgrind output

```
[65534] tcp.0: [1651752638.008761239, {"foo"=>"bar"}]
[2022/05/05 21:10:54] [debug] [out flush] cb_destroy coro_id=0
[2022/05/05 21:10:54] [debug] [task] destroy task=0x4e67bd0 (task_id=0)
^C[2022/05/05 21:10:55] [engine] caught signal (SIGINT)
[2022/05/05 21:10:55] [ warn] [engine] service will shutdown in max 5 seconds
[2022/05/05 21:10:55] [ info] [engine] service has stopped (0 pending tasks)
[2022/05/05 21:10:55] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/05/05 21:10:55] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==115272== 
==115272== HEAP SUMMARY:
==115272==     in use at exit: 0 bytes in 0 blocks
==115272==   total heap usage: 263,593 allocs, 263,593 frees, 1,108,922,588 bytes allocated
==115272== 
==115272== All heap blocks were freed -- no leaks are possible
==115272== 
==115272== For lists of detected and suppressed errors, rerun with: -s
==115272== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```



<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
