### PR TITLE
packaging: update to provide AL 2022 as an official target

### DIFF
--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -2,6 +2,8 @@
     "linux_targets": [
         "amazonlinux/2",
         "amazonlinux/2.arm64v8",
+        "amazonlinux/2022",
+        "amazonlinux/2022.arm64v8",
         "centos/7",
         "centos/7.arm64v8",
         "centos/8",

--- a/packaging/server/README.md
+++ b/packaging/server/README.md
@@ -1,3 +1,5 @@
+# Release server support
+
 This directory contains the necessary files to support publishing release packages.
 
 The [publish-all.sh](./publish-all.sh) script is intended to cover everything required to push a new (1.9+) version.
@@ -7,16 +9,19 @@ An Aptly [config file](./aptly.conf) is also provided, intended to be installed 
 ## Process
 
 Assuming some variables like so:
+
 - GPG_KEY - the GPG signing key to use, e.g. "a@b.com".
 - VERSION - the new version you want to publish.
 
 For YUM repos, it is:
+
 1. Copy RPMs to the destination dir, e.g. `/var/www/apt.fluentbit.io/amazonlinux/2/aarch64`: `find "$SOURCE_DIR/amazonlinux/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64" \;`
 2. Sign the RPMs if they have not been (CI for 1.9 signs them): `rpm --define "_gpg_name $GPG_KEY" --addsign "*-bit-$VERSION-*aarch64*.rpm"`
 3. Update the repo meta data: `createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64"`
 4. Sign the repo meta data: `find "/var/www/apt.fluentbit.io/" -name repomd.xml -exec gpg --detach-sign --batch --armor --yes -u "$GPG_KEY" {} \;`
 
 For APT repos, it is:
+
 1. Add Debs to the repo: `aptly repo add flb-debian-buster "*-bit_$VERSION*.deb"`
 2. Create a snapshot for the version: `aptly snapshot create "fluent-bit-debian-buster-${VERSION}" from repo flb-debian-buster`
 3. Publish the snapshot: `aptly publish switch -gpg-key="$GPG_KEY" buster filesystem:debian/buster: "fluent-bit-debian-buster-${VERSION}"`

--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -24,49 +24,66 @@ if [[ ! -d "$SOURCE_DIR" ]]; then
     echo "Missing source directory: $SOURCE_DIR"
 fi
 
+# Handle Ubuntu 18/22 differences - no support on Ubuntu 20
+CREATE_REPO_CMD=${CREATE_REPO_CMD:-}
+
+# Assume if set we want to use it
+if [[ -n "$CREATE_REPO_CMD" ]]; then
+    echo "Using $CREATE_REPO_CMD"
+elif command -v createrepo &> /dev/null; then
+    echo "Found createrepo"
+    CREATE_REPO_CMD="createrepo -dvp"
+elif command -v createrepo_c &> /dev/null; then
+    echo "Found createrepo_c"
+    CREATE_REPO_CMD="createrepo_c -dvp"
+else
+    echo "Unable to find a command equivalent to createrepo"
+    exit 1
+fi
+
 # Amazon Linux 2022
 if [[ -d "$SOURCE_DIR/amazonlinux/2022/" ]]; then
     echo "Publishing AmazonLinux 2022"
     mkdir -p /var/www/apt.fluentbit.io/amazonlinux/2022/x86_64 /var/www/apt.fluentbit.io/amazonlinux/2022/aarch64
     find "$SOURCE_DIR/amazonlinux/2022" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2022/x86_64" \;
-    createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2022/x86_64"
+    "$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/amazonlinux/2022/x86_64"
 
     find "$SOURCE_DIR/amazonlinux/2022" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2022/aarch64" \;
-    createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2022/aarch64"
+    "$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/amazonlinux/2022/aarch64"
 fi
 
 # Amazon Linux 2
 echo "Publishing AmazonLinux 2"
 find "$SOURCE_DIR/amazonlinux/2" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64"
 
 find "$SOURCE_DIR/amazonlinux/2" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64"
 
 # Centos 7
 echo "Publishing Centos 7"
 find "$SOURCE_DIR/centos/7/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/7/aarch64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/centos/7/aarch64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/7/aarch64"
 
 find "$SOURCE_DIR/centos/7/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/7/x86_64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/centos/7/x86_64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/7/x86_64"
 
 # Centos 8
 echo "Publishing Centos 8"
 find "$SOURCE_DIR/centos/8/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/8/aarch64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/centos/8/aarch64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/8/aarch64"
 
 find "$SOURCE_DIR/centos/8/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/8/x86_64" \;
-createrepo -dvp "/var/www/apt.fluentbit.io/centos/8/x86_64"
+"$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/8/x86_64"
 
 # Centos 9
 if [[ -d "$SOURCE_DIR/centos/9/" ]]; then
     echo "Publishing Centos 9"
     find "$SOURCE_DIR/centos/9/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/9/aarch64" \;
-    createrepo -dvp "/var/www/apt.fluentbit.io/centos/9/aarch64"
+    "$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/9/aarch64"
 
     find "$SOURCE_DIR/centos/9/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/centos/9/x86_64" \;
-    createrepo -dvp "/var/www/apt.fluentbit.io/centos/9/x86_64"
+    "$CREATE_REPO_CMD" "/var/www/apt.fluentbit.io/centos/9/x86_64"
 fi
 
 # Debian 10 Buster

--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -24,12 +24,23 @@ if [[ ! -d "$SOURCE_DIR" ]]; then
     echo "Missing source directory: $SOURCE_DIR"
 fi
 
+# Amazon Linux 2022
+if [[ -d "$SOURCE_DIR/amazonlinux/2022/" ]]; then
+    echo "Publishing AmazonLinux 2022"
+    mkdir -p /var/www/apt.fluentbit.io/amazonlinux/2022/x86_64 /var/www/apt.fluentbit.io/amazonlinux/2022/aarch64
+    find "$SOURCE_DIR/amazonlinux/2022" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2022/x86_64" \;
+    createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2022/x86_64"
+
+    find "$SOURCE_DIR/amazonlinux/2022" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2022/aarch64" \;
+    createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2022/aarch64"
+fi
+
 # Amazon Linux 2
 echo "Publishing AmazonLinux 2"
-find "$SOURCE_DIR/amazonlinux/" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64" \;
+find "$SOURCE_DIR/amazonlinux/2" -iname "*-bit-$VERSION-*aarch64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64" \;
 createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/aarch64"
 
-find "$SOURCE_DIR/amazonlinux/" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64" \;
+find "$SOURCE_DIR/amazonlinux/2" -iname "*-bit-$VERSION-*x86_64*.rpm" -exec cp -fv {} "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64" \;
 createrepo -dvp "/var/www/apt.fluentbit.io/amazonlinux/2/x86_64"
 
 # Centos 7

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2022
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2022
@@ -1,0 +1,46 @@
+# For staging upgrade we use the 'staging-upgrade-prep' as the base
+ARG STAGING_BASE=dokken/amazonlinux-2022
+
+ARG RELEASE_URL=https://packages.fluentbit.io
+ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
+
+# hadolint ignore=DL3006
+FROM dokken/amazonlinux-2022 as official-install
+
+ARG RELEASE_URL
+ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}
+
+ARG RELEASE_KEY
+ENV FLUENT_BIT_PACKAGES_KEY=${RELEASE_KEY}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit
+
+COPY ./test.sh /test.sh
+RUN chmod a+x /test.sh
+
+FROM official-install as staging-upgrade-prep
+RUN rm -f /etc/yum.repos.d/*-bit.repo
+
+# hadolint ignore=DL3006
+FROM ${STAGING_BASE} as staging-install
+ARG STAGING_VERSION
+ENV STAGING_VERSION=${STAGING_VERSION}
+
+ARG STAGING_URL
+ENV FLUENT_BIT_PACKAGES_URL=${STAGING_URL}
+
+ARG STAGING_KEY=${STAGING_URL}/fluentbit.key
+ENV FLUENT_BIT_PACKAGES_KEY=${STAGING_KEY}
+
+# hadolint ignore=DL3032
+RUN rpm --import "$FLUENT_BIT_PACKAGES_KEY" && \
+    wget -q "$FLUENT_BIT_PACKAGES_URL/amazonlinux-2022.repo" -O /etc/yum.repos.d/staging.repo && \
+    yum update -y && yum install -y fluent-bit && \
+    systemctl enable fluent-bit
+
+COPY ./test.sh /test.sh
+RUN chmod a+x /test.sh
+
+FROM staging-install as staging-upgrade


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Part of steps for #6020 to provide official Amazon Linux 2022 packages.
Also handles usage of `createrepo_c` on Ubuntu 22 for packaging usage - partly required for https://github.com/fluent/fluent-bit/issues/6174.
Final steps are docs and release process itself.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
