### PR TITLE
1.9: core: new memory-ring-buffering mechanism (memrb)

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -274,6 +274,10 @@ struct flb_input_instance {
     struct cmt_counter *cmt_bytes;       /* metric: input_bytes_total   */
     struct cmt_counter *cmt_records;     /* metric: input_records_total */
 
+    /* memory ring buffer (memrb) metrics */
+    struct cmt_counter *cmt_memrb_dropped_chunks;
+    struct cmt_counter *cmt_memrb_dropped_bytes;
+
     /*
      * Indexes for generated chunks: simple hash tables that keeps the latest
      * available chunks for writing data operations. This optimizes the

--- a/include/fluent-bit/flb_storage.h
+++ b/include/fluent-bit/flb_storage.h
@@ -24,6 +24,12 @@
 #include <chunkio/chunkio.h>
 #include <chunkio/cio_stats.h>
 
+/* Storage type */
+#define FLB_STORAGE_FS      CIO_STORE_FS    /* 0 */
+#define FLB_STORAGE_MEM     CIO_STORE_MEM   /* 1 */
+#define FLB_STORAGE_MEMRB   10
+
+/* Storage defaults */
 #define FLB_STORAGE_BL_MEM_LIMIT   "100M"
 #define FLB_STORAGE_MAX_CHUNKS_UP  128
 
@@ -42,6 +48,20 @@ struct flb_storage_input {
     struct cio_stream *stream;
     struct cio_ctx *cio;
 };
+
+static inline char *flb_storage_get_type(int type)
+{
+    switch(type) {
+        case FLB_STORAGE_FS:
+            return "'filesystem' (memory + filesystem)";
+        case FLB_STORAGE_MEM:
+            return "'memory' (memory only)";
+        case FLB_STORAGE_MEMRB:
+            return "'memrb' (memory ring buffer)";
+    };
+
+    return NULL;
+}
 
 int flb_storage_create(struct flb_config *ctx);
 int flb_storage_input_create(struct cio_ctx *cio,

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -413,10 +413,13 @@ int flb_input_set_property(struct flb_input_instance *ins,
     else if (prop_key_check("storage.type", k, len) == 0 && tmp) {
         /* Set the storage type */
         if (strcasecmp(tmp, "filesystem") == 0) {
-            ins->storage_type = CIO_STORE_FS;
+            ins->storage_type = FLB_STORAGE_FS;
         }
         else if (strcasecmp(tmp, "memory") == 0) {
-            ins->storage_type = CIO_STORE_MEM;
+            ins->storage_type = FLB_STORAGE_MEM;
+        }
+        else if (strcasecmp(tmp, "memrb") == 0) {
+            ins->storage_type = FLB_STORAGE_MEMRB;
         }
         else {
             flb_sds_destroy(tmp);
@@ -425,7 +428,7 @@ int flb_input_set_property(struct flb_input_instance *ins,
         flb_sds_destroy(tmp);
     }
     else if (prop_key_check("storage.pause_on_chunks_overlimit", k, len) == 0 && tmp) {
-        if (ins->storage_type == CIO_STORE_FS) {
+        if (ins->storage_type == FLB_STORAGE_FS) {
             ret = flb_utils_bool(tmp);
             if (ret == -1) {
                 return -1;
@@ -609,18 +612,44 @@ int flb_input_instance_init(struct flb_input_instance *ins,
         return -1;
     }
 
-    /* Register generic input plugin metrics */
+    /*
+     * Register generic input plugin metrics
+     */
+
+    /* fluentbit_input_bytes_total */
     ins->cmt_bytes = cmt_counter_create(ins->cmt,
                                         "fluentbit", "input", "bytes_total",
                                         "Number of input bytes.",
                                         1, (char *[]) {"name"});
     cmt_counter_set(ins->cmt_bytes, ts, 0, 1, (char *[]) {name});
 
+    /* fluentbit_input_records_total */
     ins->cmt_records = cmt_counter_create(ins->cmt,
                                         "fluentbit", "input", "records_total",
                                         "Number of input records.",
                                         1, (char *[]) {"name"});
     cmt_counter_set(ins->cmt_records, ts, 0, 1, (char *[]) {name});
+
+
+    if (ins->storage_type == FLB_STORAGE_MEMRB) {
+        /* fluentbit_input_memrb_dropped_chunks */
+        ins->cmt_memrb_dropped_chunks = cmt_counter_create(ins->cmt,
+                                                          "fluentbit", "input",
+                                                          "memrb_dropped_chunks",
+                                                          "Number of memrb dropped chunks.",
+                                                          1, (char *[]) {"name"});
+        cmt_counter_set(ins->cmt_memrb_dropped_chunks, ts, 0, 1, (char *[]) {name});
+
+
+        /* fluentbit_input_memrb_dropped_bytes */
+        ins->cmt_memrb_dropped_bytes = cmt_counter_create(ins->cmt,
+                                                          "fluentbit", "input",
+                                                          "memrb_dropped_bytes",
+                                                          "Number of memrb dropped bytes.",
+                                                          1, (char *[]) {"name"});
+
+        cmt_counter_set(ins->cmt_memrb_dropped_bytes, ts, 0, 1, (char *[]) {name});
+    }
 
     /* OLD Metrics */
     ins->metrics = flb_metrics_create(name);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1462,7 +1462,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
             /* update metrics if required */
             if (dropped_chunks > 0 || dropped_bytes > 0) {
                 /* timestamp and input plugin name for label */
-                ts = cfl_time_now();
+                ts = cmt_time_now();
                 name = (char *) flb_input_name(in);
 
                 /* update counters */

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -414,7 +414,6 @@ int flb_input_chunk_release_space_compound(
                                                    FLB_INPUT_CHUNK_RELEASE_SCOPE_LOCAL);
 
             if (result) {
-                printf("FAILED\n");
                 return -5;
             }
 
@@ -619,7 +618,6 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
     if (count != 0) {
         flb_error("[input chunk] fail to drop enough chunks in order to place new data");
     }
-
     return 0;
 }
 
@@ -1157,7 +1155,6 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
         if (new_chunk || flb_routes_mask_is_empty(ic->routes_mask) == FLB_TRUE) {
             flb_input_chunk_destroy(ic, FLB_TRUE);
         }
-
         return NULL;
     }
 
@@ -1181,8 +1178,7 @@ static inline int flb_input_chunk_is_storage_overlimit(struct flb_input_instance
 {
     struct flb_storage_input *storage = (struct flb_storage_input *)i->storage;
 
-
-    if (storage->type == CIO_STORE_FS) {
+    if (storage->type == FLB_STORAGE_FS) {
         if (i->storage_pause_on_chunks_overlimit == FLB_TRUE) {
             if (storage->cio->total_chunks >= storage->cio->max_chunks_up) {
                 return FLB_TRUE;
@@ -1220,6 +1216,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
 
     /* Gather total number of enqueued bytes */
     total = flb_input_chunk_total_size(in);
+
     /* Register the total into the context variable */
     in->mem_chunks_size = total;
 
@@ -1278,11 +1275,24 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i)
         return FLB_TRUE;
     }
 
-    if (storage->type == CIO_STORE_FS) {
+    if (storage->type == FLB_STORAGE_FS) {
         return FLB_FALSE;
     }
 
     if (flb_input_chunk_is_mem_overlimit(i) == FLB_TRUE) {
+        /*
+         * if the plugin is already overlimit and the strategy is based on
+         * a memory-ring-buffer logic, do not pause the plugin, upon next
+         * try of ingestion 'memrb' will make sure to release some bytes.
+         */
+        if (i->storage_type == FLB_STORAGE_MEMRB) {
+            return FLB_FALSE;
+        }
+
+        /*
+         * The plugin is using 'memory' buffering only and already reached
+         * it limit, just pause the ingestion.
+         */
         flb_warn("[input] %s paused (mem buf overlimit)",
                  i->name);
         if (!flb_input_buf_paused(i)) {
@@ -1356,6 +1366,65 @@ int flb_input_chunk_set_up(struct flb_input_chunk *ic)
     return 0;
 }
 
+static int memrb_input_chunk_release_space(struct flb_input_instance *ins,
+                                           size_t required_space,
+                                           size_t *dropped_chunks, size_t *dropped_bytes)
+{
+    int ret;
+    int released;
+    size_t removed_chunks = 0;
+    ssize_t chunk_size;
+    ssize_t released_space = 0;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_input_chunk *ic;
+
+    mk_list_foreach_safe(head, tmp, &ins->chunks) {
+        ic = mk_list_entry(head, struct flb_input_chunk, _head);
+
+        /* check if is there any task or no users associated */
+        ret = flb_input_chunk_is_task_safe_delete(ic->task);
+        if (ret == FLB_FALSE) {
+            continue;
+        }
+
+        /* get chunk size */
+        chunk_size = flb_input_chunk_get_real_size(ic);
+
+        released = FLB_FALSE;
+        if (ic->task != NULL) {
+            if (ic->task->users == 0) {
+                flb_task_destroy(ic->task, FLB_TRUE);
+                released = FLB_TRUE;
+            }
+        }
+        else {
+            flb_input_chunk_destroy(ic, FLB_TRUE);
+            released = FLB_TRUE;
+        }
+
+        if (released) {
+            released_space += chunk_size;
+            removed_chunks++;
+        }
+
+        if (released_space >= required_space) {
+            break;
+        }
+    }
+
+    /* no matter if we succeeded or not, set the counters */
+    *dropped_bytes = released_space;
+    *dropped_chunks = removed_chunks;
+
+    /* set the final status of the operation */
+    if (released_space >= required_space) {
+        return 0;
+    }
+
+    return -1;
+}
+
 /* Append a RAW MessagPack buffer to the input instance */
 static int input_chunk_append_raw(struct flb_input_instance *in,
                                   size_t n_records,
@@ -1367,12 +1436,49 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     int min;
     int new_chunk = FLB_FALSE;
     uint64_t ts;
+    char *name;
+    size_t dropped_chunks;
+    size_t dropped_bytes;
     size_t content_size;
     size_t real_diff;
     size_t real_size;
     size_t pre_real_size;
     struct flb_input_chunk *ic;
     struct flb_storage_input *si;
+
+    /* memory ring-buffer checker */
+    if (in->storage_type == FLB_STORAGE_MEMRB) {
+        /* check if we are overlimit */
+        ret = flb_input_chunk_is_mem_overlimit(in);
+        if (ret) {
+            /* reset counters */
+            dropped_chunks = 0;
+            dropped_bytes = 0;
+
+            /* try to release 'buf_size' */
+            ret = memrb_input_chunk_release_space(in, buf_size,
+                                                  &dropped_chunks, &dropped_bytes);
+
+            /* update metrics if required */
+            if (dropped_chunks > 0 || dropped_bytes > 0) {
+                /* timestamp and input plugin name for label */
+                ts = cfl_time_now();
+                name = (char *) flb_input_name(in);
+
+                /* update counters */
+                cmt_counter_add(in->cmt_memrb_dropped_chunks, ts,
+                                dropped_chunks, 1, (char *[]) {name});
+
+                cmt_counter_add(in->cmt_memrb_dropped_bytes, ts,
+                                dropped_bytes, 1, (char *[]) {name});
+            }
+
+            if (ret != 0) {
+                /* we could not allocate the required space, just return */
+                return -1;
+            }
+        }
+    }
 
     /* Check if the input plugin has been paused */
     if (flb_input_buf_paused(in) == FLB_TRUE) {
@@ -1435,7 +1541,8 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
      */
     if (new_chunk == FLB_TRUE) {
         pre_real_size = 0;
-    } else {
+    }
+    else {
         pre_real_size = flb_input_chunk_get_real_size(ic);
     }
 
@@ -1550,7 +1657,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
      */
     si = (struct flb_storage_input *) in->storage;
     if (flb_input_chunk_is_mem_overlimit(in) == FLB_TRUE &&
-        si->type == CIO_STORE_FS) {
+        si->type == FLB_STORAGE_FS) {
         if (cio_chunk_is_up(ic->chunk) == CIO_TRUE) {
             /*
              * If we are already over limit, a sub-sequent data ingestion

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -380,26 +380,36 @@ static void log_cb(void *ctx, int level, const char *file, int line,
 int flb_storage_input_create(struct cio_ctx *cio,
                              struct flb_input_instance *in)
 {
+    int cio_storage_type;
     struct flb_storage_input *si;
     struct cio_stream *stream;
 
     /* storage config: get stream type */
     if (in->storage_type == -1) {
-        in->storage_type = CIO_STORE_MEM;
+        in->storage_type = FLB_STORAGE_MEM;
     }
 
-    if (in->storage_type == CIO_STORE_FS && cio->options.root_path == NULL) {
+    if (in->storage_type == FLB_STORAGE_FS && cio->options.root_path == NULL) {
         flb_error("[storage] instance '%s' requested filesystem storage "
                   "but no filesystem path was defined.",
                   flb_input_name(in));
         return -1;
     }
 
+    /*
+     * The input instance can define it owns storage type which is based on some
+     * specific Chunk I/O storage type. We handle the proper initialization here.
+     */
+    cio_storage_type = in->storage_type;
+    if (in->storage_type == FLB_STORAGE_MEMRB) {
+        cio_storage_type = FLB_STORAGE_MEM;
+    }
+
     /* Check for duplicates */
     stream = cio_stream_get(cio, in->name);
     if (!stream) {
         /* create stream for input instance */
-        stream = cio_stream_create(cio, in->name, in->storage_type);
+        stream = cio_stream_create(cio, in->name, cio_storage_type);
         if (!stream) {
             flb_error("[storage] cannot create stream for instance %s",
                       in->name);


### PR DESCRIPTION
The memory-ring-buffer mechanism is an optional buffering strategy for input plugins that relies only in memory. When this is enabled, the chunks management behaves as a ring buffer of a fixed size were setting up `mem_buf_limit` is mandatory to specify that limit.

When the chunks are enqueued, and `mem_buf_limit` is reached, instead  of pausing the input plugin as normally would happen with the default memory strategy, this new mechanism removes the oldest Chunks from  the queue until to make sure there is enough space for the new incoming data.

The configuration of this new strategy is as follows:
    
```
[INPUT]
    name          tail
    path          /var/log/*
    # new configuration options for memory ring buffer
    storage.type  memrb
    mem_buf_limit 20M
```

NOTE: by default Fluent Bit tries to enqueue Chunks of size around  2M, this is an internal size that cannot be changed, but there are scenarios where the Chunk size can be greater than that. So `mem_buf_limit`  should be no less than 20M.

## Metrics

In addition to the ring-buffer functionality, this PR implements an extension of metrics to count the number of `dropped bytes` and `dropped chunks`, e.g:

```
# HELP fluentbit_input_memrb_dropped_chunks Number of memrb dropped chunks.
# TYPE fluentbit_input_memrb_dropped_chunks counter
fluentbit_input_memrb_dropped_chunks{name="dummy.0"} 22
# HELP fluentbit_input_memrb_dropped_bytes Number of memrb dropped bytes.
# TYPE fluentbit_input_memrb_dropped_bytes counter
fluentbit_input_memrb_dropped_bytes{name="dummy.0"} 572
```

The metrics above are an example of how they are retrieved when exposed through the Prometheus Exporter output plugin. The following configuration was used:

```
[INPUT]
    name          dummy
    # new configuration options for memory ring buffer
    storage.type  memrb
    mem_buf_limit 20M

[INPUT]
    name        fluentbit_metrics
    tag         metrics
        
[OUTPUT]
    name        prometheus_exporter
    match       metrics

[OUTPUT]
    name        http
    match       dummy*
    host        127.0.0.1
    port        9999
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
