### PR TITLE
trace: update docker build for example with new compile flag.

### DIFF
--- a/examples/tracing/docker-compose.yml
+++ b/examples/tracing/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - "2020:2020"
     volumes:
       - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+    command:
+      - /fluent-bit/bin/fluent-bit
+      - -Z
+      - -c
+      - /fluent-bit/etc/fluent-bit.conf
 
   enable-tracing:
     image: ubuntu:20.04

--- a/examples/tracing/docker-compose.yml
+++ b/examples/tracing/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../..
       dockerfile: dockerfiles/Dockerfile
       args:
-        - FLB_TRACE=On
+        - FLB_CHUNK_TRACE=On
     ports:
       - "2020:2020"
     volumes:


### PR DESCRIPTION
<!-- Provide summary of changes -->
Update the docker-compose example for tracing to use the new compile flag `FLB_CHUNK_TRACE` instead of the old `FLB_TRACE` to enable tracing.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
