### PR TITLE
config/yaml: clist and slist support

### DIFF
--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -24,6 +24,12 @@
 #include <fluent-bit/flb_sds.h>
 #include <monkey/mk_core.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_sds.h>
+#include <cfl/cfl_array.h>
+#include <cfl/cfl_list.h>
+#include <cfl/cfl_variant.h>
+
 #define FLB_CF_ERROR_SERVICE_EXISTS "SERVICE definition already exists"
 #define FLB_CF_ERROR_META_CHAR      "invalid first meta character: '@' expected"
 #define FLB_CF_ERROR_KV_INVALID_KEY "invalid key content"
@@ -57,14 +63,14 @@ enum section_type {
 
 struct flb_cf_group {
     flb_sds_t name;               /* group name */
-    struct mk_list properties;    /* key value properties */
+    struct cfl_kvlist *properties;    /* key value properties */
     struct mk_list _head;         /* link to struct flb_cf_section->groups */
 };
 
 struct flb_cf_section {
     int type;
     flb_sds_t name;               /* name (used for FLB_CF_OTHER type) */
-    struct mk_list properties;    /* key value properties              */
+    struct cfl_kvlist *properties;    /* key value properties              */
 
     struct mk_list groups;        /* list of groups */
 
@@ -116,8 +122,12 @@ void flb_cf_destroy(struct flb_cf *cf);
 
 void flb_cf_dump(struct flb_cf *cf);
 
+struct flb_kv *flb_cf_env_property_add(struct flb_cf *cf,
+                                       char *k_buf, size_t k_len,
+                                       char *v_buf, size_t v_len);
+
 /* metas */
-struct flb_kv *flb_cf_meta_create(struct flb_cf *cf, char *meta, int len);
+struct flb_kv *flb_cf_meta_property_add(struct flb_cf *cf, char *meta, int len);
 
 #define flb_cf_foreach_meta(cf) \
 
@@ -137,13 +147,21 @@ void flb_cf_section_destroy(struct flb_cf *cf, struct flb_cf_section *s);
 void flb_cf_section_destroy_all(struct flb_cf *cf);
 
 /* properties */
-struct flb_kv *flb_cf_property_add(struct flb_cf *cf,
-                                   struct mk_list *kv_list,
-                                   char *k_buf, size_t k_len,
-                                   char *v_buf, size_t v_len);
+struct cfl_variant *flb_cf_section_property_add(struct flb_cf *cf,
+                                              struct cfl_kvlist *kv_list,
+                                              char *k_buf, size_t k_len,
+                                              char *v_buf, size_t v_len);
 
+struct cfl_array *flb_cf_section_property_add_list(struct flb_cf *cf,
+                                                   struct cfl_kvlist *kv_list,
+                                                   char *k_buf, size_t k_len);
 
-char *flb_cf_section_property_get(struct flb_cf *cf, struct flb_cf_section *s,
-                                  char *key);
+struct cfl_variant *flb_cf_section_property_get(struct flb_cf *cf,
+                                      struct flb_cf_section *s,
+                                      char *key);
+
+char *flb_cf_section_property_get_string(struct flb_cf *cf,
+                                         struct flb_cf_section *s,
+                                         char *key);
 
 #endif

--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -420,6 +420,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     struct flb_cf_meta *meta;
     struct flb_cf_section *current_section = NULL;
     struct flb_cf_group *current_group = NULL;
+    struct cfl_variant *var;
 
     struct flb_kv *kv;
     FILE *f = NULL;
@@ -527,8 +528,8 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
             continue;
         }
         else if (buf[0] == '@' && len > 3) {
-            meta = flb_cf_meta_create(cf, buf, len);
-            if (!meta) {
+            meta = flb_cf_meta_property_add(cf, buf, len);
+            if (meta == NULL) {
                 goto error;
             }
             continue;
@@ -659,18 +660,18 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         }
 
         /* register entry: key and val are copied as duplicated */
-        kv = NULL;
+        var = NULL;
         if (current_group) {
-            kv = flb_cf_property_add(cf, &current_group->properties,
-                                     key, key_len,
-                                     val, val_len);
+            var = flb_cf_section_property_add(cf, current_group->properties,
+                                              key, key_len,
+                                              val, val_len);
         }
         else if (current_section) {
-            kv = flb_cf_property_add(cf, &current_section->properties,
-                                     key, key_len,
-                                     val, val_len);
+            var = flb_cf_section_property_add(cf, current_section->properties,
+                                              key, key_len,
+                                              val, val_len);
         }
-        if (!kv) {
+        if (var == NULL) {
             config_error(cfg_file, line, "could not allocate key value pair");
             goto error;
         }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -25,6 +25,11 @@
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_slist.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_sds.h>
+#include <cfl/cfl_variant.h>
+#include <cfl/cfl_kvlist.h>
+
 #include <yaml.h>
 
 #include <ctype.h>
@@ -105,6 +110,7 @@ struct parser_state {
 
     /* active section */
     struct flb_cf_section *cf_section;
+    struct cfl_array *values; /* pointer to current values in a list. */
 
     /* active group */
     struct flb_cf_group *cf_group;
@@ -349,7 +355,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     int len;
     int ret;
     char *value;
-    struct mk_list *list;
     struct flb_kv *kv;
     char *last_included = get_last_included_file(ctx);
 
@@ -429,10 +434,9 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             }
 
             /* value is the 'custom plugin name', create a section instance */
-            kv = flb_cf_property_add(cf, &s->cf_section->properties,
-                                     "name", 4,
-                                     value, len);
-            if (!kv) {
+            if (flb_cf_section_property_add(cf, s->cf_section->properties,
+                                            "name", 4,
+                                            value, len) < 0) {
                 return YAML_FAILURE;
             }
 
@@ -495,9 +499,9 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->val = flb_sds_create(value);
 
             /* register key/value pair as a property */
-            flb_cf_property_add(cf, &s->cf_section->properties,
-                                s->key, flb_sds_len(s->key),
-                                s->val, flb_sds_len(s->val));
+            flb_cf_section_property_add(cf, s->cf_section->properties,
+                                        s->key, flb_sds_len(s->key),
+                                        s->val, flb_sds_len(s->val));
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
             break;
@@ -681,17 +685,23 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
 
             /* Check if the incoming k/v pair set a config environment variable */
             if (s->section == SECTION_ENV) {
-                list = &cf->env;
+                kv = flb_cf_env_property_add(cf,
+                                             s->key, flb_sds_len(s->key),
+                                             s->val, flb_sds_len(s->val));
+                if (kv == NULL) {
+                    return YAML_FAILURE;
+                }
             }
             else {
-                list = &s->cf_section->properties;
-            }
-            /* register key/value pair as a property */
-            kv = flb_cf_property_add(cf, list,
-                                     s->key, flb_sds_len(s->key),
-                                     s->val, flb_sds_len(s->val));
-            if (!kv) {
-                return YAML_FAILURE;
+                /* register key/value pair as a property */
+                if (s->cf_section == NULL) {
+                    return YAML_FAILURE;
+                }
+                if (flb_cf_section_property_add(cf, s->cf_section->properties,
+                                                s->key, flb_sds_len(s->key),
+                                                s->val, flb_sds_len(s->val)) < 0) {
+                    return YAML_FAILURE;
+                }
             }
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
@@ -770,6 +780,8 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
         case YAML_MAPPING_END_EVENT:
             s->state = STATE_PLUGIN_TYPE;
             break;
+        case YAML_SEQUENCE_END_EVENT:
+            break;
         default:
             yaml_error_event(ctx, s, event);
             return YAML_FAILURE;
@@ -784,9 +796,14 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->val = flb_sds_create(value);
 
             /* register key/value pair as a property */
-            flb_cf_property_add(cf, &s->cf_section->properties,
-                                s->key, flb_sds_len(s->key),
-                                s->val, flb_sds_len(s->val));
+            if (flb_cf_section_property_add(cf, s->cf_section->properties,
+                                            s->key, flb_sds_len(s->key),
+                                            s->val, flb_sds_len(s->val)) < 0) {
+                return YAML_FAILURE;
+            }
+            if (cfl_kvlist_count(s->cf_section->properties) <= 0) {
+                return YAML_FAILURE;
+            }
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
             break;
@@ -798,6 +815,34 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             if (!s->cf_group) {
                 return YAML_FAILURE;
             }
+            break;
+        case YAML_SEQUENCE_START_EVENT:
+            s->state = STATE_PLUGIN_VAL_LIST;
+            s->values = flb_cf_section_property_add_list(cf,
+                                                         s->cf_section->properties,
+                                                         s->key, flb_sds_len(s->key));
+            if (s->values == NULL) {
+                return YAML_FAILURE;
+            }
+            flb_sds_destroy(s->key);
+        break;
+        default:
+            yaml_error_event(ctx, s, event);
+            return YAML_FAILURE;
+        }
+        break;
+
+    case STATE_PLUGIN_VAL_LIST:
+        switch(event->type) {
+        case YAML_SCALAR_EVENT:
+            if (s->values == NULL) {
+                return YAML_FAILURE;
+            }
+            cfl_array_append_string(s->values, (char *)event->data.scalar.value);
+            break;
+        case YAML_SEQUENCE_END_EVENT:
+            s->values = NULL;
+            s->state = STATE_PLUGIN_KEY;
             break;
         default:
             yaml_error_event(ctx, s, event);
@@ -830,9 +875,9 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->val = flb_sds_create(value);
 
             /* register key/value pair as a property */
-            flb_cf_property_add(cf, &s->cf_group->properties,
-                                s->key, flb_sds_len(s->key),
-                                s->val, flb_sds_len(s->val));
+            flb_cf_section_property_add(cf, s->cf_group->properties,
+                                        s->key, flb_sds_len(s->key),
+                                        s->val, flb_sds_len(s->val));
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
             break;

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -16,12 +16,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+#include <ctype.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_config_format.h>
+
+#include <cfl/cfl.h>
+#include <cfl/cfl_sds.h>
+#include <cfl/cfl_variant.h>
+#include <cfl/cfl_kvlist.h>
 
 int flb_cf_file_read()
 {
@@ -104,10 +110,226 @@ static enum section_type get_section_type(char *name, int len)
     return FLB_CF_OTHER;
 }
 
-struct flb_kv *flb_cf_property_add(struct flb_cf *cf,
-                                   struct mk_list *kv_list,
-                                   char *k_buf, size_t k_len,
-                                   char *v_buf, size_t v_len)
+int flb_cf_plugin_property_add(struct flb_cf *cf,
+                               struct cfl_kvlist *kv_list,
+                               char *k_buf, size_t k_len,
+                               char *v_buf, size_t v_len)
+{
+    int i;
+    int ret;
+    flb_sds_t key;
+    flb_sds_t val;
+
+    if (k_len == 0) {
+        k_len = strlen(k_buf);
+    }
+    if (v_len == 0) {
+        v_len = strlen(v_buf);
+    }
+
+    key = flb_sds_create_len(k_buf, k_len);
+    if (key == NULL) {
+        return -1;
+    }
+
+    val = flb_sds_create_len(v_buf, v_len);
+    if (val == NULL) {
+        flb_sds_destroy(key);
+        return -1;
+    }
+
+    /* sanitize key and value by removing empty spaces */
+    ret = flb_sds_trim(key);
+    if (ret == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_KEY);
+        flb_sds_destroy(key);
+        flb_sds_destroy(val);
+        return -1;
+    }
+
+    ret = flb_sds_trim(val);
+    if (ret == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_VAL);
+        flb_sds_destroy(key);
+        flb_sds_destroy(val);
+        return ret;
+    }
+
+    ret = cfl_kvlist_insert_string(kv_list, key, val);
+    flb_sds_destroy(key);
+    flb_sds_destroy(val);
+    return ret;
+}
+
+struct cfl_variant *flb_cf_section_property_add(struct flb_cf *cf,
+                                              struct cfl_kvlist *kv_list,
+                                              char *k_buf, size_t k_len,
+                                              char *v_buf, size_t v_len)
+{
+    int i;
+    int rc;
+    flb_sds_t key;
+    flb_sds_t val;
+    struct cfl_variant *var;
+
+
+    if (k_len == 0) {
+        k_len = strlen(k_buf);
+    }
+    key = flb_sds_create_len(k_buf, k_len);
+    if (key == NULL) {
+        goto key_error;
+    }
+
+    /* sanitize key and value by removing empty spaces */
+    rc = flb_sds_trim(key);
+    if (rc == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_KEY);
+        goto val_error;
+    }
+
+    for (i = 0; i < flb_sds_len(key); i++) {
+        key[i] = tolower(key[i]);
+    }
+
+    if (v_len == 0) {
+        v_len = strlen(k_buf);
+    }
+    val = flb_sds_create_len(v_buf, v_len);
+    if (val == NULL) {
+        goto val_error;
+    }
+    /* sanitize key and value by removing empty spaces */
+    rc = flb_sds_trim(val);
+    if (rc == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_VAL);
+        goto var_error;
+    }
+
+    var = cfl_variant_create_from_string(val);
+    if (var == NULL) {
+        goto var_error;
+    }
+
+    rc = cfl_kvlist_insert(kv_list, key, var);
+    if (rc < 0) {
+        goto insert_error;
+    }
+
+    flb_sds_destroy(val);
+    flb_sds_destroy(key);
+    return var;
+
+insert_error:
+    cfl_variant_destroy(var);
+var_error:
+    flb_sds_destroy(val);
+val_error:
+    flb_sds_destroy(key);
+key_error:
+    return NULL;
+}
+
+struct cfl_array *flb_cf_section_property_add_list(struct flb_cf *cf,
+                                                   struct cfl_kvlist *kv_list,
+                                                   char *k_buf, size_t k_len)
+{
+    int rc;
+    flb_sds_t key;
+    struct cfl_array *arr;
+
+
+    if (k_len == 0) {
+        k_len = strlen(k_buf);
+    }
+    key = flb_sds_create_len(k_buf, k_len);
+    if (key == NULL) {
+        goto key_error;
+    }
+
+    arr = cfl_array_create(10);
+    if (arr == NULL) {
+        goto array_error;
+    }
+    cfl_array_resizable(arr, 1);
+
+    /* sanitize key and value by removing empty spaces */
+    rc = flb_sds_trim(key);
+    if (rc == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_KEY);
+        goto cfg_error;
+    }
+
+    rc = cfl_kvlist_insert_array(kv_list, key, arr);
+    if (rc < 0) {
+        goto cfg_error;
+    }
+
+    flb_sds_destroy(key);
+    return arr;
+
+cfg_error:
+    cfl_array_destroy(arr);
+array_error:
+    flb_sds_destroy(key);
+key_error:
+    return NULL;
+}
+
+flb_sds_t flb_cf_section_property_get_string(struct flb_cf *cf, struct flb_cf_section *s,
+                                             char *key)
+{
+    (void) cf;
+    flb_sds_t tkey;
+    struct cfl_variant *val;
+    flb_sds_t ret = NULL;
+    struct cfl_variant *entry;
+    int i;
+
+
+    tkey = flb_sds_create(key);
+    for (i = 0; i < strlen(key); i++) {
+        tkey[i] = tolower(key[i]);
+    }
+
+    val = cfl_kvlist_fetch(s->properties, key);
+    flb_sds_destroy(tkey);
+    if (val == NULL) {
+        return NULL;
+    }
+
+    if (val->type == CFL_VARIANT_STRING) {
+        ret = flb_sds_create(val->data.as_string);
+    }
+    if (val->type == CFL_VARIANT_ARRAY) {
+        // recreate the format SLISTS are expecting...
+        ret = flb_sds_create("  ");
+        for (i = 0; i < val->data.as_array->entry_count; i++) {
+            entry = val->data.as_array->entries[i];
+            if (entry->type != CFL_VARIANT_STRING) {
+                flb_sds_destroy(ret);
+                return NULL;
+            }
+            if ((i+1) < val->data.as_array->entry_count) {
+                flb_sds_printf(&ret, "%s ", entry->data.as_string);
+            } else {
+                flb_sds_printf(&ret, "%s", entry->data.as_string);
+            }
+        }
+    }
+    return ret;
+}
+
+struct cfl_variant * flb_cf_section_property_get(struct flb_cf *cf, struct flb_cf_section *s,
+                                                 char *key)
+{
+    (void) cf;
+    return cfl_kvlist_fetch(s->properties, key);
+}
+
+struct flb_kv *flb_cf_env_property_add(struct flb_cf *cf,
+                                       char *k_buf, size_t k_len,
+                                       char *v_buf, size_t v_len)
 {
     int ret;
     struct flb_kv *kv;
@@ -119,7 +341,7 @@ struct flb_kv *flb_cf_property_add(struct flb_cf *cf,
         v_len = strlen(v_buf);
     }
 
-    kv = flb_kv_item_create_len(kv_list, k_buf, k_len, v_buf, v_len);
+    kv = flb_kv_item_create_len(&cf->env, k_buf, k_len, v_buf, v_len);
     if (!kv) {
         return NULL;
     }
@@ -142,19 +364,48 @@ struct flb_kv *flb_cf_property_add(struct flb_cf *cf,
     return kv;
 }
 
-char *flb_cf_section_property_get(struct flb_cf *cf, struct flb_cf_section *s,
-                                  char *key)
+static struct flb_kv *meta_property_add(struct flb_cf *cf,
+                                        char *k_buf, size_t k_len,
+                                        char *v_buf, size_t v_len)
 {
-    (void) cf;
-    return (char *) flb_kv_get_key_value(key, &s->properties);
+    int ret;
+    struct flb_kv *kv;
+
+    if (k_len == 0) {
+        k_len = strlen(k_buf);
+    }
+    if (v_len == 0) {
+        v_len = strlen(v_buf);
+    }
+
+    kv = flb_kv_item_create_len(&cf->metas, k_buf, k_len, v_buf, v_len);
+    if (!kv) {
+        return NULL;
+    }
+
+    /* sanitize key and value by removing empty spaces */
+    ret = flb_sds_trim(kv->key);
+    if (ret == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_KEY);
+        flb_kv_item_destroy(kv);
+        return NULL;
+    }
+
+    ret = flb_sds_trim(kv->val);
+    if (ret == -1) {
+        flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_VAL);
+        flb_kv_item_destroy(kv);
+        return NULL;
+    }
+
+    return kv;
 }
 
-struct flb_kv *flb_cf_meta_create(struct flb_cf *cf, char *meta, int len)
+struct flb_kv *flb_cf_meta_property_add(struct flb_cf *cf, char *meta, int len)
 {
     int xlen;
     char *p;
     char *tmp;
-    struct flb_kv *kv;
 
     if (len <= 0) {
         len = strlen(meta);
@@ -173,14 +424,9 @@ struct flb_kv *flb_cf_meta_create(struct flb_cf *cf, char *meta, int len)
     xlen = (tmp - p);
 
     /* create k/v pair */
-    kv = flb_cf_property_add(cf, &cf->metas,
-                            meta + 1, xlen - 1,
-                            meta + xlen + 1, len - xlen - 1);
-    if (!kv) {
-        return NULL;
-    }
-
-    return kv;
+    return meta_property_add(cf,
+                             meta + 1, xlen - 1,
+                             meta + xlen + 1, len - xlen - 1);
 }
 
 struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_section *s,
@@ -200,7 +446,7 @@ struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_sectio
     }
 
     /* initialize lists */
-    flb_kv_init(&g->properties);
+    g->properties = cfl_kvlist_create();
 
     /* determinate type by name */
     if (len <= 0) {
@@ -226,7 +472,7 @@ void flb_cf_group_destroy(struct flb_cf_group *g)
         flb_sds_destroy(g->name);
     }
 
-    flb_kv_release(&g->properties);
+    cfl_kvlist_destroy(g->properties);
     mk_list_del(&g->_head);
     flb_free(g);
 }
@@ -261,7 +507,7 @@ struct flb_cf_section *flb_cf_section_create(struct flb_cf *cf, char *name, int 
     }
 
     /* initialize lists */
-    flb_kv_init(&s->properties);
+    s->properties = cfl_kvlist_create();
     mk_list_init(&s->groups);
 
     /* create a NULL terminated name */
@@ -331,7 +577,7 @@ void flb_cf_section_destroy(struct flb_cf *cf, struct flb_cf_section *s)
         flb_sds_destroy(s->name);
         s->name = NULL;
     }
-    flb_kv_release(&s->properties);
+    cfl_kvlist_destroy(s->properties);
 
     /* groups */
     mk_list_foreach_safe(head, tmp, &s->groups) {
@@ -400,18 +646,18 @@ static char *section_type_str(int type)
 static void dump_section(struct flb_cf_section *s)
 {
     struct mk_list *head;
-    struct mk_list *p_head;
-    struct flb_kv *kv;
+    struct cfl_list *p_head;
+    struct cfl_kvpair *kv;
     struct flb_cf_group *g;
 
     printf("> section:\n  name: %s\n  type: %s\n",
            s->name, section_type_str(s->type));
 
-    if (mk_list_size(&s->properties) > 0) {
+    if (cfl_list_size(&s->properties->list) > 0) {
         printf("  properties:\n");
-        mk_list_foreach(p_head, &s->properties) {
-            kv = mk_list_entry(p_head, struct flb_kv, _head);
-            printf("    - %-15s: %s\n", kv->key, kv->val);
+        cfl_list_foreach(p_head, &s->properties->list) {
+            kv = mk_list_entry(p_head, struct cfl_kvpair, _head);
+            printf("    - %-15s: %s\n", kv->key, kv->val->data.as_string);
         }
     }
     else {
@@ -427,11 +673,11 @@ static void dump_section(struct flb_cf_section *s)
         g = mk_list_entry(head, struct flb_cf_group, _head);
         printf("    > group:\n      name: %s\n", g->name);
 
-        if (mk_list_size(&g->properties) > 0) {
+        if (cfl_list_size(&g->properties->list) > 0) {
             printf("      properties:\n");
-            mk_list_foreach(p_head, &g->properties) {
-                kv = mk_list_entry(p_head, struct flb_kv, _head);
-                printf("        - %-11s: %s\n", kv->key, kv->val);
+            cfl_list_foreach(p_head, &g->properties->list) {
+                kv = cfl_list_entry(p_head, struct cfl_kvpair, _head);
+                printf("        - %-11s: %s\n", kv->key, kv->val->data.as_string);
             }
         }
         else {

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -656,7 +656,7 @@ static void dump_section(struct flb_cf_section *s)
     if (cfl_list_size(&s->properties->list) > 0) {
         printf("  properties:\n");
         cfl_list_foreach(p_head, &s->properties->list) {
-            kv = mk_list_entry(p_head, struct cfl_kvpair, _head);
+            kv = cfl_list_entry(p_head, struct cfl_kvpair, _head);
             printf("    - %-15s: %s\n", kv->key, kv->val->data.as_string);
         }
     }

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -36,6 +36,9 @@
 #include <fluent-bit/multiline/flb_ml_parser.h>
 #include <fluent-bit/multiline/flb_ml_rule.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_kvlist.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits.h>
@@ -430,21 +433,23 @@ static flb_sds_t get_parser_key(struct flb_config *config,
                                 char *key)
 
 {
-    char *tmp;
+    flb_sds_t tmp;
     flb_sds_t val;
 
-    tmp = flb_cf_section_property_get(cf, s, key);
+    tmp = flb_cf_section_property_get_string(cf, s, key);
     if (!tmp) {
         return NULL;
     }
 
     val = flb_env_var_translate(config->env, tmp);
     if (!val) {
+        flb_sds_destroy(tmp);
         return NULL;
     }
 
     if (flb_sds_len(val) == 0) {
         flb_sds_destroy(val);
+        flb_sds_destroy(tmp);
         return NULL;
     }
 
@@ -626,14 +631,14 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
     int ret;
     char *to_state = NULL;
     struct mk_list list;
-    struct mk_list *head;
-    struct flb_kv *entry;
+    struct cfl_list *head;
+    struct cfl_kvpair *entry;
     struct flb_slist_entry *from_state;
     struct flb_slist_entry *regex_pattern;
     struct flb_slist_entry *tmp;
 
-    mk_list_foreach(head, &section->properties) {
-        entry = mk_list_entry(head, struct flb_kv, _head);
+    cfl_list_foreach(head, &section->properties->list) {
+        entry = cfl_list_entry(head, struct cfl_kvpair, _head);
 
         /* only process 'rule' keys */
         if (strcasecmp(entry->key, "rule") != 0) {
@@ -641,7 +646,7 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
         }
 
         mk_list_init(&list);
-        ret = flb_slist_split_tokens(&list, entry->val, 3);
+        ret = flb_slist_split_tokens(&list, entry->val->data.as_string, 3);
         if (ret == -1) {
             flb_error("[multiline parser: %s] invalid section on key '%s'",
                       ml_parser->name, entry->key);

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -453,6 +453,7 @@ static flb_sds_t get_parser_key(struct flb_config *config,
         return NULL;
     }
 
+    flb_sds_destroy(tmp);
     return val;
 }
 

--- a/src/flb_parser_decoder.c
+++ b/src/flb_parser_decoder.c
@@ -27,6 +27,9 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_kv.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_kvlist.h>
+
 #include <msgpack.h>
 
 #define TYPE_OUT_STRING  0  /* unstructured text         */
@@ -603,7 +606,7 @@ struct mk_list *flb_parser_decoder_list_create(struct flb_cf_section *section)
     int type;
     int backend;
     int size;
-    struct mk_list *head;
+    struct cfl_list *head;
     struct mk_list *list = NULL;
     struct mk_list *split;
     struct flb_split_entry *decoder;
@@ -611,7 +614,7 @@ struct mk_list *flb_parser_decoder_list_create(struct flb_cf_section *section)
     struct flb_split_entry *action;
     struct flb_parser_dec *dec;
     struct flb_parser_dec_rule *dec_rule;
-    struct flb_kv *entry;
+    struct cfl_kvpair *entry;
 
     /* Global list to be referenced by parent parser definition */
     list = flb_malloc(sizeof(struct mk_list));
@@ -621,8 +624,8 @@ struct mk_list *flb_parser_decoder_list_create(struct flb_cf_section *section)
     }
     mk_list_init(list);
 
-    mk_list_foreach(head, &section->properties) {
-        entry = mk_list_entry(head, struct flb_kv, _head);
+    cfl_list_foreach(head, &section->properties->list) {
+        entry = cfl_list_entry(head, struct cfl_kvpair, _head);
 
         /* Lookup for specific Decode rules */
         if (strcasecmp(entry->key, "decode_field") == 0) {
@@ -636,7 +639,7 @@ struct mk_list *flb_parser_decoder_list_create(struct flb_cf_section *section)
         }
 
         /* Split the value */
-        split = flb_utils_split(entry->val, ' ', 3);
+        split = flb_utils_split(entry->val->data.as_string, ' ', 3);
         if (!split) {
             flb_error("[parser] invalid number of parameters in decoder");
             flb_parser_decoder_list_destroy(list);

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -28,6 +28,10 @@
 #include <fluent-bit/flb_plugin.h>
 #include <fluent-bit/flb_plugin_proxy.h>
 
+#include <cfl/cfl_sds.h>
+#include <cfl/cfl_variant.h>
+#include <cfl/cfl_kvlist.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -329,11 +333,11 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
     char tmp[PATH_MAX + 1];
     char *cfg = NULL;
     struct mk_list *head;
-    struct mk_list *head_e;
+    struct cfl_list *head_e;
     struct stat st;
     struct flb_cf *cf;
     struct flb_cf_section *section;
-    struct flb_kv *entry;
+    struct cfl_kvpair *entry;
 
 #ifndef FLB_HAVE_STATIC_CONF
     ret = stat(file, &st);
@@ -371,14 +375,14 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
             continue;
         }
 
-        mk_list_foreach(head_e, &section->properties) {
-            entry = mk_list_entry(head_e, struct flb_kv, _head);
+        cfl_list_foreach(head_e, &section->properties->list) {
+            entry = cfl_list_entry(head_e, struct cfl_kvpair, _head);
             if (strcasecmp(entry->key, "path") != 0) {
                 continue;
             }
 
             /* Load plugin with router function */
-            ret = flb_plugin_load_router(entry->val, config);
+            ret = flb_plugin_load_router(entry->val->data.as_string, config);
             if (ret == -1) {
                 flb_cf_destroy(cf);
                 return -1;

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -132,8 +132,8 @@ static struct flb_upstream_node *create_node(int id,
     char *tls_crt_file = NULL;
     char *tls_key_file = NULL;
     char *tls_key_passwd = NULL;
-    struct mk_list *head;
-    struct flb_kv *entry;
+    struct cfl_list *head;
+    struct cfl_kvpair *entry;
     struct flb_hash_table *ht;
     const char *known_keys[] = {"name", "host", "port",
                                 "tls", "tls.vhost", "tls.verify", "tls.debug",
@@ -143,7 +143,7 @@ static struct flb_upstream_node *create_node(int id,
     struct flb_upstream_node *node;
 
     /* name */
-    name = flb_cf_section_property_get(cf, s, "name");
+    name = flb_cf_section_property_get_string(cf, s, "name");
     if (!name) {
         flb_error("[upstream_ha] no 'name' has been set on node #%i",
                   id + 1);
@@ -151,7 +151,7 @@ static struct flb_upstream_node *create_node(int id,
     }
 
     /* host */
-    host = flb_cf_section_property_get(cf, s, "host");
+    host = flb_cf_section_property_get_string(cf, s, "host");
     if (!host) {
         flb_error("[upstream_ha] no 'host' has been set on node #%i",
                   id + 1);
@@ -159,7 +159,7 @@ static struct flb_upstream_node *create_node(int id,
     }
 
     /* port */
-    port = flb_cf_section_property_get(cf, s, "port");
+    port = flb_cf_section_property_get_string(cf, s, "port");
     if (!port) {
         flb_error("[upstream_ha] no 'port' has been set on node #%i",
                   id + 1);
@@ -167,40 +167,40 @@ static struct flb_upstream_node *create_node(int id,
     }
 
     /* tls */
-    tmp = flb_cf_section_property_get(cf, s, "tls");
+    tmp = flb_cf_section_property_get_string(cf, s, "tls");
     if (tmp) {
         tls = flb_utils_bool(tmp);
     }
 
     /* tls.verify */
-    tmp = flb_cf_section_property_get(cf, s, "tls.verify");
+    tmp = flb_cf_section_property_get_string(cf, s, "tls.verify");
     if (tmp) {
         tls_verify = flb_utils_bool(tmp);
     }
 
     /* tls.debug */
-    tmp = flb_cf_section_property_get(cf, s, "tls.debug");
+    tmp = flb_cf_section_property_get_string(cf, s, "tls.debug");
     if (tmp) {
         tls_debug = atoi(tmp);
     }
 
     /* tls.vhost */
-    tls_vhost = flb_cf_section_property_get(cf, s, "tls.vhost");
+    tls_vhost = flb_cf_section_property_get_string(cf, s, "tls.vhost");
 
     /* tls.ca_path */
-    tls_ca_path = flb_cf_section_property_get(cf, s, "tls.ca_path");
+    tls_ca_path = flb_cf_section_property_get_string(cf, s, "tls.ca_path");
 
     /* tls.ca_file */
-    tls_ca_file = flb_cf_section_property_get(cf, s, "tls.ca_file");
+    tls_ca_file = flb_cf_section_property_get_string(cf, s, "tls.ca_file");
 
     /* tls.crt_file */
-    tls_crt_file = flb_cf_section_property_get(cf, s, "tls.crt_file");
+    tls_crt_file = flb_cf_section_property_get_string(cf, s, "tls.crt_file");
 
     /* tls.key_file */
-    tls_key_file = flb_cf_section_property_get(cf, s, "tls.key_file");
+    tls_key_file = flb_cf_section_property_get_string(cf, s, "tls.key_file");
 
     /* tls.key_file */
-    tls_key_passwd = flb_cf_section_property_get(cf, s, "tls.key_passwd");
+    tls_key_passwd = flb_cf_section_property_get_string(cf, s, "tls.key_passwd");
 
     /*
      * Create hash table to store unknown key/values that might be used
@@ -216,8 +216,8 @@ static struct flb_upstream_node *create_node(int id,
      * Iterate mk_rconf section internals, find all unknown keys and add
      * them to the hash table associated to the node.
      */
-    mk_list_foreach(head, &s->properties) {
-        entry = mk_list_entry(head, struct flb_kv, _head);
+    cfl_list_foreach(head, &s->properties->list) {
+        entry = cfl_list_entry(head, struct cfl_kvpair, _head);
 
         /* If this is a known entry, just skip it */
         skip = FLB_FALSE;
@@ -232,7 +232,7 @@ static struct flb_upstream_node *create_node(int id,
         }
 
         klen = flb_sds_len(entry->key);
-        vlen = flb_sds_len(entry->val);
+        vlen = flb_sds_len(entry->val->data.as_string);
 
         /* Always store keys in lowercase */
         for (i = 0; i < klen; i++) {
@@ -306,7 +306,7 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
     }
 
     /* upstream name */
-    tmp = flb_cf_section_property_get(cf, section, "name");
+    tmp = flb_cf_section_property_get_string(cf, section, "name");
     if (!tmp) {
         flb_error("[upstream_ha] missing name for upstream at %s", cfg);
         flb_cf_destroy(cf);

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -107,14 +107,14 @@ static int sp_config_file(struct flb_config *config, struct flb_sp *sp,
         exec = NULL;
 
         /* name */
-        name = flb_cf_section_property_get(cf, section, "name");
+        name = flb_cf_section_property_get_string(cf, section, "name");
         if (!name) {
             flb_error("[sp] task 'name' not found in file '%s'", cfg);
             goto fconf_error;
         }
 
         /* exec */
-        exec = flb_cf_section_property_get(cf, section, "exec");
+        exec = flb_cf_section_property_get_string(cf, section, "exec");
         if (!exec) {
             flb_error("[sp] task '%s' don't have an 'exec' command", name);
             goto fconf_error;

--- a/tests/internal/config_format.c
+++ b/tests/internal/config_format.c
@@ -5,6 +5,10 @@
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_config_format.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_variant.h>
+#include <cfl/cfl_kvlist.h>
+
 #include "flb_tests_internal.h"
 
 void test_api()
@@ -13,8 +17,8 @@ void test_api()
 	struct flb_cf_section *s_tmp;
 	struct flb_cf_section *service;
 	struct flb_cf_group *g_tmp;
+	struct cfl_variant *ret;
 	struct flb_kv *meta;
-	struct flb_kv *kv;
 
 	/* create context */
 	cf = flb_cf_create();
@@ -25,24 +29,16 @@ void test_api()
 	TEST_CHECK(service != NULL);
 
 	/* add a property */
-	kv = flb_cf_property_add(cf, &service->properties, "key", 3, "val", 3);
-	TEST_CHECK(kv != NULL);
+	ret = flb_cf_section_property_add(cf, service->properties, "key", 3, "val", 3);
+	TEST_CHECK(ret != NULL);
 
 	/* add a property with empty spaces on left/right */
-	kv = flb_cf_property_add(cf, &service->properties, " key ", 5, " val   ", 7);
-	TEST_CHECK(kv != NULL);
-
-	/* property: check key */
-	TEST_CHECK(flb_sds_len(kv->key) == 3);
-	TEST_CHECK(strcmp(kv->key, "key") == 0);
-
-	/* property: check val */
-	TEST_CHECK(flb_sds_len(kv->key) == 3);
-	TEST_CHECK(strcmp(kv->key, "key") == 0);
+	ret = flb_cf_section_property_add(cf, service->properties, " key ", 5, " val   ", 7);
+	TEST_CHECK(ret != NULL);
 
 	/* add an invalid property */
-	kv = flb_cf_property_add(cf, &service->properties, "   ", 3, "", 0);
-	TEST_CHECK(kv == NULL);
+	ret = flb_cf_section_property_add(cf, service->properties, "   ", 3, "", 0);
+	TEST_CHECK(ret == NULL);
 
 	/* try to add another 'SERVICE' section, it should return the same one */
 	s_tmp = flb_cf_section_create(cf, "SERVICE", 7);
@@ -55,29 +51,29 @@ void test_api()
 	TEST_CHECK(mk_list_size(&cf->inputs) == 1);
 
 	/* add property to the section recently created */
-	kv = flb_cf_property_add(cf, &s_tmp->properties, "key", 3, "val", 3);
-	TEST_CHECK(kv != NULL);
+	ret = flb_cf_section_property_add(cf, s_tmp->properties, "key", 3, "val", 3);
+	TEST_CHECK(ret != NULL);
 
 	/* groups: add groups to the last section created */
 	g_tmp = flb_cf_group_create(cf, s_tmp, "FLUENT GROUP", 12);
 	TEST_CHECK(g_tmp != NULL);
 
 	/* add properties to the group */
-	kv = flb_cf_property_add(cf, &g_tmp->properties, "key", 3, "val", 3);
-	TEST_CHECK(kv != NULL);
+	ret = flb_cf_section_property_add(cf, g_tmp->properties, "key", 3, "val", 3);
+	TEST_CHECK(ret != NULL);
 
 	/* groups: invalid group */
 	g_tmp = flb_cf_group_create(cf, s_tmp, "", 0);
 	TEST_CHECK(g_tmp == NULL);
 
 	/* Meta commands */
-	meta = flb_cf_meta_create(cf, "@SET        a=1     ", 20);
-	TEST_CHECK(meta != NULL);
-	TEST_CHECK(flb_sds_len(meta->key) == 3 && strcmp(meta->key, "SET") == 0);
-	TEST_CHECK(flb_sds_len(meta->val) == 3 && strcmp(meta->val, "a=1") == 0);
+	meta = flb_cf_meta_property_add(cf, "@SET        a=1     ", 20);
+        TEST_CHECK(meta != NULL);
+        TEST_CHECK(flb_sds_len(meta->key) == 3 && strcmp(meta->key, "SET") == 0);
+        TEST_CHECK(flb_sds_len(meta->val) == 3 && strcmp(meta->val, "a=1") == 0);
 
 	/* invalid meta */
-	meta = flb_cf_meta_create(cf, "@a=1 ", 5);
+	meta = flb_cf_meta_property_add(cf, "@a=1 ", 5);
 	TEST_CHECK(meta == NULL);
 
 	/* destroy context */

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -7,6 +7,9 @@
 #include <fluent-bit/flb_sds.h>
 #include <sys/stat.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_list.h>
+
 #include "flb_tests_internal.h"
 
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/classic/fluent-bit.conf"
@@ -32,7 +35,7 @@ void test_basic()
 	/* SERVICE check */
     TEST_CHECK(cf->service != NULL);
     if (cf->service) {
-        TEST_CHECK(mk_list_size(&cf->service->properties) == 3);
+        TEST_CHECK(cfl_list_size(&cf->service->properties->list) == 3);
     }
 
     /* Meta commands */
@@ -54,7 +57,7 @@ void test_basic()
 
     mk_list_foreach(head, &s->groups) {
         g = mk_list_entry(head, struct flb_cf_group, _head);
-        TEST_CHECK(mk_list_size(&g->properties) == 2);
+        TEST_CHECK(cfl_list_size(&g->properties->list) == 2);
     }
 
     printf("\n");

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -5,6 +5,9 @@
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_config_format.h>
 
+#include <cfl/cfl.h>
+#include <cfl/cfl_list.h>
+
 #include "flb_tests_internal.h"
 
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/yaml/fluent-bit.yaml"
@@ -29,7 +32,7 @@ void test_basic()
 	/* SERVICE check */
     TEST_CHECK(cf->service != NULL);
     if (cf->service) {
-        TEST_CHECK(mk_list_size(&cf->service->properties) == 3);
+        TEST_CHECK(cfl_list_size(&cf->service->properties->list) == 3);
     }
 
     /* Check number sections per list */
@@ -48,14 +51,12 @@ void test_basic()
 
     mk_list_foreach(head, &s->groups) {
         g = mk_list_entry(head, struct flb_cf_group, _head);
-        TEST_CHECK(mk_list_size(&g->properties) == 2);
+        TEST_CHECK(cfl_list_size(&g->properties->list) == 2);
     }
 
     printf("\n");
     flb_cf_dump(cf);
     flb_cf_destroy(cf);
-
-
 }
 
 TEST_LIST = {


### PR DESCRIPTION
<!-- Provide summary of changes -->

This adds support for lists in the YAML file configuration format. Here is an example:

```yaml
pipeline:
  filters:
    - name: record_modifier
      match: *
      record:
        - powered_by calyptia
        - generated_by fluent-bit
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Disccussed in https://github.com/fluent/fluent-bit/discussions/6029.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
