### PR TITLE
1.9.8: pack backport fixes

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -323,11 +323,13 @@ int flb_pack_state_init(struct flb_pack_state *s)
 void flb_pack_state_reset(struct flb_pack_state *s)
 {
     flb_free(s->tokens);
+    s->tokens = NULL;
     s->tokens_size  = 0;
     s->tokens_count = 0;
     s->last_byte    = 0;
     s->buf_size     = 0;
     flb_free(s->buf_data);
+    s->buf_data = NULL;
 }
 
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -312,6 +312,7 @@ int flb_pack_state_init(struct flb_pack_state *s)
     if (!s->buf_data) {
         flb_errno();
         flb_free(s->tokens);
+        s->tokens = NULL;
         return -1;
     }
     s->buf_size = size;
@@ -395,7 +396,7 @@ int flb_pack_json_state(const char *js, size_t len,
         return ret;
     }
 
-    if (state->tokens_count == 0) {
+    if (state->tokens_count == 0 || state->tokens == NULL) {
         state->last_byte = last;
         return FLB_ERR_JSON_INVAL;
     }


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
