### PR TITLE
out_cloudwatch_logs: support record_accessor

### DIFF
--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -38,6 +38,10 @@ void flb_ra_dump(struct flb_record_accessor *ra);
 flb_sds_t flb_ra_translate(struct flb_record_accessor *ra,
                            char *tag, int tag_len,
                            msgpack_object map, struct flb_regex_search *result);
+flb_sds_t flb_ra_translate_check(struct flb_record_accessor *ra,
+                                 char *tag, int tag_len,
+                                 msgpack_object map, struct flb_regex_search *result,
+                                 int check);
 int flb_ra_is_static(struct flb_record_accessor *ra);
 int flb_ra_strcmp(struct flb_record_accessor *ra, msgpack_object map,
                   char *str, int len);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -209,7 +209,7 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     }
 
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                      ctx->log_group, 0)) {
+                      stream->group, 0)) {
         goto error;
     }
 
@@ -484,22 +484,22 @@ int process_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
 }
 
 /* Resets or inits a cw_flush struct */
-void reset_flush_buf(struct flb_cloudwatch *ctx, struct cw_flush *buf,
-                    struct log_stream *stream) {
+void reset_flush_buf(struct flb_cloudwatch *ctx, struct cw_flush *buf) {
     buf->event_index = 0;
     buf->tmp_buf_offset = 0;
     buf->event_index = 0;
     buf->data_size = PUT_LOG_EVENTS_HEADER_LEN + PUT_LOG_EVENTS_FOOTER_LEN;
-    buf->data_size += strlen(stream->name);
-    buf->data_size += strlen(ctx->log_group);
-    if (stream->sequence_token) {
-        buf->data_size += strlen(stream->sequence_token);
+    if (buf->current_stream != NULL) {
+        buf->data_size += strlen(buf->current_stream->name);
+        buf->data_size += strlen(buf->current_stream->group);
+        if (buf->current_stream->sequence_token) {
+            buf->data_size += strlen(buf->current_stream->sequence_token);
+        }
     }
 }
 
 /* sorts events, constructs a put payload, and then sends */
-int send_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
-                    struct log_stream *stream) {
+int send_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf) {
     int ret;
     int offset;
     int i;
@@ -513,11 +513,11 @@ int send_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     qsort(buf->events, buf->event_index, sizeof(struct cw_event), compare_events);
 
 retry:
-    stream->newest_event = 0;
-    stream->oldest_event = 0;
+    buf->current_stream->newest_event = 0;
+    buf->current_stream->oldest_event = 0;
 
     offset = 0;
-    ret = init_put_payload(ctx, buf, stream, &offset);
+    ret = init_put_payload(ctx, buf, buf->current_stream, &offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to initialize PutLogEvents payload");
         return -1;
@@ -547,7 +547,7 @@ retry:
     }
 
     flb_plg_debug(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
-    ret = put_log_events(ctx, buf, stream, (size_t) offset);
+    ret = put_log_events(ctx, buf, buf->current_stream, (size_t) offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send log events");
         return -1;
@@ -571,13 +571,20 @@ int add_event(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     int retry_add = FLB_FALSE;
     int event_bytes = 0;
 
-    if (buf->event_index == 0) {
-        /* init */
-        reset_flush_buf(ctx, buf, stream);
+    if (buf->event_index > 0 && buf->current_stream != stream) {
+        /* we already have events for a different stream, send them first */
+        retry_add = FLB_TRUE;
+        goto send;
     }
 
 retry_add_event:
+    buf->current_stream = stream;
     retry_add = FLB_FALSE;
+    if (buf->event_index == 0) {
+        /* init */
+        reset_flush_buf(ctx, buf);
+    }
+
     ret = process_event(ctx, buf, obj, tms);
     if (ret < 0) {
         return -1;
@@ -632,8 +639,8 @@ retry_add_event:
     return 0;
 
 send:
-    ret = send_log_events(ctx, buf, stream);
-    reset_flush_buf(ctx, buf, stream);
+    ret = send_log_events(ctx, buf);
+    reset_flush_buf(ctx, buf);
     if (ret < 0) {
         return -1;
     }
@@ -797,7 +804,7 @@ int pack_emf_payload(struct flb_cloudwatch *ctx,
  * return value is the number of events processed
  */
 int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, 
-                     struct cw_flush *buf, struct log_stream *stream, 
+                     struct cw_flush *buf, flb_sds_t tag,
                      const char *data, size_t bytes)
 {
     size_t off = 0;
@@ -814,6 +821,8 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
     msgpack_object emf_payload;
     /* msgpack::sbuffer is a simple buffer implementation. */
     msgpack_sbuffer mp_sbuf;
+
+    struct log_stream *stream;
 
     char *key_str = NULL;
     size_t key_str_size = 0;
@@ -858,6 +867,12 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
         /* Get the record/map */
         map = root.via.array.ptr[1];
         map_size = map.via.map.size;
+
+        stream = get_log_stream(ctx, tag, map);
+        if (!stream) {
+            flb_plg_debug(ctx->ins, "Couldn't determine log group & stream for record with tag %s", tag);
+            goto error;
+        }
 
         if (ctx->log_key) {
             key_str = NULL;
@@ -975,8 +990,8 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
     msgpack_unpacked_destroy(&result);
 
     /* send any remaining events */
-    ret = send_log_events(ctx, buf, stream);
-    reset_flush_buf(ctx, buf, stream);
+    ret = send_log_events(ctx, buf);
+    reset_flush_buf(ctx, buf);
     if (ret < 0) {
         return -1;
     }
@@ -989,39 +1004,22 @@ error:
     return -1;
 }
 
-
-struct log_stream *get_dynamic_log_stream(struct flb_cloudwatch *ctx,
-                                          const char *tag, int tag_len)
+struct log_stream *get_or_create_log_stream(struct flb_cloudwatch *ctx,
+                                            flb_sds_t stream_name,
+                                            flb_sds_t group_name)
 {
     int ret;
     struct log_stream *new_stream;
     struct log_stream *stream;
     struct mk_list *tmp;
     struct mk_list *head;
-    flb_sds_t name = NULL;
-    flb_sds_t tmp_s = NULL;
     time_t now;
-
-    name = flb_sds_create(ctx->log_stream_prefix);
-    if (!name) {
-        flb_errno();
-        return NULL;
-    }
-
-    tmp_s = flb_sds_cat(name, tag, tag_len);
-    if (!tmp_s) {
-        flb_errno();
-        flb_sds_destroy(name);
-        return NULL;
-    }
-    name = tmp_s;
 
     /* check if the stream already exists */
     now = time(NULL);
     mk_list_foreach_safe(head, tmp, &ctx->streams) {
         stream = mk_list_entry(head, struct log_stream, _head);
-        if (strcmp(name, stream->name) == 0) {
-            flb_sds_destroy(name);
+        if (strcmp(stream_name, stream->name) == 0 && strcmp(group_name, stream->group) == 0) {
             return stream;
         }
         else {
@@ -1037,10 +1035,18 @@ struct log_stream *get_dynamic_log_stream(struct flb_cloudwatch *ctx,
     new_stream = flb_calloc(1, sizeof(struct log_stream));
     if (!new_stream) {
         flb_errno();
-        flb_sds_destroy(name);
         return NULL;
     }
-    new_stream->name = name;
+    new_stream->name = flb_sds_create(stream_name);
+    if (new_stream->name == NULL) {
+        flb_errno();
+        return NULL;
+    }
+    new_stream->group = flb_sds_create(group_name);
+    if (new_stream->group == NULL) {
+        flb_errno();
+        return NULL;
+    }
 
     ret = create_log_stream(ctx, new_stream, FLB_TRUE);
     if (ret < 0) {
@@ -1053,29 +1059,78 @@ struct log_stream *get_dynamic_log_stream(struct flb_cloudwatch *ctx,
     return new_stream;
 }
 
-struct log_stream *get_log_stream(struct flb_cloudwatch *ctx,
-                                  const char *tag, int tag_len)
+struct log_stream *get_log_stream(struct flb_cloudwatch *ctx, flb_sds_t tag,
+                                  const msgpack_object map)
 {
+    flb_sds_t group_name = NULL;
+    flb_sds_t stream_name = NULL;
+    flb_sds_t tmp_s = NULL;
+    int free_group = FLB_FALSE;
+    int free_stream = FLB_FALSE;
     struct log_stream *stream;
-    int ret;
 
-    if (ctx->log_stream_name) {
-        stream = &ctx->stream;
-        if (ctx->stream_created == FLB_FALSE) {
-            ret = create_log_stream(ctx, stream, FLB_TRUE);
-            if (ret < 0) {
-                return NULL;
-            }
-            stream->expiration = time(NULL) + FOUR_HOURS_IN_SECONDS;
-            ctx->stream_created = FLB_TRUE;
-        }
-        return stream;
+    /* templates take priority */
+    if (ctx->ra_stream) {
+        stream_name = flb_ra_translate_check(ctx->ra_stream, tag, flb_sds_len(tag),
+                                             map, NULL, FLB_TRUE);
     }
 
-     return get_dynamic_log_stream(ctx, tag, tag_len);
+    if (ctx->ra_group) {
+        group_name = flb_ra_translate_check(ctx->ra_group, tag, flb_sds_len(tag),
+                                            map, NULL, FLB_TRUE);
+    }
+    
+    if (stream_name == NULL) {
+        if (ctx->stream_name) {
+            stream_name = ctx->stream_name;
+        } else {
+            free_stream = FLB_TRUE;
+            /* use log_stream_prefix */
+            stream_name = flb_sds_create(ctx->log_stream_prefix);
+            if (!stream_name) {
+                flb_errno();
+                if (group_name) {
+                    flb_sds_destroy(group_name);
+                }
+                return NULL;
+            }
+
+            tmp_s = flb_sds_cat(stream_name, tag, flb_sds_len(tag));
+            if (!tmp_s) {
+                flb_errno();
+                flb_sds_destroy(stream_name);
+                if (group_name) {
+                    flb_sds_destroy(group_name);
+                }
+                return NULL;
+            }
+            stream_name = tmp_s;
+        }
+    } else {
+        free_stream = FLB_TRUE;
+    }
+    
+    if (group_name == NULL) {
+        group_name = ctx->group_name;
+    } else {
+        free_group = FLB_TRUE;
+    }
+
+    flb_plg_debug(ctx->ins, "Using stream=%s, group=%s", stream_name, group_name);
+
+    stream = get_or_create_log_stream(ctx, stream_name, group_name);
+
+    if (free_group == FLB_TRUE) {
+        flb_sds_destroy(group_name);
+    }
+    if (free_stream == FLB_TRUE) {
+        flb_sds_destroy(stream_name);
+    }
+    return stream;
 }
 
-static int set_log_group_retention(struct flb_cloudwatch *ctx)
+
+static int set_log_group_retention(struct flb_cloudwatch *ctx, struct log_stream *stream)
 {
     if (ctx->log_retention_days <= 0) {
         /* no need to set */
@@ -1088,9 +1143,9 @@ static int set_log_group_retention(struct flb_cloudwatch *ctx)
     flb_sds_t tmp;
     flb_sds_t error;
 
-    flb_plg_info(ctx->ins, "Setting retention policy on log group %s to %dd", ctx->log_group, ctx->log_retention_days);
+    flb_plg_info(ctx->ins, "Setting retention policy on log group %s to %dd", stream->group, ctx->log_retention_days);
 
-    body = flb_sds_create_size(68 + strlen(ctx->log_group));
+    body = flb_sds_create_size(68 + strlen(stream->group));
     if (!body) {
         flb_sds_destroy(body);
         flb_errno();
@@ -1098,7 +1153,7 @@ static int set_log_group_retention(struct flb_cloudwatch *ctx)
     }
 
     /* construct CreateLogGroup request body */
-    tmp = flb_sds_printf(&body, "{\"logGroupName\":\"%s\",\"retentionInDays\":%d}", ctx->log_group, ctx->log_retention_days);
+    tmp = flb_sds_printf(&body, "{\"logGroupName\":\"%s\",\"retentionInDays\":%d}", stream->group, ctx->log_retention_days);
     if (!tmp) {
         flb_sds_destroy(body);
         flb_errno();
@@ -1152,7 +1207,7 @@ static int set_log_group_retention(struct flb_cloudwatch *ctx)
     return -1;
 }
 
-int create_log_group(struct flb_cloudwatch *ctx)
+int create_log_group(struct flb_cloudwatch *ctx, struct log_stream *stream)
 {
     struct flb_http_client *c = NULL;
     struct flb_aws_client *cw_client;
@@ -1161,9 +1216,9 @@ int create_log_group(struct flb_cloudwatch *ctx)
     flb_sds_t error;
     int ret;
 
-    flb_plg_info(ctx->ins, "Creating log group %s", ctx->log_group);
+    flb_plg_info(ctx->ins, "Creating log group %s", stream->group);
 
-    body = flb_sds_create_size(25 + strlen(ctx->log_group));
+    body = flb_sds_create_size(25 + strlen(stream->group));
     if (!body) {
         flb_sds_destroy(body);
         flb_errno();
@@ -1171,7 +1226,7 @@ int create_log_group(struct flb_cloudwatch *ctx)
     }
 
     /* construct CreateLogGroup request body */
-    tmp = flb_sds_printf(&body, "{\"logGroupName\":\"%s\"}", ctx->log_group);
+    tmp = flb_sds_printf(&body, "{\"logGroupName\":\"%s\"}", stream->group);
     if (!tmp) {
         flb_sds_destroy(body);
         flb_errno();
@@ -1194,11 +1249,10 @@ int create_log_group(struct flb_cloudwatch *ctx)
 
         if (c->resp.status == 200) {
             /* success */
-            flb_plg_info(ctx->ins, "Created log group %s", ctx->log_group);
-            ctx->group_created = FLB_TRUE;
+            flb_plg_info(ctx->ins, "Created log group %s", stream->group);
             flb_sds_destroy(body);
             flb_http_client_destroy(c);
-            ret = set_log_group_retention(ctx);
+            ret = set_log_group_retention(ctx, stream);
             return ret;
         }
 
@@ -1208,17 +1262,16 @@ int create_log_group(struct flb_cloudwatch *ctx)
             if (error != NULL) {
                 if (strcmp(error, ERR_CODE_ALREADY_EXISTS) == 0) {
                     flb_plg_info(ctx->ins, "Log Group %s already exists",
-                                  ctx->log_group);
-                    ctx->group_created = FLB_TRUE;
+                                 stream->group);
                     flb_sds_destroy(body);
                     flb_sds_destroy(error);
                     flb_http_client_destroy(c);
-                    ret = set_log_group_retention(ctx);
+                    ret = set_log_group_retention(ctx, stream);
                     return ret;
                 }
                 /* some other error occurred; notify user */
                 flb_aws_print_error(c->resp.payload, c->resp.payload_size,
-                                        "CreateLogGroup", ctx->ins);
+                                    "CreateLogGroup", ctx->ins);
                 flb_sds_destroy(error);
             }
             else {
@@ -1248,9 +1301,9 @@ int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream,
     int ret;
 
     flb_plg_info(ctx->ins, "Creating log stream %s in log group %s",
-                 stream->name, ctx->log_group);
+                 stream->name, stream->group);
 
-    body = flb_sds_create_size(50 + strlen(ctx->log_group) +
+    body = flb_sds_create_size(50 + strlen(stream->group) +
                                strlen(stream->name));
     if (!body) {
         flb_sds_destroy(body);
@@ -1261,7 +1314,7 @@ int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream,
     /* construct CreateLogStream request body */
     tmp = flb_sds_printf(&body,
                          "{\"logGroupName\":\"%s\",\"logStreamName\":\"%s\"}",
-                         ctx->log_group,
+                         stream->group,
                          stream->name);
     if (!tmp) {
         flb_sds_destroy(body);
@@ -1312,8 +1365,8 @@ int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream,
 
                     if (ctx->create_group == FLB_TRUE) {
                         flb_plg_info(ctx->ins, "Log Group %s not found. Will attempt to create it.",
-                                 ctx->log_group);
-                        ret = create_log_group(ctx);
+                                     stream->group);
+                        ret = create_log_group(ctx, stream);
                         if (ret < 0) {
                             return -1;
                         } else {
@@ -1327,7 +1380,7 @@ int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream,
                         }
                     } else {
                         flb_plg_error(ctx->ins, "Log Group %s not found and `auto_create_group` disabled.",
-                                     ctx->log_group);
+                                      stream->group);
                     }
                     return -1;
                 }
@@ -1365,17 +1418,6 @@ int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     flb_sds_t error;
     int num_headers = 1;
     int retry = FLB_TRUE;
-
-    buf->put_events_calls++;
-
-    if (buf->put_events_calls >= 4) {
-        /*
-         * In normal execution, even under high throughput, 4+ calls per flush
-         * should be extremely rare. This is needed for edge cases basically.
-         */
-        flb_plg_debug(ctx->ins, "Too many calls this flush, sleeping for 250 ms");
-        usleep(250000);
-    }
 
     flb_plg_debug(ctx->ins, "Sending log events to log stream %s", stream->name);
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -42,16 +42,16 @@
 
 void cw_flush_destroy(struct cw_flush *buf);
 
-int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, struct cw_flush *buf,
-                     struct log_stream *stream,
+int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, 
+                     struct cw_flush *buf, flb_sds_t tag,
                      const char *data, size_t bytes);
 int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream, int can_retry);
-struct log_stream *get_log_stream(struct flb_cloudwatch *ctx,
-                                  const char *tag, int tag_len);
+struct log_stream *get_log_stream(struct flb_cloudwatch *ctx, flb_sds_t tag,
+                                  const msgpack_object map);
 int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
                    struct log_stream *stream,
                    size_t payload_size);
-int create_log_group(struct flb_cloudwatch *ctx);
+int create_log_group(struct flb_cloudwatch *ctx, struct log_stream *stream);
 int compare_events(const void *a_arg, const void *b_arg);
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

#3246 

Doc PR: https://github.com/fluent/fluent-bit-docs/pull/834

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
