### PR TITLE
workflows: add YAML support to MacOS builds

### DIFF
--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install bison flex || true
+          brew install bison flex libyaml-dev || true
       - name: Build Fluent Bit packages
         run: |
           export LIBRARY_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib:$LIBRARY_PATH


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves issue with MacOS builds not including YAML support: https://github.com/fluent/fluent-bit/runs/6961364919?check_suite_focus=true

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
