### PR TITLE
out_loki: support label_map_path

### DIFF
--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -22,6 +22,8 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_sds_list.h>
 #include <monkey/mk_core.h>
 #include <msgpack.h>
 
@@ -60,4 +62,5 @@ int flb_ra_append_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
 int flb_ra_update_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
                           void **out_map, size_t *out_size,
                           msgpack_object *in_key, msgpack_object *in_val);
+flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list, int translate_env);
 #endif

--- a/include/fluent-bit/flb_record_accessor.h
+++ b/include/fluent-bit/flb_record_accessor.h
@@ -62,5 +62,6 @@ int flb_ra_append_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
 int flb_ra_update_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
                           void **out_map, size_t *out_size,
                           msgpack_object *in_key, msgpack_object *in_val);
-flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list, int translate_env);
+flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list);
+struct flb_record_accessor *flb_ra_create_from_list(struct flb_sds_list *str_list, int translate_env);
 #endif

--- a/include/fluent-bit/flb_sds_list.h
+++ b/include/fluent-bit/flb_sds_list.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_SDS_LIST_H
+#define FLB_SDS_LIST_H
+
+#include <fluent-bit/flb_sds.h>
+#include <monkey/mk_core.h>
+
+struct flb_sds_list_entry {
+    flb_sds_t str;
+    struct mk_list _head;
+};
+
+struct flb_sds_list {
+    struct mk_list strs;
+};
+
+size_t flb_sds_list_size(struct flb_sds_list *list);
+struct flb_sds_list *flb_sds_list_create();
+int flb_sds_list_destroy(struct flb_sds_list*);
+int flb_sds_list_add(struct flb_sds_list*, char*, size_t);
+int flb_sds_list_del(struct flb_sds_list_entry*);
+int flb_sds_list_del_last_entry(struct flb_sds_list*);
+int flb_sds_list_destroy_str_array(char **array);
+char **flb_sds_list_create_str_array(struct flb_sds_list *list);
+
+#endif

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -28,6 +28,7 @@
 #include <fluent-bit/flb_mp.h>
 
 #include <ctype.h>
+#include <sys/stat.h>
 
 #include "loki.h"
 
@@ -407,6 +408,235 @@ static flb_sds_t pack_labels(struct flb_loki *ctx,
     return 0;
 }
 
+static int create_label_map_entry(struct flb_loki *ctx,
+                                  struct flb_sds_list *list, msgpack_object *val, int *ra_used)
+{
+    msgpack_object key;
+    flb_sds_t label_key;
+    flb_sds_t val_str;
+    int i;
+    int len;
+    int ret;
+
+    if (ctx == NULL || list == NULL || val == NULL || ra_used == NULL) {
+        return -1;
+    }
+
+    switch (val->type) {
+    case MSGPACK_OBJECT_STR:
+        label_key = flb_sds_create_len(val->via.str.ptr, val->via.str.size);
+        if (label_key == NULL) {
+            flb_errno();
+            return -1;
+        }
+
+        val_str = flb_ra_create_str_from_list(list);
+        if (val_str == NULL) {
+            flb_plg_error(ctx->ins, "[%s] flb_ra_create_from_list failed", __FUNCTION__);
+            flb_sds_destroy(label_key);
+            return -1;
+        }
+
+        /* for debugging
+          printf("label_key=%s val_str=%s\n", label_key, val_str);
+         */
+
+        ret = flb_loki_kv_append(ctx, label_key, val_str);
+        flb_sds_destroy(label_key);
+        flb_sds_destroy(val_str);
+        if (ret == -1) {
+            return -1;
+        }
+        *ra_used = *ra_used + 1;
+
+        break;
+    case MSGPACK_OBJECT_MAP:
+        len = val->via.map.size;
+        for (i=0; i<len; i++) {
+            key = val->via.map.ptr[i].key;
+            if (key.type != MSGPACK_OBJECT_STR) {
+                flb_plg_error(ctx->ins, "[%s] key is not string", __FUNCTION__);
+                return -1;
+            }
+            ret = flb_sds_list_add(list, (char*)key.via.str.ptr, key.via.str.size);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "[%s] flb_sds_list_add failed", __FUNCTION__);
+                return -1;
+            }
+
+            ret = create_label_map_entry(ctx, list, &val->via.map.ptr[i].val, ra_used);
+            if (ret < 0) {
+                return -1;
+            }
+
+            ret = flb_sds_list_del_last_entry(list);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "[%s] flb_sds_list_del_last_entry failed", __FUNCTION__);
+                return -1;
+            }
+        }
+
+        break;
+    default:
+        flb_plg_error(ctx->ins, "[%s] value type is not str or map. type=%d", val->type);
+        return -1;
+    }
+    return 0;
+}
+
+static int create_label_map_entries(struct flb_loki *ctx,
+                                    char *msgpack_buf, size_t msgpack_size, int *ra_used)
+{
+    struct flb_sds_list *list = NULL;
+    msgpack_unpacked result;
+    size_t off = 0;
+    int i;
+    int len;
+    int ret;
+    msgpack_object key;
+
+    if (ctx == NULL || msgpack_buf == NULL || ra_used == NULL) {
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    while(msgpack_unpack_next(&result, msgpack_buf, msgpack_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "[%s] data type is not map", __FUNCTION__);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        len = result.data.via.map.size;
+        for (i=0; i<len; i++) {
+            list = flb_sds_list_create();
+            if (list == NULL) {
+                flb_plg_error(ctx->ins, "[%s] flb_sds_list_create failed", __FUNCTION__);
+                msgpack_unpacked_destroy(&result);
+                return -1;
+            }
+            key = result.data.via.map.ptr[i].key;
+            if (key.type != MSGPACK_OBJECT_STR) {
+                flb_plg_error(ctx->ins, "[%s] key is not string", __FUNCTION__);
+                flb_sds_list_destroy(list);
+                msgpack_unpacked_destroy(&result);
+                return -1;
+            }
+
+            ret = flb_sds_list_add(list, (char*)key.via.str.ptr, key.via.str.size);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "[%s] flb_sds_list_add failed", __FUNCTION__);
+                flb_sds_list_destroy(list);
+                msgpack_unpacked_destroy(&result);
+                return -1;
+            }
+
+            ret = create_label_map_entry(ctx, list, &result.data.via.map.ptr[i].val, ra_used);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "[%s] create_label_map_entry failed", __FUNCTION__);
+                flb_sds_list_destroy(list);
+                msgpack_unpacked_destroy(&result);
+                return -1;
+            }
+
+            flb_sds_list_destroy(list);
+            list = NULL;
+        }
+    }
+
+    msgpack_unpacked_destroy(&result);
+
+    return 0;
+}
+
+static int read_label_map_path_file(struct flb_output_instance *ins, flb_sds_t path,
+                                    char **out_buf, size_t *out_size)
+{
+    int ret;
+    int root_type;
+    char *buf = NULL;
+    char *msgp_buf = NULL;
+    FILE *fp = NULL;
+    struct stat st;
+    size_t file_size;
+    size_t ret_size;
+
+    ret = access(path, R_OK);
+    if (ret < 0) {
+        flb_errno();
+        flb_plg_error(ins, "can't access %s", path);
+        return -1;
+    }
+
+    ret = stat(path, &st);
+    if (ret < 0) {
+        flb_errno();
+        flb_plg_error(ins, "stat failed %s", path);
+        return -1;
+    }
+    file_size = st.st_size;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        flb_plg_error(ins, "can't open %s", path);
+        return -1;
+    }
+
+    buf = flb_malloc(file_size);
+    if (buf == NULL) {
+        flb_plg_error(ins, "malloc failed");
+        fclose(fp);
+        return -1;
+    }
+
+    ret_size = fread(buf, 1, file_size, fp);
+    if (ret_size < file_size && feof(fp) != 0) {
+        flb_plg_error(ins, "fread failed");
+        fclose(fp);
+        flb_free(buf);
+        return -1;
+    }
+
+    ret = flb_pack_json(buf, file_size, &msgp_buf, &ret_size, &root_type);
+    if (ret < 0) {
+        flb_plg_error(ins, "flb_pack_json failed");
+        fclose(fp);
+        flb_free(buf);
+        return -1;
+    }
+
+    *out_buf = msgp_buf;
+    *out_size = ret_size;
+
+    fclose(fp);
+    flb_free(buf);
+    return 0;
+}
+
+static int load_label_map_path(struct flb_loki *ctx, flb_sds_t path, int *ra_used)
+{
+    int ret;
+    char *msgpack_buf = NULL;
+    size_t msgpack_size;
+
+    ret = read_label_map_path_file(ctx->ins, path, &msgpack_buf, &msgpack_size);
+    if (ret < 0) {
+        return -1;
+    }
+
+    ret = create_label_map_entries(ctx, msgpack_buf, msgpack_size, ra_used);
+    if (ret < 0) {
+        flb_free(msgpack_buf);
+        return -1;
+    }
+
+    if (msgpack_buf != NULL) {
+        flb_free(msgpack_buf);
+    }
+
+    return 0;
+}
+
 static int parse_labels(struct flb_loki *ctx)
 {
     int ret;
@@ -489,6 +719,14 @@ static int parse_labels(struct flb_loki *ctx)
             else if (ret > 0) {
                 ra_used++;
             }
+        }
+    }
+
+    /* label_map_path */
+    if (ctx->label_map_path) {
+        ret = load_label_map_path(ctx, ctx->label_map_path, &ra_used);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed to load label_map_path");
         }
     }
 
@@ -1356,6 +1594,12 @@ static struct flb_config_map config_map[] = {
      "the Fluent Bit record dumped as json. If set to 'key_value', the log line "
      "will be each item in the record concatenated together (separated by a "
      "single space) in the format '='."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "label_map_path", NULL,
+     0, FLB_TRUE, offsetof(struct flb_loki, label_map_path),
+     "A label map file path"
     },
 
     {

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -66,6 +66,8 @@ struct flb_loki {
     struct mk_list *label_keys;
     struct mk_list *remove_keys;
 
+    flb_sds_t label_map_path;
+
     /* Private */
     int tcp_port;
     char *tcp_host;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(src
   flb_pack.c
   flb_pack_gelf.c
   flb_sds.c
+  flb_sds_list.c
   flb_pipe.c
   flb_meta.c
   flb_kernel.c

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -338,7 +338,7 @@ struct flb_record_accessor *flb_ra_create(char *str, int translate_env)
      e.g. {"aa", "bb", "cc", NULL} -> "$aa['bb']['cc']"
     Return value should be freed using flb_sds_destroy after using.
  */
-flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list, int translate_env)
+flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list)
 {
     int i = 0;
     int ret_i = 0;
@@ -397,6 +397,23 @@ flb_sds_t flb_ra_create_str_from_list(struct flb_sds_list *str_list, int transla
     flb_sds_list_destroy_str_array(strs);
 
     return str;
+}
+
+struct flb_record_accessor *flb_ra_create_from_list(struct flb_sds_list *str_list, int translate_env)
+{
+    flb_sds_t tmp = NULL;
+    struct flb_record_accessor *ret = NULL;
+
+    tmp = flb_ra_create_str_from_list(str_list);
+    if (tmp == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    ret = flb_ra_create(tmp, translate_env);
+    flb_sds_destroy(tmp);
+
+    return ret;
 }
 
 void flb_ra_dump(struct flb_record_accessor *ra)

--- a/src/flb_sds_list.c
+++ b/src/flb_sds_list.c
@@ -1,0 +1,185 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds_list.h>
+
+size_t flb_sds_list_size(struct flb_sds_list *list)
+{
+    if (list == NULL) {
+        return 0;
+    }
+    return mk_list_size(&list->strs);
+}
+
+struct flb_sds_list *flb_sds_list_create()
+{
+    struct flb_sds_list *ret = NULL;
+
+    ret = flb_calloc(1, sizeof(struct flb_sds_list));
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    mk_list_init(&ret->strs);
+
+    return ret;
+}
+
+int flb_sds_list_del(struct flb_sds_list_entry* entry)
+{
+    if (entry == NULL) {
+        return -1;
+    }
+    if (entry->str != NULL) {
+        flb_sds_destroy(entry->str);
+    }
+    mk_list_del(&entry->_head);
+    flb_free(entry);
+
+    return 0;
+}
+
+
+int flb_sds_list_destroy(struct flb_sds_list *list)
+{
+    struct mk_list *tmp = NULL;
+    struct mk_list *head = NULL;
+    struct flb_sds_list_entry *entry = NULL;
+
+    if (list == NULL) {
+        return -1;
+    }
+
+    mk_list_foreach_safe(head, tmp, &list->strs) {
+        entry = mk_list_entry(head, struct flb_sds_list_entry, _head);
+        flb_sds_list_del(entry);
+    }
+    flb_free(list);
+
+    return 0;
+}
+
+int flb_sds_list_add(struct flb_sds_list* list, char *in_str, size_t in_size)
+{
+    flb_sds_t str;
+    struct flb_sds_list_entry *entry = NULL;
+
+    if (list == NULL || in_str == NULL || in_size == 0) {
+        return -1;
+    }
+
+    str = flb_sds_create_len(in_str, in_size);
+    if (str == NULL) {
+        return -1;
+    }
+
+    entry = flb_malloc(sizeof(struct flb_sds_list_entry));
+    if (entry == NULL) {
+        flb_errno();
+        flb_sds_destroy(str);
+        return -1;
+    }
+    entry->str = str;
+
+    mk_list_add(&entry->_head, &list->strs);
+
+    return 0;
+}
+
+int flb_sds_list_destroy_str_array(char **array)
+{
+    char **str = array;
+    int i = 0;
+
+    if (array == NULL) {
+        return -1;
+    }
+    while(str[i] != NULL) {
+        flb_free(str[i]);
+        i++;
+    }
+    flb_free(array);
+
+    return 0;
+}
+
+
+/*
+  This function allocates NULL terminated string array from list. 
+  The array should be destroyed by flb_sds_list_destroy_str_array.
+*/
+char **flb_sds_list_create_str_array(struct flb_sds_list *list)
+{
+    int i = 0;
+    size_t size;
+    char **ret = NULL;
+    struct mk_list *tmp = NULL;
+    struct mk_list *head = NULL;
+    struct flb_sds_list_entry *entry = NULL;
+
+    if (list == NULL) {
+        return NULL;
+    }
+
+    size = flb_sds_list_size(list);
+    if (size == 0) {
+        return NULL;
+    }
+
+    ret = flb_malloc(sizeof(char*) * (size + 1));
+    if (ret == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    mk_list_foreach_safe(head, tmp, &list->strs) {
+        entry = mk_list_entry(head, struct flb_sds_list_entry, _head);
+        if (entry == NULL) {
+            flb_free(ret);
+            return NULL;
+        }
+        ret[i] = flb_malloc(flb_sds_len(entry->str)+1);
+        if (ret[i] == NULL) {
+            flb_free(ret);
+            return NULL;
+        }
+        strncpy(ret[i], entry->str, flb_sds_len(entry->str));
+        ret[i][flb_sds_len(entry->str)] = '\0';
+        i++;
+    }
+    ret[i] = NULL;
+
+    return ret;
+}
+
+int flb_sds_list_del_last_entry(struct flb_sds_list* list)
+{
+    struct flb_sds_list_entry *entry = NULL;
+
+    if (list == NULL || flb_sds_list_size(list) == 0) {
+        return -1;
+    }
+
+    entry = mk_list_entry_last(&list->strs, struct flb_sds_list_entry, _head);
+    if (entry == NULL) {
+        return -1;
+    }
+    return flb_sds_list_del(entry);
+}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TESTS_FILES
   pack.c
   pipe.c
   sds.c
+  sds_list.c
   hmac.c
   crypto.c
   hash.c

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -1603,7 +1603,7 @@ void cb_ra_create_str_from_list()
             i++;
         }
 
-        ret_str = flb_ra_create_str_from_list(list, FLB_FALSE);
+        ret_str = flb_ra_create_str_from_list(list);
         if (!TEST_CHECK(ret_str != NULL)) {
             TEST_MSG("%d: flb_ra_create_str_from failed", case_i);
             flb_sds_list_destroy(list);
@@ -1624,7 +1624,7 @@ void cb_ra_create_str_from_list()
         TEST_MSG("flb_sds_list_create failed");
         exit(EXIT_FAILURE);
     }
-    ret_str = flb_ra_create_str_from_list(list, FLB_FALSE);
+    ret_str = flb_ra_create_str_from_list(list);
     if (!TEST_CHECK(ret_str == NULL)) {
         TEST_MSG("flb_ra_create_str_from should be failed");
         flb_sds_list_destroy(list);

--- a/tests/internal/sds_list.c
+++ b/tests/internal/sds_list.c
@@ -1,0 +1,238 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_sds_list.h>
+
+#include "flb_tests_internal.h"
+
+static void test_sds_list_create_destroy()
+{
+    struct flb_sds_list *list = NULL;
+    int ret = 0;
+
+    list = flb_sds_list_create();
+    if(!TEST_CHECK(list != NULL)) {
+        TEST_MSG("failed to allocate flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_sds_list_destroy(list);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to destroy flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void test_sds_list_add()
+{
+    struct flb_sds_list *list = NULL;
+    int ret = 0;
+
+    list = flb_sds_list_create();
+    if(!TEST_CHECK(list != NULL)) {
+        TEST_MSG("failed to allocate flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_sds_list_add(list, "hoge", 4);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to flb_sds_list_add");
+        flb_sds_list_destroy(list);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_sds_list_destroy(list);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to destroy flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void test_sds_list_array()
+{
+    struct flb_sds_list *list = NULL;
+    char *c_array[] = {
+        "hoge", "moge", "aaa", NULL
+    };
+    char **ret_array = NULL;
+    int i;
+    int ret = 0;
+
+    list = flb_sds_list_create();
+    if(!TEST_CHECK(list != NULL)) {
+        TEST_MSG("failed to allocate flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+
+    for (i=0; c_array[i] != NULL; i++) {
+        ret = flb_sds_list_add(list, c_array[i], strlen(c_array[i]));
+        if(!TEST_CHECK(ret == 0)) {
+            TEST_MSG("flb_sds_list_add failed");
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    ret_array = flb_sds_list_create_str_array(list);
+    if (!TEST_CHECK(ret_array != NULL)) {
+        TEST_MSG("flb_sds_list_create_str_array failed");
+        flb_sds_list_destroy(list);
+        exit(EXIT_FAILURE);
+    }
+
+    for (i=0; c_array[i] != NULL; i++) {
+        if (!TEST_CHECK(ret_array[i] != NULL)) {
+            TEST_MSG("ret_array[%d] should not be NULL", i);
+            flb_sds_list_destroy_str_array(ret_array);
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+        if(!TEST_CHECK(strcmp(c_array[i], ret_array[i]) == 0)) {
+            TEST_MSG("%d:mismatch. c=%s sds=%s",i, c_array[i], ret_array[i]);
+            flb_sds_list_destroy_str_array(ret_array);
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    ret = flb_sds_list_destroy_str_array(ret_array);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_sds_list_destroy_str_array failed");
+        flb_sds_list_destroy(list);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_sds_list_destroy(list);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to destroy flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void test_sds_list_size()
+{
+    struct flb_sds_list *list = NULL;
+    char *c_array[] = {
+        "hoge", "moge", "aaa", NULL
+    };
+    int i;
+    int ret = 0;
+    size_t size = 0;
+
+    list = flb_sds_list_create();
+    if(!TEST_CHECK(list != NULL)) {
+        TEST_MSG("failed to allocate flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+
+    for (i=0; c_array[i] != NULL; i++) {
+        ret = flb_sds_list_add(list, c_array[i], strlen(c_array[i]));
+        size++;
+        if(!TEST_CHECK(ret == 0)) {
+            TEST_MSG("flb_sds_list_add failed");
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+
+        if (!TEST_CHECK(size == flb_sds_list_size(list))) {
+            TEST_MSG("%d: size mismatch. got=%lu expect=%lu",i, flb_sds_list_size(list), size);
+        }
+    }
+
+    ret = flb_sds_list_destroy(list);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to destroy flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void test_sds_list_del_last_entry()
+{
+    struct flb_sds_list *list = NULL;
+    char *c_array[] = {
+        "hoge", "moge", "aaa", NULL
+    };
+    char **str_array = NULL;
+    int i;
+    int ret = 0;
+    size_t size = 0;
+
+    list = flb_sds_list_create();
+    if(!TEST_CHECK(list != NULL)) {
+        TEST_MSG("failed to allocate flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+
+    for (i=0; c_array[i] != NULL; i++) {
+        ret = flb_sds_list_add(list, c_array[i], strlen(c_array[i]));
+        size++;
+        if(!TEST_CHECK(ret == 0)) {
+            TEST_MSG("flb_sds_list_add failed");
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+
+        if (!TEST_CHECK(size == flb_sds_list_size(list))) {
+            TEST_MSG("%d: size mismatch. got=%zu expect=%zu",i, flb_sds_list_size(list), size);
+        }
+    }
+
+    size = flb_sds_list_size(list);
+
+    while(size > 0) {
+        ret = flb_sds_list_del_last_entry(list);
+        if (!TEST_CHECK(ret==0)) {
+            TEST_MSG("flb_sds_list_del_last_entry failed");
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+        size--;
+        if (!TEST_CHECK(size == flb_sds_list_size(list))) {
+            TEST_MSG("size mismatch. got=%zu expect=%zu",flb_sds_list_size(list), size);
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+        if (size == 0) {
+            break;
+        }
+
+        str_array = flb_sds_list_create_str_array(list);
+        if (!TEST_CHECK(str_array != NULL)) {
+            TEST_MSG("flb_sds_list_create_str_array failed. size=%zu", size);
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+
+        for (i=0; str_array[i] != NULL; i++) {
+            if (!TEST_CHECK(str_array[i] != NULL)) {
+                TEST_MSG("str_array[%d] should not be NULL", i);
+                flb_sds_list_destroy_str_array(str_array);
+                flb_sds_list_destroy(list);
+                exit(EXIT_FAILURE);
+            }
+            if(!TEST_CHECK(strcmp(c_array[i], str_array[i]) == 0)) {
+                TEST_MSG("%d:mismatch. c=%s sds=%s",i, c_array[i], str_array[i]);
+                flb_sds_list_destroy_str_array(str_array);
+                flb_sds_list_destroy(list);
+                exit(EXIT_FAILURE);
+            }
+        }
+        flb_sds_list_destroy_str_array(str_array);
+    }
+
+    ret = flb_sds_list_destroy(list);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("failed to destroy flb_sds_list");
+        exit(EXIT_FAILURE);
+    }
+}
+
+TEST_LIST = {
+    { "sds_list_create_destroy" , test_sds_list_create_destroy},
+    { "sds_list_add" , test_sds_list_add},
+    { "sds_list_array" , test_sds_list_array},
+    { "sds_list_size" , test_sds_list_size},
+    { "sds_list_del_last_entry" , test_sds_list_del_last_entry},
+    { 0 }
+};

--- a/tests/runtime/data/loki/labelmap.json
+++ b/tests/runtime/data/loki/labelmap.json
@@ -1,0 +1,10 @@
+{
+  "kubernetes": {
+    "container_name": "container",
+    "pod_name": "pod",
+    "namespace_name": "namespace",
+    "labels" : {
+        "team": "team"
+    }
+  }
+}

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -22,6 +22,32 @@
 #include <fluent-bit/flb_sds.h>
 #include "flb_tests_runtime.h"
 
+#define DPATH_LOKI FLB_TESTS_DATA_PATH "/data/loki"
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
 #define JSON_BASIC "[12345678, {\"key\":\"value\"}]"
 static void cb_check_basic(void *ctx, int ffd,
                            int res_ret, void *res_data, size_t res_size,
@@ -442,6 +468,85 @@ void flb_test_remove_keys()
     flb_destroy(ctx);
 }
 
+static void cb_check_label_map_path(void *ctx, int ffd,
+                                    int res_ret, void *res_data, size_t res_size,
+                                    void *data)
+{
+    char *p;
+    flb_sds_t out_log = res_data;
+    char *expected[] = {
+        "\"container\":\"promtail\"",
+        "\"pod\":\"promtail-xxx\"",
+        "\"namespace\":\"prod\"",
+        "\"team\":\"lalala\"",
+        NULL};
+    int i = 0;
+
+    set_output_num(1);
+
+    while(expected[i] != NULL) {
+        p = strstr(out_log, expected[i]);
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Given:%s Expect:%s", out_log, expected[i]);
+        }
+        i++;
+    }
+
+    flb_sds_destroy(out_log);
+}
+
+void flb_test_label_map_path()
+{
+    int ret;
+    char *str = "[12345678, {\"kubernetes\":{\"container_name\":\"promtail\",\"pod_name\":\"promtail-xxx\",\"namespace_name\":\"prod\",\"labels\":{\"team\": \"lalala\"}},\"log\":\"log\"}]";
+    int size = strlen(str);
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "label_map_path", DPATH_LOKI "/labelmap.json",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_label_map_path,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, str, size);
+    TEST_CHECK(ret == size);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"remove_keys_remove_map" , flb_test_remove_map},
@@ -451,5 +556,6 @@ TEST_LIST = {
     {"labels"           , flb_test_labels },
     {"label_keys"       , flb_test_label_keys },
     {"line_format"      , flb_test_line_format },
+    {"label_map_path"   , flb_test_label_map_path},
     {NULL, NULL}
 };


### PR DESCRIPTION
Fixes #5996 
See also https://github.com/grafana/loki/issues/4648#issuecomment-1223622156

This patch is to port `LabelMapPath` of go-loki plugin.
https://grafana.com/docs/loki/latest/clients/fluentbit/#labelmappath

This patch is to

1. Adds `flb_sds_list` to handle a string list
2. Loads json file and converts msgpack
3. Converts msgpack into record accessor string using `flb_sds_list`
4. Save string using `flb_loki_kv_append`

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

native.conf:
```
[INPUT]
    Name dummy
# https://grafana.com/docs/loki/latest/clients/fluentbit/#labelmappath
    Dummy {"kubernetes": {"container_name": "promtail","pod_name": "promtail-xxx","namespace_name": "prod","labels" : {"team": "x-men"}},"HOSTNAME": "docker-desktop","log" : "a log line","time": "20190926T152206Z"}

[OUTPUT]
    Name loki
    Match *
    label_map_path map.json
```

map.json:
```json
{
  "kubernetes": {
    "container_name": "container",
    "pod_name": "pod",
    "namespace_name": "namespace",
    "labels" : {
        "team": "team"
    }
  }
}
```

## Debug /Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c native.conf 
==34245== Memcheck, a memory error detector
==34245== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==34245== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==34245== Command: bin/fluent-bit -c native.conf
==34245== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/09/11 09:09:45] [ info] [fluent bit] version=2.0.0, commit=fdbd7161fc, pid=34245
[2022/09/11 09:09:45] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/09/11 09:09:45] [ info] [cmetrics] version=0.3.6
[2022/09/11 09:09:45] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2022/09/11 09:09:45] [ info] [sp] stream processor started
^C[2022/09/11 09:10:06] [engine] caught signal (SIGINT)
[2022/09/11 09:10:06] [ warn] [engine] service will shutdown in max 5 seconds
[2022/09/11 09:10:06] [ info] [input] pausing dummy.0
[2022/09/11 09:10:06] [ info] [engine] service has stopped (0 pending tasks)
[2022/09/11 09:10:06] [ info] [input] pausing dummy.0
==34245== 
==34245== HEAP SUMMARY:
==34245==     in use at exit: 0 bytes in 0 blocks
==34245==   total heap usage: 2,915 allocs, 2,915 frees, 9,314,783 bytes allocated
==34245== 
==34245== All heap blocks were freed -- no leaks are possible
==34245== 
==34245== For lists of detected and suppressed errors, rerun with: -s
==34245== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
