### PR TITLE
openssl: remove deprecated SSL_load_error_strings

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -68,8 +68,6 @@ static int tls_init(void)
     OPENSSL_add_all_algorithms_noconf();
     SSL_load_error_strings();
     SSL_library_init();
-#else
-    SSL_load_error_strings();
 #endif
     return 0;
 }


### PR DESCRIPTION
Refer to doc, `SSL_load_error_strings` has been deprecated since OpenSSL v1.1.0.
https://www.openssl.org/docs/man3.0/man3/SSL_load_error_strings.html
```
The ERR_load_crypto_strings(), SSL_load_error_strings(), and ERR_free_strings() functions were deprecated in OpenSSL 1.1.0 by OPENSSL_init_crypto() and OPENSSL_init_ssl() and should not be used.
```

I think it causes below valgrind leak report.
```
$ valgrind --leak-check=full --show-leak-kinds=all bin/fluent-bit -i dummy -o null
==38038== Memcheck, a memory error detector
==38038== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==38038== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==38038== Command: bin/fluent-bit -i dummy -o null
==38038== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/18 12:56:04] [ info] [fluent bit] version=2.0.0, commit=8cb84b17d2, pid=38038
[2022/08/18 12:56:04] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/18 12:56:04] [ info] [cmetrics] version=0.3.5
[2022/08/18 12:56:04] [ info] [output:null:null.0] worker #0 started
[2022/08/18 12:56:04] [ info] [sp] stream processor started
^C[2022/08/18 12:56:04] [engine] caught signal (SIGINT)
[2022/08/18 12:56:04] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/18 12:56:04] [ info] [input] pausing dummy.0
[2022/08/18 12:56:05] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/18 12:56:05] [ info] [input] pausing dummy.0
[2022/08/18 12:56:05] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/08/18 12:56:05] [ info] [output:null:null.0] thread worker #0 stopped
==38038== 
==38038== HEAP SUMMARY:
==38038==     in use at exit: 106,442 bytes in 3,650 blocks
==38038==   total heap usage: 5,586 allocs, 1,936 frees, 683,646 bytes allocated
==38038== 
==38038== 8 bytes in 1 blocks are still reachable in loss record 1 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9931A: CRYPTO_strdup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3E02: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F45D7: CONF_module_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3D96: OPENSSL_load_builtin_modules (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A37: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BB77: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038== 
==38038== 8 bytes in 1 blocks are still reachable in loss record 2 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A6796D: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A67C59: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A684C1: ENGINE_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A69721: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B47C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BC0C: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A3C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 9 bytes in 1 blocks are still reachable in loss record 3 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9931A: CRYPTO_strdup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3E02: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F45D7: CONF_module_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A37: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BB77: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 12 bytes in 1 blocks are still reachable in loss record 4 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9931A: CRYPTO_strdup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3E02: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F45D7: CONF_module_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3D8C: OPENSSL_load_builtin_modules (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A37: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BB77: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038== 
==38038== 12 bytes in 1 blocks are still reachable in loss record 5 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9931A: CRYPTO_strdup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3E02: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F45D7: CONF_module_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3D9B: OPENSSL_load_builtin_modules (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A37: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BB77: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038== 
==38038== 12 bytes in 1 blocks are still reachable in loss record 6 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8FC0D: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BD45: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6BBFF: ERR_get_state (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6BD5C: ERR_clear_error (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B47C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BC0C: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A3C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 13 bytes in 1 blocks are still reachable in loss record 7 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9931A: CRYPTO_strdup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3E02: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F45D7: CONF_module_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F3D91: OPENSSL_load_builtin_modules (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x49F4A37: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B4F3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BB77: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038== 
==38038== 16 bytes in 1 blocks are still reachable in loss record 8 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8BDAD: OPENSSL_atexit (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B74AF: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B759A: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x1772AD: flb_start (flb_lib.c:655)
==38038==    by 0x168B87: flb_main (fluent-bit.c:1191)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 9 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7D4: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 10 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7D4: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 11 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7E1: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 12 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7E1: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 13 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7EE: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 14 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7EE: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 15 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7FB: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 16 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F7FB: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 17 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F808: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 18 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F808: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 19 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DEF5: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9A173: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A845A4: EVP_add_cipher (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F815: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038== 
==38038== 24 bytes in 1 blocks are still reachable in loss record 20 of 545
==38038==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A9A138: OBJ_NAME_add (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6F815: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B54C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA9A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038==    by 0x1BF4FC: tls_init (openssl.c:72)
==38038==    by 0x1C075B: flb_tls_init (flb_tls.c:150)
==38038==    by 0x1760F1: flb_init_env (flb_lib.c:117)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038== 
(snip)
==38038== 16,384 bytes in 1 blocks are still reachable in loss record 545 of 545
==38038==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==38038==    by 0x4A8DE93: OPENSSL_LH_insert (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6B242: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6B403: ERR_load_ERR_strings (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6B65C: ERR_load_strings_const (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A9CD73: ERR_load_OCSP_strings (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A6C992: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8B56C: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x486F4DE: __pthread_once_slow (pthread_once.c:116)
==38038==    by 0x4AF6AAC: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x4A8BA3A: OPENSSL_init_crypto (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==38038==    by 0x48B7574: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==38038== 
==38038== LEAK SUMMARY:
==38038==    definitely lost: 0 bytes in 0 blocks
==38038==    indirectly lost: 0 bytes in 0 blocks
==38038==      possibly lost: 0 bytes in 0 blocks
==38038==    still reachable: 106,442 bytes in 3,650 blocks
==38038==         suppressed: 0 bytes in 0 blocks
==38038== 
==38038== For lists of detected and suppressed errors, rerun with: -s
==38038== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/fluent-bit -i dummy -o null
==35807== Memcheck, a memory error detector
==35807== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==35807== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==35807== Command: bin/fluent-bit -i dummy -o null
==35807== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/18 12:53:27] [ info] [fluent bit] version=2.0.0, commit=8cb84b17d2, pid=35807
[2022/08/18 12:53:27] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/18 12:53:27] [ info] [cmetrics] version=0.3.5
[2022/08/18 12:53:27] [ info] [output:null:null.0] worker #0 started
[2022/08/18 12:53:27] [ info] [sp] stream processor started
^C[2022/08/18 12:53:29] [engine] caught signal (SIGINT)
[2022/08/18 12:53:29] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/18 12:53:29] [ info] [input] pausing dummy.0
[2022/08/18 12:53:29] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/18 12:53:29] [ info] [input] pausing dummy.0
[2022/08/18 12:53:29] [ info] [output:null:null.0] thread worker #0 stopping...
[2022/08/18 12:53:29] [ info] [output:null:null.0] thread worker #0 stopped
==35807== 
==35807== HEAP SUMMARY:
==35807==     in use at exit: 0 bytes in 0 blocks
==35807==   total heap usage: 1,072 allocs, 1,072 frees, 529,953 bytes allocated
==35807== 
==35807== All heap blocks were freed -- no leaks are possible
==35807== 
==35807== For lists of detected and suppressed errors, rerun with: -s
==35807== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
