### PR TITLE
input: added missing mandatory TLS parameter detection and reporting.

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -883,6 +883,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     struct flb_config *ctx = ins->config;
     struct mk_list *config_map;
     struct flb_input_plugin *p = ins->p;
+    const char *tls_error_message;
 
     if (ins->log_level == -1 && config->log != NULL) {
         ins->log_level = config->log->level;
@@ -1057,19 +1058,42 @@ int flb_input_instance_init(struct flb_input_instance *ins,
 
 #ifdef FLB_HAVE_TLS
     if (ins->use_tls == FLB_TRUE) {
-        ins->tls = flb_tls_create(FLB_TLS_SERVER_MODE,
-                                  ins->tls_verify,
-                                  ins->tls_debug,
-                                  ins->tls_vhost,
-                                  ins->tls_ca_path,
-                                  ins->tls_ca_file,
-                                  ins->tls_crt_file,
-                                  ins->tls_key_file,
-                                  ins->tls_key_passwd);
+        if (ins->tls_crt_file == NULL) {
+            tls_error_message = "certificate file missing";
+
+            ins->tls = NULL;
+        }
+        else if (ins->tls_key_file == NULL) {
+            tls_error_message = "private key file missing";
+
+            ins->tls = NULL;
+        }
+        else {
+            tls_error_message = NULL;
+
+            ins->tls = flb_tls_create(FLB_TLS_SERVER_MODE,
+                                      ins->tls_verify,
+                                      ins->tls_debug,
+                                      ins->tls_vhost,
+                                      ins->tls_ca_path,
+                                      ins->tls_ca_file,
+                                      ins->tls_crt_file,
+                                      ins->tls_key_file,
+                                      ins->tls_key_passwd);
+        }
+
         if (ins->tls == NULL) {
-            flb_error("[input %s] error initializing TLS context",
-                      ins->name);
+            if (tls_error_message != NULL) {
+                flb_error("[input %s] error initializing TLS context (%s)",
+                          ins->name, tls_error_message);
+            }
+            else {
+                flb_error("[input %s] error initializing TLS context",
+                          ins->name);
+            }
+
             flb_input_instance_destroy(ins);
+
             return -1;
         }
     }


### PR DESCRIPTION
This PR adds a check to ensure the user is providing both a certificate and a private key file when using TLS in input plugins.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>