### PR TITLE
dockerfiles: add FLUENT_BIT_VERSION environment variable to containers

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -274,6 +274,7 @@ jobs:
           load: false
           build-args: |
             FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
+            RELEASE_VERSION=${{ inputs.version }}
 
       - id: debug-meta
         uses: docker/metadata-action@v4
@@ -297,6 +298,7 @@ jobs:
           load: false
           build-args: |
             FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
+            RELEASE_VERSION=${{ inputs.version }}
 
   call-build-images-generate-schema:
     needs:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@
 # docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
 
 # Set this to the current release version: it gets done so as part of the release.
-ARG RELEASE_VERSION=1.9.4
+ARG RELEASE_VERSION=1.9.5
 
 # For multi-arch builds - assumption is running on an AMD64 host
 FROM multiarch/qemu-user-static:x86_64-arm as qemu-arm32

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -10,8 +10,8 @@
 # docker buildx inspect --bootstrap
 # docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
 
-# Set this to the current release version
-ARG RELEASE_VERSION=1.9.1
+# Set this to the current release version: it gets done so as part of the release.
+ARG RELEASE_VERSION=1.9.4
 
 # For multi-arch builds - assumption is running on an AMD64 host
 FROM multiarch/qemu-user-static:x86_64-arm as qemu-arm32
@@ -145,6 +145,7 @@ RUN find /dpkg/ -type d -empty -delete && \
 # hadolint ignore=DL3006
 FROM gcr.io/distroless/cc-debian11 as production
 ARG RELEASE_VERSION
+ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture container image" \
       vendor="Fluent Organization" \
       version="${RELEASE_VERSION}" \
@@ -175,6 +176,7 @@ CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
 
 FROM debian:bullseye-slim as debug
 ARG RELEASE_VERSION
+ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture debug container image" \
       vendor="Fluent Organization" \
       version="${RELEASE_VERSION}-debug" \

--- a/update_version.sh
+++ b/update_version.sh
@@ -17,10 +17,7 @@ sed -i "s/FLB_VERSION_PATCH  [0-9]/FLB_VERSION_PATCH  $patch/g" CMakeLists.txt
 git commit -s -m "build: bump to v$1" -- CMakeLists.txt
 
 # Dockerfile
-sed -i "s/ENV FLB_MAJOR [0-9]/ENV FLB_MAJOR $major/g" dockerfiles/Dockerfile*
-sed -i "s/ENV FLB_MINOR [0-9]/ENV FLB_MINOR $minor/g" dockerfiles/Dockerfile*
-sed -i "s/ENV FLB_PATCH [0-9]/ENV FLB_PATCH $patch/g" dockerfiles/Dockerfile*
-sed -i "s/ENV FLB_VERSION [0-9].[0-9].[0-9]/ENV FLB_VERSION $1/g" dockerfiles/Dockerfile*
+sed -i "s/ARG RELEASE_VERSION=[0-9].[0-9].[0-9]/ARG RELEASE_VERSION=$1/g" dockerfiles/Dockerfile*
 
 git commit -s -m "dockerfile: bump to v$1" -- dockerfiles/*
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #5344 - containers have the variable set.
Also fixed the version update script to ensure it works for containers - although doesn't matter too much as the Github Action overwrites the label it is used for currently!

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Containers:
```
$ docker buildx build -t test --target=debug -f ./dockerfiles/Dockerfile .
$ docker run --rm -it test env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=52759e978f94
TERM=xterm
FLUENT_BIT_VERSION=1.9.4
DEBIAN_FRONTEND=noninteractive
HOME=/root
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
