### PR TITLE
ring_buffer: occupancy based smart flush mechanism

### DIFF
--- a/include/fluent-bit/flb_ring_buffer.h
+++ b/include/fluent-bit/flb_ring_buffer.h
@@ -20,14 +20,23 @@
 #ifndef FLB_RING_BUFFER_H
 #define FLB_RING_BUFFER_H
 
+#include <fluent-bit/flb_pipe.h>
+
 struct flb_ring_buffer {
-    void *ctx;               /* pointer to backend context */
-    uint64_t data_size;      /* ring buffer size */
-    void *data_buf;          /* ring buffer */
+    void *ctx;                        /* pointer to backend context */
+    void *event_loop;                 /* event loop where this ring buffer emits flush request signals */
+    int flush_pending;                /* flag meant to prevent flush request signal flood */
+    void *signal_event;               /* event loop entry for the flush request signal */
+    flb_pipefd_t signal_channels[2];  /* flush request signaling channel */
+    uint64_t data_window;             /* 0% - 100% occupancy window flush request */
+    uint64_t data_size;               /* ring buffer size */
+    void *data_buf;                   /* ring buffer */
 };
 
 struct flb_ring_buffer *flb_ring_buffer_create(uint64_t size);
 void flb_ring_buffer_destroy(struct flb_ring_buffer *rb);
+
+int flb_ring_buffer_register(struct flb_ring_buffer *rb, void *evl, uint8_t window_size);
 
 int flb_ring_buffer_write(struct flb_ring_buffer *rb, void *ptr, size_t size);
 int flb_ring_buffer_read(struct flb_ring_buffer *rb, void *ptr, size_t size);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1702,6 +1702,8 @@ void flb_input_chunk_ring_buffer_collector(struct flb_config *ctx, void *data)
             }
             cr = NULL;
         }
+
+        ins->rb->flush_pending = FLB_FALSE;
     }
 }
 

--- a/tests/internal/ring_buffer.c
+++ b/tests/internal/ring_buffer.c
@@ -2,7 +2,10 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_ring_buffer.h>
+#include <fluent-bit/flb_event_loop.h>
+#include <fluent-bit/flb_bucket_queue.h>
 
 #include "flb_tests_internal.h"
 
@@ -12,59 +15,157 @@ struct check {
 };
 
 struct check checks[] = {
-	{"a1", "a2"},
-	{"b1", "b2"},
-	{"c1", "c2"},
-	{"d1", "d2"},
-	{"e1", "e2"},
+    {"a1", "a2"},
+    {"b1", "b2"},
+    {"c1", "c2"},
+    {"d1", "d2"},
+    {"e1", "e2"},
 };
 
 static void test_basic()
 {
-	int i;
-	int ret;
-	int elements;
-	struct check *c;
-	struct check *tmp;
-	struct flb_ring_buffer *rb;
+    int i;
+    int ret;
+    int elements;
+    struct check *c;
+    struct check *tmp;
+    struct flb_ring_buffer *rb;
 
-	elements = sizeof(checks) / sizeof(struct check);
+    elements = sizeof(checks) / sizeof(struct check);
 
-	rb = flb_ring_buffer_create(sizeof(struct check *) * elements);
-	TEST_CHECK(rb != NULL);
-	if (!rb) {
-		exit(EXIT_FAILURE);
-	}
+    rb = flb_ring_buffer_create(sizeof(struct check *) * elements);
+    TEST_CHECK(rb != NULL);
+    if (!rb) {
+        exit(EXIT_FAILURE);
+    }
 
-	for (i = 0; i < elements; i++) {
-		c = &checks[i];
-		ret = flb_ring_buffer_write(rb, (void *) &c, sizeof(c));
-		TEST_CHECK(ret == 0);
-	}
+    for (i = 0; i < elements; i++) {
+        c = &checks[i];
+        ret = flb_ring_buffer_write(rb, (void *) &c, sizeof(c));
+        TEST_CHECK(ret == 0);
+    }
 
-	/* try to write another record, it must fail */
-	tmp = c;
-	ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
-	TEST_CHECK(ret == -1);
+    /* try to write another record, it must fail */
+    tmp = c;
+    ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
+    TEST_CHECK(ret == -1);
 
-	c = NULL;
+    c = NULL;
 
-	/* consume one entry */
-	ret = flb_ring_buffer_read(rb, (void *) &c, sizeof(c));
-	TEST_CHECK(ret == 0);
+    /* consume one entry */
+    ret = flb_ring_buffer_read(rb, (void *) &c, sizeof(c));
+    TEST_CHECK(ret == 0);
 
-	/* the consumed entry must be equal to the first one */
-	c = &checks[0];
-	TEST_CHECK(strcmp(c->buf_a, "a1") == 0 && strcmp(c->buf_b, "a2") ==0);
+    /* the consumed entry must be equal to the first one */
+    c = &checks[0];
+    TEST_CHECK(strcmp(c->buf_a, "a1") == 0 && strcmp(c->buf_b, "a2") ==0);
 
-	/* try 'again' to write 'c2', it should succeed */
-	ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
-	TEST_CHECK(ret == 0);
+    /* try 'again' to write 'c2', it should succeed */
+    ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
+    TEST_CHECK(ret == 0);
 
-	flb_ring_buffer_destroy(rb);
+    flb_ring_buffer_destroy(rb);
 }
 
+static void test_smart_flush()
+{
+    int i;
+    int ret;
+    int n_events;
+    int elements;
+    size_t slots;
+    uint64_t window;
+    struct check *c;
+    struct check *tmp;
+    int flush_event_detected;
+	char signal_buffer[512];
+    struct mk_event *event;
+    struct mk_event_loop *evl;
+    struct flb_ring_buffer *rb;
+	struct flb_ring_buffer *erb;
+    struct flb_bucket_queue *bktq;
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+    WSAStartup(0x0201, &wsa_data);
+#endif
+
+    evl = mk_event_loop_create(100);
+    TEST_CHECK(evl != NULL);
+    if (!evl) {
+        exit(EXIT_FAILURE);
+    }
+
+    bktq = flb_bucket_queue_create(10);
+    TEST_CHECK(bktq != NULL);
+    if (!bktq) {
+        exit(EXIT_FAILURE);
+    }
+
+    elements = sizeof(checks) / sizeof(struct check);
+    slots = elements * 2;
+    window = (((double) (elements + 1)) / slots) * 100;
+
+    /* The slot count was chosen to trigger the flush request
+     * after writing the predefined elements + 1
+     */
+
+    rb = flb_ring_buffer_create(sizeof(struct check *) * slots);
+    TEST_CHECK(rb != NULL);
+    if (!rb) {
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_ring_buffer_register(rb, evl, window);
+    TEST_CHECK(ret == 0);
+    if (ret) {
+        exit(EXIT_FAILURE);
+    }
+
+    for (i = 0; i < elements; i++) {
+        c = &checks[i];
+        ret = flb_ring_buffer_write(rb, (void *) &c, sizeof(c));
+        TEST_CHECK(ret == 0);
+
+        n_events = mk_event_wait_2(evl, 0);
+        TEST_CHECK(n_events == 0);
+    }
+
+    /* write another record, a signal must be produced */
+    ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
+    TEST_CHECK(ret == 0);
+
+    n_events = mk_event_wait_2(evl, 0);
+    TEST_CHECK(n_events == 1);
+
+    flush_event_detected = FLB_FALSE;
+    flb_event_priority_live_foreach(event, bktq, evl, 10) {
+        if(event->type == FLB_ENGINE_EV_THREAD_INPUT) {
+            erb = (struct flb_ring_buffer *) event->data;
+
+            flb_pipe_r(erb->signal_channels[0], signal_buffer, sizeof(signal_buffer));
+
+		    flush_event_detected = FLB_TRUE;
+        }
+    }
+
+    TEST_CHECK(flush_event_detected == FLB_TRUE);
+
+    /* write another record, a signal must not be produced because the previous one
+     * was not acknowledged by setting `flush_pending` to `FLB_FALSE`
+     */
+    ret = flb_ring_buffer_write(rb, (void *) &tmp, sizeof(tmp));
+    TEST_CHECK(ret == 0);
+
+    n_events = mk_event_wait_2(evl, 0);
+    TEST_CHECK(n_events == 0);
+
+    flb_ring_buffer_destroy(rb);
+    flb_bucket_queue_destroy(bktq);
+    mk_event_loop_destroy(evl);
+}
 TEST_LIST = {
-    { "basic",   test_basic},
+    { "basic",       test_basic},
+    { "smart_flush", test_smart_flush},
     { 0 }
 };


### PR DESCRIPTION
An occupancy based smart flush mechanism was added, in order to enable it `flb_ring_buffer_register` needs to be invoked 
with an event loop and window size. When the ring buffer holds enough elements to exceed the window size it will produce a signal in a channel that was previously registered in the event loop with the event type `FLB_ENGINE_EV_THREAD_INPUT`.

This mechanism is meant to prevent ring buffer slot exhaustion when the ingestion flow exceeds the periodic flush mechanism capacity.

There is a corner case in which `flb_input_chunk_ring_buffer_collector` could reset the `flush_pending` flag right after it was set which could cause more a second `flb_ring_buffer_write` call to enqueue one more flush request signal than strictly required. This should be rare enough not to be a concern and much less to justify the use of a mutex as the only side effect would be causing the main thread to iterate the input list to determine if there are any ring buffers that can be flushed.

There is a unit test designed to prove that : 

1. Writes will not generate flush requests if the occupancy window is not reached
2. A flush request will be issued as soon as the occupancy window is reached
3. A flush request will NOT be issued if there is a write request when the occupancy window is exceeded but there is a pending flush request that has not been acknowledged by resetting the `flush_pending` flag.
