### PR TITLE
lib: macos: Call pthread_cancel explicitly to ensure thread termination

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -667,7 +667,9 @@ int flb_start(flb_ctx_t *ctx)
         fd = event->fd;
         bytes = flb_pipe_r(fd, &val, sizeof(uint64_t));
         if (bytes <= 0) {
+#if defined(FLB_SYSTEM_MACOS)
             pthread_cancel(tid);
+#endif
             pthread_join(tid, NULL);
             ctx->status = FLB_LIB_ERROR;
             return -1;
@@ -680,7 +682,9 @@ int flb_start(flb_ctx_t *ctx)
         }
         else if (val == FLB_ENGINE_FAILED) {
             flb_error("[lib] backend failed");
+#if defined(FLB_SYSTEM_MACOS)
             pthread_cancel(tid);
+#endif
             pthread_join(tid, NULL);
             ctx->status = FLB_LIB_ERROR;
             return -1;
@@ -712,7 +716,9 @@ int flb_stop(flb_ctx_t *ctx)
          * the service exited for some reason (plugin action). Always
          * wait and double check that the child thread is not running.
          */
+#if defined(FLB_SYSTEM_MACOS)
         pthread_cancel(tid);
+#endif
         pthread_join(tid, NULL);
         return 0;
     }
@@ -728,7 +734,9 @@ int flb_stop(flb_ctx_t *ctx)
     flb_debug("[lib] sending STOP signal to the engine");
 
     flb_engine_exit(ctx->config);
+#if defined(FLB_SYSTEM_MACOS)
     pthread_cancel(tid);
+#endif
     ret = pthread_join(tid, NULL);
     if (ret != 0) {
         flb_errno();

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -680,6 +680,7 @@ int flb_start(flb_ctx_t *ctx)
         }
         else if (val == FLB_ENGINE_FAILED) {
             flb_error("[lib] backend failed");
+            pthread_cancel(tid);
             pthread_join(tid, NULL);
             ctx->status = FLB_LIB_ERROR;
             return -1;
@@ -711,6 +712,7 @@ int flb_stop(flb_ctx_t *ctx)
          * the service exited for some reason (plugin action). Always
          * wait and double check that the child thread is not running.
          */
+        pthread_cancel(tid);
         pthread_join(tid, NULL);
         return 0;
     }
@@ -726,6 +728,7 @@ int flb_stop(flb_ctx_t *ctx)
     flb_debug("[lib] sending STOP signal to the engine");
 
     flb_engine_exit(ctx->config);
+    pthread_cancel(tid);
     ret = pthread_join(tid, NULL);
     if (ret != 0) {
         flb_errno();


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

This patch ensures to call `pthread_cancel` on flb_lib termination phases.

In macOS, without calling pthread_cancel, we always SEGV on `flb-rt-in_forward` test cases. We should fix those SEGV failures.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
