### PR TITLE
aws_util: fix type of extra_user_agent

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -79,7 +79,7 @@ struct flb_aws_client {
     int port;
     char *proxy;
     int flags;
-    flb_sds_t *extra_user_agent;
+    flb_sds_t extra_user_agent;
     int free_user_agent;
 
     /*


### PR DESCRIPTION
This patch is to fix below warnings.

Currently a type of `extra_user_agent` is a `flb_sds_t *`.
I think it should be `flb_sds_t`.

-  `flb_sds_destroy` needs a `flb_sds_t`.
- `flb_sds_create` returns `flb_sds_t`.
```c
        tmp = flb_sds_create(buf);
        if (!tmp) {
            flb_errno();
            goto error;
        }
        aws_client->extra_user_agent = tmp;
```


Warnings:
```
[ 28%] Building C object src/aws/CMakeFiles/flb-aws.dir/flb_aws_util.c.o
/home/taka/git/fluent-bit/src/aws/flb_aws_util.c: In function ‘flb_aws_client_destroy’:
/home/taka/git/fluent-bit/src/aws/flb_aws_util.c:234:39: warning: passing argument 1 of ‘flb_sds_destroy’ from incompatible pointer type [-Wincompatible-pointer-types]
  234 |             flb_sds_destroy(aws_client->extra_user_agent);
      |                             ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
      |                                       |
      |                                       char **
In file included from /home/taka/git/fluent-bit/src/aws/flb_aws_util.c:21:
/home/taka/git/fluent-bit/include/fluent-bit/flb_sds.h:109:32: note: expected ‘flb_sds_t’ {aka ‘char *’} but argument is of type ‘char **’
  109 | void flb_sds_destroy(flb_sds_t s);
      |                      ~~~~~~~~~~^
/home/taka/git/fluent-bit/src/aws/flb_aws_util.c: In function ‘request_do’:
/home/taka/git/fluent-bit/src/aws/flb_aws_util.c:364:38: warning: assignment to ‘char **’ from incompatible pointer type ‘flb_sds_t’ {aka ‘char *’} [-Wincompatible-pointer-types]
  364 |         aws_client->extra_user_agent = tmp;
      |                                      ^
/home/taka/git/fluent-bit/src/aws/flb_aws_util.c:370:30: warning: passing argument 1 of ‘strcasecmp’ from incompatible pointer type [-Wincompatible-pointer-types]
  370 |     if (strcasecmp(aws_client->extra_user_agent, AWS_USER_AGENT_NONE) == 0) {
      |                    ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
      |                              |
      |                              char **
In file included from /usr/include/string.h:432,
                 from /home/taka/git/fluent-bit/lib/monkey/include/monkey/mk_core/mk_utils.h:25,
                 from /home/taka/git/fluent-bit/lib/monkey/include/monkey/mk_core/mk_iov.h:25,
                 from /home/taka/git/fluent-bit/lib/monkey/include/monkey/mk_core.h:35,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_macros.h:23,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_sds.h:29,
                 from /home/taka/git/fluent-bit/src/aws/flb_aws_util.c:21:
/usr/include/strings.h:116:36: note: expected ‘const char *’ but argument is of type ‘char **’
  116 | extern int strcasecmp (const char *__s1, const char *__s2)
      |                        ~~~~~~~~~~~~^~~~
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
