### PR TITLE
packaging: add initial build support for Amazon Linux 2022

### DIFF
--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -46,18 +46,18 @@ RUN yum -y update && \
                    cmake3 libyaml-devel && \
     yum clean all
 
-# FROM --platform=arm64 amazonlinux:2022 as amazonlinux-2022-base.arm64v8-base
+FROM --platform=arm64 amazonlinux:2022 as amazonlinux-2022.arm64v8-base
 
-# COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
-# # hadolint ignore=DL3033
-# RUN yum -y update && \
-#     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-#                    wget unzip systemd-devel wget flex bison \
-#                    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
-#                    postgresql-devel postgresql-libs \
-#                    cmake3 libyaml-devel && \
-#     yum clean all
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+                   wget unzip systemd-devel wget flex bison \
+                   cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+                   postgresql-devel postgresql-libs \
+                   cmake3 libyaml-devel && \
+    yum clean all
 
 # Common build for all distributions now
 # hadolint ignore=DL3006

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -46,6 +46,7 @@ RUN yum -y update && \
                    cmake3 libyaml-devel && \
     yum clean all
 
+# hadolint ignore=DL3029
 FROM --platform=arm64 amazonlinux:2022 as amazonlinux-2022.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
 
 # hadolint ignore=DL3033
 RUN yum -y update && \
-    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    yum install -y rpm-build ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
                    postgresql-devel postgresql-libs \

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -46,18 +46,18 @@ RUN yum -y update && \
                    cmake3 libyaml-devel && \
     yum clean all
 
-FROM arm64v8/amazonlinux:2022 as amazonlinux-2022-base.arm64v8-base
+# FROM --platform=arm64 amazonlinux:2022 as amazonlinux-2022-base.arm64v8-base
 
-COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+# COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
-# hadolint ignore=DL3033
-RUN yum -y update && \
-    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-                   wget unzip systemd-devel wget flex bison \
-                   cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
-                   postgresql-devel postgresql-libs \
-                   cmake3 libyaml-devel && \
-    yum clean all
+# # hadolint ignore=DL3033
+# RUN yum -y update && \
+#     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+#                    wget unzip systemd-devel wget flex bison \
+#                    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+#                    postgresql-devel postgresql-libs \
+#                    cmake3 libyaml-devel && \
+#     yum clean all
 
 # Common build for all distributions now
 # hadolint ignore=DL3006

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -28,9 +28,33 @@ COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
 
 # hadolint ignore=DL3033
 RUN yum -y update && \
-    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    yum install -y rpm-build ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \
                    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+                   postgresql-devel postgresql-libs \
+                   cmake3 libyaml-devel && \
+    yum clean all
+
+FROM amazonlinux:2022 as amazonlinux-2022-base
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build ca-certificates gcc gcc-c++ cmake make bash \
+                   wget unzip systemd-devel wget flex bison \
+                   cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+                   postgresql-devel postgresql-libs \
+                   cmake3 libyaml-devel && \
+    yum clean all
+
+FROM arm64v8/amazonlinux:2022 as amazonlinux-2022-base.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+                   wget unzip systemd-devel wget flex bison \
+                   cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
                    postgresql-devel postgresql-libs \
                    cmake3 libyaml-devel && \
     yum clean all


### PR DESCRIPTION
Initial packaging support to build (not release) for Amazon Linux 2022 so addresses #6020.

This only provides the option to build, it will require further updates to build this target for release - related to #6039 as well to get those changes to config in.

Note AL2022 is still not stable/released so I don't think we can create release packages for it until then.

We will also need to update the release server to provide the necessary repositories.

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
