### PR TITLE
core: new memory-ring-buffering mechanism (memrb)

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -306,6 +306,10 @@ struct flb_input_instance {
     struct cmt_counter *cmt_bytes;       /* metric: input_bytes_total   */
     struct cmt_counter *cmt_records;     /* metric: input_records_total */
 
+    /* memory ring buffer (memrb) metrics */
+    struct cmt_counter *cmt_memrb_dropped_chunks;
+    struct cmt_counter *cmt_memrb_dropped_bytes;
+
     /*
      * Indexes for generated chunks: simple hash tables that keeps the latest
      * available chunks for writing data operations. This optimizes the

--- a/include/fluent-bit/flb_storage.h
+++ b/include/fluent-bit/flb_storage.h
@@ -24,6 +24,12 @@
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_stats.h>
 
+/* Storage type */
+#define FLB_STORAGE_FS      CIO_STORE_FS    /* 0 */
+#define FLB_STORAGE_MEM     CIO_STORE_MEM   /* 1 */
+#define FLB_STORAGE_MEMRB   10
+
+/* Storage defaults */
 #define FLB_STORAGE_BL_MEM_LIMIT   "100M"
 #define FLB_STORAGE_MAX_CHUNKS_UP  128
 
@@ -42,6 +48,20 @@ struct flb_storage_input {
     struct cio_stream *stream;
     struct cio_ctx *cio;
 };
+
+static inline char *flb_storage_get_type(int type)
+{
+    switch(type) {
+        case FLB_STORAGE_FS:
+            return "'filesystem' (memory + filesystem)";
+        case FLB_STORAGE_MEM:
+            return "'memory' (memory only)";
+        case FLB_STORAGE_MEMRB:
+            return "'memrb' (memory ring buffer)";
+    };
+
+    return NULL;
+}
 
 int flb_storage_create(struct flb_config *ctx);
 int flb_storage_input_create(struct cio_ctx *cio,

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -333,7 +333,7 @@ static void print_storage_info(struct flb_config *ctx, struct cio_ctx *cio)
         type = "memory+filesystem";
     }
     else {
-        type = "memory-only";
+        type = "memory";
     }
 
     if (cio->options.flags & CIO_FULL_SYNC) {
@@ -344,13 +344,13 @@ static void print_storage_info(struct flb_config *ctx, struct cio_ctx *cio)
     }
 
     if (cio->options.flags & CIO_CHECKSUM) {
-        checksum = "enabled";
+        checksum = "on";
     }
     else {
-        checksum = "disabled";
+        checksum = "off";
     }
 
-    flb_info("[storage] version=%s, type=%s, sync=%s, checksum=%s, max_chunks_up=%i",
+    flb_info("[storage] ver=%s, type=%s, sync=%s, checksum=%s, max_chunks_up=%i",
              cio_version(), type, sync, checksum, ctx->storage_max_chunks_up);
 
     /* Storage input plugin */
@@ -380,26 +380,36 @@ static void log_cb(void *ctx, int level, const char *file, int line,
 int flb_storage_input_create(struct cio_ctx *cio,
                              struct flb_input_instance *in)
 {
+    int cio_storage_type;
     struct flb_storage_input *si;
     struct cio_stream *stream;
 
     /* storage config: get stream type */
     if (in->storage_type == -1) {
-        in->storage_type = CIO_STORE_MEM;
+        in->storage_type = FLB_STORAGE_MEM;
     }
 
-    if (in->storage_type == CIO_STORE_FS && cio->options.root_path == NULL) {
+    if (in->storage_type == FLB_STORAGE_FS && cio->options.root_path == NULL) {
         flb_error("[storage] instance '%s' requested filesystem storage "
                   "but no filesystem path was defined.",
                   flb_input_name(in));
         return -1;
     }
 
+    /*
+     * The input instance can define it owns storage type which is based on some
+     * specific Chunk I/O storage type. We handle the proper initialization here.
+     */
+    cio_storage_type = in->storage_type;
+    if (in->storage_type == FLB_STORAGE_MEMRB) {
+        cio_storage_type = FLB_STORAGE_MEM;
+    }
+
     /* Check for duplicates */
     stream = cio_stream_get(cio, in->name);
     if (!stream) {
         /* create stream for input instance */
-        stream = cio_stream_create(cio, in->name, in->storage_type);
+        stream = cio_stream_create(cio, in->name, cio_storage_type);
         if (!stream) {
             flb_error("[storage] cannot create stream for instance %s",
                       in->name);


### PR DESCRIPTION
The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up `mem_buf_limit` is mandatory to specify that limit.

When the chunks are enqueued, and `mem_buf_limit` is reached, instead  of pausing the input plugin as normally would happen with the default memory strategy, this new mechanism removes the oldest Chunks from  the queue until to make sure there is enough space for the new incoming data.

The configuration of this new strategy is as follows:
    
```
[INPUT]
    name          tail
    path          /var/log/*
    # new configuration options for memory ring buffer
    storage.type  memrb
    mem_buf_limit 20M
```

NOTE: by default Fluent Bit tries to enqueue Chunks of size around  2M, this is an internal size that cannot be changed, but there are scenarios where the Chunk size can be greater than that. So `mem_buf_limit`  should be no less than 20M.

## Metrics

In addition to the ring-buffer functionality, this PR implements an extension of metrics to count the number of `dropped bytes` and `dropped chunks`, e.g:

```
# HELP fluentbit_input_memrb_dropped_chunks Number of memrb dropped chunks.
# TYPE fluentbit_input_memrb_dropped_chunks counter
fluentbit_input_memrb_dropped_chunks{name="dummy.0"} 22
# HELP fluentbit_input_memrb_dropped_bytes Number of memrb dropped bytes.
# TYPE fluentbit_input_memrb_dropped_bytes counter
fluentbit_input_memrb_dropped_bytes{name="dummy.0"} 572
```

The metrics above are an example of how they are retrieved when exposed through the Prometheus Exporter output plugin. The following configuration was used:

```
[INPUT]
    name          dummy
    # new configuration options for memory ring buffer
    storage.type  memrb
    mem_buf_limit 20M

[INPUT]
    name        fluentbit_metrics
    tag         metrics
        
[OUTPUT]
    name        prometheus_exporter
    match       metrics

[OUTPUT]
    name        http
    match       dummy*
    host        127.0.0.1
    port        9999
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
