### PR TITLE
parser: logfmt: Allow the logfmt parser to reject messages that have keys without values

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -50,6 +50,7 @@ struct flb_parser {
     int time_offset;      /* fixed UTC offset */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
+    int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */
     char *time_frac_secs; /* time format have fractional seconds ? */
     struct flb_parser_types *types; /* type casting */
     int types_len;
@@ -95,6 +96,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *time_offset,
                                      int time_keep,
                                      int time_strict,
+                                     int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,
                                      struct mk_list *decoders,

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -150,6 +150,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *time_offset,
                                      int time_keep,
                                      int time_strict,
+                                     int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,
                                      struct mk_list *decoders,
@@ -318,6 +319,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
 
     p->time_keep = time_keep;
     p->time_strict = time_strict;
+    p->logfmt_no_bare_keys = logfmt_no_bare_keys;
     p->types = types;
     p->types_len = types_len;
     return p;
@@ -473,6 +475,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
     int skip_empty;
     int time_keep;
     int time_strict;
+    int logfmt_no_bare_keys;
     int types_len;
     struct mk_list *head;
     struct mk_list *decoders = NULL;
@@ -549,6 +552,14 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         /* time_offset (UTC offset) */
         time_offset = get_parser_key(config, cf, s, "time_offset");
 
+        /* logfmt_no_bare_keys */
+        logfmt_no_bare_keys = FLB_FALSE;
+        tmp_str = get_parser_key(config, cf, s, "logfmt_no_bare_keys");
+        if (tmp_str) {
+            logfmt_no_bare_keys = flb_utils_bool(tmp_str);
+            flb_sds_destroy(tmp_str);
+        }
+
         /* types */
         types_str = get_parser_key(config, cf, s, "types");
         if (types_str) {
@@ -564,7 +575,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         /* Create the parser context */
         if (!flb_parser_create(name, format, regex, skip_empty,
                                time_fmt, time_key, time_offset, time_keep, time_strict,
-                               types, types_len, decoders, config)) {
+                               logfmt_no_bare_keys, types, types_len, decoders, config)) {
             goto fconf_error;
         }
 

--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -40,6 +40,7 @@ static struct flb_parser *cri_parser_create(struct flb_config *config)
                           NULL,                    /* time offset */
                           FLB_TRUE,                /* time keep */
                           FLB_FALSE,               /* time strict */
+                          FLB_FALSE,               /* no bare keys */
                           NULL,                    /* parser types */
                           0,                       /* types len */
                           NULL,                    /* decoders */

--- a/src/multiline/flb_ml_parser_docker.c
+++ b/src/multiline/flb_ml_parser_docker.c
@@ -35,6 +35,7 @@ static struct flb_parser *docker_parser_create(struct flb_config *config)
                           NULL,                   /* time offset */
                           FLB_TRUE,               /* time keep */
                           FLB_FALSE,              /* time strict */
+                          FLB_FALSE,              /* no bare keys */
                           NULL,                   /* parser types */
                           0,                      /* types len */
                           NULL,                   /* decoders */

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -136,7 +136,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
     flb_input_set(ctx, in_ffd, (char *) "A", NULL);
 
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
-                                "%s.%L", "time", NULL, MK_FALSE, 0,
+                                "%s.%L", "time", NULL, MK_FALSE, 0, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     filter_ffd = flb_filter(ctx, (char *) "parser", NULL);
     int ret;

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -34,7 +34,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     /* json parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "json", NULL, FLB_TRUE, NULL,
-                                    NULL, NULL, MK_FALSE, MK_TRUE,
+                                    NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                     NULL, 0, NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size, 
                   &out_buf, &out_size, &out_time);

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -17,7 +17,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE,
-                                    MK_TRUE, NULL, 0, NULL, fuzz_config);
+                                    MK_TRUE, FLB_FALSE, NULL, 0, NULL,
+                                    fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -17,7 +17,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE, 
-                                    MK_TRUE, NULL, 0, NULL,
+                                    MK_TRUE, FLB_FALSE, NULL, 0, NULL,
                                     fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -151,7 +151,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     /* now call into the parser */
     fuzz_parser = flb_parser_create("fuzzer", format, pregex, FLB_TRUE,
-            time_fmt, time_key, time_offset, time_keep, 0,
+            time_fmt, time_key, time_offset, time_keep, 0, FLB_FALSE,
             types, types_len, list, fuzz_config);
 
     /* Second step is to use the random parser to parse random input */

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -99,7 +99,7 @@ void flb_test_filter_parser_extract_fields()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -184,7 +184,7 @@ void flb_test_filter_parser_reserve_data_off()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -260,7 +260,7 @@ void flb_test_filter_parser_handle_time_key()
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                "%Y-%m-%dT%H:%M:%S.%L",
                                "time",
-                               NULL, MK_FALSE, MK_TRUE,
+                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -336,7 +336,7 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                "%s.%L",
                                "time",
-                               NULL, MK_FALSE, MK_TRUE,
+                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -416,7 +416,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     parser = flb_parser_create("timestamp", "regex",
                                "^(?<time>.*)$", FLB_TRUE,
                                "%Y-%m-%dT%H:%M:%S.%L", "time",
-                               NULL, FLB_FALSE, MK_TRUE,
+                               NULL, FLB_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -492,7 +492,7 @@ void flb_test_filter_parser_preserve_original_field()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -575,13 +575,13 @@ void flb_test_filter_parser_first_matched_when_mutilple_parser()
     /* Parser */
     parser = flb_parser_create("one", "regex", "^(?<one>.+?)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
     parser = flb_parser_create("two", "regex", "^(?<two>.+?)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -660,7 +660,7 @@ void flb_test_filter_parser_skip_empty_values_false()
     /* Parser */
     parser = flb_parser_create("one", "regex", "^(?<one>.+?)$",
                                FLB_FALSE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 


### PR DESCRIPTION
To allow a gradual move towards logfmt and otel messages, we need to enable logfmt parsing in a way that does not try to parse non-logfmt messages. Unlike the json parser, which has an easy time rejecting non-json messages, the logfmt parser will hapily accept any log messages and parse them into something quite unusable.

By making it possible (but not required) that all items in a logfmt message have a value, we give the logfmt parser the capability to reject message and enable a gradual move towards logfmt messages.

We've been running with this (in a different form, as a parser that always rejects lines with value-les kesy) in production for over a year, and I can say it's been the only way to get people to adopt structured logging. In an environment where random libraries can throw things into your logstream, it's just been impossible to rely on everything being properly logfmt'ed.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
