### PR TITLE
workflows: Install 32bit version of openssl libraries via vcpkg

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -39,6 +39,16 @@ jobs:
   call-build-windows-package:
     runs-on: windows-latest
     environment: ${{ inputs.environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Windows 32bit"
+            arch: x86
+            vcpkg_triplet: x86-windows-static
+          - name: "Windows 64bit"
+            arch: x64
+            vcpkg_triplet: x64-windows-static
     permissions:
       contents: read
     steps:
@@ -61,7 +71,13 @@ jobs:
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
-          arch: x64
+          arch: ${{ matrix.config.arch }}
+
+      - name: Build openssl with vcpkg
+        if: ${{ matrix.config.arch == 'x86' }}
+        run: |
+          C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
+        shell: cmd
 
       - name: Build Fluent Bit packages
         run: |

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -46,9 +46,11 @@ jobs:
           - name: "Windows 32bit"
             arch: x86
             vcpkg_triplet: x86-windows-static
+            vcpkg_cmake_opt: -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
           - name: "Windows 64bit"
             arch: x64
             vcpkg_triplet: x64-windows-static
+            vcpkg_cmake_opt: ""
     permissions:
       contents: read
     steps:
@@ -81,7 +83,7 @@ jobs:
 
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ${{ matrix.config.vcpkg_cmake_opt }} ../
           cmake --build .
           cpack
         working-directory: build

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -46,11 +46,11 @@ jobs:
           - name: "Windows 32bit"
             arch: x86
             vcpkg_triplet: x86-windows-static
-            vcpkg_cmake_opt: -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+            openssl_root_dir_opt: -DOPENSSL_ROOT_DIR=C:\vcpkg\packages\openssl_x86-windows-static
           - name: "Windows 64bit"
             arch: x64
             vcpkg_triplet: x64-windows-static
-            vcpkg_cmake_opt: ""
+            openssl_root_dir_opt: ""
     permissions:
       contents: read
     steps:
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ${{ matrix.config.vcpkg_cmake_opt }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ${{ matrix.config.openssl_root_dir_opt }} ../
           cmake --build .
           cpack
         working-directory: build

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -80,7 +80,7 @@ jobs:
 
   unstable-build-images:
     needs: unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: ./.github/workflows/call-build-images.yaml
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -116,7 +116,7 @@ jobs:
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
+    uses: ./.github/workflows/call-build-linux-packages.yaml
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -129,7 +129,7 @@ jobs:
   unstable-build-windows-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
+    uses: ./.github/workflows/call-build-windows.yaml
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
@@ -141,7 +141,7 @@ jobs:
   unstable-build-macos-package:
     needs:
       - unstable-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@master
+    uses: ./.github/workflows/call-build-macos.yaml
     with:
       version: ${{ needs.unstable-build-get-meta.outputs.branch }}
       ref: ${{ needs.unstable-build-get-meta.outputs.branch }}

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -66,7 +66,7 @@ jobs:
 
   staging-build-images:
     needs: staging-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
+    uses: ./.github/workflows/call-build-images.yaml
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}
@@ -130,7 +130,7 @@ jobs:
     needs:
       - staging-build-get-meta
       - staging-build-generate-matrix
-    uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
+    uses: ./.github/workflows/call-build-linux-packages.yaml
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}
@@ -147,7 +147,7 @@ jobs:
   staging-build-windows-packages:
     needs:
       - staging-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
+    uses: ./.github/workflows/call-build-windows.yaml
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}
@@ -161,7 +161,7 @@ jobs:
   staging-build-macos-packages:
     needs:
       - staging-build-get-meta
-    uses: fluent/fluent-bit/.github/workflows/call-build-macos.yaml@master
+    uses: ./.github/workflows/call-build-macos.yaml
     with:
       version: ${{ needs.staging-build-get-meta.outputs.version }}
       ref: ${{ github.event.inputs.version || github.ref_name }}


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->
Before deprecation of AppVeyor CI builds, we have to implement CI target for Windows 32bit.
Currently, GitHub Actions workers do not provide 32bit version of OpenSSL libraries on Windows workers. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/5599

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
