### PR TITLE
stream_processor: fixed bison deprecation warning

### DIFF
--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -1,4 +1,4 @@
-%name-prefix="flb_sp_"  // replace with %define api.prefix {flb_sp_}
+%name-prefix "flb_sp_"  // replace with %define api.prefix {flb_sp_}
 %define api.pure full
 %define parse.error verbose
 %parse-param { struct flb_sp_cmd *cmd };


### PR DESCRIPTION
This fixes the first warning reported in https://github.com/fluent/fluent-bit/issues/4427.

Signed-off-by: Lionel Cons <lionel.cons@cern.ch>