### PR TITLE
mp: sort flb_record_accessor by a number of subkeys(#5546)

### DIFF
--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -34,6 +34,7 @@ struct flb_record_accessor {
     struct mk_list _head;        /* Head to custom list (only used by flb_mp.h) */
 };
 
+int flb_ra_subkey_num(struct flb_record_accessor *ra);
 struct flb_record_accessor *flb_ra_create(char *str, int translate_env);
 void flb_ra_destroy(struct flb_record_accessor *ra);
 void flb_ra_dump(struct flb_record_accessor *ra);

--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -34,7 +34,7 @@ struct flb_record_accessor {
     struct mk_list _head;        /* Head to custom list (only used by flb_mp.h) */
 };
 
-int flb_ra_subkey_num(struct flb_record_accessor *ra);
+int flb_ra_subkey_count(struct flb_record_accessor *ra);
 struct flb_record_accessor *flb_ra_create(char *str, int translate_env);
 void flb_ra_destroy(struct flb_record_accessor *ra);
 void flb_ra_dump(struct flb_record_accessor *ra);

--- a/include/fluent-bit/record_accessor/flb_ra_parser.h
+++ b/include/fluent-bit/record_accessor/flb_ra_parser.h
@@ -64,6 +64,7 @@ struct flb_ra_key *flb_ra_parser_key_add(struct flb_ra_parser *ra, char *key);
 int flb_ra_parser_subentry_add_string(struct flb_ra_parser *rp, char *key);
 int flb_ra_parser_subentry_add_array_id(struct flb_ra_parser *rp, int id);
 
+int flb_ra_parser_subkey_num(struct flb_ra_parser *rp);
 void flb_ra_parser_dump(struct flb_ra_parser *rp);
 struct flb_ra_parser *flb_ra_parser_string_create(char *str, int len);
 struct flb_ra_parser *flb_ra_parser_regex_id_create(int id);

--- a/include/fluent-bit/record_accessor/flb_ra_parser.h
+++ b/include/fluent-bit/record_accessor/flb_ra_parser.h
@@ -64,7 +64,7 @@ struct flb_ra_key *flb_ra_parser_key_add(struct flb_ra_parser *ra, char *key);
 int flb_ra_parser_subentry_add_string(struct flb_ra_parser *rp, char *key);
 int flb_ra_parser_subentry_add_array_id(struct flb_ra_parser *rp, int id);
 
-int flb_ra_parser_subkey_num(struct flb_ra_parser *rp);
+int flb_ra_parser_subkey_count(struct flb_ra_parser *rp);
 void flb_ra_parser_dump(struct flb_ra_parser *rp);
 struct flb_ra_parser *flb_ra_parser_string_create(char *str, int len);
 struct flb_ra_parser *flb_ra_parser_regex_id_create(int id);

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -350,30 +350,6 @@ void flb_mp_array_header_end(struct flb_mp_map_header *mh)
     flb_mp_set_array_header_size(ptr, mh->entries);
 }
 
-/* TODO: move to mk_list.h ? */
-static inline void list_add_before(struct mk_list *_new,
-                                   struct mk_list *next,
-                                   struct mk_list *head)
-{
-    struct mk_list *prev;
-
-    if (_new == NULL || next == NULL || head == NULL) {
-        return;
-    }
-
-    if ((head->prev == head && head->next == head) /*empty*/||
-        next == head) {
-        mk_list_add(_new, head);
-        return;
-    }
-
-    prev = next->prev;
-    _new->next = next;
-    _new->prev = prev;
-    prev->next = _new;
-    next->prev = _new;
-}
-
 static int insert_by_subkey_num(struct flb_record_accessor *ra, struct flb_mp_accessor *mpa)
 {
     int subkey_num;
@@ -394,7 +370,7 @@ static int insert_by_subkey_num(struct flb_record_accessor *ra, struct flb_mp_ac
         val_ra = mk_list_entry(h, struct flb_record_accessor, _head);
         num = flb_ra_subkey_num(val_ra);
         if (num >=  subkey_num) {
-            list_add_before(&ra->_head, &val_ra->_head, &mpa->ra_list);
+            mk_list_add_before(&ra->_head, &val_ra->_head, &mpa->ra_list);
             return 0;
         }
     }

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -350,10 +350,10 @@ void flb_mp_array_header_end(struct flb_mp_map_header *mh)
     flb_mp_set_array_header_size(ptr, mh->entries);
 }
 
-static int insert_by_subkey_num(struct flb_record_accessor *ra, struct flb_mp_accessor *mpa)
+static int insert_by_subkey_count(struct flb_record_accessor *ra, struct flb_mp_accessor *mpa)
 {
-    int subkey_num;
-    int num;
+    int subkey_count;
+    int count;
     struct mk_list *h;
     struct flb_record_accessor *val_ra;
 
@@ -365,11 +365,11 @@ static int insert_by_subkey_num(struct flb_record_accessor *ra, struct flb_mp_ac
      *    $kubernetes[2]['a']
      *    $kubernetes[2]['annotations']['fluentbit.io/tag']
      */
-    subkey_num = flb_ra_subkey_num(ra);
+    subkey_count = flb_ra_subkey_count(ra);
     mk_list_foreach(h, &mpa->ra_list) {
         val_ra = mk_list_entry(h, struct flb_record_accessor, _head);
-        num = flb_ra_subkey_num(val_ra);
-        if (num >=  subkey_num) {
+        count = flb_ra_subkey_count(val_ra);
+        if (count >=  subkey_count) {
             mk_list_add_before(&ra->_head, &val_ra->_head, &mpa->ra_list);
             return 0;
         }
@@ -419,7 +419,7 @@ struct flb_mp_accessor *flb_mp_accessor_create(struct mk_list *slist_patterns)
             mk_list_add(&ra->_head, &mpa->ra_list);
             continue;
         }
-        insert_by_subkey_num(ra, mpa);
+        insert_by_subkey_count(ra, mpa);
     }
 
     if (mk_list_size(&mpa->ra_list) == 0) {

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -413,12 +413,6 @@ struct flb_mp_accessor *flb_mp_accessor_create(struct mk_list *slist_patterns)
             flb_mp_accessor_destroy(mpa);
             return NULL;
         }
-
-        /* first time */
-        if (mk_list_size(&mpa->ra_list) == 0) {
-            mk_list_add(&ra->_head, &mpa->ra_list);
-            continue;
-        }
         insert_by_subkey_count(ra, mpa);
     }
 

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -247,6 +247,27 @@ void flb_ra_destroy(struct flb_record_accessor *ra)
     flb_free(ra);
 }
 
+int flb_ra_subkey_num(struct flb_record_accessor *ra)
+{
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+    int ret = -1;
+    int tmp;
+
+    if (ra == NULL) {
+        return -1;
+    }
+    mk_list_foreach(head, &ra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        tmp = flb_ra_parser_subkey_num(rp);
+        if (tmp > ret) {
+            ret = tmp;
+        }
+    }
+
+    return ret;
+}
+
 struct flb_record_accessor *flb_ra_create(char *str, int translate_env)
 {
     int ret;

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -247,7 +247,7 @@ void flb_ra_destroy(struct flb_record_accessor *ra)
     flb_free(ra);
 }
 
-int flb_ra_subkey_num(struct flb_record_accessor *ra)
+int flb_ra_subkey_count(struct flb_record_accessor *ra)
 {
     struct mk_list *head;
     struct flb_ra_parser *rp;
@@ -259,7 +259,7 @@ int flb_ra_subkey_num(struct flb_record_accessor *ra)
     }
     mk_list_foreach(head, &ra->list) {
         rp = mk_list_entry(head, struct flb_ra_parser, _head);
-        tmp = flb_ra_parser_subkey_num(rp);
+        tmp = flb_ra_parser_subkey_count(rp);
         if (tmp > ret) {
             ret = tmp;
         }

--- a/src/record_accessor/flb_ra_parser.c
+++ b/src/record_accessor/flb_ra_parser.c
@@ -27,6 +27,21 @@
 #include "ra_parser.h"
 #include "ra_lex.h"
 
+int flb_ra_parser_subkey_num(struct flb_ra_parser *rp)
+{
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
+    else if (rp->type != FLB_RA_PARSER_KEYMAP) {
+        return 0;
+    }
+    else if(rp->key->subkeys == NULL) {
+        return -1;
+    }
+
+    return mk_list_size(rp->key->subkeys);
+}
+
 void flb_ra_parser_dump(struct flb_ra_parser *rp)
 {
     struct mk_list *head;

--- a/src/record_accessor/flb_ra_parser.c
+++ b/src/record_accessor/flb_ra_parser.c
@@ -27,7 +27,7 @@
 #include "ra_parser.h"
 #include "ra_lex.h"
 
-int flb_ra_parser_subkey_num(struct flb_ra_parser *rp)
+int flb_ra_parser_subkey_count(struct flb_ra_parser *rp)
 {
     if (rp == NULL || rp->key == NULL) {
         return -1;

--- a/tests/internal/mp.c
+++ b/tests/internal/mp.c
@@ -145,9 +145,209 @@ void test_accessor_keys_remove()
     msgpack_unpacked_destroy(&result);
 }
 
+/* https://github.com/fluent/fluent-bit/issues/5546 */
+void test_keys_remove_subkey_key()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *buf;
+    size_t size;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char final_json[2048] = {0};
+    msgpack_unpacked result;
+    msgpack_unpacked result_final;
+    msgpack_object map;
+    struct flb_mp_accessor *mpa;
+    struct mk_list patterns;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\","
+        "                       \"extra\": false\""
+        "}}]}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &buf, &size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack the content */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, buf, size, &off);
+    map = result.data;
+
+    /* Create list of patterns */
+    flb_slist_create(&patterns);
+
+    /* sub key -> key */
+    flb_slist_add(&patterns, "$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    flb_slist_add(&patterns, "$kubernetes");
+
+
+    /* Create mp accessor */
+    mpa = flb_mp_accessor_create(&patterns);
+    TEST_CHECK(mpa != NULL);
+
+    /* Remove the entry that matches the pattern(s) */
+    ret = flb_mp_accessor_keys_remove(mpa, &map, (void *) &out_buf, &out_size);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    printf("\n=== ORIGINAL  ===\n");
+    flb_pack_print(buf, size);
+    flb_free(buf);
+
+    printf("=== FINAL MAP ===\n");
+    if (ret == FLB_TRUE) {
+        flb_pack_print(out_buf, out_size);
+    }
+    msgpack_unpacked_destroy(&result);
+
+    off = 0;
+    msgpack_unpacked_init(&result_final);
+    msgpack_unpack_next(&result_final, out_buf, out_size, &off);
+    flb_msgpack_to_json(&final_json[0], sizeof(final_json), &result_final.data);
+
+    if (!TEST_CHECK(strstr(&final_json[0] ,"kubernetes") == NULL)) {
+        TEST_MSG("kubernetes field should be removed");
+    }
+
+    msgpack_unpacked_destroy(&result_final);
+
+    flb_free(out_buf);
+    flb_mp_accessor_destroy(mpa);
+    flb_slist_destroy(&patterns);
+
+}
+
+void remove_subkey_keys(char *list[], int list_size, int index_start)
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *buf;
+    size_t size;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char final_json[2048] = {0};
+    msgpack_unpacked result;
+    msgpack_unpacked result_final;
+    msgpack_object map;
+    struct flb_mp_accessor *mpa;
+    struct mk_list patterns;
+    int i;
+    int count = 0;
+
+    /* Sample JSON message */
+    json =
+        "{\"key1\": \"something\", "
+        "\"kubernetes\": "
+        "   [true, "
+        "    false, "
+        "    {\"a\": false, "
+        "     \"annotations\": { "
+        "                       \"fluentbit.io/tag\": \"thetag\","
+        "                       \"extra\": false\""
+        "}}]}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &buf, &size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack the content */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, buf, size, &off);
+    map = result.data;
+
+    /* Create list of patterns */
+    flb_slist_create(&patterns);
+
+    /* sub keys */
+    for (i=index_start; count<list_size; i++) {
+        if (i>=list_size) {
+            i = 0;
+        }
+        flb_slist_add(&patterns, list[i]);
+        count++;
+    }
+
+    /* Create mp accessor */
+    mpa = flb_mp_accessor_create(&patterns);
+    TEST_CHECK(mpa != NULL);
+
+    /* Remove the entry that matches the pattern(s) */
+    ret = flb_mp_accessor_keys_remove(mpa, &map, (void *) &out_buf, &out_size);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    printf("\n=== ORIGINAL  ===\n");
+    flb_pack_print(buf, size);
+    flb_free(buf);
+
+    printf("=== FINAL MAP ===\n");
+    if (ret == FLB_TRUE) {
+        flb_pack_print(out_buf, out_size);
+    }
+    msgpack_unpacked_destroy(&result);
+
+    off = 0;
+    msgpack_unpacked_init(&result_final);
+    msgpack_unpack_next(&result_final, out_buf, out_size, &off);
+    flb_msgpack_to_json(&final_json[0], sizeof(final_json), &result_final.data);
+
+    if (!TEST_CHECK(strstr(&final_json[0] ,"kubernetes") == NULL)) {
+        TEST_MSG("kubernetes field should be removed");
+    }
+
+    msgpack_unpacked_destroy(&result_final);
+
+    flb_free(out_buf);
+    flb_mp_accessor_destroy(mpa);
+    flb_slist_destroy(&patterns);
+}
+
+void test_keys_remove_subkey_keys()
+{
+    char *list[] = {"$kubernetes[2]['annotations']['fluentbit.io/tag']",
+                    "$kubernetes[2]['a']", 
+                    "$kubernetes"};
+    char *list2[] = {"$kubernetes[2]['annotations']['fluentbit.io/tag']",
+                     "$kubernetes",
+                     "$kubernetes[2]['a']"};
+
+    int size = sizeof(list)/sizeof(char*);
+    int i;
+    
+    for (i=0; i<size; i++) {
+        remove_subkey_keys(list, size, i);
+    }
+    for (i=0; i<size; i++) {
+        remove_subkey_keys(list2, size, i);
+    }
+}
+
 TEST_LIST = {
     {"count"                , test_count},
     {"map_header"           , test_map_header},
     {"accessor_keys_remove" , test_accessor_keys_remove},
+    {"accessor_keys_remove_subkey_key" , test_keys_remove_subkey_key},
+    {"accessor_keys_remove_subkey_keys" , test_keys_remove_subkey_keys},
     { 0 }
 };


### PR DESCRIPTION
Fixes #5546 

out_loki tries to remove key/value using flb_mp_accessor_keys_remove.
The API needs a key lists to indicate which key should be removed.

I tested the API and I found that the list should be sorted if it is passed nested key/value.
However the lists is not sorted at current master. It may not work if user passes nested key/value.

This patch is to fix it.
- Add test code
- Add API to get subkey number
- Insert record_accessor sorted by subkey number

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    dummy {"log":"blahblah","kubernetes":{"pod_name":"nginx", "namespace_name":"default"}}

[OUTPUT]
    Name loki
    auto_kubernetes_labels off
    labels pod=$kubernetes['pod_name']
    remove_keys kubernetes
    port 9200
    Log_Level debug
```

http_server.go:
```go
package main

import (
	"fmt"
	"io"
	"log"
	"net/http"
	"strconv"
)

func main() {
	port := 9200
	ps := strconv.Itoa(port)

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		defer r.Body.Close()
		b, err := io.ReadAll(r.Body)
		if err != nil {
			log.Printf("ReadAll error=%s\n", err)
		} else {
			log.Printf("%+v\n", string(b))
		}
		//w.WriteHeader(400)
	})
	fmt.Printf("Listen port=%s\n", ps)
	err := http.ListenAndServe(":"+ps, nil)
	if err != nil {
		log.Printf("ListenAndServe err=%s\n", err)
	}
}
```

## Debug log

```
$ ../bin/fluent-bit -c a.conf 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/26 12:37:40] [ info] [fluent bit] version=1.9.5, commit=71e53850ab, pid=40379
[2022/06/26 12:37:40] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/26 12:37:40] [ info] [cmetrics] version=0.3.4
[2022/06/26 12:37:40] [debug] [output:loki:loki.0] remove_mpa size: 2
[2022/06/26 12:37:40] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:9200
[2022/06/26 12:37:40] [ info] [sp] stream processor started
[2022/06/26 12:37:41] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
[2022/06/26 12:37:42] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
^C[2022/06/26 12:37:42] [engine] caught signal (SIGINT)
[2022/06/26 12:37:42] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/26 12:37:42] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
[2022/06/26 12:37:43] [ info] [engine] service has stopped (0 pending tasks)
```

"kubernetes" field is removed.
```
$ go run http_server.go 
Listen port=9200
2022/06/26 12:37:41 {"streams":[{"stream":{"pod":"nginx"},"values":[["1656214660553074560","{\"log\":\"blahblah\"}"]]}]}
2022/06/26 12:37:42 {"streams":[{"stream":{"pod":"nginx"},"values":[["1656214661552289828","{\"log\":\"blahblah\"}"]]}]}
```

## Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==40385== Memcheck, a memory error detector
==40385== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==40385== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==40385== Command: ../bin/fluent-bit -c a.conf
==40385== 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/26 12:38:56] [ info] [fluent bit] version=1.9.5, commit=71e53850ab, pid=40385
[2022/06/26 12:38:56] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/26 12:38:56] [ info] [cmetrics] version=0.3.4
[2022/06/26 12:38:56] [debug] [output:loki:loki.0] remove_mpa size: 2
[2022/06/26 12:38:56] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:9200
[2022/06/26 12:38:56] [ info] [sp] stream processor started
[2022/06/26 12:38:57] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
[2022/06/26 12:38:58] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
^C[2022/06/26 12:38:58] [engine] caught signal (SIGINT)
[2022/06/26 12:38:58] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/26 12:38:58] [debug] [output:loki:loki.0] 127.0.0.1:9200, HTTP status=200
[2022/06/26 12:38:59] [ info] [engine] service has stopped (0 pending tasks)
==40385== 
==40385== HEAP SUMMARY:
==40385==     in use at exit: 0 bytes in 0 blocks
==40385==   total heap usage: 1,399 allocs, 1,399 frees, 1,439,096 bytes allocated
==40385== 
==40385== All heap blocks were freed -- no leaks are possible
==40385== 
==40385== For lists of detected and suppressed errors, rerun with: -s
==40385== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
