### PR TITLE
out_es: add option to compress payload

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_signv4.h>
 #include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_ra_key.h>
 #include <msgpack.h>
@@ -800,6 +801,7 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     struct flb_upstream_conn *u_conn;
     struct flb_http_client *c;
     flb_sds_t signature = NULL;
+    int compressed = FLB_FALSE;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -820,6 +822,29 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
     pack = (char *) out_buf;
     pack_size = out_size;
+
+    /* Should we compress the payload ? */
+    if (ctx->compress_gzip == FLB_TRUE) {
+        ret = flb_gzip_compress((void *) pack, pack_size,
+                                &out_buf, &out_size);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins,
+                          "cannot gzip payload, disabling compression");
+        }
+        else {
+            compressed = FLB_TRUE;
+        }
+
+        /*
+         * The payload buffer is different than pack, means we must be free it.
+         */
+        if (out_buf != pack) {
+            flb_free(pack);
+        }
+
+        pack = (char *) out_buf;
+        pack_size = out_size;
+    }
 
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
@@ -851,6 +876,11 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
         flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
     }
 #endif
+
+    /* Content Encoding: gzip */
+    if (compressed == FLB_TRUE) {
+        flb_http_set_content_encoding_gzip(c);
+    }
 
     /* Map debug callbacks */
     flb_http_client_debug(c, ctx->ins->callback);
@@ -918,6 +948,11 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
  retry:
     flb_http_client_destroy(c);
     flb_free(pack);
+
+    if (out_buf != pack) {
+        flb_free(out_buf);
+    }
+
     flb_upstream_conn_release(u_conn);
     FLB_OUTPUT_RETURN(FLB_RETRY);
 }
@@ -958,6 +993,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "http_passwd", "",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, http_passwd),
      "Password for user defined in HTTP_User"
+    },
+
+    /* HTTP Compression */
+    {
+     FLB_CONFIG_MAP_STR, "compress", NULL,
+     0, FLB_FALSE, 0,
+     "Set payload compression mechanism. Option available is 'gzip'"
     },
 
     /* Cloud Authentication */

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -122,6 +122,9 @@ struct flb_elasticsearch {
 
     struct flb_record_accessor *ra_prefix_key;
 
+    /* Compression mode (gzip) */
+    int compress_gzip;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -186,6 +186,15 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
         io_flags |= FLB_IO_IPV6;
     }
 
+    /* Compress (gzip) */
+    tmp = flb_output_get_property("compress", ins);
+    ctx->compress_gzip = FLB_FALSE;
+    if (tmp) {
+        if (strcasecmp(tmp, "gzip") == 0) {
+            ctx->compress_gzip = FLB_TRUE;
+        }
+    }
+
     /* Prepare an upstream handler */
     upstream = flb_upstream_create(config,
                                    ins->host.name,


### PR DESCRIPTION
Add option to the elasticsearch ouput to allow compressing with gzip the payload when sending data.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change: [fluentbit.config.txt](https://github.com/fluent/fluent-bit/files/8878489/fluentbit.config.txt)
- [x] Debug log output from testing the change: See valgrind.txt below
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found: [valgrind.txt](https://github.com/fluent/fluent-bit/files/8878483/valgrind.txt)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
- [x] Documentation required for this feature: https://github.com/fluent/fluent-bit-docs/pull/824

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
