### PR TITLE
lib: monkey: core event kqueue: don't use NOTE_SECONDS on macOS (#5756 backport to 1.9)

### DIFF
--- a/lib/monkey/mk_core/mk_event_kqueue.c
+++ b/lib/monkey/mk_core/mk_event_kqueue.c
@@ -201,12 +201,14 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
     event->_priority_head.next = NULL;
     event->_priority_head.prev = NULL;
 
-#ifdef NOTE_SECONDS
+#if defined(NOTE_SECONDS) && !defined(__APPLE__)
     /* FreeBSD or LINUX_KQUEUE defined */
     /* TODO : high resolution interval support. */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, NOTE_SECONDS, sec, event);
 #else
     /* Other BSD have no NOTE_SECONDS & specify milliseconds */
+    /* Also, on macOS, NOTE_SECONDS has severe side effect that cause
+     * performance degradation. */
     EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, (sec * 1000) + (nsec / 1000000) , event);
 #endif
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);


### PR DESCRIPTION
When using NOTE_SECONDS side of EV_SET routine on macOS,
we got a severe performance degradation on threaded input plugin
environment.

Instead, we shouldn't use NOTE_SECONDS event filtering flag and
specify as milliseconds on macOS.

Closes https://github.com/fluent/fluent-bit/issues/5760

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
