### PR TITLE
parser: refine exit path

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -491,7 +491,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         name = get_parser_key(config, cf, s, "name");
         if (!name) {
             flb_error("[parser] no parser 'name' found in file '%s'", cfg);
-            goto fconf_error;
+            goto fconf_early_error;
         }
 
         /* format */
@@ -499,7 +499,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         if (!format) {
             flb_error("[parser] no parser 'format' found for '%s' in file '%s'",
                       name, cfg);
-            goto fconf_error;
+            goto fconf_early_error;
         }
 
         /* regex (if 'format' == 'regex') */
@@ -507,7 +507,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         if (!regex && strcmp(format, "regex") == 0) {
             flb_error("[parser] no parser 'regex' found for '%s' in file '%s",
                       name, cfg);
-            goto fconf_error;
+            goto fconf_early_error;
         }
         
         /* skip_empty_values */
@@ -586,6 +586,19 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
     }
 
     return 0;
+
+ /* Use early exit before call to flb_parser_create */
+ fconf_early_error:
+    if (name) {
+        flb_sds_destroy(name);
+    }
+    if (format) {
+        flb_sds_destroy(format);
+    }
+    if (regex) {
+        flb_sds_destroy(regex);
+    }
+    return -1;
 
  fconf_error:
     flb_sds_destroy(name);


### PR DESCRIPTION
Only limited fields should be freed when an early error happens in `parser_conf_file`. Otherwise, we will either free too much such that a double free will happen when used in combination with `flb_parser_exit` and `flb_config_exit`, or, memory leaks will happen. This fixes so neither of these situations happen.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51223

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
