### PR TITLE
build: libyaml: Search libyaml with pkg-config and handle homebrew-ed libyaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,7 +679,7 @@ if(FLB_CONFIG_YAML)
     include_directories(${LIBYAML_INCLUDEDIR})
     link_directories(${LIBYAML_LIBRARY_DIRS})
   else()
-    # Requies libyaml support
+    # Requires libyaml support
     check_c_source_compiles("
       #include <yaml.h>
       int main() {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,24 +666,38 @@ endif()
 
 # Configuration file YAML format support
 if(FLB_CONFIG_YAML)
-# Requies libyaml support
-check_c_source_compiles("
-  #include <yaml.h>
-  int main() {
-    yaml_parser_t parser;
-    return 0;
-  }" FLB_HAVE_LIBYAML)
+  find_package(PkgConfig)
+  # libyaml's corresponding pkg-config file is yaml-0.1.pc.
+  # We should search it first.
+  pkg_check_modules(LIBYAML QUIET yaml-0.1)
 
-  if(NOT FLB_HAVE_LIBYAML)
-    message(FATAL_ERROR
-      "YAML development dependencies required for YAML configuration format handling.\n"
-      "This is a build time dependency, you can either install the "
-      "dependencies or disable the feature setting the CMake option "
-      "-DFLB_CONFIG_YAML=Off ."
-      )
+  if (LIBYAML_FOUND)
+    # For if(FLB_HAVE_LIBYAML) clause on CMakeList.txt.
+    set(FLB_HAVE_LIBYAML 1)
+    FLB_DEFINITION(FLB_HAVE_LIBYAML)
+    # For non-standard libyaml installation paths such as homebrew bottled libyaml.
+    include_directories(${LIBYAML_INCLUDEDIR})
+    link_directories(${LIBYAML_LIBRARY_DIRS})
+  else()
+    # Requies libyaml support
+    check_c_source_compiles("
+      #include <yaml.h>
+      int main() {
+        yaml_parser_t parser;
+        return 0;
+      }" FLB_HAVE_LIBYAML)
+
+    if(NOT FLB_HAVE_LIBYAML)
+      message(FATAL_ERROR
+        "YAML development dependencies required for YAML configuration format handling.\n"
+        "This is a build time dependency, you can either install the "
+        "dependencies or disable the feature setting the CMake option "
+        "-DFLB_CONFIG_YAML=Off ."
+        )
+    endif()
+
+    FLB_DEFINITION(FLB_HAVE_LIBYAML)
   endif()
-
-  FLB_DEFINITION(FLB_HAVE_LIBYAML)
 endif()
 
 # check attribute alloc_size


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->
In https://github.com/fluent/fluent-bit/issues/5630, we found that libyaml is already installed on macOS runners but including libyaml's headers and linking libyaml are not working.
I found that homebrew-ed libyaml is not using normal include and library directories.
We have to search libyaml include and its library directories with cmake.

Note that pkg-config module name of libyaml is not `libyaml` but `yaml-0.1`.

I also confirmed that macOS executables can handle yaml configuration:

```yaml
service:
    flush:       1
    log_level:   info

pipeline:
    inputs:
       - dummy
       - forward:
            listen: 0.0.0.0

    outputs:
       - stdout:
            match: "*"
```

```console
% bin/fluent-bit -c fluent.yaml
Fluent Bit v1.9.6
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/27 13:54:09] [ info] [fluent bit] version=1.9.6, commit=a165b9ae71, pid=35713
[2022/06/27 13:54:09] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/27 13:54:09] [ info] [cmetrics] version=0.3.4
[2022/06/27 13:54:09] [ info] [output:stdout:stdout.0] worker #0 started
[2022/06/27 13:54:09] [ info] [sp] stream processor started
[0] dummy.0: [1656305650.254757000, {"message"=>"dummy"}]
[0] dummy.0: [1656305651.255040000, {"message"=>"dummy"}]
[0] dummy.0: [1656305652.254605000, {"message"=>"dummy"}]
^C[2022/06/27 13:54:13] [engine] caught signal (SIGINT)
[0] dummy.0: [1656305653.254344000, {"message"=>"dummy"}]
[2022/06/27 13:54:13] [ warn] [engine] service will shutdown in max 5 seconds
[2022/06/27 13:54:14] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/27 13:54:14] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/06/27 13:54:14] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2022/06/27 13:54:14] [  Error] kevent: No such file or directory, errno=2 at /Users/cosmo/GitHub/fluent-bit/lib/monkey/mk_core/mk_event_kqueue.c:151
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes #5630.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
