### PR TITLE
windows: enabled Kinesis Firehose, Kinesis Stream, and AWS Filter

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -75,7 +75,8 @@ if(FLB_WINDOWS_DEFAULTS)
   set(FLB_OUT_KAFKA_REST         No)
   set(FLB_OUT_CLOUDWATCH_LOGS   Yes)
   set(FLB_OUT_S3                Yes)
-  set(FLB_OUT_KINESIS_FIREHOSE   No)
+  set(FLB_OUT_KINESIS_FIREHOSE   Yes)
+  set(FLB_OUT_KINESIS_STREAMS   Yes)
 
   # FILTER plugins
   # ==============
@@ -91,6 +92,7 @@ if(FLB_WINDOWS_DEFAULTS)
   set(FLB_FILTER_RECORD_MODIFIER Yes)
   set(FLB_FILTER_REWRITE_TAG    Yes)
   set(FLB_FILTER_GEOIP2         Yes)
+  set(FLB_FILTER_AWS         Yes)
 endif()
 
 # Search bison and flex executables

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -305,7 +305,7 @@ struct flush *new_flush_buffer()
     }
     buf->tmp_buf_size = PUT_RECORD_BATCH_PAYLOAD_SIZE;
 
-    buf->events = flb_malloc(sizeof(struct event) * MAX_EVENTS_PER_PUT);
+    buf->events = flb_malloc(sizeof(struct firehose_event) * MAX_EVENTS_PER_PUT);
     if (!buf->events) {
         flb_errno();
         flush_destroy(buf);

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -41,7 +41,7 @@ struct flush {
     size_t data_size;
 
     /* log records- each of these has a pointer to their message in tmp_buf */
-    struct event *events;
+    struct firehose_event *events;
     int events_capacity;
     /* current event */
     int event_index;
@@ -58,7 +58,7 @@ struct flush {
     int records_processed;
 };
 
-struct event {
+struct firehose_event {
     char *json;
     size_t len;
     struct timespec timestamp;

--- a/plugins/out_kinesis_firehose/firehose_api.c
+++ b/plugins/out_kinesis_firehose/firehose_api.c
@@ -42,8 +42,11 @@
 #include <msgpack.h>
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <unistd.h>
+#endif
 
 #include "firehose_api.h"
 
@@ -100,7 +103,7 @@ error:
  * Writes a log event to the output buffer
  */
 static int write_event(struct flb_firehose *ctx, struct flush *buf,
-                       struct event *event, int *offset)
+                       struct firehose_event *event, int *offset)
 {
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "{\"Data\":\"", 9)) {
@@ -154,7 +157,7 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
     int ret;
     size_t size;
     size_t b64_len;
-    struct event *event;
+    struct firehose_event *event;
     char *tmp_buf_ptr;
     char *time_key_ptr;
     struct tm time_stamp;
@@ -341,7 +344,7 @@ static int send_log_events(struct flb_firehose *ctx, struct flush *buf) {
     int ret;
     int offset;
     int i;
-    struct event *event;
+    struct firehose_event *event;
 
     if (buf->event_index <= 0) {
         /*
@@ -415,7 +418,7 @@ static int add_event(struct flb_firehose *ctx, struct flush *buf,
                      const msgpack_object *obj, struct flb_time *tms)
 {
     int ret;
-    struct event *event;
+    struct firehose_event *event;
     int retry_add = FLB_FALSE;
     size_t event_bytes = 0;
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -96,10 +96,10 @@ if(FLB_IN_LIB)
   endif()
 
   FLB_RT_TEST(FLB_OUT_CLOUDWATCH_LOGS   "out_cloudwatch.c")
-    # These plugins works only on Linux
+  FLB_RT_TEST(FLB_OUT_KINESIS_FIREHOSE  "out_firehose.c")
+  FLB_RT_TEST(FLB_OUT_KINESIS_STREAMS   "out_kinesis.c")
+    # These plugins work only on Linux
   if(NOT FLB_SYSTEM_WINDOWS)
-    FLB_RT_TEST(FLB_OUT_KINESIS_FIREHOSE  "out_firehose.c")
-    FLB_RT_TEST(FLB_OUT_KINESIS_STREAMS   "out_kinesis.c")
     FLB_RT_TEST(FLB_OUT_FILE              "out_file.c")
   endif()
   FLB_RT_TEST(FLB_OUT_S3                "out_s3.c")


### PR DESCRIPTION
## Summary

Currently, Windows release artifacts do not include the following-
- Kinesis Firehose output plugin
- Kinesis Streams output plugin
- AWS Filter

In this change, we are making the required changes to enable support for the same.

<!-- Provide summary of changes -->
The changes for the same include-
- Changing the struct name for Kinesis Firehose plugin so that the build can succeed (`error C2011: 'event': 'struct' type redefinition`)
- Addition of `FLB_OUT_KINESIS_STREAMS` to the Windows cmake file
- Adding of  `FLB_FILTER_AWS` to the Windows cmake file

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
