### PR TITLE
workflows: pin cosign-installer to v1

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -383,7 +383,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v1
 
       - name: Cosign keyless signing using Rektor public transparency log
         # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v1
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -235,7 +235,7 @@ jobs:
       GHCR_RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v1
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
We now have tags available in the cosign-installer, which allows us to pin the latest release via `v1`.

