### PR TITLE
workflows: fix incorrect label running

### DIFF
--- a/.github/workflows/pr-perf-test.yaml
+++ b/.github/workflows/pr-perf-test.yaml
@@ -25,7 +25,7 @@ jobs:
 
   pr-perf-test-upload:
     name: PR - performance test upload
-    if: always()
+    # Label check from previous
     runs-on: ubuntu-latest
     needs:
       - pr-perf-test-run
@@ -82,6 +82,7 @@ jobs:
   pr-perf-test-complete:
     # Only runs on success
     name: PR - performance test complete
+    # Label check from previous
     runs-on: ubuntu-latest
     needs:
       - pr-perf-test-run


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves issues with incorrect checks before running the perf-test: https://github.com/fluent/fluent-bit/runs/7153550752?check_suite_focus=true

Previously it was running whenever a PR was labelled as the second stage was intended to run `always` to pick up any results even in failure modes, however this is no longer required and now it should be chained to the previous check - if that is skipped (i.e. not a valid label for this workflow) then so will this stage.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
