### PR TITLE
conf: parser: fix envoy access log rubular.com link

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -94,10 +94,10 @@
     Time_Key time
 
 [PARSER]
-    # https://rubular.com/r/3fVxCrE5iFiZim
+    # https://rubular.com/r/0VZmcYcLWMGAp1
     Name    envoy
     Format  regex
-    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"  
+    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
     Time_Keep   On
     Time_Key start_time


### PR DESCRIPTION
<!-- Provide summary of changes -->
Wrong rubular link was attached, updated it according to https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string
<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
