### PR TITLE
in_systemd: fix 'db.sync' property (#5426)

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -545,7 +545,7 @@ static struct flb_config_map config_map[] = {
     },
 #ifdef FLB_HAVE_SQLDB
     {
-      FLB_CONFIG_MAP_STR, "db_sync", (char *)NULL,
+      FLB_CONFIG_MAP_STR, "db.sync", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_systemd_config, db_sync_mode),
       "Set the database sync mode: extra, full, normal or off"
     },


### PR DESCRIPTION
Fixes #5426 

in_systemd ignores a property `db.sync` from v1.9.0.
This patch is to fix it.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name systemd
    db.sync normal


[OUTPUT]
    Name counter
    Match *
```

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/05/07 08:50:57] [ info] [fluent bit] version=1.9.4, commit=5db875b1e0, pid=14424
[2022/05/07 08:50:57] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/05/07 08:50:57] [ info] [cmetrics] version=0.3.1
[2022/05/07 08:50:57] [ info] [sp] stream processor started
1651881057.247195,3019 (total = 3019)
1651881057.284064,1254 (total = 4273)
1651881058.219775,3011 (total = 7284)
^C[2022/05/07 08:50:58] [engine] caught signal (SIGINT)
[2022/05/07 08:50:58] [ info] [input] pausing systemd.0
1651881058.262758,3032 (total = 10316)
[2022/05/07 08:50:58] [ warn] [engine] service will shutdown in max 5 seconds
1651881058.273036,2935 (total = 13251)
1651881058.284133,2936 (total = 16187)
1651881058.299666,2892 (total = 19079)
1651881058.312519,2968 (total = 22047)
1651881058.330288,2953 (total = 25000)
1651881058.347209,2964 (total = 27964)
1651881058.357256,2901 (total = 30865)
1651881058.382885,2682 (total = 33547)
1651881058.393011,2806 (total = 36353)
1651881058.421239,2926 (total = 39279)
1651881058.449572,2942 (total = 42221)
1651881058.462160,2944 (total = 45165)
1651881058.486127,3052 (total = 48217)
1651881058.495982,2600 (total = 50817)
1651881058.523554,2917 (total = 53734)
1651881058.549370,2998 (total = 56732)
1651881058.564083,2964 (total = 59696)
1651881058.579670,1213 (total = 60909)
[2022/05/07 08:50:59] [ info] [engine] service has stopped (0 pending tasks)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==14428== Memcheck, a memory error detector
==14428== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==14428== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==14428== Command: bin/fluent-bit -c a.conf
==14428== 
Fluent Bit v1.9.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/05/07 08:51:18] [ info] [fluent bit] version=1.9.4, commit=5db875b1e0, pid=14428
[2022/05/07 08:51:18] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/05/07 08:51:18] [ info] [cmetrics] version=0.3.1
[2022/05/07 08:51:18] [ info] [sp] stream processor started
1651881080.591064,1732 (total = 1732)
^C[2022/05/07 08:51:21] [engine] caught signal (SIGINT)
[2022/05/07 08:51:21] [ info] [input] pausing systemd.0
[2022/05/07 08:51:21] [ warn] [engine] service will shutdown in max 5 seconds
1651881081.679569,1287 (total = 3019)
[2022/05/07 08:51:22] [ info] [engine] service has stopped (0 pending tasks)
==14428== 
==14428== HEAP SUMMARY:
==14428==     in use at exit: 0 bytes in 0 blocks
==14428==   total heap usage: 1,652 allocs, 1,652 frees, 9,466,516 bytes allocated
==14428== 
==14428== All heap blocks were freed -- no leaks are possible
==14428== 
==14428== For lists of detected and suppressed errors, rerun with: -s
==14428== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
