### PR TITLE
tests: runtime: in_fluentbit_metrics: add test code

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -48,6 +48,7 @@ if(FLB_OUT_LIB)
   FLB_RT_TEST(FLB_IN_TAIL          "in_tail.c")
   FLB_RT_TEST(FLB_IN_TCP          "in_tcp.c")
   FLB_RT_TEST(FLB_IN_FORWARD       "in_forward.c")
+  FLB_RT_TEST(FLB_IN_FLUENTBIT_METRICS "in_fluentbit_metrics.c")
 endif()
 
 # Filter Plugins

--- a/tests/runtime/in_fluentbit_metrics.c
+++ b/tests/runtime/in_fluentbit_metrics.c
@@ -1,0 +1,198 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_time.h>
+#include <float.h>
+#include "flb_tests_runtime.h"
+
+struct test_ctx {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd (unused) */
+    int o_ffd;         /* Output fd */
+};
+
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+/* Callback to check expected results */
+static int cb_check_json_str_list(void *record, size_t size, void *data)
+{
+    char *p;
+    char *result;
+    int num = get_output_num();
+    size_t i;
+    struct str_list *l = (struct str_list*)data;
+
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("Data is NULL");
+        flb_free(record);
+        return 0;
+    }
+
+    set_output_num(num+1);
+
+    result = (char *) record;
+
+    for (i=0; i<l->size; i++) {
+        p = strstr(result, l->lists[i]);
+        if(!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected to find: '%s' in result '%s'",
+                     l->lists[i], result);
+        }
+    }
+
+    /*
+     * If you want to debug your test
+     *
+     * printf("Expect: '%s' in result '%s'", expected, result);
+     */
+    flb_free(record);
+    return 0;
+}
+
+static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+{
+    int o_ffd;
+    struct test_ctx *ctx = NULL;
+
+    ctx = flb_malloc(sizeof(struct test_ctx));
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("malloc failed");
+        flb_errno();
+        return NULL;
+    }
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    ctx->i_ffd = flb_input(ctx->flb, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(ctx->i_ffd >= 0);
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    ctx->o_ffd = o_ffd;
+    TEST_CHECK(ctx->o_ffd >= 0);
+
+    return ctx;
+}
+
+static void test_ctx_destroy(struct test_ctx *ctx)
+{
+    TEST_CHECK(ctx != NULL);
+
+    sleep(1);
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+#ifdef FLB_HAVE_METRICS
+char *basic_expected_strs[] = {"\"uptime\"", "\"records_total\"", "\"bytes_total\"", "\"proc_records_total\"", "\"proc_bytes_total\"", "\"errors_total\"", "\"retries_total\"", "\"retries_failed_total\"", "\"dropped_records_total\"", "\"retried_records_total\""};
+
+static void test_basic(void)
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    struct str_list expected = {
+                                .size = sizeof(basic_expected_strs)/sizeof(char*),
+                                .lists = &basic_expected_strs[0],
+    };
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_json_str_list;
+    cb_data.data = &expected;
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+    /* Input */
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "scrape_interval", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+#endif
+
+TEST_LIST = {
+#ifdef FLB_HAVE_METRICS
+    {"basic", test_basic},
+#endif
+    {NULL, NULL}
+};


### PR DESCRIPTION
This patch is to add a test code for in_fluentbit_metrics.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_fluentbit_metrics 
==2763== Memcheck, a memory error detector
==2763== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2763== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==2763== Command: bin/flb-rt-in_fluentbit_metrics
==2763== 
Test basic...                                   ==2763== Warning: client switching stacks?  SP change: 0x5ff7778 --> 0x5488e20
==2763==          to suppress, use: --max-stackframe=11987288 or greater
==2763== Warning: client switching stacks?  SP change: 0x5488d78 --> 0x5ff7778
==2763==          to suppress, use: --max-stackframe=11987456 or greater
==2763== Warning: client switching stacks?  SP change: 0x5ff79a8 --> 0x5488d78
==2763==          to suppress, use: --max-stackframe=11988016 or greater
==2763==          further instances of this message will not be shown.
[ OK ]
SUCCESS: All unit tests have passed.
==2763== 
==2763== HEAP SUMMARY:
==2763==     in use at exit: 0 bytes in 0 blocks
==2763==   total heap usage: 1,658 allocs, 1,658 frees, 877,832 bytes allocated
==2763== 
==2763== All heap blocks were freed -- no leaks are possible
==2763== 
==2763== For lists of detected and suppressed errors, rerun with: -s
==2763== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
