### PR TITLE
cf_fluentbit: report undefined value error(#5880)

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -603,8 +603,12 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         key = buf + indent_len;
         key_len = i;
 
-        if (!key || i < 0) {
+        if (!key) {
             config_error(cfg_file, line, "undefined key - check config is in valid classic format");
+            goto error;
+        }
+        else if(i < 0) {
+            config_error(cfg_file, line, "undefined value - check config is in valid classic format");
             goto error;
         }
 

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -4,10 +4,15 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_config_format.h>
+#include <fluent-bit/flb_sds.h>
+#include <sys/stat.h>
 
 #include "flb_tests_internal.h"
 
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/classic/fluent-bit.conf"
+#define FLB_001 FLB_TESTS_DATA_PATH "/data/config_format/classic/issue_5880.conf"
+
+#define ERROR_LOG "fluentbit_conf_error.log"
 
 /* data/config_format/fluent-bit.conf */
 void test_basic()
@@ -57,7 +62,103 @@ void test_basic()
     flb_cf_destroy(cf);
 }
 
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+static int check_str_list(struct str_list *list, FILE *fp)
+{
+    flb_sds_t error_str = NULL;
+    char *p = NULL;
+    size_t size;
+    int str_size = 4096;
+    int i;
+    int fd = fileno(fp);
+    struct stat st;
+
+    if (!TEST_CHECK(list != NULL)) {
+        TEST_MSG("list is NULL");
+        return -1;
+    }
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fp is NULL");
+        return -1;
+    }
+
+    if (!TEST_CHECK(fstat(fd, &st) == 0)) {
+        TEST_MSG("fstat failed");
+        return -1;
+    }
+    str_size = st.st_size;
+    error_str = flb_sds_create_size(str_size);
+    if (!TEST_CHECK(error_str != NULL)) {
+        TEST_MSG("flb_sds_create_size failed.");
+        return -1;
+    }
+
+    size = fread(error_str, 1, str_size, fp);
+    if (size < str_size) {
+        if (!TEST_CHECK(ferror(fp) == 0)) {
+            TEST_MSG("fread failed.");
+            clearerr(fp);
+            flb_sds_destroy(error_str);
+            return -1;
+        }
+        clearerr(fp);
+    }
+
+    for (i=0; i<list->size; i++) {
+        p = strstr(error_str, list->lists[i]);
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("  Got   :%s\n  expect:%s", error_str, list->lists[i]);
+        }
+    }
+
+    flb_sds_destroy(error_str);
+    return 0;
+}
+
+
+/* https://github.com/fluent/fluent-bit/issues/5880 */
+void missing_value()
+{
+	struct flb_cf *cf;
+    FILE *fp = NULL;
+    char *expected_strs[] = {"undefined value", ":9:" /* lieno*/ };
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    unlink(ERROR_LOG);
+
+    fp = freopen(ERROR_LOG, "w+", stderr);
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("freopen failed. errno=%d path=%s", errno, ERROR_LOG);
+        exit(EXIT_FAILURE);
+    }
+
+    cf = flb_cf_fluentbit_create(NULL, FLB_001, NULL, 0);
+    TEST_CHECK(cf == NULL);
+    fflush(fp);
+    fclose(fp);
+
+    fp = fopen(ERROR_LOG, "r");
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fopen failed. errno=%d path=%s", errno, ERROR_LOG);
+        unlink(ERROR_LOG);
+        exit(EXIT_FAILURE);
+    }
+
+    check_str_list(&expected, fp);
+
+    fclose(fp);
+    unlink(ERROR_LOG);
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
+    { "missing_value_issue5880" , missing_value},
     { 0 }
 };

--- a/tests/internal/data/config_format/classic/issue_5880.conf
+++ b/tests/internal/data/config_format/classic/issue_5880.conf
@@ -1,0 +1,14 @@
+[INPUT]
+    Name dummy
+    Tag dummy
+
+[FILTER]
+    Name modify
+    Match *
+    ADD foo bar
+    ADD
+
+[OUTPUT]
+    Name stdout
+    Match *
+    Format


### PR DESCRIPTION
Fixes #5880 

This patch is to report undefined value error.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->


## Configuration 

```
[INPUT]
    Name dummy
    Tag dummy

[FILTER]
    Name modify
    Match *
    ADD foo bar
    ADD

[OUTPUT]
    Name stdout
    Match *
    Format
```

## Debug / Valgrind output
Fluent-bit reports below error.
```
[2022/08/13 11:04:49] [error] [config] error in a.conf:9: undefined value - check config is in valid classic format
```

```
$ valgrind --leak-check=full ../bin/fluent-bit -c a.conf 
==107791== Memcheck, a memory error detector
==107791== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==107791== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==107791== Command: ../bin/fluent-bit -c a.conf
==107791== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/13 11:04:49] [error] [config] error in a.conf:9: undefined value - check config is in valid classic format
[2022/08/13 11:04:49] [ info] [fluent bit] version=2.0.0, commit=50087cac0a, pid=107791
[2022/08/13 11:04:49] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/13 11:04:49] [ info] [cmetrics] version=0.3.5
[2022/08/13 11:04:50] [ info] [sp] stream processor started
^C[2022/08/13 11:04:51] [engine] caught signal (SIGINT)
[2022/08/13 11:04:51] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/13 11:04:51] [ info] [input] pausing dummy.0
[2022/08/13 11:04:51] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/13 11:04:51] [ info] [input] pausing dummy.0
==107791== 
==107791== HEAP SUMMARY:
==107791==     in use at exit: 106,442 bytes in 3,650 blocks
==107791==   total heap usage: 5,491 allocs, 1,841 frees, 701,186 bytes allocated
==107791== 
==107791== LEAK SUMMARY:
==107791==    definitely lost: 0 bytes in 0 blocks
==107791==    indirectly lost: 0 bytes in 0 blocks
==107791==      possibly lost: 0 bytes in 0 blocks
==107791==    still reachable: 106,442 bytes in 3,650 blocks
==107791==         suppressed: 0 bytes in 0 blocks
==107791== Reachable blocks (those to which a pointer was found) are not shown.
==107791== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==107791== 
==107791== For lists of detected and suppressed errors, rerun with: -s
==107791== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
