### PR TITLE
workflows: fix workflow name for fluent-bit-ci calls

### DIFF
--- a/.github/workflows/master-integration-test.yaml
+++ b/.github/workflows/master-integration-test.yaml
@@ -21,7 +21,7 @@ jobs:
   master-integration-test-run-integration:
     name: Master - integration test
     needs: master-integration-test-build
-    uses: fluent/fluent-bit-ci/.github/workflows/call-integration-test.yaml@main
+    uses: fluent/fluent-bit-ci/.github/workflows/call-run-integration-test.yaml@main
     with:
       image_name: ghcr.io/${{ github.repository }}/master
       image_tag: x86_64

--- a/.github/workflows/pr-integration-test.yaml
+++ b/.github/workflows/pr-integration-test.yaml
@@ -43,7 +43,7 @@ jobs:
     name: PR - K8S integration test
     needs:
       - pr-integration-test-build
-    uses: fluent/fluent-bit-ci/.github/workflows/call-integration-test.yaml@main
+    uses: fluent/fluent-bit-ci/.github/workflows/call-run-integration-test.yaml@main
     with:
       image_name: ghcr.io/${{ github.repository }}/pr-${{ github.event.pull_request.number }}
       image_tag: ${{ github.sha }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves workflow name to be correct.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
