### PR TITLE
in_dummy_thread: remove unused vars

### DIFF
--- a/plugins/in_dummy_thread/in_dummy_thread.c
+++ b/plugins/in_dummy_thread/in_dummy_thread.c
@@ -60,8 +60,6 @@ static void in_dummy_thread_callback(int write_fd, void *data)
 static int in_dummy_thread_init(struct flb_input_instance *in,
                                 struct flb_config *config, void *data)
 {
-    const char *conf;
-    int val;
     int ret;
     struct flb_in_dummy_thread_config *ctx;
     (void) data;


### PR DESCRIPTION
This is to remove below warning.
```
[ 63%] Building C object plugins/in_dummy_thread/CMakeFiles/flb-plugin-in_dummy_thread.dir/in_dummy_thread.c.o
/home/taka/git/fluent-bit/plugins/in_dummy_thread/in_dummy_thread.c: In function ‘in_dummy_thread_init’:
/home/taka/git/fluent-bit/plugins/in_dummy_thread/in_dummy_thread.c:64:9: warning: unused variable ‘val’ [-Wunused-variable]
   64 |     int val;
      |         ^~~
/home/taka/git/fluent-bit/plugins/in_dummy_thread/in_dummy_thread.c:63:17: warning: unused variable ‘conf’ [-Wunused-variable]
   63 |     const char *conf;
      |                 ^~~~

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log/Valgrind 

```
$ valgrind --leak-check=full bin/fluent-bit -i dummy_thread -o stdout
==48659== Memcheck, a memory error detector
==48659== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==48659== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==48659== Command: bin/fluent-bit -i dummy_thread -o stdout
==48659== 
Fluent Bit v1.9.6
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/06/26 14:32:26] [ info] [fluent bit] version=1.9.6, commit=1bec2348e1, pid=48659
[2022/06/26 14:32:26] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/06/26 14:32:26] [ info] [cmetrics] version=0.3.4
[2022/06/26 14:32:26] [ info] [output:stdout:stdout.0] worker #0 started
[2022/06/26 14:32:26] [ info] [sp] stream processor started
[0] dummy_thread.0: [1656221546.477237699, {"message"=>"thready dummy"}]
^C[2022/06/26 14:32:27] [engine] caught signal (SIGINT)
[2022/06/26 14:32:27] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy_thread.0: [1656221547.515949742, {"message"=>"thready dummy"}]
[2022/06/26 14:32:28] [ info] [engine] service has stopped (0 pending tasks)
[2022/06/26 14:32:28] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/06/26 14:32:28] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==48659== 
==48659== HEAP SUMMARY:
==48659==     in use at exit: 0 bytes in 0 blocks
==48659==   total heap usage: 1,074 allocs, 1,074 frees, 865,347 bytes allocated
==48659== 
==48659== All heap blocks were freed -- no leaks are possible
==48659== 
==48659== For lists of detected and suppressed errors, rerun with: -s
==48659== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
