### PR TITLE
tests: macos fixes, mostly TLS initialization stuff

### DIFF
--- a/lib/monkey/include/monkey/mk_core/mk_utils.h
+++ b/lib/monkey/include/monkey/mk_core/mk_utils.h
@@ -86,8 +86,7 @@ extern pthread_key_t mk_utils_error_key;
 #define MK_UTILS_LIBC_ERRNO_BUFFER()                                    \
     int _err  = errno;                                                  \
     char bufs[256];                                                     \
-    char *buf = (char *) pthread_getspecific(mk_utils_error_key);       \
-    if (!buf) buf = bufs;                                               \
+    char *buf = bufs;                                                   \
     if (strerror_r(_err, buf, MK_UTILS_ERROR_SIZE) != 0) {              \
         mk_err("strerror_r() failed");                                  \
     }

--- a/plugins/in_dummy_thread/in_dummy_thread.c
+++ b/plugins/in_dummy_thread/in_dummy_thread.c
@@ -70,6 +70,8 @@ static int in_dummy_thread_init(struct flb_input_instance *in,
         flb_errno();
         return -1;
     }
+    ctx->it.coll_fd = -1;
+    ctx->ins = in;
     
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *)ctx);
@@ -124,6 +126,13 @@ static int in_dummy_thread_exit(void *in_context, struct flb_config *config)
 
     it = in_context;
     ctx = container_of(it, struct flb_in_dummy_thread_config, it);
+
+    if (it->coll_fd != -1) {
+        flb_input_collector_delete(it->coll_fd, ctx->ins);
+
+        it->coll_fd = -1;
+    }
+
     flb_input_thread_destroy(it, ctx->ins);
     flb_free(ctx);
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -409,7 +409,9 @@ void flb_config_exit(struct flb_config *config)
 
     /* Event flush */
     if (config->evl) {
-        mk_event_timeout_destroy(config->evl, &config->event_flush);
+        if (config->event_flush.status != MK_EVENT_NONE) {
+            mk_event_timeout_destroy(config->evl, &config->event_flush);
+        }
     }
 
     /* Release scheduler */

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -451,7 +451,7 @@ int flb_downstream_conn_timeouts(struct mk_list *list)
                 if (connection->event.status != MK_EVENT_NONE) {
                     mk_event_inject(connection->evl,
                                     &connection->event,
-                                    MK_EVENT_READ | MK_EVENT_WRITE,
+                                    connection->event.mask,
                                     FLB_TRUE);
                 }
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -843,7 +843,7 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
                 if (u_conn->event.status != MK_EVENT_NONE) {
                     mk_event_inject(u_conn->evl,
                                     &u_conn->event,
-                                    MK_EVENT_READ | MK_EVENT_WRITE,
+                                    u_conn->event.mask,
                                     FLB_TRUE);
                 }
 

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_config_format.h>

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -14,6 +14,19 @@
 
 #define ERROR_LOG "fluentbit_conf_error.log"
 
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
+
 /* data/config_format/fluent-bit.conf */
 void test_basic()
 {
@@ -21,6 +34,8 @@ void test_basic()
 	struct flb_cf *cf;
     struct flb_cf_section *s;
     struct flb_cf_group *g;
+
+    initialization_crutch();
 
     cf = flb_cf_fluentbit_create(NULL, FLB_000, NULL, 0);
     TEST_CHECK(cf != NULL);
@@ -130,6 +145,8 @@ void missing_value()
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
     };
+
+    initialization_crutch();
 
     unlink(ERROR_LOG);
 

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -103,8 +103,8 @@ void test_timeout_create(struct mk_event_loop *loop,
 void test_timeout_destroy(struct mk_event_loop *loop, void *data)
 {
     struct mk_event *event = (struct mk_event *) data;
-    flb_pipe_close(event->fd);
     mk_event_del(loop, event);
+    flb_pipe_close(event->fd);
 }
 
 struct test_evl_context *evl_context_create()

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -18,7 +18,14 @@
 
 #define EVENT_LOOP_TEST_PRIORITIES 7
 #define EVENT_LOOP_MAX_EVENTS 64
-#ifdef _WIN32
+
+/* I don't think those are CI friendly parameters,
+ * at least in github macos exceeds them considerably.
+ */
+
+#ifdef FLB_SYSTEM_MACOS
+    #define TIME_EPSILON_MS 200
+#elif FLB_SYSTEM_WINDOWS
     #define TIME_EPSILON_MS 30
 #else
     #define TIME_EPSILON_MS 10

--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -31,6 +31,19 @@
 #define D_SEC 1647061992.123;
 const char eventtime[8] = {0x62, 0x2c, 0x2b, 0xe8, 0x07, 0x54, 0xd4, 0xc0 };
 
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
+
 void test_to_nanosec()
 {
     uint64_t expect = 123000000456;
@@ -224,6 +237,8 @@ void test_msgpack_to_time_invalid()
 
 
     msgpack_object tm_obj;
+
+    initialization_crutch();
 
     /* create int object*/
     msgpack_sbuffer_init(&mp_sbuf);

--- a/tests/internal/fstore.c
+++ b/tests/internal/fstore.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_fstore.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_compat.h>
@@ -37,6 +38,18 @@
 #define FSF_STORE_PATH "/tmp/flb-fstore"
 #endif
 
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
 void cb_all()
 {
     int ret;
@@ -46,6 +59,8 @@ void cb_all()
     struct flb_fstore *fs;
     struct flb_fstore_stream *st;
     struct flb_fstore_file *fsf;
+
+    initialization_crutch();
 
     cio_utils_recursive_delete(FSF_STORE_PATH);
 

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -408,6 +408,7 @@ void flb_test_input_chunk_fs_chunks_size_real()
     struct mk_event_loop *evl;
     struct cio_options opts = {0};
 
+    flb_init_env();
     cfg = flb_config_init();
     evl = mk_event_loop_create(256);
 

--- a/tests/internal/metrics.c
+++ b/tests/internal/metrics.c
@@ -1,11 +1,25 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_metrics.h>
 
 #include "flb_tests_internal.h"
+
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
 
 static void test_create_usage()
 {
@@ -15,6 +29,8 @@ static void test_create_usage()
     int id_3;
     struct flb_metric *m;
     struct flb_metrics *ctx;
+
+    initialization_crutch();
 
     /* Create and destroy */
     ctx = flb_metrics_create("metrics");

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_error.h>
@@ -13,7 +14,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <math.h> /* for NAN */
-
 
 #include "flb_tests_internal.h"
 
@@ -36,6 +36,19 @@ struct pack_test {
 /* If we get more than 256 tests, just update the size */
 struct pack_test pt[256];
 
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
+
 static inline void consume_bytes(char *buf, int bytes, int length)
 {
     memmove(buf, buf + bytes, length - bytes);
@@ -50,6 +63,8 @@ void test_json_pack()
     char *data;
     char *out_buf;
     size_t out_size;
+
+    initialization_crutch();
 
     data = mk_file_to_buffer(JSON_SINGLE_MAP1);
     TEST_CHECK(data != NULL);
@@ -73,6 +88,8 @@ void test_json_pack_iter()
     char *out_buf = NULL;
     int out_size;
     struct flb_pack_state state;
+
+    initialization_crutch();
 
     data = mk_file_to_buffer(JSON_SINGLE_MAP1);
     TEST_CHECK(data != NULL);
@@ -114,6 +131,8 @@ void test_json_pack_mult()
     msgpack_unpacked result;
     msgpack_object root;
     struct flb_pack_state state;
+
+    initialization_crutch();
 
     data1 = mk_file_to_buffer(JSON_SINGLE_MAP1);
     TEST_CHECK(data1 != NULL);
@@ -182,6 +201,8 @@ void test_json_pack_mult_iter()
     msgpack_unpacked result;
     msgpack_object root;
     struct flb_pack_state state;
+
+    initialization_crutch();
 
     data1 = mk_file_to_buffer(JSON_SINGLE_MAP1);
     TEST_CHECK(data1 != NULL);
@@ -263,6 +284,8 @@ void test_json_dup_keys()
     flb_sds_t out_json;
     flb_sds_t d;
 
+    initialization_crutch();
+
     /* Read JSON input file */
     data_in = mk_file_to_buffer(JSON_DUP_KEYS_I);
     TEST_CHECK(data_in != NULL);
@@ -312,6 +335,9 @@ void test_json_pack_bug342()
     struct stat st;
     struct flb_pack_state state;
     msgpack_unpacked result;
+
+    initialization_crutch();
+
     ret = stat(JSON_BUG342, &st);
     if (ret == -1) {
         perror("stat");
@@ -396,6 +422,8 @@ static int utf8_tests_create()
     struct dirent *entry;
     struct stat st;
 
+    initialization_crutch();
+
     memset(pt, '\0', sizeof(pt));
 
     dir = opendir(PACK_SAMPLES);
@@ -471,6 +499,8 @@ void test_utf8_to_json()
     size_t json_size;
     struct stat st;
     struct pack_test *test;
+
+    initialization_crutch();
 
     n_tests = utf8_tests_create();
 
@@ -562,6 +592,8 @@ void test_json_pack_bug1278()
                    "\"\\\\n\"",
     };
 
+    initialization_crutch();
+
     printf("\n");
     items = sizeof(in) / sizeof(char *);
     for (i = 0; i < items; i++) {
@@ -647,6 +679,8 @@ void test_json_pack_nan()
     msgpack_zone mempool;
 
     config.convert_nan_to_null = FLB_TRUE;
+
+    initialization_crutch();
 
     // initialize msgpack
     msgpack_sbuffer_init(&mp_sbuf);
@@ -769,6 +803,8 @@ void test_json_pack_bug5336()
     size_t off = 0;
 
     int loop_cnt = 0;
+
+    initialization_crutch();
 
     for (i=len; i<len*2; i++) {
         loop_cnt++;

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_sds.h>
@@ -30,6 +31,19 @@
 #include "flb_tests_internal.h"
 
 #include <stdlib.h>
+
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
 
 static int create_map(char *input_json, msgpack_object *out_map,
                       char **out_buf, msgpack_unpacked *out_result)
@@ -73,6 +87,8 @@ static int set_str_to_msgpack_object(char *str, msgpack_object *obj)
 void cb_keys()
 {
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     printf("\n=== test ===");
     ra = flb_ra_create("$aaa['a'] extra $bbb['b'] final access", FLB_TRUE);
@@ -136,6 +152,8 @@ void cb_translate()
     msgpack_unpacked result;
     msgpack_object map;
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -209,6 +227,8 @@ void cb_translate_tag()
     msgpack_object map;
     struct flb_record_accessor *ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json =
         "{\"k1\": \"string\", \"k2\": true, \"k3\": false," \
@@ -264,6 +284,8 @@ void cb_dots_subkeys()
     msgpack_unpacked result;
     msgpack_object map;
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -326,6 +348,8 @@ void cb_array_id()
     msgpack_unpacked result;
     msgpack_object map;
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -396,6 +420,8 @@ void cb_get_kv_pair()
     msgpack_unpacked result;
     msgpack_object map;
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -474,6 +500,8 @@ void cb_update_key_val()
 
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -580,6 +608,8 @@ void cb_update_val()
 
     struct flb_record_accessor *ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json =
         "{\"key1\": \"something\", "
@@ -669,6 +699,8 @@ void cb_update_key()
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json =
         "{\"key1\": \"something\", "
@@ -757,6 +789,8 @@ void cb_dash_key()
     msgpack_object map;
     struct flb_record_accessor *ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json = "{\"key-dash\": \"something\"}";
 
@@ -817,6 +851,8 @@ void cb_dot_and_slash_key()
     msgpack_object map;
     struct flb_record_accessor *ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json = "{\"root.with/symbols\": \"something\"}";
 
@@ -875,6 +911,8 @@ static int order_lookup_check(char *buf, size_t size,
     msgpack_object map;
     struct flb_record_accessor *ra;
 
+    initialization_crutch();
+
     /* Check bool is 'true' */
     fmt = flb_sds_create(fmt);
     if (!TEST_CHECK(fmt != NULL)) {
@@ -924,6 +962,8 @@ void cb_key_order_lookup()
     size_t out_size;
     char *json;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json = "{\"key\": \"abc\", \"bool\": false, \"bool\": true, "
              "\"str\": \"bad\", \"str\": \"good\", "
@@ -963,6 +1003,8 @@ void cb_issue_4917()
     struct flb_record_accessor *ra;
     msgpack_unpacked result;
     msgpack_object map;
+
+    initialization_crutch();
 
     fmt_out = "from.new.fluent.bit.out";
 
@@ -1046,6 +1088,8 @@ void cb_update_root_key()
 
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -1145,6 +1189,8 @@ void cb_update_root_key_val()
 
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json =
@@ -1255,6 +1301,8 @@ void cb_add_key_val()
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json =
         "{\"key1\": \"something\", "
@@ -1359,6 +1407,8 @@ void cb_add_root_key_val()
     struct flb_record_accessor *ra;
     struct flb_record_accessor *updated_ra;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json =
         "{\"key1\": \"something\", "
@@ -1453,6 +1503,8 @@ void cb_ra_translate_check()
     struct flb_record_accessor *ra;
     int check_translation = FLB_TRUE;
 
+    initialization_crutch();
+
     /* Sample JSON message */
     json = "{\"root.with/symbols\": \"something\"}";
 
@@ -1515,6 +1567,8 @@ void cb_issue_5936_last_array()
     msgpack_unpacked result;
     msgpack_object map;
     struct flb_record_accessor *ra;
+
+    initialization_crutch();
 
     /* Sample JSON message */
     json ="{ \"key\": {\"nested\":[\"val0\", \"val1\"]}}";

--- a/tests/internal/signv4.c
+++ b/tests/internal/signv4.c
@@ -33,6 +33,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_http_client.h>
@@ -78,6 +79,19 @@ struct aws_test {
     struct flb_http_client *c;
     struct mk_list _head;
 };
+
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
 
 static struct request *http_request_create(char *request)
 {
@@ -557,6 +571,8 @@ static void aws_test_suite()
     struct aws_test *awt;
     struct flb_aws_provider *provider;
 
+    initialization_crutch();
+
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
         flb_errno();
@@ -640,6 +656,8 @@ static void check_normalize(char *s, size_t len, char *out)
 
 void normalize()
 {
+    initialization_crutch();
+
     /* get-relative */
     check_normalize("/example/..", 11, "/");
 

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_error.h>
@@ -53,6 +54,19 @@
     FLB_TESTS_DATA_PATH "/data/stream_processor/samples-hw/"
 
 #define MP_UOK MSGPACK_UNPACK_SUCCESS
+
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
 
 int flb_sp_fd_event_test(int fd, struct flb_sp_task *task, struct sp_buffer *out_buf)
 {
@@ -199,6 +213,8 @@ static void invalid_queries()
     struct flb_sp *sp;
     struct flb_sp_task *task;
 
+    initialization_crutch();
+
     /* Total number of checks for invalid queries */
     checks = sizeof(invalid_query_checks) / sizeof(char *);
 
@@ -242,6 +258,8 @@ static void test_select_keys()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    initialization_crutch();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -328,6 +346,8 @@ static void test_select_subkeys()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    initialization_crutch();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -456,6 +476,8 @@ static void test_window()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    initialization_crutch();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -607,6 +629,8 @@ static void test_snapshot()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    initialization_crutch();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -466,7 +466,7 @@ static void test_window()
     int t;
     int checks;
     int ret;
-    char datafile[100];
+    char datafile[PATH_MAX];
     struct sp_buffer data_buf;
     struct sp_buffer out_buf;
     struct task_check *check;
@@ -551,8 +551,9 @@ static void test_window()
             task->window.fd_hop = 1;
             double record_timestamp = 1.0;
             for (t = 0; t < check->window_size_sec + check->window_hop_sec; t++) {
-                sprintf(datafile, "%s%d.mp",
-                        DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
+                snprintf(datafile, sizeof(datafile) - 1,
+                         "%s%d.mp",
+                         DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
                 ret = file_to_buf(datafile, &data_buf);
                 if (ret == -1) {
                     flb_error("[sp test] cannot open DATA_SAMPLES file %s", datafile);
@@ -614,7 +615,7 @@ static void test_snapshot()
     int t;
     int checks;
     int ret;
-    char datafile[100];
+    char datafile[PATH_MAX];
     char stream_name[100];
     char window_val[3];
     struct sp_buffer data_buf;
@@ -690,8 +691,9 @@ static void test_snapshot()
 
         /* Read 1.mp -> 5.mp message pack buffers created for window tests */
         for (t = 0; t < 5; t++) {
-            sprintf(datafile, "%s%d.mp",
-                    DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
+            snprintf(datafile, sizeof(datafile) - 1,
+                     "%s%d.mp",
+                     DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
 
             if (data_buf.buffer) {
                 flb_free(data_buf.buffer);

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -1,11 +1,11 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_utils.h>
 
 #include "flb_tests_internal.h"
-
 
 struct url_check {
     int ret;
@@ -37,6 +37,19 @@ struct url_check url_checks[] = {
     {-1, "://", NULL, NULL, NULL, NULL},
 };
 
+static void initialization_crutch()
+{
+    struct flb_config *config;
+
+    config = flb_config_init();
+
+    if (config == NULL) {
+        return;
+    }
+
+    flb_config_exit(config);
+}
+
 void test_url_split()
 {
     int i;
@@ -47,6 +60,8 @@ void test_url_split()
     char *port;
     char *uri;
     struct url_check *u;
+
+    initialization_crutch();
 
     size = sizeof(url_checks) / sizeof(struct url_check);
     for (i = 0; i < size; i ++) {
@@ -133,6 +148,9 @@ static void write_str_test_cases_w_buf_size(struct write_str_case *cases, int bu
     int ret;
 
     struct write_str_case *tcase = cases;
+
+    initialization_crutch();
+
     while (!(tcase->input == 0 && tcase->output == 0)) {
         memset(buf, 0, size);
         off = 0;
@@ -174,6 +192,8 @@ void test_write_str()
     int size = sizeof(buf);
     int off;
     int ret;
+
+    initialization_crutch();
 
     off = 0;
     ret = flb_utils_write_str(buf, &off, size, "a", 1);
@@ -393,6 +413,8 @@ void test_proxy_url_split() {
     char *username;
     char *password;
     struct proxy_url_check *u;
+
+    initialization_crutch();
 
     size = sizeof(proxy_url_checks) / sizeof(struct proxy_url_check);
     for (i = 0; i < size; i++) {

--- a/tests/runtime/config_map_opts.c
+++ b/tests/runtime/config_map_opts.c
@@ -15,6 +15,9 @@ void flb_test_config_map_opts(void)
 {
     flb_ctx_t    *ctx    = NULL;
     int in_ffd, r;
+
+    flb_init_env();
+
     ctx = flb_create();
     in_ffd = flb_input(ctx, (char *) "tail", NULL);
     r = flb_input_property_check(ctx, in_ffd, "invalid_option", "invalid value");

--- a/tests/runtime/flb_tests_runtime.h.in
+++ b/tests/runtime/flb_tests_runtime.h.in
@@ -21,19 +21,26 @@
 #ifndef FLB_TESTS_RUNTIME_H
 #define FLB_TESTS_RUNTIME_H
 
+#include <sys/stat.h>
+
 #include "../lib/acutest/acutest.h"
 #define FLB_TESTS_DATA_PATH "@FLB_TESTS_DATA_PATH@"
 
-static inline int wait_for_file(char *path, int access_type, int time_limit)
+static inline int wait_for_file(char *path, 
+                                size_t minimum_size, 
+                                int time_limit)
 {
-    int elapsed_time;
-    int result;
+    int         elapsed_time;
+    struct stat file_info;
+    int         result;
 
     for (elapsed_time = 0 ; elapsed_time < time_limit ; elapsed_time++) {
-        result = access(path, access_type);
+        result = stat(path, &file_info);
 
         if (result == 0) {
-            break;
+            if (file_info.st_size >= minimum_size) {
+                break;
+            }
         }
 
         sleep(1);

--- a/tests/runtime/flb_tests_runtime.h.in
+++ b/tests/runtime/flb_tests_runtime.h.in
@@ -24,4 +24,22 @@
 #include "../lib/acutest/acutest.h"
 #define FLB_TESTS_DATA_PATH "@FLB_TESTS_DATA_PATH@"
 
+static inline int wait_for_file(char *path, int access_type, int time_limit)
+{
+    int elapsed_time;
+    int result;
+
+    for (elapsed_time = 0 ; elapsed_time < time_limit ; elapsed_time++) {
+        result = access(path, access_type);
+
+        if (result == 0) {
+            break;
+        }
+
+        sleep(1);
+    }
+
+    return result;
+}
+
 #endif

--- a/tests/runtime/in_syslog.c
+++ b/tests/runtime/in_syslog.c
@@ -866,7 +866,9 @@ TEST_LIST = {
     {"syslog_rfc3164", flb_test_syslog_rfc3164},
 #ifdef FLB_HAVE_UNIX_SOCKET
     {"syslog_tcp_unix", flb_test_syslog_tcp_unix},
+#ifndef FLB_SYSTEM_MACOS
     {"syslog_udp_unix", flb_test_syslog_udp_unix},
+#endif
 #endif
     {NULL, NULL}
 };

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -50,6 +50,7 @@ TEST_LIST = {
 
 #define TEST_LOGFILE "flb_test_file_dummy.log"
 #define TEST_LOGPATH "out_file"
+#define TEST_TIMEOUT 5
 
 void flb_test_file_json_invalid(void)
 {
@@ -129,7 +130,8 @@ void flb_test_file_json_long(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -175,7 +177,8 @@ void flb_test_file_json_small(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -223,7 +226,8 @@ void flb_test_file_format_csv(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -272,7 +276,8 @@ void flb_test_file_format_ltsv(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -320,7 +325,8 @@ void flb_test_file_format_out_file(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -433,7 +439,8 @@ void flb_test_file_path(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -498,7 +505,8 @@ void flb_test_file_path_file(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -548,7 +556,8 @@ void flb_test_file_delim_csv(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -605,7 +614,8 @@ void flb_test_file_delim_ltsv(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -663,7 +673,8 @@ void flb_test_file_label_delim(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -720,7 +731,8 @@ void flb_test_file_template(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -794,7 +806,8 @@ void flb_test_file_mkdir(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);

--- a/tests/runtime/out_plot.c
+++ b/tests/runtime/out_plot.c
@@ -89,7 +89,7 @@ void flb_test_plot_json_multiple(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
     TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
@@ -140,7 +140,7 @@ void flb_test_plot_key_mismatch(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
     TEST_CHECK(ret == 0);
 
     flb_stop(ctx);

--- a/tests/runtime/out_plot.c
+++ b/tests/runtime/out_plot.c
@@ -20,6 +20,7 @@ TEST_LIST = {
 };
 
 #define TEST_LOGFILE "flb_test_plot_dummy.log"
+#define TEST_TIMEOUT 5
 
 void flb_test_plot_json_invalid(void)
 {
@@ -88,7 +89,8 @@ void flb_test_plot_json_multiple(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -138,7 +140,8 @@ void flb_test_plot_key_mismatch(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);

--- a/tests/runtime_shell/in_http_tls_expect.sh
+++ b/tests/runtime_shell/in_http_tls_expect.sh
@@ -18,7 +18,7 @@ test_in_http_tls_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_VHOST=leo.vcap.me
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999
+    export LISTENER_PORT=50000
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_tcp_plaintext_expect.sh
+++ b/tests/runtime_shell/in_syslog_tcp_plaintext_expect.sh
@@ -15,7 +15,7 @@ input_generator() {
 test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999 
+    export LISTENER_PORT=50001
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_tcp_tls_expect.sh
+++ b/tests/runtime_shell/in_syslog_tcp_tls_expect.sh
@@ -16,7 +16,7 @@ test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_VHOST=leo.vcap.me
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999
+    export LISTENER_PORT=50002
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_udp_plaintext_expect.sh
+++ b/tests/runtime_shell/in_syslog_udp_plaintext_expect.sh
@@ -15,7 +15,7 @@ input_generator() {
 test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999 
+    export LISTENER_PORT=50003
 
     input_generator &
 


### PR DESCRIPTION
There's nothing special about this PR, in fact, it's pretty crude but it's necessary.
If someone wants to refactor this it'd be great but we need to run those initialization steps
to keep the logger macro that accesses the TLS from crashing in macos.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>