### PR TITLE
engine: pass config->ch_event explicitly

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -627,7 +627,7 @@ int flb_engine_start(struct flb_config *config)
     ret = mk_event_channel_create(config->evl,
                                   &config->ch_manager[0],
                                   &config->ch_manager[1],
-                                  config);
+                                  &config->ch_event);
     if (ret != 0) {
         flb_error("[engine] could not create manager channels");
         return -1;


### PR DESCRIPTION
&config and &config->ch_event points same address since ch_event is a first member of struct.
We can pass &config instead of &config->ch_event.
However it is a risk of bug.
- If the first member of struct will be changed, the code will be broken. However we can compile it. #5843 
- We misunderstand the function needs a config, not a ch_event.

This patch is to pass `config->ch_event` explicitly.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
