### PR TITLE
connection: address processing improvements

### DIFF
--- a/include/fluent-bit/flb_connection.h
+++ b/include/fluent-bit/flb_connection.h
@@ -23,7 +23,6 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_config.h>
-// #include <fluent-bit/flb_stream.h>
 
 #define FLB_UNKNOWN_CONNECTION    0
 #define FLB_UPSTREAM_CONNECTION   1
@@ -163,6 +162,8 @@ struct flb_connection *flb_connection_create(flb_sockfd_t socket,
 
 void flb_connection_destroy(struct flb_connection *connection);
 
+void flb_connection_set_remote_host(struct flb_connection *connection,
+                                    struct sockaddr *remote_host);
 char *flb_connection_get_remote_address(struct flb_connection *connection);
 
 int flb_connection_get_flags(struct flb_connection *connection);

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -30,6 +30,7 @@
 
 #define FLB_NETWORK_DEFAULT_BACKLOG_SIZE              128
 #define FLB_NETWORK_UNIX_SOCKET_PEER_ADDRESS_TEMPLATE "pid_%s"
+#define FLB_NETWORK_ADDRESS_UNAVAILABLE               "unavailable"
 
 /* FLB_NETWORK_MAX_UNIX_ADDRESS_LENGTH should be enough for the
  * string "PID " plus the string form of a signed 32 bit integer


### PR DESCRIPTION
This PR adds a remote host address setter to `flb_connection` which is used to provide some info on the remote host before the connection is established just in case it times out, the same setter should be used when trying to send data to hosts through UDP while using a downstream listerner (shoddy, yeah).

We might want to improve UDP support since there are some implicit concepts in the `io` layer that could be confusing and cause issues in the future.