### PR TITLE
tests: internal: fuzzers: engine_fuzzer: fix build

### DIFF
--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -67,7 +67,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                     entry = mk_list_entry(head, struct flb_input_instance, _head);
                     if (entry->storage != NULL) {
                         char bufbuf[100];
-                        flb_input_chunk_append_raw(entry, "A", 1, "\0", 0);
+                        flb_input_chunk_append_raw(entry, FLB_INPUT_LOGS, 0, "A",
+                                                   1, "\0", 0);
 
                         struct flb_input_chunk *ic = NULL;
                         ic = flb_input_chunk_create(entry, nm3, 10);


### PR DESCRIPTION
Fix API of engine fuzzer to match latest changes.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->
Fixes a broken fuzzer

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
