### PR TITLE
workflows: resolve AWS sync issue due to client upgrade on runners

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -99,6 +99,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: "us-east-1"
       shell: bash
 
     - name: GPG set up keys for signing
@@ -124,6 +125,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: "us-east-1"
       shell: bash
 
   # We have two options here:


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

See https://github.com/actions/virtual-environments/issues/5679#issuecomment-1165385662 for full details and links out.

The new client on the runners needs the region explicitly specifying which was done for staging builds but not releases so these fail to sync: https://github.com/fluent/fluent-bit/runs/7249669328?check_suite_focus=true

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Same as staging build now which works.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
