### PR TITLE
conf: parser: add istio-envoy-proxy parser

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -103,6 +103,15 @@
     Time_Key start_time
 
 [PARSER]
+    # https://rubular.com/r/17KGEdDClwiuDG
+    Name    istio-envoy-proxy
+    Format  regex
+    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<response_code>[^ ]*) (?<response_flags>[^ ]*) (?<response_code_details>[^ ]*) (?<connection_termination_details>[^ ]*) (?<upstream_transport_failure_reason>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<x_request_id>[^\"]*)" (?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)" (?<upstream_cluster>[^ ]*) (?<upstream_local_address>[^ ]*) (?<downstream_local_address>[^ ]*) (?<downstream_remote_address>[^ ]*) (?<requested_server_name>[^ ]*) (?<route_name>[^  ]*)
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
+    Time_Key start_time
+
+[PARSER]
     # http://rubular.com/r/tjUt3Awgg4
     Name cri
     Format regex


### PR DESCRIPTION
Add parser for parsing istio's envoy proxy access logs.

- access log format: https://istio.io/latest/docs/tasks/observability/logs/access-log/#default-access-log-format

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
