### PR TITLE
core: add compile flag to disable control chars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,11 @@ if(FLB_TRACE)
   FLB_DEFINITION(FLB_HAVE_TRACE)
 endif()
 
+# Disable colors and any other control characters in the output
+if (FLB_LOG_NO_CONTROL_CHARS)
+  FLB_DEFINITION(FLB_LOG_NO_CONTROL_CHARS)
+endif()
+
 if(FLB_HTTP_SERVER)
   FLB_OPTION(FLB_METRICS ON)
   FLB_DEFINITION(FLB_HAVE_METRICS)

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -53,10 +53,10 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Must be run from root of repo
-WORKDIR /tmp/fluent-bit/
+WORKDIR /src/fluent-bit/
 COPY . ./
 
-WORKDIR /tmp/fluent-bit/build/
+WORKDIR /src/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
@@ -69,6 +69,7 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_OUT_KAFKA=On \
           -DFLB_OUT_PGSQL=On \
           -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+          -DFLB_LOG_NO_CONTROL_CHARS=On \
           ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"

--- a/include/fluent-bit/flb_version.h.in
+++ b/include/fluent-bit/flb_version.h.in
@@ -55,16 +55,33 @@ static inline void flb_version()
 
 static inline void flb_version_banner()
 {
+    const char *copyright_color = ANSI_BOLD ANSI_YELLOW;
+    const char *bold_color = ANSI_BOLD;
+    const char *reset_color = ANSI_RESET;
+
+    #ifdef FLB_LOG_NO_CONTROL_CHARS
+    copyright_color = "";
+    bold_color = "";
+    reset_color = "";
+    #else
+    /* Only print colors to a terminal */
+    if (!isatty(STDOUT_FILENO)) {
+        copyright_color = "";
+        bold_color = "";
+        reset_color = "";
+    }
+    #endif // FLB_LOG_NO_CONTROL_CHARS
+
 #ifdef FLB_NIGHTLY_BUILD
     fprintf(stderr,
             "%sFluent Bit v%s | NIGHTLY_BUILD=%s - DO NOT USE IN PRODUCTION!"
-            "%s\n", ANSI_BOLD, FLB_VERSION_STR, STR(FLB_NIGHTLY_BUILD), ANSI_RESET);
+            "%s\n", bold_color, FLB_VERSION_STR, STR(FLB_NIGHTLY_BUILD), reset_color);
 #else
     fprintf(stderr,
-            "%sFluent Bit v%s%s\n", ANSI_BOLD, FLB_VERSION_STR, ANSI_RESET);
+            "%sFluent Bit v%s%s\n", bold_color, FLB_VERSION_STR, reset_color);
 #endif
     fprintf(stderr, "* %sCopyright (C) 2015-2022 The Fluent Bit Authors%s\n",
-            ANSI_BOLD ANSI_YELLOW, ANSI_RESET);
+            copyright_color, reset_color);
     fprintf(stderr, "* Fluent Bit is a CNCF sub-project under the "
             "umbrella of Fluentd\n");
     fprintf(stderr, "* https://fluentbit.io\n\n");

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -370,12 +370,18 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
         break;
     }
 
+    #ifdef FLB_LOG_NO_CONTROL_CHARS
+    header_color = "";
+    bold_color = "";
+    reset_color = "";
+    #else
     /* Only print colors to a terminal */
     if (!isatty(STDOUT_FILENO)) {
         header_color = "";
         bold_color = "";
         reset_color = "";
     }
+    #endif // FLB_LOG_NO_CONTROL_CHARS
 
     now = time(NULL);
     current = localtime_r(&now, &result);


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses https://github.com/fluent/fluent-bit/issues/5002 by allowing us to compile out the control codes and then use this for containers.

Rebased version of #5140 .

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

```
$ docker buildx build -t test --target=production -f ./dockerfiles/Dockerfile .
$ docker run --rm -it test
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/16 14:46:58] [ info] [fluent bit] version=1.9.5, commit=341ae83608, pid=1
[2022/06/16 14:46:58] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/16 14:46:58] [ info] [cmetrics] version=0.3.4
[2022/06/16 14:46:58] [ info] [sp] stream processor started
[2022/06/16 14:46:58] [ info] [output:stdout:stdout.0] worker #0 started
[0] cpu.local: [1655390819.641267013, {"cpu_p"=>0.500000, "user_p"=>0.250000, "system_p"=>0.250000, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>0.000000, "cpu2.p_user"=>0.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>0.000000, "cpu3.p_user"=>0.000000, "cpu3.p_system"=>0.000000, "cpu4.p_cpu"=>0.000000, "cpu4.p_user"=>0.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>2.000000, "cpu5.p_user"=>1.000000, "cpu5.p_system"=>1.000000, "cpu6.p_cpu"=>1.000000, "cpu6.p_user"=>0.000000, "cpu6.p_system"=>1.000000, "cpu7.p_cpu"=>0.000000, "cpu7.p_user"=>0.000000, "cpu7.p_system"=>0.000000, "cpu8.p_cpu"=>0.000000, "cpu8.p_user"=>0.000000, "cpu8.p_system"=>0.000000, "cpu9.p_cpu"=>0.000000, "cpu9.p_user"=>0.000000, "cpu9.p_system"=>0.000000, "cpu10.p_cpu"=>0.000000, "cpu10.p_user"=>0.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>0.000000, "cpu11.p_user"=>0.000000, "cpu11.p_system"=>0.000000, "cpu12.p_cpu"=>1.000000, "cpu12.p_user"=>1.000000, "cpu12.p_system"=>0.000000, "cpu13.p_cpu"=>1.000000, "cpu13.p_user"=>0.000000, "cpu13.p_system"=>1.000000, "cpu14.p_cpu"=>0.000000, "cpu14.p_user"=>0.000000, "cpu14.p_system"=>0.000000, "cpu15.p_cpu"=>1.000000, "cpu15.p_user"=>1.000000, "cpu15.p_system"=>0.000000}]
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
