### PR TITLE
core: rename macro __FILENAME__ as __FLB_FILENAME__

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FLB_FILENAME__=__FILE__")
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")

--- a/include/fluent-bit/flb_custom_plugin.h
+++ b/include/fluent-bit/flb_custom_plugin.h
@@ -48,6 +48,6 @@
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
         flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
                       "[custom:%s:%s at %s:%i] " fmt,                   \
-                      ctx->p->name, flb_custom_name(ctx), __FILENAME__, \
+                      ctx->p->name, flb_custom_name(ctx), __FLB_FILENAME__, \
                       __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_filter_plugin.h
+++ b/include/fluent-bit/flb_filter_plugin.h
@@ -48,6 +48,6 @@
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
         flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
                       "[filter:%s:%s at %s:%i] " fmt,                   \
-                      ctx->p->name, flb_filter_name(ctx), __FILENAME__, \
+                      ctx->p->name, flb_filter_name(ctx), __FLB_FILENAME__, \
                       __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_input_plugin.h
+++ b/include/fluent-bit/flb_input_plugin.h
@@ -49,6 +49,6 @@
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
         flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
                       "[input:%s:%s at %s:%i] " fmt,                    \
-                      ctx->p->name, flb_input_name(ctx), __FILENAME__,  \
+                      ctx->p->name, flb_input_name(ctx), __FLB_FILENAME__,  \
                       __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -171,8 +171,8 @@ int flb_log_is_truncated(int type, const char *file, int line, const char *fmt, 
 int flb_log_worker_init(struct flb_worker *worker);
 int flb_errno_print(int errnum, const char *file, int line);
 
-#ifdef __FILENAME__
-#define flb_errno() flb_errno_print(errno, __FILENAME__, __LINE__)
+#ifdef __FLB_FILENAME__
+#define flb_errno() flb_errno_print(errno, __FLB_FILENAME__, __LINE__)
 #else
 #define flb_errno() flb_errno_print(errno, __FILE__, __LINE__)
 #endif

--- a/include/fluent-bit/flb_output_plugin.h
+++ b/include/fluent-bit/flb_output_plugin.h
@@ -51,6 +51,6 @@
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
         flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
                       "[output:%s:%s at %s:%i] " fmt,                   \
-                      ctx->p->name, flb_output_name(ctx), __FILENAME__, \
+                      ctx->p->name, flb_output_name(ctx), __FLB_FILENAME__, \
                       __LINE__, ##__VA_ARGS__)
 #endif


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
