### PR TITLE
filter_expect: support 'result_key' property and add test code

### DIFF
--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -171,6 +171,9 @@ static struct flb_expect *context_create(struct flb_filter_instance *ins,
         else if (strcasecmp(tmp, "exit") == 0) {
             ctx->action = FLB_EXP_EXIT;
         }
+        else if (strcasecmp(tmp, "result_key") == 0) {
+            ctx->action = FLB_EXP_RESULT_KEY;
+        }
         else {
             flb_plg_error(ctx->ins, "unexpected 'action' value '%s'", tmp);
             flb_free(ctx);
@@ -191,6 +194,11 @@ static struct flb_expect *context_create(struct flb_filter_instance *ins,
 
         /* Validate the type of the rule */
         type = key_to_type(kv->key);
+        if (strcasecmp(kv->key, "result_key") == 0) {
+            /* skip */
+            continue;
+        }
+
         if (type == -1 && strcasecmp(kv->key, "action") != 0) {
             flb_plg_error(ctx->ins, "unknown configuration rule '%s'", kv->key);
             context_destroy(ctx);
@@ -405,6 +413,14 @@ static int cb_expect_filter(const void *data, size_t bytes,
     msgpack_object root;
     struct flb_expect *ctx = filter_context;
 
+    int i;
+    int rule_matched = FLB_TRUE;
+    struct flb_time tm;
+    msgpack_object *obj;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    msgpack_object_kv *kv;
+
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
@@ -422,10 +438,52 @@ static int cb_expect_filter(const void *data, size_t bytes,
             else if (ctx->action == FLB_EXP_EXIT) {
                 flb_engine_exit_status(config, 255);
             }
+            else if (ctx->action == FLB_EXP_RESULT_KEY) {
+                rule_matched = FLB_FALSE;
+            }
             break;
         }
     }
     msgpack_unpacked_destroy(&result);
+
+    /* Append result key when action is "result_key"*/
+    if (ctx->action == FLB_EXP_RESULT_KEY) {
+        off = 0;
+        msgpack_unpacked_init(&result);
+
+        /* Create temporary msgpack buffer */
+        msgpack_sbuffer_init(&tmp_sbuf);
+        msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+        while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+            flb_time_pop_from_msgpack(&tm, &result, &obj);
+            msgpack_pack_array(&tmp_pck, 2);
+            flb_time_append_to_msgpack(&tm, &tmp_pck, 0);
+
+            msgpack_pack_map(&tmp_pck, obj->via.map.size + 1);
+            msgpack_pack_str(&tmp_pck, flb_sds_len(ctx->result_key));
+            msgpack_pack_str_body(&tmp_pck, ctx->result_key,
+                                  flb_sds_len(ctx->result_key));
+            if (rule_matched) {
+                msgpack_pack_true(&tmp_pck);
+            }
+            else {
+                msgpack_pack_false(&tmp_pck);
+            }
+
+            kv = obj->via.map.ptr;
+            for (i=0; i<map.via.map.size; i++) {
+                msgpack_pack_object(&tmp_pck, (kv+i)->key);
+                msgpack_pack_object(&tmp_pck, (kv+i)->val);
+            }
+        }
+        msgpack_unpacked_destroy(&result);
+
+        *out_buf   = tmp_sbuf.data;
+        *out_bytes = tmp_sbuf.size;
+
+        return FLB_FILTER_MODIFIED;
+    }
 
     return FLB_FILTER_NOTOUCH;
 }
@@ -485,7 +543,13 @@ static struct flb_config_map config_map[] =
     {
       FLB_CONFIG_MAP_STR, "action", "warn",
       0, FLB_FALSE, 0,
-      "action to take when a rule does not match: 'warn' or 'exit'"
+      "action to take when a rule does not match: 'warn', 'exit' or 'result_key'."
+    },
+    {
+      FLB_CONFIG_MAP_STR, "result_key", "matched",
+      0, FLB_TRUE, offsetof(struct flb_expect, result_key),
+      "specify the key name to append a boolean that indicates rule is matched or not. "
+      "This key is to be used only when 'action' is 'result_key'."
     },
 
     /* EOF */

--- a/plugins/filter_expect/expect.h
+++ b/plugins/filter_expect/expect.h
@@ -21,10 +21,12 @@
 #define FLB_FILTER_EXPECT_H
 
 #include <fluent-bit/flb_filter_plugin.h>
+#include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_record_accessor.h>
 
 #define FLB_EXP_WARN              0
 #define FLB_EXP_EXIT              1
+#define FLB_EXP_RESULT_KEY        2
 
 /* Rule types */
 #define FLB_EXP_KEY_EXISTS        0   /* key exists */
@@ -43,6 +45,7 @@ struct flb_expect_rule {
 
 struct flb_expect {
     int action;
+    flb_sds_t result_key;
     struct mk_list rules;
     struct flb_filter_instance *ins;
 };

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 # Filter Plugins
 if(FLB_IN_LIB AND FLB_OUT_LIB)
   FLB_RT_TEST(FLB_FILTER_CHECKLIST       "filter_checklist.c")
+  FLB_RT_TEST(FLB_FILTER_EXPECT          "filter_expect.c")
   FLB_RT_TEST(FLB_FILTER_STDOUT          "filter_stdout.c")
   FLB_RT_TEST(FLB_FILTER_GREP            "filter_grep.c")
   FLB_RT_TEST(FLB_FILTER_THROTTLE        "filter_throttle.c")

--- a/tests/runtime/filter_expect.c
+++ b/tests/runtime/filter_expect.c
@@ -1,0 +1,555 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_sds.h>
+#include "flb_tests_runtime.h"
+
+struct test_ctx {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd */
+    int o_ffd;         /* Output fd */
+};
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+/* Callback to check expected results */
+static int cb_check_result_json(void *record, size_t size, void *data)
+{
+    char *p;
+    char *expected;
+    char *result;
+    int num = get_output_num();
+
+    set_output_num(num+1);
+
+    expected = (char *) data;
+    result = (char *) record;
+
+    p = strstr(result, expected);
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected to find: '%s' in result '%s'",
+                  expected, result);
+    }
+    /*
+     * If you want to debug your test
+     *
+     * printf("Expect: '%s' in result '%s'", expected, result);
+     */
+    flb_free(record);
+    return 0;
+}
+
+
+static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int f_ffd;
+    int o_ffd;
+    struct test_ctx *ctx;
+
+    ctx = flb_malloc(sizeof(struct test_ctx));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "Error",
+                    NULL);
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "lib", NULL);
+    TEST_CHECK(i_ffd >= 0);
+    flb_input_set(ctx->flb, i_ffd, "tag", "test", NULL);
+    ctx->i_ffd = i_ffd;
+
+    /* Filter configuration */
+    f_ffd = flb_filter(ctx->flb, (char *) "expect", NULL);
+    TEST_CHECK(f_ffd >= 0);
+    flb_filter_set(ctx->flb, f_ffd, 
+                   "match", "*", "action", "result_key",
+                   "result_key", "result", 
+                   NULL);
+    ctx->f_ffd = f_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    TEST_CHECK(o_ffd >= 0);
+    flb_output_set(ctx->flb, o_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+    ctx->o_ffd = o_ffd;
+
+    return ctx;
+}
+
+static void test_ctx_destroy(struct test_ctx *ctx)
+{
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+void flb_test_key_exists_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":true";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_exists", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_exists_not_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":false";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_exists", "not_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_not_exists_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":true";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_not_exists", "not_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_not_exists_not_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":false";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_not_exists", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_is_null_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":null}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":true";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_is_null", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_is_null_not_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":false";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_is_null", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_is_not_null_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":true";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_is_not_null", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_is_not_null_not_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":null}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":false";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_is_not_null", "key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_eq_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":true";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_eq", "key val",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_key_val_eq_not_matched()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int len;
+    int ret;
+    int bytes;
+    char *input = "[0, {\"key\":\"val\"}]";
+
+    clear_output_num();
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"result\":false";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "key_val_eq", "not_key val",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    len = strlen(input);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, input, len);
+    TEST_CHECK(bytes == len);
+    flb_time_msleep(500);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("no output");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+
+TEST_LIST = {
+    {"key_exists_matched", flb_test_key_exists_matched},
+    {"key_exists_not_matched", flb_test_key_exists_not_matched},
+    {"key_not_exists_matched", flb_test_key_not_exists_matched},
+    {"key_not_exists_not_matched", flb_test_key_not_exists_not_matched},
+    {"key_val_is_null_matched", flb_test_key_val_is_null_matched},
+    {"key_val_is_null_not_matched", flb_test_key_val_is_null_not_matched},
+    {"key_val_is_not_null_matched", flb_test_key_val_is_not_null_matched},
+    {"key_val_is_not_null_not_matched", flb_test_key_val_is_not_null_not_matched},
+    {"key_val_eq_matched", flb_test_key_val_eq_matched},
+    {"key_val_eq_not_matched", flb_test_key_val_eq_not_matched},
+    {NULL, NULL}
+};


### PR DESCRIPTION
This patch is to 
- Support `result_key` property and `action result_key`
- Add test code for filter_expect

A property `action result_key` will append a result that rule is matched or not.
It is useful to test to check if the result value is true or false.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    Name dummy

[FILTER]
    Name Expect
    Match *
    Action result_key
    result_key result_is
    Key_Not_Exists hoge

[OUTPUT]
    Name stdout
    Match *
```

## Debug log / Valgrind output 
The key `result_is` is added.
```
[1656831381.289275294, {"result_is"=>true, "message"=>"dummy"}]
```

```
$ valgrind --leak-check=full bin/fluent-bit -c expect.conf 
==98553== Memcheck, a memory error detector
==98553== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==98553== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==98553== Command: bin/fluent-bit -c expect.conf
==98553== 
Fluent Bit v1.9.6
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/03 15:56:19] [ info] [fluent bit] version=1.9.6, commit=7b23b94676, pid=98553
[2022/07/03 15:56:19] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/03 15:56:19] [ info] [cmetrics] version=0.3.5
[2022/07/03 15:56:19] [ info] [output:stdout:stdout.0] worker #0 started
[2022/07/03 15:56:19] [ info] [sp] stream processor started
[0] dummy.0: [1656831380.296893567, {"result_is"=>true, "message"=>"dummy"}]
^C[2022/07/03 15:56:22] [engine] caught signal (SIGINT)
[0] dummy.0: [1656831381.289275294, {"result_is"=>true, "message"=>"dummy"}]
[2022/07/03 15:56:22] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/03 15:56:22] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/03 15:56:22] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/07/03 15:56:22] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==98553== 
==98553== HEAP SUMMARY:
==98553==     in use at exit: 0 bytes in 0 blocks
==98553==   total heap usage: 1,233 allocs, 1,233 frees, 953,706 bytes allocated
==98553== 
==98553== All heap blocks were freed -- no leaks are possible
==98553== 
==98553== For lists of detected and suppressed errors, rerun with: -s
==98553== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
