### PR TITLE
tests: core_chunk_trace: Enable chunk trace correctly

### DIFF
--- a/tests/runtime/core_chunk_trace.c
+++ b/tests/runtime/core_chunk_trace.c
@@ -87,6 +87,7 @@ void do_test_records_trace(void (*records_cb)(struct callback_records *))
 
     TEST_CHECK(flb_service_set(ctx, "Flush", "0.5",
                                     "Grace", "1",
+                                    "Enable_Chunk_Trace", "On",
                                     NULL) == 0);
 
 


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

We need to enable chunk trace feature on unit test.

This feature should be needed to enable explicitly by command line arguments like this:
```console
$ ./bin/fluent-bit -H -i dummy -F record_modifier -m '*' -p record="foo bar" -o stdout -m '*' -f 1 -Z
```

And HTTPie:

```console
$ http -v 127.0.0.1:2020/api/v1/trace/dummy.0 output=stdout prefix=trace. enable:=true params:='{"format":"json"}'
POST /api/v1/trace/dummy.0 HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 86
Content-Type: application/json
Host: 127.0.0.1:2020
User-Agent: HTTPie/3.2.1

{
    "enable": true,
    "output": "stdout",
    "params": {
        "format": "json"
    },
    "prefix": "trace."
}


HTTP/1.1 200 OK
Date: Wed, 14 Sep 2022 07:32:10 GMT
Server: Monkey/1.7.0
Transfer-Encoding: chunked

{"status":"ok"}
```

in actual use case.

For test cases, we need to enable it by `Enable_Chunk_Trace On` on service section.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
```console
$ ./bin/flb-rt-core_chunk_trace
Test trace...                                   [2022/09/14 16:42:59] [ info] [fluent bit] version=2.0.0, commit=db45187d68, pid=63751
[2022/09/14 16:42:59] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/09/14 16:42:59] [ info] [cmetrics] version=0.4.0
[2022/09/14 16:42:59] [ info] [sp] stream processor started
[2022/09/14 16:42:59] [ info] [fluent bit] version=2.0.0, commit=db45187d68, pid=63751
[2022/09/14 16:42:59] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/09/14 16:42:59] [ info] [cmetrics] version=0.4.0
[2022/09/14 16:42:59] [ info] [sp] stream processor started
[2022/09/14 16:42:59] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1663141380.340303000, {"message"=>"dummy"}]
[2022/09/14 16:43:01] [ info] [test] flush record
[2022/09/14 16:43:01] [ info] [test] flush record
[0] dummy.0: [1663141381.336118000, {"message"=>"dummy"}]
[2022/09/14 16:43:02] [ info] [test] flush record
[2022/09/14 16:43:02] [ info] [test] flush record
[0] dummy.0: [1663141382.338588000, {"message"=>"dummy"}]
[2022/09/14 16:43:03] [ info] [test] flush record
[2022/09/14 16:43:03] [ info] [test] flush record
[0] dummy.0: [1663141383.336060000, {"message"=>"dummy"}]
[2022/09/14 16:43:04] [ info] [test] flush record
[2022/09/14 16:43:04] [ info] [test] flush record
[2022/09/14 16:43:04] [ info] [input] pausing dummy.0
[2022/09/14 16:43:04] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/09/14 16:43:04] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
SUCCESS: All unit tests have passed.
```
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
