### PR TITLE
in_opentelemetry: add support for raw traces

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -172,5 +172,5 @@ struct flb_input_plugin in_opentelemetry_plugin = {
     .cb_exit      = in_opentelemetry_exit,
     .config_map   = config_map,
     .flags        = FLB_INPUT_NET,
-    .event_type   = FLB_INPUT_METRICS
+    .event_type   = FLB_INPUT_LOGS | FLB_INPUT_METRICS 
 };


### PR DESCRIPTION
This PR adds support for exporting raw traces using the OpenTelemetry input plugin.
Traces are exported from the application to the endpoint `/traces` on a host running the OTel input plugin, which reads the data and serialises it into a msgpack array (without trying to parse it), and forwards it to the next plugin with event type `FLB_INPUT_LOGS`.