### PR TITLE
tests: runtime: out_tcp: remove unused out_lib_cb

### DIFF
--- a/tests/runtime/out_http.c
+++ b/tests/runtime/out_http.c
@@ -227,7 +227,7 @@ static void cb_check_msgpack_kv(void *ctx, int ffd, int res_ret,
     return ;
 }
 
-static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+static struct test_ctx *test_ctx_create()
 {
     int i_ffd;
     int o_ffd;
@@ -254,7 +254,7 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
     ctx->i_ffd = i_ffd;
 
     /* Output */
-    o_ffd = flb_output(ctx->flb, (char *) "http", (void *) data);
+    o_ffd = flb_output(ctx->flb, (char *) "http", NULL);
     ctx->o_ffd = o_ffd;
 
     return ctx;
@@ -272,7 +272,6 @@ static void test_ctx_destroy(struct test_ctx *ctx)
 
 void flb_test_format_msgpack()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -288,7 +287,7 @@ void flb_test_format_msgpack()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -326,7 +325,6 @@ void flb_test_format_msgpack()
 
 void flb_test_format_json()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -344,7 +342,7 @@ void flb_test_format_json()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -384,7 +382,6 @@ void flb_test_format_json()
 
 void flb_test_format_json_stream()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -402,7 +399,7 @@ void flb_test_format_json_stream()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -442,7 +439,6 @@ void flb_test_format_json_stream()
 
 void flb_test_format_json_lines()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -460,7 +456,7 @@ void flb_test_format_json_lines()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -500,7 +496,6 @@ void flb_test_format_json_lines()
 
 void flb_test_format_gelf()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -516,7 +511,7 @@ void flb_test_format_gelf()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -556,7 +551,6 @@ void flb_test_format_gelf()
 
 void flb_test_format_gelf_host_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -572,7 +566,7 @@ void flb_test_format_gelf_host_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -612,7 +606,6 @@ void flb_test_format_gelf_host_key()
 
 void flb_test_format_gelf_timestamp_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -628,7 +621,7 @@ void flb_test_format_gelf_timestamp_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -668,7 +661,6 @@ void flb_test_format_gelf_timestamp_key()
 
 void flb_test_format_gelf_full_message_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -684,7 +676,7 @@ void flb_test_format_gelf_full_message_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -724,7 +716,6 @@ void flb_test_format_gelf_full_message_key()
 
 void flb_test_format_gelf_level_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -740,7 +731,7 @@ void flb_test_format_gelf_level_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -780,7 +771,6 @@ void flb_test_format_gelf_level_key()
 
 void flb_test_set_json_date_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -796,7 +786,7 @@ void flb_test_set_json_date_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -835,7 +825,6 @@ void flb_test_set_json_date_key()
 
 void flb_test_disable_json_date_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -851,7 +840,7 @@ void flb_test_disable_json_date_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -890,7 +879,6 @@ void flb_test_disable_json_date_key()
 
 void flb_test_json_date_format_epoch()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -906,7 +894,7 @@ void flb_test_json_date_format_epoch()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -945,7 +933,6 @@ void flb_test_json_date_format_epoch()
 
 void flb_test_json_date_format_iso8601()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -961,7 +948,7 @@ void flb_test_json_date_format_iso8601()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -1000,7 +987,6 @@ void flb_test_json_date_format_iso8601()
 
 void flb_test_json_date_format_java_sql_timestamp()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -1016,7 +1002,7 @@ void flb_test_json_date_format_java_sql_timestamp()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);

--- a/tests/runtime/out_syslog.c
+++ b/tests/runtime/out_syslog.c
@@ -106,7 +106,7 @@ static void cb_check_str_list(void *ctx, int ffd, int res_ret,
     flb_sds_destroy(out_line);
 }
 
-static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+static struct test_ctx *test_ctx_create()
 {
     int i_ffd;
     int o_ffd;
@@ -133,7 +133,7 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
     ctx->i_ffd = i_ffd;
 
     /* Output */
-    o_ffd = flb_output(ctx->flb, (char *) "syslog", (void *) data);
+    o_ffd = flb_output(ctx->flb, (char *) "syslog", NULL);
     ctx->o_ffd = o_ffd;
 
     return ctx;
@@ -151,7 +151,6 @@ static void test_ctx_destroy(struct test_ctx *ctx)
 
 void flb_test_syslog_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -167,7 +166,7 @@ void flb_test_syslog_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -206,7 +205,6 @@ void flb_test_syslog_rfc5424()
 
 void flb_test_severity_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -223,7 +221,7 @@ void flb_test_severity_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -263,7 +261,6 @@ void flb_test_severity_key_rfc5424()
 
 void flb_test_severity_key_rfc3164()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -280,7 +277,7 @@ void flb_test_severity_key_rfc3164()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -320,7 +317,6 @@ void flb_test_severity_key_rfc3164()
 
 void flb_test_facility_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -337,7 +333,7 @@ void flb_test_facility_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -377,7 +373,6 @@ void flb_test_facility_key_rfc5424()
 
 void flb_test_facility_key_rfc3164()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -394,7 +389,7 @@ void flb_test_facility_key_rfc3164()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -434,7 +429,6 @@ void flb_test_facility_key_rfc3164()
 
 void flb_test_severity_facility_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -451,7 +445,7 @@ void flb_test_severity_facility_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -492,7 +486,6 @@ void flb_test_severity_facility_key_rfc5424()
 
 void flb_test_severity_facility_key_rfc3164()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -509,7 +502,7 @@ void flb_test_severity_facility_key_rfc3164()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -550,7 +543,6 @@ void flb_test_severity_facility_key_rfc3164()
 
 void flb_test_hostname_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -567,7 +559,7 @@ void flb_test_hostname_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -607,7 +599,6 @@ void flb_test_hostname_key_rfc5424()
 
 void flb_test_hostname_key_rfc3164()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -624,7 +615,7 @@ void flb_test_hostname_key_rfc3164()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -664,7 +655,6 @@ void flb_test_hostname_key_rfc3164()
 
 void flb_test_appname_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -681,7 +671,7 @@ void flb_test_appname_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -721,7 +711,6 @@ void flb_test_appname_key_rfc5424()
 
 void flb_test_appname_key_rfc3164()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -738,7 +727,7 @@ void flb_test_appname_key_rfc3164()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -778,7 +767,6 @@ void flb_test_appname_key_rfc3164()
 
 void flb_test_procid_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -795,7 +783,7 @@ void flb_test_procid_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -835,7 +823,6 @@ void flb_test_procid_key_rfc5424()
 
 void flb_test_msgid_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -852,7 +839,7 @@ void flb_test_msgid_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -892,7 +879,6 @@ void flb_test_msgid_key_rfc5424()
 
 void flb_test_sd_key_rfc5424()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -909,7 +895,7 @@ void flb_test_sd_key_rfc5424()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);

--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -234,7 +234,7 @@ static void cb_check_msgpack_kv(void *ctx, int ffd, int res_ret,
     return ;
 }
 
-static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
+static struct test_ctx *test_ctx_create()
 {
     int i_ffd;
     int o_ffd;
@@ -261,7 +261,7 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
     ctx->i_ffd = i_ffd;
 
     /* Output */
-    o_ffd = flb_output(ctx->flb, (char *) "tcp", (void *) data);
+    o_ffd = flb_output(ctx->flb, (char *) "tcp", NULL);
     ctx->o_ffd = o_ffd;
 
     return ctx;
@@ -284,7 +284,6 @@ void flb_test_tcp_with_tls()
     size_t                 out_buf_size;
     char                   in_buf[256];
     struct flb_downstream *downstream;
-    struct flb_lib_out_cb  cb_data;
     const char            *out_buf;
     unsigned short int     port;
     struct test_ctx       *ctx;
@@ -298,7 +297,7 @@ void flb_test_tcp_with_tls()
 
     memset(in_buf, 0, sizeof(in_buf));
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -385,7 +384,6 @@ void flb_test_tcp_with_tls()
 
 void flb_test_format_msgpack()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -401,7 +399,7 @@ void flb_test_format_msgpack()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -439,7 +437,6 @@ void flb_test_format_msgpack()
 
 void flb_test_format_json()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -457,7 +454,7 @@ void flb_test_format_json()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -497,7 +494,6 @@ void flb_test_format_json()
 
 void flb_test_format_json_stream()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -515,7 +511,7 @@ void flb_test_format_json_stream()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -555,7 +551,6 @@ void flb_test_format_json_stream()
 
 void flb_test_format_json_lines()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -573,7 +568,7 @@ void flb_test_format_json_lines()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -613,7 +608,6 @@ void flb_test_format_json_lines()
 
 void flb_test_set_json_date_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -629,7 +623,7 @@ void flb_test_set_json_date_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -668,7 +662,6 @@ void flb_test_set_json_date_key()
 
 void flb_test_disable_json_date_key()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -684,7 +677,7 @@ void flb_test_disable_json_date_key()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -723,7 +716,6 @@ void flb_test_disable_json_date_key()
 
 void flb_test_json_date_format_epoch()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -739,7 +731,7 @@ void flb_test_json_date_format_epoch()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -778,7 +770,6 @@ void flb_test_json_date_format_epoch()
 
 void flb_test_json_date_format_iso8601()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -794,7 +785,7 @@ void flb_test_json_date_format_iso8601()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
@@ -833,7 +824,6 @@ void flb_test_json_date_format_iso8601()
 
 void flb_test_json_date_format_java_sql_timestamp()
 {
-    struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
     int ret;
     int num;
@@ -849,7 +839,7 @@ void flb_test_json_date_format_java_sql_timestamp()
 
     clear_output_num();
 
-    ctx = test_ctx_create(&cb_data);
+    ctx = test_ctx_create();
     if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This patch is to remove unused value of test code.
I removed out_lib callback values from out_tcp/out_http/out_syslog test code.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log

```
$ bin/flb-rt-out_syslog 
Test format_severity_key_rfc3164...             [ OK ]
Test format_facility_key_rfc3164...             [ OK ]
Test format_severity_facility_key_rfc3164...    [ OK ]
Test format_hostname_key_rfc3164...             [ OK ]
Test format_appname_key_rfc3164...              [ OK ]
Test format_syslog_rfc5424...                   [ OK ]
Test format_severity_key_rfc5424...             [ OK ]
Test format_facility_key_rfc5424...             [ OK ]
Test format_severity_facility_key_rfc5424...    [ OK ]
Test format_hostname_key_rfc5424...             [ OK ]
Test format_appname_key_rfc5424...              [ OK ]
Test format_procid_key_rfc5424...               [ OK ]
Test format_msgid_key_rfc5424...                [ OK ]
Test format_sd_key_rfc5424...                   [ OK ]
SUCCESS: All unit tests have passed.
$ bin/flb-rt-out_http
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test format_gelf...                             [ OK ]
Test format_gelf_host_key...                    [ OK ]
Test format_gelf_timestamp_key...               [ OK ]
Test format_gelf_full_message_key...            [ OK ]
Test format_gelf_level_key...                   [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
$ bin/flb-rt-out_tcp
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
$
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
