### PR TITLE
metrics: add warn message when 'title' was truncated

### DIFF
--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -102,11 +102,15 @@ struct flb_metrics *flb_metrics_create(const char *title)
 int flb_metrics_title(const char *title, struct flb_metrics *metrics)
 {
     int ret;
+    size_t size = sizeof(metrics->title) - 1;
 
-    ret = snprintf(metrics->title, sizeof(metrics->title) - 1, "%s", title);
+    ret = snprintf(metrics->title, size, "%s", title);
     if (ret == -1) {
         flb_errno();
         return -1;
+    }
+    else if (ret >= size){
+        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
     }
     metrics->title_len = strlen(metrics->title);
     return 0;
@@ -116,6 +120,7 @@ int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
 {
     int ret;
     struct flb_metric *m;
+    size_t size;
 
     /* Create context */
     m = flb_malloc(sizeof(struct flb_metric));
@@ -124,14 +129,19 @@ int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
         return -1;
     }
     m->val = 0;
+    size = sizeof(m->title) - 1;
 
     /* Write title */
-    ret = snprintf(m->title, sizeof(m->title) - 1, "%s", title);
+    ret = snprintf(m->title, size, "%s", title);
     if (ret == -1) {
         flb_errno();
         flb_free(m);
         return -1;
     }
+    else if (ret >= size) {
+        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
+    }
+
     m->title_len = strlen(m->title);
 
     /* Assign an ID */


### PR DESCRIPTION
This patch is to add warn message when title was truncated.
https://linux.die.net/man/3/snprintf
```
The functions snprintf() and vsnprintf() do not write more than size bytes (including the terminating null byte ('\0')). If the output was truncated due to this limit then the return value is the number of characters (excluding the terminating null byte) which would have been written to the final string if enough space had been available. Thus, a return value of size or more means that the output was truncated.
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
