### PR TITLE
in_http: allow multiple json payloads(#5810)

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -194,9 +194,6 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
                 flb_input_chunk_append_raw(ctx->ins, NULL, 0, mp_sbuf.data, mp_sbuf.size);
             }
             msgpack_sbuffer_destroy(&mp_sbuf);
-
-            break;
-    
         } 
         else if (result.data.type == MSGPACK_OBJECT_ARRAY) {
             obj = &result.data;


### PR DESCRIPTION
Fixes #5810 

This patch is to allow multiple json payloads per one http post.

input :
```
curl -d $'{"1":1}{"2":2}' -H "content-type: application/json" http://127.0.0.1:8888
```

output : 
```
[0] http.0: [1659219897.698633420, {"1"=>1}]
[1] http.0: [1659219897.698633420, {"2"=>2}]
```

Note: 
in_http already supports array to ingest multiple json.
```
curl -d $'[{"1":1}, {"2":2}]' -H "content-type: application/json" http://127.0.0.1:9880
```



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name http

[OUTPUT]
    Name stdout
```

## Debug log/Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==11225== Memcheck, a memory error detector
==11225== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11225== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==11225== Command: ../bin/fluent-bit -c a.conf
==11225== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/07/31 07:24:55] [ info] [fluent bit] version=2.0.0, commit=ce66b748e3, pid=11225
[2022/07/31 07:24:55] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/07/31 07:24:55] [ info] [cmetrics] version=0.3.5
[2022/07/31 07:24:55] [ info] [input:http:http.0] listening on 0.0.0.0:9880
[2022/07/31 07:24:55] [ info] [sp] stream processor started
[2022/07/31 07:24:55] [ info] [output:stdout:stdout.0] worker #0 started
[0] http.0: [1659219897.698633420, {"1"=>1}]
[1] http.0: [1659219897.698633420, {"2"=>2}]
^C[2022/07/31 07:24:59] [engine] caught signal (SIGINT)
[2022/07/31 07:24:59] [ warn] [engine] service will shutdown in max 5 seconds
[2022/07/31 07:25:00] [ info] [engine] service has stopped (0 pending tasks)
[2022/07/31 07:25:00] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/07/31 07:25:00] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==11225== 
==11225== HEAP SUMMARY:
==11225==     in use at exit: 0 bytes in 0 blocks
==11225==   total heap usage: 1,102 allocs, 1,102 frees, 1,179,095 bytes allocated
==11225== 
==11225== All heap blocks were freed -- no leaks are possible
==11225== 
==11225== For lists of detected and suppressed errors, rerun with: -s
==11225== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
