### PR TITLE
pack: Fix oss-fuzz crash

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -322,6 +322,7 @@ int flb_pack_state_init(struct flb_pack_state *s)
     if (!s->buf_data) {
         flb_errno();
         flb_free(s->tokens);
+        s->tokens = NULL;
         return -1;
     }
     s->buf_size = size;
@@ -405,7 +406,7 @@ int flb_pack_json_state(const char *js, size_t len,
         return ret;
     }
 
-    if (state->tokens_count == 0) {
+    if (state->tokens_count == 0 || state->tokens == NULL) {
         state->last_byte = last;
         return FLB_ERR_JSON_INVAL;
     }


### PR DESCRIPTION
This is a continuation of https://github.com/fluent/fluent-bit/pull/5883 in order to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45978 Now same file make fluent-bit to crash in a different place.
The fix is to reset the `tokens` pointer to NULL after it is freed and handle that the value may be NULL in a different place.