### PR TITLE
flb_network: Fix argument glitch when detection of unix socket support is failed

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1629,7 +1629,9 @@ flb_sockfd_t flb_net_server_unix(const char *listen_path,
     return fd;
 }
 #else
-flb_sockfd_t flb_net_server_unix(const char *listen_path)
+flb_sockfd_t flb_net_server_unix(const char *listen_path,
+                                 int stream_mode,
+                                 int backlog)
 {
     flb_error("Unix sockets are not available in this platform");
 


### PR DESCRIPTION
In macOS, when detection of unix socket support is failed, the following error is occurred on FLB_HAVE_UNIX_SOCKET's else branch:

```log
/Users/cosmo/GitHub/fluent-bit/src/flb_network.c:1632:14: error: conflicting types for 'flb_net_server_unix'
flb_sockfd_t flb_net_server_unix(const char *listen_path)
             ^
/Users/cosmo/GitHub/fluent-bit/include/fluent-bit/flb_network.h:162:14: note: previous declaration is here
flb_sockfd_t flb_net_server_unix(const char *listen_path, int stream_mode,
             ^
```

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
