### PR TITLE
workflows: ensure we substitute variables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ sudo -k
 # Will require sudo
 case ${OS} in
     amzn|amazonlinux)
-        sudo sh <<'SCRIPT'
+        sudo sh <<SCRIPT
 rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 [fluent-bit]
@@ -49,7 +49,7 @@ yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
     centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
-        sudo sh <<'SCRIPT'
+        sudo sh <<SCRIPT
 rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 [fluent-bit]

--- a/install.sh
+++ b/install.sh
@@ -34,17 +34,21 @@ sudo -k
 # Will require sudo
 case ${OS} in
     amzn|amazonlinux)
+        # We need variable expansion and non-expansion on the URL line to pick up the base URL.
+        # Therefore we combine things with sed to handle it.
         sudo sh <<SCRIPT
 rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 [fluent-bit]
 name = Fluent Bit
-baseurl = $RELEASE_URL/amazonlinux/\$releasever/\$basearch/
+baseurl = $RELEASE_URL/amazonlinux/VERSION_ARCH_SUBSTR
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
 enabled=1
 EOF
+sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
+cat /etc/yum.repos.d/fluent-bit.repo
 yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;
@@ -60,6 +64,8 @@ repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
 enabled=1
 EOF
+sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
+cat /etc/yum.repos.d/fluent-bit.repo
 yum -y install fluent-bit || yum -y install td-agent-bit
 SCRIPT
     ;;

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 [fluent-bit]
 name = Fluent Bit
-baseurl = $RELEASE_URL/centos/\$releasever/\$basearch/
+baseurl = $RELEASE_URL/centos/VERSION_ARCH_SUBSTR
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
@@ -79,6 +79,7 @@ curl $RELEASE_KEY | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
 cat > /etc/apt/sources.list.d/fluent-bit.list <<EOF
 deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] $RELEASE_URL/${OS}/${CODENAME} ${CODENAME} main
 EOF
+cat /etc/apt/sources.list.d/fluent-bit.list
 apt-get -y update
 apt-get -y install fluent-bit || apt-get -y install td-agent-bit
 SCRIPT

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -9,6 +9,7 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
 fi
 
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+INSTALL_SCRIPT=${INSTALL_SCRIPT:-https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh}
 
 APT_TARGETS=("ubuntu:18.04"
     "ubuntu:20.04"
@@ -26,7 +27,7 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "apt-get update && apt-get install -y sudo gpg curl;curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh"
+        sh -c "apt-get update && apt-get install -y sudo gpg curl;curl $INSTALL_SCRIPT | sh"
 done
 
 for IMAGE in "${YUM_TARGETS[@]}"
@@ -36,5 +37,5 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "yum install -y curl sudo;curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh"
+        sh -c "yum install -y curl sudo;curl $INSTALL_SCRIPT | sh"
 done


### PR DESCRIPTION
Resolves #5484 for Yum-based repositories.

The issue is that on a single line we need to both substitute variables and not substitute special variables:
```
baseurl = $RELEASE_URL/amazonlinux/\$releasever/\$basearch/
```
This was complicated by the use of a HEREDOC script wrapping a HEREDOC `cat` call so in the end the easiest approach is to `sed` it afterwards:
```
baseurl = $RELEASE_URL/amazonlinux/VERSION_ARCH_SUBSTR
...
sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
```

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

The following all pass now whereas before only the Apt-based installs worked:
```
$ docker run --rm -it centos:7 sh -c "yum install -y curl sudo;curl https://raw.githubusercontent.com/fluent/fluent-bit/feb72f47aa13252d9c69a49096333f00b3b2bca7/install.sh | sh"
$ docker run --rm -it amazonlinux:2 sh -c "yum install -y curl sudo;curl https://raw.githubusercontent.com/fluent/fluent-bit/feb72f47aa13252d9c69a49096333f00b3b2bca7/install.sh | sh"
$ docker run --rm -it debian:11 sh -c "apt-get update && apt-get install -y sudo gpg curl;curl https://raw.githubusercontent.com/fluent/fluent-bit/feb72f47aa13252d9c69a49096333f00b3b2bca7/install.sh | sh"
$ docker run --rm -it ubuntu:20.04 sh -c "apt-get update && apt-get install -y sudo gpg curl;curl https://raw.githubusercontent.com/fluent/fluent-bit/feb72f47aa13252d9c69a49096333f00b3b2bca7/install.sh | sh"
```

Additionally, the test script as well also passes which sets the variables:
```
$ export INSTALL_SCRIPT=https://raw.githubusercontent.com/fluent/fluent-bit/feb72f47aa13252d9c69a49096333f00b3b2bca7/install.sh
$ ./packaging/test-release-packages.sh
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
