### PR TITLE
smoke-tests: update smoke test for new YAML format.

### DIFF
--- a/packaging/testing/smoke/container/fluent-bit.yaml
+++ b/packaging/testing/smoke/container/fluent-bit.yaml
@@ -7,27 +7,27 @@ service:
 
 pipeline:
     inputs:
-        - random:
-            tag: test
-            samples: 10
+        - name: random
+          tag: test
+          samples: 10
 
     filters:
-        - lua:
-            match: test
-            call: append_tag
-            code: |
-                function append_tag(tag, timestamp, record)
-                   new_record = record
-                   new_record["tag"] = tag
-                   return 1, timestamp, new_record
-                end
+        - name: lua
+          match: test
+          call: append_tag
+          code: |
+              function append_tag(tag, timestamp, record)
+                 new_record = record
+                 new_record["tag"] = tag
+                 return 1, timestamp, new_record
+              end
 
-        - expect:
-            match: test
-            key_exists: tag
-            key_val_eq: tag test
-            action: exit
+        - name: expect
+          match: test
+          key_exists: tag
+          key_val_eq: tag test
+          action: exit
 
     outputs:
-        - stdout:
-              match: test
+        - name: stdout
+          match: test


### PR DESCRIPTION
Update smoke test to work with new YAML 2.0 yaml format.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
This fix is for #6029, which has already been merged.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
