### PR TITLE
workflows: unstable ci updates

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -319,7 +319,7 @@ jobs:
       - name: Generate schema
         run: |
           docker run --rm -t ${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }} -J > fluent-bit-schema-${{ inputs.version }}.json
-          cat fluent-bit-schema.json | jq -M > fluent-bit-schema-pretty-${{ inputs.version }}.json
+          cat fluent-bit-schema-${{ inputs.version }}.json | jq -M > fluent-bit-schema-pretty-${{ inputs.version }}.json
         shell: bash
 
       - name: Upload the schema

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -93,7 +93,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref }}
+          # Need latest for checksum packaging script
+          ref: master
 
       - name: Download all artefacts
         continue-on-error: true

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -13,8 +13,8 @@ on:
   # Run nightly build at this time, bit of trial and error but this seems good.
   schedule:
   - cron: "0 6 * * *"   # master build
-  - cron: "0 12 * * *"  # 1.9 build
   # Not available currently so will fail until it is
+  # - cron: "0 12 * * *"  # 1.9 build
   - cron: "0 18 * * *"  # 1.8 build
   # A 1.8 build requires merging all the changes from master to handle packaging from local
 


### PR DESCRIPTION
Resolves #5493 with various tweaks:
* Corrects JSON schema filename now it includes the version
* Disables 1.9 branch builds for now
* Use master branch for Windows packaging scripts as not present on 1.8

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
