### PR TITLE
out_s3: add store_dir_limit_size to limit S3 disk usage

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -506,7 +506,6 @@ static int cb_s3_init(struct flb_output_instance *ins,
     int ret;
     flb_sds_t tmp_sds;
     int async_flags;
-    int len;
     char *role_arn = NULL;
     char *session_name;
     const char *tmp;
@@ -540,6 +539,15 @@ static int cb_s3_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    /* the check against -1 is works here because size_t is unsigned
+     * and (int) -1 == unsigned max value
+     * Fluent Bit uses -1 (which becomes max value) to indicate undefined
+     */
+    if (ctx->ins->total_limit_size != -1) {
+        flb_plg_warn(ctx->ins, "Please use 'store_dir_limit_size' with s3 output instead of 'storage.total_limit_size'. "
+                     "S3 has its own buffer files located in the store_dir.");
+    }
+
     /* Date key */
     ctx->date_key = ctx->json_date_key;
     tmp = flb_output_get_property("json_date_key", ins);
@@ -568,15 +576,6 @@ static int cb_s3_init(struct flb_output_instance *ins,
     if (!tmp) {
         flb_plg_error(ctx->ins, "'bucket' is a required parameter");
         return -1;
-    }
-
-    tmp = flb_output_get_property("chunk_buffer_dir", ins);
-    if (tmp) {
-        len = strlen(tmp);
-        if (tmp[len - 1] == '/' || tmp[len - 1] == '\\') {
-            flb_plg_error(ctx->ins, "'chunk_buffer_dir' can not end in a / or \\");
-            return -1;
-        }
     }
 
     /*
@@ -2361,6 +2360,15 @@ static struct flb_config_map config_map[] = {
      "Directory to locally buffer data before sending. Plugin uses the S3 Multipart "
      "upload API to send data in chunks of 5 MB at a time- only a small amount of"
      " data will be locally buffered at any given point in time."
+    },
+
+    {
+     FLB_CONFIG_MAP_SIZE, "store_dir_limit_size", (char *) NULL,
+     0, FLB_TRUE, offsetof(struct flb_s3, store_dir_limit_size),
+     "S3 plugin has its own buffering system with files in the `store_dir`. "
+     "Use the `store_dir_limit_size` to limit the amount of data S3 buffers in "
+     "the `store_dir` to limit disk usage. If the limit is reached, "
+     "data will be discarded. Default is 0 which means unlimited."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -120,6 +120,10 @@ struct flb_s3 {
     int compression;
     int port;
     int insecure;
+    size_t store_dir_limit_size;
+
+    /* track the total amount of buffered data */
+    size_t current_buffer_size;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -130,6 +130,13 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
     int ret;
     flb_sds_t name;
     struct flb_fstore_file *fsf;
+    size_t space_remaining;
+
+    if (ctx->store_dir_limit_size > 0 && ctx->current_buffer_size + bytes >= ctx->store_dir_limit_size) {
+        flb_plg_error(ctx->ins, "Buffer is full: current_buffer_size=%zu, new_data=%zu, store_dir_limit_size=%zu bytes",
+                    ctx->current_buffer_size, bytes, ctx->store_dir_limit_size);
+        return -1;
+    }
 
     /* If no target file was found, create a new one */
     if (!s3_file) {
@@ -184,6 +191,17 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
         return -1;
     }
     s3_file->size += bytes;
+    ctx->current_buffer_size += bytes;
+
+    /* if buffer is 95% full, warn user */
+    if (ctx->store_dir_limit_size > 0) {
+        space_remaining = ctx->store_dir_limit_size - ctx->current_buffer_size;
+        if ((space_remaining * 20) < ctx->store_dir_limit_size) {
+            flb_plg_warn(ctx->ins, "Buffer is almost full: current_buffer_size=%zu, store_dir_limit_size=%zu bytes",
+                        ctx->current_buffer_size, ctx->store_dir_limit_size);
+            return -1;
+        }
+    }
 
     return 0;
 }
@@ -397,6 +415,7 @@ int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file)
     struct flb_fstore_file *fsf;
 
     fsf = s3_file->fsf;
+    ctx->current_buffer_size -= s3_file->size;
 
     /* permanent deletion */
     flb_fstore_file_delete(ctx->fs, fsf);


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/956/files

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
