### PR TITLE
out_syslog: support preset configuration

### DIFF
--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -695,11 +695,22 @@ static flb_sds_t syslog_format(struct flb_syslog *ctx, msgpack_object *o,
     ret = msgpack_to_syslog(ctx, o, &msg);
     if (!ret) {
         if (msg.severity < 0) {
-            msg.severity = 6;
+            msg.severity = ctx->severity_preset;
         }
-
         if (msg.facility  < 0) {
-            msg.facility = 1;
+            msg.facility = ctx->facility_preset;
+        }
+        if (msg.hostname == NULL && ctx->hostname_preset) {
+            msg.hostname = flb_sds_create(ctx->hostname_preset);
+        }
+        if (msg.appname == NULL && ctx->appname_preset) {
+            msg.appname = flb_sds_create(ctx->appname_preset);
+        }
+        if (msg.procid == NULL && ctx->procid_preset) {
+            msg.procid = flb_sds_create(ctx->procid_preset);
+        }
+        if (msg.msgid == NULL && ctx->msgid_preset) {
+            msg.msgid = flb_sds_create(ctx->msgid_preset);
         }
 
         if (ctx->parsed_format == FLB_SYSLOG_RFC3164) {
@@ -1020,10 +1031,24 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_INT, "syslog_severity_preset", "6",
+     0, FLB_TRUE, offsetof(struct flb_syslog, severity_preset),
+     "Specify the preset severity number. It must be 0-7. "
+     " This configuration is optional."
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "syslog_facility_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_syslog, facility_key),
      "Specify the name of the key from the original record that contains the Syslog "
      "facility number. This configuration is optional."
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "syslog_facility_preset", "1",
+     0, FLB_TRUE, offsetof(struct flb_syslog, facility_preset),
+     "Specify the preset facility number. It must be 0-23. "
+     " This configuration is optional."
     },
 
     {
@@ -1034,10 +1059,22 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_STR, "syslog_hostname_preset", NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, hostname_preset),
+     "Specify the preset hostname. This configuration is optional."
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "syslog_appname_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_syslog, appname_key),
      "Specify the key name from the original record that contains the application "
      "name that generated the message. This configuration is optional."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "syslog_appname_preset", NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, appname_preset),
+     "Specify the preset appname. This configuration is optional."
     },
 
     {
@@ -1048,10 +1085,22 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_STR, "syslog_procid_preset", NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, procid_preset),
+     "Specify the preset procid.  This configuration is optional."
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "syslog_msgid_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_syslog, msgid_key),
      "Specify the key name from the original record that contains the Message ID "
      "associated to the message. This configuration is optional."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "syslog_msgid_preset", NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, msgid_preset),
+     "Specify the preset msgid. This configuration is optional."
     },
 
     {

--- a/plugins/out_syslog/syslog_conf.h
+++ b/plugins/out_syslog/syslog_conf.h
@@ -20,6 +20,11 @@
 #ifndef FLB_OUT_SYSLOG_CONF_H
 #define FLB_OUT_SYSLOG_CONF_H
 
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_pipe.h>
+
+
 #define FLB_SYSLOG_UDP 0
 #define FLB_SYSLOG_TCP 1
 #define FLB_SYSLOG_TLS 2
@@ -42,6 +47,14 @@ struct flb_syslog {
     flb_sds_t msgid_key;
     struct mk_list *sd_keys;
     flb_sds_t message_key;
+
+    /* Preset */
+    int severity_preset;
+    int facility_preset;
+    flb_sds_t hostname_preset;
+    flb_sds_t appname_preset;
+    flb_sds_t procid_preset;
+    flb_sds_t msgid_preset;
 
     /* Internal */
     int parsed_mode;

--- a/tests/runtime/out_syslog.c
+++ b/tests/runtime/out_syslog.c
@@ -259,6 +259,63 @@ void flb_test_severity_key_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+
+void flb_test_severity_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"s_key\":\"5\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<13>" /* 1(user-level messages) * 8 + 5(severity) */,
+                             "<13>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_severity_preset", "5",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_severity_key_rfc3164()
 {
     struct test_ctx *ctx;
@@ -288,6 +345,62 @@ void flb_test_severity_key_rfc3164()
                          "syslog_format", "rfc3164",
                          "syslog_message_key", "msg",
                          "syslog_severity_key", "s_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_severity_preset_rfc3164()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"s_key\":\"5\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "Jan  1 00:00:01", "<13>" /* 1(user-level messages) * 8 + 5(severity) */,
+                             "<13>Jan  1 00:00:01 hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc3164",
+                         "syslog_message_key", "msg",
+                         "syslog_severity_preset", "5",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -371,6 +484,62 @@ void flb_test_facility_key_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_facility_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"f_key\":\"13\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<110>" /* 13(log audit) * 8 + 6(default severity) */,
+                             "<110>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_facility_preset", "13",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_facility_key_rfc3164()
 {
     struct test_ctx *ctx;
@@ -400,6 +569,62 @@ void flb_test_facility_key_rfc3164()
                          "syslog_format", "rfc3164",
                          "syslog_message_key", "msg",
                          "syslog_facility_key", "f_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_facility_preset_rfc3164()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"f_key\":\"13\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "Jan  1 00:00:01", "<110>" /* 13(log audit) * 8 + 6(default severity) */,
+                             "<110>Jan  1 00:00:01 hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc3164",
+                         "syslog_message_key", "msg",
+                         "syslog_facility_preset", "13",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -597,6 +822,62 @@ void flb_test_hostname_key_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_hostname_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"h_key\":\"localhost\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "localhost",
+                             "<14>1 1970-01-01T00:00:01.000000Z localhost - - - - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_hostname_preset", "localhost",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_hostname_key_rfc3164()
 {
     struct test_ctx *ctx;
@@ -626,6 +907,62 @@ void flb_test_hostname_key_rfc3164()
                          "syslog_format", "rfc3164",
                          "syslog_message_key", "msg",
                          "syslog_hostname_key", "h_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_hostname_preset_rfc3164()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"h_key\":\"localhost\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "Jan  1 00:00:01", "localhost",
+                             "<14>Jan  1 00:00:01 localhost hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc3164",
+                         "syslog_message_key", "msg",
+                         "syslog_hostname_preset", "localhost",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -709,6 +1046,62 @@ void flb_test_appname_key_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_appname_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"a_key\":\"fluent-bit\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "fluent-bit",
+                             "<14>1 1970-01-01T00:00:01.000000Z - fluent-bit - - - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_appname_preset", "fluent-bit",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_appname_key_rfc3164()
 {
     struct test_ctx *ctx;
@@ -738,6 +1131,62 @@ void flb_test_appname_key_rfc3164()
                          "syslog_format", "rfc3164",
                          "syslog_message_key", "msg",
                          "syslog_appname_key", "a_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_appname_preset_rfc3164()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"a_key\":\"fluent-bit\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "Jan  1 00:00:01", "fluent-bit",
+                             "<14>Jan  1 00:00:01 fluent-bit: hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc3164",
+                         "syslog_message_key", "msg",
+                         "syslog_appname_preset", "fluent-bit",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -821,6 +1270,62 @@ void flb_test_procid_key_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_procid_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"p_key\":\"1234\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "1234",
+                             "<14>1 1970-01-01T00:00:01.000000Z - - 1234 - - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_procid_preset", "1234",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_msgid_key_rfc5424()
 {
     struct test_ctx *ctx;
@@ -850,6 +1355,62 @@ void flb_test_msgid_key_rfc5424()
                          "syslog_format", "rfc5424",
                          "syslog_message_key", "msg",
                          "syslog_msgid_key", "m_key",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set_test(ctx->flb, ctx->o_ffd,
+                         "formatter", cb_check_str_list,
+                          &expected, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf, size);
+    TEST_CHECK(ret >= 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_msgid_preset_rfc5424()
+{
+    struct test_ctx *ctx;
+    int ret;
+    int num;
+
+    char *buf = "[1, {\"msg\":\"hello world\", \"m_key\":\"TCPIN\"}]";
+    size_t size = strlen(buf);
+
+    char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "TCPIN",
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - TCPIN - ﻿hello world"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    clear_output_num();
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "syslog_format", "rfc5424",
+                         "syslog_message_key", "msg",
+                         "syslog_msgid_preset", "TCPIN",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -941,6 +1502,10 @@ TEST_LIST = {
     {"format_severity_facility_key_rfc3164", flb_test_severity_facility_key_rfc3164},
     {"format_hostname_key_rfc3164", flb_test_hostname_key_rfc3164},
     {"format_appname_key_rfc3164", flb_test_appname_key_rfc3164},
+    {"format_severity_preset_rfc3164", flb_test_severity_preset_rfc3164},
+    {"format_facility_preset_rfc3164", flb_test_facility_preset_rfc5424},
+    {"format_hostname_preset_rfc3164", flb_test_hostname_preset_rfc5424},
+    {"format_appname_preset_rfc3164", flb_test_appname_preset_rfc3164},
 
     /* rfc5424 (Default) */
     {"format_syslog_rfc5424", flb_test_syslog_rfc5424},
@@ -952,7 +1517,12 @@ TEST_LIST = {
     {"format_procid_key_rfc5424", flb_test_procid_key_rfc5424},
     {"format_msgid_key_rfc5424", flb_test_msgid_key_rfc5424},
     {"format_sd_key_rfc5424", flb_test_sd_key_rfc5424},
-
+    {"format_severity_preset_rfc5424", flb_test_severity_preset_rfc5424},
+    {"format_facility_preset_rfc5424", flb_test_facility_preset_rfc5424},
+    {"format_hostname_preset_rfc5424", flb_test_hostname_preset_rfc5424},
+    {"format_appname_preset_rfc5424", flb_test_appname_preset_rfc5424},
+    {"format_procid_preset_rfc5424", flb_test_procid_preset_rfc5424},
+    {"format_msgid_preset_rfc5424", flb_test_msgid_preset_rfc5424},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
In some cases, a record doesn't contain a value for syslog. This patch adds *_preset properties to set a default value.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy

[OUTPUT]
    Name syslog
    syslog_message_key dummy
    syslog_appname_preset fluent-bit
    syslog_hostname_preset localhost
```

## Debug/Valgrind output

netcat got a default appname and hostname.
```
$ nc -l 12345
<14>1 2022-09-18T23:39:48.184920Z localhost fluent-bit - - -
```

```
$ valgrind --leak-check=full bin/fluent-bit -c syslog.conf 
==11967== Memcheck, a memory error detector
==11967== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11967== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==11967== Command: bin/fluent-bit -c syslog.conf
==11967== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/09/19 08:39:47] [ info] [fluent bit] version=2.0.0, commit=e1a58dfc80, pid=11967
[2022/09/19 08:39:47] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/09/19 08:39:47] [ info] [cmetrics] version=0.4.0
[2022/09/19 08:39:47] [ info] [output:syslog:syslog.0] setup done for 127.0.0.1:12345 (TLS=off)
[2022/09/19 08:39:47] [ info] [sp] stream processor started
==11967== Warning: client switching stacks?  SP change: 0x5ff7738 --> 0x548f1d0
==11967==          to suppress, use: --max-stackframe=11961704 or greater
==11967== Warning: client switching stacks?  SP change: 0x548f128 --> 0x5ff7738
==11967==          to suppress, use: --max-stackframe=11961872 or greater
==11967== Warning: client switching stacks?  SP change: 0x5ff7968 --> 0x548f128
==11967==          to suppress, use: --max-stackframe=11962432 or greater
==11967==          further instances of this message will not be shown.
[2022/09/19 08:39:50] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:50] [ warn] [engine] failed to flush chunk '11967-1663544389.186228240.flb', retry in 8 seconds: task_id=0, input=dummy.0 > output=syslog.0 (out_id=0)
[2022/09/19 08:39:51] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:51] [ warn] [engine] failed to flush chunk '11967-1663544390.122259213.flb', retry in 9 seconds: task_id=1, input=dummy.0 > output=syslog.0 (out_id=0)
[2022/09/19 08:39:52] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:52] [ warn] [engine] failed to flush chunk '11967-1663544391.124665914.flb', retry in 6 seconds: task_id=2, input=dummy.0 > output=syslog.0 (out_id=0)
^C[2022/09/19 08:39:52] [engine] caught signal (SIGINT)
[2022/09/19 08:39:52] [ warn] [engine] service will shutdown in max 5 seconds
[2022/09/19 08:39:52] [ info] [input] pausing dummy.0
[2022/09/19 08:39:52] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:52] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:52] [ warn] [engine] failed to flush chunk '11967-1663544392.122204493.flb', retry in 1 seconds: task_id=3, input=dummy.0 > output=syslog.0 (out_id=0)
[2022/09/19 08:39:52] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:52] [ warn] [engine] chunk '11967-1663544389.186228240.flb' cannot be retried: task_id=0, input=dummy.0 > output=syslog.0
[2022/09/19 08:39:52] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:52] [ warn] [engine] chunk '11967-1663544390.122259213.flb' cannot be retried: task_id=1, input=dummy.0 > output=syslog.0
[2022/09/19 08:39:52] [ warn] [engine] chunk '11967-1663544391.124665914.flb' cannot be retried: task_id=2, input=dummy.0 > output=syslog.0
[2022/09/19 08:39:53] [ info] [task] dummy/dummy.0 has 1 pending task(s):
[2022/09/19 08:39:53] [ info] [task]   task_id=3 still running on route(s): syslog/syslog.0 
[2022/09/19 08:39:53] [ info] [input] pausing dummy.0
[2022/09/19 08:39:53] [error] [output:syslog:syslog.0] no upstream connections available
[2022/09/19 08:39:53] [ warn] [engine] chunk '11967-1663544392.122204493.flb' cannot be retried: task_id=3, input=dummy.0 > output=syslog.0
[2022/09/19 08:39:54] [ info] [engine] service has stopped (0 pending tasks)
[2022/09/19 08:39:54] [ info] [input] pausing dummy.0
==11967== 
==11967== HEAP SUMMARY:
==11967==     in use at exit: 0 bytes in 0 blocks
==11967==   total heap usage: 1,526 allocs, 1,526 frees, 2,807,921 bytes allocated
==11967== 
==11967== All heap blocks were freed -- no leaks are possible
==11967== 
==11967== For lists of detected and suppressed errors, rerun with: -s
==11967== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
taka@taka-VirtualBox:~/git/fluent-bit/build$ 
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
