### PR TITLE
multiline: ruby: support built-in ruby parser

### DIFF
--- a/include/fluent-bit/multiline/flb_ml_parser.h
+++ b/include/fluent-bit/multiline/flb_ml_parser.h
@@ -52,6 +52,7 @@ struct flb_ml_parser *flb_ml_parser_docker(struct flb_config *config);
 struct flb_ml_parser *flb_ml_parser_cri(struct flb_config *config);
 struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key);
 struct flb_ml_parser *flb_ml_parser_go(struct flb_config *config, char *key);
+struct flb_ml_parser *flb_ml_parser_ruby(struct flb_config *config, char *key);
 struct flb_ml_parser *flb_ml_parser_python(struct flb_config *config, char *key);
 
 #endif

--- a/src/multiline/CMakeLists.txt
+++ b/src/multiline/CMakeLists.txt
@@ -5,6 +5,7 @@ set(src_multiline
   multiline/flb_ml_parser_python.c
   multiline/flb_ml_parser_java.c
   multiline/flb_ml_parser_go.c
+  multiline/flb_ml_parser_ruby.c
   # core
   multiline/flb_ml_stream.c
   multiline/flb_ml_parser.c

--- a/src/multiline/flb_ml_parser.c
+++ b/src/multiline/flb_ml_parser.c
@@ -69,6 +69,13 @@ int flb_ml_parser_builtin_create(struct flb_config *config)
         return -1;
     }
 
+    /* Ruby */
+    mlp = flb_ml_parser_ruby(config, NULL);
+    if (!mlp) {
+        flb_error("[multiline] could not init 'ruby' built-in parser");
+        return -1;
+    }
+
     /* Python */
     mlp = flb_ml_parser_python(config, NULL);
     if (!mlp) {

--- a/src/multiline/flb_ml_parser_ruby.c
+++ b/src/multiline/flb_ml_parser_ruby.c
@@ -1,0 +1,87 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/multiline/flb_ml.h>
+#include <fluent-bit/multiline/flb_ml_rule.h>
+#include <fluent-bit/multiline/flb_ml_parser.h>
+
+#define rule flb_ml_rule_create
+
+static void rule_error(struct flb_ml_parser *mlp)
+{
+    int id;
+
+    id = mk_list_size(&mlp->regex_rules);
+    flb_error("[multiline: ruby] rule #%i could not be created", id);
+    flb_ml_parser_destroy(mlp);
+}
+
+/* Ruby mode */
+struct flb_ml_parser *flb_ml_parser_ruby(struct flb_config *config, char *key)
+{
+    int ret;
+    struct flb_ml_parser *mlp;
+
+    mlp = flb_ml_parser_create(config,               /* Fluent Bit context */
+                               "ruby",                 /* name      */
+                               FLB_ML_REGEX,         /* type      */
+                               NULL,                 /* match_str */
+                               FLB_FALSE,            /* negate    */
+                               FLB_ML_FLUSH_TIMEOUT, /* flush_ms  */
+                               key,                  /* key_content */
+                               NULL,                 /* key_group   */
+                               NULL,                 /* key_pattern */
+                               NULL,                 /* parser ctx  */
+                               NULL);                /* parser name */
+
+    if (!mlp) {
+        flb_error("[multiline] could not create 'ruby mode'");
+        return NULL;
+    }
+
+    ret = rule(mlp,
+               "start_state, ruby_start_exception",
+               "/^.+:\\d+:in\\s+.*/",
+               "ruby_after_exception", NULL);
+    if (ret != 0) {
+        rule_error(mlp);
+        return NULL;
+    }
+
+    ret = rule(mlp,
+               "ruby_after_exception, ruby",
+               "/^\\s+from\\s+.*:\\d+:in\\s+.*/",
+               "ruby", NULL);
+    if (ret != 0) {
+        rule_error(mlp);
+        return NULL;
+    }
+
+
+    /* Map the rules (mandatory for regex rules) */
+    ret = flb_ml_parser_init(mlp);
+    if (ret != 0) {
+        flb_error("[multiline: ruby] error on mapping rules");
+        flb_ml_parser_destroy(mlp);
+        return NULL;
+    }
+
+    return mlp;
+}

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -146,6 +146,28 @@ struct record_check java_output[] = {
   }
 };
 
+struct record_check ruby_input[] = {
+    {"/app/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)"},
+    {"	from /app/config/routes.rb:6:in `block in <main>'"},
+    {"	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'"},
+    {"	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'"},
+    {"	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'"},
+    {"	from /app/config/routes.rb:1:in `<main>'"},
+    {"hello world, not multiline\n"}
+};
+
+struct record_check ruby_output[] = {
+    {
+        "/app/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)\n"
+        "	from /app/config/routes.rb:6:in `block in <main>'\n"
+        "	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'\n"
+        "	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'\n"
+        "	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'\n"
+        "	from /app/config/routes.rb:1:in `<main>'\n"
+    },
+    {"hello world, not multiline\n"}
+};
+
 /* Python stacktrace detection */
 struct record_check python_input[] = {
   {"Traceback (most recent call last):\n"},
@@ -714,6 +736,65 @@ static void test_parser_python()
     entries = sizeof(python_input) / sizeof(struct record_check);
     for (i = 0; i < entries; i++) {
         r = &python_input[i];
+        len = strlen(r->buf);
+
+        /* Package as msgpack */
+        flb_time_get(&tm);
+        flb_ml_append(ml, stream_id, FLB_ML_TYPE_TEXT, &tm, r->buf, len);
+    }
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    flb_config_exit(config);
+}
+
+static void test_parser_ruby()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    /* Expected results context */
+    res.key = "log";
+    res.out_records = ruby_output;
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    /* Initialize environment */
+    config = flb_config_init();
+
+    /* Create docker multiline mode */
+    ml = flb_ml_create(config, "ruby-test");
+    TEST_CHECK(ml != NULL);
+
+    /* Generate an instance of multiline ruby parser */
+    mlp_i = flb_ml_parser_instance_create(ml, "ruby");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "ruby", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&tm);
+
+    printf("\n");
+    entries = sizeof(ruby_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &ruby_input[i];
         len = strlen(r->buf);
 
         /* Package as msgpack */
@@ -1377,6 +1458,7 @@ TEST_LIST = {
     { "parser_cri",     test_parser_cri},
     { "parser_java",    test_parser_java},
     { "parser_python",  test_parser_python},
+    { "parser_ruby",    test_parser_ruby},
     { "parser_elastic", test_parser_elastic},
     { "parser_go",      test_parser_go},
     { "container_mix",  test_container_mix},


### PR DESCRIPTION
Fixes #6050 

This patch is to support multiline parser for ruby backtrace.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    Name tail
    path a.log
    Read_From_Head on
    multiline.parser ruby

[OUTPUT]
    Name stdout
    Match *
```

a.log:

<details>

This log was generated invalid ruby on rails application.
- ruby 3.0.2p107
- Rails 7.0.4

1. `rails new backtrace_test`
2. modify `config/routes.rb`. Add `a = 10 /0`
3. `rails server`

```
/home/taka/backtrace_test/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)
	from /home/taka/backtrace_test/config/routes.rb:6:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'
	from /home/taka/backtrace_test/config/routes.rb:1:in `<main>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `block in load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:24:in `reload!'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:38:in `block in updater'
	from /var/lib/gems/3.0.0/gems/activesupport-7.0.4/lib/active_support/file_update_checker.rb:83:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:13:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:158:in `block in <module:Finisher>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
	from /home/taka/backtrace_test/config/environment.rb:5:in `<main>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:249:in `app'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:422:in `wrapped_app'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:36:in `start'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
aaa
/home/taka/backtrace_test/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)
	from /home/taka/backtrace_test/config/routes.rb:6:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'
	from /home/taka/backtrace_test/config/routes.rb:1:in `<main>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `block in load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:24:in `reload!'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:38:in `block in updater'
	from /var/lib/gems/3.0.0/gems/activesupport-7.0.4/lib/active_support/file_update_checker.rb:83:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:13:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:158:in `block in <module:Finisher>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
	from /home/taka/backtrace_test/config/environment.rb:5:in `<main>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:249:in `app'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:422:in `wrapped_app'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:36:in `start'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
```
</details>

## Debug/Valgrind output

```
$ ../../bin/fluent-bit -c a.conf 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/10 21:08:53] [ info] [fluent bit] version=2.0.0, commit=130acf743d, pid=2925
[2022/10/10 21:08:53] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/10 21:08:53] [ info] [cmetrics] version=0.5.2
[2022/10/10 21:08:53] [ info] [input:tail:tail.0] initializing
[2022/10/10 21:08:53] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2022/10/10 21:08:53] [ info] [input:tail:tail.0] multiline core started
[2022/10/10 21:08:53] [ info] [sp] stream processor started
[2022/10/10 21:08:53] [ info] [input:tail:tail.0] inotify_fs_add(): inode=4596361 watch_fd=1 name=a.log
[2022/10/10 21:08:53] [ info] [output:stdout:stdout.0] worker #0 started
[0] tail.0: [1665403733.856689612, {"log"=>"/home/taka/backtrace_test/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)
	from /home/taka/backtrace_test/config/routes.rb:6:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'
	from /home/taka/backtrace_test/config/routes.rb:1:in `<main>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `block in load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:24:in `reload!'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:38:in `block in updater'
	from /var/lib/gems/3.0.0/gems/activesupport-7.0.4/lib/active_support/file_update_checker.rb:83:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:13:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:158:in `block in <module:Finisher>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
	from /home/taka/backtrace_test/config/environment.rb:5:in `<main>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:249:in `app'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:422:in `wrapped_app'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:36:in `start'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
"}]
[1] tail.0: [1665403733.856689612, {"log"=>"aaa
"}]
[0] tail.0: [1665403733.857254934, {"log"=>"/home/taka/backtrace_test/config/routes.rb:6:in `/': divided by 0 (ZeroDivisionError)
	from /home/taka/backtrace_test/config/routes.rb:6:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'
	from /var/lib/gems/3.0.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'
	from /home/taka/backtrace_test/config/routes.rb:1:in `<main>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `block in load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load_paths'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:24:in `reload!'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:38:in `block in updater'
	from /var/lib/gems/3.0.0/gems/activesupport-7.0.4/lib/active_support/file_update_checker.rb:83:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:13:in `execute'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:158:in `block in <module:Finisher>'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `call'
	from /usr/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
	from /usr/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
	from /home/taka/backtrace_test/config/environment.rb:5:in `<main>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block in <main>'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:249:in `app'
	from /var/lib/gems/3.0.0/gems/rack-2.2.4/lib/rack/server.rb:422:in `wrapped_app'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:36:in `start'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /var/lib/gems/3.0.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /var/lib/gems/3.0.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
"}]
^C[2022/10/10 21:09:01] [engine] caught signal (SIGINT)
[2022/10/10 21:09:01] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/10 21:09:01] [ info] [input] pausing tail.0
[2022/10/10 21:09:01] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/10 21:09:01] [ info] [input] pausing tail.0
[2022/10/10 21:09:01] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=4596361 watch_fd=1
[2022/10/10 21:09:01] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/10/10 21:09:01] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
