### PR TITLE
config: remove unused ch_event

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -40,8 +40,6 @@
 
 /* Main struct to hold the configuration of the runtime service */
 struct flb_config {
-    struct mk_event ch_event;
-
     int support_mode;         /* enterprise support mode ?      */
     int is_ingestion_active;  /* date ingestion active/allowed  */
     int is_shutting_down;     /* is the service shutting down ? */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -176,7 +176,6 @@ struct flb_config *flb_config_init()
         return NULL;
     }
 
-    MK_EVENT_ZERO(&config->ch_event);
     MK_EVENT_ZERO(&config->event_flush);
     MK_EVENT_ZERO(&config->event_shutdown);
 
@@ -347,11 +346,6 @@ void flb_config_exit(struct flb_config *config)
     if (config->kernel) {
         flb_free(config->kernel->s_version.data);
         flb_free(config->kernel);
-    }
-
-    /* release resources */
-    if (config->ch_event.fd) {
-        mk_event_closesocket(config->ch_event.fd);
     }
 
     /* Pipe */


### PR DESCRIPTION
This patch is to remove unused variable `config->ch_event`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
