### PR TITLE
in-mem: add system uptime

### DIFF
--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -112,6 +112,8 @@ static int mem_calc(struct flb_in_mem_info *m_info)
     m_info->swap_free     = calc_kb(info.freeswap, info.mem_unit);
     m_info->swap_used     = m_info->swap_total - m_info->swap_free;
 
+    m_info->system_uptime = info.uptime;
+
     return 0;
 }
 
@@ -169,7 +171,7 @@ static int in_mem_collect(struct flb_input_instance *i_ins,
 {
     int ret;
     int len;
-    int entries = 6;/* (total,used,free) * (memory, swap) */
+    int entries = 7;/* (total,used,free) * (memory, swap) */
     struct proc_task *task = NULL;
     struct flb_in_mem_config *ctx = in_context;
     struct flb_in_mem_info info;
@@ -230,6 +232,9 @@ static int in_mem_collect(struct flb_input_instance *i_ins,
     msgpack_pack_str_body(&mp_pck, "Swap.free", 9);
     msgpack_pack_uint64(&mp_pck, info.swap_free);
 
+    msgpack_pack_str(&mp_pck, 13);
+    msgpack_pack_str_body(&mp_pck, "System.uptime", 13);
+    msgpack_pack_uint64(&mp_pck, info.system_uptime);
 
     if (task) {
         /* RSS bytes */

--- a/plugins/in_mem/mem.c
+++ b/plugins/in_mem/mem.c
@@ -171,7 +171,7 @@ static int in_mem_collect(struct flb_input_instance *i_ins,
 {
     int ret;
     int len;
-    int entries = 7;/* (total,used,free) * (memory, swap) */
+    int entries = 7;/* (total,used,free) * (memory, swap) + system uptime*/
     struct proc_task *task = NULL;
     struct flb_in_mem_config *ctx = in_context;
     struct flb_in_mem_info info;

--- a/plugins/in_mem/mem.h
+++ b/plugins/in_mem/mem.h
@@ -35,6 +35,7 @@ struct flb_in_mem_info {
     uint64_t swap_total;
     uint64_t swap_used;
     uint64_t swap_free;
+    long system_uptime;
 };
 
 struct flb_in_mem_config {


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch adds the system uptime which is available via [sysinfo()](https://man7.org/linux/man-pages/man2/sysinfo.2.html) as well as the other mem values.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->


** Example configuration **
```
[INPUT]
    Name mem

[OUTPUT]
    Name stdout
```
** Debug log output **
```
└─$ bin/fluent-bit -c a.conf                                                            
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/23 23:07:23] [ info] [fluent bit] version=1.9.5, commit=a6e3a2a617, pid=125297
[2022/06/23 23:07:23] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/23 23:07:23] [ info] [cmetrics] version=0.3.4
[2022/06/23 23:07:23] [ info] [sp] stream processor started
[2022/06/23 23:07:23] [ info] [output:stdout:stdout.0] worker #0 started
[0] mem.0: [1656018444.837934233, {"Mem.total"=>31665732, "Mem.used"=>21884768, "Mem.free"=>9780964, "Swap.total"=>2097148, "Swap.used"=>0, "Swap.free"=>2097148, "System.uptime"=>11458}]
[0] mem.0: [1656018445.837789514, {"Mem.total"=>31665732, "Mem.used"=>21884796, "Mem.free"=>9780936, "Swap.total"=>2097148, "Swap.used"=>0, "Swap.free"=>2097148, "System.uptime"=>11459}]
[0] mem.0: [1656018446.837738901, {"Mem.total"=>31665732, "Mem.used"=>21886480, "Mem.free"=>9779252, "Swap.total"=>2097148, "Swap.used"=>0, "Swap.free"=>2097148, "System.uptime"=>11460}]
```
** Valgrind output **
```

└─$ valgrind --leak-check=full bin/flb-rt-in_mem
==131141== Memcheck, a memory error detector
==131141== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==131141== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==131141== Command: bin/flb-rt-in_mem
==131141== 
Test mem_flush...                               [2022/06/23 23:10:24] [ info] [fluent bit] version=1.9.5, commit=a6e3a2a617, pid=131141
[2022/06/23 23:10:24] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/23 23:10:24] [ info] [cmetrics] version=0.3.4
[2022/06/23 23:10:24] [ info] [sp] stream processor started
[2022/06/23 23:10:25] [ info] [test] flush triggered
[2022/06/23 23:10:26] [ info] [test] flush triggered
[2022/06/23 23:10:26] [ info] [test] check status 1
[2022/06/23 23:10:27] [ info] [test] flush triggered
[2022/06/23 23:10:28] [ info] [test] flush triggered
[2022/06/23 23:10:28] [ info] [test] check status 2
[2022/06/23 23:10:28] [ warn] [engine] service will shutdown in max 1 seconds
[2022/06/23 23:10:28] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==131141== 
==131141== HEAP SUMMARY:
==131141==     in use at exit: 0 bytes in 0 blocks
==131141==   total heap usage: 5,620 allocs, 5,620 frees, 1,641,733 bytes allocated
==131141== 
==131141== All heap blocks were freed -- no leaks are possible
==131141== 
==131141== For lists of detected and suppressed errors, rerun with: -s
==131141== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
