### PR TITLE
log: add flb_*_is_truncated functions to check if log will be truncated

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -104,7 +104,7 @@ int flb_log_set_file(struct flb_config *config, char *out);
 
 int flb_log_destroy(struct flb_log *log, struct flb_config *config);
 void flb_log_print(int type, const char *file, int line, const char *fmt, ...);
-
+int flb_log_is_truncated(int type, const char *file, int line, const char *fmt, ...);
 
 /* Logging macros */
 #define flb_helper(fmt, ...)                                    \
@@ -114,28 +114,58 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...);
     if (flb_log_check(FLB_LOG_ERROR))                                \
         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
 
+#define flb_error_is_truncated(fmt, ...)                                   \
+    flb_log_check(FLB_LOG_ERROR)                                           \
+        ? flb_log_is_truncated(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__) \
+        : 0
+
 #define flb_warn(fmt, ...)                                           \
     if (flb_log_check(FLB_LOG_WARN))                                 \
         flb_log_print(FLB_LOG_WARN, NULL, 0, fmt, ##__VA_ARGS__)
+
+#define flb_warn_is_truncated(fmt, ...     )                              \
+    flb_log_check(FLB_LOG_WARN)                                           \
+        ? flb_log_is_truncated(FLB_LOG_WARN, NULL, 0, fmt, ##__VA_ARGS__) \
+        : 0
 
 #define flb_info(fmt, ...)                                           \
     if (flb_log_check(FLB_LOG_INFO))                                 \
         flb_log_print(FLB_LOG_INFO, NULL, 0, fmt, ##__VA_ARGS__)
 
+#define flb_info_is_truncated(fmt, ...)                                   \
+    flb_log_check(FLB_LOG_INFO)                                           \
+        ? flb_log_is_truncated(FLB_LOG_INFO, NULL, 0, fmt, ##__VA_ARGS__) \
+        : 0
+
 #define flb_debug(fmt, ...)                                         \
     if (flb_log_check(FLB_LOG_DEBUG))                               \
         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
 
+#define flb_debug_is_truncated(fmt, ...       )                            \
+    flb_log_check(FLB_LOG_DEBUG)                                           \
+        ? flb_log_is_truncated(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__) \
+        : 0
+
 #define flb_idebug(fmt, ...)                                        \
     flb_log_print(FLB_LOG_IDEBUG, NULL, 0, fmt, ##__VA_ARGS__)
+
+#define flb_idebug_is_truncated(fmt, ...)                           \
+    flb_log_is_truncated(FLB_LOG_IDEBUG, NULL, 0, fmt, ##__VA_ARGS__)
 
 #ifdef FLB_HAVE_TRACE
 #define flb_trace(fmt, ...)                                             \
     if (flb_log_check(FLB_LOG_TRACE))                                   \
         flb_log_print(FLB_LOG_TRACE, __FILE__, __LINE__,                \
                       fmt, ##__VA_ARGS__)
+
+#define flb_trace_is_truncated(fmt, ...)                           \
+    flb_log_check(FLB_LOG_TRACE)                                   \
+        ? flb_log_is_truncated(FLB_LOG_TRACE, __FILE__, __LINE__,  \
+                      fmt, ##__VA_ARGS__)                          \
+        : 0
 #else
 #define flb_trace(fmt, ...)  do {} while(0)
+#define flb_trace_is_truncated(fmt, ...)  do {} while(0)
 #endif
 
 int flb_log_worker_init(struct flb_worker *worker);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 # Output Plugins
 if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_LIB              "core_engine.c")
+  FLB_RT_TEST(FLB_OUT_LIB              "core_log.c")
   FLB_RT_TEST(FLB_OUT_LIB              "config_map_opts.c")
   FLB_RT_TEST(FLB_OUT_COUNTER          "out_counter.c")
   FLB_RT_TEST(FLB_OUT_DATADOG          "out_datadog.c")

--- a/tests/runtime/core_log.c
+++ b/tests/runtime/core_log.c
@@ -1,0 +1,308 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_log.h>
+
+#include "flb_tests_runtime.h"
+
+
+static void check_result(char *level, int ret, int expect_truncated)
+{
+    if (expect_truncated == FLB_TRUE) {
+        if (!TEST_CHECK(ret > 0)) {
+            TEST_MSG("log is not truncated.level=%s ret=%d",level, ret);
+            /*
+              printf("ret=%d\n", ret);
+            */
+        }
+    }
+    else {
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("log is truncated.level=%s ret=%d",level, ret);
+            /*
+              printf("ret=%d\n", ret);
+            */
+        }
+    }
+
+}
+static void check_if_truncated(char* data, int expect_truncated)
+{
+    int ret;
+    ret = flb_error_is_truncated("%s", data);
+    check_result("error", ret, expect_truncated);
+
+    ret = flb_warn_is_truncated("%s", data);
+    check_result("warn", ret, expect_truncated);
+
+    ret = flb_info_is_truncated("%s", data);
+    check_result("info", ret, expect_truncated);
+
+    ret = flb_debug_is_truncated("%s", data);
+    check_result("debug", ret, expect_truncated);
+}
+
+static int cb_not_truncated_log(void *record, size_t size, void *data)
+{
+    check_if_truncated((char*)data, FLB_FALSE);
+
+    flb_free(record);
+    return 0;
+}
+
+
+static int cb_truncated_log(void *record, size_t size, void *data)
+{
+    check_if_truncated((char*)data, FLB_TRUE);
+
+    flb_free(record);
+    return 0;
+}
+
+static int cb_resize(void *record, size_t size, void *data)
+{
+    int ret;
+    char *log = (char*)data;
+
+    ret = flb_error_is_truncated("%s", log);
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("log is not truncated.ret=%d", ret);
+    }
+
+    ret = flb_error_is_truncated("%.*s", strlen(log) - ret, log);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("log is truncated.ret=%d", ret);
+    }
+
+    flb_free(record);
+    return 0;
+}
+
+static int cb_log_level(void *record, size_t size, void *data)
+{
+    int ret;
+    char *log = (char*)data;
+
+    ret = flb_error_is_truncated("%s", log);
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("log is not truncated.ret=%d", ret);
+    }
+
+    /* log_level is error. The function will return 0 */
+    ret = flb_info_is_truncated("%s", log);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("log is truncated.ret=%d", ret);
+    }
+
+    flb_free(record);
+    return 0;
+}
+
+void test_not_truncated_log()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int i;
+    char *msg = "[1, {\"msg\":\"body\"}]";
+    char log[128] = {0};
+    struct flb_lib_out_cb cb_data;
+
+    cb_data.cb = cb_not_truncated_log;
+    cb_data.data = &log[0];
+
+    for (i=0; i<sizeof(log)-1; i++) {
+        log[i] = 'a';
+    }
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void*)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "*",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, msg, strlen(msg));
+    TEST_CHECK(ret >= 0);
+
+    sleep(1);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+}
+
+void test_truncated_log()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int i;
+    char *msg = "[1, {\"msg\":\"body\"}]";
+    char log[4096 * 5] = {0};
+    struct flb_lib_out_cb cb_data;
+
+    cb_data.cb = cb_truncated_log;
+    cb_data.data = &log[0];
+
+    for (i=0; i<sizeof(log)-1; i++) {
+        log[i] = 'a';
+    }
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void*)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "*",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, msg, strlen(msg));
+    TEST_CHECK(ret >= 0);
+
+    sleep(1);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+}
+
+void test_resize()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int i;
+    char *msg = "[1, {\"msg\":\"body\"}]";
+    char log[4096 * 5] = {0};
+    struct flb_lib_out_cb cb_data;
+
+    cb_data.cb = cb_resize;
+    cb_data.data = &log[0];
+
+    for (i=0; i<sizeof(log)-1; i++) {
+        log[i] = 'a';
+    }
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void*)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "*",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, msg, strlen(msg));
+    TEST_CHECK(ret >= 0);
+
+    sleep(1);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+}
+
+void test_log_level()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int i;
+    char *msg = "[1, {\"msg\":\"body\"}]";
+    char log[4096 * 5] = {0};
+    struct flb_lib_out_cb cb_data;
+
+    cb_data.cb = cb_log_level;
+    cb_data.data = &log[0];
+
+    for (i=0; i<sizeof(log)-1; i++) {
+        log[i] = 'a';
+    }
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void*)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "*",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, msg, strlen(msg));
+    TEST_CHECK(ret >= 0);
+
+    sleep(1);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+}
+
+/* Test list */
+TEST_LIST = {
+    {"not_truncated_log", test_not_truncated_log },
+    {"truncated_log", test_truncated_log },
+    {"resize", test_resize },
+    {"log_level", test_log_level },
+    {NULL, NULL}
+};


### PR DESCRIPTION
Requested at https://github.com/fluent/fluent-bit/pull/5761#issuecomment-1216978362.

This patch splits `flb_log_print` function.
1. Construct log and check the buffer size.
2. Send log to pipe.

This patch also adds a function to check if the log will be truncated or not using Step1 of `flb_log_print` and test codes.
The function doesn't flush log buffer, only checks.
It needs args like printf and returns the result.

Return value
 0              : The log is not truncated or filtered by log level setting.
 -1             : Some error occurs.
 positive number: The log will be truncated. Return value means the excess size.


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug log/Valgrind log

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/flb-rt-core_log 
==127391== Memcheck, a memory error detector
==127391== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==127391== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==127391== Command: bin/flb-rt-core_log
==127391== 
Test not_truncated_log...                       [2022/08/28 20:07:01] [ info] [fluent bit] version=2.0.0, commit=7b3a6bf87e, pid=127392
[2022/08/28 20:07:01] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/08/28 20:07:01] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/28 20:07:01] [ info] [cmetrics] version=0.3.6
[2022/08/28 20:07:01] [debug] [lib:lib.0] created event channels: read=21 write=22
[2022/08/28 20:07:01] [debug] [lib:lib.0] created event channels: read=25 write=26
[2022/08/28 20:07:01] [debug] [router] match rule lib.0:lib.0
[2022/08/28 20:07:01] [ info] [sp] stream processor started
[2022/08/28 20:07:01] [debug] [input chunk] update output instances with new chunk size diff=12
[2022/08/28 20:07:02] [debug] [task] created task=0x548afc0 id=0 OK
==127392== Warning: client switching stacks?  SP change: 0x5ff7778 --> 0x5491470
==127392==          to suppress, use: --max-stackframe=11952904 or greater
==127392== Warning: client switching stacks?  SP change: 0x54913c8 --> 0x5ff7778
==127392==          to suppress, use: --max-stackframe=11953072 or greater
==127392== Warning: client switching stacks?  SP change: 0x5ff79a8 --> 0x54913c8
==127392==          to suppress, use: --max-stackframe=11953632 or greater
==127392==          further instances of this message will not be shown.
[2022/08/28 20:07:02] [debug] [out flush] cb_destroy coro_id=0
[2022/08/28 20:07:02] [debug] [task] destroy task=0x548afc0 (task_id=0)
[2022/08/28 20:07:02] [ warn] [engine] service will shutdown in max 1 seconds
[2022/08/28 20:07:03] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
==127392== 
==127392== HEAP SUMMARY:
==127392==     in use at exit: 64 bytes in 1 blocks
==127392==   total heap usage: 1,024 allocs, 1,023 frees, 591,751 bytes allocated
==127392== 
==127392== 64 bytes in 1 blocks are still reachable in loss record 1 of 1
==127392==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==127392==    by 0x1674BE: main (acutest.h:1632)
==127392== 
==127392== LEAK SUMMARY:
==127392==    definitely lost: 0 bytes in 0 blocks
==127392==    indirectly lost: 0 bytes in 0 blocks
==127392==      possibly lost: 0 bytes in 0 blocks
==127392==    still reachable: 64 bytes in 1 blocks
==127392==         suppressed: 0 bytes in 0 blocks
==127392== 
==127392== For lists of detected and suppressed errors, rerun with: -s
==127392== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test truncated_log...                           [2022/08/28 20:07:04] [ info] [fluent bit] version=2.0.0, commit=7b3a6bf87e, pid=127398
[2022/08/28 20:07:04] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/08/28 20:07:04] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/08/28 20:07:04] [ info] [cmetrics] version=0.3.6
[2022/08/28 20:07:04] [debug] [lib:lib.0] created event channels: read=21 write=22
[2022/08/28 20:07:04] [debug] [lib:lib.0] created event channels: read=25 write=26
[2022/08/28 20:07:04] [debug] [router] match rule lib.0:lib.0
[2022/08/28 20:07:04] [ info] [sp] stream processor started
[2022/08/28 20:07:04] [debug] [input chunk] update output instances with new chunk size diff=12
[2022/08/28 20:07:04] [debug] [task] created task=0x548afc0 id=0 OK
==127398== Warning: client switching stacks?  SP change: 0x5ff7778 --> 0x5491470
==127398==          to suppress, use: --max-stackframe=11952904 or greater
==127398== Warning: client switching stacks?  SP change: 0x54913c8 --> 0x5ff7778
==127398==          to suppress, use: --max-stackframe=11953072 or greater
==127398== Warning: client switching stacks?  SP change: 0x5ff79a8 --> 0x54913c8
==127398==          to suppress, use: --max-stackframe=11953632 or greater
==127398==          further instances of this message will not be shown.
[2022/08/28 20:07:04] [debug] [out flush] cb_destroy coro_id=0
[2022/08/28 20:07:04] [debug] [task] destroy task=0x548afc0 (task_id=0)
[2022/08/28 20:07:05] [ warn] [engine] service will shutdown in max 1 seconds
[2022/08/28 20:07:05] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
==127398== 
==127398== HEAP SUMMARY:
==127398==     in use at exit: 64 bytes in 1 blocks
==127398==   total heap usage: 1,024 allocs, 1,023 frees, 591,751 bytes allocated
==127398== 
==127398== 64 bytes in 1 blocks are still reachable in loss record 1 of 1
==127398==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==127398==    by 0x1674BE: main (acutest.h:1632)
==127398== 
==127398== LEAK SUMMARY:
==127398==    definitely lost: 0 bytes in 0 blocks
==127398==    indirectly lost: 0 bytes in 0 blocks
==127398==      possibly lost: 0 bytes in 0 blocks
==127398==    still reachable: 64 bytes in 1 blocks
==127398==         suppressed: 0 bytes in 0 blocks
==127398== 
==127398== For lists of detected and suppressed errors, rerun with: -s
==127398== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test resize...                                  ==127401== Warning: client switching stacks?  SP change: 0x5ff7778 --> 0x548ffd0
==127401==          to suppress, use: --max-stackframe=11958184 or greater
==127401== Warning: client switching stacks?  SP change: 0x548ff28 --> 0x5ff7778
==127401==          to suppress, use: --max-stackframe=11958352 or greater
==127401== Warning: client switching stacks?  SP change: 0x5ff79a8 --> 0x548ff28
==127401==          to suppress, use: --max-stackframe=11958912 or greater
==127401==          further instances of this message will not be shown.
[ OK ]
==127401== 
==127401== HEAP SUMMARY:
==127401==     in use at exit: 64 bytes in 1 blocks
==127401==   total heap usage: 1,024 allocs, 1,023 frees, 591,751 bytes allocated
==127401== 
==127401== 64 bytes in 1 blocks are still reachable in loss record 1 of 1
==127401==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==127401==    by 0x1674BE: main (acutest.h:1632)
==127401== 
==127401== LEAK SUMMARY:
==127401==    definitely lost: 0 bytes in 0 blocks
==127401==    indirectly lost: 0 bytes in 0 blocks
==127401==      possibly lost: 0 bytes in 0 blocks
==127401==    still reachable: 64 bytes in 1 blocks
==127401==         suppressed: 0 bytes in 0 blocks
==127401== 
==127401== For lists of detected and suppressed errors, rerun with: -s
==127401== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test log_level...                               ==127404== Warning: client switching stacks?  SP change: 0x5ff7778 --> 0x548ffd0
==127404==          to suppress, use: --max-stackframe=11958184 or greater
==127404== Warning: client switching stacks?  SP change: 0x548ff28 --> 0x5ff7778
==127404==          to suppress, use: --max-stackframe=11958352 or greater
==127404== Warning: client switching stacks?  SP change: 0x5ff79a8 --> 0x548ff28
==127404==          to suppress, use: --max-stackframe=11958912 or greater
==127404==          further instances of this message will not be shown.
[ OK ]
==127404== 
==127404== HEAP SUMMARY:
==127404==     in use at exit: 64 bytes in 1 blocks
==127404==   total heap usage: 1,024 allocs, 1,023 frees, 591,751 bytes allocated
==127404== 
==127404== 64 bytes in 1 blocks are still reachable in loss record 1 of 1
==127404==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==127404==    by 0x1674BE: main (acutest.h:1632)
==127404== 
==127404== LEAK SUMMARY:
==127404==    definitely lost: 0 bytes in 0 blocks
==127404==    indirectly lost: 0 bytes in 0 blocks
==127404==      possibly lost: 0 bytes in 0 blocks
==127404==    still reachable: 64 bytes in 1 blocks
==127404==         suppressed: 0 bytes in 0 blocks
==127404== 
==127404== For lists of detected and suppressed errors, rerun with: -s
==127404== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==127391== 
==127391== HEAP SUMMARY:
==127391==     in use at exit: 0 bytes in 0 blocks
==127391==   total heap usage: 3 allocs, 3 frees, 1,125 bytes allocated
==127391== 
==127391== All heap blocks were freed -- no leaks are possible
==127391== 
==127391== For lists of detected and suppressed errors, rerun with: -s
==127391== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
