### PR TITLE
tiger-1.8.15 20220628

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -350,7 +350,10 @@ int sb_segregate_chunks(struct flb_config *config)
             chunk = mk_list_entry(chunk_iterator, struct cio_chunk, _head);
 
             if (!cio_chunk_is_up(chunk)) {
-                cio_chunk_up_force(chunk);
+                ret = cio_chunk_up_force(chunk);
+                if (ret == CIO_CORRUPTED) {
+                    continue;
+                }
             }
 
             if (!cio_chunk_is_up(chunk)) {


### PR DESCRIPTION
changes:

- 131949192  in_storage_backlog: skip corrupted chunks