### PR TITLE
tests: internal: macos: Ensure TLS initialization for config function on every startup

### DIFF
--- a/tests/include/flb_tests_initialize_tls.h
+++ b/tests/include/flb_tests_initialize_tls.h
@@ -18,26 +18,27 @@
  *  limitations under the License.
  */
 
-#ifndef FLB_TEST_INTERNAL_H
-#define FLB_TEST_INTERNAL_H
+#ifndef FLB_TESTS_INITALIZE_TLS_H
+#define FLB_TESTS_INITALIZE_TLS_H
 
-#ifdef FLB_TEST_INIT_NOP
-static inline void init_nop() {};
-#define TEST_INIT { init_nop(); }
-#else
-#include "../include/flb_tests_initialize_tls.h"
-#define TEST_INIT { flb_test_env_config_init(); }
-#endif
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_mem.h>
 
-#ifdef FLB_TEST_FINI_NOP
-static inline void fini_nop() {};
-#define TEST_FINI { fini_nop(); }
-#else
-#include "../include/flb_tests_initialize_tls.h"
-#define TEST_FINI { flb_test_env_config_destroy(); }
-#endif
+struct flb_config *test_env_config = NULL;
 
-#include "../lib/acutest/acutest.h"
-#define FLB_TESTS_DATA_PATH "@FLB_TESTS_DATA_PATH@"
+static inline void flb_test_env_config_init(void)
+{
+    test_env_config = flb_config_init();
+
+    if (test_env_config == NULL) {
+        return;
+    }
+}
+
+static inline void flb_test_env_config_destroy(void) {
+    if (test_env_config != NULL) {
+        flb_config_exit(test_env_config);
+    }
+}
 
 #endif


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

macOS requests to initialize TLS correctly.
The previous patch, https://github.com/fluent/fluent-bit/pull/5980, needs to put `flb_config` calling and destroy code on the every needed places of unit test files.
This should be sick for us to clean up code after TLS refactoring.

With this approach, we can remove TLS initializing code completely from unit tests with removing `TEST_INIT` and `TEST_FINI` part from flb_tests_internal.h.in.

Before TLS refactoring, we need to initialize TLS with `flb_config_init` because fluent-bit's logging mechanism is heavily relying on TLS for thread specific settings for worker.
Thus, once we use flb_{trace, debug, info, warn, error} function on somewhere, it implicitly depends on fluent-bit's logging mechanism. This should be one of the obstacles to make passing unit tests on macOS.

When TLS are once got initialized, we can proceed logging operation on test cases on macOS.

Also, this patch provides `FLB_TEST_INIT_NOP` and `FLB_TEST_FINI_NOP` macro to turn off `flb_config_init` and `flb_config_exit` calling respectively on every setup/teardown for internal test cases.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
