### PR TITLE
filter_expect: use flb_free instead of free

### DIFF
--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -295,7 +295,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                           "exception on rule #%i 'key_exists', key '%s' "
                           "not found. Record content:\n%s",
                           n, rule->value, json);
-            free(json);
+            flb_free(json);
             return FLB_FALSE;
         }
         else if (rule->type == FLB_EXP_KEY_NOT_EXISTS) {
@@ -308,7 +308,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                           "exception on rule #%i 'key_not_exists', key '%s' "
                           "exists. Record content:\n%s",
                           n, rule->value, json);
-            free(json);
+            flb_free(json);
             flb_ra_key_value_destroy(val);
             return FLB_FALSE;
         }
@@ -319,7 +319,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                               "exception on rule #%i 'key_val_is_null', "
                               "key '%s' not found. Record content:\n%s",
                               n, rule->value, json);
-                free(json);
+                flb_free(json);
                 return FLB_FALSE;
             }
             if (val->type != FLB_RA_NULL) {
@@ -330,7 +330,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                               "Record content:\n%s",
                               n, rule->value,
                               ra_value_type_to_str(val), json);
-                free(json);
+                flb_free(json);
                 flb_ra_key_value_destroy(val);
                 return FLB_FALSE;
             }
@@ -343,7 +343,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                               "exception on rule #%i 'key_val_is_not_null', "
                               "key '%s' not found. Record content:\n%s",
                               n, rule->value, json);
-                free(json);
+                flb_free(json);
                 return FLB_FALSE;
             }
             if (val->type == FLB_RA_NULL) {
@@ -354,7 +354,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                               "Record content:\n%s",
                               n, rule->value,
                               ra_value_type_to_str(val), json);
-                free(json);
+                flb_free(json);
                 flb_ra_key_value_destroy(val);
                 return FLB_FALSE;
             }
@@ -367,7 +367,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                               "exception on rule #%i 'key_val_is_null', "
                               "key '%s' not found. Record content:\n%s",
                               n, rule->value, json);
-                free(json);
+                flb_free(json);
                 return FLB_FALSE;
             }
 
@@ -380,7 +380,7 @@ static int rule_apply(struct flb_expect *ctx, msgpack_object map)
                                   "key value '%s' is different than "
                                   "expected: '%s'. Record content:\n%s",
                                   n, val->val.string, rule->expect, json);
-                    free(json);
+                    flb_free(json);
                     flb_ra_key_value_destroy(val);
                     return FLB_FALSE;
                 }


### PR DESCRIPTION
This patch is to replace `free` with `flb_free`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_expect 
==4595== Memcheck, a memory error detector
==4595== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4595== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4595== Command: bin/flb-rt-filter_expect
==4595== 
Test key_exists_matched...                      [ OK ]
Test key_exists_not_matched...                  [2022/07/09 07:49:00] [error] [filter:expect:expect.0] exception on rule #1 'key_exists', key 'not_key' not found. Record content:
{"key":"val"}
[ OK ]
Test key_not_exists_matched...                  [ OK ]
Test key_not_exists_not_matched...              [2022/07/09 07:49:02] [error] [filter:expect:expect.0] exception on rule #1 'key_not_exists', key 'key' exists. Record content:
{"key":"val"}
[ OK ]
Test key_val_is_null_matched...                 [ OK ]
Test key_val_is_null_not_matched...             [2022/07/09 07:49:04] [error] [filter:expect:expect.0] exception on rule #1 'key_val_is_null', key 'key' contains a value type 'string'. Record content:
{"key":"val"}
[ OK ]
Test key_val_is_not_null_matched...             [ OK ]
Test key_val_is_not_null_not_matched...         [2022/07/09 07:49:06] [error] [filter:expect:expect.0] exception on rule #1 'key_val_is_not_null', key 'key' contains a value type 'null'. Record content:
{"key":null}
[ OK ]
Test key_val_eq_matched...                      [ OK ]
Test key_val_eq_not_matched...                  [2022/07/09 07:49:08] [error] [filter:expect:expect.0] exception on rule #1 'key_val_is_null', key 'not_key val' not found. Record content:
{"key":"val"}
[ OK ]
SUCCESS: All unit tests have passed.
==4595== 
==4595== HEAP SUMMARY:
==4595==     in use at exit: 0 bytes in 0 blocks
==4595==   total heap usage: 11,116 allocs, 11,116 frees, 5,857,060 bytes allocated
==4595== 
==4595== All heap blocks were freed -- no leaks are possible
==4595== 
==4595== For lists of detected and suppressed errors, rerun with: -s
==4595== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
