### PR TITLE
filter_record_modifier: fix ignoring whitelist_keys (#6200)

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -43,7 +43,7 @@ static int config_allowlist_key(struct record_modifier_ctx *ctx,
         return -1;
     }
 
-    flb_config_map_foreach(head, mv, ctx->allowlist_keys_map) {
+    flb_config_map_foreach(head, mv, list) {
         mod_key = flb_malloc(sizeof(struct modifier_key));
         if (!mod_key) {
             flb_errno();


### PR DESCRIPTION
Fixes #6200 

This patch is to allow `Whitelist_keys` for compatibility.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"a":"aaa", "b":"bbb", "c":"ccc"}

[FILTER]
    Name record_modifier
    Match *
    Whitelist_Key a
    Whitelist_Key b


[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full ../../bin/fluent-bit -c a.conf 
==17672== Memcheck, a memory error detector
==17672== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17672== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==17672== Command: ../../bin/fluent-bit -c a.conf
==17672== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/15 07:23:12] [ info] [fluent bit] version=2.0.0, commit=095d090aeb, pid=17672
[2022/10/15 07:23:12] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/15 07:23:12] [ info] [cmetrics] version=0.5.2
[2022/10/15 07:23:12] [ info] [input:dummy:dummy.0] initializing
[2022/10/15 07:23:12] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/10/15 07:23:12] [ info] [output:stdout:stdout.0] worker #0 started
[2022/10/15 07:23:12] [ info] [sp] stream processor started
==17672== Warning: client switching stacks?  SP change: 0x6ffb8b8 --> 0x54a6b60
==17672==          to suppress, use: --max-stackframe=28659032 or greater
==17672== Warning: client switching stacks?  SP change: 0x54a6ab8 --> 0x6ffb8b8
==17672==          to suppress, use: --max-stackframe=28659200 or greater
==17672== Warning: client switching stacks?  SP change: 0x6ffb8b8 --> 0x54a6ab8
==17672==          to suppress, use: --max-stackframe=28659200 or greater
==17672==          further instances of this message will not be shown.
[0] dummy.0: [1665786193.173945255, {"a"=>"aaa", "b"=>"bbb"}]
[0] dummy.0: [1665786194.160469296, {"a"=>"aaa", "b"=>"bbb"}]
^C[2022/10/15 07:23:15] [engine] caught signal (SIGINT)
[2022/10/15 07:23:15] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [1665786195.134433248, {"a"=>"aaa", "b"=>"bbb"}]
[2022/10/15 07:23:15] [ info] [input] pausing dummy.0
[2022/10/15 07:23:16] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/15 07:23:16] [ info] [input] pausing dummy.0
[2022/10/15 07:23:16] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/10/15 07:23:16] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17672== 
==17672== HEAP SUMMARY:
==17672==     in use at exit: 0 bytes in 0 blocks
==17672==   total heap usage: 1,590 allocs, 1,590 frees, 1,335,572 bytes allocated
==17672== 
==17672== All heap blocks were freed -- no leaks are possible
==17672== 
==17672== For lists of detected and suppressed errors, rerun with: -s
==17672== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
