### PR TITLE
out_es: fix trace_error truncating the response

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -886,12 +886,24 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
                 if (ctx->trace_error) {
                     /*
                      * If trace_error is set, trace the actual
-                     * input/output to Elasticsearch that caused the problem.
+                     * response from Elasticsearch explaining the problem.
+                     * Trace_Output can be used to see the request. 
                      */
-                    flb_plg_debug(ctx->ins, "error caused by: Input\n%s\n",
-                                  pack);
-                    flb_plg_error(ctx->ins, "error: Output\n%s",
-                                  c->resp.payload);
+                    if (pack_size < 4000) {
+                        flb_plg_debug(ctx->ins, "error caused by: Input\n%.*s\n",
+                                      (int) pack_size, pack);
+                    }
+                    if (c->resp.payload_size < 4000) {
+                        flb_plg_error(ctx->ins, "error: Output\n%s",
+                                      c->resp.payload);
+                    } else {
+                        /*
+                        * We must use fwrite since the flb_log functions
+                        * will truncate data at 4KB
+                        */
+                        fwrite(c->resp.payload, 1, c->resp.payload_size, stderr);
+                        fflush(stderr);
+                    }
                 }
                 goto retry;
             }

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -902,13 +902,25 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
                 /* we got an error */
                 if (ctx->trace_error) {
                     /*
-                     * If trace_error is set, trace the actual input/output to
-                     * OpenSearch that caused the problem.
+                     * If trace_error is set, trace the actual
+                     * response from Elasticsearch explaining the problem.
+                     * Trace_Output can be used to see the request. 
                      */
-                    flb_plg_debug(ctx->ins, "error caused by: Input\n%s\n",
-                                  pack);
-                    flb_plg_error(ctx->ins, "error: Output\n%s",
-                                  c->resp.payload);
+                    if (pack_size < 4000) {
+                        flb_plg_debug(ctx->ins, "error caused by: Input\n%.*s\n",
+                                      (int) pack_size, pack);
+                    }
+                    if (c->resp.payload_size < 4000) {
+                        flb_plg_error(ctx->ins, "error: Output\n%s",
+                                      c->resp.payload);
+                    } else {
+                        /*
+                        * We must use fwrite since the flb_log functions
+                        * will truncate data at 4KB
+                        */
+                        fwrite(c->resp.payload, 1, c->resp.payload_size, stderr);
+                        fflush(stderr);
+                    }
                 }
                 goto retry;
             }


### PR DESCRIPTION
Fixes #5314 5314


Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
