### PR TITLE
pack: handle snprintf return value

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -946,6 +946,11 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
                                sizeof(time_formatted) - 1 - s,
                                ".%06" PRIu64,
                                (uint64_t) tms.tm.tv_nsec / 1000);
+
+                /* If the output was truncated, or failure, dont continue */
+                if (len < 0 || len > (sizeof(time_formatted) - 1 - s)) {
+                  break;
+                }
                 s += len;
                 msgpack_pack_str(&tmp_pck, s);
                 msgpack_pack_str_body(&tmp_pck, time_formatted, s);


### PR DESCRIPTION
Ensure validation of return value from snprintf.

This is similar in nature to the fixes from
https://github.com/fluent/fluent-bit/pull/2798

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45208

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
