### PR TITLE
plugins: in_winevtlog: adds ability to ignore channels missing in Windows Event Log

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -239,7 +239,7 @@ static struct flb_config_map config_map[] = {
       "Use ANSI encoding on eventlog messages"
     },
     {
-      FLB_CONFIG_MAP_BOOL, "use_ansi", "false",
+      FLB_CONFIG_MAP_BOOL, "ignore_missing_channels", "false",
       0, FLB_TRUE, offsetof(struct winevtlog_config, ignore_missing_channels),
       "Whether to ignore channels missing in eventlog"
     },

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -241,7 +241,7 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_BOOL, "use_ansi", "false",
       0, FLB_TRUE, offsetof(struct winevtlog_config, ignore_missing_channels),
-      "Use ANSI encoding on eventlog messages"
+      "Whether to ignore channels missing in eventlog"
     },
 
     /* EOF */

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -68,7 +68,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
         tmp = "Application";
     }
 
-    ctx->active_channel = winevtlog_open_all(tmp, ctx->read_existing_events);
+    ctx->active_channel = winevtlog_open_all(tmp, ctx->read_existing_events, ctx->ignore_missing_channels);
     if (!ctx->active_channel) {
         flb_plg_error(ctx->ins, "failed to open channels");
         flb_free(ctx);
@@ -236,6 +236,11 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_BOOL, "use_ansi", "false",
       0, FLB_TRUE, offsetof(struct winevtlog_config, use_ansi),
+      "Use ANSI encoding on eventlog messages"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "use_ansi", "false",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, ignore_missing_channels),
       "Use ANSI encoding on eventlog messages"
     },
 

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -616,6 +616,9 @@ struct mk_list *winevtlog_open_all(const char *channels, int read_existing_event
             if (ch) {
                 mk_list_add(&ch->_head, list);
             }
+            else {
+                flb_debug("[in_winevtlog] channel '%s' does not exist", channel);
+            }             
         }
         else {
             if (!ch) {

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -587,7 +587,7 @@ int winevtlog_read(struct winevtlog_channel *ch, msgpack_packer *mp_pck, struct 
  *
  * "channels" are comma-separated names like "Setup,Security".
  */
-struct mk_list *winevtlog_open_all(const char *channels, int read_existing_events)
+struct mk_list *winevtlog_open_all(const char *channels, int read_existing_events, int ignore_missing_channels)
 {
     char *tmp;
     char *channel;
@@ -612,14 +612,27 @@ struct mk_list *winevtlog_open_all(const char *channels, int read_existing_event
     channel = strtok_s(tmp , ",", &state);
     while (channel) {
         ch = winevtlog_subscribe(channel, read_existing_events, NULL);
-        if (!ch) {
-            flb_free(tmp);
-            winevtlog_close_all(list);
-            return NULL;
+        if (ignore_missing_channels) {
+            if (ch) {
+                mk_list_add(&ch->_head, list);
+            }
         }
-        mk_list_add(&ch->_head, list);
+        else {
+            if (!ch) {
+                flb_free(tmp);
+                winevtlog_close_all(list);
+                return NULL;
+            }
+        }
         channel = strtok_s(NULL, ",", &state);
     }
+
+    if (mk_list_size(list) == 0) {
+        flb_free(tmp);
+        winevtlog_close_all(list);
+        return NULL;
+    }
+
     flb_free(tmp);
     return list;
 }

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -31,6 +31,7 @@ struct winevtlog_config {
     int read_existing_events;
     int render_event_as_xml;
     int use_ansi;
+    int ignore_missing_channels;
 
     struct mk_list *active_channel;
     struct flb_sqldb *db;
@@ -80,7 +81,7 @@ int winevtlog_read(struct winevtlog_channel *ch, msgpack_packer *mp_pck,
  *
  * "channels" are comma-separated names like "Setup,Security".
  */
-struct mk_list *winevtlog_open_all(const char *channels, int read_exising_events);
+struct mk_list *winevtlog_open_all(const char *channels, int read_exising_events, int ignore_missing_channels);
 void winevtlog_close_all(struct mk_list *list);
 
 void winevtlog_pack_xml_event(msgpack_packer *mp_pck, WCHAR *system_xml, WCHAR *message,


### PR DESCRIPTION
<!-- Provide summary of changes -->

Additions to in_winevtlog plugin to allow scenarios where one or more channels are missing on Windows Event Log
ex: PowerShellCore/Operational needs the proper software installed to
    appear under Application and Services Log

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

Added information in comments

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
