### PR TITLE
multiline: fix flush timeout logic (fixes #5504)

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -151,7 +151,7 @@ static void cb_ml_flush_timer(struct flb_config *ctx, void *data)
     struct flb_ml *ml = data;
 
     now = time_ms_now();
-    if (ml->last_flush + ml->flush_ms < now) {
+    if (ml->last_flush + ml->flush_ms > now) {
         return;
     }
 

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -1287,6 +1287,90 @@ static void test_issue_4034()
     flb_config_exit(config);
 }
 
+static void test_issue_5504()
+{
+    uint64_t last_flush;
+    struct flb_config *config;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct mk_event_loop *evl;
+    struct flb_sched *sched;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_sched_timer *timer;
+    void (*cb)(struct flb_config *, void *);
+    int timeout = 500;
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+    WSAStartup(0x0201, &wsa_data);
+#endif
+
+    /* Initialize environment */
+    config = flb_config_init();
+    ml = flb_ml_create(config, "5504-test");
+    TEST_CHECK(ml != NULL);
+    
+    /* Create the event loop */
+    evl = config->evl;
+    config->evl = mk_event_loop_create(32);
+    TEST_CHECK(config->evl != NULL);
+
+    /* Initialize the scheduler */
+    sched = config->sched;
+    config->sched = flb_sched_create(config, config->evl);
+    TEST_CHECK(config->sched != NULL);
+
+    /* Generate an instance of any multiline parser */
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+
+    flb_ml_parser_instance_set(mlp_i, "key_content", "log");
+
+    /* Set the flush timeout */
+    ml->flush_ms = timeout;
+
+    /* Initialize the auto flush */
+    flb_ml_auto_flush_init(ml);
+
+    /* Store the initial last_flush time */
+    last_flush = ml->last_flush;
+
+    /* Find the cb_ml_flush_timer callback from the timers */
+    mk_list_foreach_safe(head, tmp, &((struct flb_sched *)config->sched)->timers) {
+        timer = mk_list_entry(head, struct flb_sched_timer, _head);
+        if (timer->type == FLB_SCHED_TIMER_CB_PERM) {
+            cb = timer->cb;
+        }
+    }
+    TEST_CHECK(cb != NULL);
+
+    /* Trigger the callback without delay */ 
+    cb(config, ml);
+    /* This should not update the last_flush since it is before the timeout */
+    TEST_CHECK(ml->last_flush == last_flush);
+
+    /* Sleep just enough time to pass the timeout */
+    flb_time_msleep(timeout + 1);
+
+    /* Retrigger the callback */
+    cb(config, ml);
+    /* Ensure this time the last_flush has been updated */
+    TEST_CHECK(ml->last_flush > last_flush);
+
+    /* Cleanup */
+    flb_sched_destroy(config->sched);
+    config->sched = sched;
+    mk_event_loop_destroy(config->evl);
+    config->evl = evl;
+    flb_ml_destroy(ml);
+    flb_config_exit(config);
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
+}
+
 TEST_LIST = {
     /* Normal features tests */
     { "parser_docker",  test_parser_docker},
@@ -1302,5 +1386,6 @@ TEST_LIST = {
     { "issue_3817_1"  , test_issue_3817_1},
     { "issue_4034"    , test_issue_4034},
     { "issue_4949"    , test_issue_4949},
+    { "issue_5504"    , test_issue_5504},
     { 0 }
 };

--- a/tests/runtime/data/tail/parsers_multiline_json.conf
+++ b/tests/runtime/data/tail/parsers_multiline_json.conf
@@ -7,7 +7,7 @@
    key_content   message
    type          regex
    parser        json
-   flush_timeout 3000
+   flush_timeout 2000
 
    #
    # Regex rules for multiline parsing

--- a/tests/runtime/filter_multiline.c
+++ b/tests/runtime/filter_multiline.c
@@ -193,6 +193,7 @@ static void flb_test_multiline_buffered_two_output_record()
                          "multiline.key_content", "log",
                          "multiline.parser", "go",
                          "buffer", "on",
+                         "flush_ms", "1500",
                          "debug_flush", "on",
                          NULL);
     TEST_CHECK(ret == 0);
@@ -236,7 +237,7 @@ static void flb_test_multiline_buffered_two_output_record()
     TEST_CHECK(bytes == len);
 
     /* check number of outputted records */
-    sleep(2);
+    sleep(3);
     TEST_CHECK(expected.actual_records == expected.expected_records);
     filter_test_destroy(ctx);
 }

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -748,7 +748,7 @@ void flb_test_in_tail_multiline_json_and_regex()
     ctx = flb_create();
 
     TEST_CHECK(flb_service_set(ctx, "Flush", "0.5",
-                                    "Grace", "1",
+                                    "Grace", "5",
                                     NULL) == 0);
 
     ret = flb_service_set(ctx,


### PR DESCRIPTION
Logic for checking if it is too early to flush in the multiline timer callback was inverted.
You want to ignore flushing in the timer callback if the last flush plus the timeout is after now time and not before.

fixes #5504

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
