### PR TITLE
workflows: fix release test job

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -298,6 +298,8 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
 
   # This will require a sign off so can be done after packages are updated to confirm
+  # Until S3 bucket is set up as release will only test what is in the server from a prior release.
+  # TODO: https://github.com/fluent/fluent-bit/issues/5098
   staging-release-smoke-test:
     name: Run smoke tests on release artefacts
     permissions:

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -23,7 +23,7 @@ YUM_TARGETS=("centos:7"
 for IMAGE in "${APT_TARGETS[@]}"
 do
     echo "Testing $IMAGE"
-    $CONTAINER_RUNTIME run --rm -it \
+    $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
@@ -33,7 +33,7 @@ done
 for IMAGE in "${YUM_TARGETS[@]}"
 do
     echo "Testing $IMAGE"
-    $CONTAINER_RUNTIME run --rm -it \
+    $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \


### PR DESCRIPTION
Partial fix for smoke test failures of #5539.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
