### PR TITLE
upstream: event injection macos fix

### DIFF
--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -451,7 +451,7 @@ int flb_downstream_conn_timeouts(struct mk_list *list)
                 if (connection->event.status != MK_EVENT_NONE) {
                     mk_event_inject(connection->evl,
                                     &connection->event,
-                                    MK_EVENT_READ | MK_EVENT_WRITE,
+                                    u_conn->event.mask,
                                     FLB_TRUE);
                 }
 

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -451,7 +451,7 @@ int flb_downstream_conn_timeouts(struct mk_list *list)
                 if (connection->event.status != MK_EVENT_NONE) {
                     mk_event_inject(connection->evl,
                                     &connection->event,
-                                    u_conn->event.mask,
+                                    connection->event.mask,
                                     FLB_TRUE);
                 }
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -843,7 +843,7 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
                 if (u_conn->event.status != MK_EVENT_NONE) {
                     mk_event_inject(u_conn->evl,
                                     &u_conn->event,
-                                    MK_EVENT_READ | MK_EVENT_WRITE,
+                                    u_conn->event.mask,
                                     FLB_TRUE);
                 }
 


### PR DESCRIPTION
This PR fixes fixes the issue where fluent-bit tries to remove a file descriptor
from both read and write "lists" when a timeout occurs, this is not a problem 
normally but it does generate a spurious kernel trip.