### PR TITLE
event_loop: Check loop condition before removing event from bucket queue

### DIFF
--- a/include/fluent-bit/flb_event_loop.h
+++ b/include/fluent-bit/flb_event_loop.h
@@ -76,27 +76,26 @@ static inline void flb_event_load_injected_events(struct flb_bucket_queue *bktq,
     int __flb_event_priority_live_foreach_n_events = evl->n_events;                     \
     for (                                                                               \
         /* init */                                                                      \
-        flb_event_load_bucket_queue(bktq, evl),                                         \
-        event = flb_bucket_queue_find_min(bktq) ?                                       \
-                mk_list_entry(                                                          \
-                    flb_bucket_queue_pop_min(bktq), struct mk_event, _priority_head) :  \
-                NULL;                                                                   \
+        flb_event_load_bucket_queue(bktq, evl);                                         \
                                                                                         \
         /* condition */                                                                 \
-        event != NULL &&                                                                \
-        (__flb_event_priority_live_foreach_iter < max_iter || max_iter == -1);          \
+        (__flb_event_priority_live_foreach_iter < max_iter || max_iter == -1)           \
+        && (NULL != (                                                                   \
+            event = flb_bucket_queue_find_min(bktq)                                     \
+                    ? mk_list_entry(flb_bucket_queue_pop_min(bktq),                     \
+                                    struct mk_event,                                    \
+                                    _priority_head)                                     \
+                    : NULL                                                              \
+        ));                                                                             \
                                                                                         \
         /* update */                                                                    \
         ++__flb_event_priority_live_foreach_iter,                                       \
-        flb_event_load_injected_events(bktq, evl,                                       \
-                                      __flb_event_priority_live_foreach_n_events),      \
+        flb_event_load_injected_events(bktq,                                            \
+                                       evl,                                             \
+                                       __flb_event_priority_live_foreach_n_events),     \
         mk_event_wait_2(evl, 0),                                                        \
         __flb_event_priority_live_foreach_n_events = evl->n_events,                     \
-        flb_event_load_bucket_queue(bktq, evl),                                         \
-        event = flb_bucket_queue_find_min(bktq) ?                                       \
-                mk_list_entry(                                                          \
-                    flb_bucket_queue_pop_min(bktq), struct mk_event, _priority_head) :  \
-                NULL                                                                    \
+        flb_event_load_bucket_queue(bktq, evl)                                          \
     )
 
 #endif /* !FLB_EVENT_LOOP_H */

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -25,6 +25,7 @@
 #endif
 
 #define TIMER_COARSE_EPSION_MS 300
+#define LOOP_SIZE 3
 
 struct test_evl_context {
     struct mk_event_loop *evl;
@@ -578,10 +579,77 @@ void event_loop_stress_priority_add_delete()
 #endif
 }
 
+void test_inject_event_priority_loop()
+{
+    int i;
+    int iter;
+    struct mk_event priority_0_events[LOOP_SIZE];
+    struct mk_event priority_2_events[LOOP_SIZE];
+    struct mk_event injected_event;
+    struct mk_event *event;
+    struct test_evl_context *ctx = evl_context_create();
+
+    /* add priority 0 events to the event loop */
+    for (i = 0; i < LOOP_SIZE; i++) {
+        test_timeout_create(ctx->evl, 0, 0, &priority_0_events[i]);
+        priority_0_events[i].priority = 0;
+    }
+
+    /* add priority 2 events to the event loop */
+    for (i = 0; i < LOOP_SIZE; i++) {
+        test_timeout_create(ctx->evl, 0, 0, &priority_2_events[i]);
+        priority_2_events[i].priority = 2;
+    }
+
+    /* create priority 1 event that we will inject */
+    MK_EVENT_ZERO(&injected_event);
+    injected_event._priority_head.next = NULL;
+    injected_event._priority_head.prev = NULL;
+    injected_event.priority = 1;
+
+    usleep(400000);
+    mk_event_wait_2(ctx->evl, 0);
+
+    do {
+        iter = 0;
+        /* first loop, event priorities: {0, 0, 0, 2, 2, 2} */
+        flb_event_priority_live_foreach(event, ctx->bktq, ctx->evl, LOOP_SIZE) {
+            if (iter == 0) {
+                /* inject an event, new priorities: {0, 0, 0, 1, 2, 2, 2} */
+                mk_event_inject(ctx->evl, &injected_event, MK_EVENT_READ, FLB_TRUE);
+            }
+            /* delete event */
+            test_timeout_destroy(ctx->evl, event);
+
+            iter++;
+        }
+    } while(0);
+
+    do {
+        iter = 0;
+        /* second loop, event priorities: {1, 2, 2, 2} */
+        flb_event_priority_live_foreach(event, ctx->bktq, ctx->evl, LOOP_SIZE + 1) {
+            if (iter == 0) {
+                TEST_CHECK(event->priority == 1);
+                TEST_MSG("Expected injected event with priority 1, "
+                         "got event with priority %i instead",
+                         event->priority);
+            }
+            /* delete event */
+            test_timeout_destroy(ctx->evl, event);
+
+            iter++;
+        }
+    } while(0);
+
+    evl_context_destroy(ctx);
+}
+
 TEST_LIST = {
     {"test_simple_timeout_1000ms", test_simple_timeout_1000ms},
     {"test_non_blocking_and_blocking_timeout", test_non_blocking_and_blocking_timeout},
     {"test_infinite_wait", test_infinite_wait},
     {"event_loop_stress_priority_add_delete", event_loop_stress_priority_add_delete},
+    {"test_inject_event_priority_loop", test_inject_event_priority_loop},
     { 0 }
 };


### PR DESCRIPTION
Fluent Bit sometimes doesn't resume coroutines for timed out network events. This can also cause deadlocks in some cases, like AWS credentials provider refresh function, if the control is not returned to the function that sets a lock before a network call.

This is caused by the priority event loop handling of network timeout events. That kind of event is injected into the loop and then added to the bucket queue, but only once. If the event is not handled after being removed from the bucket queue, such event is not re-added to the queue, and not processed on loop re-entry. This situation happens because the event is first removed from the bucket queue, and then the loop condition is checked.

* Changed the order of statements in priority queue loop macro: we now check if the loop has reached the iteration limit before removing the event from the bucket queue.
* Added a test for event priority loop. It validates that when the event loop finishes all iterations, and the injected event is next in the priority queue, then this event will be processed next time the priority event loop runs.

Signed-off-by: zhenyami <zhenyamzk+GitHub@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes https://github.com/fluent/fluent-bit/issues/5553
----
#### Related changes
* https://github.com/fluent/fluent-bit/pull/4869
* https://github.com/fluent/fluent-bit/pull/4624

<!-- Enter `[N/A]` in the box, if an item is not applicable to your change. -->

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
