### PR TITLE
out_stackdriver: add name label to the metrics emitted

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2337,14 +2337,15 @@ static void update_http_metrics(struct flb_stackdriver *ctx,
 
     /* convert status to string format */
     snprintf(tmp, sizeof(tmp) - 1, "%i", http_status);
+    char *name = (char *) flb_output_name(ctx->ins);
 
     /* processed records total */
     cmt_counter_add(ctx->cmt_proc_records_total, ts, event_chunk->total_events,
-                    1, (char *[]) {tmp});
+                    2, (char *[]) {tmp, name});
 
     /* HTTP status */
     if (http_status != STACKDRIVER_NET_ERROR) {
-        cmt_counter_inc(ctx->cmt_requests_total, ts, 1, (char *[]) {tmp});
+        cmt_counter_inc(ctx->cmt_requests_total, ts, 2, (char *[]) {tmp, name});
     }
 }
 #endif

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -537,21 +537,21 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                                                  "stackdriver",
                                                  "requests_total",
                                                  "Total number of requests.",
-                                                  1, (char *[]) {"status"});
+                                                  2, (char *[]) {"status", "name"});
 
     ctx->cmt_proc_records_total = cmt_counter_create(ins->cmt,
                                                      "fluentbit",
                                                      "stackdriver",
                                                      "proc_records_total",
                                                      "Total number of processed records.",
-                                                     1, (char *[]) {"status"});
+                                                     2, (char *[]) {"status", "name"});
 
     ctx->cmt_retried_records_total = cmt_counter_create(ins->cmt,
                                                         "fluentbit",
                                                         "stackdriver",
                                                         "retried_records_total",
                                                         "Total number of retried records.",
-                                                        1, (char *[]) {"status"});
+                                                        2, (char *[]) {"status", "name"});
 
     /* OLD api */
     flb_metrics_add(FLB_STACKDRIVER_SUCCESSFUL_REQUESTS,


### PR DESCRIPTION
This change adds the `name` label to the metrics. When used with multiple
of the same exporter, the metrics from each of them become
indistinguishable from the others. This leads to problems when ingesting
metrics. For example the `prometheus` receiver in Open Telemetry will
assume they are one and the same metric and will replace existing data
points with later ones.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release -> Needed for the Ops Agent -> https://github.com/fluent/fluent-bit/pull/5837


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
