### PR TITLE
scripts: add netcat to code analysis helper script

### DIFF
--- a/run_code_analysis.sh
+++ b/run_code_analysis.sh
@@ -11,7 +11,7 @@ CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
 # From the Dockerfile
 FLB_CMAKE_OPTIONS=${FLB_CMAKE_OPTIONS:--DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=On}
-ADDITIONAL_DEPS=${ADDITIONAL_DEPS:-libssl-dev libsasl2-dev pkg-config libsystemd-dev zlib1g-dev libpq-dev postgresql-server-dev-all flex bison libyaml-dev}
+ADDITIONAL_DEPS=${ADDITIONAL_DEPS:-libssl-dev libsasl2-dev pkg-config libsystemd-dev zlib1g-dev libpq-dev postgresql-server-dev-all flex bison libyaml-dev netcat}
 
 # From the Unit Tests script
 SKIP_TESTS=${SKIP_TESTS:-flb-rt-out_elasticsearch flb-it-network flb-it-fstore flb-rt-out_elasticsearch flb-rt-out_td flb-rt-out_forward flb-rt-in_disk flb-rt-in_proc}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Recent updates for unit tests mean netcat is required now so added to the helper container as an extra dependency.

Without this PR it just stalls running the following:

```shell
$ ./run_code_analysis.sh
...
 61/109 Test  #61: in_syslog_tcp_tls_expect.sh ................   Passed    6.03 sec
        Start  62: in_syslog_tcp_plaintext_expect.sh
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Now completes successfully.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
