### PR TITLE
record_accessor: add NULL check(#5846)

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -619,6 +619,9 @@ int flb_ra_regex_match(struct flb_record_accessor *ra, msgpack_object map,
     struct flb_ra_parser *rp;
 
     rp = mk_list_entry_first(&ra->list, struct flb_ra_parser, _head);
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
     return flb_ra_key_regex_match(rp->key->name, map, rp->key->subkeys,
                                   regex, result);
 }


### PR DESCRIPTION
This patch is to prevent below SIGSEGV of filter_rewrite_tag.

```
$ ../bin/fluent-bit -c bug.conf 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/12 14:03:37] [ info] [fluent bit] version=2.0.0, commit=fc325524d5, pid=43215
[2022/08/12 14:03:37] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/12 14:03:37] [ info] [cmetrics] version=0.3.5
[2022/08/12 14:03:37] [ info] [sp] stream processor started
[2022/08/12 14:03:37] [ info] [output:stdout:stdout.0] worker #0 started
[2022/08/12 14:03:37] [engine] caught signal (SIGSEGV)
#0  0x5611f7c539eb      in  flb_ra_regex_match() at src/flb_record_accessor.c:622
#1  0x5611f7d71b12      in  process_record() at plugins/filter_rewrite_tag/rewrite_tag.c:333
#2  0x5611f7d71ddb      in  cb_rewrite_tag_filter() at plugins/filter_rewrite_tag/rewrite_tag.c:421
#3  0x5611f7c16d09      in  flb_filter_do() at src/flb_filter.c:124
#4  0x5611f7c5bb31      in  input_chunk_append_raw() at src/flb_input_chunk.c:1480
#5  0x5611f7c5c277      in  flb_input_chunk_append_raw() at src/flb_input_chunk.c:1727
#6  0x5611f7c9aeb8      in  in_dummy_collect() at plugins/in_dummy/in_dummy.c:109
#7  0x5611f7c1376a      in  flb_input_collector_fd() at src/flb_input.c:1536
#8  0x5611f7c2c9d2      in  flb_engine_handle_event() at src/flb_engine.c:441
#9  0x5611f7c2c9d2      in  flb_engine_start() at src/flb_engine.c:802
#10 0x5611f7c04e74      in  flb_lib_worker() at src/flb_lib.c:626
#11 0x7f3e26da8608      in  start_thread() at 2.31/nptl/pthread_create.c:477
#12 0x7f3e26a8a132      in  ???() at /x86_64/clone.S:95
#13 0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    Name dummy
    Tag input

[FILTER]
    Name rewrite_tag
    Match input
    Rule $TAG hoge new_tag false

[OUTPUT]
    Name stdout
    Match *
```

## Debug / Valgrind output

```
$ valgrind --leak-check=full ../bin/fluent-bit -c bug.conf 
==64607== Memcheck, a memory error detector
==64607== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==64607== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==64607== Command: ../bin/fluent-bit -c bug.conf
==64607== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/12 14:38:20] [ info] [fluent bit] version=2.0.0, commit=fc325524d5, pid=64607
[2022/08/12 14:38:20] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/12 14:38:20] [ info] [cmetrics] version=0.3.5
[2022/08/12 14:38:20] [ info] [output:stdout:stdout.0] worker #0 started
[2022/08/12 14:38:20] [ info] [sp] stream processor started
[0] input: [1660282701.789670450, {"message"=>"dummy"}]
[0] input: [1660282702.770458517, {"message"=>"dummy"}]
^C[2022/08/12 14:38:24] [engine] caught signal (SIGINT)
[2022/08/12 14:38:24] [ warn] [engine] service will shutdown in max 5 seconds
[0] input: [1660282703.749755398, {"message"=>"dummy"}]
[2022/08/12 14:38:24] [ info] [input] pausing dummy.0
[2022/08/12 14:38:24] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/12 14:38:24] [ info] [input] pausing dummy.0
[2022/08/12 14:38:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/08/12 14:38:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==64607== 
==64607== HEAP SUMMARY:
==64607==     in use at exit: 0 bytes in 0 blocks
==64607==   total heap usage: 1,325 allocs, 1,325 frees, 1,366,260 bytes allocated
==64607== 
==64607== All heap blocks were freed -- no leaks are possible
==64607== 
==64607== For lists of detected and suppressed errors, rerun with: -s
==64607== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
