### PR TITLE
workflows: include Windows MSI installers in release sync

### DIFF
--- a/.github/actions/release-server-sync/action.yaml
+++ b/.github/actions/release-server-sync/action.yaml
@@ -65,7 +65,7 @@ runs:
       ssh $USERNAME@$HOST mkdir -p /home/$USERNAME/apt
       rsync --include="*/" \
         --include="*.rpm" --include="*.deb" \
-        --include="*.zip" --include="*.exe" \
+        --include="*.zip" --include="*.exe" --include="*.msi" \
         --include="*.tar.gz" \
         --include="*.md5" --include="*.sha256" \
         --include="fluent-bit-schema*.json" \

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -94,6 +94,7 @@ jobs:
           name: windows-packages
           path: |
             build/*-bit-*.exe
+            build/*-bit-*.msi
             build/*-bit-*.zip
           if-no-files-found: error
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #5616 by including Windows MSI installer binaries in releases

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
