### PR TITLE
filter_lua: Fix record split in mpack implementation

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -47,6 +47,7 @@ struct flb_lua_l2c_config {
     struct mk_list l2c_types;  /* data types (lua -> C) */
 };
 
+int flb_lua_arraylength(lua_State *l);
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm);
 int flb_lua_is_valid_func(lua_State *l, flb_sds_t func);
 int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader);

--- a/src/flb_lua.c
+++ b/src/flb_lua.c
@@ -243,7 +243,7 @@ static int lua_table_maxn(lua_State *l)
 #endif
 }
 
-static int lua_arraylength(lua_State *l)
+int flb_lua_arraylength(lua_State *l)
 {
     lua_Integer n;
     int count = 0;
@@ -442,7 +442,7 @@ void flb_lua_tompack(lua_State *l,
                 mpack_write_false(writer);
             break;
         case LUA_TTABLE:
-            len = lua_arraylength(l);
+            len = flb_lua_arraylength(l);
             if (len > 0) {
                 mpack_write_tag(writer, mpack_tag_array(len));
                 for (i = 1; i <= len; i++) {
@@ -533,7 +533,7 @@ void flb_lua_tomsgpack(lua_State *l,
                 msgpack_pack_false(pck);
             break;
         case LUA_TTABLE:
-            len = lua_arraylength(l);
+            len = flb_lua_arraylength(l);
             if (len > 0) {
                 msgpack_pack_array(pck, len);
                 for (i = 1; i <= len; i++) {


### PR DESCRIPTION
Fix the mpack implementation of lua, which didn't handle record
splitting.

Fix #5496

Signed-off-by: Thiago Padilha <thiago@calyptia.com>

