### PR TITLE
aws_util: use conccurent safe strtok_r

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -685,7 +685,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
     flb_sds_t s3_key = NULL;
     flb_sds_t tmp_key = NULL;
     flb_sds_t tmp_tag = NULL;
-    struct tm *gmt = NULL;
+    struct tm gmt = {0};
 
     if (strlen(format) > S3_KEY_SIZE){
         flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
@@ -829,7 +829,10 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
     tmp_key = NULL;
     flb_free(random_alphanumeric);
 
-    gmt = gmtime(&time);
+    if (!gmtime_r(&time, &gmt)) {
+        flb_error("[s3_key] Failed to create timestamp.");
+        goto error;
+    }
 
     flb_sds_destroy(tmp);
     tmp = NULL;
@@ -840,7 +843,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
         goto error;
     }
 
-    ret = strftime(key, S3_KEY_SIZE, s3_key, gmt);
+    ret = strftime(key, S3_KEY_SIZE, s3_key, &gmt);
     if(ret == 0){
         flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
     }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
