### PR TITLE
macos: tests: Fix most of unit tests failures on macOS

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -416,7 +416,9 @@ void flb_config_exit(struct flb_config *config)
 
     /* Event flush */
     if (config->evl) {
-        mk_event_timeout_destroy(config->evl, &config->event_flush);
+        if (config->event_flush.status != MK_EVENT_NONE) {
+            mk_event_timeout_destroy(config->evl, &config->event_flush);
+        }
     }
 
     /* Release scheduler */

--- a/tests/internal/aws_credentials.c
+++ b/tests/internal/aws_credentials.c
@@ -192,6 +192,8 @@ static void test_environment_provider_only_access()
     struct flb_config *config;
     int ret;
 
+    unsetenv_credentials();
+
     config = flb_config_init();
 
     if (config == NULL) {

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -103,8 +103,8 @@ void test_timeout_create(struct mk_event_loop *loop,
 void test_timeout_destroy(struct mk_event_loop *loop, void *data)
 {
     struct mk_event *event = (struct mk_event *) data;
-    flb_pipe_close(event->fd);
     mk_event_del(loop, event);
+    flb_pipe_close(event->fd);
 }
 
 struct test_evl_context *evl_context_create()

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -20,6 +20,8 @@
 #define EVENT_LOOP_MAX_EVENTS 64
 #ifdef _WIN32
     #define TIME_EPSILON_MS 30
+#elif FLB_SYSTEM_MACOS
+    #define TIME_EPSILON_MS 200
 #else
     #define TIME_EPSILON_MS 10
 #endif

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -408,6 +408,7 @@ void flb_test_input_chunk_fs_chunks_size_real()
     struct mk_event_loop *evl;
     struct cio_options opts = {0};
 
+    flb_init_env();
     cfg = flb_config_init();
     evl = mk_event_loop_create(256);
 

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -8,6 +8,7 @@
 #include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_router.h>
+#include <fluent-bit/flb_time.h>
 #include "flb_tests_internal.h"
 #include "chunkio/chunkio.h"
 #include "data/input_chunk/log/test_buffer_drop_chunks.h"
@@ -313,7 +314,7 @@ void flb_test_input_chunk_dropping_chunks()
         flb_input_chunk_destroy(ic, FLB_TRUE);
     }
 
-    sleep(2);
+    flb_time_msleep(2100);
     flb_stop(ctx);
     flb_destroy(ctx);
 }

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -370,8 +370,8 @@ static int gen_buf(msgpack_sbuffer *mp_sbuf, char *buf, size_t buf_size)
     return 0;
 }
 
-static void log_cb(void *data, int level, const char *file, int line,
-                   const char *str)
+static int log_cb(struct cio_ctx *data, int level, const char *file, int line,
+                  char *str)
 {
     if (level == CIO_LOG_ERROR) {
         flb_error("[fstore] %s", str);
@@ -385,6 +385,8 @@ static void log_cb(void *data, int level, const char *file, int line,
     else if (level == CIO_LOG_DEBUG) {
         flb_debug("[fstore] %s", str);
     }
+
+    return 0;
 }
 
 /* This tests uses the subsystems of the engine directly

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -6,6 +6,7 @@
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_time.h>
 
 #include <time.h>
 #include "flb_tests_internal.h"
@@ -84,6 +85,12 @@ static void test_client_server(int is_ipv6)
     ret = flb_net_tcp_fd_connect(fd_client, host, atol(TEST_PORT));
     TEST_CHECK(ret == -1);
     TEST_CHECK(errno == EINPROGRESS);
+
+#ifdef FLB_SYSTEM_MACOS
+    /* On macOS, its internal timer's is inacccurate without waiting code.
+     * We need to proceed its timer tick for processing events. */
+    flb_time_msleep(50);
+#endif
 
     /* Event loop */
     while (1) {

--- a/tests/runtime/config_map_opts.c
+++ b/tests/runtime/config_map_opts.c
@@ -15,6 +15,9 @@ void flb_test_config_map_opts(void)
 {
     flb_ctx_t    *ctx    = NULL;
     int in_ffd, r;
+
+    flb_init_env();
+
     ctx = flb_create();
     in_ffd = flb_input(ctx, (char *) "tail", NULL);
     r = flb_input_property_check(ctx, in_ffd, "invalid_option", "invalid value");

--- a/tests/runtime/core_chunk_trace.c
+++ b/tests/runtime/core_chunk_trace.c
@@ -43,12 +43,16 @@ int callback_add_record(void* data, size_t size, void* cb_data)
 
     if (size > 0) {
         flb_info("[test] flush record");
+        /* We should check ctx->num_records has a valid value. */
+        if (ctx->num_records < 0) {
+            return -1;
+        }
         if (ctx->records == NULL) {
             ctx->records = (struct callback_record *)
                            flb_calloc(1, sizeof(struct callback_record));
         } else {
             ctx->records = (struct callback_record *)
-                           flb_realloc(ctx->records, 
+                           flb_realloc(ctx->records,
                                        (ctx->num_records+1)*sizeof(struct callback_record));
         }
         if (ctx->records ==  NULL) {

--- a/tests/runtime/flb_tests_runtime.h.in
+++ b/tests/runtime/flb_tests_runtime.h.in
@@ -21,19 +21,26 @@
 #ifndef FLB_TESTS_RUNTIME_H
 #define FLB_TESTS_RUNTIME_H
 
+#include <sys/stat.h>
+
 #include "../lib/acutest/acutest.h"
 #define FLB_TESTS_DATA_PATH "@FLB_TESTS_DATA_PATH@"
 
-static inline int wait_for_file(char *path, int access_type, int time_limit)
+static inline int wait_for_file(char *path, 
+                                size_t minimum_size, 
+                                int time_limit)
 {
-    int elapsed_time;
-    int result;
+    int         elapsed_time;
+    struct stat file_info;
+    int         result;
 
     for (elapsed_time = 0 ; elapsed_time < time_limit ; elapsed_time++) {
-        result = access(path, access_type);
+        result = stat(path, &file_info);
 
         if (result == 0) {
-            break;
+            if (file_info.st_size >= minimum_size) {
+                break;
+            }
         }
 
         sleep(1);

--- a/tests/runtime/flb_tests_runtime.h.in
+++ b/tests/runtime/flb_tests_runtime.h.in
@@ -24,4 +24,22 @@
 #include "../lib/acutest/acutest.h"
 #define FLB_TESTS_DATA_PATH "@FLB_TESTS_DATA_PATH@"
 
+static inline int wait_for_file(char *path, int access_type, int time_limit)
+{
+    int elapsed_time;
+    int result;
+
+    for (elapsed_time = 0 ; elapsed_time < time_limit ; elapsed_time++) {
+        result = access(path, access_type);
+
+        if (result == 0) {
+            break;
+        }
+
+        sleep(1);
+    }
+
+    return result;
+}
+
 #endif

--- a/tests/runtime/in_fluentbit_metrics.c
+++ b/tests/runtime/in_fluentbit_metrics.c
@@ -61,6 +61,35 @@ struct str_list {
     char **lists;
 };
 
+void wait_with_timeout(uint32_t timeout_ms, int *output_num)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb = 0;
+
+    flb_time_get(&start_time);
+
+    while (true) {
+        *output_num = get_output_num();
+
+        if (*output_num > 0) {
+            break;
+        }
+
+        flb_time_msleep(100);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_time_flb > timeout_ms) {
+            flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
+            // Reached timeout.
+            break;
+        }
+    }
+}
+
 /* Callback to check expected results */
 static int cb_check_json_str_list(void *record, size_t size, void *data)
 {
@@ -179,9 +208,8 @@ static void test_basic(void)
     TEST_CHECK(ret == 0);
 
     /* waiting to flush */
-    flb_time_msleep(1500);
+    wait_with_timeout(3000, &num);
 
-    num = get_output_num();
     if (!TEST_CHECK(num > 0))  {
         TEST_MSG("no outputs");
     }

--- a/tests/runtime/in_syslog.c
+++ b/tests/runtime/in_syslog.c
@@ -868,7 +868,9 @@ TEST_LIST = {
     {"syslog_rfc3164", flb_test_syslog_rfc3164},
 #ifdef FLB_HAVE_UNIX_SOCKET
     {"syslog_tcp_unix", flb_test_syslog_tcp_unix},
+#ifndef FLB_SYSTEM_MACOS
     {"syslog_udp_unix", flb_test_syslog_udp_unix},
+#endif
 #endif
     {NULL, NULL}
 };

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -38,6 +38,12 @@ Approach for this tests is basing on filter_kubernetes tests
 
 #define DPATH_COMMON       FLB_TESTS_DATA_PATH "/data/common"
 
+#ifdef _WIN32
+    #define TIME_EPSILON_MS 30
+#else
+    #define TIME_EPSILON_MS 10
+#endif
+
 struct test_tail_ctx {
     flb_ctx_t *flb;    /* Fluent Bit library context */
     int i_ffd;         /* Input fd  */
@@ -275,6 +281,33 @@ struct tail_file_lines {
   int lines_c;
 };
 
+void wait_with_timeout(uint32_t timeout_ms, struct tail_test_result *result, int nExpected)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb = 0;
+    int64_t ret = 0;
+
+    flb_time_get(&start_time);
+
+    while (true) {
+        if (result->nMatched == nExpected) {
+            break;
+        }
+
+        flb_time_msleep(100);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_time_flb > timeout_ms - TIME_EPSILON_MS) {
+            flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
+            // Reached timeout.
+            break;
+        }
+    }
+}
 
 static inline int64_t set_result(int64_t v)
 {
@@ -473,10 +506,13 @@ void do_test(char *system, const char *target, int tExpected, int nExpected, ...
     ret = flb_start(ctx);
     TEST_CHECK_(ret == 0, "starting engine");
 
-    /* Poll for up to 2 seconds or until we got a match */
+    /* Poll for up to 5 seconds or until we got a match */
     for (ret = 0; ret < tExpected && result.nMatched < nExpected; ret++) {
         usleep(1000);
     }
+
+    /* Wait until matching nExpected results */
+    wait_with_timeout(5000, &result, nExpected);
 
     TEST_CHECK(result.nMatched == nExpected);
     TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, nExpected);
@@ -622,7 +658,7 @@ void flb_test_in_tail_skip_long_lines()
     ret = flb_start(ctx);
     TEST_CHECK_(ret == 0, "starting engine");
 
-    sleep(2);
+    wait_with_timeout(5000, &result, nExpected);
 
     TEST_CHECK(result.nMatched == nExpected);
     TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, nExpected);
@@ -705,7 +741,7 @@ void flb_test_in_tail_issue_3943()
     ret = flb_start(ctx);
     TEST_CHECK_(ret == 0, "starting engine");
 
-    sleep(2);
+    wait_with_timeout(3000, &result, nExpected);
 
     TEST_CHECK(result.nMatched == nExpected);
     TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, nExpected);
@@ -792,6 +828,7 @@ void flb_test_in_tail_multiline_json_and_regex()
     for (ret = 0; ret < t_expected && result.nMatched < n_expected; ret++) {
         usleep(1000);
     }
+    wait_with_timeout(5000, &result, n_expected);
 
     TEST_CHECK(result.nMatched == n_expected);
     TEST_MSG("result.nMatched: %i\nnExpected: %i", result.nMatched, n_expected);

--- a/tests/runtime/out_file.c
+++ b/tests/runtime/out_file.c
@@ -50,6 +50,7 @@ TEST_LIST = {
 
 #define TEST_LOGFILE "flb_test_file_dummy.log"
 #define TEST_LOGPATH "out_file"
+#define TEST_TIMEOUT 5
 
 void flb_test_file_json_invalid(void)
 {
@@ -129,7 +130,8 @@ void flb_test_file_json_long(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -175,7 +177,8 @@ void flb_test_file_json_small(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -223,7 +226,8 @@ void flb_test_file_format_csv(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -272,7 +276,8 @@ void flb_test_file_format_ltsv(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -320,7 +325,8 @@ void flb_test_file_format_out_file(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -433,7 +439,8 @@ void flb_test_file_path(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -498,7 +505,8 @@ void flb_test_file_path_file(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -548,7 +556,8 @@ void flb_test_file_delim_csv(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -605,7 +614,8 @@ void flb_test_file_delim_ltsv(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -663,7 +673,8 @@ void flb_test_file_label_delim(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -720,7 +731,8 @@ void flb_test_file_template(void)
     bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
     TEST_CHECK(bytes == strlen(p));
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -794,7 +806,8 @@ void flb_test_file_mkdir(void)
         TEST_CHECK(bytes == 1);
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(path, 1, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);

--- a/tests/runtime/out_plot.c
+++ b/tests/runtime/out_plot.c
@@ -89,7 +89,7 @@ void flb_test_plot_json_multiple(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
     TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
@@ -140,7 +140,7 @@ void flb_test_plot_key_mismatch(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    ret = wait_for_file(TEST_LOGFILE, 1, TEST_TIMEOUT);
     TEST_CHECK(ret == 0);
 
     flb_stop(ctx);

--- a/tests/runtime/out_plot.c
+++ b/tests/runtime/out_plot.c
@@ -20,6 +20,7 @@ TEST_LIST = {
 };
 
 #define TEST_LOGFILE "flb_test_plot_dummy.log"
+#define TEST_TIMEOUT 5
 
 void flb_test_plot_json_invalid(void)
 {
@@ -88,7 +89,8 @@ void flb_test_plot_json_multiple(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -138,7 +140,8 @@ void flb_test_plot_key_mismatch(void)
         TEST_CHECK(bytes == strlen(p));
     }
 
-    sleep(1); /* waiting flush */
+    ret = wait_for_file(TEST_LOGFILE, R_OK, TEST_TIMEOUT);
+    TEST_CHECK(ret == 0);
 
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, unit tests on macOS are failing on every time. 
One of the reasons is that macOS's filesystem is relatively slow due to inotify is not supported. 
Another reason is macOS's timer is not accurate for other platforms such as Windows and Linux. This is because macOS's timer is not precise under microseconds. Always macOS's timestamp are zeroed the last 3 digits of nanosecond scale of time.

~~There is still a SEGV issue on `mk_event_loop_destroy(log->evl);` at `flb_log_destroy`. 
But, this is timing issue. Not every time occurred.~~ This issue is fixed by https://github.com/fluent/fluent-bit/pull/6135.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
