### PR TITLE
tests: internal: fuzzers: fix index error

### DIFF
--- a/tests/internal/fuzzers/multiline_fuzzer.c
+++ b/tests/internal/fuzzers/multiline_fuzzer.c
@@ -101,7 +101,7 @@ void test_multiline_parser(msgpack_object *root2, int rand_val) {
         flb_time_get(&tm2);
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 5; j++) {
-                if (random_strings[j] != NULL) {
+                if (random_strings[i] != NULL && stream_ids[j] != NULL) {
                     /* stream_ids index by j, random_strings index by i */
                     flb_ml_append(ml, stream_ids[j], FLB_ML_TYPE_TEXT, &tm2,
                                   random_strings[i], strlen(random_strings[i]));


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45911

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
