### PR TITLE
time: add strict event time type checking

### DIFF
--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -20,9 +20,16 @@
 
 #include <fluent-bit.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
 #include <mpack/mpack.h>
+#include <msgpack.h>
+#include <msgpack/timestamp.h>
 #include "flb_tests_internal.h"
 
+#define SEC_32BIT  1647061992 /* 0x622c2be8 */
+#define NSEC_32BIT 123000000  /* 123ms 0x0754d4c0 */
+#define D_SEC 1647061992.123;
+const char eventtime[8] = {0x62, 0x2c, 0x2b, 0xe8, 0x07, 0x54, 0xd4, 0xc0 };
 
 void test_to_nanosec()
 {
@@ -88,8 +95,241 @@ void test_append_to_mpack_v1() {
     flb_free(data);
 }
 
+void test_msgpack_to_time_int()
+{
+    struct flb_time tm;
+    int64_t expect = SEC_32BIT;
+    int ret;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+
+    msgpack_object tm_obj;
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_int(&mp_pck, expect);
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_time_msgpack_to_time failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(tm.tm.tv_sec == expect && tm.tm.tv_nsec == 0)) {
+        TEST_MSG("got %ld.%ld, expect %ld.%d", tm.tm.tv_sec, tm.tm.tv_nsec, expect, 0);
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_msgpack_to_time_double()
+{
+    struct flb_time tm;
+    double d_time = D_SEC;
+    int64_t expect_sec = SEC_32BIT;
+    int64_t expect_nsec = NSEC_32BIT;
+
+    int ret;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+
+    msgpack_object tm_obj;
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_double(&mp_pck, d_time);
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_time_msgpack_to_time failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(tm.tm.tv_sec == expect_sec &&
+                    llabs(tm.tm.tv_nsec - expect_nsec ) < 10000 /* 10us*/)) {
+        TEST_MSG("got %ld.%ld, expect %ld.%ld", tm.tm.tv_sec, tm.tm.tv_nsec, expect_sec, expect_nsec);
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_msgpack_to_time_eventtime()
+{
+    struct flb_time tm;
+    int64_t expect_sec = SEC_32BIT;
+    int64_t expect_nsec = NSEC_32BIT;
+    char ext_data[8] = {0};
+    int ret;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+
+    msgpack_object tm_obj;
+
+    memcpy(&ext_data[0], &eventtime[0], 8);
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format */
+    msgpack_pack_ext(&mp_pck, 8/*fixext8*/, 0);
+    msgpack_pack_ext_body(&mp_pck, ext_data, sizeof(ext_data));
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_time_msgpack_to_time failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(tm.tm.tv_sec == expect_sec &&
+                    llabs(tm.tm.tv_nsec - expect_nsec ) < 10000 /* 10us*/)) {
+        TEST_MSG("got %ld.%ld, expect %ld.%ld", tm.tm.tv_sec, tm.tm.tv_nsec, expect_sec, expect_nsec);
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_msgpack_to_time_invalid()
+{
+    struct flb_time tm;
+    char ext_data[8] = {0x00, 0x11, 0x22, 0xaa, 0xbb, 0xcc, 0xdd, 0xee};
+    int ret;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+
+
+    msgpack_object tm_obj;
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_ext(&mp_pck, 5 /* invalid size */, 0);
+    msgpack_pack_ext_body(&mp_pck, ext_data, 5);
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+
+    /* Check if ext */
+    TEST_CHECK(tm_obj.type == MSGPACK_OBJECT_EXT);
+    TEST_CHECK(tm_obj.via.ext.type == 0);
+    TEST_CHECK(tm_obj.via.ext.size == 5);
+
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    if(!TEST_CHECK(ret != 0)) {
+        TEST_MSG("flb_time_msgpack_to_time should fail");
+        exit(EXIT_FAILURE);
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_ext(&mp_pck, 8, 10 /* invalid type */);
+    msgpack_pack_ext_body(&mp_pck, ext_data, 8);
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+
+    /* Check if ext */
+    TEST_CHECK(tm_obj.type == MSGPACK_OBJECT_EXT);
+    TEST_CHECK(tm_obj.via.ext.type == 10);
+    TEST_CHECK(tm_obj.via.ext.size == 8);
+
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    if(!TEST_CHECK(ret != 0)) {
+        TEST_MSG("flb_time_msgpack_to_time should fail");
+        exit(EXIT_FAILURE);
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_append_to_msgpack_eventtime()
+{
+    struct flb_time tm;
+    int ret;
+    char expect_data[8] = {0};
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+
+    msgpack_object tm_obj;
+
+    memcpy(&expect_data[0], &eventtime[0], 8);
+
+    tm.tm.tv_sec  = SEC_32BIT;
+    tm.tm.tv_nsec = NSEC_32BIT;
+
+    /* create int object*/
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    ret = flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_V1_FIXEXT);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_time_append_to_msgpack failed");
+        exit(EXIT_FAILURE);
+    }
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+
+    tm_obj = result.data;
+
+    /* Check if Eventtime */
+    TEST_CHECK(tm_obj.type == MSGPACK_OBJECT_EXT);
+    TEST_CHECK(tm_obj.via.ext.type == 0);
+    TEST_CHECK(tm_obj.via.ext.size == 8);
+
+    if (!TEST_CHECK(memcmp(&expect_data[0], tm_obj.via.ext.ptr, 8) == 0) ) {
+        TEST_MSG("got 0x%x, expect 0x%x", *(uint32_t*)tm_obj.via.ext.ptr, *((uint32_t*)&expect_data[0]));
+    }
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    msgpack_unpacked_destroy(&result);
+}
+
 TEST_LIST = {
     { "flb_time_to_nanosec"           , test_to_nanosec},
     { "flb_time_append_to_mpack_v1"   , test_append_to_mpack_v1},
+    { "msgpack_to_time_int"           , test_msgpack_to_time_int},
+    { "msgpack_to_time_double"        , test_msgpack_to_time_double},
+    { "msgpack_to_time_eventtime"     , test_msgpack_to_time_eventtime},
+    { "msgpack_to_time_invalid"       , test_msgpack_to_time_invalid},
+    { "append_to_msgpack_eventtime"   , test_append_to_msgpack_eventtime},
     { NULL, NULL }
 };


### PR DESCRIPTION
This patch is to
- Add strict event time type checking
- Add some test cases to test type converting

Currently, time API only check if Ext type or not.
It caused an issue https://github.com/fluent/fluent-bit/issues/5215 indirectly.

This patch is to check the ext type and ext data size.

https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v0#eventtime-ext-format
https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
According above links, the type of event time should be 0 and its size is 8.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-it-flb_time 
Test flb_time_to_nanosec...                     [ OK ]
Test flb_time_append_to_mpack_v1...             [ OK ]
Test msgpack_to_time_int...                     [ OK ]
Test msgpack_to_time_double...                  [ OK ]
Test msgpack_to_time_eventtime...               [ OK ]
Test msgpack_to_time_invalid...                 [2022/05/14 21:05:31] [ warn] [time] unknown ext type. type=0 size=5
[2022/05/14 21:05:31] [ warn] [time] unknown ext type. type=10 size=8
[ OK ]
Test append_to_msgpack_eventtime...             [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-flb_time 
==11383== Memcheck, a memory error detector
==11383== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11383== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==11383== Command: bin/flb-it-flb_time
==11383== 
Test flb_time_to_nanosec...                     [ OK ]
Test flb_time_append_to_mpack_v1...             [ OK ]
Test msgpack_to_time_int...                     [ OK ]
Test msgpack_to_time_double...                  [ OK ]
Test msgpack_to_time_eventtime...               [ OK ]
Test msgpack_to_time_invalid...                 [2022/05/14 21:05:53] [ warn] [time] unknown ext type. type=0 size=5
[2022/05/14 21:05:53] [ warn] [time] unknown ext type. type=10 size=8
[ OK ]
Test append_to_msgpack_eventtime...             [ OK ]
SUCCESS: All unit tests have passed.
==11383== 
==11383== HEAP SUMMARY:
==11383==     in use at exit: 0 bytes in 0 blocks
==11383==   total heap usage: 26 allocs, 26 frees, 93,224 bytes allocated
==11383== 
==11383== All heap blocks were freed -- no leaks are possible
==11383== 
==11383== For lists of detected and suppressed errors, rerun with: -s
==11383== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
