### PR TITLE
pack: Fix Heap-double-free in flb_pack_state_reset

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -323,11 +323,13 @@ int flb_pack_state_init(struct flb_pack_state *s)
 void flb_pack_state_reset(struct flb_pack_state *s)
 {
     flb_free(s->tokens);
+    s->tokens = NULL;
     s->tokens_size  = 0;
     s->tokens_count = 0;
     s->last_byte    = 0;
     s->buf_size     = 0;
     flb_free(s->buf_data);
+    s->buf_data = NULL;
 }
 
 


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45978

In `in_lib_collect`:
```cpp
    else if (ret == FLB_ERR_JSON_INVAL) {
        flb_plg_warn(ctx->ins, "lib data invalid");
        flb_pack_state_reset(&ctx->state);
        flb_pack_state_init(&ctx->state);
        return -1;
    }
```
When `flb_pack_state_init` returns with an error because `s->tokens = flb_malloc(size);` fails, it leaves `s->buf_data` with already freed pointer value because `flb_pack_state_reset` only frees the `s->buf_data` but doesn't reset its value. Later it leads to double free when `flb_pack_state_reset(&ctx->state);` is called on the same `ctx->state`.