### PR TITLE
config: fix flush timeout destroy handling (kqueue)

### DIFF
--- a/lib/monkey/mk_core/mk_event_kqueue.c
+++ b/lib/monkey/mk_core/mk_event_kqueue.c
@@ -245,6 +245,7 @@ static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data
         mk_list_del(&event->_priority_head);
     }
 
+    close(event->fd);
     MK_EVENT_NEW(event);
 
     return 0;

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -401,9 +401,8 @@ void flb_config_exit(struct flb_config *config)
 
     /* Event flush */
     if (config->evl) {
-        mk_event_del(config->evl, &config->event_flush);
+        mk_event_timeout_destroy(config->evl, &config->event_flush);
     }
-    mk_event_closesocket(config->flush_fd);
 
     /* Release scheduler */
     flb_sched_destroy(config->sched);


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
