### PR TITLE
conf: adding parser for confluent schema registry

### DIFF
--- a/conf/parsers_kafka.conf
+++ b/conf/parsers_kafka.conf
@@ -1,0 +1,16 @@
+[PARSER]
+    # Confluent Schema Registry 7.1.1 default format
+    Name confluent-schema-registry
+    Format regex
+    Time_Key time
+    Time_Format %Y-%m-%d %H:%M:%S,%L
+    Regex ^\[(?<time>\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2},\d{1,4})] (?<level>[A-Z]{1,8}) (?<src>[\d.]+) - - \[(?<date>.*)] \"(?<method>[A-Z]+) (?<path>\/[\S]+|\/) (?<http_version>HTTP\/[\d]\.[\d])\" (?<code>[\d]{1,3}) (?<size>[\d]+) \"-\" \"(?<agent>.*)\" (?<extra_info>.*)
+
+
+[PARSER]
+    # Confluent Schema Registry 7.1.1 default format - with _sr_ prefix to allow `nest`
+    Name confluent-schema-registry-prefixed
+    Format regex
+    Time_Key _sr_time
+    Time_Format %Y-%m-%d %H:%M:%S,%L
+    Regex ^\[(?<_sr_time>\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2},\d{1,4})] (?<_sr_level>[A-Z]{1,8}) (?<_sr_src>[\d.]+) - - \[(?<_sr_date>.*)] \"(?<_sr_method>[A-Z]+) (?<_sr_path>\/[\S]+|\/) (?<_sr_http_version>HTTP\/[\d]\.[\d])\" (?<_sr_code>[\d]{1,3}) (?<_sr_size>[\d]+) \"-\" \"(?<_sr_agent>.*)\" (?<_sr_extra_info>.*)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adding Regex filter for kafka applications (more to come).
First parser for confluent schema registry, with and without prefix to allow `nest` filter.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Full configuration

/fluent-bit/etc/fluent-bit.conf content
```
[INPUT]
    Name tcp
    Listen 127.0.0.1
    Port 8877
    Tag firelens-healthcheck

[INPUT]
    Name forward
    unix_path /var/run/fluent.sock

[INPUT]
    Name forward
    Listen 127.0.0.1
    Port 24224

[FILTER]
    Name record_modifier
    Match *
    Record ecs_cluster dev
    Record ecs_task_arn arn:aws:ecs:eu-west-1:722657399118:task/dev/da0ffbfcb33345cb8d82ec1c74294d4a
    Record ecs_task_definition schemaregistry:105

@INCLUDE /compose_x_rendered/firelens.conf

[OUTPUT]
    Name null
    Match firelens-healthcheck

[OUTPUT]
    Name cloudwatch
    Match schemaregistry-firelens*
    auto_create_group true
    log_group_name kafka--confluent-dev/svc/ecs/dev/schemaregistry
    log_stream_prefix kafka--confluent-dev-schemaregistry
    region eu-west-1

```
/compose_x_rendered/firelens.conf
```
[SERVICE]
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_PORT    2020
    Health_Check On
    # customize error and retry thresholds and evaluation period as desired
    HC_Errors_Count 5
    HC_Retry_Failure_Count 5
    HC_Period 5

[SERVICE]
    Parsers_File /compose_x_rendered/parser.conf


[SERVICE]
    Flush 1
    Grace 30

[FILTER]
    Name Parser
    Parser confluent-schema-registry
    Key_Name log
    Reserve_Data True
    Match *
    Preserve_Key False

```

/compose_x_rendered/parser.conf
```
[PARSER]
    Name confluent-schema-registry
    Format regex
    Time_Key time
    Time_Format %Y-%m-%d %H:%M:%S,%L
    Regex ^\[(?<time>\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2},\d{1,4})] (?<level>[A-Z]{1,8}) (?<src>[\d.]+) - - \[(?<date>.*)] \"(?<method>[A-Z]+) (?<path>\/[\S]+|\/) (?<http_version>HTTP\/[\d]\.[\d])\" (?<code>[\d]{1,3}) (?<size>[\d]+) \"-\" \"(?<agent>.*)\" (?<extra_info>.*)


[PARSER]
    Name confluent-schema-registry-prefixed
    Format regex
    Time_Key _sr_time
    Time_Format %Y-%m-%d %H:%M:%S,%L
    Regex ^\[(?<_sr_time>\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2},\d{1,4})] (?<_sr_level>[A-Z]{1,8}) (?<_sr_src>[\d.]+) - - \[(?<_sr_date>.*)] \"(?<_sr_method>[A-Z]+) (?<_sr_path>\/[\S]+|\/) (?<_sr_http_version>HTTP\/[\d]\.[\d])\" (?<_sr_code>[\d]{1,3}) (?<_sr_size>[\d]+) \"-\" \"(?<_sr_agent>.*)\" (?<_sr_extra_info>.*)

```

Sample original logs

```
[2022-06-13 09:44:32,264] INFO 10.8.71.219 - - [13/Jun/2022:09:44:32 +0000] \"GET /mode HTTP/1.1\" 200 2 \"-\" \"ELB-HealthChecker/2.0\" 2 (io.confluent.rest-utils.requests:62)
```

Resulting into (removed `log`, and fields `ecs_cluster` are added by FireLens generated configuration via `record_modifier`)
```json
{
    "agent": "ELB-HealthChecker/2.0",
    "code": "200",
    "container_id": "da0ffbfcb33345cb8d82ec1c74294d4a-3980910229",
    "container_name": "schemaregistry",
    "date": "13/Jun/2022:09:44:32 +0000",
    "ecs_cluster": "dev",
    "ecs_task_arn": "arn:aws:ecs:eu-west-1:722657399118:task/dev/da0ffbfcb33345cb8d82ec1c74294d4a",
    "ecs_task_definition": "schemaregistry:105",
    "extra_info": "2 (io.confluent.rest-utils.requests:62)",
    "http_version": "HTTP/1.1",
    "level": "INFO",
    "method": "GET",
    "path": "/mode",
    "size": "2",
    "source": "stdout",
    "src": "10.8.71.219"
}
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
