### PR TITLE
in_kmsg: support prio_level property.

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -132,6 +132,11 @@ static inline int process_line(const char *line,
     /* Priority */
     priority = FLB_KLOG_PRI(val);
 
+    if (priority > ctx->prio_level) {
+        /* Drop line */
+        return 0;
+    }
+
     /* Sequence */
     p = strchr(p, ',');
     if (!p) {
@@ -308,6 +313,7 @@ static int in_kmsg_init(struct flb_input_instance *ins,
         flb_free(ctx);
         return -1;
     }
+    flb_plg_debug(ctx->ins, "prio_level is %d", ctx->prio_level);
 
     /* Set our collector based on a file descriptor event */
     ret = flb_input_set_collector_event(ins,
@@ -339,6 +345,12 @@ static int in_kmsg_exit(void *data, struct flb_config *config)
 }
 
 static struct flb_config_map config_map[] = {
+    {
+      FLB_CONFIG_MAP_INT, "prio_level", "8",
+      0, FLB_TRUE, offsetof(struct flb_in_kmsg_config, prio_level),
+      "The log level to filter. The kernel log is dropped if its priority is more than prio_level. "
+      "Allowed values are 0-8. Default is 8."
+    },
     /* EOF */
     {0}
 };

--- a/plugins/in_kmsg/in_kmsg.h
+++ b/plugins/in_kmsg/in_kmsg.h
@@ -48,6 +48,8 @@ struct flb_in_kmsg_config {
     int fd;                    /* descriptor -> FLB_KMSG_DEV */
     struct timeval boot_time;  /* System boot time           */
 
+    int prio_level;
+
     /* Line processing */
     int buffer_id;
 


### PR DESCRIPTION
This patch is to add `prio_level`. It is useful to filter debug kernel logs.

If user sets prio_level=4, the logs that priority is greater than 4 are ignored.
Priority=5,6,7 are ignored.

Default value is 8. It means all logs are saved.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name kmsg
    Prio_Level 4

[OUTPUT]
    Name stdout
    Match *
```

## Debug log / Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==23318== Memcheck, a memory error detector
==23318== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23318== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==23318== Command: bin/fluent-bit -c a.conf
==23318== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/17 16:48:17] [ info] [fluent bit] version=2.0.0, commit=47cdf2c385, pid=23318
[2022/07/17 16:48:17] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/17 16:48:17] [ info] [cmetrics] version=0.3.5
[2022/07/17 16:48:17] [ info] [output:stdout:stdout.0] worker #0 started
[2022/07/17 16:48:17] [ info] [sp] stream processor started
[0] kmsg.0: [1658025794.000000000, {"priority"=>4, "sequence"=>8, "sec"=>0, "usec"=>0, "msg"=>"[Firmware Bug]: TSC doesn't count with P0 frequency!"}]
[1] kmsg.0: [1658025794.590094000, {"priority"=>4, "sequence"=>367, "sec"=>0, "usec"=>590094, "msg"=>"platform eisa.0: EISA: Cannot allocate resource for mainboard
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[2] kmsg.0: [1658025794.590095000, {"priority"=>4, "sequence"=>368, "sec"=>0, "usec"=>590095, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 1
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[3] kmsg.0: [1658025794.590096000, {"priority"=>4, "sequence"=>369, "sec"=>0, "usec"=>590096, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 2
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[4] kmsg.0: [1658025794.590097000, {"priority"=>4, "sequence"=>370, "sec"=>0, "usec"=>590097, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 3
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[5] kmsg.0: [1658025794.590098000, {"priority"=>4, "sequence"=>371, "sec"=>0, "usec"=>590098, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 4
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[6] kmsg.0: [1658025794.590099000, {"priority"=>4, "sequence"=>372, "sec"=>0, "usec"=>590099, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 5
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[7] kmsg.0: [1658025794.590100000, {"priority"=>4, "sequence"=>373, "sec"=>0, "usec"=>590100, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 6
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[8] kmsg.0: [1658025794.590101000, {"priority"=>4, "sequence"=>374, "sec"=>0, "usec"=>590101, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 7
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[9] kmsg.0: [1658025794.590102000, {"priority"=>4, "sequence"=>375, "sec"=>0, "usec"=>590102, "msg"=>"platform eisa.0: Cannot allocate resource for EISA slot 8
 SUBSYSTEM=platform
 DEVICE=+platform:eisa.0"}]
[10] kmsg.0: [1658025796.340375000, {"priority"=>4, "sequence"=>479, "sec"=>2, "usec"=>340375, "msg"=>"usb 1-2: config 1 interface 0 altsetting 0 endpoint 0x81 has invalid maxpacket 512, setting to 64
 SUBSYSTEM=usb
 DEVICE=+usb:1-2"}]
[11] kmsg.0: [1658025796.340381000, {"priority"=>4, "sequence"=>480, "sec"=>2, "usec"=>340381, "msg"=>"usb 1-2: config 1 interface 0 altsetting 0 endpoint 0x2 has invalid maxpacket 512, setting to 64
 SUBSYSTEM=usb
 DEVICE=+usb:1-2"}]
[12] kmsg.0: [1658025797.243649000, {"priority"=>3, "sequence"=>592, "sec"=>3, "usec"=>243649, "msg"=>"[drm:vmw_host_log [vmwgfx]] *ERROR* Failed to send host log message."}]
[13] kmsg.0: [1658025798.380672000, {"priority"=>4, "sequence"=>629, "sec"=>4, "usec"=>380672, "msg"=>"vboxguest: loading out-of-tree module taints kernel."}]
[14] kmsg.0: [1658025798.427280000, {"priority"=>4, "sequence"=>631, "sec"=>4, "usec"=>427280, "msg"=>"vgdrvHeartbeatInit: Setting up heartbeat to trigger every 2000 milliseconds"}]
[15] kmsg.0: [1658025798.443288000, {"priority"=>4, "sequence"=>633, "sec"=>4, "usec"=>443288, "msg"=>"vboxguest: Successfully loaded version 6.1.34 r150636"}]
[16] kmsg.0: [1658025798.443312000, {"priority"=>4, "sequence"=>634, "sec"=>4, "usec"=>443312, "msg"=>"vboxguest: misc device minor 122, IRQ 20, I/O port d040, MMIO at 00000000f0400000 (size 0x400000)"}]
[17] kmsg.0: [1658025806.796189000, {"priority"=>4, "sequence"=>653, "sec"=>12, "usec"=>796189, "msg"=>"kauditd_printk_skb: 36 callbacks suppressed"}]
[18] kmsg.0: [1658025820.005131000, {"priority"=>4, "sequence"=>660, "sec"=>26, "usec"=>5131, "msg"=>"vboxvideo: loading version 6.1.34 r150636"}]
[19] kmsg.0: [1658025820.112693000, {"priority"=>4, "sequence"=>661, "sec"=>26, "usec"=>112693, "msg"=>"21:55:09.022663 main     VBoxService 6.1.34 r150636 (verbosity: 0) linux.amd64 (Mar 23 2022 00:46:49) release log\x0a21:55:09.022670 main     Log opened 2022-07-16T21:55:09.021548000Z"}]
[20] kmsg.0: [1658025820.112754000, {"priority"=>4, "sequence"=>662, "sec"=>26, "usec"=>112754, "msg"=>"21:55:09.022789 main     OS Product: Linux"}]
[21] kmsg.0: [1658025820.112785000, {"priority"=>4, "sequence"=>663, "sec"=>26, "usec"=>112785, "msg"=>"21:55:09.022825 main     OS Release: 5.13.0-52-generic"}]
[22] kmsg.0: [1658025820.112869000, {"priority"=>4, "sequence"=>664, "sec"=>26, "usec"=>112869, "msg"=>"21:55:09.022855 main     OS Version: #59~20.04.1-Ubuntu SMP Thu Jun 16 21:21:28 UTC 2022"}]
[23] kmsg.0: [1658025820.113576000, {"priority"=>4, "sequence"=>665, "sec"=>26, "usec"=>113576, "msg"=>"21:55:09.023574 main     Executable: /opt/VBoxGuestAdditions-6.1.34/sbin/VBoxService\x0a21:55:09.023577 main     Process ID: 1881\x0a21:55:09.023577 main     Package type: LINUX_64BITS_GENERIC"}]
[24] kmsg.0: [1658025820.116378000, {"priority"=>4, "sequence"=>666, "sec"=>26, "usec"=>116378, "msg"=>"21:55:09.026394 main     6.1.34 r150636 started. Verbose level = 0"}]
[25] kmsg.0: [1658025820.123187000, {"priority"=>4, "sequence"=>667, "sec"=>26, "usec"=>123187, "msg"=>"21:55:09.033173 main     vbglR3GuestCtrlDetectPeekGetCancelSupport: Supported (#1)"}]
[26] kmsg.0: [1658025838.739198000, {"priority"=>4, "sequence"=>673, "sec"=>44, "usec"=>739198, "msg"=>"FAT-fs (sdb1): Volume was not properly unmounted. Some data may be corrupt. Please run fsck."}]
[27] kmsg.0: [1658035460.436649000, {"priority"=>4, "sequence"=>696, "sec"=>9666, "usec"=>436649, "msg"=>"02:59:28.290126 timesync vgsvcTimeSyncWorker: Radical host time change: 7 236 864 000 000ns (HostNow=1 658 026 768 280 000 000 ns HostLast=1 658 019 531 416 000 000 ns)"}]
[28] kmsg.0: [1658035470.441867000, {"priority"=>4, "sequence"=>697, "sec"=>9676, "usec"=>441867, "msg"=>"02:59:38.949949 timesync vgsvcTimeSyncWorker: Radical guest time change: 7 237 620 762 000ns (GuestNow=1 658 026 778 949 934 000 ns GuestLast=1 658 019 541 329 172 000 ns fSetTimeLastLoop=true )"}]
[29] kmsg.0: [1658038580.542490000, {"priority"=>4, "sequence"=>698, "sec"=>12786, "usec"=>542490, "msg"=>"04:44:01.841040 timesync vgsvcTimeSyncWorker: Radical host time change: 3 163 445 000 000ns (HostNow=1 658 033 041 841 000 000 ns HostLast=1 658 029 878 396 000 000 ns)"}]
[30] kmsg.0: [1658038590.463322000, {"priority"=>4, "sequence"=>699, "sec"=>12796, "usec"=>463322, "msg"=>"04:44:11.841323 timesync vgsvcTimeSyncWorker: Radical guest time change: 3 162 765 893 000ns (GuestNow=1 658 033 051 841 307 000 ns GuestLast=1 658 029 889 075 414 000 ns fSetTimeLastLoop=true )"}]
[31] kmsg.0: [1658040260.419018000, {"priority"=>4, "sequence"=>700, "sec"=>14466, "usec"=>419018, "msg"=>"06:44:20.852239 timesync vgsvcTimeSyncWorker: Radical host time change: 5 549 134 000 000ns (HostNow=1 658 040 260 842 000 000 ns HostLast=1 658 034 711 708 000 000 ns)"}]
[32] kmsg.0: [1658040270.213874000, {"priority"=>4, "sequence"=>701, "sec"=>14476, "usec"=>213874, "msg"=>"06:44:30.855741 timesync vgsvcTimeSyncWorker: Radical guest time change: 5 548 970 091 000ns (GuestNow=1 658 040 270 855 727 000 ns GuestLast=1 658 034 721 885 636 000 ns fSetTimeLastLoop=true )"}]
^C[2022/07/17 16:48:20] [engine] caught signal (SIGINT)
[2022/07/17 16:48:20] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/17 16:48:21] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/17 16:48:21] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/07/17 16:48:21] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==23318== 
==23318== HEAP SUMMARY:
==23318==     in use at exit: 0 bytes in 0 blocks
==23318==   total heap usage: 1,208 allocs, 1,208 frees, 1,103,955 bytes allocated
==23318== 
==23318== All heap blocks were freed -- no leaks are possible
==23318== 
==23318== For lists of detected and suppressed errors, rerun with: -s
==23318== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
