### PR TITLE
out_loki: enable processing multiple tasks in loki output plugin.

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1658,5 +1658,5 @@ struct flb_output_plugin out_loki_plugin = {
     /* for testing */
     .test_formatter.callback = cb_loki_format_test,
 
-    .flags       = FLB_OUTPUT_NET | FLB_IO_OPT_TLS | FLB_OUTPUT_NO_MULTIPLEX,
+    .flags       = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };


### PR DESCRIPTION
The Loki output plugin previously disabled processing mulitple tasks per flush because Loki historically did not support out-of-order writes. However this behavior had a deleterious effect on throughput.

Signed-off-by: Paul Wheeler <pwheeler@revacomm.com>

This change simply removes the `FLB_OUTPUT_NO_MULTIPLEX` from the Loki output plugin flags. I will open a separate issue for adding a backward compatibility configuration that preserves the existing behavior for user who may still be using older versions of Loki.

Fixes #5868

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
    [fluent-bit.config](https://github.com/fluent/fluent-bit/files/9700933/fluent-bit.config.txt)
    See [this repository](https://github.com/revacomm-pwheeler/fluent-bit-loki-grafana/tree/out_loki_enable_multiplex) for a complete test setup.
- [X] Debug log output from testing the change
    [fluent-bit-logs.txt](https://github.com/fluent/fluent-bit/files/9700932/fluent-bit-logs.txt)
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
Do not backport. This is potentially a breaking change for older versions of Loki.

- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
