### PR TITLE
codeowners: fix issue with non-existent user and error

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,7 +30,7 @@
 /src/flb_signv4.c        @pettitwesley
 /src/flb_lib.c           @edsiper @niedbalski
 
-@ Core: AWS Auth & Utils
+# Core: AWS Auth & Utils
 # ------------
 /src/aws                 @pettitwesley
 
@@ -54,7 +54,7 @@
 
 # Output Plugins
 # --------------
-/plugins/out_datadog     @clamoriniere
+/plugins/out_datadog     @nokute78 @edsiper
 /plugins/out_es          @pettitwesley @edsiper
 /plugins/out_pgsql       @sxd
 # AWS Plugins 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves issues with missing codeowner and error in comment.

Currently #4798 can be merged by any maintainer rather than requiring codeowner approval.
There is also an errant `@` in the comments which also triggers an error.
![Screenshot from 2022-06-14 21-17-32](https://user-images.githubusercontent.com/6388272/173680928-6f60feae-d745-42b2-a46d-9c4168944e5a.png)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
