### PR TITLE
out_tcp: modify to be more testable add format test code

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -76,6 +76,7 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_SPLUNK           "out_splunk.c")
   FLB_RT_TEST(FLB_OUT_STDOUT           "out_stdout.c")
   FLB_RT_TEST(FLB_OUT_SYSLOG           "out_syslog.c")
+  FLB_RT_TEST(FLB_OUT_TCP              "out_tcp.c")
 
   if (FLB_RECORD_ACCESSOR)
     FLB_RT_TEST(FLB_OUT_STACKDRIVER      "out_stackdriver.c")

--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -1,0 +1,784 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <string.h>
+#include <float.h>
+#include <msgpack.h>
+#include "flb_tests_runtime.h"
+
+struct test_ctx {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd (unused) */
+    int o_ffd;         /* Output fd */
+};
+
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+/* Callback to check expected results */
+static void cb_check_str_list(void *ctx, int ffd, int res_ret, 
+                              void *res_data, size_t res_size, void *data)
+{
+    char *p;
+    flb_sds_t out_line = res_data;
+    int num = get_output_num();
+    size_t i;
+    struct str_list *l = (struct str_list *)data;
+
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("l is NULL");
+        flb_sds_destroy(out_line);
+        return;
+    }
+
+    if(!TEST_CHECK(res_ret == 0)) {
+        TEST_MSG("callback ret=%d", res_ret);
+    }
+    if (!TEST_CHECK(res_data != NULL)) {
+        TEST_MSG("res_data is NULL");
+        flb_sds_destroy(out_line);
+        return;
+    }
+
+    for (i=0; i<l->size; i++) {
+        p = strstr(out_line, l->lists[i]);
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("  Got   :%s\n  expect:%s", out_line, l->lists[i]);
+        }
+    }
+    set_output_num(num+1);
+
+    flb_sds_destroy(out_line);
+}
+
+static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
+{
+    int ret = -1;
+
+    if (str == NULL) {
+        flb_error("str is NULL");
+        return -1;
+    }
+
+    switch (obj.type)  {
+    case MSGPACK_OBJECT_STR:
+        if (obj.via.str.size != str_len) {
+            return -1;
+        }
+        ret = strncmp(str, obj.via.str.ptr, str_len);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            unsigned long val = strtoul(str, NULL, 10);
+            if (val == (unsigned long)obj.via.u64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            long long val = strtoll(str, NULL, 10);
+            if (val == (unsigned long)obj.via.i64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            double val = strtod(str, NULL);
+            if ((val - obj.via.f64) < DBL_EPSILON) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            if (str_len != 4 /*true*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "true", 4);
+        }
+        else {
+            if (str_len != 5 /*false*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "false", 5);
+        }
+        break;
+    default:
+        flb_error("not supported");
+    }
+
+    return ret;
+}
+
+/* Callback to check expected results */
+static void cb_check_msgpack_kv(void *ctx, int ffd, int res_ret, 
+                                void *res_data, size_t res_size, void *data)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+    struct str_list *l = (struct str_list *)data;
+    int i_map;
+    int map_size;
+    int i_list;
+    int num = get_output_num();
+
+    if (!TEST_CHECK(res_data != NULL)) {
+        TEST_MSG("res_data is NULL");
+        return;
+    }
+
+    if (!TEST_CHECK(data != NULL)) {
+        flb_error("data is NULL");
+        return;
+    }
+
+    /* Iterate each item array and apply rules */
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, res_data, res_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        obj = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+        if (obj.type != MSGPACK_OBJECT_ARRAY || obj.via.array.size != 2) {
+            flb_error("array error. type = %d", obj.type);
+            continue;
+        }
+        obj = obj.via.array.ptr[1];
+        if (obj.type != MSGPACK_OBJECT_MAP) {
+            flb_error("map error. type = %d", obj.type);
+            continue;
+        }
+        map_size = obj.via.map.size;
+        for (i_map=0; i_map<map_size; i_map++) {
+            if (obj.via.map.ptr[i_map].key.type != MSGPACK_OBJECT_STR) {
+                flb_error("key is not string. type =%d", obj.via.map.ptr[i_map].key.type);
+                continue;
+            }
+            for (i_list=0; i_list< l->size/2; i_list++)  {
+                if (msgpack_strncmp(l->lists[i_list*2], strlen(l->lists[i_list*2]),
+                                    obj.via.map.ptr[i_map].key) == 0 &&
+                    msgpack_strncmp(l->lists[i_list*2+1], strlen(l->lists[i_list*2+1]),
+                                    obj.via.map.ptr[i_map].val) == 0) {
+                    num++;
+                }
+            }
+        }
+    }
+    set_output_num(num);
+
+    msgpack_unpacked_destroy(&result);
+
+    return ;
+}
+
+static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int o_ffd;
+    struct test_ctx *ctx = NULL;
+
+    ctx = flb_malloc(sizeof(struct test_ctx));
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("malloc failed");
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "lib", NULL);
+    TEST_CHECK(i_ffd >= 0);
+    ctx->i_ffd = i_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "tcp", (void *) data);
+    ctx->o_ffd = o_ffd;
+
+    return ctx;
+}
+
+static void test_ctx_destroy(struct test_ctx *ctx)
+{
+    TEST_CHECK(ctx != NULL);
+
+    sleep(1);
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+void flb_test_format_msgpack()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\", \"val\":1000, \"nval\":-10000, \"bool\":true, \"float\":1.234}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"msg", "hello world", "val", "1000", "nval", "-10000", "bool", "true", "float", "1.234"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "msgpack",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_msgpack_kv,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == expected.size / 2))  {
+        TEST_MSG("got %d, expected %lu", num, expected.size/2);
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_json()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+    char *buf2 = "[2, {\"msg\":\"hello world\"}]";
+    size_t size2 = strlen(buf2);
+
+    char *expected_strs[] = {"[{\"date\":1.0,\"msg\":\"hello world\"},{\"date\":2.0,\"msg\":\"hello world\"}]"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf2, size2);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_json_stream()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+    char *buf2 = "[2, {\"msg\":\"hello world\"}]";
+    size_t size2 = strlen(buf2);
+
+    char *expected_strs[] = {"{\"date\":1.0,\"msg\":\"hello world\"}{\"date\":2.0,\"msg\":\"hello world\"}"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json_stream",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf2, size2);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_json_lines()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+    char *buf2 = "[2, {\"msg\":\"hello world\"}]";
+    size_t size2 = strlen(buf2);
+
+    char *expected_strs[] = {"{\"date\":1.0,\"msg\":\"hello world\"}\n{\"date\":2.0,\"msg\":\"hello world\"}"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json_lines",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf2, size2);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_set_json_date_key()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"{\"timestamp\":1.0,\"msg\":\"hello world\"}"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         "json_date_key", "timestamp",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_disable_json_date_key()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"{\"msg\":\"hello world\"}"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         "json_date_key", "false",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_json_date_format_epoch()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"{\"date\":1,\"msg\":\"hello world\"}"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         "json_date_format", "epoch",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_json_date_format_iso8601()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"\"msg\":\"hello world\"", "\"date\":\"1970-01-01T00:00:01.000000Z\""};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         "json_date_format", "iso8601",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_json_date_format_java_sql_timestamp()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"\"msg\":\"hello world\"", "\"date\":\"1970-01-01 00:00:01.000000\""};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         "json_date_format", "java_sql_timestamp",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"format_msgpack" , flb_test_format_msgpack},
+    {"format_json" , flb_test_format_json},
+    {"format_json_stream" , flb_test_format_json_stream},
+    {"format_json_lines" , flb_test_format_json_lines},
+    {"set_json_date_key" , flb_test_set_json_date_key},
+    {"disable_json_date_key" , flb_test_disable_json_date_key},
+    {"json_date_format_epoch" , flb_test_json_date_format_epoch},
+    {"json_date_format_iso8601" , flb_test_json_date_format_iso8601},
+    {"json_date_format_java_sql_timestamp" , flb_test_json_date_format_java_sql_timestamp},
+    {NULL, NULL}
+};


### PR DESCRIPTION
This patch is to
* Modify out_tcp to add formatter and be more testable. 
* Add format test code for out_tcp


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log
```
$ bin/flb-rt-out_tcp 
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ nc -l 3000 &
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o tcp -p port=3000 -p format=json
==58677== Memcheck, a memory error detector
==58677== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==58677== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==58677== Command: bin/fluent-bit -i cpu -o tcp -p port=3000 -p format=json
==58677== 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/11 17:09:42] [ info] [fluent bit] version=1.9.5, commit=8f9fea3977, pid=58677
[2022/06/11 17:09:43] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/11 17:09:43] [ info] [cmetrics] version=0.3.1
[2022/06/11 17:09:43] [ info] [output:tcp:tcp.0] worker #0 started
[2022/06/11 17:09:43] [ info] [output:tcp:tcp.0] worker #1 started
[2022/06/11 17:09:43] [ info] [sp] stream processor started
^C[2022/06/11 17:09:46] [engine] caught signal (SIGINT)
[2022/06/11 17:09:46] [ info] [input] pausing cpu.0
[2022/06/11 17:09:46] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/11 17:09:46] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/11 17:09:46] [ info] [output:tcp:tcp.0] thread worker #0 stopping...
[2022/06/11 17:09:46] [ info] [output:tcp:tcp.0] thread worker #0 stopped
[2022/06/11 17:09:46] [ info] [output:tcp:tcp.0] thread worker #1 stopping...
[2022/06/11 17:09:46] [ info] [output:tcp:tcp.0] thread worker #1 stopped
==58677== 
==58677== HEAP SUMMARY:
==58677==     in use at exit: 0 bytes in 0 blocks
==58677==   total heap usage: 1,243 allocs, 1,243 frees, 1,411,036 bytes allocated
==58677== 
==58677== All heap blocks were freed -- no leaks are possible
==58677== 
==58677== For lists of detected and suppressed errors, rerun with: -s
==58677== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

```
$ valgrind --leak-check=full bin/flb-rt-out_tcp 
==58573== Memcheck, a memory error detector
==58573== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==58573== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==58573== Command: bin/flb-rt-out_tcp
==58573== 
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
==58573== 
==58573== HEAP SUMMARY:
==58573==     in use at exit: 0 bytes in 0 blocks
==58573==   total heap usage: 9,486 allocs, 9,486 frees, 5,282,126 bytes allocated
==58573== 
==58573== All heap blocks were freed -- no leaks are possible
==58573== 
==58573== For lists of detected and suppressed errors, rerun with: -s
==58573== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
