### PR TITLE
aws_util: set AWS Fluent Bit user agent based on environment

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -79,7 +79,8 @@ struct flb_aws_client {
     int port;
     char *proxy;
     int flags;
-    char *extra_user_agent;
+    flb_sds_t *extra_user_agent;
+    int free_user_agent;
 
     /*
      * Additional headers which will be added to all requests.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Set AWS Fluent Bit user agent. The user agent can either be specified by:
1. Cloudwatch extra_user_agent option OR
2. environment variable $FLB_AWS_USER_AGENT

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

*Valgrind result:*
- With `extra_user_agent` set:
```
==23461== 
==23461== HEAP SUMMARY:
==23461==     in use at exit: 102,912 bytes in 3,432 blocks
==23461==   total heap usage: 65,209 allocs, 61,777 frees, 13,830,990 bytes allocated
==23461== 
==23461== LEAK SUMMARY:
==23461==    definitely lost: 0 bytes in 0 blocks
==23461==    indirectly lost: 0 bytes in 0 blocks
==23461==      possibly lost: 0 bytes in 0 blocks
==23461==    still reachable: 102,912 bytes in 3,432 blocks
==23461==         suppressed: 0 bytes in 0 blocks
==23461== Rerun with --leak-check=full to see details of leaked memory
==23461== 
==23461== For lists of detected and suppressed errors, rerun with: -s
==23461== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
- Without `extra_user_agent` set:
```
==24379== HEAP SUMMARY:
==24379==     in use at exit: 102,912 bytes in 3,432 blocks
==24379==   total heap usage: 62,756 allocs, 59,324 frees, 10,768,721 bytes allocated
==24379== 
==24379== LEAK SUMMARY:
==24379==    definitely lost: 0 bytes in 0 blocks
==24379==    indirectly lost: 0 bytes in 0 blocks
==24379==      possibly lost: 0 bytes in 0 blocks
==24379==    still reachable: 102,912 bytes in 3,432 blocks
==24379==         suppressed: 0 bytes in 0 blocks
==24379== Rerun with --leak-check=full to see details of leaked memory
==24379== 
==24379== For lists of detected and suppressed errors, rerun with: -s
==24379== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
