### PR TITLE
tests: runtime_shell: spread the ports so they don't collide

### DIFF
--- a/tests/runtime_shell/in_http_tls_expect.sh
+++ b/tests/runtime_shell/in_http_tls_expect.sh
@@ -18,7 +18,7 @@ test_in_http_tls_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_VHOST=leo.vcap.me
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999
+    export LISTENER_PORT=50000
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_tcp_plaintext_expect.sh
+++ b/tests/runtime_shell/in_syslog_tcp_plaintext_expect.sh
@@ -15,7 +15,7 @@ input_generator() {
 test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999 
+    export LISTENER_PORT=50001
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_tcp_tls_expect.sh
+++ b/tests/runtime_shell/in_syslog_tcp_tls_expect.sh
@@ -16,7 +16,7 @@ test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_VHOST=leo.vcap.me
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999
+    export LISTENER_PORT=50002
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_udp_plaintext_expect.sh
+++ b/tests/runtime_shell/in_syslog_udp_plaintext_expect.sh
@@ -15,7 +15,7 @@ input_generator() {
 test_in_syslog_tcp_plaintext_filter_expect() {
     export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
     export LISTENER_HOST=127.0.0.1 
-    export LISTENER_PORT=9999 
+    export LISTENER_PORT=50003 
 
     input_generator &
 

--- a/tests/runtime_shell/in_syslog_uds_dgram_plaintext_expect.sh
+++ b/tests/runtime_shell/in_syslog_uds_dgram_plaintext_expect.sh
@@ -17,7 +17,7 @@ test_in_syslog_uds_stream_plaintext_filter_expect() {
     if test "$platform" != "Darwin"
         then    
         export SIGNAL_FILE_PATH="/tmp/fb_signal_$$"
-        export SOCKET_PATH=/tmp/fluent_bit_syslog_uds_stream.sock
+        export SOCKET_PATH=/tmp/fluent_bit_syslog_uds_dgram.sock
 
         input_generator &
 


### PR DESCRIPTION
This PR spreads the shell script ports so they don't collide when 
running ctest with more than one job.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>