### PR TITLE
input_thread: macos: Add a missing pthread_cond_init

### DIFF
--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -218,6 +218,9 @@ static struct flb_input_thread_instance *input_thread_instance_create(struct flb
     thi->init_status = 0;
     pthread_mutex_init(&thi->init_mutex, NULL);
 
+    /* init condition */
+    pthread_cond_init(&thi->init_condition, NULL);
+
     /* initialize lists */
     mk_list_init(&thi->input_coro_list);
     mk_list_init(&thi->input_coro_list_destroy);


### PR DESCRIPTION
ref: https://github.com/lemmy/BlockingQueue/issues/3

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

On macOS, don't wait on a condition that is not initialized yet.
We must initialize it at first.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

None for the accurate related issue.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
