### PR TITLE
in_netif: add missing return type

### DIFF
--- a/plugins/in_netif/in_netif.c
+++ b/plugins/in_netif/in_netif.c
@@ -184,7 +184,7 @@ static inline uint64_t calc_diff(struct netif_entry *entry)
 }
 
 #define LINE_LEN 256
-static read_proc_file_linux(struct flb_in_netif_config *ctx)
+static int read_proc_file_linux(struct flb_in_netif_config *ctx)
 {
     FILE *fp = NULL;
     char line[LINE_LEN] = {0};


### PR DESCRIPTION
This patch is to suppress below warning.
```
$ valgrind --leak-check=full bin/flb-rt-in_netif 
==17484== Memcheck, a memory error detector
==17484== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17484== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==17484== Command: bin/flb-rt-in_netif
==17484== 
Test normal case...                             [ OK ]
Test no interface...                            [2022/06/25 07:36:56] [error] [input:netif:netif.0] 'interface' is not set
[2022/06/25 07:36:56] [error] Failed initialize input netif.0
[2022/06/25 07:36:56] [error] [lib] backend failed
[ OK ]
Test invalid interface...                       [2022/06/25 07:36:57] [error] [lib] backend failed
[2022/06/25 07:36:57] [error] [input:netif:netif.0] 	
: init test failed
[2022/06/25 07:36:57] [error] Failed initialize input netif.0
[ OK ]
Test verbose...                                 [ OK ]
SUCCESS: All unit tests have passed.
==17484== 
==17484== HEAP SUMMARY:
==17484==     in use at exit: 0 bytes in 0 blocks
==17484==   total heap usage: 7,425 allocs, 7,425 frees, 4,010,768 bytes allocated
==17484== 
==17484== All heap blocks were freed -- no leaks are possible
==17484== 
==17484== For lists of detected and suppressed errors, rerun with: -s
==17484== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_netif 
==17484== Memcheck, a memory error detector
==17484== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17484== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==17484== Command: bin/flb-rt-in_netif
==17484== 
Test normal case...                             [ OK ]
Test no interface...                            [2022/06/25 07:36:56] [error] [input:netif:netif.0] 'interface' is not set
[2022/06/25 07:36:56] [error] Failed initialize input netif.0
[2022/06/25 07:36:56] [error] [lib] backend failed
[ OK ]
Test invalid interface...                       [2022/06/25 07:36:57] [error] [lib] backend failed
[2022/06/25 07:36:57] [error] [input:netif:netif.0] 	
: init test failed
[2022/06/25 07:36:57] [error] Failed initialize input netif.0
[ OK ]
Test verbose...                                 [ OK ]
SUCCESS: All unit tests have passed.
==17484== 
==17484== HEAP SUMMARY:
==17484==     in use at exit: 0 bytes in 0 blocks
==17484==   total heap usage: 7,425 allocs, 7,425 frees, 4,010,768 bytes allocated
==17484== 
==17484== All heap blocks were freed -- no leaks are possible
==17484== 
==17484== For lists of detected and suppressed errors, rerun with: -s
==17484== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
