### PR TITLE
config_format: fluentbit: set config file number limit and check recursion(#5998)

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -447,6 +447,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
                 cfg_file = tmp;
             }
         }
+#ifndef _WIN32
         /* check if readed file */
         for (i=0; i<*ino_num; i++) {
             if (st.st_ino == ino_table[i]) {
@@ -456,6 +457,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         }
         ino_table[*ino_num]  = st.st_ino;
         *ino_num += 1;
+#endif
     }
 #endif
 

--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -41,6 +41,7 @@
 #endif
 
 #define FLB_CF_BUF_SIZE     4096
+#define FLB_CF_FILE_NUM_LIMIT 1000
 
 /* indent checker return codes */
 #define INDENT_ERROR          -1
@@ -70,7 +71,7 @@ struct local_ctx {
 };
 
 static int read_config(struct flb_cf *cf, struct local_ctx *ctx, char *cfg_file,
-                       char *buf, size_t size);
+                       char *buf, size_t size, ino_t *ino_table, int *ino_num);
 
 /* Raise a configuration schema error */
 static void config_error(const char *path, int line, const char *msg)
@@ -137,7 +138,8 @@ static int static_fgets(char *out, size_t size, const char *data, size_t *off)
 #endif
 
 #ifndef _WIN32
-static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char * path)
+static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char * path,
+                     ino_t *ino_table, int *ino_num)
 {
     int ret = -1;
     glob_t glb;
@@ -174,7 +176,7 @@ static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char * path
     }
 
     for (i = 0; i < glb.gl_pathc; i++) {
-        ret = read_config(cf, ctx, glb.gl_pathv[i], NULL, 0);
+        ret = read_config(cf, ctx, glb.gl_pathv[i], NULL, 0, ino_table, ino_num);
         if (ret < 0) {
             break;
         }
@@ -184,7 +186,8 @@ static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char * path
     return ret;
 }
 #else
-static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char *path)
+static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char *path,
+                     ino_t *ino_table, int *ino_num)
 {
     char *star, *p0, *p1;
     char pattern[MAX_PATH];
@@ -252,13 +255,13 @@ static int read_glob(struct flb_cf *cf, struct local_ctx *ctx, const char *path)
         }
 
         if (strchr(p1, '*')) {
-            read_glob(cf, ctx, buf); /* recursive */
+            read_glob(cf, ctx, buf, ino_table, ino_num); /* recursive */
             continue;
         }
 
         ret = stat(buf, &st);
         if (ret == 0 && (st.st_mode & S_IFMT) == S_IFREG) {
-            if (read_config(cf, ctx, buf, NULL, 0) < 0) {
+            if (read_config(cf, ctx, buf, NULL, 0, ino_table, ino_num) < 0) {
                 return -1;
             }
         }
@@ -397,7 +400,8 @@ static int check_indent(const char *line, const char *indent, int *out_level)
 }
 
 static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
-                       char *cfg_file, char *in_data, size_t in_size)
+                       char *cfg_file, char *in_data, size_t in_size,
+                       ino_t *ino_table, int *ino_num)
 {
     int i;
     int len;
@@ -422,8 +426,11 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     struct flb_cf_group *current_group = NULL;
     struct cfl_variant *var;
 
-    struct flb_kv *kv;
     FILE *f = NULL;
+
+    if (*ino_num >= FLB_CF_FILE_NUM_LIMIT) {
+        return -1;
+    }
 
     /* Check if the path exists (relative cases for included files) */
 #ifndef FLB_HAVE_STATIC_CONF
@@ -440,6 +447,15 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
                 cfg_file = tmp;
             }
         }
+        /* check if readed file */
+        for (i=0; i<*ino_num; i++) {
+            if (st.st_ino == ino_table[i]) {
+                flb_warn("[config] Read twice. path=%s", cfg_file);
+                return -1;
+            }
+        }
+        ino_table[*ino_num]  = st.st_ino;
+        *ino_num += 1;
     }
 #endif
 
@@ -512,10 +528,10 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
 
         if (len > 9 && strncasecmp(buf, "@INCLUDE ", 9) == 0) {
             if (strchr(buf + 9, '*') != NULL) {
-                ret = read_glob(cf, ctx, buf + 9);
+                ret = read_glob(cf, ctx, buf + 9, ino_table, ino_num);
             }
             else {
-                ret = read_config(cf, ctx, buf + 9, NULL, 0);
+                ret = read_config(cf, ctx, buf + 9, NULL, 0, ino_table, ino_num);
             }
             if (ret == -1) {
                 ctx->level--;
@@ -723,6 +739,8 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
 {
     int ret;
     struct local_ctx ctx;
+    ino_t ino_table[FLB_CF_FILE_NUM_LIMIT];
+    int ino_num = 0;
 
     if (!cf) {
         cf = flb_cf_create();
@@ -739,12 +757,15 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
         return NULL;
     }
 
-    ret = read_config(cf, &ctx, file_path, buf, size);
+    ret = read_config(cf, &ctx, file_path, buf, size, &ino_table[0], &ino_num);
 
     local_exit(&ctx);
 
     if (ret == -1) {
         flb_cf_destroy(cf);
+        if (ino_num >= FLB_CF_FILE_NUM_LIMIT) {
+            flb_error("Too many config files. Limit = %d", FLB_CF_FILE_NUM_LIMIT);
+        }
         return NULL;
     }
 

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -15,6 +15,7 @@
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/classic/fluent-bit.conf"
 #define FLB_001 FLB_TESTS_DATA_PATH "/data/config_format/classic/issue_5880.conf"
 #define FLB_002 FLB_TESTS_DATA_PATH "/data/config_format/classic/indent_level_error.conf"
+#define FLB_003 FLB_TESTS_DATA_PATH "/data/config_format/classic/recursion.conf"
 
 #define ERROR_LOG "fluentbit_conf_error.log"
 
@@ -208,9 +209,25 @@ void indent_level_error()
     unlink(ERROR_LOG);
 }
 
+void recursion()
+{
+	struct flb_cf *cf;
+
+    cf = flb_cf_create();
+    if (!TEST_CHECK(cf != NULL)) {
+        TEST_MSG("flb_cf_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    cf = flb_cf_fluentbit_create(cf, FLB_003, NULL, 0);
+
+    /* No SIGSEGV means success */
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
     { "missing_value_issue5880" , missing_value},
     { "indent_level_error" , indent_level_error},
+    { "recursion" , recursion},
     { 0 }
 };

--- a/tests/internal/data/config_format/classic/recursion.conf
+++ b/tests/internal/data/config_format/classic/recursion.conf
@@ -1,0 +1,1 @@
+@INCLUDE rec*


### PR DESCRIPTION
This commit 
- Sets a limit number of config files. (1000)
- Checks recursion based on inode number.

Fluent-bit allocates an array to save inodes to compare new file's inode.
If the inode is matched, fluent-bit aborts.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
@INCLUDE *
```

## Debug log

```
$ ../../bin/fluent-bit -c error.conf 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/16 09:13:59] [ warn] [config] Read twice. path=/home/taka/git/fluent-bit/build/issues/5998//error.conf
[2022/10/16 09:13:59] [error] configuration file contains errors, aborting.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
