### PR TITLE
plugins: added collector destruction before listener disposal to fix macos issue

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -167,6 +167,7 @@ static int in_fw_init(struct flb_input_instance *ins,
     if (!ctx) {
         return -1;
     }
+    ctx->coll_fd = -1;
     ctx->ins = ins;
     mk_list_init(&ctx->connections);
 

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -70,6 +70,12 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
 
 int fw_config_destroy(struct flb_in_fw_config *config)
 {
+    if (config->coll_fd != -1) {
+        flb_input_collector_delete(config->coll_fd, config->ins);
+
+        config->coll_fd = -1;
+    }
+
     if (config->downstream != NULL) {
         flb_downstream_destroy(config->downstream);
     }

--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -77,6 +77,8 @@ static int in_http_init(struct flb_input_instance *ins,
         return -1;
     }
 
+    ctx->collector_id = -1;
+
     /* Populate context with config map defaults and incoming properties */
     ret = flb_input_config_map_set(ins, (void *) ctx);
     if (ret == -1) {
@@ -129,6 +131,8 @@ static int in_http_init(struct flb_input_instance *ins,
 
         return -1;
     }
+
+    ctx->collector_id = ret;
 
     return 0;
 }

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -36,6 +36,8 @@ struct flb_http {
     flb_sds_t tcp_port;
     const char *tag_key;
 
+    int collector_id;
+
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */
 

--- a/plugins/in_http/http_config.c
+++ b/plugins/in_http/http_config.c
@@ -66,6 +66,12 @@ int http_config_destroy(struct flb_http *ctx)
     /* release all connections */
     http_conn_release_all(ctx);
 
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }

--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -74,6 +74,7 @@ static int in_opentelemetry_init(struct flb_input_instance *ins,
     if (!ctx) {
         return -1;
     }
+    ctx->collector_id = -1;
 
     /* Populate context with config map defaults and incoming properties */
     ret = flb_input_config_map_set(ins, (void *) ctx);
@@ -128,6 +129,8 @@ static int in_opentelemetry_init(struct flb_input_instance *ins,
         opentelemetry_config_destroy(ctx);
         return -1;
     }
+
+    ctx->collector_id = ret;
 
     return 0;
 }

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -38,6 +38,7 @@ struct flb_opentelemetry {
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */
 
+    int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* linked list of connections */
     struct mk_event_loop *evl;         /* Event loop context */

--- a/plugins/in_opentelemetry/opentelemetry_config.c
+++ b/plugins/in_opentelemetry/opentelemetry_config.c
@@ -70,6 +70,12 @@ int opentelemetry_config_destroy(struct flb_opentelemetry *ctx)
     /* release all connections */
     opentelemetry_conn_release_all(ctx);
 
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -107,6 +107,7 @@ static int in_syslog_init(struct flb_input_instance *in,
         flb_plg_error(in, "could not initialize plugin");
         return -1;
     }
+    ctx->collector_id = -1;
 
     if ((ctx->mode == FLB_SYSLOG_UNIX_TCP || ctx->mode == FLB_SYSLOG_UNIX_UDP)
         && !ctx->unix_path) {
@@ -171,6 +172,7 @@ static int in_syslog_init(struct flb_input_instance *in,
         return -1;
     }
 
+    ctx->collector_id = ret;
     ctx->collector_event = flb_input_collector_get_event(ret, in);
 
     if (ret == -1) {

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -64,6 +64,7 @@ struct flb_syslog {
     struct flb_parser *parser;
 
     int dgram_mode_flag;
+    int collector_id;
     struct mk_event *collector_event;
     struct flb_downstream *downstream;
     struct syslog_conn *dummy_conn;

--- a/plugins/in_syslog/syslog_conn.c
+++ b/plugins/in_syslog/syslog_conn.c
@@ -222,7 +222,9 @@ int syslog_conn_del(struct syslog_conn *conn)
     /* The downstream unregisters the file descriptor from the event-loop
      * so there's nothing to be done by the plugin
      */
-    flb_downstream_conn_release(conn->connection);
+    if (!ctx->dgram_mode_flag) {
+        flb_downstream_conn_release(conn->connection);
+    }
 
     /* Release resources */
     mk_list_del(&conn->_head);

--- a/plugins/in_syslog/syslog_server.c
+++ b/plugins/in_syslog/syslog_server.c
@@ -192,6 +192,12 @@ int syslog_server_create(struct flb_syslog *ctx)
 
 int syslog_server_destroy(struct flb_syslog *ctx)
 {
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
 

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -77,6 +77,7 @@ static int in_tcp_init(struct flb_input_instance *in,
     if (!ctx) {
         return -1;
     }
+    ctx->collector_id = -1;
     ctx->ins = in;
     mk_list_init(&ctx->connections);
 
@@ -116,6 +117,8 @@ static int in_tcp_init(struct flb_input_instance *in,
 
         return -1;
     }
+
+    ctx->collector_id = ret;
 
     return 0;
 }

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -39,6 +39,7 @@ struct flb_in_tcp_config {
     char *tcp_port;                    /* TCP Port                    */
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
+    int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* List of active connections  */
     struct mk_event_loop *evl;         /* Event loop file descriptor  */

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -124,6 +124,12 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *ins)
 
 int tcp_config_destroy(struct flb_in_tcp_config *ctx)
 {
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }

--- a/plugins/in_udp/udp.c
+++ b/plugins/in_udp/udp.c
@@ -63,6 +63,7 @@ static int in_udp_init(struct flb_input_instance *in,
         return -1;
     }
 
+    ctx->collector_id = -1;
     ctx->ins = in;
 
     /* Set the context */
@@ -122,6 +123,7 @@ static int in_udp_init(struct flb_input_instance *in,
         return -1;
     }
 
+    ctx->collector_id = ret;
     ctx->collector_event = flb_input_collector_get_event(ret, in);
 
     if (ret == -1) {

--- a/plugins/in_udp/udp.h
+++ b/plugins/in_udp/udp.h
@@ -42,6 +42,7 @@ struct flb_in_udp_config {
     char *port;                        /* Port                        */
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
+    int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager              */
     struct udp_conn *dummy_conn;       /* Datagram dummy connection   */
     struct mk_event_loop *evl;         /* Event loop file descriptor  */

--- a/plugins/in_udp/udp_config.c
+++ b/plugins/in_udp/udp_config.c
@@ -124,6 +124,12 @@ struct flb_in_udp_config *udp_config_init(struct flb_input_instance *ins)
 
 int udp_config_destroy(struct flb_in_udp_config *ctx)
 {
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }

--- a/plugins/in_unix_socket/unix_socket.c
+++ b/plugins/in_unix_socket/unix_socket.c
@@ -117,6 +117,7 @@ static int in_unix_socket_init(struct flb_input_instance *in,
         return -1;
     }
 
+    ctx->collector_id = -1;
     ctx->ins = in;
 
     mk_list_init(&ctx->connections);
@@ -229,6 +230,7 @@ static int in_unix_socket_init(struct flb_input_instance *in,
         return -1;
     }
 
+    ctx->collector_id = ret;
     ctx->collector_event = flb_input_collector_get_event(ret, in);
 
     if (ret == -1) {

--- a/plugins/in_unix_socket/unix_socket.h
+++ b/plugins/in_unix_socket/unix_socket.h
@@ -43,6 +43,7 @@ struct flb_in_unix_socket_config {
     int socket_acl;                    /* Unix socket ACL             */
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
+    int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager              */
     struct unix_socket_conn *dummy_conn;/* Datagram dummy connection   */
     struct mk_list connections;        /* List of active connections  */

--- a/plugins/in_unix_socket/unix_socket_config.c
+++ b/plugins/in_unix_socket/unix_socket_config.c
@@ -123,6 +123,12 @@ struct flb_in_unix_socket_config *unix_socket_config_init(struct flb_input_insta
 
 int unix_socket_config_destroy(struct flb_in_unix_socket_config *ctx)
 {
+    if (ctx->collector_id != -1) {
+        flb_input_collector_delete(ctx->collector_id, ctx->ins);
+
+        ctx->collector_id = -1;
+    }
+
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }


### PR DESCRIPTION
This PR fixes a long standing macos shutdown issue that persisted after the downstream upgrade.
When an input plugin registers a socket collector it is automatically added to the event loop. If the 
plugin then closes the file descriptor on its destructor without disposing of the collector when 
`flb_input_instance_destroy`  iterates the collector list destroying them it tries to unregister the already
closed file descriptor which causes a corruption that we are still investigating to determine if it's a 
bug in the `mk_event` layer.

Regardless of that, properly disposing of the collector (`flb_input_collector_pause` would work as well) 
before closing the socket solves the issue.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>