### PR TITLE
test: runtime: filter_stdout: Ensure TLS(thread local storage) initialization on macOS.

### DIFF
--- a/tests/runtime/filter_stdout.c
+++ b/tests/runtime/filter_stdout.c
@@ -34,6 +34,13 @@ void flb_test_filter_stdout_case_insensitive(void)
         TEST_MSG("%s should be valid\n", filter_name);
     }
 
+    /* Initialize thread local storage (FLB_TLS) properly when without calling flb_start().
+     * Then, FLB_TLS_GET working on macOS.
+     * In general, macOS requests surely initialization for pthread stuffs.
+     */
+    flb_init_env();
+
+    flb_stop(ctx);
     flb_destroy(ctx);
 }
 


### PR DESCRIPTION
This is because macOS requests surely initialization for pthread stuffs.
    
In our code base, flb_init_env() should initialize thread local storage stuffs.
    
Otherwise, FLB_TLS_GET returns invalid values.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
