### PR TITLE
logfmt: bare keys get "true" as value, not "nil"

### DIFF
--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -182,7 +182,7 @@ static int logfmt_parser(struct flb_parser *parser,
                                 msgpack_pack_str(tmp_pck, 0);
                             }
                             else {
-                                msgpack_pack_nil(tmp_pck);
+                                msgpack_pack_true(tmp_pck);
                             }
                         }
                         else {


### PR DESCRIPTION
In #4359, @nokute78 notes that bare keys in logfmt lines get the wrong
value after parsing: they should get a `true` value, not `nil`.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
