### PR TITLE
workflows: fix renamed perf-test call

### DIFF
--- a/.github/workflows/pr-perf-test.yaml
+++ b/.github/workflows/pr-perf-test.yaml
@@ -13,7 +13,7 @@ jobs:
   pr-perf-test-run:
     # We only need to test this once as the rest are chained from it.
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-performance-test')
-    uses: fluent/fluent-bit-ci/.github/workflows/call-run-test.yaml@main
+    uses: fluent/fluent-bit-ci/.github/workflows/call-run-performance-test.yaml@main
     with:
       vm-name: fb-perf-test-pr-${{ github.event.number }}
       git-branch: ${{ github.head_ref }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves failure due to renamed tests workflow: https://github.com/fluent/fluent-bit/actions/runs/2569218222

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
