### PR TITLE
plugins: out_azure_kusto: removed deprecated header

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -25,7 +25,6 @@
 #include <fluent-bit/flb_utils.h>
 
 #include <math.h>
-#include <mbedtls/base64.h>
 #include <msgpack.h>
 
 #include "azure_kusto_ingest.h"


### PR DESCRIPTION
Removed a reference to a deprecated header. 

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>