### PR TITLE
parser: free allocated types

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -607,9 +607,9 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
     }
     if (types_len) {
         for (i=0; i<types_len; i++){
-	    if (types[i].key != NULL) {
+            if (types[i].key != NULL) {
                 flb_free(types[i].key);
-	    }
+            }
         }
         flb_free(types);
     }

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -455,6 +455,7 @@ static flb_sds_t get_parser_key(struct flb_config *config,
 static int parser_conf_file(const char *cfg, struct flb_cf *cf,
                             struct flb_config *config)
 {
+    int i = 0;
     flb_sds_t name;
     flb_sds_t format;
     flb_sds_t regex;
@@ -605,7 +606,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         flb_sds_destroy(types_str);
     }
     if (types_len) {
-        for (int i=0; i<types_len; i++){
+        for (i=0; i<types_len; i++){
 	    if (types[i].key != NULL) {
                 flb_free(types[i].key);
 	    }

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -604,6 +604,14 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
     if (types_str) {
         flb_sds_destroy(types_str);
     }
+    if (types_len) {
+        for (int i=0; i<types_len; i++){
+	    if (types[i].key != NULL) {
+                flb_free(types[i].key);
+	    }
+        }
+        flb_free(types);
+    }
     if (decoders) {
         flb_parser_decoder_list_destroy(decoders);
     }


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45973

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
