### PR TITLE
in_tail: fix ingestion when incoming data span multiple buffers when ingested via IN_MODIFY events.

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -314,6 +314,47 @@ static int in_tail_watcher_callback(struct flb_input_instance *ins,
     return ret;
 }
 
+static int in_tail_progress_check_callback(struct flb_input_instance *ins,
+                                           struct flb_config *config, void *context)
+{
+    int ret = 0;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_tail_config *ctx = context;
+    struct flb_tail_file *file;
+    struct stat st;
+    (void) config;
+
+    mk_list_foreach_safe(head, tmp, &ctx->files_static) {
+        file = mk_list_entry(head, struct flb_tail_file, _head);
+
+        ret = fstat(file->fd, &st);
+        if (ret == -1) {
+            flb_plg_error(ins, "fstat error");
+            continue;
+        }
+
+        if (file->offset < st.st_size) {
+            flb_tail_file_chunk(file);
+        }
+    }
+
+    mk_list_foreach_safe(head, tmp, &ctx->files_event) {
+        file = mk_list_entry(head, struct flb_tail_file, _head);
+
+        ret = fstat(file->fd, &st);
+        if (ret == -1) {
+            flb_plg_error(ins, "fstat error");
+            continue;
+        }
+
+        if (file->offset < st.st_size) {
+            flb_tail_file_chunk(file);
+        }
+    }
+    return 0;
+}
+
 int in_tail_collect_event(void *file, struct flb_config *config)
 {
     int ret;
@@ -404,6 +445,17 @@ static int in_tail_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->coll_fd_watcher = ret;
+
+    /* Register callback to check current tail offsets */
+    ret = flb_input_set_collector_time(in, in_tail_progress_check_callback,
+                                       ctx->progress_check_interval,
+                                       ctx->progress_check_interval_nsec,
+                                       config);
+    if (ret == -1) {
+        flb_tail_config_destroy(ctx);
+        return -1;
+    }
+    ctx->coll_fd_progress_check = ret;
 
     /* Register callback to purge rotated files */
     ret = flb_input_set_collector_time(in, flb_tail_file_purge,
@@ -569,6 +621,14 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_TIME, "watcher_interval", "2s",
      0, FLB_TRUE, offsetof(struct flb_tail_config, watcher_interval),
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "progress_check_interval", "2s",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, progress_check_interval),
+    },
+    {
+     FLB_CONFIG_MAP_INT, "progress_check_interval_nsec", "0",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, progress_check_interval_nsec),
     },
     {
      FLB_CONFIG_MAP_TIME, "rotate_wait", FLB_TAIL_ROTATE_WAIT,

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -69,6 +69,7 @@ struct flb_tail_config {
     int coll_fd_inactive;
     int coll_fd_dmode_flush;
     int coll_fd_mult_flush;
+    int coll_fd_progress_check;
 
     /* Backend collectors */
     int coll_fd_fs1;           /* used by fs_inotify & fs_stat */
@@ -92,6 +93,9 @@ struct flb_tail_config {
     int   skip_long_lines;     /* skip long lines              */
     int   skip_empty_lines;    /* skip empty lines (off)       */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+
+    int progress_check_interval;      /* watcher interval             */
+    int progress_check_interval_nsec; /* watcher interval             */
 
 #ifdef FLB_HAVE_INOTIFY
     int   inotify_watcher;     /* enable/disable inotify monitor */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes an issue where not all events are ingested by in_tail when triggered by IN_MODIFY events using inotify.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
