### PR TITLE
engine: close descriptors opened by mk_event_channel_create.

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -169,6 +169,7 @@ int flb_log_is_truncated(int type, const char *file, int line, const char *fmt, 
 #endif
 
 int flb_log_worker_init(struct flb_worker *worker);
+int flb_log_worker_fini(struct flb_worker *worker);
 int flb_errno_print(int errnum, const char *file, int line);
 
 #ifdef __FLB_FILENAME__

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -917,6 +917,10 @@ int flb_engine_start(struct flb_config *config)
                                  ret);
                         ret = config->exit_status_code;
                         flb_engine_shutdown(config);
+                        mk_event_channel_destroy(config->evl,
+                                                 config->ch_self_events[0],
+                                                 config->ch_self_events[1],
+                                                 (void *)&config->event_thread_init);
                         config = NULL;
                         return ret;
                     }

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -168,6 +168,22 @@ int flb_log_worker_init(struct flb_worker *worker)
     return 0;
 }
 
+int flb_log_worker_fini(struct flb_worker *worker)
+{
+    int rc1;
+    int rc2;
+
+    rc1 = close(worker->log[0]);
+    rc2 = close(worker->log[1]);
+    if (rc1 != 0) {
+        return rc1;
+    }
+    if (rc2 != 0) {
+        return rc2;
+    }
+    return 0;
+}
+
 int flb_log_set_level(struct flb_config *config, int level)
 {
     config->log->level = level;
@@ -516,6 +532,7 @@ int flb_log_destroy(struct flb_log *log, struct flb_config *config)
     /* Release resources */
     mk_event_loop_destroy(log->evl);
     flb_pipe_destroy(log->ch_mng);
+    flb_log_worker_fini(log->worker);
     flb_free(log->worker);
     flb_free(log);
 

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -352,6 +352,10 @@ static void output_thread(void *data)
      * - scheduler context
      * - parameters helper for coroutines
      */
+    mk_event_channel_destroy(th_ins->evl,
+                             th_ins->ch_thread_events[0],
+                             th_ins->ch_thread_events[1],
+                             &event_local);
     upstream_thread_destroy(th_ins);
     flb_upstream_conn_active_destroy_list(&th_ins->upstreams);
     flb_upstream_conn_pending_destroy_list(&th_ins->upstreams);
@@ -550,6 +554,10 @@ void flb_output_thread_pool_destroy(struct flb_output_instance *ins)
             continue;
         }
         pthread_join(th->tid, NULL);
+        mk_event_channel_destroy(th_ins->evl,
+                                 th_ins->ch_parent_events[0],
+                                 th_ins->ch_parent_events[1],
+                                 th_ins);
         flb_free(th_ins);
     }
 

--- a/src/flb_worker.c
+++ b/src/flb_worker.c
@@ -143,6 +143,7 @@ void flb_worker_destroy(struct flb_worker *worker)
     }
 
     mk_list_del(&worker->_head);
+    flb_log_worker_fini(worker);
     flb_free(worker);
 }
 


### PR DESCRIPTION
This pull request should fix several file descriptor leaks, most of which have not caused any issues since they usually only occur once when starting and stopping the main engine.

This work is relevant for #5580.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**

- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
