### PR TITLE
out_websocket: unable to use TLS with websocket

### DIFF
--- a/plugins/out_websocket/websocket_conf.c
+++ b/plugins/out_websocket/websocket_conf.c
@@ -67,7 +67,7 @@ struct flb_out_ws *flb_ws_conf_create(struct flb_output_instance *ins,
     io_flags = FLB_IO_TCP;
 #endif
 
-    upstream = flb_upstream_create(config, ins->host.name, ins->host.port, io_flags, (void *)&ins->tls);
+    upstream = flb_upstream_create(config, ins->host.name, ins->host.port, io_flags, ins->tls);
     if (!upstream) {
         flb_free(ctx);
         return NULL;


### PR DESCRIPTION
out_websocket: Fluent-bit crashing when TLS is enabled

<!-- Provide summary of changes -->
The address of the tls pointer was passed to the flb_upstream_create function instead of just the pointer. Hence removed & to pass the pointer to tls directly. Also removed the type conversion to void.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#5186

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
 [N/A] Documentation required for this feature 

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
