### PR TITLE
out_stackdriver: free metadata_server when 'METADATA_SERVER' is not set

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2427,7 +2427,7 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, "metadata_server", (char *)NULL,
-     0, FLB_TRUE, offsetof(struct flb_stackdriver, metadata_server),
+     0, FLB_FALSE, 0,
      "Set the metadata server"
     },
     {

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -261,7 +261,9 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
     }
 
     /* Lookup metadata server URL */
-    if (ctx->metadata_server == NULL) {
+    ctx->metadata_server = NULL;
+    tmp = flb_output_get_property("metadata_server", ins);
+    if (tmp == NULL) {
         tmp = getenv("METADATA_SERVER");
         if(tmp) {
             if (ctx->env == NULL) {
@@ -278,6 +280,9 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         else {
             ctx->metadata_server = flb_sds_create(FLB_STD_METADATA_SERVER);
         }
+    }
+    else {
+        ctx->metadata_server = flb_sds_create(tmp);
     }
     flb_plg_info(ctx->ins, "metadata_server set to %s", ctx->metadata_server);
 

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -563,8 +563,19 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
         }
         if (ctx->env->metadata_server) {
             flb_sds_destroy(ctx->env->metadata_server);
+            /*
+             * If ctx->env is not NULL,
+             * ctx->metadata_server points ctx->env->metadata_server.
+             *
+             * We set ctx->metadata_server to NULL to prevent double free.
+             */
+            ctx->metadata_server = NULL;
         }
         flb_free(ctx->env);
+    }
+
+    if (ctx->metadata_server) {
+        flb_sds_destroy(ctx->metadata_server);
     }
     
     if (ctx->is_k8s_resource_type){


### PR DESCRIPTION
If no environmental variables are not set, out_stackdriver allocates `ctx->metadata_server` and sets default value.
However it is not freed since `ctx->env` is NULL.
This patch is to fix it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
