### PR TITLE
dockerfiles: update Windows build

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -97,17 +97,10 @@ In addition, metadata as defined in OCI image spec annotations, is leveraged in 
 ### Minimum set of build-args
 ```powershell
 docker build --no-cache `
-  --build-arg WINDOWS_VERSION=1809 --build-arg FLUENTBIT_VERSION=1.8.11 `
-  -t fluent/fluent-bit:1.8.11-nanoserver -f ./dockerfiles/Dockerfile.windows ./dockerfiles/
+  --build-arg WINDOWS_VERSION=ltsc2019 `
+  -t fluent/fluent-bit:master-windows -f ./dockerfiles/Dockerfile.windows .
 ```
-### Full set of build-args
-```powershell
-docker build --no-cache `
-  --build-arg WINDOWS_VERSION=1809 --build-arg FLUENTBIT_VERSION=1.8.11 `
-  --build-arg IMAGE_CREATE_DATE="$(Get-Date((Get-Date).ToUniversalTime()) -UFormat '%Y-%m-%dT%H:%M:%SZ')" `
-  --build-arg IMAGE_SOURCE_REVISION="$(git rev-parse HEAD)" `
-  -t fluent/fluent-bit:1.8.11-nanoserver -f ./dockerfiles/Dockerfile.windows ./dockerfiles/
-```
+
 ## Contact
 
 Feel free to join us on our Mailing List or IRC:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Minor docs changes to ensure we use the correct context for Windows builds.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
