### PR TITLE
workflows: add automated Dockerhub description update

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -221,6 +221,25 @@ jobs:
           TAG: ${{ matrix.tag }}
         shell: bash
 
+  staging-release-images-dockerhub-update:
+    name: Update Dockerhub description
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    environment: release
+    needs: staging-release-images
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.repository }}
+          readme-filepath: ./dockerfiles/dockerhub-description.md
+          short-description: 'Fluent Bit, lightweight logs and metrics collector and forwarder'
+
   staging-release-images-sign:
     name: Sign container image manifests
     permissions:

--- a/.github/workflows/update-dockerhub.yaml
+++ b/.github/workflows/update-dockerhub.yaml
@@ -1,0 +1,24 @@
+---
+name: Update Dockerhub description
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-dockerhub:
+    name: Update Dockerhub description
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.repository }}
+          readme-filepath: ./dockerfiles/dockerhub-description.md
+          short-description: 'Fluent Bit, lightweight logs and metrics collector and forwarder'

--- a/dockerfiles/dockerhub-description.md
+++ b/dockerfiles/dockerhub-description.md
@@ -1,0 +1,65 @@
+# Fluent Bit
+
+[Fluent Bit](https://fluentbit.io/) is a lightweight and high performance log processor.
+In this repository you will find the container images ready for production usage.
+Our stable images are based in [Distroless](https://github.com/GoogleContainerTools/distroless) focusing on security containing just the Fluent Bit binary, minimal system libraries and basic configuration.
+
+Optionally, we provide debug images which contain shells and tooling that can be used to troubleshoot or for testing purposes.
+
+For a detailed list of Tags and versions available, please refer to the the official documentation:
+
+<https://docs.fluentbit.io/manual/installation/docker>
+
+## Getting Started
+
+Run a Fluent Bit instance that will receive messages over TCP port 24224 through the [Forward](https://docs.fluentbit.io/manual/pipeline/outputs/forward) protocol, and send the messages to the STDOUT interface in JSON format every second:
+
+```shell
+docker run -p 127.0.0.1:24224:24224 fluent/fluent-bit /fluent-bit/bin/fluent-bit -i forward -o stdout -p format=json_lines -f 1
+```
+
+Now run a separate container that will send a test message.
+This time the Docker container will use the Fluent Forward Protocol as the logging driver:
+
+```shell
+docker run --log-driver=fluentd -t ubuntu echo "Testing a log message"
+```
+
+On Fluent Bit container, it will print to stdout something like this:
+
+```shell
+Fluent Bit v1.9.8
+* Copyright (C) 2015-2022 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+[2022/09/16 10:03:48] [ info] [fluent bit] version=1.9.8, commit=97a5e9dcf3, pid=1
+[2022/09/16 10:03:48] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
+[2022/09/16 10:03:48] [ info] [cmetrics] version=0.3.6
+[2022/09/16 10:03:48] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
+[2022/09/16 10:03:48] [ info] [sp] stream processor started
+[2022/09/16 10:03:48] [ info] [output:stdout:stdout.0] worker #0 started
+{"date":1663322636.0,"source":"stdout","log":"Testing a log message\r","container_id":"e29e02e84ffa00116818a86f6f99305a7d0f77f25420eceeb9206b725f137af4","container_name":"/intelligent_austin"}
+```
+
+## Contact
+
+Feel free to contact us through the following community channels:
+
+Slack: <https://slack.fluentd.org> / channel #fluent-bit
+Github: <https://github.com/fluent/fluent-bit>
+Twitter: <https://twitter.com/fluentbit>
+
+## Fluent Bit & Fluentd
+
+[Fluent Bit](https://fluentbit.io/) is a [CNCF](https://cncf.io/) sub-project under the umbrella of [Fluentd](https://www.fluentd.org/).
+
+## License
+
+This program is under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+## Authors
+
+[Fluent Bit](https://fluentbit.io/) is a [CNCF](https://cncf.io/) sub-project under the umbrella of [Fluentd](https://www.fluentd.org/).
+
+Made with love by [many contributors](https://github.com/fluent/fluent-bit/graphs/contributors) :).

--- a/dockerfiles/dockerhub-description.md
+++ b/dockerfiles/dockerhub-description.md
@@ -6,7 +6,7 @@ Our stable images are based in [Distroless](https://github.com/GoogleContainerTo
 
 Optionally, we provide debug images which contain shells and tooling that can be used to troubleshoot or for testing purposes.
 
-For a detailed list of Tags and versions available, please refer to the the official documentation:
+For a detailed list of tags and versions available, please refer to the the official documentation:
 
 <https://docs.fluentbit.io/manual/installation/docker>
 
@@ -41,6 +41,12 @@ Fluent Bit v1.9.8
 [2022/09/16 10:03:48] [ info] [output:stdout:stdout.0] worker #0 started
 {"date":1663322636.0,"source":"stdout","log":"Testing a log message\r","container_id":"e29e02e84ffa00116818a86f6f99305a7d0f77f25420eceeb9206b725f137af4","container_name":"/intelligent_austin"}
 ```
+
+## Dockerfile
+
+Refer to the definition in the source repository: <https://github.com/fluent/fluent-bit/blob/master/dockerfiles/Dockerfile>.
+
+The container is built according to the instructions here: <https://github.com/fluent/fluent-bit/tree/master/dockerfiles>.
 
 ## Contact
 


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #5793 by ensuring we update the description in Dockerhub automatically on release but also adding a manual update option.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
