### PR TITLE
tests: internal: fuzzer: limit input size

### DIFF
--- a/tests/internal/fuzzers/pack_json_state_fuzzer.c
+++ b/tests/internal/fuzzers/pack_json_state_fuzzer.c
@@ -8,6 +8,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_pack_state state;
     flb_malloc_p = 0;
 
+    /* Exit early to avoid timeouts due to excessive size */
+    if (size > 4096)
+        return 0;
+
     /* Target json packer */
     flb_pack_state_init(&state);
     flb_pack_json_state(data, size, &out_buf, &out_size, &state);


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35730

The issue is not really interesting, but is just a consequence of processing large amounts of data which is to be expected.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
