### PR TITLE
out_datadog: switch noisy info level to debug level

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -376,12 +376,12 @@ static void cb_datadog_flush(struct flb_event_chunk *event_chunk,
         }
         else {
             if (client->resp.payload) {
-                flb_plg_info(ctx->ins, "%s%s, port=%i, HTTP status=%i payload=%s",
+                flb_plg_debug(ctx->ins, "%s%s, port=%i, HTTP status=%i payload=%s",
                              ctx->scheme, ctx->host, ctx->port,
                              client->resp.status, client->resp.payload);
             }
             else {
-                flb_plg_info(ctx->ins, "%s%s, port=%i, HTTP status=%i",
+                flb_plg_debug(ctx->ins, "%s%s, port=%i, HTTP status=%i",
                              ctx->scheme, ctx->host, ctx->port,
                              client->resp.status);
             }


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #5144 by dropping info level log to debug level.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
