### PR TITLE
record_accessor: add NULL check(#5846)

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -619,6 +619,9 @@ int flb_ra_regex_match(struct flb_record_accessor *ra, msgpack_object map,
     struct flb_ra_parser *rp;
 
     rp = mk_list_entry_first(&ra->list, struct flb_ra_parser, _head);
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
     return flb_ra_key_regex_match(rp->key->name, map, rp->key->subkeys,
                                   regex, result);
 }


### PR DESCRIPTION
This patch is to prevent below SIGSEGV of filter_rewrite_tag for 1.9 branch.
Original PR is https://github.com/fluent/fluent-bit/pull/5877 .

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    Name dummy
    Tag input

[FILTER]
    Name rewrite_tag
    Match input
    Rule $TAG hoge new_tag false

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c 5846/bug.conf 
==87908== Memcheck, a memory error detector
==87908== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==87908== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==87908== Command: bin/fluent-bit -c 5846/bug.conf
==87908== 
Fluent Bit v1.9.8
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/16 07:24:14] [ info] [fluent bit] version=1.9.8, commit=9501e6d60a, pid=87908
[2022/08/16 07:24:14] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/16 07:24:14] [ info] [cmetrics] version=0.3.5
[2022/08/16 07:24:14] [ info] [output:stdout:stdout.0] worker #0 started
[2022/08/16 07:24:14] [ info] [sp] stream processor started
[0] input: [1660602255.027152861, {"message"=>"dummy"}]
[0] input: [1660602256.022172044, {"message"=>"dummy"}]
^C[2022/08/16 07:24:17] [engine] caught signal (SIGINT)
[0] input: [1660602256.997265834, {"message"=>"dummy"}]
[2022/08/16 07:24:17] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/16 07:24:17] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/16 07:24:18] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/08/16 07:24:18] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==87908== 
==87908== HEAP SUMMARY:
==87908==     in use at exit: 106,442 bytes in 3,650 blocks
==87908==   total heap usage: 5,831 allocs, 2,181 frees, 1,502,401 bytes allocated
==87908== 
==87908== LEAK SUMMARY:
==87908==    definitely lost: 0 bytes in 0 blocks
==87908==    indirectly lost: 0 bytes in 0 blocks
==87908==      possibly lost: 0 bytes in 0 blocks
==87908==    still reachable: 106,442 bytes in 3,650 blocks
==87908==         suppressed: 0 bytes in 0 blocks
==87908== Reachable blocks (those to which a pointer was found) are not shown.
==87908== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==87908== 
==87908== For lists of detected and suppressed errors, rerun with: -s
==87908== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
