### PR TITLE
build: macos: openssl: Search homebrewed OpenSSL installed directory

### DIFF
--- a/cmake/homebrew.cmake
+++ b/cmake/homebrew.cmake
@@ -20,3 +20,15 @@ if (HOMEBREW_FLEX EQUAL 0 AND EXISTS "${HOMEBREW_FLEX_PREFIX}")
   message(STATUS "Using flex keg installed by Homebrew at ${HOMEBREW_FLEX_PREFIX}")
   set(FLEX_EXECUTABLE "${HOMEBREW_FLEX_PREFIX}/bin/flex")
 endif()
+
+# Also, searching homebrewed OpenSSL automatically.
+execute_process(
+  COMMAND brew --prefix openssl
+  RESULT_VARIABLE HOMEBREW_OPENSSL
+  OUTPUT_VARIABLE HOMEBREW_OPENSSL_PREFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if (HOMEBREW_OPENSSL EQUAL 0 AND EXISTS "${HOMEBREW_OPENSSL_PREFIX}")
+  message(STATUS "Using openssl keg installed by Homebrew at ${HOMEBREW_OPENSSL_PREFIX}")
+  set(OPENSSL_ROOT_DIR "${HOMEBREW_OPENSSL_PREFIX}")
+endif()


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

In recent mebedtls removal, OpenSSL installation became one of the requirements to build fluent-bit.
And specifying every time of `-DOPENSSL_ROOT_DIR=$(brew --prefix openssl)` is a bit of redundant for CI and self building by users. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

No issue is not tied for this PR but it might be another follow up for #5887 and #5874.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
