### PR TITLE
sds: fix flb_sds_snprintf  not alloc '\0'

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -484,12 +484,12 @@ int flb_sds_snprintf(flb_sds_t *str, size_t size, const char *fmt, ...)
     va_start(va, fmt);
     ret = vsnprintf(*str, size, fmt, va);
     if (ret > size) {
-        tmp = flb_sds_increase(*str, ret-size);
+        tmp = flb_sds_increase(*str, ret-size + 1);
         if (tmp == NULL) {
             return -1;
         }
         *str = tmp;
-        size = ret;
+        size = ret + 1;
         va_end(va);
         goto retry_snprintf;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
