### PR TITLE
in_tail: added event based file ingestion batch limit

### DIFF
--- a/plugins/in_tail/tail.h
+++ b/plugins/in_tail/tail.h
@@ -38,6 +38,7 @@
 #define FLB_TAIL_REFRESH                 60   /* refresh every 60 seconds */
 #define FLB_TAIL_ROTATE_WAIT             "5"  /* time to monitor after rotation */
 #define FLB_TAIL_STATIC_BATCH_SIZE      "50M" /* static batch size */
+#define FLB_TAIL_EVENT_BATCH_SIZE       "50M" /* event batch size */
 
 int in_tail_collect_event(void *file, struct flb_config *config);
 

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -56,6 +56,9 @@ struct flb_tail_config {
     /* Static files processor */
     size_t static_batch_size;
 
+    /* Event files processor */
+    size_t event_batch_size;
+
     /* Collectors */
     int coll_fd_static;
     int coll_fd_scan;


### PR DESCRIPTION
This PR adds a batch limit to the tail function that ingests pending data from files that have been promoted to event mode.