### PR TITLE
ml: clear last recently used parser to match next parser(#5524)

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -709,9 +709,11 @@ int flb_ml_append(struct flb_ml *ml, uint64_t stream_id,
             }
         }
         else if (lru_parser && lru_parser->last_stream_id > 0) {
-            flb_ml_flush_parser_instance(ml,
-                                         lru_parser,
-                                         lru_parser->last_stream_id);
+            /*
+             * Clear last recently used parser to match new parser.
+             * Do not flush last_stream_id since it should continue to parsing.
+             */
+            lru_parser = NULL;
         }
     }
 
@@ -819,9 +821,11 @@ int flb_ml_append_object(struct flb_ml *ml, uint64_t stream_id,
             }
         }
         else if (lru_parser && lru_parser->last_stream_id > 0) {
-            flb_ml_flush_parser_instance(ml,
-                                         lru_parser,
-                                         lru_parser->last_stream_id);
+            /*
+             * Clear last recently used parser to match new parser.
+             * Do not flush last_stream_id since it should continue to parsing.
+             */
+            lru_parser = NULL;
         }
     }
 

--- a/tests/runtime/filter_multiline.c
+++ b/tests/runtime/filter_multiline.c
@@ -49,6 +49,78 @@ static int cb_check_result(void *record, size_t size, void *data)
 }
 
 
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+struct str_list {
+    size_t size; /* size of lists */
+    int ignore_min_line_num; /* ignore line if the length is less than this value */
+    char **lists; /* string lists */
+};
+
+/* Callback to check expected results */
+static int cb_check_str_list(void *record, size_t size, void *data)
+{
+    char *p;
+    char *out_line = record;
+    int num = get_output_num();
+    int count = 0;
+    size_t i;
+    struct str_list *l = (struct str_list *)data;
+
+    if (!TEST_CHECK(out_line != NULL)) {
+        TEST_MSG("out_line is NULL");
+        return -1;
+    }
+
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("l is NULL");
+        flb_free(out_line);
+        return -1;
+    }
+
+    if (strlen(out_line) < l->ignore_min_line_num) {
+        flb_free(out_line);
+        return 0;
+    }
+
+    for (i=0; i<l->size; i++) {
+        p = strstr(out_line, l->lists[i]);
+        if (p != NULL) {
+            count++;
+        }
+    }
+    if(!TEST_CHECK(count != 0)) {
+        TEST_MSG("%s is not matched", out_line);
+    }
+    set_output_num(num+count);
+
+    flb_free(out_line);
+    return 0;
+}
+
+
 
 static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
 {
@@ -86,7 +158,7 @@ static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
     o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
     TEST_CHECK(o_ffd >= 0);
     flb_output_set(ctx->flb, o_ffd,
-                   "match", "test",
+                   "match", "test*",
                    "format", "json",
                    NULL);
 
@@ -426,7 +498,196 @@ static void flb_test_multiline_partial_message_concat_two_ids()
     filter_test_destroy(ctx);
 }
 
+
+/*
+ * create 2 in_lib instances and pass multiline
+ * https://github.com/fluent/fluent-bit/issues/5524
+*/
+static void flb_test_ml_buffered_two_streams()
+{
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    int i_ffd_2;
+    int ret;
+    int i;
+    int bytes;
+    int len;
+    char line_buf[2048] = {0};
+    int line_num;
+    int num;
+
+    char *expected_strs[] = {"Exception in thread main java.lang.IllegalStateException: ..null property\\n     at com.example.myproject.Author.getBookIds(xx.java:38)\\n     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)\\nCaused by: java.lang.NullPointerException\\n     at com.example.myproject.Book.getId(Book.java:22)\\n     at com.example.myproject.Author.getBookIds(Author.java:35)\\n     ... 1 more",
+    "Dec 14 06:41:08 Exception in thread main java.lang.RuntimeException: Something has gone wrong, aborting!\\n    at com.myproject.module.MyProject.badMethod(MyProject.java:22)\\n    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)\\n    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)\\n    at com.myproject.module.MyProject.someMethod(MyProject.java:10)\\n    at com.myproject.module.MyProject.main(MyProject.java:6)"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+                                .ignore_min_line_num = 64,
+    };
+
+    char *ml_logs_1[] = {"Exception in thread main java.lang.IllegalStateException: ..null property",
+                         "     at com.example.myproject.Author.getBookIds(xx.java:38)",
+                         "     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)",
+                         "Caused by: java.lang.NullPointerException",
+                         "     at com.example.myproject.Book.getId(Book.java:22)",
+                         "     at com.example.myproject.Author.getBookIds(Author.java:35)",
+                         "     ... 1 more",
+                         "single line"};
+    char *ml_logs_2[] = {
+                         "single line...",
+                         "Dec 14 06:41:08 Exception in thread main java.lang.RuntimeException: Something has gone wrong, aborting!",
+                         "    at com.myproject.module.MyProject.badMethod(MyProject.java:22)",
+                         "    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)",
+                         "    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)",
+                         "    at com.myproject.module.MyProject.someMethod(MyProject.java:10)",
+                         "    at com.myproject.module.MyProject.main(MyProject.java:6)",
+                         "another line..."};
+
+    cb_data.cb = cb_check_str_list;
+    cb_data.data = (void *)&expected;
+
+    clear_output_num();
+
+    TEST_CHECK(sizeof(ml_logs_1)/sizeof(char*) == sizeof(ml_logs_2)/sizeof(char*));
+    line_num = sizeof(ml_logs_1)/sizeof(char*);
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+    i_ffd_2 = flb_input(ctx->flb, (char *) "lib", NULL);
+    TEST_CHECK(i_ffd_2 >= 0);
+    flb_input_set(ctx->flb, i_ffd_2, "tag", "test2", NULL);
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "java",
+                         "buffer", "on",
+                         "debug_flush", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    for (i=0; i<line_num; i++) {
+        sprintf(&line_buf[0], "[%d, {\"log\":\"%s\"}]", i, ml_logs_1[i]);
+        len = strlen(line_buf);
+        bytes = flb_lib_push(ctx->flb, ctx->i_ffd, &line_buf[0], len);
+        TEST_CHECK(bytes == len);
+
+
+        sprintf(&line_buf[0], "[%d, {\"log\":\"%s\"}]", i, ml_logs_2[i]);
+        len = strlen(line_buf);
+        bytes = flb_lib_push(ctx->flb, i_ffd_2, &line_buf[0], len);
+        TEST_CHECK(bytes == len);
+    }
+    sleep(3);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2))  {
+        TEST_MSG("output error. got %d expect 2", num);
+    }
+
+    filter_test_destroy(ctx);
+}
+
+static void flb_test_ml_buffered_16_streams()
+{
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    int i_ffds[16] = {0};
+    int ffd_num = sizeof(i_ffds)/sizeof(int);
+    int ret;
+    int i;
+    int j;
+    int bytes;
+    int len;
+    char line_buf[2048] = {0};
+    char tag_buf[32] = {0};
+    int line_num;
+    int num;
+
+    char *expected_strs[] = {"Exception in thread main java.lang.IllegalStateException: ..null property\\n     at com.example.myproject.Author.getBookIds(xx.java:38)\\n     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)\\nCaused by: java.lang.NullPointerException\\n     at com.example.myproject.Book.getId(Book.java:22)\\n     at com.example.myproject.Author.getBookIds(Author.java:35)\\n     ... 1 more"};
+
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+                                .ignore_min_line_num = 64,
+    };
+
+    char *ml_logs[] = {"Exception in thread main java.lang.IllegalStateException: ..null property",
+                       "     at com.example.myproject.Author.getBookIds(xx.java:38)",
+                       "     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)",
+                       "Caused by: java.lang.NullPointerException",
+                       "     at com.example.myproject.Book.getId(Book.java:22)",
+                       "     at com.example.myproject.Author.getBookIds(Author.java:35)",
+                       "     ... 1 more",
+                       "single line"};
+
+    cb_data.cb = cb_check_str_list;
+    cb_data.data = (void *)&expected;
+
+    clear_output_num();
+
+    line_num = sizeof(ml_logs)/sizeof(char*);
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    i_ffds[0] = ctx->i_ffd;
+    for (i=1; i<ffd_num; i++) {
+        i_ffds[i] = flb_input(ctx->flb, (char *) "lib", NULL);
+        TEST_CHECK(i_ffds[i] >= 0);
+        sprintf(&tag_buf[0], "test%d", i);
+        flb_input_set(ctx->flb, i_ffds[i], "tag", tag_buf, NULL);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "java",
+                         "buffer", "on",
+                         "debug_flush", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    for (i=0; i<line_num; i++) {
+        sprintf(&line_buf[0], "[%d, {\"log\":\"%s\"}]", i, ml_logs[i]);
+        len = strlen(line_buf);
+        for (j=0; j<ffd_num; j++)  {
+            bytes = flb_lib_push(ctx->flb, i_ffds[j], &line_buf[0], len);
+            TEST_CHECK(bytes == len);
+        }
+    }
+    sleep(3);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == ffd_num))  {
+        TEST_MSG("output error. got %d expect %d", num, ffd_num);
+    }
+
+    filter_test_destroy(ctx);
+}
+
+
+
+
 TEST_LIST = {
+    {"ml_buffered_two_streams" , flb_test_ml_buffered_two_streams},
+    {"ml_buffered_16_streams" , flb_test_ml_buffered_16_streams},
+
     {"multiline_buffered_one_record"                      , flb_test_multiline_buffered_one_output_record },
     {"multiline_buffered_two_record"                      , flb_test_multiline_buffered_two_output_record },
     {"flb_test_multiline_unbuffered"                      , flb_test_multiline_unbuffered },


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/5524

Currently, multiline doesn't update a last recently used parser `lru_parser`.
It causes second+ stream can't be parsed correctly.

This patch is to fix it and add test cases. 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
## Configuration

https://github.com/fluent/fluent-bit/issues/5524#issuecomment-1146395607

## Debug log

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/12 20:25:09] [ info] [fluent bit] version=1.9.5, commit=b98b935de6, pid=208771
[2022/06/12 20:25:09] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/12 20:25:09] [ info] [cmetrics] version=0.3.1
[2022/06/12 20:25:09] [ info] [filter:multiline:multiline.0] created emitter: emitter_for_multiline.0
[2022/06/12 20:25:09] [ info] [sp] stream processor started
[2022/06/12 20:25:09] [ info] [filter:multiline:multiline.0] created new multiline stream for tail.0_java.1
[2022/06/12 20:25:09] [ info] [filter:multiline:multiline.0] created new multiline stream for tail.1_java.2
[2022/06/12 20:25:09] [ info] [input:tail:tail.0] inotify_fs_add(): inode=525856 watch_fd=1 name=java1.log
[2022/06/12 20:25:09] [ info] [input:tail:tail.1] inotify_fs_add(): inode=529130 watch_fd=1 name=java2.log
[2022/06/12 20:25:09] [ info] [output:stdout:stdout.0] worker #0 started
[0] java.1: [1655033109.152638255, {"log"=>"Exception in thread "main" java.lang.IllegalStateException: ..null property
     at com.example.myproject.Author.getBookIds(xx.java:38)
     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
Caused by: java.lang.NullPointerException
     at com.example.myproject.Book.getId(Book.java:22)
     at com.example.myproject.Author.getBookIds(Author.java:35)
     ... 1 more"}]
[1] java.1: [1655033109.152644536, {"log"=>"single line"}]
[0] java.2: [1655033109.152784151, {"log"=>"single line..."}]
[1] java.2: [1655033109.152785663, {"log"=>"Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: Something has gone wrong, aborting!
    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
    at com.myproject.module.MyProject.main(MyProject.java:6)"}]
[2] java.2: [1655033109.152787216, {"log"=>"another line..."}]
^C[2022/06/12 20:25:11] [engine] caught signal (SIGINT)
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==208775== Memcheck, a memory error detector
==208775== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==208775== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==208775== Command: bin/fluent-bit -c a.conf
==208775== 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/12 20:25:39] [ info] [fluent bit] version=1.9.5, commit=b98b935de6, pid=208775
[2022/06/12 20:25:40] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/12 20:25:40] [ info] [cmetrics] version=0.3.1
[2022/06/12 20:25:40] [ info] [filter:multiline:multiline.0] created emitter: emitter_for_multiline.0
[2022/06/12 20:25:40] [ info] [output:stdout:stdout.0] worker #0 started
[2022/06/12 20:25:40] [ info] [sp] stream processor started
[2022/06/12 20:25:40] [ info] [filter:multiline:multiline.0] created new multiline stream for tail.0_java.1
[2022/06/12 20:25:40] [ info] [filter:multiline:multiline.0] created new multiline stream for tail.1_java.2
[2022/06/12 20:25:40] [ info] [input:tail:tail.0] inotify_fs_add(): inode=525856 watch_fd=1 name=java1.log
[2022/06/12 20:25:40] [ info] [input:tail:tail.1] inotify_fs_add(): inode=529130 watch_fd=1 name=java2.log
[0] java.1: [1655033140.167003121, {"log"=>"Exception in thread "main" java.lang.IllegalStateException: ..null property
     at com.example.myproject.Author.getBookIds(xx.java:38)
     at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
Caused by: java.lang.NullPointerException
     at com.example.myproject.Book.getId(Book.java:22)
     at com.example.myproject.Author.getBookIds(Author.java:35)
     ... 1 more"}]
[1] java.1: [1655033140.171368330, {"log"=>"single line"}]
[0] java.2: [1655033140.304598653, {"log"=>"single line..."}]
[1] java.2: [1655033140.304628525, {"log"=>"Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: Something has gone wrong, aborting!
    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
    at com.myproject.module.MyProject.main(MyProject.java:6)"}]
[2] java.2: [1655033140.304684874, {"log"=>"another line..."}]
^C[2022/06/12 20:25:41] [engine] caught signal (SIGINT)
[2022/06/12 20:25:41] [ info] [input] pausing tail.0
[2022/06/12 20:25:41] [ info] [input] pausing tail.1
[2022/06/12 20:25:41] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/12 20:25:42] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/12 20:25:42] [ info] [input:tail:tail.1] inotify_fs_remove(): inode=529130 watch_fd=1
[2022/06/12 20:25:42] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=525856 watch_fd=1
[2022/06/12 20:25:42] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/06/12 20:25:42] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==208775== 
==208775== HEAP SUMMARY:
==208775==     in use at exit: 0 bytes in 0 blocks
==208775==   total heap usage: 1,788 allocs, 1,788 frees, 1,941,519 bytes allocated
==208775== 
==208775== All heap blocks were freed -- no leaks are possible
==208775== 
==208775== For lists of detected and suppressed errors, rerun with: -s
==208775== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/flb-rt-filter_multiline 
==208784== Memcheck, a memory error detector
==208784== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==208784== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==208784== Command: bin/flb-rt-filter_multiline
==208784== 
Test ml_buffered_two_streams...                 [2022/06/12 20:26:05] [ info] [fluent bit] version=1.9.5, commit=b98b935de6, pid=208784
[2022/06/12 20:26:05] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/12 20:26:05] [ info] [cmetrics] version=0.3.1
[2022/06/12 20:26:05] [ info] [filter:multiline:multiline.0] created emitter: emitter_for_multiline.0
[2022/06/12 20:26:05] [ info] [sp] stream processor started
(snip)
[ OK ]
SUCCESS: All unit tests have passed.
==208784== 
==208784== HEAP SUMMARY:
==208784==     in use at exit: 0 bytes in 0 blocks
==208784==   total heap usage: 10,773 allocs, 10,773 frees, 22,830,246 bytes allocated
==208784== 
==208784== All heap blocks were freed -- no leaks are possible
==208784== 
==208784== For lists of detected and suppressed errors, rerun with: -s
==208784== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
