### PR TITLE
cmake: wix: windows: Use configured FLB_OUT_NAME value for fluent-bit executables' name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1110,9 +1110,11 @@ endif()
 if(CPACK_GENERATOR MATCHES "WIX")
   set(CPACK_WIX_UPGRADE_GUID cb6825fd-37e6-4596-a55d-6d490d4fe178)
   configure_file(LICENSE "${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt")
+  configure_file(${CMAKE_SOURCE_DIR}/cpack/wix/WIX.template.in.cmakein
+    ${CMAKE_CURRENT_BINARY_DIR}/WIX.template.in)
   # Specify LICENSE file that has .txt extension
   set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt")
-  set(CPACK_WIX_TEMPLATE ${CMAKE_SOURCE_DIR}/cpack/wix/WIX.template.in)
+  set(CPACK_WIX_TEMPLATE ${CMAKE_CURRENT_BINARY_DIR}/WIX.template.in)
   set(CPACK_WIX_LIGHT_EXTENSIONS "WixUtilExtension")
 endif()
 

--- a/cpack/wix/WIX.template.in.cmakein
+++ b/cpack/wix/WIX.template.in.cmakein
@@ -78,19 +78,19 @@
         <?include "product_fragment.wxi"?>
 
         <Property Id="CreateFluentBitWinSvc" Value=" "/>
-        <CustomAction Id="SetCreateFluentBitWinSvcCommand" Property="CreateFluentBitWinSvc" Value="&quot;sc.exe&quot; create $(var.CPACK_PACKAGE_NAME) binpath= &quot;\&quot;[INSTALL_ROOT]bin\fluent-bit.exe\&quot; -c \&quot;[INSTALL_ROOT]conf\fluent-bit.conf\&quot;&quot; start= delayed-auto" Execute="immediate" />
+        <CustomAction Id="SetCreateFluentBitWinSvcCommand" Property="CreateFluentBitWinSvc" Value="&quot;sc.exe&quot; create @FLB_OUT_NAME@ binpath= &quot;\&quot;[INSTALL_ROOT]bin\@FLB_OUT_NAME@.exe\&quot; -c \&quot;[INSTALL_ROOT]conf\@FLB_OUT_NAME@.conf\&quot;&quot; start= delayed-auto" Execute="immediate" />
         <CustomAction Id="CreateFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
 
         <Property Id="LaunchFluentBitWinSvc" Value=" "/>
-        <CustomAction Id="SetLaunchFluentBitWinSvcCommand" Property="LaunchFluentBitWinSvc" Value="&quot;sc.exe&quot; start $(var.CPACK_PACKAGE_NAME)" Execute="immediate" />
+        <CustomAction Id="SetLaunchFluentBitWinSvcCommand" Property="LaunchFluentBitWinSvc" Value="&quot;sc.exe&quot; start @FLB_OUT_NAME@" Execute="immediate" />
         <CustomAction Id="LaunchFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
 
         <Property Id="StopFluentBitWinSvc" Value=" "/>
-        <CustomAction Id="SetStopFluentBitWinSvcCommand" Property="StopFluentBitWinSvc" Value="&quot;sc.exe&quot; stop $(var.CPACK_PACKAGE_NAME)" Execute="immediate" />
+        <CustomAction Id="SetStopFluentBitWinSvcCommand" Property="StopFluentBitWinSvc" Value="&quot;sc.exe&quot; stop @FLB_OUT_NAME@" Execute="immediate" />
         <CustomAction Id="StopFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
 
         <Property Id="DeleteFluentBitWinSvc" Value=" "/>
-        <CustomAction Id="SetDeleteFluentBitWinSvcCommand" Property="DeleteFluentBitWinSvc" Value="&quot;sc.exe&quot; delete $(var.CPACK_PACKAGE_NAME)" Execute="immediate" />
+        <CustomAction Id="SetDeleteFluentBitWinSvcCommand" Property="DeleteFluentBitWinSvc" Value="&quot;sc.exe&quot; delete @FLB_OUT_NAME@" Execute="immediate" />
         <CustomAction Id="DeleteFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
 
         <InstallExecuteSequence>


### PR DESCRIPTION

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

Previous implementation of Wix template uses the fixed name for fluent-bit's executable name.
In this PR, we make to be configurable for this executables' name.

Note that `@FLB_OUT_NAME@` is not referrable on cpack variables. So, we have to use `configure_file` to replace `@FLB_OUT_NAME@` cmake configurating variable.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
None.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
