### PR TITLE
config_format: fluentbit: return NULL when some error occurs

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -721,7 +721,6 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
                                        char *file_path, char *buf, size_t size)
 {
     int ret;
-    int created = FLB_FALSE;
     struct local_ctx ctx;
 
     if (!cf) {
@@ -729,12 +728,11 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
         if (!cf) {
             return NULL;
         }
-        created = FLB_TRUE;
     }
 
     ret = local_init(&ctx, file_path);
     if (ret != 0) {
-        if (cf && created) {
+        if (cf) {
             flb_cf_destroy(cf);
         }
         return NULL;
@@ -744,7 +742,7 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
 
     local_exit(&ctx);
 
-    if (ret == -1 && created) {
+    if (ret == -1) {
         flb_cf_destroy(cf);
         return NULL;
     }

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -11,6 +11,7 @@
 
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/classic/fluent-bit.conf"
 #define FLB_001 FLB_TESTS_DATA_PATH "/data/config_format/classic/issue_5880.conf"
+#define FLB_002 FLB_TESTS_DATA_PATH "/data/config_format/classic/indent_level_error.conf"
 
 #define ERROR_LOG "fluentbit_conf_error.log"
 
@@ -157,8 +158,56 @@ void missing_value()
     unlink(ERROR_LOG);
 }
 
+void indent_level_error()
+{
+	struct flb_cf *cf;
+    FILE *fp = NULL;
+    char *expected_strs[] = {"invalid", "indent", "level"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    unlink(ERROR_LOG);
+
+    fp = freopen(ERROR_LOG, "w+", stderr);
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("freopen failed. errno=%d path=%s", errno, ERROR_LOG);
+        exit(EXIT_FAILURE);
+    }
+
+    cf = flb_cf_create();
+    if (!TEST_CHECK(cf != NULL)) {
+        TEST_MSG("flb_cf_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    cf = flb_cf_fluentbit_create(cf, FLB_002, NULL, 0);
+    TEST_CHECK(cf == NULL);
+    fflush(fp);
+    fclose(fp);
+
+    fp = fopen(ERROR_LOG, "r");
+    if (!TEST_CHECK(fp != NULL)) {
+        TEST_MSG("fopen failed. errno=%d path=%s", errno, ERROR_LOG);
+        if (cf != NULL) {
+            flb_cf_destroy(cf);
+        }
+        unlink(ERROR_LOG);
+        exit(EXIT_FAILURE);
+    }
+
+    check_str_list(&expected, fp);
+    if (cf != NULL) {
+        flb_cf_destroy(cf);
+    }
+    fclose(fp);
+    unlink(ERROR_LOG);
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
     { "missing_value_issue5880" , missing_value},
+    { "indent_level_error" , indent_level_error},
     { 0 }
 };

--- a/tests/internal/data/config_format/classic/indent_level_error.conf
+++ b/tests/internal/data/config_format/classic/indent_level_error.conf
@@ -1,0 +1,6 @@
+[INPUT]
+    Name dummy
+
+[OUTPUT]
+      Name stdout
+      Match *


### PR DESCRIPTION
Relates #5888 #5911 

If user passed `cf` as args, `flb_cf_fluentbit_create` didn't return error.
Therefore fluent-bit will not stop even if some configuration error.

This patch is to modify it and the function returns NULL when some error occurs.

Note: `flb_cf_yaml_create` returns error even if user passed `cf`.
Note: v1.8.15 stops when indentation level error occurs.
```
$ ~/git/WORKTREE/v1.8.15/build/bin/fluent-bit -c issues/5888/a.conf 
Fluent Bit v1.8.15
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/28 09:11:50] [  Error] File issues/5888/a.conf
[2022/08/28 09:11:50] [  Error] Error in line 3: Invalid indentation level
Error: Configuration file contains errors. Aborting
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
   Name mem
    Tag aaa
```

## Debug log

```
$ bin/fluent-bit -c issues/5888/a.conf
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/08/28 09:08:40] [error] [config] extra indentation level found
[2022/08/28 09:08:40] [error] [config] error in issues/5888/a.conf:3: invalid indentation level
[2022/08/28 09:08:40] [error] configuration file contains errors, aborting.
$
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
