### PR TITLE
[WIP] out_stackdriver: Add credentials chain options

### DIFF
--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -69,5 +69,7 @@ int flb_oauth2_token_expired(struct flb_oauth2 *ctx);
 
 int flb_oauth2_parse_json_response(const char *json_data, size_t json_size,
                         struct flb_oauth2 *ctx);
+int flb_oauth2_parse_delegated_json_response(const char *json_data, size_t json_size,
+                        struct flb_oauth2 *ctx);
 
 #endif

--- a/plugins/out_stackdriver/gce_metadata.h
+++ b/plugins/out_stackdriver/gce_metadata.h
@@ -25,6 +25,9 @@
 /* Metadata server URL */
 #define FLB_STD_METADATA_SERVER "http://metadata.google.internal"
 
+/* IAM Credential API URL */
+#define FLB_STD_IAMCREDS_SERVER "https://iamcredentials.googleapis.com"
+
 /* Project ID metadata URI */
 #define FLB_STD_METADATA_PROJECT_ID_URI "/computeMetadata/v1/project/project-id"
 
@@ -36,6 +39,9 @@
 
 /* Service account metadata URI */
 #define FLB_STD_METADATA_SERVICE_ACCOUNT_URI "/computeMetadata/v1/instance/service-accounts/"
+
+/* IAM Creds URI for delegated */
+#define FLB_STD_IAMCREDS_SERVICE_ACCOUNT_URI "/v1/projects/-/serviceAccounts/"
 
 /* Max size of token response from metadata server */
 #define FLB_STD_METADATA_TOKEN_SIZE_MAX 14336

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -77,6 +77,7 @@
 #define STDERR "stderr"
 
 #define DEFAULT_TAG_REGEX "(?<pod_name>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\\.log$"
+#define DEFAULT_TOKEN_LIFETIME "3600s"
 
 /* Metrics */
 #ifdef FLB_HAVE_METRICS
@@ -114,6 +115,11 @@ struct flb_stackdriver {
     flb_sds_t auth_uri;
     flb_sds_t token_uri;
     bool metadata_server_auth;
+    /* Delegation chain specific details */
+    flb_sds_t final_service_account_email;
+    flb_sds_t delegation_chain;
+    flb_sds_t token_lifetime;
+    bool use_delegates;
 
     /* metadata server (GCP specific, WIP) */
     flb_sds_t metadata_server;
@@ -185,6 +191,9 @@ struct flb_stackdriver {
 
     /* upstream context for metadata end-point */
     struct flb_upstream *metadata_u;
+
+    /* upstream context for iamcredentials end-point */
+    struct flb_upstream *iamcredentials_u;
 
 #ifdef FLB_HAVE_METRICS
     /* metrics */

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -369,6 +369,16 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
         ctx->client_email = ctx->creds->client_email;
     }
 
+    flb_plg_debug(ctx->ins, "final_service_account_email set to %s", ctx->final_service_account_email);
+    flb_plg_debug(ctx->ins, "delegation_chain set to %s", ctx->delegation_chain);
+    ctx->use_delegates = NULL;
+    if ((ctx->final_service_account_email != NULL) && (ctx->delegation_chain != NULL)) {
+        ctx->use_delegates = true;
+    	flb_plg_info(ctx->ins, "using delegation chain to assume %s with renewals every %s", 
+		     ctx->final_service_account_email,
+		     ctx->token_lifetime);
+    }
+
     /*
      * If only client email has been provided, fetch token from
      * the GCE metadata server.
@@ -598,6 +608,10 @@ int flb_stackdriver_conf_destroy(struct flb_stackdriver *ctx)
 
     if (ctx->metadata_u) {
         flb_upstream_destroy(ctx->metadata_u);
+    }
+
+    if (ctx->iamcredentials_u) {
+        flb_upstream_destroy(ctx->iamcredentials_u);
     }
 
     if (ctx->u) {


### PR DESCRIPTION
This PR adds the ability to write to stackdriver as a service account that requires a delegation chain to assume.

For example, running FluentBit from within a GCP project, we can designate a separate project to write to and a service account to do it as. If a chained delegation is needed, it can be provided. In the config below, the instance email is used to to authenticate to GCP's internal metadata service. The auth token associated with the compute service account is then used to fetch an auth token for finale@fluent-bit-issue-5410.iam.gserviceaccount.com via a delegation chain through second@fluent-bit-issue-5410.iam.gserviceaccount.com. Finally, finale@fluent-bit-issue-5410.iam.gserviceaccount.com writes logs to the fluent-bit-issue-5410-sink project after the finale@ service account has been made a principal with Log Write permissions in the sink project.

```
[SERVICE]
    Flush     5
    Daemon    off
    Log_Level debug

[INPUT]
    Name  cpu
    Tag   my_cpu

[OUTPUT]
    Name                         stackdriver
    Match                        *
    export_to_project_id         fluent-bit-issue-5410-sink
    service_account_email        100237134624-compute@developer.gserviceaccount.com
    final_service_account_email  finale@fluent-bit-issue-5410.iam.gserviceaccount.com 
    delegation_chain             ["second@fluent-bit-issue-5410.iam.gserviceaccount.com"]
```

Addresses #5410

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/817

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
