### PR TITLE
workflows: disable MacOS for release builds as not stable

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -158,16 +158,17 @@ jobs:
       access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  staging-build-macos-packages:
-    needs:
-      - staging-build-get-meta
-    uses: ./.github/workflows/call-build-macos.yaml
-    with:
-      version: ${{ needs.staging-build-get-meta.outputs.version }}
-      ref: ${{ github.event.inputs.version || github.ref_name }}
-      environment: staging
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
-      access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # MacOS is currently not officially supported and under "flux" so do not fail a build for it
+  # staging-build-macos-packages:
+  #   needs:
+  #     - staging-build-get-meta
+  #   uses: ./.github/workflows/call-build-macos.yaml
+  #   with:
+  #     version: ${{ needs.staging-build-get-meta.outputs.version }}
+  #     ref: ${{ github.event.inputs.version || github.ref_name }}
+  #     environment: staging
+  #   secrets:
+  #     token: ${{ secrets.GITHUB_TOKEN }}
+  #     bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
+  #     access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -38,17 +38,17 @@ docker buildx rm builder
 docker buildx create --name builder --use
 docker buildx inspect --bootstrap
 ```
-4. Build Fluent Bit from the root of the Git repo:
+4. Build Fluent Bit from the **root of the Git repo (not from this directory)**:
 ```
-docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" --target=production .
+docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" --target=production -f dockerfiles/Dockerfile .
 ```
 
 ## Build and test
 
 1. Checkout the branch you want, e.g. 1.8 for 1.8.X containers.
-2. Build the container image using the appropriate Dockerfile in this directory.
+2. Build Fluent Bit from the **root of the Git repo (not from this directory)**:
 ```
-$ docker build -t fluent/fluent-bit --target=production .
+$ docker build -t fluent/fluent-bit --target=production -f dockerfiles/Dockerfile .
 ```
 3. Test the container.
 ```


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Currently MacOS builds will fail due to OpenSSL dependency issues: https://github.com/fluent/fluent-bit/runs/7227819137?check_suite_focus=true

Disable this for staging builds (i.e. releases).

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
