### PR TITLE
in_forward: support unix_perm 

### DIFF
--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -36,6 +36,8 @@ struct flb_in_fw_config {
 
     /* Unix Socket (TCP only) */
     char *unix_path;                /* Unix path for socket        */
+    unsigned int unix_perm;         /* Permission for socket       */
+    flb_sds_t unix_perm_str;        /* Permission (config map)     */
 
     int coll_fd;
     struct mk_list connections;     /* List of active connections */

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -53,6 +53,12 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         snprintf(tmp, sizeof(tmp) - 1, "%d", i_ins->host.port);
         config->tcp_port = flb_strdup(tmp);
     }
+    else {
+        /* Unix socket mode */
+        if (config->unix_perm_str) {
+            config->unix_perm = strtol(config->unix_perm_str, NULL, 8) & 07777;
+        }
+    }
 
     if (!config->unix_path) {
         flb_debug("[in_fw] Listen='%s' TCP_Port=%s",


### PR DESCRIPTION
Fixes #5483 

This patch is to support `unix_perm` to set a permission for unix socket like `in_syslog`.


| Key                 | Description                                                                                                                                                                                                                                                                                                                                 | Default |
|:--------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :--- |
| Unix_Perm           | Set the permission of the unix socket file. If _Unix_Path_ is not set, this parameter is ignored.                                                                                                                                                                                                                                      | |

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug output 

```
$ bin/flb-rt-in_forward 
Test forward...                                 [2022/05/28 10:14:16] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/05/28 10:14:19] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/05/28 10:14:22] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/05/28 10:14:25] [ info] [input] pausing forward.0
[ OK ]
Test unix_perm...                               [2022/05/28 10:14:28] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output 

```
$ valgrind --leak-check=full bin/flb-rt-in_forward 
==25507== Memcheck, a memory error detector
==25507== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25507== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==25507== Command: bin/flb-rt-in_forward
==25507== 
Test forward...                                 [2022/05/28 10:13:35] [ info] [input] pausing forward.0
[ OK ]
Test forward_port...                            [2022/05/28 10:13:38] [ info] [input] pausing forward.0
[ OK ]
Test tag_prefix...                              [2022/05/28 10:13:41] [ info] [input] pausing forward.0
[ OK ]
Test unix_path...                               [2022/05/28 10:13:44] [ info] [input] pausing forward.0
[ OK ]
Test unix_perm...                               [2022/05/28 10:13:47] [ info] [input] pausing forward.0
[ OK ]
SUCCESS: All unit tests have passed.
==25507== 
==25507== HEAP SUMMARY:
==25507==     in use at exit: 0 bytes in 0 blocks
==25507==   total heap usage: 5,193 allocs, 5,193 frees, 7,872,937 bytes allocated
==25507== 
==25507== All heap blocks were freed -- no leaks are possible
==25507== 
==25507== For lists of detected and suppressed errors, rerun with: -s
==25507== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
