### PR TITLE
pack: Fix read Stack-buffer-overflow READ in msgpack_sbuffer_write

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -828,6 +828,7 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
 {
     int i;
     int len;
+    int max_len;
     int ok = MSGPACK_UNPACK_SUCCESS;
     int records = 0;
     int map_size;
@@ -926,11 +927,12 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
                 s = strftime(time_formatted, sizeof(time_formatted) - 1,
                              FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT, &tm);
 
+                max_len = sizeof(time_formatted) - 1 - s;
                 len = snprintf(time_formatted + s,
-                               sizeof(time_formatted) - 1 - s,
+                               max_len,
                                ".%06" PRIu64,
                                (uint64_t) tms.tm.tv_nsec / 1000);
-                s += len;
+                s += (len < max_len) ? len : max_len;
                 msgpack_pack_str(&tmp_pck, s);
                 msgpack_pack_str_body(&tmp_pck, time_formatted, s);
                 break;


### PR DESCRIPTION
This PR fixes Stack-buffer-overflow in msgpack_sbuffer_write revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45208

The root cause is that `snprintf` call in `flb_pack_msgpack_to_json_format` returns the number of characters that would have been written if the buffer had been sufficiently large.
It leads to reading out of the boundaries of the buffer later.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
