### PR TITLE
workflows: fix publish script

### DIFF
--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -13,7 +13,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 VERSION="$1"
-MAJOR_VERSION=${MAJOR_VERSION:-$VERSION##\.*}
+MAJOR_VERSION=${MAJOR_VERSION:-}
+
+if [[ -z "$MAJOR_VERSION" ]]; then
+    MAJOR_VERSION=${VERSION%.*}
+fi
+echo "Publishing packages for $VERSION (major: $MAJOR_VERSION)"
 
 if [[ ! -d "$SOURCE_DIR" ]]; then
     echo "Missing source directory: $SOURCE_DIR"
@@ -117,15 +122,6 @@ fi
 # Sign YUM repo meta-data
 find "/var/www/apt.fluentbit.io" -name repomd.xml -exec gpg --detach-sign --armor --yes -u "releases@fluentbit.io" {} \;
 
-# Windows - we do want word splitting and ensure some files exist
-if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
-    echo "Copying Windows artefacts"
-    # shellcheck disable=SC2086
-    cp -vf "$SOURCE_DIR"/windows/*$VERSION* /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION"/
-else
-    echo "Missing Windows builds"
-fi
-
 # Handle the JSON schema by copying in the new versions (if they exist) and then updating the symlinks that point at the latest.
 if compgen -G "$SOURCE_DIR/fluent-bit-schema*.json" > /dev/null; then
     echo "Updating JSON schema"
@@ -138,4 +134,13 @@ if compgen -G "$SOURCE_DIR/fluent-bit-schema*.json" > /dev/null; then
     popd
 else
     echo "Missing JSON schema"
+fi
+
+# Windows - we do want word splitting and ensure some files exist
+if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
+    echo "Copying Windows artefacts"
+    # shellcheck disable=SC2086
+    cp -vf "$SOURCE_DIR"/windows/*$VERSION* /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION"/
+else
+    echo "Missing Windows builds"
 fi

--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -144,3 +144,12 @@ if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
 else
     echo "Missing Windows builds"
 fi
+
+# Source - we do want word splitting and ensure some files exist
+if compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
+    echo "Copying source artefacts"
+    # shellcheck disable=SC2086
+    cp -vf "$SOURCE_DIR"/source/*$VERSION* /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION"/
+else
+    echo "Missing source artefacts"
+fi


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #5539 by adjusting calculation of MAJOR_VERSION for Windows.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
