### PR TITLE
out_lib: support metrics input

### DIFF
--- a/plugins/out_lib/out_lib.c
+++ b/plugins/out_lib/out_lib.c
@@ -149,6 +149,19 @@ static void out_lib_flush(struct flb_event_chunk *event_chunk,
             data_size = alloc_size;
             break;
         case FLB_OUT_LIB_FMT_JSON:
+#ifdef FLB_HAVE_METRICS
+            if (event_chunk->type == FLB_EVENT_TYPE_METRIC) {
+                alloc_size = (off - last_off) + 4096;
+                buf = flb_msgpack_to_json_str(alloc_size, &result.data);
+                if (buf == NULL) {
+                    msgpack_unpacked_destroy(&result);
+                    FLB_OUTPUT_RETURN(FLB_ERROR);
+                }
+                data_size = strlen(buf);
+                data_for_user = buf;
+            }
+            else {
+#endif
             /* JSON is larger than msgpack */
             alloc_size = (off - last_off) + 128;
 
@@ -174,6 +187,9 @@ static void out_lib_flush(struct flb_event_chunk *event_chunk,
             flb_free(buf);
             data_for_user = out_buf;
             data_size = len;
+#ifdef FLB_HAVE_METRICS
+            }
+#endif
             break;
         }
 
@@ -201,5 +217,6 @@ struct flb_output_plugin out_lib_plugin = {
     .cb_init      = out_lib_init,
     .cb_flush     = out_lib_flush,
     .cb_exit      = out_lib_exit,
+    .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
     .flags        = 0,
 };


### PR DESCRIPTION
This patch is to support metrics data type.
It is useful to test some metrics input plugins.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-out_lib 
==94166== Memcheck, a memory error detector
==94166== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==94166== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==94166== Command: bin/flb-rt-out_lib
==94166== 
Test metrics_msgpack...                         [ OK ]
Test metrics_json...                            [ OK ]
Test format_json...                             [ OK ]
Test format_msgpack...                          [ OK ]
Test max_records...                             [ OK ]
SUCCESS: All unit tests have passed.
==94166== 
==94166== HEAP SUMMARY:
==94166==     in use at exit: 0 bytes in 0 blocks
==94166==   total heap usage: 11,222 allocs, 11,222 frees, 4,203,697 bytes allocated
==94166== 
==94166== All heap blocks were freed -- no leaks are possible
==94166== 
==94166== For lists of detected and suppressed errors, rerun with: -s
==94166== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
