### PR TITLE
out_stackdriver: Initialize the metadata_server value to NULL

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2426,7 +2426,7 @@ static struct flb_config_map config_map[] = {
      "Set the path for the google service credentials file"
     },
     {
-     FLB_CONFIG_MAP_STR, "metadata_server", FLB_STD_METADATA_SERVER,
+     FLB_CONFIG_MAP_STR, "metadata_server", (char *)NULL,
      0, FLB_TRUE, offsetof(struct flb_stackdriver, metadata_server),
      "Set the metadata server"
     },

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -275,6 +275,9 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             ctx->env->metadata_server = flb_sds_create(tmp);
             ctx->metadata_server = ctx->env->metadata_server;
         }
+        else {
+            ctx->metadata_server = flb_sds_create(FLB_STD_METADATA_SERVER);
+        }
     }
     flb_plg_info(ctx->ins, "metadata_server set to %s", ctx->metadata_server);
 


### PR DESCRIPTION
Initialize the metadata_server value to NULL so that environment values are checked and fetched properly. If this default is set, environment variables are never checked and hence always falls holds default value. This is a regression introduced in v1.9
