### PR TITLE
filter_throttle: add mutex to prevent race issue

### DIFF
--- a/plugins/filter_throttle/throttle.h
+++ b/plugins/filter_throttle/throttle.h
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_pthread.h>
 
 /* actions */
 #define THROTTLE_RET_KEEP  0


### PR DESCRIPTION
Thread sanitizer reports data race using below configuration.
It reports main thread and timer thread access `ctx->hash->total` without exclusion.
This patch is to add mutex.
```
cmake .. -DSANITIZE_THREAD=on && make
bin/fluent-bit -c a.conf
```

a.conf:
```
[INPUT]
    Name dummy
    Rate 10000

[FILTER]
    Name throttle
    Match *
    interval 1s
    Rate 100

[OUTPUT]
    Name null
```

```
==================
WARNING: ThreadSanitizer: data race (pid=16321)
  Read of size 4 at 0x7b140000280c by thread T1:
    #0 throttle_data /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:98 (fluent-bit+0x289198)
    #1 cb_throttle_filter /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:217 (fluent-bit+0x2898ec)
    #2 flb_filter_do /home/taka/git/fluent-bit/src/flb_filter.c:124 (fluent-bit+0x97ff8)
    #3 input_chunk_append_raw /home/taka/git/fluent-bit/src/flb_input_chunk.c:1478 (fluent-bit+0xfeaab)
    #4 flb_input_chunk_append_raw /home/taka/git/fluent-bit/src/flb_input_chunk.c:1592 (fluent-bit+0xfef36)
    #5 in_dummy_collect /home/taka/git/fluent-bit/plugins/in_dummy/in_dummy.c:107 (fluent-bit+0x162108)
    #6 flb_input_collector_fd /home/taka/git/fluent-bit/src/flb_input.c:1210 (fluent-bit+0x97378)
    #7 flb_engine_handle_event /home/taka/git/fluent-bit/src/flb_engine.c:440 (fluent-bit+0xb842c)
    #8 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:763 (fluent-bit+0xb842c)
    #9 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:626 (fluent-bit+0x818bb)

  Previous write of size 4 at 0x7b140000280c by thread T3:
    #0 window_add /home/taka/git/fluent-bit/plugins/filter_throttle/window.c:94 (fluent-bit+0x28a82d)
    #1 time_ticker /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:77 (fluent-bit+0x288f79)

  Location is heap block of size 72 at 0x7b1400002800 allocated by thread T1:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:651 (libtsan.so.0+0x30323)
    #1 flb_malloc /home/taka/git/fluent-bit/include/fluent-bit/flb_mem.h:79 (fluent-bit+0x289e46)
    #2 window_create /home/taka/git/fluent-bit/plugins/filter_throttle/window.c:37 (fluent-bit+0x28a334)
    #3 cb_throttle_init /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:175 (fluent-bit+0x289718)
    #4 flb_filter_init_all /home/taka/git/fluent-bit/src/flb_filter.c:480 (fluent-bit+0x99362)
    #5 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:659 (fluent-bit+0xb7cc4)
    #6 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:626 (fluent-bit+0x818bb)

  Thread T1 'flb-pipeline' (tid=16323, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:962 (libtsan.so.0+0x5ea79)
    #1 mk_utils_worker_spawn /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_utils.c:284 (fluent-bit+0x567f54)
    #2 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1191 (fluent-bit+0x72a55)
    #3 main /home/taka/git/fluent-bit/src/fluent-bit.c:1217 (fluent-bit+0x72b9a)

  Thread T3 (tid=16325, running) created by thread T1 at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:962 (libtsan.so.0+0x5ea79)
    #1 cb_throttle_init /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:178 (fluent-bit+0x2897a4)
    #2 flb_filter_init_all /home/taka/git/fluent-bit/src/flb_filter.c:480 (fluent-bit+0x99362)
    #3 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:659 (fluent-bit+0xb7cc4)
    #4 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:626 (fluent-bit+0x818bb)

SUMMARY: ThreadSanitizer: data race /home/taka/git/fluent-bit/plugins/filter_throttle/throttle.c:98 in throttle_data
==================
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

Above.

## Debug log 

```
$ bin/fluent-bit -c a.conf 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/24 21:32:34] [ info] [fluent bit] version=1.9.5, commit=4a32432179, pid=20467
[2022/06/24 21:32:34] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/24 21:32:34] [ info] [cmetrics] version=0.3.4
[2022/06/24 21:32:34] [ info] [sp] stream processor started
[2022/06/24 21:32:34] [ info] [output:null:null.0] worker #0 started
^C[2022/06/24 21:32:36] [engine] caught signal (SIGINT)
[2022/06/24 21:32:36] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/24 21:32:37] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/24 21:32:37] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/06/24 21:32:37] [ info] [output:null:null.0] thread worker #0 stopped
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==20477== Memcheck, a memory error detector
==20477== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==20477== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==20477== Command: bin/fluent-bit -c a.conf
==20477== 
Fluent Bit v1.9.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/24 21:32:59] [ info] [fluent bit] version=1.9.5, commit=4a32432179, pid=20477
[2022/06/24 21:32:59] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/24 21:32:59] [ info] [cmetrics] version=0.3.4
==20477== Thread 4:
==20477== Conditional jump or move depends on uninitialised value(s)
==20477==    at 0x2CC148: time_ticker (throttle.c:84)
==20477==    by 0x4866608: start_thread (pthread_create.c:477)
==20477==    by 0x4BE3132: clone (clone.S:95)
==20477== 
[2022/06/24 21:32:59] [ info] [sp] stream processor started
[2022/06/24 21:32:59] [ info] [output:null:null.0] worker #0 started
^C[2022/06/24 21:33:05] [engine] caught signal (SIGINT)
[2022/06/24 21:33:05] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/24 21:33:06] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/24 21:33:06] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/06/24 21:33:06] [ info] [output:null:null.0] thread worker #0 stopped
==20477== 
==20477== HEAP SUMMARY:
==20477==     in use at exit: 0 bytes in 0 blocks
==20477==   total heap usage: 285,392 allocs, 285,392 frees, 4,980,997,378 bytes allocated
==20477== 
==20477== All heap blocks were freed -- no leaks are possible
==20477== 
==20477== Use --track-origins=yes to see where uninitialised values come from
==20477== For lists of detected and suppressed errors, rerun with: -s
==20477== ERROR SUMMARY: 7 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
