### PR TITLE
lib/monkey: sync with upstream.

### DIFF
--- a/lib/monkey/include/monkey/mk_core/mk_event.h
+++ b/lib/monkey/include/monkey/mk_core/mk_event.h
@@ -67,6 +67,9 @@
 #define MK_EP_SOCKET_DONE     3
 /* ---- end ---- */
 
+
+#define MK_EVENT_IS_REGISTERED(event) ((event->status & MK_EVENT_REGISTERED) != 0)
+
 #if defined(_WIN32)
     #include "mk_event_libevent.h"
 #elif defined(MK_HAVE_EVENT_SELECT)
@@ -142,6 +145,8 @@ int mk_event_timeout_disable(struct mk_event_loop *loop, void *data);
 int mk_event_timeout_destroy(struct mk_event_loop *loop, void *data);
 int mk_event_channel_create(struct mk_event_loop *loop,
                             int *r_fd, int *w_fd, void *data);
+int mk_event_channel_destroy(struct mk_event_loop *loop,
+                             int r_fd, int w_fd, void *data);
 int mk_event_wait(struct mk_event_loop *loop);
 int mk_event_wait_2(struct mk_event_loop *loop, int timeout);
 int mk_event_translate(struct mk_event_loop *loop);

--- a/lib/monkey/include/monkey/mk_core/mk_list.h
+++ b/lib/monkey/include/monkey/mk_core/mk_list.h
@@ -22,6 +22,7 @@
 #define   	MK_LIST_H_
 
 #include <stddef.h>
+#include "mk_macros.h"
 
 #ifdef _WIN32
 /* Windows */
@@ -82,6 +83,59 @@ static inline void mk_list_add_after(struct mk_list *_new,
     next->prev = _new;
 }
 
+static inline int mk_list_is_empty(struct mk_list *head)
+{
+    if (head->next == head) return 0;
+    else return -1;
+}
+
+static inline void mk_list_add_before(struct mk_list *_new,
+                                      struct mk_list *next,
+                                      struct mk_list *head)
+{
+    struct mk_list *prev;
+
+    if (_new == NULL || next == NULL || head == NULL) {
+        return;
+    }
+
+    if (mk_list_is_empty(head) == 0 /*empty*/||
+        next == head) {
+        mk_list_add(_new, head);
+        return;
+    }
+
+    prev = next->prev;
+    _new->next = next;
+    _new->prev = prev;
+    prev->next = _new;
+    next->prev = _new;
+}
+
+static inline void mk_list_append(struct mk_list *_new, struct mk_list *head)
+{
+    if (mk_list_is_empty(head) == 0) {
+        __mk_list_add(_new, head->prev, head);
+    }
+    else {
+        mk_list_add_after(_new,
+                          head->prev,
+                          head);
+    }
+}
+
+static inline void mk_list_prepend(struct mk_list *_new, struct mk_list *head)
+{
+    if (mk_list_is_empty(head) == 0) {
+        __mk_list_add(_new, head->prev, head);
+    }
+    else {
+        mk_list_add_before(_new,
+                           head->next,
+                           head);
+    }
+}
+
 static inline void __mk_list_del(struct mk_list *prev, struct mk_list *next)
 {
     prev->next = next;
@@ -93,12 +147,6 @@ static inline void mk_list_del(struct mk_list *entry)
     __mk_list_del(entry->prev, entry->next);
     entry->prev = NULL;
     entry->next = NULL;
-}
-
-static inline int mk_list_is_empty(struct mk_list *head)
-{
-    if (head->next == head) return 0;
-    else return -1;
 }
 
 static inline int mk_list_is_set(struct mk_list *head)
@@ -116,6 +164,22 @@ static inline int mk_list_size(struct mk_list *head)
     struct mk_list *it;
     for (it = head->next; it != head; it = it->next, ret++);
     return ret;
+}
+
+static inline void mk_list_entry_init(struct mk_list *list)
+{
+    list->next = NULL;
+    list->prev = NULL;
+}
+
+static inline int mk_list_entry_is_orphan(struct mk_list *head)
+{
+    if (head->next != NULL &&
+        head->prev != NULL) {
+        return MK_FALSE;
+    }
+
+    return MK_TRUE;
 }
 
 static inline int mk_list_entry_orphan(struct mk_list *head)

--- a/lib/monkey/include/monkey/mk_core/mk_utils.h
+++ b/lib/monkey/include/monkey/mk_core/mk_utils.h
@@ -79,17 +79,14 @@ extern pthread_key_t mk_utils_error_key;
 #endif
 
 /*
- * Helpers to format and print out common errno errors, we use thread
- * keys to hold a buffer per thread so strerror_r(2) can be used without
- * a memory allocation.
+ * Helpers to format and print out common errno errors.
  */
-#define MK_UTILS_LIBC_ERRNO_BUFFER()                                    \
-    int _err  = errno;                                                  \
-    char bufs[256];                                                     \
-    char *buf = (char *) pthread_getspecific(mk_utils_error_key);       \
-    if (!buf) buf = bufs;                                               \
-    if (strerror_r(_err, buf, MK_UTILS_ERROR_SIZE) != 0) {              \
-        mk_err("strerror_r() failed");                                  \
+#define MK_UTILS_LIBC_ERRNO_BUFFER()                       \
+    char buf[MK_UTILS_ERROR_SIZE];                         \
+    int  _err;                                             \
+    _err = errno;                                          \
+    if (strerror_r(_err, buf, MK_UTILS_ERROR_SIZE) != 0) { \
+        mk_err("strerror_r() failed");                     \
     }
 
 static inline void mk_utils_libc_error(char *caller, char *file, int line)

--- a/lib/monkey/mk_core/mk_event.c
+++ b/lib/monkey/mk_core/mk_event.c
@@ -106,8 +106,6 @@ int mk_event_add(struct mk_event_loop *loop, int fd,
 int mk_event_inject(struct mk_event_loop *loop, struct mk_event *event,
                     int flags, int prevent_duplication)
 {
-    int result;
-
     if (loop->n_events + 1 >= loop->size) {
         return -1;
     }
@@ -176,6 +174,18 @@ int mk_event_channel_create(struct mk_event_loop *loop,
     mk_bug(!data);
     ctx = loop->data;
     return _mk_event_channel_create(ctx, r_fd, w_fd, data);
+}
+
+/* Destroy channel created to distribute signals */
+int mk_event_channel_destroy(struct mk_event_loop *loop,
+                            int r_fd, int w_fd,
+                            void *data)
+{
+    struct mk_event_ctx *ctx;
+
+    mk_bug(!data);
+    ctx = loop->data;
+    return _mk_event_channel_destroy(ctx, r_fd, w_fd, data);
 }
 
 /* Poll events */

--- a/lib/monkey/mk_core/mk_event_kqueue.c
+++ b/lib/monkey/mk_core/mk_event_kqueue.c
@@ -239,11 +239,10 @@ static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data
         return 0;
     }
 
+    event = (struct mk_event *) data;
     if (!MK_EVENT_IS_REGISTERED(event)) {
         return 0;
     }
-
-    event = (struct mk_event *) data;
     EV_SET(&ke, event->fd, EVFILT_TIMER, EV_DELETE, 0,0, NULL);
 
     ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);

--- a/lib/monkey/mk_core/mk_event_select.c
+++ b/lib/monkey/mk_core/mk_event_select.c
@@ -100,6 +100,9 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
 {
     struct mk_event *event;
 
+    mk_bug(ctx == NULL);
+    mk_bug(data == NULL);
+
     if (fd > FD_SETSIZE) {
         return -1;
     }
@@ -114,10 +117,11 @@ static inline int _mk_event_add(struct mk_event_ctx *ctx, int fd,
     event = (struct mk_event *) data;
     event->fd   = fd;
     event->mask = events;
-    event->priority = MK_EVENT_PRIORITY_DEFAULT;
-    event->_priority_head.next = NULL;
-    event->_priority_head.prev = NULL;
     event->status = MK_EVENT_REGISTERED;
+
+    event->priority = MK_EVENT_PRIORITY_DEFAULT;
+    mk_list_entry_init(&event->_priority_head);
+
     if (type != MK_EVENT_UNMODIFIED) {
         event->type = type;
     }
@@ -137,7 +141,10 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     int fd;
     struct mk_event *s_event;
 
-    if ((event->status & MK_EVENT_REGISTERED) == 0) {
+    mk_bug(ctx == NULL);
+    mk_bug(event == NULL);
+
+    if (!MK_EVENT_IS_REGISTERED(event)) {
         return 0;
     }
 
@@ -169,8 +176,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
     ctx->events[fd] = NULL;
 
     /* Remove from priority queue */
-    if (event->_priority_head.next != NULL &&
-        event->_priority_head.prev != NULL) {
+    if (!mk_list_entry_is_orphan(&event->_priority_head)) {
         mk_list_del(&event->_priority_head);
     }
 
@@ -294,6 +300,8 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
     int fd[2];
     struct mk_event *event;
 
+    mk_bug(data == NULL);
+
     ret = pipe(fd);
     if (ret < 0) {
         mk_libc_error("pipe");
@@ -316,6 +324,29 @@ static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
 
     *r_fd = fd[0];
     *w_fd = fd[1];
+
+    return 0;
+}
+
+static inline int _mk_event_channel_destroy(struct mk_event_ctx *ctx,
+                                            int r_fd, int w_fd, void *data)
+{
+    struct mk_event *event;
+    int ret;
+
+
+    event = (struct mk_event *)data;
+    if (event->fd != r_fd) {
+        return -1;
+    }
+
+    ret = _mk_event_del(ctx, event);
+    if (ret != 0) {
+        return ret;
+    }
+
+    close(r_fd);
+    close(w_fd);
 
     return 0;
 }

--- a/lib/monkey/mk_core/mk_rconf.c
+++ b/lib/monkey/mk_core/mk_rconf.c
@@ -102,6 +102,10 @@ struct mk_rconf *mk_rconf_create(const char *name)
 
     /* Alloc configuration node */
     conf = mk_mem_alloc_z(sizeof(struct mk_rconf));
+    if (!conf) {
+        perror("malloc");
+        return NULL;
+    }
     conf->created = time(NULL);
     conf->file = mk_string_dup(name);
     mk_list_init(&conf->sections);
@@ -152,7 +156,6 @@ static int mk_rconf_meta_add(struct mk_rconf *conf, char *buf, int len)
 
     meta = mk_mem_alloc(sizeof(struct mk_rconf_entry));
     if (!meta) {
-        perror("malloc");
         return -1;
     }
 
@@ -250,6 +253,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
     /* Allocate temporal buffer to read file content */
     buf = mk_mem_alloc(MK_RCONF_KV_SIZE);
     if (!buf) {
+        fclose(f);
         perror("malloc");
         return -1;
     }
@@ -271,6 +275,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
              */
             if (!feof(f)) {
                 mk_config_error(path, line, "Length of content has exceeded limit");
+                fclose(f);
                 mk_mem_free(buf);
                 return -1;
             }
@@ -335,12 +340,22 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
                 /* Create new section */
                 section = mk_string_copy_substr(buf, 1, end);
                 current = mk_rconf_section_add(conf, section);
+                if (!current) {
+                    fclose(f);
+                    if (indent) {
+                        mk_mem_free(indent);
+                    }
+                    mk_mem_free(buf);
+                    mk_mem_free(section);
+                    return -1;
+                }
                 mk_mem_free(section);
                 n_keys = 0;
                 continue;
             }
             else {
                 mk_config_error(path, line, "Bad header definition");
+                fclose(f);
                 mk_mem_free(buf);
                 return -1;
             }
@@ -364,6 +379,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
         /* Validate indentation level */
         if (check_indent(buf, indent) < 0) {
             mk_config_error(path, line, "Invalid indentation level");
+            fclose(f);
             return -1;
         }
 
@@ -382,6 +398,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
 
         if (!key || !val || i < 0) {
             mk_config_error(path, line, "Each key must have a value");
+            fclose(f);
             mk_mem_free(key);
             mk_mem_free(val);
             return -1;
@@ -393,6 +410,7 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
 
         if (strlen(val) == 0) {
             mk_config_error(path, line, "Key has an empty value");
+            fclose(f);
             mk_mem_free(key);
             mk_mem_free(val);
             return -1;
@@ -437,7 +455,6 @@ static int mk_rconf_read(struct mk_rconf *conf, const char *path)
     /* Append this file to the list */
     file = mk_mem_alloc(sizeof(struct mk_rconf_file));
     if (!file) {
-        perror("malloc");
         conf->level--;
         return -1;
     }
@@ -621,6 +638,10 @@ struct mk_rconf *mk_rconf_open(const char *path)
 
     /* Alloc configuration node */
     conf = mk_mem_alloc_z(sizeof(struct mk_rconf));
+    if (!conf) {
+        perror("malloc");
+        return NULL;
+    }
     conf->created = time(NULL);
     conf->file = mk_string_dup(path);
     conf->level = -1;
@@ -709,6 +730,9 @@ struct mk_rconf_section *mk_rconf_section_add(struct mk_rconf *conf,
 
     /* Alloc section node */
     new = mk_mem_alloc(sizeof(struct mk_rconf_section));
+    if (!new) {
+        return NULL;
+    }
     new->name = mk_string_dup(name);
     mk_list_init(&new->entries);
     mk_list_add(&new->_head, &conf->sections);

--- a/lib/monkey/mk_core/mk_string.c
+++ b/lib/monkey/mk_core/mk_string.c
@@ -340,11 +340,15 @@ char *mk_string_dup(const char *s)
     size_t len;
     char *p;
 
-    if (!s)
+    if (!s) {
         return NULL;
+    }
 
     len = strlen(s);
     p = mk_mem_alloc(len + 1);
+    if (!p) {
+        return NULL;
+    }
     memcpy(p, s, len);
     p[len] = '\0';
 
@@ -364,6 +368,9 @@ struct mk_list *mk_string_split_line(const char *line)
     }
 
     list = mk_mem_alloc(sizeof(struct mk_list));
+    if (!list) {
+        return NULL;
+    }
     mk_list_init(list);
 
     len = strlen(line);
@@ -590,8 +597,9 @@ char *mk_string_copy_substr(const char *string, int pos_init, int pos_end)
     }
 
     size = (unsigned int) (pos_end - pos_init) + 1;
-    if (size <= 2)
+    if (size <= 2) {
         size = 4;
+    }
 
     buffer = mk_mem_alloc(size);
 
@@ -611,6 +619,10 @@ char *mk_string_tolower(const char *in)
     char *out = mk_string_dup(in);
     const char *ip = in;
     char *op = out;
+
+    if (!out) {
+        return NULL;
+    }
 
     while (*ip) {
         *op = tolower(*ip);

--- a/lib/monkey/mk_server/mk_lib.c
+++ b/lib/monkey/mk_server/mk_lib.c
@@ -388,6 +388,7 @@ int mk_config_set(mk_ctx_t *ctx, ...)
         value = va_arg(va, char *);
         if (!value) {
             /* Wrong parameter */
+            va_end(va);
             return -1;
         }
 

--- a/lib/monkey/mk_server/mk_stream.c
+++ b/lib/monkey/mk_server/mk_stream.c
@@ -27,6 +27,9 @@ struct mk_channel *mk_channel_new(int type, int fd)
     struct mk_channel *channel;
 
     channel = mk_mem_alloc(sizeof(struct mk_channel));
+    if (!channel) {
+        return NULL;
+    }
     channel->type   = type;
     channel->fd     = fd;
     channel->status = MK_CHANNEL_OK;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Sync with upstream commit [754088d69ffb507e8cd651701fda93511f07cf69]. This provides several fixes for tests as well as new functionality for the upcoming 2.0 release.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
