### PR TITLE
out_http: Implement "body_key" and "headers_key" options

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -69,9 +70,43 @@ static int cb_http_init(struct flb_output_instance *ins,
     return 0;
 }
 
+static void append_headers(struct flb_http_client *c,
+                           char **headers)
+{
+    int i;
+    char *header_key;
+    char *header_value;
+
+    i = 0;
+    header_key = NULL;
+    header_value = NULL;
+    while (*headers) {
+        if (i % 2 == 0) {
+            header_key = *headers;
+        }
+        else {
+            header_value = *headers;
+        }
+        if (header_key && header_value) {
+            flb_http_add_header(c,
+                                header_key,
+                                strlen(header_key),
+                                header_value,
+                                strlen(header_value));
+            flb_free(header_key);
+            flb_free(header_value);
+            header_key = NULL;
+            header_value = NULL;
+        }
+        headers++;
+        i++;
+    }
+}
+
 static int http_post(struct flb_out_http *ctx,
                      const void *body, size_t body_len,
-                     const char *tag, int tag_len)
+                     const char *tag, int tag_len,
+                     char **headers)
 {
     int ret;
     int out_ret = FLB_OK;
@@ -136,7 +171,10 @@ static int http_post(struct flb_out_http *ctx,
     c->cb_ctx = ctx->ins->callback;
 
     /* Append headers */
-    if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
+    if (headers) {
+        append_headers(c, headers);
+    }
+    else if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_STREAM) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES) ||
         (ctx->out_format == FLB_HTTP_OUT_GELF)) {
@@ -328,10 +366,164 @@ static int http_gelf(struct flb_out_http *ctx,
         s = tmp;
     }
 
-    ret = http_post(ctx, s, flb_sds_len(s), tag, tag_len);
+    ret = http_post(ctx, s, flb_sds_len(s), tag, tag_len, NULL);
     flb_sds_destroy(s);
     msgpack_unpacked_destroy(&result);
 
+    return ret;
+}
+
+static char **extract_headers(msgpack_object *obj) {
+    size_t i;
+    char **headers = NULL;
+    size_t str_count;
+    msgpack_object_map map;
+    msgpack_object_str k;
+    msgpack_object_str v;
+
+    if (obj->type != MSGPACK_OBJECT_MAP) {
+        goto err;
+    }
+
+    map = obj->via.map;
+    str_count = map.size * 2 + 1;
+    headers = flb_calloc(str_count, sizeof *headers);
+
+    if (!headers) {
+        goto err;
+    }
+
+    for (i = 0; i < map.size; i++) {
+        if (map.ptr[i].key.type != MSGPACK_OBJECT_STR ||
+            map.ptr[i].val.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        k = map.ptr[i].key.via.str;
+        v = map.ptr[i].val.via.str;
+
+        headers[i * 2] = strndup(k.ptr, k.size);
+
+        if (!headers[i]) {
+            goto err;
+        }
+
+        headers[i * 2 + 1] = strndup(v.ptr, v.size);
+
+        if (!headers[i]) {
+            goto err;
+        }
+    }
+
+    return headers;
+
+err:
+    if (headers) {
+        for (i = 0; i < str_count; i++) {
+            if (headers[i]) {
+                flb_free(headers[i]);
+            }
+        }
+        flb_free(headers);
+    }
+    return NULL;
+}
+static int post_all_requests(struct flb_out_http *ctx,
+                             const char *data, size_t size,
+                             flb_sds_t body_key,
+                             flb_sds_t headers_key,
+                             struct flb_event_chunk *event_chunk)
+{
+    struct flb_time t;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object map;
+    msgpack_object *obj;
+    msgpack_object *k;
+    msgpack_object *v;
+    const char *body;
+    size_t body_size;
+    bool body_found;
+    bool headers_found;
+    char **headers;
+    size_t len;
+    size_t key_count;
+    size_t i;
+    size_t off = 0;
+    size_t record_count = 0;
+    int ret = 0;
+
+    msgpack_unpacked_init(&result);
+
+    while (msgpack_unpack_next(&result, data, size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        headers = NULL;
+        body_found = false;
+        headers_found = false;
+        root = result.data;
+
+        if (root.type != MSGPACK_OBJECT_ARRAY) {
+            ret = -1;
+            break;
+        }
+
+        if (root.via.array.size != 2) {
+            ret = -1;
+            break;
+        }
+
+        flb_time_pop_from_msgpack(&t, &result, &obj);
+
+        map = root.via.array.ptr[1];
+        if (map.type != MSGPACK_OBJECT_MAP) {
+            ret = -1;
+            break;
+        }
+        key_count = map.via.map.size;
+
+        for (i = 0; i < key_count; i++) {
+            k = &map.via.map.ptr[i].key;
+            v = &map.via.map.ptr[i].val;
+
+            if (k->type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            len = k->via.str.size;
+            if (len == flb_sds_len(body_key) &&
+                !memcmp(k->via.str.ptr, body_key, len)) {
+                if (v->type != MSGPACK_OBJECT_STR && v->type != MSGPACK_OBJECT_BIN) {
+                    flb_plg_error(ctx->ins,
+                            "body must be a msgpack string");
+                    continue;
+                }
+
+                body_size = v->via.str.size;
+                body = v->via.str.ptr;
+                body_found = true;
+            }
+            else if (len == flb_sds_len(headers_key) &&
+                !memcmp(k->via.str.ptr, headers_key, len)) {
+                headers = extract_headers(v);
+                if (!headers) {
+                    flb_plg_error(ctx->ins,
+                            "failed to extract headers from key \"%s\"",
+                            ctx->headers_key);
+                    continue;
+                }
+                headers_found = true;
+            }
+        }
+
+        if (body_found && headers_found) {
+            flb_plg_trace(ctx->ins, "posting record %d", record_count++);
+            ret = http_post(ctx, body, body_size, event_chunk->tag,
+                            flb_sds_len(event_chunk->tag), headers);
+        }
+
+        flb_free(headers);
+    }
+
+    msgpack_unpacked_destroy(&result);
     return ret;
 }
 
@@ -346,7 +538,15 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
     struct flb_out_http *ctx = out_context;
     (void) i_ins;
 
-    if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
+    if (ctx->body_key) {
+        ret = post_all_requests(ctx, event_chunk->data, event_chunk->size,
+                                ctx->body_key, ctx->headers_key, event_chunk);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins,
+                          "failed to post requests body key \"%s\"", ctx->body_key);
+        }
+    }
+    else if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_STREAM) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES)) {
 
@@ -357,7 +557,7 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
                                                ctx->date_key);
         if (json != NULL) {
             ret = http_post(ctx, json, flb_sds_len(json),
-                            event_chunk->tag, flb_sds_len(event_chunk->tag));
+                            event_chunk->tag, flb_sds_len(event_chunk->tag), NULL);
             flb_sds_destroy(json);
         }
     }
@@ -369,7 +569,7 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
     else {
         ret = http_post(ctx,
                         event_chunk->data, event_chunk->size,
-                        event_chunk->tag, flb_sds_len(event_chunk->tag));
+                        event_chunk->tag, flb_sds_len(event_chunk->tag), NULL);
     }
 
     FLB_OUTPUT_RETURN(ret);
@@ -486,6 +686,16 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "gelf_level_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_http, gelf_fields.level_key),
      "Specify the key to use for the 'level' in gelf format"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "body_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_http, body_key),
+     "Specify the key which contains the body"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "headers_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_http, headers_key),
+     "Specify the key which contains the headers"
     },
 
     /* EOF */

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -68,6 +68,12 @@ struct flb_out_http {
     /* GELF fields */
     struct flb_gelf_fields gelf_fields;
 
+    /* which record key to use as body */
+    flb_sds_t body_key;
+
+    /* override headers with contents of the map in the key specified here */
+    flb_sds_t headers_key;
+
     /* Include tag in header */
     flb_sds_t header_tag;
 

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -71,8 +71,12 @@ struct flb_out_http {
     /* which record key to use as body */
     flb_sds_t body_key;
 
+    struct flb_record_accessor *body_ra;
+
     /* override headers with contents of the map in the key specified here */
     flb_sds_t headers_key;
+
+    struct flb_record_accessor *headers_ra;
 
     /* Include tag in header */
     flb_sds_t header_tag;

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -59,6 +59,18 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    if (ctx->headers_key && !ctx->body_key) {
+        flb_plg_error(ctx->ins, "when setting headers_key, body_key is also required");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    if (ctx->body_key && !ctx->headers_key) {
+        flb_plg_error(ctx->ins, "when setting body_key, headers_key is also required");
+        flb_free(ctx);
+        return NULL;
+    }
+
     /*
      * Check if a Proxy have been set, if so the Upstream manager will use
      * the Proxy end-point and then we let the HTTP client know about it, so

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_record_accessor.h>
 #ifdef FLB_HAVE_SIGNV4
 #ifdef FLB_HAVE_AWS
 #include <fluent-bit/flb_aws_credentials.h>
@@ -69,6 +70,22 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         flb_plg_error(ctx->ins, "when setting body_key, headers_key is also required");
         flb_free(ctx);
         return NULL;
+    }
+
+    if (ctx->body_key && ctx->headers_key) {
+        ctx->body_ra = flb_ra_create(ctx->body_key, FLB_FALSE);
+        if (!ctx->body_ra) {
+            flb_plg_error(ctx->ins, "failed to allocate body record accessor");
+            flb_free(ctx);
+            return NULL;
+        }
+
+        ctx->headers_ra = flb_ra_create(ctx->headers_key, FLB_FALSE);
+        if (!ctx->headers_ra) {
+            flb_plg_error(ctx->ins, "failed to allocate headers record accessor");
+            flb_free(ctx);
+            return NULL;
+        }
     }
 
     /*
@@ -256,6 +273,11 @@ void flb_http_conf_destroy(struct flb_out_http *ctx)
 {
     if (!ctx) {
         return;
+    }
+
+    if (ctx->body_ra && ctx->headers_ra) {
+        flb_ra_destroy(ctx->body_ra);
+        flb_ra_destroy(ctx->headers_ra);
     }
 
     if (ctx->u) {


### PR DESCRIPTION
Add two new options to out_http that allows greater flexibility in controlling the http request body and headers.

"body_key" specifies a key in the record that contains the actual http body. This key's value must be a msgpack string or binary.

"headers_key" specifies a key in the record that contains headers the should be added to the request. This key's value must be a msgpack map.

To help in testing these new options, I've pasted here a configuration + helper files

Fluent bit configuration (http_body_headers_key.conf):
```ini
[SERVICE]
    flush      0.1
    grace      2
    log_level  info

[INPUT]
    name tail
    read_from_head true
    path_key file_name
    exit_on_eof true
    path record*.txt

[FILTER]
    Name    lua
    Match   *
    script  add_headers.lua
    call    process_record

[OUTPUT]
    name http
    host 127.0.0.1
    port 8443
    body_key $sample_body
    headers_key $sample_headers
```

add_headers.lua (lua filter that modifies the record to add headers and body):

```lua
local record_index = 0
function process_record(tag, timestamp, record)
    record_index = record_index + 1
    return 1, 0, {
        sample_headers = {
            ['content-type'] = 'application/json',
            ['x-my-header'] = 'custom-header-value',
            ['x-my-second-header'] = 'custom-header-value2',
            ['x-record-index'] = tostring(record_index),
        },
        sample_body = '{"log-message": "'..record.log..'"}'
    }
end
```

records1.txt:

```txt
some record
one
```

records2.txt

```txt
another record
two
```

http_server.js (simple node.js http server that prints both headers and body):
```js
const http = require('http');

http.createServer(function (req, res) {
    console.log("\n\n=======REQUEST========")
    console.log("=======HEADERS========")
    for (const [k, v] of Object.entries(req.headers)) {
        console.log(`${k}: ${v}`);
    }
    console.log("=======BODY========")
    req.pipe(process.stdout, { end: false })
    console.log("\n")
    res.end("OK");
}).listen(8443);
```

Sample output from http server:

```
=======REQUEST========
=======HEADERS========
host: 127.0.0.1:8443
content-length: 33
x-record-index: 1
content-type: application/json
x-my-second-header: custom-header-value2
x-my-header: custom-header-value
user-agent: Fluent-Bit
=======BODY========


{"log message": "another record"}

=======REQUEST========
=======HEADERS========
host: 127.0.0.1:8443
content-length: 22
x-record-index: 2
content-type: application/json
x-my-second-header: custom-header-value2
x-my-header: custom-header-value
user-agent: Fluent-Bit
=======BODY========


{"log message": "two"}

=======REQUEST========
=======HEADERS========
host: 127.0.0.1:8443
content-length: 30
x-record-index: 3
content-type: application/json
x-my-second-header: custom-header-value2
x-my-header: custom-header-value
user-agent: Fluent-Bit
=======BODY========


{"log message": "some record"}

=======REQUEST========
=======HEADERS========
host: 127.0.0.1:8443
content-length: 22
x-record-index: 4
content-type: application/json
x-my-second-header: custom-header-value2
x-my-header: custom-header-value
user-agent: Fluent-Bit
=======BODY========


{"log message": "one"}
```

fluent-bit output with valgrind:

```
$ valgrind --leak-check=full ./build/bin/fluent-bit -c http_body_headers_key.conf
==80208== Memcheck, a memory error detector
==80208== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==80208== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==80208== Command: ./build/bin/fluent-bit -c http_body_headers_key.conf
==80208==
Fluent Bit v1.9.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/05/11 12:52:39] [ info] [fluent bit] version=1.9.4, commit=08e90f54d3, pid=80208
[2022/05/11 12:52:39] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/05/11 12:52:39] [ info] [cmetrics] version=0.3.1
[2022/05/11 12:52:39] [ info] [output:http:http.0] worker #0 started
[2022/05/11 12:52:39] [ info] [output:http:http.0] worker #1 started
[2022/05/11 12:52:39] [ info] [sp] stream processor started
[2022/05/11 12:52:39] [ info] [input:tail:tail.0] inode=16639596 file=record2.txt ended, stop
[2022/05/11 12:52:39] [ info] [input:tail:tail.0] inotify_fs_add(): inode=16639596 watch_fd=1 name=record2.txt
[2022/05/11 12:52:39] [ info] [input:tail:tail.0] inode=16639594 file=records1.txt ended, stop
[2022/05/11 12:52:39] [ info] [input] pausing tail.0
[2022/05/11 12:52:39] [ info] [input:tail:tail.0] inotify_fs_add(): inode=16639594 watch_fd=2 name=records1.txt
[2022/05/11 12:52:39] [ warn] [engine] service will shutdown in max 2 seconds
[2022/05/11 12:52:40] [ info] [output:http:http.0] 127.0.0.1:8443, HTTP status=200
OK
[2022/05/11 12:52:40] [ info] [output:http:http.0] 127.0.0.1:8443, HTTP status=200
OK
[2022/05/11 12:52:40] [ info] [output:http:http.0] 127.0.0.1:8443, HTTP status=200
OK
[2022/05/11 12:52:40] [ info] [output:http:http.0] 127.0.0.1:8443, HTTP status=200
OK
[2022/05/11 12:52:40] [ info] [engine] service has stopped (0 pending tasks)
[2022/05/11 12:52:40] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=16639596 watch_fd=1
[2022/05/11 12:52:40] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=16639594 watch_fd=2
[2022/05/11 12:52:40] [ info] [output:http:http.0] thread worker #0 stopping...
[2022/05/11 12:52:40] [ info] [output:http:http.0] thread worker #0 stopped
[2022/05/11 12:52:40] [ info] [output:http:http.0] thread worker #1 stopping...
[2022/05/11 12:52:40] [ info] [output:http:http.0] thread worker #1 stopped
==80208==
==80208== HEAP SUMMARY:
==80208==     in use at exit: 0 bytes in 0 blocks
==80208==   total heap usage: 1,664 allocs, 1,664 frees, 828,418 bytes allocated
==80208==
==80208== All heap blocks were freed -- no leaks are possible
==80208==
==80208== For lists of detected and suppressed errors, rerun with: -s
==80208== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```