### PR TITLE
debian: add missing fluent-bit configs to debian conffiles

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,3 +1,6 @@
 /etc/td-agent-bit/parsers.conf
 /etc/td-agent-bit/plugins.conf
 /etc/td-agent-bit/td-agent-bit.conf
+/etc/fluent-bit/parsers.conf
+/etc/fluent-bit/plugins.conf
+/etc/fluent-bit/fluent-bit.conf


### PR DESCRIPTION
Fixes #5377

Signed-off-by: Jorge Niedbalski <j@calyptia.com>