### PR TITLE
out_stackdriver: removed unused variables

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -946,9 +946,7 @@ static void pack_labels(struct flb_stackdriver *ctx,
                         msgpack_object *payload_labels_ptr)
 {
     int i;
-    int ret;
     int labels_size = 0;
-    char *val;
     struct mk_list *head;
     struct flb_kv *list_kv;
     msgpack_object_kv *obj_kv = NULL;
@@ -1486,7 +1484,6 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     const char *newtag;
     const char *new_log_name;
     msgpack_object *obj;
-    msgpack_object *labels_ptr;
     msgpack_unpacked result;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -182,7 +182,6 @@ static int parse_configuration_labels(struct flb_stackdriver *ctx)
     flb_sds_t val;
     struct mk_list *head;
     struct flb_slist_entry *entry;
-    msgpack_object_kv *kv = NULL;
 
     if (ctx->labels) {
         mk_list_foreach(head, ctx->labels) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

Prevent compiler warnings:

```
...
Scanning dependencies of target flb-plugin-out_stackdriver
[ 67%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_conf.c.o
[ 67%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_operation.c.o
[ 67%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver.c.o
[ 68%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/gce_metadata.c.o
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver_conf.c: In function 'parse_configuration_labels':
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver_conf.c:215:17: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
             ret = flb_kv_item_create(&ctx->config_labels, key, val);
                 ^
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver_conf.c:185:24: warning: unused variable 'kv' [-Wunused-variable]
     msgpack_object_kv *kv = NULL;
                        ^~
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c: In function 'pack_labels':
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c:951:11: warning: unused variable 'val' [-Wunused-variable]
     char *val;
           ^~~
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c:949:9: warning: unused variable 'ret' [-Wunused-variable]
     int ret;
         ^~~
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c: In function 'stackdriver_format':
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c:2036:20: warning: return makes pointer from integer without a cast [-Wint-conversion]
             return -1;
                    ^
/tmp/fluent-bit/plugins/out_stackdriver/stackdriver.c:1489:21: warning: unused variable 'labels_ptr' [-Wunused-variable]
     msgpack_object *labels_ptr;
                     ^~~~~~~~~~
[ 68%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_source_location.c.o
[ 68%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_http_request.c.o
[ 68%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_timestamp.c.o
[ 68%] Building C object plugins/out_stackdriver/CMakeFiles/flb-plugin-out_stackdriver.dir/stackdriver_helper.c.o
[ 68%] Linking C static library ../../library/libflb-plugin-out_stackdriver.a
[ 68%] Built target flb-plugin-out_stackdriver
...
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

***Valgrind*** 
```
valgrind --leak-check=full bin/flb-rt-out_stackdriver &> valgrind-stackdriver.txt
```
Complete log: [valgrind-stackdriver.txt](https://github.com/fluent/fluent-bit/files/9048918/valgrind-stackdriver.txt)


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
