### PR TITLE
workflows: add post-release test job

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -272,3 +272,28 @@ jobs:
         shell: bash
         env:
           COSIGN_EXPERIMENTAL: "true"
+
+  # This will require a sign off so can be done after packages are updated to confirm
+  staging-release-smoke-test:
+    name: Run smoke tests on release artefacts
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    environment: release
+    needs:
+      - staging-release-packages-server
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Test release packages
+        run: |
+          ./packaging/test-release-packages.sh
+        shell: bash
+
+      - name: Test containers
+        run: |
+          ./packaging/testing/smoke/container/container-smoke-test.sh
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.version }}

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -282,6 +282,7 @@ jobs:
     environment: release
     needs:
       - staging-release-packages-server
+      - staging-release-images
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>
Resolves #5366.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
