### PR TITLE
out_opentelemetry: add gzip compression

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -28,6 +28,7 @@
 #include <fluent-otel-proto/fluent-otel.h>
 
 #include <cmetrics/cmetrics.h>
+#include <fluent-bit/flb_gzip.h>
 #include <cmetrics/cmt_encode_opentelemetry.h>
 
 #include <ctraces/ctraces.h>
@@ -55,6 +56,9 @@ static int http_post(struct opentelemetry_context *ctx,
     struct flb_config_map_val *mv;
     struct flb_slist_entry *key = NULL;
     struct flb_slist_entry *val = NULL;
+    void *final_body = NULL;
+    size_t final_body_len = 0;
+    int compressed = FLB_FALSE;
 
     /* Get upstream context and connection */
     u = ctx->u;
@@ -64,10 +68,21 @@ static int http_post(struct opentelemetry_context *ctx,
                       u->tcp_host, u->tcp_port);
         return FLB_RETRY;
     }
-
+     if (ctx->compress_gzip == FLB_TRUE) {
+        ret = flb_gzip_compress((void *) body, body_len,
+                                &final_body, &final_body_len);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "cannot gzip payload, disabling compression");
+        } else {
+            compressed = FLB_TRUE;
+        }
+    } else {
+        final_body = body;
+        final_body_len = body_len;
+    }
     /* Create HTTP client context */
     c = flb_http_client(u_conn, FLB_HTTP_POST, uri,
-                        body, body_len,
+                        final_body, final_body_len,
                         ctx->host, ctx->port,
                         ctx->proxy, 0);
 
@@ -107,7 +122,9 @@ static int http_post(struct opentelemetry_context *ctx,
                             key->str, flb_sds_len(key->str),
                             val->str, flb_sds_len(val->str));
     }
-
+    if (compressed == FLB_TRUE) {
+        flb_http_set_content_encoding_gzip(c);
+    }
     ret = flb_http_do(c, &b_sent);
     if (ret == 0) {
         /*
@@ -605,6 +622,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "log_response_payload", "true",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, log_response_payload),
      "Specify if the response paylod should be logged or not"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "compress", NULL,
+     0, FLB_FALSE, 0,
+     "Set payload compression mechanism. Option available is 'gzip'"
     },
     /* EOF */
     {0}

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -171,6 +171,13 @@ static int http_post(struct opentelemetry_context *ctx,
         out_ret = FLB_RETRY;
     }
 
+    /*
+     * If the payload buffer is different than incoming records in body, means
+     * we generated a different payload and must be freed.
+     */
+    if (final_body != body) {
+        flb_free(final_body);
+    }
     /* Destroy HTTP client context */
     flb_http_client_destroy(c);
 

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -62,6 +62,9 @@ struct opentelemetry_context {
 
     /* instance context */
     struct flb_output_instance *ins;
+
+    /* Compression mode (gzip) */
+    int compress_gzip;
 };
 
 #endif

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -132,6 +132,7 @@ struct opentelemetry_context *flb_opentelemetry_context_create(
     char *logs_uri = NULL;
     struct flb_upstream *upstream;
     struct opentelemetry_context *ctx = NULL;
+    char *tmp = NULL;
 
     /* Allocate plugin context */
     ctx = flb_calloc(1, sizeof(struct opentelemetry_context));
@@ -231,6 +232,14 @@ struct opentelemetry_context *flb_opentelemetry_context_create(
 
     /* Set instance flags into upstream */
     flb_output_upstream_set(ctx->u, ins);
+
+    tmp = flb_output_get_property("compress", ins);
+    ctx->compress_gzip = FLB_FALSE;
+    if (tmp) {
+        if (strcasecmp(tmp, "gzip") == 0) {
+            ctx->compress_gzip = FLB_TRUE;
+        }
+    }
 
     return ctx;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add GZIP compression option to opentelemetry output plugin. 


**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/939

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

