### PR TITLE
out_datadog: fix/add error handling for all flb_sds calls

### DIFF
--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -33,6 +33,7 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     struct flb_upstream *upstream;
     const char *api_key;
     const char *tmp;
+    flb_sds_t tmp_sds;
 
     int ret;
     char *protocol = NULL;
@@ -75,12 +76,18 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     /* use TLS ? */
     if (ins->use_tls == FLB_TRUE) {
         io_flags = FLB_IO_TLS;
-        ctx->scheme = flb_sds_create("https://");
+        tmp_sds = flb_sds_create("https://");
     }
     else {
         io_flags = FLB_IO_TCP;
-        ctx->scheme = flb_sds_create("http://");
+        tmp_sds = flb_sds_create("http://");
     }
+    if (!tmp_sds) {
+        flb_errno();
+        flb_datadog_conf_destroy(ctx);
+        return NULL;
+    }
+    ctx->scheme = tmp_sds;
     flb_plg_debug(ctx->ins, "scheme: %s", ctx->scheme);
 
     /* configure URI */
@@ -126,11 +133,17 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
 
     /* Get network configuration */
     if (!ins->host.name) {
-        ctx->host = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
+        tmp_sds = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
     }
     else {
-        ctx->host = flb_sds_create(ins->host.name);
+        tmp_sds = flb_sds_create(ins->host.name);
     }
+    if (!tmp_sds) {
+        flb_errno();
+        flb_datadog_conf_destroy(ctx);
+        return NULL;
+    }
+    ctx->host = tmp_sds;
     flb_plg_debug(ctx->ins, "host: %s", ctx->host);
 
     if (ins->host.port != 0) {

--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -28,98 +28,172 @@ const char *ECS_ARN_PREFIX = "arn:aws:ecs:";
 const char *ECS_CLUSTER_PREFIX = "cluster/";
 const char *ECS_TASK_PREFIX = "task/";
 
-static void dd_remap_append_kv_to_ddtags(const char *key,
-                                         const char *val, size_t val_len, flb_sds_t dd_tags)
+static int dd_remap_append_kv_to_ddtags(const char *key,
+                                        const char *val, size_t val_len, flb_sds_t *dd_tags_buf)
 {
-    if (flb_sds_len(dd_tags) != 0) {
-        flb_sds_cat(dd_tags, FLB_DATADOG_TAG_SEPERATOR, strlen(FLB_DATADOG_TAG_SEPERATOR));
+    flb_sds_t tmp;
+
+    if (flb_sds_len(*dd_tags_buf) != 0) {
+        tmp = flb_sds_cat(*dd_tags_buf, FLB_DATADOG_TAG_SEPERATOR, strlen(FLB_DATADOG_TAG_SEPERATOR));
+        if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+        *dd_tags_buf = tmp;
     }
-    flb_sds_cat(dd_tags, key, strlen(key));
-    flb_sds_cat(dd_tags, ":", 1);
-    flb_sds_cat(dd_tags, val, val_len);
+
+    tmp = flb_sds_cat(*dd_tags_buf, key, strlen(key));
+    if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+    *dd_tags_buf = tmp;
+
+    tmp = flb_sds_cat(*dd_tags_buf, ":", 1);
+    if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+    *dd_tags_buf = tmp;
+
+    tmp = flb_sds_cat(*dd_tags_buf, val, val_len);
+    if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+    *dd_tags_buf = tmp;
+
+    return 0;
 }
 
 /* default remapping: just move the key/val pair under dd_tags */
-static void dd_remap_move_to_tags(const char *tag_name,
-                                  msgpack_object attr_value, flb_sds_t dd_tags)
+static int dd_remap_move_to_tags(const char *tag_name,
+                                  msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
-    dd_remap_append_kv_to_ddtags(tag_name, attr_value.via.str.ptr,
-                                 attr_value.via.str.size, dd_tags);
+    return dd_remap_append_kv_to_ddtags(tag_name, attr_value.via.str.ptr,
+                                        attr_value.via.str.size, dd_tags_buf);
 }
 
 /* remapping function for container_name */
-static void dd_remap_container_name(const char *tag_name,
-                                    msgpack_object attr_value, flb_sds_t dd_tags)
+static int dd_remap_container_name(const char *tag_name,
+                                    msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
     /* remove the first / if present */
     unsigned int adjust;
-    flb_sds_t buf;
+    flb_sds_t buf = NULL;
+    int ret;
 
     adjust = attr_value.via.str.ptr[0] == '/' ? 1 : 0;
     buf = flb_sds_create_len(attr_value.via.str.ptr + adjust,
                              attr_value.via.str.size - adjust);
-    dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
+    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
     flb_sds_destroy(buf);
+    if (ret < 0) {
+        return -1;
+    }
+
+    return 0;
 }
 
 /* remapping function for ecs_cluster */
-static void dd_remap_ecs_cluster(const char *tag_name,
-                                 msgpack_object attr_value, flb_sds_t dd_tags)
+static int dd_remap_ecs_cluster(const char *tag_name,
+                                 msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
-    flb_sds_t buf;
+    flb_sds_t buf = NULL;
     char *cluster_name;
+    int ret;
 
     buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
     cluster_name = strstr(buf, ECS_CLUSTER_PREFIX);
 
     if (cluster_name != NULL) {
         cluster_name += strlen(ECS_CLUSTER_PREFIX);
-        dd_remap_append_kv_to_ddtags(tag_name, cluster_name, strlen(cluster_name), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags(tag_name, cluster_name, strlen(cluster_name), dd_tags_buf);
+        if (ret < 0) {
+            flb_sds_destroy(buf);
+            return -1;
+        }
     }
     else {
         /*
          * here the input is invalid: not in form of "XXXXXXcluster/"cluster-name
          * we preverse the original value under tag "cluster_name".
          */
-        dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
+        if (ret < 0) {
+            flb_sds_destroy(buf);
+            return -1;
+        }
     }
     flb_sds_destroy(buf);
+    return 0;
 }
 
 /* remapping function for ecs_task_definition */
-static void dd_remap_ecs_task_definition(const char *tag_name,
-                                         msgpack_object attr_value, flb_sds_t dd_tags)
+static int dd_remap_ecs_task_definition(const char *tag_name,
+                                         msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
-    flb_sds_t buf;
+    flb_sds_t buf = NULL;
     char *split;
+    int ret;
 
     buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
     split = strchr(buf, ':');
 
     if (split != NULL) {
-        dd_remap_append_kv_to_ddtags("task_family", buf, split-buf, dd_tags);
-        dd_remap_append_kv_to_ddtags("task_version", split+1, strlen(split+1), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags("task_family", buf, split-buf, dd_tags_buf);
+        if (ret < 0) {
+            flb_sds_destroy(buf);
+            return -1;
+        }
+        ret = dd_remap_append_kv_to_ddtags("task_version", split+1, strlen(split+1), dd_tags_buf);
+        if (ret < 0) {
+            flb_sds_destroy(buf);
+            return -1;
+        }
     }
     else {
         /*
          * here the input is invalid: not in form of task_name:task_version
          * we preverse the original value under tag "ecs_task_definition".
          */
-        dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
+        if (ret < 0) {
+            flb_sds_destroy(buf);
+            return -1;
+        }
     }
     flb_sds_destroy(buf);
+    return 0;
 }
 
 /* remapping function for ecs_task_arn */
-static void dd_remap_ecs_task_arn(const char *tag_name,
-                                  msgpack_object attr_value, flb_sds_t dd_tags)
+static int dd_remap_ecs_task_arn(const char *tag_name,
+                                  msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
     flb_sds_t buf;
     char *remain;
     char *split;
     char *task_arn;
+    int ret;
 
     buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
 
     /*
      * if the input is invalid, not in the form of "arn:aws:ecs:region:XXXX"
@@ -132,7 +206,11 @@ static void dd_remap_ecs_task_arn(const char *tag_name,
         split = strchr(remain, ':');
 
         if (split != NULL) {
-            dd_remap_append_kv_to_ddtags("region", remain, split-remain, dd_tags);
+            ret = dd_remap_append_kv_to_ddtags("region", remain, split-remain, dd_tags_buf);
+            if (ret < 0) {
+                flb_sds_destroy(buf);
+                return -1;
+            }
         }
     }
 
@@ -140,16 +218,21 @@ static void dd_remap_ecs_task_arn(const char *tag_name,
     if (task_arn != NULL) {
         /* parse out the task_arn */
         task_arn += strlen(ECS_TASK_PREFIX);
-        dd_remap_append_kv_to_ddtags(tag_name, task_arn, strlen(task_arn), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags(tag_name, task_arn, strlen(task_arn), dd_tags_buf);
     }
     else {
         /*
          * if the input is invalid, not in the form of "XXXXXXXXtask/"task-arn
          * then we preverse the original value under tag "task_arn".
          */
-        dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags);
+        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
     }
     flb_sds_destroy(buf);
+    if (ret < 0) {
+         return -1;
+    }
+
+    return 0;
 }
 
 /*

--- a/plugins/out_datadog/datadog_remap.h
+++ b/plugins/out_datadog/datadog_remap.h
@@ -22,10 +22,12 @@
 
 #include "datadog.h"
 
+typedef int (*dd_attr_remap_to_tag_fn)(const char*, msgpack_object, flb_sds_t*);
+
 struct dd_attr_tag_remapping {
     char* origin_attr_name; /* original attribute name */
     char* remap_tag_name;   /* tag name to remap to */
-    void (*remap_to_tag) (const char*, msgpack_object, flb_sds_t);  /* remapping function */
+    dd_attr_remap_to_tag_fn remap_to_tag;  /* remapping function */
 };
 
 extern const struct dd_attr_tag_remapping remapping[];


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
