### PR TITLE
in_exec: use flb_calloc to fill NULL (#5715)

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -219,7 +219,7 @@ static int in_exec_init(struct flb_input_instance *in,
     int ret = -1;
 
     /* Allocate space for the configuration */
-    ctx = flb_malloc(sizeof(struct flb_exec));
+    ctx = flb_calloc(1, sizeof(struct flb_exec));
     if (!ctx) {
         return -1;
     }


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/5715#issuecomment-1184409540
Valgrind reports using uninitialized `ctx->parser_name`.
I modified to fill NULL using `flb_calloc`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[SERVICE]
    Flush        1
    Daemon       Off
    Parsers_File parsers.conf 
    
[INPUT]
    Name          tail
    Tag           json
    Path          ./static/*.json
    Path_Key       filename
    DB            ./static/json.db
    Parser         docker

[INPUT]
    Name          exec
    Tag           bin
    Command       ls ./static/*.bin
    Interval_Sec  2
    Interval_NSec 0

[OUTPUT]
    Name null
    Match *
```

## Debug log/Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==29660== Memcheck, a memory error detector
==29660== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==29660== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==29660== Command: ../bin/fluent-bit -c a.conf
==29660== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/14 21:57:32] [ info] [fluent bit] version=2.0.0, commit=82d1819c65, pid=29660
[2022/07/14 21:57:32] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/14 21:57:32] [ info] [cmetrics] version=0.3.5
[2022/07/14 21:57:33] [ info] [sp] stream processor started
[2022/07/14 21:57:33] [ info] [output:null:null.0] worker #0 started
[2022/07/14 21:57:33] [ info] [input:tail:tail.0] inotify_fs_add(): inode=1450535 watch_fd=1 name=./static/a.json
^C[2022/07/14 21:57:34] [engine] caught signal (SIGINT)
[2022/07/14 21:57:34] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/14 21:57:34] [ info] [input] pausing tail.0
[2022/07/14 21:57:35] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/14 21:57:35] [ info] [input] pausing tail.0
[2022/07/14 21:57:35] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=1450535 watch_fd=1
[2022/07/14 21:57:35] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/07/14 21:57:35] [ info] [output:null:null.0] thread worker #0 stopped
==29660== 
==29660== HEAP SUMMARY:
==29660==     in use at exit: 0 bytes in 0 blocks
==29660==   total heap usage: 3,363 allocs, 3,363 frees, 1,017,442 bytes allocated
==29660== 
==29660== All heap blocks were freed -- no leaks are possible
==29660== 
==29660== For lists of detected and suppressed errors, rerun with: -s
==29660== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
