### PR TITLE
filter_parser: use string as a default value

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -367,12 +367,12 @@ static struct flb_config_map config_map[] = {
      "Multiple Parser entries are allowed (one per line)."
     },
     {
-     FLB_CONFIG_MAP_BOOL, "Preserve_Key", FLB_FALSE,
+     FLB_CONFIG_MAP_BOOL, "Preserve_Key", "false",
      0, FLB_TRUE, offsetof(struct filter_parser_ctx, preserve_key),
      "Keep original Key_Name field in the parsed result. If false, the field will be removed."
     },
     {
-     FLB_CONFIG_MAP_BOOL, "Reserve_Data", FLB_FALSE,
+     FLB_CONFIG_MAP_BOOL, "Reserve_Data", "false",
      0, FLB_TRUE, offsetof(struct filter_parser_ctx, reserve_data),
      "Keep all other original fields in the parsed result. "
      "If false, all other original fields will be removed."


### PR DESCRIPTION
A type of default value `def_value` should be flb_sds_t.
It means FLB_TRUE/FLB_FALSE is invalid as a default value.
However filter_parser use FLB_FALSE as a default value. I fixed it.

```c
struct flb_config_map {
    /* Public fields used by plugins at registration */
    int type;                      /* type */
    flb_sds_t name;                /* property name */
    flb_sds_t def_value;           /* default value */
    int flags;                     /* option flags (e.g: multiple entries allowed) */
    int set_property;              /* set context property ? (use offset ?) */
    uintptr_t offset;              /* member offset */
    flb_sds_t desc;                /* description */

    struct flb_config_map_val value; /* lookup value */
    struct mk_list _head;
};
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Parsers_File parsers.cnf

[INPUT]
    Name dummy
    Dummy {"level": "INFO","logger": "my_logger","thread_name": "my_thread","thread_id": 1,"marker_name": "Marker","marker_id": 100,"message": "https://github.com GET Host: github.com 200 50"}

[FILTER]
    Name parser
    Match *
    Parser log_processed_app
    Key_Name message

[OUTPUT]
    Name stdout
```

parsers.cnf:
```
[PARSER]
    Name        log_processed_app
    Format      regex
    Regex       ^(?<request_uri>[^\s]+)\s+(?<method>[^\s]+)\s+(?<headers>.*?)\s*(?:(?<status>(\d+|null))\s(?<request_time>\d+))?$
```

## Debug log / Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==43469== Memcheck, a memory error detector
==43469== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==43469== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==43469== Command: ../bin/fluent-bit -c a.conf
==43469== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/16 21:06:56] [ info] [fluent bit] version=2.0.0, commit=7c069411a4, pid=43469
[2022/07/16 21:06:56] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/16 21:06:56] [ info] [cmetrics] version=0.3.5
[2022/07/16 21:06:56] [ info] [output:stdout:stdout.0] worker #0 started
[2022/07/16 21:06:56] [ info] [sp] stream processor started
[0] dummy.0: [1657973216.901890896, {"request_uri"=>"https://github.com", "method"=>"GET", "headers"=>"Host: github.com", "status"=>"200", "request_time"=>"50"}]
^C[2022/07/16 21:06:58] [engine] caught signal (SIGINT)
[0] dummy.0: [1657973217.891446702, {"request_uri"=>"https://github.com", "method"=>"GET", "headers"=>"Host: github.com", "status"=>"200", "request_time"=>"50"}]
[2022/07/16 21:06:58] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/16 21:06:58] [ info] [input] pausing dummy.0
[2022/07/16 21:06:58] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/16 21:06:58] [ info] [input] pausing dummy.0
[2022/07/16 21:06:58] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/07/16 21:06:58] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==43469== 
==43469== HEAP SUMMARY:
==43469==     in use at exit: 0 bytes in 0 blocks
==43469==   total heap usage: 1,342 allocs, 1,342 frees, 977,519 bytes allocated
==43469== 
==43469== All heap blocks were freed -- no leaks are possible
==43469== 
==43469== For lists of detected and suppressed errors, rerun with: -s
==43469== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
