### PR TITLE
ra_key: save value when the data type is array(#5936)

### DIFF
--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -150,7 +150,9 @@ static int subkey_to_object(msgpack_object *map, struct mk_list *subkeys,
                 return -1;
             }
 
-            cur = cur.via.array.ptr[entry->array_id];
+            val = &cur.via.array.ptr[entry->array_id];
+            cur = *val;
+            key = NULL; /* fill NULL since the type is array. */
             goto next;
         }
 

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -1496,6 +1496,71 @@ void cb_ra_translate_check()
     msgpack_unpacked_destroy(&result);
 }
 
+/*
+ * https://github.com/fluent/fluent-bit/issues/5936
+ *  If the last nested element is an array, record accessor can't get its value.
+ */
+void cb_issue_5936_last_array()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    msgpack_unpacked result;
+    msgpack_object map;
+    struct flb_record_accessor *ra;
+
+    /* Sample JSON message */
+    json ="{ \"key\": {\"nested\":[\"val0\", \"val1\"]}}";
+
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &out_buf, &out_size, &type);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key['nested'][1]");
+    fmt_out = "val1";
+
+    ra = flb_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(ra != NULL);
+    if (!ra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack msgpack object */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, out_buf, out_size, &off);
+    map = result.data;
+
+    /* Do translation */
+    str = flb_ra_translate(ra, NULL, -1, map, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_ra_destroy(ra);
+    flb_free(out_buf);
+    msgpack_unpacked_destroy(&result);
+}
+
 TEST_LIST = {
     { "keys"            , cb_keys},
     { "dash_key"        , cb_dash_key},
@@ -1518,5 +1583,6 @@ TEST_LIST = {
     { "add_root_key_val", cb_add_root_key_val},
     { "issue_4917"      , cb_issue_4917},
     { "flb_ra_translate_check" , cb_ra_translate_check},
+    { "issue_5936_last_array"      , cb_issue_5936_last_array},
     { NULL }
 };


### PR DESCRIPTION
Fixes #5936 

`subkey_to_object` doesn't save a value if the last element is an array.
Therefore, we can't get like `$key['nest'][1]`

This patch is to save it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"method": "GET","requestHeader": {"User-Agent": ["mydevice"]}}

[FILTER]
    Name grep
    Match *
    Regex $requestHeader['User-Agent'] myde

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c issues/5936/a.conf 
==16303== Memcheck, a memory error detector
==16303== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16303== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==16303== Command: bin/fluent-bit -c issues/5936/a.conf
==16303== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/27 07:56:59] [ info] [fluent bit] version=2.0.0, commit=74a21b176c, pid=16303
[2022/08/27 07:56:59] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/27 07:56:59] [ info] [cmetrics] version=0.3.5
[2022/08/27 07:56:59] [ info] [output:stdout:stdout.0] worker #0 started
[2022/08/27 07:56:59] [ info] [sp] stream processor started
==16303== Warning: client switching stacks?  SP change: 0x6ff98b8 --> 0x5496f80
==16303==          to suppress, use: --max-stackframe=28715320 or greater
==16303== Warning: client switching stacks?  SP change: 0x5496ed8 --> 0x6ff98b8
==16303==          to suppress, use: --max-stackframe=28715488 or greater
==16303== Warning: client switching stacks?  SP change: 0x6ff98b8 --> 0x5496ed8
==16303==          to suppress, use: --max-stackframe=28715488 or greater
==16303==          further instances of this message will not be shown.
[0] dummy.0: [1661554619.988799106, {"method"=>"GET", "requestHeader"=>{"User-Agent"=>["mydevice"]}}]
[0] dummy.0: [1661554620.984007872, {"method"=>"GET", "requestHeader"=>{"User-Agent"=>["mydevice"]}}]
^C[2022/08/27 07:57:02] [engine] caught signal (SIGINT)
[0] dummy.0: [1661554621.954630213, {"method"=>"GET", "requestHeader"=>{"User-Agent"=>["mydevice"]}}]
[2022/08/27 07:57:02] [ warn] [engine] service will shutdown in max 5 seconds
[2022/08/27 07:57:02] [ info] [input] pausing dummy.0
[2022/08/27 07:57:02] [ info] [engine] service has stopped (0 pending tasks)
[2022/08/27 07:57:02] [ info] [input] pausing dummy.0
[2022/08/27 07:57:03] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/08/27 07:57:03] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==16303== 
==16303== HEAP SUMMARY:
==16303==     in use at exit: 0 bytes in 0 blocks
==16303==   total heap usage: 1,243 allocs, 1,243 frees, 1,303,472 bytes allocated
==16303== 
==16303== All heap blocks were freed -- no leaks are possible
==16303== 
==16303== For lists of detected and suppressed errors, rerun with: -s
==16303== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
