### PR TITLE
out_opentelemetry: export traces

### DIFF
--- a/plugins/in_event_type/event_type.c
+++ b/plugins/in_event_type/event_type.c
@@ -45,7 +45,7 @@ static struct ctrace_id *create_random_span_id()
     ssize_t ret;
     struct ctrace_id *cid;
 
-    buf = calloc(1, OTEL_SPAN_ID_LEN);
+    buf = flb_malloc(OTEL_SPAN_ID_LEN);
     if (!buf) {
         ctr_errno();
         return NULL;
@@ -53,12 +53,12 @@ static struct ctrace_id *create_random_span_id()
 
     ret = ctr_random_get(buf, OTEL_SPAN_ID_LEN);
     if (ret < 0) {
-        free(buf);
+        flb_free(buf);
         return NULL;
     }
 
     cid = ctr_id_create(buf, OTEL_SPAN_ID_LEN);
-    free(buf);
+    flb_free(buf);
 
     return cid;
 

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -618,6 +618,6 @@ struct flb_output_plugin out_opentelemetry_plugin = {
     .cb_flush    = cb_opentelemetry_flush,
     .cb_exit     = cb_opentelemetry_exit,
     .config_map  = config_map,
-    .event_type  = FLB_OUTPUT_LOGS,
+    .event_type  = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS | FLB_OUTPUT_TRACES,
     .flags       = FLB_OUTPUT_NET | FLB_IO_OPT_TLS,
 };

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -38,6 +38,7 @@ struct opentelemetry_context {
     int proxy_port;
 
     /* HTTP URI */
+    char *traces_uri;
     char *metrics_uri;
     char *logs_uri;
     char *host;


### PR DESCRIPTION
<!-- Provide summary of changes -->
out_opentelemetry:
- export traces (add config option for traces uri)

in_event_type:
- use correct buffer length for span id
- set correct event type

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[INPUT]
	Name event_type
	type traces

[OUTPUT]
	name opentelemetry
	match *
	host 0.0.0.0
	port 4318

[OUTPUT]
	name stdout
	match *
```

- [x] Debug log output from testing the change

https://pastebin.com/vDeE3xPN

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

https://pastebin.com/YFVmt1ZJ

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
