### PR TITLE
proxy: use flb_error api

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -141,8 +141,8 @@ static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
 #endif
     }
     else {
-        fprintf(stderr, "[proxy] unrecognized input proxy handler %i\n",
-                pc->proxy->def->proxy);
+        flb_error("[proxy] unrecognized input proxy handler %i",
+                  pc->proxy->def->proxy);
     }
 
     /* Set the context */
@@ -367,8 +367,8 @@ int flb_plugin_proxy_output_init(struct flb_plugin_proxy *proxy,
 #endif
     }
     else {
-        fprintf(stderr, "[proxy] unrecognized proxy handler %i\n",
-                proxy->def->proxy);
+        flb_error("[proxy] unrecognized proxy handler %i",
+                  proxy->def->proxy);
     }
 
     return ret;
@@ -383,8 +383,8 @@ struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
     /* Load shared library */
     handle = dlopen(dso_path, RTLD_LAZY);
     if (!handle) {
-        fprintf(stderr, "[proxy] error opening plugin %s: '%s'\n",
-                dso_path, dlerror());
+        flb_error("[proxy] error opening plugin %s: '%s'",
+                  dso_path, dlerror());
         return NULL;
     }
 

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -77,7 +77,7 @@ int proxy_go_output_register(struct flb_plugin_proxy *proxy,
 
     plugin->cb_init  = flb_plugin_proxy_symbol(proxy, "FLBPluginInit");
     if (!plugin->cb_init) {
-        fprintf(stderr, "[go proxy]: could not load FLBPluginInit symbol\n");
+        flb_error("[go proxy]: could not load FLBPluginInit symbol");
         flb_free(plugin);
         return -1;
     }
@@ -187,7 +187,7 @@ int proxy_go_input_register(struct flb_plugin_proxy *proxy,
 
     plugin->cb_init  = flb_plugin_proxy_symbol(proxy, "FLBPluginInit");
     if (!plugin->cb_init) {
-        fprintf(stderr, "[go proxy]: could not load FLBPluginInit symbol\n");
+        flb_error("[go proxy]: could not load FLBPluginInit symbol");
         flb_free(plugin);
         return -1;
     }


### PR DESCRIPTION
In some cases, fluent-bit calls fprintf to log error.
I think it should use flb_error or something.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Plugins_File ./plugins.conf

[INPUT]
    Name dummy

[OUTPUT]
    Name stdout
    Match *

[OUTPUT]
    Name gstdout
    Match *
```

plugins.conf:
``` 
[PLUGINS]
    Path /not/found/out_gstdout.so
```

## Debug log /Valgrind log

Valgrind reports errors.
I think it is not related this PR since only changing logging API.

```
$ valgrind  bin/fluent-bit -c gstdout.conf
==8004== Memcheck, a memory error detector
==8004== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8004== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==8004== Command: bin/fluent-bit -c gstdout.conf
==8004== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/06 07:43:42] [error] [proxy] error opening plugin /not/found/out_gstdout.so: '/not/found/out_gstdout.so: cannot open shared object file: No such file or directory'
[2022/08/06 07:43:42] [error] [plugin] error loading proxy plugin: /not/found/out_gstdout.so
[2022/08/06 07:43:42] [error] [config] section 'gstdout' tried to instance a plugin name that don't exists
[2022/08/06 07:43:42] [error] configuration file contains errors, aborting.
==8004== 
==8004== HEAP SUMMARY:
==8004==     in use at exit: 111,381 bytes in 431 blocks
==8004==   total heap usage: 807 allocs, 376 frees, 158,592 bytes allocated
==8004== 
==8004== LEAK SUMMARY:
==8004==    definitely lost: 0 bytes in 0 blocks
==8004==    indirectly lost: 0 bytes in 0 blocks
==8004==      possibly lost: 69,255 bytes in 413 blocks
==8004==    still reachable: 42,126 bytes in 18 blocks
==8004==                       of which reachable via heuristic:
==8004==                         newarray           : 320 bytes in 4 blocks
==8004==         suppressed: 0 bytes in 0 blocks
==8004== Rerun with --leak-check=full to see details of leaked memory
==8004== 
==8004== For lists of detected and suppressed errors, rerun with: -s
==8004== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
