### PR TITLE
out_kafka: add support to force flush when shutdown. (fluent#5593)

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -495,10 +495,29 @@ static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
     FLB_OUTPUT_RETURN(FLB_OK);
 }
 
+static void kafka_flush_force(struct flb_out_kafka *ctx,
+                              struct flb_config *config)
+{
+    int ret;
+
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->kafka.rk) {
+        ret = rd_kafka_flush(ctx->kafka.rk, config->grace * 1000);
+        if (ret != RD_KAFKA_RESP_ERR_NO_ERROR) {
+            flb_plg_warn(ctx->ins, "Failed to force flush: %s",
+                         rd_kafka_err2str(ret));
+        }
+    }
+}
+
 static int cb_kafka_exit(void *data, struct flb_config *config)
 {
     struct flb_out_kafka *ctx = data;
 
+    kafka_flush_force(ctx, config);
     flb_out_kafka_destroy(ctx);
     return 0;
 }


### PR DESCRIPTION
When fluent-bit shutdown for out_kafka plugin with rdkafka.linger.ms and
rdkafka.batch.size and then we show the warn message and lose the message.

So, this patch fixes the issue of not flushing due to the rdkafka linger.ms option.

The 'rd_kafka_flush' function is linger.ms time will be ignored for the
duration of the call, queued messages will be sent to the broker as soon as possible.

Fix: #5593 

Signed-off-by: jinyong.choi <inimax801@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [`v`] Example configuration file for the change
- [`v`] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [`N/A`] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [`N/A`] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [`N/A`] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [`N/A`] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
### Configuration
```
[SERVICE]
    flush 600
    grace 120
    log_level trace
    storage.path /var/lib/td-agent-bit/
    storage.sync normal
    storage.checksum off
    storage.backlog.mem_limit 10M

[INPUT]
    Name tail
    Path /root/test.log
    Tag test
    DB /var/lib/td-agent-bit/tail.db
    DB.sync normal

[OUTPUT]
    name kafka
    match test
    Brokers x.x.x.x:9092

    Topics report_test
    timestamp_format iso8601
    queue_full_retries 0
    Retry_Limit False

    rdkafka.log.connection.close false
    rdkafka.compression.codec gzip
    rdkafka.compression.level 5

    rdkafka.batch.size 10485760
    rdkafka.linger.ms 10000

    rdkafka.request.required.acks all
    rdkafka.enable.idempotence true
    rdkafka.max.in.flight.requests.per.connection 1
    rdkafka.message.timeout.ms 0
    rdkafka.message.send.max.retries 2147483647
    rdkafka.retries 2147483647

```
### Debug log
**before**
we show the warn log `Producer terminating with xxx messages` and lose message.
```
[2022/06/21 04:10:33] [trace] [engine] [task event] task_id=0 out_id=0 return=OK
[2022/06/21 04:10:33] [debug] [out flush] cb_destroy coro_id=0
[2022/06/21 04:10:33] [trace] [coro] destroy coroutine=0x7f90f240ae58 data=0x7f90f240ae70
[2022/06/21 04:10:33] [debug] [task] destroy task=0x7f90f2464690 (task_id=0)
[2022/06/21 04:10:33] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/21 04:10:33] [debug] [input:tail:tail.0] inode=136722563 removing file name /root/test.log
[2022/06/21 04:10:33] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=136722563 watch_fd=1
[2022/06/21 04:10:33] [ warn] [output:kafka:kafka.0] fluent-bit#producer-1: [thrd:app]: Producer terminating with 5000 messages (285000 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

**after**
If the grace option of Service is enough we show the `message delivered` log without  `Producer terminating with xxx messages` log .
```
[2022/06/21 04:14:53] [trace] [engine] [task event] task_id=0 out_id=0 return=OK
[2022/06/21 04:14:53] [debug] [out flush] cb_destroy coro_id=0
[2022/06/21 04:14:53] [trace] [coro] destroy coroutine=0x7f9a81e0ae58 data=0x7f9a81e0ae70
[2022/06/21 04:14:53] [debug] [task] destroy task=0x7f9a81e64690 (task_id=0)
[2022/06/21 04:14:53] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/21 04:14:53] [debug] [input:tail:tail.0] inode=136722563 removing file name /root/test.log
[2022/06/21 04:14:53] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=136722563 watch_fd=1
[2022/06/21 04:14:53] [debug] [output:kafka:kafka.0] message delivered (57 bytes, partition 0)
...
[2022/06/21 04:14:53] [debug] [output:kafka:kafka.0] message delivered (57 bytes, partition 0)

```

**after**
The force flush was timeout if grace is '0'.
Show the `Failed to force flush: Local: Timed out` log.
```
[2022/06/21 04:58:18] [ info] [task] tail/tail.0 has 1 pending task(s):
[2022/06/21 04:58:18] [ info] [task]   task_id=0 still running on route(s): kafka/kafka.0 
[2022/06/21 04:58:18] [ info] [task] storage_backlog/storage_backlog.1 has 1 pending task(s):
[2022/06/21 04:58:18] [ info] [task]   task_id=1 still running on route(s): kafka/kafka.0 
[2022/06/21 04:58:18] [ info] [engine] service has stopped (2 pending tasks)
[2022/06/21 04:58:18] [debug] [task] destroy task=0x7fa6d0c69700 (task_id=1)
[2022/06/21 04:58:18] [debug] [input:tail:tail.0] inode=136722563 removing file name /root/test.log
[2022/06/21 04:58:18] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=136722563 watch_fd=1
[2022/06/21 04:58:18] [debug] [task] destroy task=0x7fa6d0c69690 (task_id=0)
[2022/06/21 04:58:18] [ warn] [output:kafka:kafka.0] Failed to force flush: Local: Timed out
[2022/06/21 04:58:18] [ warn] [output:kafka:kafka.0] fluent-bit#producer-1: [thrd:app]: Producer terminating with 5000 messages (285000 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
