### PR TITLE
tests: internal: aws_credentials: Ensure to unset environment variables

### DIFF
--- a/tests/internal/aws_credentials.c
+++ b/tests/internal/aws_credentials.c
@@ -192,6 +192,8 @@ static void test_environment_provider_only_access()
     struct flb_config *config;
     int ret;
 
+    unsetenv_credentials();
+
     config = flb_config_init();
 
     if (config == NULL) {


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

`test_environment_provider_only_access` test function requires for empty definitions of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` on testing.
In CI, it does not raise any issues but, in actual local boxes, users sometimes define their own aws credentials via environment variables. This should cause test failures.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
