### PR TITLE
out_http: add test for msgpack format 

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -402,11 +402,11 @@ static int compose_payload(struct flb_out_http *ctx,
     else if (ctx->out_format == FLB_HTTP_OUT_GELF) {
         return compose_payload_gelf(ctx, in_body, in_size, out_body, out_size);
     }
-    /*
-       Nothing to do, if the format is msgpack
     else {
+        /* Nothing to do, if the format is msgpack */
+        *out_body = (void *)in_body;
+        *out_size = in_size;
     }
-    */
 
     return FLB_OK;
 }

--- a/tests/runtime/out_http.c
+++ b/tests/runtime/out_http.c
@@ -21,6 +21,8 @@
 #include <fluent-bit.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_time.h>
+#include <float.h>
+#include <msgpack.h>
 #include "flb_tests_runtime.h"
 
 struct test_ctx {
@@ -101,6 +103,130 @@ static void cb_check_str_list(void *ctx, int ffd, int res_ret,
     flb_sds_destroy(out_line);
 }
 
+static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
+{
+    int ret = -1;
+
+    if (str == NULL) {
+        flb_error("str is NULL");
+        return -1;
+    }
+
+    switch (obj.type)  {
+    case MSGPACK_OBJECT_STR:
+        if (obj.via.str.size != str_len) {
+            return -1;
+        }
+        ret = strncmp(str, obj.via.str.ptr, str_len);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            unsigned long val = strtoul(str, NULL, 10);
+            if (val == (unsigned long)obj.via.u64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            long long val = strtoll(str, NULL, 10);
+            if (val == (unsigned long)obj.via.i64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            double val = strtod(str, NULL);
+            if ((val - obj.via.f64) < DBL_EPSILON) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            if (str_len != 4 /*true*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "true", 4);
+        }
+        else {
+            if (str_len != 5 /*false*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "false", 5);
+        }
+        break;
+    default:
+        flb_error("not supported");
+    }
+
+    return ret;
+}
+
+/* Callback to check expected results */
+static void cb_check_msgpack_kv(void *ctx, int ffd, int res_ret,
+                                void *res_data, size_t res_size, void *data)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+    struct str_list *l = (struct str_list *)data;
+    int i_map;
+    int map_size;
+    int i_list;
+    int num = get_output_num();
+
+    if (!TEST_CHECK(res_data != NULL)) {
+        TEST_MSG("res_data is NULL");
+        return;
+    }
+
+    if (!TEST_CHECK(data != NULL)) {
+        flb_error("data is NULL");
+        return;
+    }
+
+    /* Iterate each item array and apply rules */
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, res_data, res_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        obj = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+        if (obj.type != MSGPACK_OBJECT_ARRAY || obj.via.array.size != 2) {
+            flb_error("array error. type = %d", obj.type);
+            continue;
+        }
+        obj = obj.via.array.ptr[1];
+        if (obj.type != MSGPACK_OBJECT_MAP) {
+            flb_error("map error. type = %d", obj.type);
+            continue;
+        }
+        map_size = obj.via.map.size;
+        for (i_map=0; i_map<map_size; i_map++) {
+            if (obj.via.map.ptr[i_map].key.type != MSGPACK_OBJECT_STR) {
+                flb_error("key is not string. type =%d", obj.via.map.ptr[i_map].key.type);
+                continue;
+            }
+            for (i_list=0; i_list< l->size/2; i_list++)  {
+                if (msgpack_strncmp(l->lists[i_list*2], strlen(l->lists[i_list*2]),
+                                    obj.via.map.ptr[i_map].key) == 0 &&
+                    msgpack_strncmp(l->lists[i_list*2+1], strlen(l->lists[i_list*2+1]),
+                                    obj.via.map.ptr[i_map].val) == 0) {
+                    num++;
+                }
+            }
+        }
+    }
+    set_output_num(num);
+
+    msgpack_unpacked_destroy(&result);
+
+    return ;
+}
+
 static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
 {
     int i_ffd;
@@ -142,6 +268,60 @@ static void test_ctx_destroy(struct test_ctx *ctx)
     flb_stop(ctx->flb);
     flb_destroy(ctx->flb);
     flb_free(ctx);
+}
+
+void flb_test_format_msgpack()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf1 = "[1, {\"msg\":\"hello world\", \"val\":1000, \"nval\":-10000, \"bool\":true, \"float\":1.234}]";
+    size_t size1 = strlen(buf1);
+
+    char *expected_strs[] = {"msg", "hello world", "val", "1000", "nval", "-10000", "bool", "true", "float", "1.234"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "msgpack",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_msgpack_kv,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == expected.size / 2))  {
+        TEST_MSG("got %d, expected %lu", num, expected.size/2);
+    }
+
+    test_ctx_destroy(ctx);
 }
 
 void flb_test_format_json()
@@ -875,6 +1055,7 @@ void flb_test_json_date_format_java_sql_timestamp()
 
 /* Test list */
 TEST_LIST = {
+    {"format_msgpack" , flb_test_format_msgpack},
     {"format_json" , flb_test_format_json},
     {"format_json_stream" , flb_test_format_json_stream},
     {"format_json_lines" , flb_test_format_json_lines},


### PR DESCRIPTION
This patch is to 
* Fill output body and size to test when a format is msgpack
* Add test case for msgpack format
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-out_http 
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test format_gelf...                             [ OK ]
Test format_gelf_host_key...                    [ OK ]
Test format_gelf_timestamp_key...               [ OK ]
Test format_gelf_full_message_key...            [ OK ]
Test format_gelf_level_key...                   [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
```

## Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-out_http 
==67299== Memcheck, a memory error detector
==67299== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==67299== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==67299== Command: bin/flb-rt-out_http
==67299== 
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test format_gelf...                             [ OK ]
Test format_gelf_host_key...                    [ OK ]
Test format_gelf_timestamp_key...               [ OK ]
Test format_gelf_full_message_key...            [ OK ]
Test format_gelf_level_key...                   [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
==67299== 
==67299== HEAP SUMMARY:
==67299==     in use at exit: 0 bytes in 0 blocks
==67299==   total heap usage: 15,465 allocs, 15,465 frees, 8,150,514 bytes allocated
==67299== 
==67299== All heap blocks were freed -- no leaks are possible
==67299== 
==67299== For lists of detected and suppressed errors, rerun with: -s
==67299== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o http -p port=9200
==67388== Memcheck, a memory error detector
==67388== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==67388== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==67388== Command: bin/fluent-bit -i cpu -o http -p port=9200
==67388== 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/11 21:13:41] [ info] [fluent bit] version=1.9.5, commit=8f9fea3977, pid=67388
[2022/06/11 21:13:41] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/11 21:13:41] [ info] [cmetrics] version=0.3.1
[2022/06/11 21:13:41] [ info] [output:http:http.0] worker #0 started
[2022/06/11 21:13:41] [ info] [output:http:http.0] worker #1 started
[2022/06/11 21:13:41] [ info] [sp] stream processor started
[2022/06/11 21:13:43] [ info] [output:http:http.0] 127.0.0.1:9200, HTTP status=200
[2022/06/11 21:13:43] [ info] [output:http:http.0] 127.0.0.1:9200, HTTP status=200
[2022/06/11 21:13:44] [ info] [output:http:http.0] 127.0.0.1:9200, HTTP status=200
^C[2022/06/11 21:13:45] [engine] caught signal (SIGINT)
[2022/06/11 21:13:45] [ info] [input] pausing cpu.0
[2022/06/11 21:13:45] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/11 21:13:45] [ info] [output:http:http.0] 127.0.0.1:9200, HTTP status=200
[2022/06/11 21:13:45] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/11 21:13:45] [ info] [output:http:http.0] thread worker #0 stopping...
[2022/06/11 21:13:45] [ info] [output:http:http.0] thread worker #0 stopped
[2022/06/11 21:13:45] [ info] [output:http:http.0] thread worker #1 stopping...
[2022/06/11 21:13:45] [ info] [output:http:http.0] thread worker #1 stopped
==67388== 
==67388== HEAP SUMMARY:
==67388==     in use at exit: 0 bytes in 0 blocks
==67388==   total heap usage: 1,361 allocs, 1,361 frees, 1,688,981 bytes allocated
==67388== 
==67388== All heap blocks were freed -- no leaks are possible
==67388== 
==67388== For lists of detected and suppressed errors, rerun with: -s
==67388== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
