### PR TITLE
upstream: Do not remove existing event from event loop if it timed out

### DIFF
--- a/lib/monkey/mk_core/mk_event.c
+++ b/lib/monkey/mk_core/mk_event.c
@@ -112,9 +112,9 @@ int mk_event_inject(struct mk_event_loop *loop, struct mk_event *event,
         return -1;
     }
 
-    _mk_event_inject(loop, event, flags, prevent_duplication);
+    result = _mk_event_inject(loop, event, flags, prevent_duplication);
 
-    return 0;
+    return result;
 }
 
 /* Remove an event */

--- a/lib/monkey/mk_core/mk_event_epoll.c
+++ b/lib/monkey/mk_core/mk_event_epoll.c
@@ -381,7 +381,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     if (prevent_duplication) {
         for (index = 0 ; index < loop->n_events ; index++) {
             if (ctx->events[index].data.ptr == event) {
-                return 0;
+                return 1;
             }
         }
     }

--- a/lib/monkey/mk_core/mk_event_kqueue.c
+++ b/lib/monkey/mk_core/mk_event_kqueue.c
@@ -298,7 +298,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     if (prevent_duplication) {
         for (index = 0 ; index < loop->n_events ; index++) {
             if (ctx->events[index].udata == event) {
-                return 0;
+                return 1;
             }
         }
     }

--- a/lib/monkey/mk_core/mk_event_libevent.c
+++ b/lib/monkey/mk_core/mk_event_libevent.c
@@ -368,7 +368,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     if (prevent_duplication) {
         for (index = 0 ; index < loop->n_events ; index++) {
             if (ctx->fired[index].data == event) {
-                return 0;
+                return 1;
             }
         }
     }

--- a/lib/monkey/mk_core/mk_event_select.c
+++ b/lib/monkey/mk_core/mk_event_select.c
@@ -333,7 +333,7 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
     if (prevent_duplication) {
         for (index = 0 ; index < loop->n_events ; index++) {
             if (ctx->fired[index]->fd == event->fd) {
-                return 0;
+                return 1;
             }
         }
     }

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -794,6 +794,7 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
 {
     time_t now;
     int drop;
+    int result;
     struct mk_list *head;
     struct mk_list *u_head;
     struct mk_list *tmp;
@@ -843,9 +844,12 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
 
             if (drop == FLB_TRUE) {
                 if (u_conn->event.status != MK_EVENT_NONE) {
-                    mk_event_inject(u_conn->evl, &u_conn->event,
-                                    MK_EVENT_READ | MK_EVENT_WRITE,
-                                    FLB_TRUE);
+                    result = mk_event_inject(u_conn->evl, &u_conn->event,
+                                             MK_EVENT_READ | MK_EVENT_WRITE,
+                                             FLB_TRUE);
+                    if (result == 1) {
+                        continue;
+                    }
                 }
                 u_conn->net_error = ETIMEDOUT;
                 prepare_destroy_conn(u_conn);


### PR DESCRIPTION
Fluent Bit sometimes doesn't resume coroutines for timed out network events. This can also cause deadlocks in some cases, like AWS provider credentials refresh function, if the control is not returned to the function that sets a lock before a network call.

This happens when Fluent Bit doesn't return control to the engine and the event loop for a long time. In that case, an async network request can time out and the OS will return it to Fluent Bit (via epoll for example). But Fluent Bit will also handle the same request via its own upstream timeout functions. In this case, the network event cannot be injected properly by the upstream Fluent Bit functions, and cannot be processed normally in the priority bucket.

* Added a return value to indicate that the event that Fluent Bit is trying to inject into the event loop is already there. In other words, this event was put there by the event wait/notification mechanism, e.g. epoll.
* Updated the timeout-handling function, so it doesn't destroy the timed out connection and doesn't remove the associated event from the event loop, when this event exists on the event loop. This allows the priority bucket queue to return the event to its handler that will resume the coroutine and handle the failed connection then.

Signed-off-by: zhenyami <zhenyamzk+GitHub@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
