### PR TITLE
config/yaml: make the name property explicit and unnest properties.

### DIFF
--- a/tests/internal/data/config_format/yaml/test/dummy_pipeline.yaml
+++ b/tests/internal/data/config_format/yaml/test/dummy_pipeline.yaml
@@ -1,13 +1,13 @@
 pipeline:
     inputs:
-        - dummy:
-            tag: success
-            group1:
-                a: b
-                c: d
+        - name: dummy
+          tag: success
+          group1:
+            a: b
+            c: d
     outputs:
-        - stdout:
-            match: "*"
+        - name: stdout
+          match: "*"
 
 unknown:
     a: b


### PR DESCRIPTION
Make the plugin property name explicit, allowing the rest of the properties to be declared at the same level.

<!-- Provide summary of changes -->

This change modifies the way properties are passed to plugins so that now there is just a single map for them instead of nesting them under a map with a single with the plugin name, ie:

```yaml
pipeline:
  inputs:
    - name: dummy
      rate: 5
 ```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This is related to the discussion of YAML 2.0: https://github.com/fluent/fluent-bit/discussions/6029.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
