### PR TITLE
out_stdout: handle error case

### DIFF
--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -173,11 +173,12 @@ static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
         while (msgpack_unpack_next(&result,
                                    event_chunk->data,
                                    event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
-            printf("[%zd] %s: [", cnt++, event_chunk->tag);
-            flb_time_pop_from_msgpack(&tmp, &result, &p);
-            printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
-            msgpack_object_print(stdout, *p);
-            printf("]\n");
+            if (flb_time_pop_from_msgpack(&tmp, &result, &p) != -1 ) {
+                printf("[%zd] %s: [", cnt++, event_chunk->tag);
+                printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
+                msgpack_object_print(stdout, *p);
+                printf("]\n");
+	    }
         }
         msgpack_unpacked_destroy(&result);
         flb_free(buf);

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -178,7 +178,7 @@ static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
                 printf("%"PRIu32".%09lu, ", (uint32_t)tmp.tm.tv_sec, tmp.tm.tv_nsec);
                 msgpack_object_print(stdout, *p);
                 printf("]\n");
-	    }
+            }
         }
         msgpack_unpacked_destroy(&result);
         flb_free(buf);


### PR DESCRIPTION
flb_time_pop_from_msgpack may return an error which should be handled.
This handles it and fixes a potential use-after-free:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45916

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
