### PR TITLE
tests: internal: aws_util: Handle difference of strftime format handling

### DIFF
--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -37,7 +37,12 @@
 #define S3_OBJECT_KEY_POST_OVERFLOW_INDEX "logs/a-0-b-c"
 
 #define S3_KEY_FORMAT_MIXED_TIMESTAMP "logs/%Y/m/%m/d/%d/%q"
+#ifdef FLB_SYSTEM_MACOS
+/* macOS's strftime throws away for % character for % and suqsequent invalid format character. */
+#define S3_OBJECT_KEY_MIXED_TIMESTAMP "logs/2020/m/08/d/15/q"
+#else
 #define S3_OBJECT_KEY_MIXED_TIMESTAMP "logs/2020/m/08/d/15/%q"
+#endif
 
 #define NO_TAG ""
 #define TAG "aa.bb.ccc"


### PR DESCRIPTION
In macOS, it uses BSD origin strftime.
This implementation throws away % character for % and subsequent invalid
format character case.

The below is the minimum repo:

```c
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>

 #define KEY_SIZE 1024

 int main(int argc, char **argv) {
   int ret = 0;
   char *key;
   char *format = "logs/2020/m/08/d/15/%q";
   struct tm gmt = {0};
   time_t tm = time(NULL);

   if (!gmtime_r(&tm, &gmt)) {
     printf("Failed to create timestamp.\n");
     goto error;
   }

   key = calloc(1, KEY_SIZE * sizeof(char));
   if (!key) {
     goto error;
   }

   ret = strftime(key, KEY_SIZE, format, &gmt);
   if(ret == 0){
     printf("Object key length is longer than the 1024 character limit.\n");
   }

   printf("[result] %s\n", key);
   return 0;

 error:
   return -1;
 }
```

In Linux, this should return as:

```console
$ ./strftime
[result] logs/2020/m/08/d/15/%q
```

But macOS, this should return as:

```console
$ ./strftime
[result] logs/2020/m/08/d/15/q
```

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This should be pointed out in https://github.com/fluent/fluent-bit/pull/5978#pullrequestreview-1094456505.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
