### PR TITLE
fstore: Suppress log cb warn

### DIFF
--- a/src/flb_fstore.c
+++ b/src/flb_fstore.c
@@ -24,8 +24,8 @@
 #include <fluent-bit/flb_sds.h>
 #include <chunkio/chunkio.h>
 
-static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
-                  char *str)
+static void log_cb(void *ctx, int level, const char *file, int line,
+                   const char *str)
 {
     if (level == CIO_LOG_ERROR) {
         flb_error("[fstore] %s", str);
@@ -39,8 +39,6 @@ static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
     else if (level == CIO_LOG_DEBUG) {
         flb_debug("[fstore] %s", str);
     }
-
-    return 0;
 }
 
 /*

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -360,8 +360,8 @@ static void print_storage_info(struct flb_config *ctx, struct cio_ctx *cio)
     }
 }
 
-static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
-                  char *str)
+static void log_cb(void *ctx, int level, const char *file, int line,
+                   const char *str)
 {
     if (level == CIO_LOG_ERROR) {
         flb_error("[storage] %s", str);
@@ -375,8 +375,6 @@ static int log_cb(struct cio_ctx *ctx, int level, const char *file, int line,
     else if (level == CIO_LOG_DEBUG) {
         flb_debug("[storage] %s", str);
     }
-
-    return 0;
 }
 
 int flb_storage_input_create(struct cio_ctx *cio,


### PR DESCRIPTION
This patch is to suppress below warnings.

```
[ 73%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_storage.c.o
/home/taka/git/fluent-bit/src/flb_storage.c: In function ‘flb_storage_create’:
/home/taka/git/fluent-bit/src/flb_storage.c:510:17: warning: assignment to ‘void (*)(void *, int,  const char *, int,  const char *)’ from incompatible pointer type ‘int (*)(struct cio_ctx *, int,  const char *, int,  char *)’ [-Wincompatible-pointer-types]
  510 |     opts.log_cb = log_cb;
      |                 ^
```

```
[ 75%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_fstore.c.o
/home/taka/git/fluent-bit/src/flb_fstore.c: In function ‘flb_fstore_create’:
/home/taka/git/fluent-bit/src/flb_fstore.c:465:17: warning: assignment to ‘void (*)(void *, int,  const char *, int,  const char *)’ from incompatible pointer type ‘int (*)(struct cio_ctx *, int,  const char *, int,  char *)’ [-Wincompatible-pointer-types]
  465 |     opts.log_cb = log_cb;
      |                 ^
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log/Valgrind

```
$ valgrind --leak-check=full bin/fluent-bit -i dummy -o null
==21915== Memcheck, a memory error detector
==21915== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==21915== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==21915== Command: bin/fluent-bit -i dummy -o null
==21915== 
Fluent Bit v1.9.6
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/03 06:56:51] [ info] [fluent bit] version=1.9.6, commit=38beddabe0, pid=21915
[2022/07/03 06:56:51] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/03 06:56:51] [ info] [cmetrics] version=0.3.4
[2022/07/03 06:56:51] [ info] [output:null:null.0] worker #0 started
[2022/07/03 06:56:51] [ info] [sp] stream processor started
^C[2022/07/03 06:56:52] [engine] caught signal (SIGINT)
[2022/07/03 06:56:52] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/03 06:56:53] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/03 06:56:53] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/07/03 06:56:53] [ info] [output:null:null.0] thread worker #0 stopped
==21915== 
==21915== HEAP SUMMARY:
==21915==     in use at exit: 0 bytes in 0 blocks
==21915==   total heap usage: 1,066 allocs, 1,066 frees, 520,536 bytes allocated
==21915== 
==21915== All heap blocks were freed -- no leaks are possible
==21915== 
==21915== For lists of detected and suppressed errors, rerun with: -s
==21915== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
