### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-branch-containers.yaml
+++ b/.github/workflows/build-branch-containers.yaml
@@ -6,8 +6,13 @@ on:
         description: Version of Fluent Bit to build, commit, branch, etc. The container image will be ghcr.io/fluent/fluent-bit/test/<this value>.
         required: true
         default: master
+permissions:
+  contents: read
+
 jobs:
   build-branch-containers:
+    permissions:
+      contents: none
     uses: fluent/fluent-bit/.github/workflows/call-build-images.yaml@master
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -14,8 +14,13 @@ on:
         default: ""
 
 name: Build packages for master
+permissions:
+  contents: read
+
 jobs:
   master-build-generate-matrix:
+    permissions:
+      contents: none
     name: Staging build matrix
     runs-on: ubuntu-latest
     outputs:
@@ -41,6 +46,8 @@ jobs:
         shell: bash
 
   master-build-packages:
+    permissions:
+      contents: none
     needs: master-build-generate-matrix
     uses: fluent/fluent-bit/.github/workflows/call-build-linux-packages.yaml@master
     with:

--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -37,6 +37,8 @@ on:
         required: false
 jobs:
   call-test-images-cosign-verify:
+    permissions:
+      contents: none
     name: Cosign verification of container image
     environment: ${{ inputs.environment }}
     runs-on: [ ubuntu-latest ]
@@ -68,6 +70,8 @@ jobs:
           IMAGE_TAG: ${{ inputs.image-tag }}
 
   call-test-images-container-architecture:
+    permissions:
+      contents: none
     name: ${{ matrix.arch }} image architecture verification
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}

--- a/.github/workflows/call-test-packages.yaml
+++ b/.github/workflows/call-test-packages.yaml
@@ -20,6 +20,9 @@ on:
         description: The name of the S3 (US-East) bucket to pull packages from.
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   call-test-packaging:
     # We use Dokken to run a series of test suites locally on containers representing

--- a/.github/workflows/cron-stale.yaml
+++ b/.github/workflows/cron-stale.yaml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     name: Mark stale
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cron-trivy.yaml
+++ b/.github/workflows/cron-trivy.yaml
@@ -12,11 +12,16 @@ on:
     - cron: 44 13 * * 4
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Run Trivy on the latest container and update the security code scanning results tab.
   trivy-latest:
     # Matrix job that pulls the latest image for each supported architecture via the multi-arch latest manifest.
     # We then re-tag it locally to ensure that when Trivy runs it does not pull the latest for the wrong architecture.
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: ${{ matrix.arch }} container scan
     runs-on: [ ubuntu-latest ]
     continue-on-error: true

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -79,6 +79,8 @@ jobs:
         shell: bash
 
   unstable-build-images:
+    permissions:
+      contents: none
     needs: unstable-build-get-meta
     uses: ./.github/workflows/call-build-images.yaml
     with:
@@ -113,6 +115,8 @@ jobs:
           ref: ${{ needs.unstable-build-get-meta.outputs.branch }}
 
   unstable-build-packages:
+    permissions:
+      contents: none
     needs:
       - unstable-build-get-meta
       - unstable-build-generate-matrix
@@ -127,6 +131,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
 
   unstable-build-windows-package:
+    permissions:
+      contents: none
     needs:
       - unstable-build-get-meta
     uses: ./.github/workflows/call-build-windows.yaml
@@ -139,6 +145,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
 
   unstable-build-macos-package:
+    permissions:
+      contents: none
     needs:
       - unstable-build-get-meta
     uses: ./.github/workflows/call-build-macos.yaml

--- a/.github/workflows/master-integration-test.yaml
+++ b/.github/workflows/master-integration-test.yaml
@@ -4,8 +4,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   master-integration-test-build:
+    permissions:
+      contents: none
     name: Master - integration build
     uses: fluent/fluent-bit/.github/workflows/call-integration-image-build.yaml@master
     with:
@@ -19,6 +24,8 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
 
   master-integration-test-run-integration:
+    permissions:
+      contents: none
     name: Master - integration test
     needs: master-integration-test-build
     uses: fluent/fluent-bit/.github/workflows/call-integration-test.yaml@master

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -9,6 +9,9 @@ on:
       - 'cmake/*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Sanity check for compilation using older compiler on CentOS 7
   pr-compile-centos-7:

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -11,6 +11,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
     pr-image-tests-build-images:
       name: PR - Buildkit docker build test

--- a/.github/workflows/pr-integration-test.yaml
+++ b/.github/workflows/pr-integration-test.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   pr-integration-test-build:
+    permissions:
+      contents: none
     name: PR - integration build
     # We only need to test this once as the rest are chained from it.
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
@@ -40,6 +42,8 @@ jobs:
           number: ${{ github.event.pull_request.number }}
 
   pr-integration-test-run-integration:
+    permissions:
+      contents: none
     name: PR - K8S integration test
     needs:
       - pr-integration-test-build

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -3,9 +3,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   hadolint-pr:
+    permissions:
+      checks: write  # for reviewdog/action-hadolint to report issues using checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     name: PR - Hadolint
     steps:

--- a/.github/workflows/pr-package-tests.yaml
+++ b/.github/workflows/pr-package-tests.yaml
@@ -7,6 +7,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   pr-package-test-build:
     name: PR - packages build

--- a/.github/workflows/pr-perf-test.yaml
+++ b/.github/workflows/pr-perf-test.yaml
@@ -10,6 +10,8 @@ jobs:
 
   pr-perf-test-run:
     # We only need to test this once as the rest are chained from it.
+    permissions:
+      contents: none
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-performance-test')
     uses: fluent/fluent-bit-ci/.github/workflows/call-run-test.yaml@main
     with:

--- a/.github/workflows/pr-windows-build.yaml
+++ b/.github/workflows/pr-windows-build.yaml
@@ -16,8 +16,13 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   pr-windows-build:
+    permissions:
+      contents: none
     uses: fluent/fluent-bit/.github/workflows/call-build-windows.yaml@master
     with:
       version: ${{ github.sha }}

--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -13,8 +13,13 @@ on:
       - '**.sh'
       - 'examples/**'
 
+permissions:
+  contents: read
+
 jobs:
   run-all-unit-tests:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Unit tests (matrix)
     steps:

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -65,6 +65,8 @@ jobs:
           flags: 'g'
 
   staging-build-images:
+    permissions:
+      contents: none
     needs: staging-build-get-meta
     uses: ./.github/workflows/call-build-images.yaml
     with:
@@ -80,6 +82,8 @@ jobs:
       cosign_private_key_password: ${{ secrets.COSIGN_PASSWORD }}
 
   staging-build-upload-schema-s3:
+    permissions:
+      contents: none
     needs:
       - staging-build-get-meta
       - staging-build-images
@@ -127,6 +131,8 @@ jobs:
           target: ${{ github.event.inputs.target || '' }}
 
   staging-build-packages:
+    permissions:
+      contents: none
     needs:
       - staging-build-get-meta
       - staging-build-generate-matrix
@@ -145,6 +151,8 @@ jobs:
       gpg_private_key_passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 
   staging-build-windows-packages:
+    permissions:
+      contents: none
     needs:
       - staging-build-get-meta
     uses: ./.github/workflows/call-build-windows.yaml
@@ -159,6 +167,8 @@ jobs:
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   staging-build-macos-packages:
+    permissions:
+      contents: none
     needs:
       - staging-build-get-meta
     uses: ./.github/workflows/call-build-macos.yaml

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -27,6 +27,8 @@ concurrency: staging-build-release
 jobs:
 
   staging-release-version-check:
+    permissions:
+      contents: none
     name: Check staging release matches
     environment: release
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-test.yaml
+++ b/.github/workflows/staging-test.yaml
@@ -11,8 +11,13 @@ on:
 
 concurrency: integration-test
 
+permissions:
+  contents: read
+
 jobs:
   staging-test-images:
+    permissions:
+      contents: none
     name: Container images staging tests
     # Workflow run always triggers on completion regardless of status
     # This prevents us from running if build fails.
@@ -30,6 +35,8 @@ jobs:
 
   # Called workflows cannot be nested
   staging-test-images-integration:
+    permissions:
+      contents: none
     name: run integration tests on GCP
     # Wait for other tests to succeed
     needs: staging-test-images
@@ -44,6 +51,8 @@ jobs:
       terraform_api_token: ${{ secrets.TF_API_TOKEN }}
 
   staging-test-packages:
+    permissions:
+      contents: none
     name: Binary packages staging test
     # Workflow run always triggers on completion regardless of status
     # This prevents us from running if build fails.

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-unit-tests-amd64:
     name: ${{ matrix.os }} - ${{ matrix.compiler }} - ${{ matrix.flb_option }} unit tests run on AMD64
@@ -92,6 +95,8 @@ jobs:
 
   # Required check looks at this so do not remove
   run-all-unit-tests:
+    permissions:
+      contents: none
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Unit tests (matrix)


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
