### PR TITLE
tests: internal: aws_util: remove timezone dependency

### DIFF
--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -3,6 +3,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_aws_util.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pthread.h>
 
 #include "flb_tests_internal.h"
 
@@ -46,6 +47,60 @@
 #define INVALID_TAG_DELIMITERS ",/"
 #define VALID_SEQ_INDEX 0
 
+
+pthread_mutex_t env_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int mktime_utc(struct tm *day, time_t *tm)
+{
+    int ret;
+    char *tzvar = NULL;
+    char orig_tz[256] = {0};
+    time_t t;
+
+    if (!TEST_CHECK(day != NULL)) {
+        TEST_MSG("struct tm is null");
+        return -1;
+    }
+    if (!TEST_CHECK(tm != NULL)) {
+        TEST_MSG("time_t is null");
+        return -1;
+    }
+
+    pthread_mutex_lock(&env_mutex);
+
+    /* save current TZ var */
+    tzvar = getenv("TZ");
+    if (tzvar != NULL) {
+        if (!TEST_CHECK(strlen(tzvar) <= sizeof(orig_tz))) {
+            TEST_MSG("TZ is large. len=%ld TZ=%s", strlen(tzvar), tzvar);
+            pthread_mutex_unlock(&env_mutex);
+            return -1;
+        }
+        strncpy(&orig_tz[0], tzvar, sizeof(orig_tz));
+    }
+
+    /* setenv is not thread safe */
+    ret = setenv("TZ", "UTC", 1);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("setenv failed");
+        pthread_mutex_unlock(&env_mutex);
+        return -1;
+    }
+
+    t = mktime(day);
+    *tm = t;
+
+    /* restore TZ */
+    if (tzvar != NULL) {
+        ret = setenv("TZ", &orig_tz[0], 1);
+    }
+    else {
+        ret = unsetenv("TZ");
+    }
+
+    pthread_mutex_unlock(&env_mutex);
+
+    return ret;
+}
 
 static void test_flb_aws_error()
 {
@@ -92,7 +147,9 @@ static void test_flb_get_s3_key_multi_tag_exists()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_TAG_PART, t, TAG, TAG_DELIMITER, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_TAG_PART) == 0);
 
@@ -103,7 +160,9 @@ static void test_flb_get_s3_key_full_tag()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_FULL_TAG, t, TAG, TAG_DELIMITER, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_FULL_TAG) == 0);
 
@@ -114,7 +173,9 @@ static void test_flb_get_s3_key_tag_special_characters()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_SPECIAL_CHARCATERS_TAG, t, TAG,
                                    TAG_DELIMITER, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_SPECIAL_CHARCATERS_TAG) == 0);
@@ -126,7 +187,9 @@ static void test_flb_get_s3_key_multi_tag_delimiter()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_TAG_PART, t, MULTI_DELIMITER_TAG,
                                    TAG_DELIMITERS, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_TAG_PART) == 0);
@@ -138,7 +201,9 @@ static void test_flb_get_s3_key_invalid_tag_delimiter()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_TAG_PART, t, MULTI_DELIMITER_TAG,
                                    INVALID_TAG_DELIMITERS, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_INVALID_DELIMITER)  == 0);
@@ -150,7 +215,9 @@ static void test_flb_get_s3_key_invalid_tag_index()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_INVALID_TAG, t, TAG, TAG_DELIMITER, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECY_KEY_INVALID_TAG) == 0);
 
@@ -169,7 +236,9 @@ static void test_flb_get_s3_key_invalid_key_length()
     }
     snprintf(buf, sizeof(buf), "%s%s", S3_KEY_FORMAT_SPECIAL_CHARCATERS_TAG, tmp);
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(buf, t, TAG, TAG_DELIMITER, 0);
     TEST_CHECK(strlen(s3_key_format) <= 1024);
 
@@ -180,7 +249,9 @@ static void test_flb_get_s3_key_static_string()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_STATIC_STRING, t, NO_TAG,
                                    TAG_DELIMITER, 0);
     TEST_CHECK(strcmp(s3_key_format, S3_KEY_FORMAT_STATIC_STRING) == 0);
@@ -192,7 +263,9 @@ static void test_flb_get_s3_key_valid_index()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_VALID_INDEX, t, NO_TAG,
                                    TAG_DELIMITER, 12);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_VALID_INDEX) == 0);
@@ -203,9 +276,10 @@ static void test_flb_get_s3_key_valid_index()
 static void test_flb_get_s3_key_increment_index()
 {
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
-
+    time_t t;
     flb_sds_t s3_key_format = NULL;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_VALID_INDEX, t, NO_TAG,
                                     TAG_DELIMITER, 5);
 
@@ -225,9 +299,10 @@ static void test_flb_get_s3_key_index_overflow()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
-
+    time_t t;
     uint64_t index = 18446744073709551615U;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_VALID_INDEX, t, NO_TAG,
                                    TAG_DELIMITER, index);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_PRE_OVERFLOW_INDEX) == 0);
@@ -245,7 +320,9 @@ static void test_flb_get_s3_key_mixed_timestamp()
 {
     flb_sds_t s3_key_format = NULL;
     struct tm day = { 0, 0, 0, 15, 7, 120};
-    time_t t = mktime(&day);
+    time_t t;
+
+    mktime_utc(&day, &t);
     s3_key_format = flb_get_s3_key(S3_KEY_FORMAT_MIXED_TIMESTAMP, t, NO_TAG,
                                    TAG_DELIMITER, 12);
     TEST_CHECK(strcmp(s3_key_format, S3_OBJECT_KEY_MIXED_TIMESTAMP) == 0);


### PR DESCRIPTION
Current `flb-it-aws_util` may fail on some environment since it uses `mktime` and it depends on timezone.

<details>
<summary> TZ=Australia/Sydney </summary>

```
$ TZ=Australia/Sydney bin/flb-it-aws_util 
Test parse_api_error...                         [ OK ]
Test flb_aws_endpoint...                        [ OK ]
Test flb_get_s3_key_multi_tag_exists...         [ FAILED ]
  aws_util.c:97: Check strcmp(s3_key_format, S3_OBJECT_KEY_TAG_PART) == 0... failed
Test flb_get_s3_key_full_tag...                 [ FAILED ]
  aws_util.c:108: Check strcmp(s3_key_format, S3_OBJECT_KEY_FULL_TAG) == 0... failed
Test flb_get_s3_key_tag_special_characters...   [ FAILED ]
  aws_util.c:120: Check strcmp(s3_key_format, S3_OBJECT_KEY_SPECIAL_CHARCATERS_TAG) == 0... failed
Test flb_get_s3_key_multi_tag_delimiter...      [ FAILED ]
  aws_util.c:132: Check strcmp(s3_key_format, S3_OBJECT_KEY_TAG_PART) == 0... failed
Test flb_get_s3_key_invalid_tag_delimiter...    [2022/08/06 12:57:05] [ warn] [s3_key] Invalid Tag delimiter: does not exist in tag. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d
[2022/08/06 12:57:05] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d, delimiters=,/
[ FAILED ]
  aws_util.c:144: Check strcmp(s3_key_format, S3_OBJECT_KEY_INVALID_DELIMITER) == 0... failed
Test flb_get_s3_key_invalid_tag_index...        [2022/08/06 12:57:05] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb.ccc, format=logs/$TAG[2]/$TAG[-1]/%Y/%m/%d, delimiters=.
[ FAILED ]
  aws_util.c:155: Check strcmp(s3_key_format, S3_OBJECY_KEY_INVALID_TAG) == 0... failed
Test flb_get_s3_key_invalid_key_length...       [2022/08/06 12:57:05] [ warn] [s3_key] Object key length is longer than the 1024 character limit.
[ OK ]
Test flb_get_s3_key_static_string...            [ OK ]
Test flb_get_s3_key_valid_index...              [ OK ]
Test flb_get_s3_key_increment_index...          [ OK ]
Test flb_get_s3_key_index_overflow...           [ OK ]
Test flb_get_s3_key_mixed_timestamp...          [ FAILED ]
  aws_util.c:251: Check strcmp(s3_key_format, S3_OBJECT_KEY_MIXED_TIMESTAMP) == 0... failed
FAILED: 7 of 14 unit tests have failed.
```

</details>

<details>
<summary> TZ=UTC </summary>

```
$ TZ=UTC bin/flb-it-aws_util 
Test parse_api_error...                         [ OK ]
Test flb_aws_endpoint...                        [ OK ]
Test flb_get_s3_key_multi_tag_exists...         [ OK ]
Test flb_get_s3_key_full_tag...                 [ OK ]
Test flb_get_s3_key_tag_special_characters...   [ OK ]
Test flb_get_s3_key_multi_tag_delimiter...      [ OK ]
Test flb_get_s3_key_invalid_tag_delimiter...    [2022/08/06 02:57:27] [ warn] [s3_key] Invalid Tag delimiter: does not exist in tag. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d
[2022/08/06 02:57:27] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d, delimiters=,/
[ OK ]
Test flb_get_s3_key_invalid_tag_index...        [2022/08/06 02:57:27] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb.ccc, format=logs/$TAG[2]/$TAG[-1]/%Y/%m/%d, delimiters=.
[ OK ]
Test flb_get_s3_key_invalid_key_length...       [2022/08/06 02:57:27] [ warn] [s3_key] Object key length is longer than the 1024 character limit.
[ OK ]
Test flb_get_s3_key_static_string...            [ OK ]
Test flb_get_s3_key_valid_index...              [ OK ]
Test flb_get_s3_key_increment_index...          [ OK ]
Test flb_get_s3_key_index_overflow...           [ OK ]
Test flb_get_s3_key_mixed_timestamp...          [ OK ]
SUCCESS: All unit tests have passed.
```

</details>

This patch is to set UTC+0 timezone to remove timezone dependency.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log / Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-aws_util 
==44056== Memcheck, a memory error detector
==44056== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==44056== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==44056== Command: bin/flb-it-aws_util
==44056== 
Test parse_api_error...                         [ OK ]
Test flb_aws_endpoint...                        [ OK ]
Test flb_get_s3_key_multi_tag_exists...         [ OK ]
Test flb_get_s3_key_full_tag...                 [ OK ]
Test flb_get_s3_key_tag_special_characters...   [ OK ]
Test flb_get_s3_key_multi_tag_delimiter...      [ OK ]
Test flb_get_s3_key_invalid_tag_delimiter...    [2022/08/06 02:54:54] [ warn] [s3_key] Invalid Tag delimiter: does not exist in tag. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d
[2022/08/06 02:54:54] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb-ccc, format=logs/$TAG[2]/$TAG[0]/%Y/%m/%d, delimiters=,/
[ OK ]
Test flb_get_s3_key_invalid_tag_index...        [2022/08/06 02:54:54] [ warn] [s3_key] Invalid / Out of bounds tag part: At most 10 tag parts ($TAG[0] - $TAG[9]) can be processed. tag=aa.bb.ccc, format=logs/$TAG[2]/$TAG[-1]/%Y/%m/%d, delimiters=.
[ OK ]
Test flb_get_s3_key_invalid_key_length...       [2022/08/06 02:54:54] [ warn] [s3_key] Object key length is longer than the 1024 character limit.
[ OK ]
Test flb_get_s3_key_static_string...            [ OK ]
Test flb_get_s3_key_valid_index...              [ OK ]
Test flb_get_s3_key_increment_index...          [ OK ]
Test flb_get_s3_key_index_overflow...           [ OK ]
Test flb_get_s3_key_mixed_timestamp...          [ OK ]
SUCCESS: All unit tests have passed.
==44056== 
==44056== HEAP SUMMARY:
==44056==     in use at exit: 0 bytes in 0 blocks
==44056==   total heap usage: 250 allocs, 250 frees, 43,401 bytes allocated
==44056== 
==44056== All heap blocks were freed -- no leaks are possible
==44056== 
==44056== For lists of detected and suppressed errors, rerun with: -s
==44056== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
