### PR TITLE
add encoding to log_id(receiver_id) 

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2150,7 +2150,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         const char *HEX = "0123456789abcdef";
         char *encoded_log_name[strlen(new_log_name) * 3 + 1];
         int position = 0;
-        for (chr = new_log_name; *chr != '\0'; chr++) {
+        for (char *chr = new_log_name; *chr != '\0'; chr++) {
             if (*chr == '.' || *chr == '_' || *chr == '-' || *chr == '/') {
                 encoded_log_name[position++] = '%';
                 encoded_log_name[position++] = HEX[*chr >> 4];

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2146,9 +2146,24 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             new_log_name = log_name;
         }
 
+        /* encode new_log_name */
+        const char *HEX = "0123456789abcdef";
+        char *encoded_log_name[strlen(new_log_name) * 3 + 1];
+        int position = 0;
+        for (chr = new_log_name; *chr != '\0'; chr++) {
+            if (*chr == '.' || *chr == '_' || *chr == '-' || *chr == '/') {
+                encoded_log_name[position++] = '%';
+                encoded_log_name[position++] = HEX[*chr >> 4];
+                encoded_log_name[position++] = HEX[*chr & 15];
+            } else {
+                encoded_log_name[position++] = *chr;
+            }
+        }
+        encoded_log_name[position] = '\0';
+
         /* logName */
         len = snprintf(path, sizeof(path) - 1,
-                       "projects/%s/logs/%s", ctx->export_to_project_id, new_log_name);
+                       "projects/%s/logs/%s", ctx->export_to_project_id, encoded_log_name);
 
         if (log_name_extracted == FLB_TRUE) {
             flb_sds_destroy(log_name);


### PR DESCRIPTION
Added url encoding to log_name.

related issue: https://github.com/fluent/fluent-bit/issues/5475

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
```
[INPUT]
    Name        tail
    Path        /var/log/messages, /var/log/syslog
    Tag         default_pipeline./a/b/c

[OUTPUT]
    Name   stdout
    Match  *
[OUTPUT]
    Match                         *
    Name                          stackdriver
    Retry_Limit                   3
    net.connect_timeout_log_error False
    resource                      gce_instance
    stackdriver_agent             Google-Cloud-Ops-Agent-Logging/2.11.0 (BuildDistro=buster;Platform=linux;ShortName=debian;ShortVersion=10.11)
    tls                           On
    tls.verify                    Off
    workers                       8
```
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
