### PR TITLE
config: fix property values being truncated.

### DIFF
--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -193,7 +193,7 @@ struct cfl_variant *flb_cf_section_property_add(struct flb_cf *cf,
     }
 
     if (v_len == 0) {
-        v_len = strlen(k_buf);
+        v_len = strlen(v_buf);
     }
     val = flb_sds_create_len(v_buf, v_len);
     if (val == NULL) {

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -723,14 +723,15 @@ static int service_configure_plugin(struct flb_config *config,
             ins = flb_output_new(config, tmp, NULL, FLB_TRUE);
         }
         flb_sds_destroy(tmp);
-        flb_sds_destroy(name);
 
         /* validate the instance creation */
         if (!ins) {
             flb_error("[config] section '%s' tried to instance a plugin name "
                       "that don't exists", name);
+            flb_sds_destroy(name);
             return -1;
         }
+        flb_sds_destroy(name);
 
         /*
          * iterate section properties and populate instance by using specific


### PR DESCRIPTION
<!-- Provide summary of changes -->
Properties values were being truncated to the length of their key. They were also not being correctly reported when there were errors.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
