### PR TITLE
filter_multiline: use flb_time API to get timestamp in millisecond

### DIFF
--- a/plugins/filter_multiline/ml_concat.c
+++ b/plugins/filter_multiline/ml_concat.c
@@ -325,11 +325,9 @@ struct split_message_packer *ml_create_packer(const char *tag, char *input_name,
 }
 
 unsigned long long ml_current_timestamp() {
-    struct timeval te; 
-    unsigned long long milliseconds;
-    gettimeofday(&te, NULL); 
-    milliseconds = te.tv_sec*1000LL + te.tv_usec/1000; 
-    return milliseconds;
+    struct flb_time te;
+    flb_time_get(&te);
+    return flb_time_to_nanosec(&te) / 1000000LL;
 }
 
 int ml_split_message_packer_write(struct split_message_packer *packer, 


### PR DESCRIPTION
This patch is to suppress below warning.
I modified to use flb_time API since `gettimeofday` is not supported on Windows.
```
[ 44%] Building C object plugins/filter_multiline/CMakeFiles/flb-plugin-filter_multiline.dir/ml_concat.c.o
/home/taka/git/fluent-bit/plugins/filter_multiline/ml_concat.c: In function ‘ml_current_timestamp’:
/home/taka/git/fluent-bit/plugins/filter_multiline/ml_concat.c:330:5: warning: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]
  330 |     gettimeofday(&te, NULL);
      |     ^~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log / Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_multiline 
==15100== Memcheck, a memory error detector
==15100== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15100== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==15100== Command: bin/flb-rt-filter_multiline
==15100== 
Test multiline_buffered_one_record...           [2022/06/25 07:23:15] [ info] [fluent bit] version=1.9.6, commit=1bec2348e1, pid=15100
[2022/06/25 07:23:15] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/25 07:23:15] [ info] [cmetrics] version=0.3.4
[2022/06/25 07:23:15] [ info] [filter:multiline:multiline.0] created emitter: emitter_for_multiline.0
[2022/06/25 07:23:15] [ info] [sp] stream processor started
[2022/06/25 07:23:15] [ info] [filter:multiline:multiline.0] created new multiline stream for lib.0_test
(snip)
Test flb_test_multiline_partial_message_concat_two_ids... [2022/06/25 07:23:34] [ info] [fluent bit] version=1.9.6, commit=1bec2348e1, pid=15100
[2022/06/25 07:23:34] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/25 07:23:34] [ info] [cmetrics] version=0.3.4
[2022/06/25 07:23:34] [ info] [filter:multiline:multiline.0] created emitter: emitter_for_multiline.0
[2022/06/25 07:23:34] [ info] [sp] stream processor started
[2022/06/25 07:23:36] [ warn] [engine] service will shutdown in max 1 seconds
[2022/06/25 07:23:37] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==15100== 
==15100== HEAP SUMMARY:
==15100==     in use at exit: 0 bytes in 0 blocks
==15100==   total heap usage: 6,166 allocs, 6,166 frees, 7,040,958 bytes allocated
==15100== 
==15100== All heap blocks were freed -- no leaks are possible
==15100== 
==15100== For lists of detected and suppressed errors, rerun with: -s
==15100== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
