### PR TITLE
in_node_exporter_metrics: handle missing fields in different kernel versions

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -25,6 +25,24 @@
 
 #include <unistd.h>
 
+/*
+ * See kernel documentation for a description:
+ * https://www.kernel.org/doc/html/latest/filesystems/proc.html
+ *
+ * user: normal processes executing in user mode
+ * nice: niced processes executing in user mode
+ * system: processes executing in kernel mode
+ * idle: twiddling thumbs
+ * iowait: In a word, iowait stands for waiting for I/O to complete. But there are several problems:
+ * irq: servicing interrupts
+ * softirq: servicing softirqs
+ * steal: involuntary wait
+ * guest: running a normal guest
+ * guest_nice: running a niced guest
+ *
+ * Ensure to pick the correct version of the documentation, older versions here:
+ * https://github.com/torvalds/linux/tree/master/Documentation
+ */
 struct cpu_stat_info {
     double user;
     double nice;
@@ -109,7 +127,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
             continue;
         }
 
-        /* Phisical ID */
+        /* Physical ID */
         ret = ne_utils_file_read_uint64(ctx->path_sysfs,
                                         entry->str,
                                         "topology", "physical_package_id",
@@ -223,8 +241,14 @@ static int stat_line(char *line, struct cpu_stat_info *st)
                  &st->steal,
                  &st->guest,
                  &st->guest_nice);
-    if (ret != 10) {
+
+    /* On some older kernels the 'guest_nice' value may be missing */
+    if (ret < 9) {
         return -1;
+    }
+    /* Ensure we zero initialise it */
+    if ( ret == 9 ) {
+        st->guest_nice = 0;
     }
 
     /* Convert to seconds based on USER_HZ kernel param */


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Older kernel versions may be missing the `guest_nice` field so instead of failing we should just ignore/zero it.
This then allows reporting of CPU metrics otherwise we get a complete failure.

```
[input:node_exporter_metrics:node_exporter_metrics.0] could not process line: cpu0 2781 461 1709 1962724 2666 22 31 427 0
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
