### PR TITLE
scheduler: set the `timer_fd` field in `schedule_request_now`

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -133,6 +133,7 @@ static int schedule_request_now(int seconds,
         return -1;
     }
     request->fd = fd;
+    timer->timer_fd = fd;
 
     /*
      * Note: mk_event_timeout_create() sets a type = MK_EVENT_NOTIFICATION by


### PR DESCRIPTION
We need to do this so that the timer can be properly disabled and 
disposed of later.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>