### PR TITLE
strptime: fix signed overflow

### DIFF
--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -706,7 +706,16 @@ _conv_num64(const unsigned char **buf, int64_t *dest, int64_t llim, int64_t ulim
 
 	/* we use rulim to break out of the loop when we run out of digits */
 	do {
+		/* Avoid overflow: result > ((2**64)/2.0) / 10.0 */
+		if (result > 922337203685477580) {
+			return (0);
+		}
 		result *= 10;
+
+		/* Avoid overflow: result > ((2**64)/2.0) - 48 */
+		if (result > 9223372036854775760) {
+			return (0);
+		}
 		result += *(*buf)++ - '0';
 		rulim /= 10;
         /* watch out for overflows. If value gets above


### PR DESCRIPTION
Return 0 if signed integer overflows occur

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47092

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
