### PR TITLE
tests: runtime: in_syslog: Add ifdef caluse for UNIX_SOCKET

### DIFF
--- a/tests/runtime/in_syslog.c
+++ b/tests/runtime/in_syslog.c
@@ -862,7 +862,9 @@ TEST_LIST = {
     {"syslog_tcp_port", flb_test_syslog_tcp_port},
     {"syslog_udp_port", flb_test_syslog_udp_port},
     {"syslog_unknown_mode", flb_test_syslog_unknown_mode},
+#ifdef FLB_HAVE_UNIX_SOCKET
     {"syslog_unix_perm", flb_test_syslog_unix_perm},
+#endif
     {"syslog_rfc3164", flb_test_syslog_rfc3164},
 #ifdef FLB_HAVE_UNIX_SOCKET
     {"syslog_tcp_unix", flb_test_syslog_tcp_unix},


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

flb_test_syslog_unix_perm does not work without unix socket support.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
