### PR TITLE
out_http: support record accessor for uri

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -107,7 +107,7 @@ static void append_headers(struct flb_http_client *c,
 static int http_post(struct flb_out_http *ctx,
                      const void *body, size_t body_len,
                      const char *tag, int tag_len,
-                     char **headers)
+                     char **headers, flb_sds_t in_uri)
 {
     int ret;
     int out_ret = FLB_OK;
@@ -123,6 +123,14 @@ static int http_post(struct flb_out_http *ctx,
     struct flb_slist_entry *key = NULL;
     struct flb_slist_entry *val = NULL;
     flb_sds_t signature = NULL;
+    flb_sds_t uri;
+
+    if (in_uri != NULL) {
+        uri = in_uri;
+    }
+    else {
+        uri = ctx->uri;
+    }
 
     /* Get upstream context and connection */
     u = ctx->u;
@@ -151,11 +159,10 @@ static int http_post(struct flb_out_http *ctx,
     }
 
     /* Create HTTP client context */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
-                        payload_buf, payload_size,
-                        ctx->host, ctx->port,
-                        ctx->proxy, 0);
-
+    c = flb_http_client(u_conn, FLB_HTTP_POST, uri,
+                            payload_buf, payload_size,
+                            ctx->host, ctx->port,
+                            ctx->proxy, 0);
 
     if (c->proxy.host) {
         flb_plg_debug(ctx->ins, "[http_client] proxy host: %s port: %i",
@@ -470,7 +477,8 @@ static int post_all_requests(struct flb_out_http *ctx,
                              const char *data, size_t size,
                              flb_sds_t body_key,
                              flb_sds_t headers_key,
-                             struct flb_event_chunk *event_chunk)
+                             struct flb_event_chunk *event_chunk,
+                             flb_sds_t uri)
 {
     struct flb_time t;
     msgpack_unpacked result;
@@ -543,7 +551,7 @@ static int post_all_requests(struct flb_out_http *ctx,
         if (body_found && headers_found) {
             flb_plg_trace(ctx->ins, "posting record %d", record_count++);
             ret = http_post(ctx, body, body_size, event_chunk->tag,
-                    flb_sds_len(event_chunk->tag), headers);
+                            flb_sds_len(event_chunk->tag), headers, uri);
         }
         else {
             flb_plg_warn(ctx->ins,
@@ -560,6 +568,34 @@ static int post_all_requests(struct flb_out_http *ctx,
     return ret;
 }
 
+static flb_sds_t compose_uri(struct flb_out_http *ctx, const void *in_body, size_t in_size,
+                             const char *tag, int tag_len)
+{
+    size_t off = 0;
+    flb_sds_t ret;
+    msgpack_object map;
+    msgpack_object root;
+    msgpack_unpacked result;
+
+    msgpack_unpacked_init(&result);
+    while(msgpack_unpack_next(&result, in_body, in_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        root = result.data;
+        if (root.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+        if (root.via.array.size != 2) {
+            continue;
+        }
+
+        map = root.via.array.ptr[1];
+        ret = flb_ra_translate(ctx->uri_ra, (char *)tag, tag_len, map, NULL);
+        msgpack_unpacked_destroy(&result);
+        return ret;
+    }
+    msgpack_unpacked_destroy(&result);
+    return NULL;
+}
+
 static void cb_http_flush(struct flb_event_chunk *event_chunk,
                           struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
@@ -568,13 +604,22 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
 {
     int ret = FLB_ERROR;
     struct flb_out_http *ctx = out_context;
+    flb_sds_t uri = NULL;
     void *out_body;
     size_t out_size;
     (void) i_ins;
 
+    if (ctx->uri_ra_static == FLB_FALSE) {
+        uri = compose_uri(ctx, event_chunk->data, event_chunk->size,
+                          event_chunk->tag, flb_sds_len(event_chunk->tag));
+        if (uri == NULL) {
+            flb_plg_debug(ctx->ins, "compose_uri failed");
+        }
+    }
+
     if (ctx->body_key) {
         ret = post_all_requests(ctx, event_chunk->data, event_chunk->size,
-                                ctx->body_key, ctx->headers_key, event_chunk);
+                                ctx->body_key, ctx->headers_key, event_chunk, uri);
         if (ret < 0) {
             flb_plg_error(ctx->ins,
                           "failed to post requests body key \"%s\"", ctx->body_key);
@@ -592,15 +637,19 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
             (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES) ||
             (ctx->out_format == FLB_HTTP_OUT_GELF)) {
             ret = http_post(ctx, out_body, out_size,
-                            event_chunk->tag, flb_sds_len(event_chunk->tag), NULL);
+                            event_chunk->tag, flb_sds_len(event_chunk->tag), NULL, uri);
             flb_sds_destroy(out_body);
         }
         else {
             /* msgpack */
             ret = http_post(ctx,
                             event_chunk->data, event_chunk->size,
-                            event_chunk->tag, flb_sds_len(event_chunk->tag), NULL);
+                            event_chunk->tag, flb_sds_len(event_chunk->tag), NULL, uri);
         }
+    }
+
+    if (uri != NULL) {
+        flb_sds_destroy(uri);
     }
 
     FLB_OUTPUT_RETURN(ret);

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -62,6 +62,8 @@ struct flb_out_http {
 
     /* HTTP URI */
     flb_sds_t uri;
+    struct flb_record_accessor *uri_ra;
+    int uri_ra_static;
     char *host;
     int port;
 

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -61,7 +61,7 @@ struct flb_out_http {
     flb_sds_t date_key;        /* internal use */
 
     /* HTTP URI */
-    char *uri;
+    flb_sds_t uri;
     char *host;
     int port;
 

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -206,6 +206,13 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         uri = tmp_uri;
     }
 
+    ctx->uri = flb_sds_create(uri);
+    flb_free(uri);
+    if (ctx->uri == NULL) {
+        flb_http_conf_destroy(ctx);
+        return NULL;
+    }
+
     /* Output format */
     ctx->out_format = FLB_PACK_JSON_FORMAT_NONE;
     tmp = flb_output_get_property("format", ins);
@@ -259,7 +266,6 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     }
 
     ctx->u = upstream;
-    ctx->uri = uri;
     ctx->host = ins->host.name;
     ctx->port = ins->host.port;
 
@@ -293,6 +299,6 @@ void flb_http_conf_destroy(struct flb_out_http *ctx)
 #endif
 
     flb_free(ctx->proxy_host);
-    flb_free(ctx->uri);
+    flb_sds_destroy(ctx->uri);
     flb_free(ctx);
 }

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -209,9 +209,18 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     ctx->uri = flb_sds_create(uri);
     flb_free(uri);
     if (ctx->uri == NULL) {
+        flb_errno();
         flb_http_conf_destroy(ctx);
         return NULL;
     }
+
+    ctx->uri_ra = flb_ra_create(ctx->uri, FLB_FALSE);
+    if (ctx->uri_ra == NULL) {
+        flb_errno();
+        flb_http_conf_destroy(ctx);
+        return NULL;
+    }
+    ctx->uri_ra_static = flb_ra_is_static(ctx->uri_ra);
 
     /* Output format */
     ctx->out_format = FLB_PACK_JSON_FORMAT_NONE;
@@ -297,6 +306,10 @@ void flb_http_conf_destroy(struct flb_out_http *ctx)
     }
 #endif
 #endif
+
+    if (ctx->uri_ra) {
+        flb_ra_destroy(ctx->uri_ra);
+    }
 
     flb_free(ctx->proxy_host);
     flb_sds_destroy(ctx->uri);


### PR DESCRIPTION
Fixes #6075 

This patch is to support record accessor for `uri`.

## Disclaimer

Record accessor should be tail of uri. e.g. `uri /log/$type`.
Record accessor in the middle will not work. e.g. `uri /log/$type/commit`


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"type":"hoge", "log":"body"}

[OUTPUT]
    name http
    match *
    port 9200
    format json
    host localhost
    uri /log/$type
```

## Debug/Valgrind output

Run mock http server.
```go
package main

import (
	"fmt"
	"io"
	"log"
	"net/http"
	"strconv"
)

func main() {
	port := 9200
	ps := strconv.Itoa(port)

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		defer r.Body.Close()
		b, err := io.ReadAll(r.Body)
		if err != nil {
			log.Printf("ReadAll error=%s\n", err)
		} else {
			log.Printf("URL=%+v\n", r.URL)
			log.Printf("%+v\n", string(b))
		}
		//w.WriteHeader(400)
	})
	fmt.Printf("Listen port=%s\n", ps)
	err := http.ListenAndServe(":"+ps, nil)
	if err != nil {
		log.Printf("ListenAndServe err=%s\n", err)
	}
}
```

http server log. URL is `/log/hoge`. `hoge` is a value of record.
```
$ go run http_server.go 
Listen port=9200
2022/10/02 08:20:29 URL=/log/hoge
2022/10/02 08:20:29 [{"date":1664666427.942208,"type":"hoge","log":"body"}]
2022/10/02 08:20:29 URL=/log/hoge
2022/10/02 08:20:29 [{"date":1664666429.001992,"type":"hoge","log":"body"}]
2022/10/02 08:20:30 URL=/log/hoge
2022/10/02 08:20:30 [{"date":1664666429.906387,"type":"hoge","log":"body"}]
```

Fluent-bit log:
```
$ valgrind --leak-check=full ../../bin/fluent-bit -c a.conf 
==42245== Memcheck, a memory error detector
==42245== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==42245== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==42245== Command: ../../bin/fluent-bit -c a.conf
==42245== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/02 08:20:27] [ info] [fluent bit] version=2.0.0, commit=9acf4af325, pid=42245
[2022/10/02 08:20:27] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/10/02 08:20:27] [ info] [cmetrics] version=0.4.0
[2022/10/02 08:20:27] [ info] [output:http:http.0] worker #0 started
[2022/10/02 08:20:27] [ info] [output:http:http.0] worker #1 started
[2022/10/02 08:20:27] [ info] [sp] stream processor started
==42245== Warning: client switching stacks?  SP change: 0x6ffb878 --> 0x5496590
==42245==          to suppress, use: --max-stackframe=28725992 or greater
==42245== Warning: client switching stacks?  SP change: 0x54964e8 --> 0x6ffb878
==42245==          to suppress, use: --max-stackframe=28726160 or greater
==42245== Warning: client switching stacks?  SP change: 0x6ffb878 --> 0x54964e8
==42245==          to suppress, use: --max-stackframe=28726160 or greater
==42245==          further instances of this message will not be shown.
[2022/10/02 08:20:29] [ info] [output:http:http.0] localhost:9200, HTTP status=200
[2022/10/02 08:20:29] [ info] [output:http:http.0] localhost:9200, HTTP status=200
^C[2022/10/02 08:20:30] [engine] caught signal (SIGINT)
[2022/10/02 08:20:30] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/02 08:20:30] [ info] [input] pausing dummy.0
[2022/10/02 08:20:30] [ info] [output:http:http.0] localhost:9200, HTTP status=200
[2022/10/02 08:20:30] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/02 08:20:30] [ info] [input] pausing dummy.0
[2022/10/02 08:20:30] [ info] [output:http:http.0] thread worker #0 stopping...
[2022/10/02 08:20:30] [ info] [output:http:http.0] thread worker #0 stopped
[2022/10/02 08:20:31] [ info] [output:http:http.0] thread worker #1 stopping...
[2022/10/02 08:20:31] [ info] [output:http:http.0] thread worker #1 stopped
==42245== 
==42245== HEAP SUMMARY:
==42245==     in use at exit: 0 bytes in 0 blocks
==42245==   total heap usage: 1,481 allocs, 1,481 frees, 1,627,541 bytes allocated
==42245== 
==42245== All heap blocks were freed -- no leaks are possible
==42245== 
==42245== For lists of detected and suppressed errors, rerun with: -s
==42245== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
