### PR TITLE
Add new metric cmt_proc_records_total_by_group

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2500,7 +2500,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 
     /* Update metrics counter by using labels/http status code */
     if (ret == 0) {
-        update_http_metrics(ctx, event_chunk, ts, c->resp.status);
+        update_http_metrics(ctx, event_chunk, ts, c->resp.status, input_name, output_name);
     }
 #endif
 

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2326,21 +2326,26 @@ static int stackdriver_format_test(struct flb_config *config,
 static void update_http_metrics(struct flb_stackdriver *ctx,
                                 struct flb_event_chunk *event_chunk,
                                 uint64_t ts,
-                                int http_status)
+                                int http_status,
+                                char *input_name,
+                                char *output_name)
 {
     char tmp[32];
 
     /* convert status to string format */
     snprintf(tmp, sizeof(tmp) - 1, "%i", http_status);
-    char *name = (char *) flb_output_name(ctx->ins);
 
     /* processed records total */
     cmt_counter_add(ctx->cmt_proc_records_total, ts, event_chunk->total_events,
-                    2, (char *[]) {tmp, name});
+                    2, (char *[]) {tmp, output_name});
+    
+    /* processed records total by group */
+    cmt_counter_add(ctx->cmt_proc_records_total_by_group, ts, event_chunk->total_events,
+                    2, (char *[]) {tmp, input_name, output_name});
 
     /* HTTP status */
     if (http_status != STACKDRIVER_NET_ERROR) {
-        cmt_counter_inc(ctx->cmt_requests_total, ts, 2, (char *[]) {tmp, name});
+        cmt_counter_inc(ctx->cmt_requests_total, ts, 2, (char *[]) {tmp, output_name});
     }
 }
 #endif
@@ -2351,7 +2356,6 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
                                  void *out_context,
                                  struct flb_config *config)
 {
-    (void) i_ins;
     (void) config;
     int ret;
     int ret_code = FLB_RETRY;
@@ -2363,7 +2367,14 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     struct flb_connection *u_conn;
     struct flb_http_client *c;
 #ifdef FLB_HAVE_METRICS
-    char *name = (char *) flb_output_name(ctx->ins);
+    char *output_name = (char *) flb_output_name(ctx->ins);
+    char *input_name;
+    if (i_ins->alias) {
+        input_name = i_ins->alias;
+    }
+    else {
+        input_name = i_ins->name;
+    }    
     uint64_t ts = cfl_time_now();
 #endif
 
@@ -2372,12 +2383,12 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     if (!u_conn) {
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
-                        ts, 1, (char *[]) {name});
+                        ts, 1, (char *[]) {output_name});
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);
 
-        update_http_metrics(ctx, event_chunk, ts, STACKDRIVER_NET_ERROR);
+        update_http_metrics(ctx, event_chunk, ts, STACKDRIVER_NET_ERROR, input_name, output_name);
 #endif
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
@@ -2390,7 +2401,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     if (!payload_buf) {
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
-                        ts, 1, (char *[]) {name});
+                        ts, 1, (char *[]) {output_name});
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);
@@ -2408,7 +2419,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         flb_sds_destroy(payload_buf);
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
-                        ts, 1, (char *[]) {name});
+                        ts, 1, (char *[]) {output_name});
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);
@@ -2442,7 +2453,7 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         flb_plg_warn(ctx->ins, "http_do=%i", ret);
         ret_code = FLB_RETRY;
 #ifdef FLB_HAVE_METRICS
-        update_http_metrics(ctx, event_chunk, ts, STACKDRIVER_NET_ERROR);
+        update_http_metrics(ctx, event_chunk, ts, STACKDRIVER_NET_ERROR, input_name, output_name);
 #endif
     }
     else {
@@ -2474,14 +2485,14 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 #ifdef FLB_HAVE_METRICS
     if (ret_code == FLB_OK) {
         cmt_counter_inc(ctx->cmt_successful_requests,
-                        ts, 1, (char *[]) {name});
+                        ts, 1, (char *[]) {output_name});
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_SUCCESSFUL_REQUESTS, 1, ctx->ins->metrics);
     }
     else {
         cmt_counter_inc(ctx->cmt_failed_requests,
-                        ts, 1, (char *[]) {name});
+                        ts, 1, (char *[]) {output_name});
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -198,6 +198,7 @@ struct flb_stackdriver {
     struct cmt_counter *cmt_failed_requests;
     struct cmt_counter *cmt_requests_total;
     struct cmt_counter *cmt_proc_records_total;
+    struct cmt_counter *cmt_proc_records_total_by_group;
     struct cmt_counter *cmt_retried_records_total;
 #endif
 

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -546,6 +546,13 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
                                                      "Total number of processed records.",
                                                      2, (char *[]) {"status", "name"});
 
+    ctx->cmt_proc_records_total_by_group = cmt_counter_create(ins->cmt,
+                                                     "fluentbit",
+                                                     "stackdriver",
+                                                     "proc_records_total_by_group",
+                                                     "Total number of processed records by group.",
+                                                     3, (char *[]) {"status", "input_name", "output_name"});
+
     ctx->cmt_retried_records_total = cmt_counter_create(ins->cmt,
                                                         "fluentbit",
                                                         "stackdriver",


### PR DESCRIPTION
Adding a new metric `cmt_proc_records_total_by_group ` which will records the number of count of processed log entries by its input plugin name and its output plugin name

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
