### PR TITLE
Fix segfault on delete unset chunk.state

### DIFF
--- a/lib/chunkio/src/cio_chunk.c
+++ b/lib/chunkio/src/cio_chunk.c
@@ -503,7 +503,9 @@ static inline void chunk_state_sync(struct cio_chunk *ch)
         return;
     }
 
-    mk_list_del(&ch->_state_head);
+    if (!mk_list_is_set(&ch->_state_head)) {
+        mk_list_del(&ch->_state_head);
+    }
     st = ch->st;
     if (cio_chunk_is_up(ch) == CIO_TRUE) {
         mk_list_add(&ch->_state_head, &st->chunks_up);


### PR DESCRIPTION
Check that chunk state is set before call delete on it

Fixes #5889

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
