### PR TITLE
ra_key: Fix Segv on unknown address in flb_ra_translate

### DIFF
--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -55,6 +55,9 @@ static int msgpack_object_to_ra_value(msgpack_object o,
         result->type = FLB_RA_STRING;
         result->val.string = flb_sds_create_len((char *) o.via.str.ptr,
                                                 o.via.str.size);
+        if (result->val.string == NULL) {
+            return -1;
+        }
         return 0;
     }
     else if (o.type == MSGPACK_OBJECT_MAP) {


### PR DESCRIPTION
This PR fixes Segv on unknown address in flb_ra_translate revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46082

The root cause is that `flb_malloc` fails to allocate memory and because of that `flb_sds_create_len` constructs an invalid `flb_ra_value` with a type `MSGPACK_OBJECT_STR` in `msgpack_object_to_ra_value`.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
