### PR TITLE
 out_es: resolve domain name not found issue in cloud_id as it contains a port.

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -30,6 +30,7 @@
 #define FLB_ES_DEFAULT_TIME_KEYF  "%Y-%m-%dT%H:%M:%S"
 #define FLB_ES_DEFAULT_TAG_KEY    "flb-key"
 #define FLB_ES_DEFAULT_HTTP_MAX   "512k"
+#define FLB_ES_DEFAULT_HTTPS_PORT 443
 #define FLB_ES_WRITE_OP_INDEX     "index"
 #define FLB_ES_WRITE_OP_CREATE    "create"
 #define FLB_ES_WRITE_OP_UPDATE    "update"

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -122,7 +122,10 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     char *aws_external_id = NULL;
     char *aws_session_name = NULL;
 #endif
+    char *cloud_port_char;
     char *cloud_host = NULL;
+    int cloud_host_port = 0;
+    int cloud_port = FLB_ES_DEFAULT_HTTPS_PORT;
     struct flb_uri *uri = ins->host.uri;
     struct flb_uri_field *f_index = NULL;
     struct flb_uri_field *f_type = NULL;
@@ -153,8 +156,36 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             flb_es_conf_destroy(ctx);
             return NULL;
         }
+        flb_plg_debug(ctx->ins, "extracted cloud_host: '%s'", cloud_host);
+
+        cloud_port_char = strchr(cloud_host, ':');
+
+	if (cloud_port_char == NULL) {
+            flb_plg_debug(ctx->ins, "cloud_host: '%s' does not contain a port: '%s'", cloud_host, cloud_host);
+        }
+        else {
+            cloud_port_char[0] = '\0';
+            cloud_port_char = &cloud_port_char[1];
+            flb_plg_debug(ctx->ins, "extracted cloud_port_char: '%s'", cloud_port_char);
+            cloud_host_port = (int) strtol(cloud_port_char, (char **) NULL, 10);
+            flb_plg_debug(ctx->ins, "converted cloud_port_char to port int: '%i'", cloud_host_port);
+	}
+
+        if (cloud_host_port == 0) {
+            cloud_host_port = cloud_port;
+        }
+
+        flb_plg_debug(ctx->ins,
+                      "checked whether extracted port was null and set it to "
+                      "default https port or not. Outcome: '%i' and cloud_host: '%s'.",
+                      cloud_host_port, cloud_host);
+
+        if (ins->host.name != NULL) {
+            flb_sds_destroy(ins->host.name);
+        }
+
         ins->host.name = cloud_host;
-        ins->host.port = 443;
+        ins->host.port = cloud_host_port;
     }
 
     /* Set default network configuration */


### PR DESCRIPTION
Complete unfinished work in PR https://github.com/fluent/fluent-bit/issues/3920
Ticket: #4260 


…g cloud_id.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change

```
[2022/05/16 07:53:42] [ info] [cmetrics] version=0.3.1
[2022/05/16 07:53:42] [debug] [output:es:es.0] extracted cloud_host: 'xyz.westeurope.azure.elastic-cloud.com:9243'
[2022/05/16 07:53:42] [debug] [output:es:es.0] check whether extracted cloud_host 'xyz.westeurope.azure.elastic-cloud.com:9243' contains a port
[2022/05/16 07:53:42] [debug] [output:es:es.0] cloud_host without port: 'xyz.westeurope.azure.elastic-cloud.com'
[2022/05/16 07:53:42] [debug] [output:es:es.0] extracted portChar: '9243'
[2022/05/16 07:53:42] [debug] [output:es:es.0] converted portChart to port int: '9243'
[2022/05/16 07:53:42] [debug] [output:es:es.0] checked whether extracted port was null and set it to default https port or not. Outcome: '9243'
[2022/05/16 07:53:42] [debug] [output:es:es.0] host=xyz.westeurope.azure.elastic-cloud.com port=9243 uri=/_bulk index=pega-bix-logs-tip-acc type=_doc
[2022/05/16 07:53:42] [ info] [sp] stream processor started

```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
