### PR TITLE
init: systemd: allow to set environment variables from file

### DIFF
--- a/init/systemd.in
+++ b/init/systemd.in
@@ -6,6 +6,8 @@ After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/sysconfig/@FLB_OUT_NAME@
+EnvironmentFile=-/etc/default/@FLB_OUT_NAME@
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c /@CMAKE_INSTALL_SYSCONFDIR@/@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
 Restart=always
 


### PR DESCRIPTION
This PR provides a more general way to give environment variables (e.g.`AWS_CONFIG_FILE`) for fluent-bit running on systemd without rewriting unit files.

environment variables are to be sourced from these files if exists.
* `/etc/default/<FLB_OUT_NAME>` (Debian based system)
* `/etc/sysconfig/<FLB_OUT_NAME>` (Others)

The file is rendered with CMake. The results of the my local build are:

```
[Unit]
Description=TD Agent Bit
Documentation=https://docs.fluentbit.io/manual/
Requires=network.target
After=network.target

[Service]
Type=simple
EnvironmentFile=-/etc/default/td-agent-bit
EnvironmentFile=-/etc/sysconfig/td-agent-bit
ExecStart=/opt/td-agent-bit/bin/td-agent-bit -c //etc/td-agent-bit/td-agent-bit.conf
Restart=always

[Install]
WantedBy=multi-user.target
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
