### PR TITLE
in_tail: Fix path_key when the file is rotated

### DIFF
--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -46,7 +46,9 @@ struct flb_tail_file {
     int   is_link;
     char *name;                 /* target file name given by scan routine */
     char *real_name;            /* real file name in the file system */
+    char *orig_name;            /* original file name (before rotation) */
     size_t name_len;
+    size_t orig_name_len;
     time_t rotated;
     int64_t pending_bytes;
 


### PR DESCRIPTION
Currently "path_key" tail option will send rotated filename after rotation, which is not the desired behavior. This PR fixes it.
