### PR TITLE
in_opentelemetry: Fixed the event type so OTel metrics 

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -172,4 +172,5 @@ struct flb_input_plugin in_opentelemetry_plugin = {
     .cb_exit      = in_opentelemetry_exit,
     .config_map   = config_map,
     .flags        = FLB_INPUT_NET,
+    .event_type   = FLB_INPUT_METRICS
 };


### PR DESCRIPTION
Opentelemetry metrics were not being properly routed because the input plugin lacked the `event_type` member in its `flb_input_plugin` structure.