### PR TITLE
workflows: resolve missing debug source

### DIFF
--- a/.github/workflows/build-branch-containers.yaml
+++ b/.github/workflows/build-branch-containers.yaml
@@ -4,11 +4,11 @@ on:
     inputs:
       version:
         description: Version of Fluent Bit to build, commit, branch, etc. The container image will be ghcr.io/fluent/fluent-bit/test/<this value>.
-        required: false
+        required: true
         default: master
 jobs:
   build-branch-containers:
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@fix_debug_container_builds_1_8
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ github.event.inputs.version }}
       ref: ${{ github.event.inputs.version }}

--- a/.github/workflows/build-branch-containers.yaml
+++ b/.github/workflows/build-branch-containers.yaml
@@ -8,7 +8,7 @@ on:
         default: master
 jobs:
   build-branch-containers:
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@fix_debug_container_builds_1_8
     with:
       version: ${{ github.event.inputs.version }}
       ref: ${{ github.event.inputs.version }}

--- a/.github/workflows/build-branch-containers.yaml
+++ b/.github/workflows/build-branch-containers.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version of Fluent Bit to build, commit, branch, etc.
+        description: Version of Fluent Bit to build, commit, branch, etc. The container image will be ghcr.io/fluent/fluent-bit/test/<this value>.
         required: false
         default: master
 jobs:
@@ -14,7 +14,7 @@ jobs:
       ref: ${{ github.event.inputs.version }}
       registry: ghcr.io
       username: ${{ github.actor }}
-      image: ${{ github.repository }}/${{ github.event.inputs.version }}
+      image: ${{ github.repository }}/test/${{ github.event.inputs.version }}
       unstable: ${{ github.event.inputs.version }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -135,7 +135,7 @@ jobs:
             raw,${{ needs.call-build-images-meta.outputs.major-version }}-debug
 
       - name: Build the legacy x86_64 debug image
-        if: arch == 'amd64'
+        if: matrix.arch == 'amd64'
         uses: docker/build-push-action@v2
         with:
           file: ./Dockerfile.x86_64.debug

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -126,6 +126,28 @@ jobs:
           username: ${{ inputs.username }}
           password: ${{ secrets.token }}
 
+      - id: debug-meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image }}
+          tags: |
+            raw,${{ inputs.version }}-debug
+            raw,${{ needs.call-build-images-meta.outputs.major-version }}-debug
+
+      - name: Build the legacy x86_64 debug image
+        if: arch == 'amd64'
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile.x86_64.debug
+          context: .
+          tags: ${{ steps.debug-meta.outputs.tags }}
+          labels: ${{ steps.debug-meta.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          load: false
+          build-args: |
+            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
+
       - name: Extract metadata from Github
         id: meta
         uses: docker/metadata-action@v3
@@ -196,27 +218,6 @@ jobs:
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
         shell: bash
-
-      - id: debug-meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ inputs.registry }}/${{ inputs.image }}
-          tags: |
-            raw,${{ inputs.version }}-debug
-            raw,${{ needs.call-build-images-meta.outputs.major-version }}-debug
-
-      - name: Build the legacy x86_64 debug image
-        uses: docker/build-push-action@v2
-        with:
-          file: ./Dockerfile.x86_64.debug
-          context: .
-          tags: ${{ steps.debug-meta.outputs.tags }}
-          labels: ${{ steps.debug-meta.outputs.labels }}
-          platforms: linux/amd64
-          push: true
-          load: false
-          build-args: |
-            FLB_TARBALL=https://github.com/fluent/fluent-bit/tarball/${{ inputs.ref }}
 
   # This is the intended approach to multi-arch image and all the other checks scanning,
   # signing, etc only trigger from this.

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -215,6 +215,8 @@ jobs:
         shell: bash
 
       - name: Create Release
+        # Do not fail the job here
+        continue-on-error: true
         run: gh release create unstable-${{ needs.unstable-build-get-meta.outputs.branch }} release-upload/*.* --repo ${{ secrets.RELEASE_REPO }} --generate-notes --prerelease --target ${{ needs.unstable-build-get-meta.outputs.branch }} --title "Nightly unstable ${{ needs.unstable-build-get-meta.outputs.branch }} build"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Ensures we can build 1.8 containers from the new workflow and with unstable builds - also prevent the current release creation failure issue from triggering a workflow failure so other issues are more obvious now.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested via https://github.com/fluent/fluent-bit/actions/runs/2280664269 which builds 1.8 branch.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
