### PR TITLE
build: flb_network: Make buildable and workable on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 
 include(GNUInstallDirs)
 include(ExternalProject)
+include(CheckIncludeFile)
 include(cmake/FindJournald.cmake)
 include(cmake/FindMonkey.cmake)
 include(cmake/macros.cmake)
@@ -677,6 +678,21 @@ check_c_source_compiles("
   }" FLB_HAVE_UNIX_SOCKET)
 if(FLB_HAVE_UNIX_SOCKET)
   FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
+endif()
+
+check_include_file(sys/ucred.h FLB_HAVE_SYS_UCRED_H)
+if(FLB_HAVE_SYS_UCRED_H)
+  FLB_DEFINITION(FLB_HAVE_SYS_UCRED_H)
+endif()
+
+check_symbol_exists(SO_PEERCRED "sys/socket.h" FLB_HAVE_DECL_SO_PEERCRED)
+if(FLB_HAVE_DECL_SO_PEERCRED)
+  FLB_DEFINITION(FLB_HAVE_DECL_SO_PEERCRED)
+endif()
+
+check_symbol_exists(LOCAL_PEERCRED "sys/un.h" FLB_HAVE_DECL_LOCAL_PEERCRED)
+if(FLB_HAVE_DECL_LOCAL_PEERCRED)
+  FLB_DEFINITION(FLB_HAVE_DECL_LOCAL_PEERCRED)
 endif()
 
 # Configuration file YAML format support

--- a/include/fluent-bit/flb_socket.h
+++ b/include/fluent-bit/flb_socket.h
@@ -37,6 +37,9 @@
 #else
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef FLB_HAVE_SYS_UCRED_H
+#include <sys/ucred.h>
+#endif
 
 #define flb_sockfd_t         int
 


### PR DESCRIPTION
This is because macOS does not have SO_PEERCRED and struct ucred.
Instead, we have to use LOCAL_PEERCRED and struct xucred for obtaining
credentials.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->
Follows up https://github.com/fluent/fluent-bit/pull/5918

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
