### PR TITLE
workflows: add PR performance test

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,7 @@
 | [pr-closed-docker](./pr-closed-docker.yaml)      | Removes docker images for PR on hub.docker.io/fluentbitdev/| on pr closed|
 | [pr-compile-check](./pr-compile-check.yaml)      | Runs some compilation sanity checks on a PR |
 | [pr-integration-test](./pr-integration-test.yaml)     | Runs the integration testing suite on a PR branch | pr opened / label created 'ok-to-test' / on new commit/push on PR(s) |
+| [pr-perf-test](./pr-integration-test.yaml)     | Runs the performance testing suite on a PR branch | pr opened / label created 'ok-to-performance-test' / on new commit/push on PR(s) |
 | [pr-stale](./pr-stale.yaml)                      | Closes stale PR(s) with no activity in 30 days | scheduled daily 01:30 AM UTC|
 | [unit-tests](./unit-tests.yaml)     | Runs the unit tests suite on master push or new PR | PR opened, merge in master branch |
 

--- a/.github/workflows/pr-perf-test.yaml
+++ b/.github/workflows/pr-perf-test.yaml
@@ -1,0 +1,64 @@
+name: Build and run performance tests for PR
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - labeled
+
+jobs:
+
+  # TODO: switch to dedicated runner workflow
+  pr-perf-test-run:
+    # We only need to test this once as the rest are chained from it.
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-performance-test')
+    name: Run performance tests for PR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y jq
+
+          # Install docker-compose
+          # Later versions have an SSL issue on this OS for remote repository builds
+          sudo curl --fail --silent -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod a+x /usr/local/bin/docker-compose
+
+          # Add promplot
+          curl --fail --silent -L https://github.com/qvl/promplot/releases/download/v0.17.0/promplot_0.17.0_linux_64bit.tar.gz| tar -xz
+          chmod a+x ./promplot
+          sudo mv -vf ./promplot  /usr/local/bin/promplot
+        shell: bash
+
+      - name: Run the tests on this runner
+        timeout-minutes: 45
+        run: |
+          curl -L https://raw.githubusercontent.com/fluent/fluent-bit-ci/master/scripts/docker-compose-monitor.sh | bash
+        shell: bash
+        env:
+          TEST_DIRECTORY: ./examples/perf-test
+          SERVICE_TO_MONITOR: fb-delta
+          RUN_TIMEOUT_MINUTES: 30
+
+      - name: Upload any results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: output/
+
+  pr-integration-test-build-complete:
+    name: PR - integration build complete
+    runs-on: ubuntu-latest
+    needs:
+      - pr-integration-test-build
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        name: Label the PR
+        with:
+          labels: ci/performance-test-ok
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-perf-test.yaml
+++ b/.github/workflows/pr-perf-test.yaml
@@ -50,12 +50,13 @@ jobs:
           name: output
           path: output/
 
-  pr-integration-test-build-complete:
-    name: PR - integration build complete
+  pr-perf-test-complete:
+    name: PR - performance test complete
     runs-on: ubuntu-latest
     needs:
-      - pr-integration-test-build
+      - pr-perf-test-run
     steps:
+      # TODO: post results as well
       - uses: actions-ecosystem/action-add-labels@v1
         name: Label the PR
         with:

--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -11,6 +11,7 @@ on:
       - '.gitignore'
       - 'appveyor.yml'
       - '**.sh'
+      - 'examples/**'
 
 jobs:
   run-all-unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,6 +14,7 @@ on:
       - '.gitignore'
       - 'appveyor.yml'
       - '**.sh'
+      - 'examples/**'
     branches:
       - master
       - 1.9

--- a/examples/perf_test/.env
+++ b/examples/perf_test/.env
@@ -1,0 +1,5 @@
+FB_BASELINE_IMAGE=fluent/fluent-bit:latest
+LOG_PREFIX=test
+LOG_COUNT=100
+LOG_RATE=2000
+LOG_SIZE=1000

--- a/examples/perf_test/docker-compose.yml
+++ b/examples/perf_test/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+
+  fb-baseline:
+    image: ${FB_BASELINE_IMAGE}
+    volumes:
+      - log-volume:/logs:ro
+      - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+
+  fb-delta:
+    build:
+      context: ../..
+      dockerfile: dockerfiles/Dockerfile
+    volumes:
+      - log-volume:/logs:ro
+      - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+    ports:
+      - "2020:2020"
+
+  data-generator:
+    image: fluentbitdev/fluent-bit-ci:benchmark
+    command: bash /scripts/entrypoint.sh
+    volumes:
+      - log-volume:/logs:rw
+      - ./scripts:/scripts:ro
+    environment:
+      LOG_PREFIX: ${LOG_PREFIX}
+      LOG_COUNT: ${LOG_COUNT}
+      LOG_SIZE: ${LOG_SIZE}
+      # For multiline set this to >0
+      LINE_COUNT: ${LINE_COUNT}
+      # For multiline set this to the sleep period between log entries rather than the rate
+      LOG_RATE: ${LOG_RATE}
+
+volumes:
+  log-volume:

--- a/examples/perf_test/fluent-bit.conf
+++ b/examples/perf_test/fluent-bit.conf
@@ -1,0 +1,27 @@
+[SERVICE]
+    Daemon Off
+    # Log_Level debug
+    HTTP_Server On
+    # HTTP_Listen 0.0.0.0
+    HTTP_Port 2020
+    flush        1
+    storage.metrics           on
+    storage.path              /data/
+    storage.sync              normal
+    storage.checksum          off
+    storage.backlog.mem_limit 1G
+    storage.max_chunks_up     128
+
+[INPUT]
+    Name dummy
+    fixed_timestamp on
+
+[INPUT]
+    Name tail
+    Path /logs/*
+    # Intended for use with multiline data generator
+    multiline.parser java
+
+[OUTPUT]
+    Name null
+    Match *

--- a/examples/perf_test/scripts/entrypoint.sh
+++ b/examples/perf_test/scripts/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu
+
+LOG_DIR=${LOG_DIR:-/logs}
+LOG_PREFIX=${LOG_PREFIX:-multi}
+LOG_COUNT=${LOG_COUNT:-100}
+LOG_RATE=${LOG_RATE:-20}
+LOG_SIZE=${LOG_SIZE:-1000}
+LINE_COUNT=${LINE_COUNT:-0}
+
+rm -vfr "${LOG_DIR:?}/$LOG_PREFIX*"
+
+for i in $(seq "$LOG_COUNT")
+do
+    export OUTPUT_LOGFILE="$LOG_DIR/$LOG_PREFIX-$i.log"
+    if [[ "$LINE_COUNT" -gt 0 ]]; then
+        /scripts/multi-line-log-generator.sh &
+    else
+        echo "Creating $OUTPUT_LOGFILE"
+        /run_log_generator.py --log-size-in-bytes "$LOG_SIZE" --log-rate "$LOG_RATE" --log-agent-input-type tail --tail-file-path "$OUTPUT_LOGFILE" &
+    fi
+done
+
+wait

--- a/examples/perf_test/scripts/multi-line-log-generator.sh
+++ b/examples/perf_test/scripts/multi-line-log-generator.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+
+OUTPUT_LOGFILE=${OUTPUT_LOGFILE:-/logs/test.log}
+rm -fv "$OUTPUT_LOGFILE"
+
+LOG_RATE=${LOG_RATE:-0.2}
+LINE_COUNT=${LINE_COUNT:-100}
+
+echo "Sleep for $LOG_RATE and create $OUTPUT_LOGFILE with $LINE_COUNT+1 lines per entry"
+
+while true; do
+    cat >> "$OUTPUT_LOGFILE" << EOF
+Exception in thread "main" java.lang.RuntimeException: A test exception
+EOF
+    for _ in $(seq "$LINE_COUNT"); do
+cat >> "$OUTPUT_LOGFILE" << EOF
+  at com.stackify.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)
+EOF
+    done
+    sleep "$LOG_RATE"
+done


### PR DESCRIPTION
Added simple compose stack as a basis for PR performance tests: a PR can update this as necessary to run tests.
Once https://github.com/fluent/fluent-bit-ci/pull/48 is merged we can use it to invoke this workflow via a label.
Eventually will transition to dedicated runners plus longer and more complex staging tests.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
