### PR TITLE
build: Make systemd init systemd detection contingent on pkgconfig

### DIFF
--- a/cmake/FindJournald.cmake
+++ b/cmake/FindJournald.cmake
@@ -5,6 +5,8 @@
 #  JOURNALD_INCLUDE_DIR - the Journald include directory
 #  JOURNALD_LIBRARIES - Link these to use Journald
 #  JOURNALD_DEFINITIONS - Compiler switches required for using Journald
+#  SYSTEMD_UNITDIR - The systemd units' directory
+#
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
@@ -16,7 +18,9 @@
 # in the FIND_PATH() and FIND_LIBRARY() calls
 find_package(PkgConfig)
 pkg_check_modules(PC_JOURNALD QUIET systemd)
+pkg_get_variable(PC_SYSTEMD_UNITDIR systemd "systemdsystemunitdir")
 
+set(SYSTEMD_UNITDIR ${PC_SYSTEMD_UNITDIR})
 set(JOURNALD_FOUND ${PC_JOURNALD_FOUND})
 set(JOURNALD_DEFINITIONS ${PC_JOURNALD_CFLAGS_OTHER})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -480,13 +480,13 @@ if(FLB_BINARY)
   endif()
 
   # Detect init system, install upstart, systemd or init.d script
-  if(IS_DIRECTORY /lib/systemd/system)
+  if(DEFINED SYSTEMD_UNITDIR)
     set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
     configure_file(
       "${PROJECT_SOURCE_DIR}/init/systemd.in"
       ${FLB_SYSTEMD_SCRIPT}
       )
-    install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION /lib/systemd/system)
+    install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
     install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
   elseif(IS_DIRECTORY /usr/share/upstart)
     set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")


### PR DESCRIPTION
Use pkg-config to get systemd.pc variables and systemdunitdir. Those
variable ensure that .service files are installed in the correct paths
and only when systemd is detected.

This addresses issues where systemd unit files are in /usr/lib and not in /lib like it was previously hardcoded. It also only installs service files on actual systemd systems.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [ N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
