### PR TITLE
1.8: fstore: ensure the chunk is up while modifying it

### DIFF
--- a/src/flb_fstore.c
+++ b/src/flb_fstore.c
@@ -76,12 +76,31 @@ int flb_fstore_file_meta_set(struct flb_fstore *fs,
                              void *meta, size_t size)
 {
     int ret;
+    int set_down = FLB_FALSE;
+
+    /* Check if the chunk is up */
+    if (cio_chunk_is_up(fsf->chunk) == CIO_FALSE) {
+        ret = cio_chunk_up_force(fsf->chunk);
+        if (ret != CIO_OK) {
+            flb_error("[fstore] error loading up file chunk");
+            return -1;
+        }
+        set_down = FLB_TRUE;
+    }
 
     ret = cio_meta_write(fsf->chunk, meta, size);
     if (ret == -1) {
         flb_error("[fstore] could not write metadata to file: %s:%s",
                   fsf->stream->name, fsf->chunk->name);
+
+        if (set_down == FLB_TRUE) {
+            cio_chunk_down(fsf->chunk);
+        }
         return -1;
+    }
+
+    if (set_down == FLB_TRUE) {
+        cio_chunk_down(fsf->chunk);
     }
 
     return meta_set(fsf, meta, size);
@@ -254,11 +273,31 @@ int flb_fstore_file_content_copy(struct flb_fstore *fs,
 int flb_fstore_file_append(struct flb_fstore_file *fsf, void *data, size_t size)
 {
     int ret;
+    int set_down = FLB_FALSE;
+
+    /* Check if the chunk is up */
+    if (cio_chunk_is_up(fsf->chunk) == CIO_FALSE) {
+        ret = cio_chunk_up_force(fsf->chunk);
+        if (ret != CIO_OK) {
+            flb_error("[fstore] error loading up file chunk");
+            return -1;
+        }
+        set_down = FLB_TRUE;
+    }
 
     ret = cio_chunk_write(fsf->chunk, data, size);
     if (ret != CIO_OK) {
         flb_error("[fstore] could not write data to file %s", fsf->name);
+
+        if (set_down == FLB_TRUE) {
+            cio_chunk_down(fsf->chunk);
+        }
+
         return -1;
+    }
+
+    if (set_down == FLB_TRUE) {
+        cio_chunk_down(fsf->chunk);
     }
 
     return 0;


### PR DESCRIPTION
This PR addresses the `error writing tag metadata` bug in [5378](https://github.com/fluent/fluent-bit/issues/5378).

This is a simplistic approach that applies the same logic used all around in fluent bit which is "If the chunk is down, bring it up, use it and set it down again". It was implemented in this particular way to ensure that the issue is fixed with minimal chances of introducing bugs.

The real solution here would be implementing a smart chunk list at stream level that acts in FIFO mode (or an optimal approach based on "hotness") where chunks are brought up whenever needed and are automatically set down displaced by others.

The simplistic fix used everywhere is not only error prone because code is copied around and people are fallible (ie. could forget to set a chunk down when returning through an error handler code path) but also because it causes chunks to be brought up and set down multiple times due where the "mitigations" are located which makes little to no sense.

After analyzing the issue I was pointed to PR [4680](https://github.com/fluent/fluent-bit/pull/4680) from @matthewfala which in my opinion implements the right concept but not in the right place and seems the have stalled due to concerns related to thread safety with which I agree.

I think the solution proposed by @matthewfala should adapted and adopted as the long term version and I'm only submitting this PR as a way to remove the pressure of fixing the bug from our backs while the proper, performant and elegant solution takes its final form.
