### PR TITLE
in_tail: fix rotation handling in windows

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1436,7 +1436,7 @@ int flb_tail_file_is_rotated(struct flb_tail_config *ctx,
         ret = lstat(file->name, &st);
         if (ret == -1) {
             /* Broken link or missing file */
-            if (errno == ENOENT) {
+            if (errno == ENOENT || errno == 0) {
                 flb_plg_info(ctx->ins, "inode=%"PRIu64" link_rotated: %s",
                              file->link_inode, file->name);
                 return FLB_TRUE;


### PR DESCRIPTION
Signed-off-by: alt-dima <dmitrii.altukhov@guesty.com>

I have a problem with in_tail in docker container inside Kubernetes with Windows 2019 nodes. Seems like rotation handling working correctly, but error appears.
```
[2022/10/18 07:04:59] [error] [C:\src\plugins\in_tail\tail_file.c:1445 errno=0] No error
[2022/10/18 07:04:59] [error] [input:tail:tail.0] link_inode=562949954146799 cannot detect if file: C:\var\log\containers\rms-poco-web-7ddc48bfb6-9k54x_default_rms-poco-web-1ad967282dda16ee80fb7b7e49930874ca695d34c0b2e554e573fe1e76623bfd.log
[2022/10/18 07:04:59] [ info] [input:tail:tail.0] inode=2814749767831688 handle rotation(): C:\var\log\containers\rms-poco-web-7ddc48bfb6-9k54x_default_rms-poco-web-1ad967282dda16ee80fb7b7e49930874ca695d34c0b2e554e573fe1e76623bfd.log => C:\ProgramData\docker\containers\1ad967282dda16ee80fb7b7e49930874ca695d34c0b2e554e573fe1e76623bfd\1ad967282dda16ee80fb7b7e49930874ca695d34c0b2e554e573fe1e76623bfd-json.log
```
Will try to fix
https://github.com/fluent/fluent-bit/blob/master/plugins/in_tail/tail_file.c#L1439
`if (errno == ENOENT) {` to `if (errno == ENOENT || errno == 0) {`

Yes! It helped, now looks good
```
│ [2022/10/18 08:12:45] [ info] [input:tail:tail.0] inode=844424930857462 link_rotated: C:\var\log\containers\rms-poco-web-7ddc48bfb6-qrwl8_default_rms-poco-web-1f6667f77f3a2b51d6eae45f0f22bb24e15c55c79ddbda0faa99740d4dc0ce87.log                      │
│ [2022/10/18 08:12:45] [ info] [input:tail:tail.0] inode=562949954146808 handle rotation(): C:\var\log\containers\rms-poco-web-7ddc48bfb6-qrwl8_default_rms-poco-web-1f6667f77f3a2b51d6eae45f0f22bb24e15c55c79ddbda0faa99740d4dc0ce87.log => C:\ProgramData\docker\containers\1f6667f77f3a2b51d6eae45f0f22bb24e15c55c79ddbda0faa99740d4dc0ce87\1f6667f77f3a2b51d6eae45f0f22bb24e15c55c79ddbda0faa99740d4dc0ce87-json.log 
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
