### PR TITLE
out_forward: 1.9 release buf when no connection available and time_as_integer is true(#6082)

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1231,7 +1231,6 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
     int mode;
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
-    void *tmp_buf = NULL;
     void *out_buf = NULL;
     size_t out_size = 0;
     struct flb_forward *ctx = out_context;
@@ -1285,7 +1284,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
             flb_plg_error(ctx->ins, "no upstream connections available");
             msgpack_sbuffer_destroy(&mp_sbuf);
             if (fc->time_as_integer == FLB_TRUE) {
-                flb_free(tmp_buf);
+                flb_free(out_buf);
             }
             flb_free(flush_ctx);
             FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -1304,7 +1303,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
             }
             msgpack_sbuffer_destroy(&mp_sbuf);
             if (fc->time_as_integer == FLB_TRUE) {
-                flb_free(tmp_buf);
+                flb_free(out_buf);
             }
             flb_free(flush_ctx);
             FLB_OUTPUT_RETURN(FLB_RETRY);


### PR DESCRIPTION
This is a porting for 1.9 branch.

Original PR is #6210

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
