### PR TITLE
packaging: handle 1.9 package builds for fluent-bit defaults

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -70,12 +70,6 @@ jobs:
           tar -czvf $SOURCE_FILENAME_PREFIX.tar.gz -C source --exclude-vcs .
           md5sum $SOURCE_FILENAME_PREFIX.tar.gz > $SOURCE_FILENAME_PREFIX.tar.gz.md5
           sha256sum $SOURCE_FILENAME_PREFIX.tar.gz > $SOURCE_FILENAME_PREFIX.tar.gz.sha256
-          if [[ -d packaging ]]; then
-            echo "Also adding 1.8 packaging code"
-            tar -czvf $SOURCE_FILENAME_PREFIX-packaging.tar.gz -C packaging --exclude-vcs .
-            md5sum $SOURCE_FILENAME_PREFIX-packaging.tar.gz > $SOURCE_FILENAME_PREFIX-packaging.tar.gz.md5
-            sha256sum $SOURCE_FILENAME_PREFIX-packaging.tar.gz > $SOURCE_FILENAME_PREFIX-packaging.tar.gz.sha256
-          fi
           # Move to a directory to simplify upload/sync
           mkdir -p source-packages
           cp -fv $SOURCE_FILENAME_PREFIX* source-packages/
@@ -145,7 +139,6 @@ jobs:
         env:
           FLB_DISTRO: ${{ matrix.distro }}
           FLB_OUT_DIR: ${{ inputs.version }}/staging
-          FLB_TD: "Off"
           FLB_NIGHTLY_BUILD: ${{ inputs.unstable }}
           CMAKE_INSTALL_PREFIX: /opt/fluent-bit/
         working-directory: packaging

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -67,6 +67,8 @@ fi
 
 # CMake configuration variables, override via environment rather than parameters
 CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-/opt/fluent-bit/}
+# This is required to ensure we set the defaults to off for 1.9 builds
+FLB_TD=${FLB_TD:-Off}
 
 echo "IMAGE_CONTEXT_DIR     => $IMAGE_CONTEXT_DIR"
 echo "CMAKE_INSTALL_PREFIX  => $CMAKE_INSTALL_PREFIX"
@@ -81,6 +83,7 @@ if ! docker build \
     --build-arg CMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
     --build-arg FLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
     --build-arg FLB_JEMALLOC="$FLB_JEMALLOC" \
+    --build-arg FLB_TD="$FLB_TD" \
     $FLB_ARG \
     -t "$MAIN_IMAGE" \
     -f "$IMAGE_CONTEXT_DIR/Dockerfile" \


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Related to #6171 to ensure we correctly default to `fluent-bit` name for 1.9 branch builds.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
