### PR TITLE
in_opentelemetry: use ctraces to decode binary payload

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -174,7 +174,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, successful_response_code),
      "Set successful response code. 200, 201 and 204 are supported."
     },
-
+    {
+     FLB_CONFIG_MAP_BOOL, "raw_traces", "false",
+     0, FLB_TRUE, offsetof(struct flb_opentelemetry, raw_traces),
+     "Forward traces without processing"
+    },
 
     /* EOF */
     {0}
@@ -193,5 +197,5 @@ struct flb_input_plugin in_opentelemetry_plugin = {
     .cb_exit      = in_opentelemetry_exit,
     .config_map   = config_map,
     .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS,
-    .event_type   = FLB_INPUT_LOGS | FLB_INPUT_METRICS 
+    .event_type   = FLB_INPUT_LOGS
 };

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -34,6 +34,7 @@ struct flb_opentelemetry {
     flb_sds_t listen;
     flb_sds_t tcp_port;
     const char *tag_key;
+    bool raw_traces;
 
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */


### PR DESCRIPTION
<!-- Provide summary of changes -->

- Use ctraces to decode binary payload
- add config option for `raw_traces` that decides whether to process or forward traces

Signed-off-by: Aditya Prajapati <aditya@calyptia.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[INPUT]
	name opentelemetry
	host 127.0.0.1
	port 4318
	raw_traces true

[OUTPUT]
	name stdout
	match *
```

- [x] Debug log output from testing the change
![image](https://user-images.githubusercontent.com/31011197/195010768-69baf22b-670a-49e0-9aaf-01749a09820c.png)

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
https://pastebin.com/cyfC0DNS

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/872
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
