### PR TITLE
utils: seek atmark from tail (#5530)

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1037,7 +1037,7 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     proto_sep += 3;
 
     /* Seperate `username:password` and `host:port` */
-    at_sep = strchr(proto_sep, '@');
+    at_sep = strrchr(proto_sep, '@');
     if (at_sep) {
         /* Parse username:passwrod part. */
         tmp = strchr(proto_sep, ':');

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -375,6 +375,9 @@ struct proxy_url_check proxy_url_checks[] = {
      "http", "proxy.com", "80", NULL, NULL},
     {0, "http://proxy.com:8080",
      "http", "proxy.com", "8080", NULL, NULL},
+    /* issue #5530. Password contains @ */
+    {0, "http://example_user:example_pass_w_@_char@proxy.com:8080",
+     "http", "proxy.com", "8080", "example_user", "example_pass_w_@_char"},
     {-1, "https://proxy.com:8080",
      NULL, NULL, NULL, NULL, NULL}
 


### PR DESCRIPTION
Fixes #5530.

User can set a password that contains '@'.
If we seek '@' from head to get proxy host, we will fail to split password.
    
e.g. `http://example_user:example_pass_w_@_char@proxy.com:8080`
 The password should be  `example_pass_w_@_char`.
However fluent-bit get 'example_pass_w_' as a password.

This patch is to fix it seeking from tail.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-it-utils 
Test url_split...                               [ OK ]
Test write_str...                               [ OK ]
Test test_write_str_invalid_trailing_bytes...   [ OK ]
Test test_write_str_invalid_leading_byte...     [ OK ]
Test test_write_str_edge_cases...               [ OK ]
Test test_write_str_invalid_leading_byte_case_2... [ OK ]
Test test_write_str_buffer_overrun...           [ OK ]
Test proxy_url_split...                         [ OK ]
```

Without patch, the test will be error.
```
$ bin/flb-it-utils 
Test url_split...                               [ OK ]
Test write_str...                               [ OK ]
Test test_write_str_invalid_trailing_bytes...   [ OK ]
Test test_write_str_invalid_leading_byte...     [ OK ]
Test test_write_str_edge_cases...               [ OK ]
Test test_write_str_invalid_leading_byte_case_2... [ OK ]
Test test_write_str_buffer_overrun...           [ OK ]
Test proxy_url_split...                         [ FAILED ]
  utils.c:425: Check ret == 0... failed
    Expected host: proxy.com
    Produced host: _char@proxy.com
FAILED: 1 of 8 unit tests has failed.

```

## Valgrind output
Valgrind reports leak but I believe it doesn't relate this PR.
```
Test proxy_url_split...                         [ OK ]
==10202== 
==10202== HEAP SUMMARY:
==10202==     in use at exit: 128 bytes in 1 blocks
==10202==   total heap usage: 22 allocs, 21 frees, 1,299 bytes allocated
==10202== 
==10202== 128 bytes in 1 blocks are still reachable in loss record 1 of 1
==10202==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==10202==    by 0x114613: main (acutest.h:1632)
==10202== 
==10202== LEAK SUMMARY:
==10202==    definitely lost: 0 bytes in 0 blocks
==10202==    indirectly lost: 0 bytes in 0 blocks
==10202==      possibly lost: 0 bytes in 0 blocks
==10202==    still reachable: 128 bytes in 1 blocks
==10202==         suppressed: 0 bytes in 0 blocks
==10202== 
==10202== For lists of detected and suppressed errors, rerun with: -s
==10202== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==10194== 
==10194== HEAP SUMMARY:
==10194==     in use at exit: 0 bytes in 0 blocks
==10194==   total heap usage: 2 allocs, 2 frees, 1,152 bytes allocated
==10194== 
==10194== All heap blocks were freed -- no leaks are possible
==10194== 
==10194== For lists of detected and suppressed errors, rerun with: -s
==10194== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
