### PR TITLE
workflows: windows: Use chocolatey's OpenSSL installer for linking OpenSSL

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -53,7 +53,7 @@ jobs:
             chocolatey_opt: --x64
     permissions:
       contents: read
-    # Default environment variables can be overridden below. To prevent library pollution.
+    # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.
     env:
       PATH: C:\ProgramData\Chocolatey\bin;c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin
     steps:

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -45,14 +45,17 @@ jobs:
         config:
           - name: "Windows 32bit"
             arch: x86
-            vcpkg_triplet: x86-windows-static
-            openssl_root_dir_opt: -DOPENSSL_ROOT_DIR=C:\vcpkg\packages\openssl_x86-windows-static
+            win32openssl: https://slproweb.com/download/Win32OpenSSL-1_1_1q.msi
+            win32openssl_dir: "C:\\Program\ Files\\OpenSSL-Win32"
           - name: "Windows 64bit"
             arch: x64
-            vcpkg_triplet: x64-windows-static
-            openssl_root_dir_opt: ""
+            win32openssl: https://slproweb.com/download/Win64OpenSSL-1_1_1q.msi
+            win32openssl_dir: "C:\\Program\ Files\\OpenSSL-Win64"
     permissions:
       contents: read
+    # Default environment variables can be overridden below
+    env:
+        PATH: c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -70,20 +73,20 @@ jobs:
           WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
         shell: pwsh
 
+      - name: Install OpenSSL on Windows (slproweb)
+        run: |
+          curl.exe --output openssl.msi ${{ matrix.config.win32openssl }}
+          msiexec /i openssl.msi /quiet /qn /norestart
+        shell: pwsh
+
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
           arch: ${{ matrix.config.arch }}
 
-      - name: Build openssl with vcpkg
-        if: ${{ matrix.config.arch == 'x86' }}
-        run: |
-          C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
-        shell: cmd
-
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} ${{ matrix.config.openssl_root_dir_opt }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} -DOPENSSL_ROOT_DIR=${{ matrix.config.win32openssl_dir }} ../
           cmake --build .
           cpack
         working-directory: build

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -45,17 +45,17 @@ jobs:
         config:
           - name: "Windows 32bit"
             arch: x86
-            win32openssl: https://slproweb.com/download/Win32OpenSSL-1_1_1q.msi
-            win32openssl_dir: "C:\\Program\ Files\\OpenSSL-Win32"
+            openssl_dir: C:\Program Files (x86)\OpenSSL-Win32
+            chocolatey_opt: --x86
           - name: "Windows 64bit"
             arch: x64
-            win32openssl: https://slproweb.com/download/Win64OpenSSL-1_1_1q.msi
-            win32openssl_dir: "C:\\Program\ Files\\OpenSSL-Win64"
+            openssl_dir: C:\Program Files\OpenSSL-Win64
+            chocolatey_opt: --x64
     permissions:
       contents: read
-    # Default environment variables can be overridden below
+    # Default environment variables can be overridden below. To prevent library pollution.
     env:
-        PATH: c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin
+      PATH: C:\ProgramData\Chocolatey\bin;c:/Program Files/Git/cmd;c:/Windows/system32;C:/Windows/System32/WindowsPowerShell/v1.0;$ENV:WIX/bin;C:/Program Files/CMake/bin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -73,11 +73,10 @@ jobs:
           WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
         shell: pwsh
 
-      - name: Install OpenSSL on Windows (slproweb)
-        run: |
-          curl.exe --output openssl.msi ${{ matrix.config.win32openssl }}
-          msiexec /i openssl.msi /quiet /qn /norestart
-        shell: pwsh
+      - name: Get dependencies w/ chocolatey
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install ${{ matrix.config.chocolatey_opt }} openssl -y
 
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
@@ -86,7 +85,7 @@ jobs:
 
       - name: Build Fluent Bit packages
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} -DOPENSSL_ROOT_DIR=${{ matrix.config.win32openssl_dir }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} -DOPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' ../
           cmake --build .
           cpack
         working-directory: build


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

On GitHub Actions, we need to refer the equivalent OpenSSL libraries than AppVeyor ones.
In AppVeyor, it seems that it installs slproweb's OpenSSL library installers to provide OpenSSL libraries.
We need to use them on GitHub Actions' workflow to solve OpenSSL linking issue on the artifacts.

### With chocolatey's OpenSSL installer (32bit)

![image](https://user-images.githubusercontent.com/700876/180702684-3be99722-54d8-4906-8a58-6748d5a78016.png)

### With chocolatey's OpenSSL installer (64bit)

![image](https://user-images.githubusercontent.com/700876/180703068-c5cc6662-487c-4bc7-a076-342904eb2a4b.png)

---

There is no reported error for dll linkage.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes #5703
 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
