### PR TITLE
out_splunk: Handle metrics type of events

### DIFF
--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -37,6 +37,7 @@
 #include <cmetrics/cmt_encode_prometheus.h>
 #include <cmetrics/cmt_encode_prometheus_remote_write.h>
 #include <cmetrics/cmt_encode_msgpack.h>
+#include <cmetrics/cmt_encode_splunk_hec.h>
 
 /* Metrics IDs for general purpose (used by core and Plugins */
 #define FLB_METRIC_N_RECORDS   0

--- a/lib/cmetrics/CMakeLists.txt
+++ b/lib/cmetrics/CMakeLists.txt
@@ -8,6 +8,32 @@ include(cmake/macros.cmake)
 include(CheckCSourceCompiles)
 include(GNUInstallDirs)
 
+# On macOS, search Homebrew for keg-only versions of Bison and Flex. Xcode does
+# not provide new enough versions for us to use.
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+        COMMAND brew --prefix bison
+        RESULT_VARIABLE BREW_BISON
+        OUTPUT_VARIABLE BREW_BISON_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_BISON EQUAL 0 AND EXISTS "${BREW_BISON_PREFIX}")
+        message(STATUS "Found Bison keg installed by Homebrew at ${BREW_BISON_PREFIX}")
+        set(BISON_EXECUTABLE "${BREW_BISON_PREFIX}/bin/bison")
+    endif()
+
+    execute_process(
+        COMMAND brew --prefix flex
+        RESULT_VARIABLE BREW_FLEX
+        OUTPUT_VARIABLE BREW_FLEX_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_FLEX EQUAL 0 AND EXISTS "${BREW_FLEX_PREFIX}")
+        message(STATUS "Found Flex keg installed by Homebrew at ${BREW_FLEX_PREFIX}")
+        set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
+    endif()
+endif()
+
 # Define macro to identify Windows system (without Cygwin)
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(CMT_SYSTEM_WINDOWS On)
@@ -31,7 +57,7 @@ endif()
 # CMetrics Version
 set(CMT_VERSION_MAJOR  0)
 set(CMT_VERSION_MINOR  5)
-set(CMT_VERSION_PATCH  2)
+set(CMT_VERSION_PATCH  3)
 set(CMT_VERSION_STR "${CMT_VERSION_MAJOR}.${CMT_VERSION_MINOR}.${CMT_VERSION_PATCH}")
 
 # Define __CMT_FILENAME__ consistently across Operating Systems

--- a/lib/cmetrics/include/cmetrics/cmt_encode_splunk_hec.h
+++ b/lib/cmetrics/include/cmetrics/cmt_encode_splunk_hec.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2022 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef CMT_ENCODE_SPLUNK_HEC_H
+#define CMT_ENCODE_SPLUNK_HEC_H
+
+#include <cmetrics/cmetrics.h>
+
+#define CMT_ENCODE_SPLUNK_HEC_SUCCESS                0
+#define CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR       1
+#define CMT_ENCODE_SPLUNK_HEC_INVALID_ARGUMENT_ERROR 2
+#define CMT_ENCODE_SPLUNK_HEC_UNEXPECTED_METRIC_TYPE 3
+#define CMT_ENCODE_SPLUNK_HEC_INVALID_DATA_ERROR     4
+
+struct cmt_splunk_hec_context {
+  const char *host;
+  const char *index;
+  const char *source;
+  const char *source_type;
+  struct cmt *cmt;
+};
+
+cfl_sds_t cmt_encode_splunk_hec_create(struct cmt *cmt, const char *host,
+                                       const char *index, const char *source, const char *source_type);
+void cmt_encode_splunk_hec_destroy(cfl_sds_t text);
+
+#endif

--- a/lib/cmetrics/src/CMakeLists.txt
+++ b/lib/cmetrics/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(src
   cmt_decode_opentelemetry.c
   cmt_encode_prometheus.c
   cmt_encode_prometheus_remote_write.c
+  cmt_encode_splunk_hec.c
   cmt_encode_text.c
   cmt_encode_influx.c
   cmt_encode_msgpack.c

--- a/lib/cmetrics/src/cmt_encode_splunk_hec.c
+++ b/lib/cmetrics/src/cmt_encode_splunk_hec.c
@@ -1,0 +1,705 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2022 The CMetrics Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_metric.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_untyped.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_time.h>
+#include <cmetrics/cmt_compat.h>
+#include <cmetrics/cmt_encode_splunk_hec.h>
+
+static cfl_sds_t double_to_string(double val)
+{
+    int len;
+    cfl_sds_t str;
+
+    str = cfl_sds_create_size(64);
+    if (!str) {
+        return NULL;
+    }
+
+    len = snprintf(str, 64, "%g", val);
+    cfl_sds_len_set(str, len);
+
+    if (!strchr(str, '.')) {
+        cfl_sds_cat_safe(&str, ".0", 2);
+    }
+
+    return str;
+}
+
+static void format_metric_name(cfl_sds_t *buf, struct cmt_map *map, const char *suffix)
+{
+    int mlen = 0;
+    int slen = 0;
+    cfl_sds_t metric_name = NULL;
+    struct cmt_opts *opts;
+
+    opts = map->opts;
+
+    if (cfl_sds_len(opts->subsystem) > 0) {
+        /* Calculate length for "metric_name:subsystem.name": */
+        mlen = 13 + cfl_sds_len(opts->subsystem) + 1 + cfl_sds_len(opts->name) + 2;
+        metric_name = cfl_sds_create_size(mlen);
+        cfl_sds_cat_safe(&metric_name, "\"metric_name:", 13);
+        cfl_sds_cat_safe(&metric_name, opts->subsystem, cfl_sds_len(opts->subsystem));
+        cfl_sds_cat_safe(&metric_name, ".", 1);
+        cfl_sds_cat_safe(&metric_name, opts->name, cfl_sds_len(opts->name));
+    }
+    else {
+        /* Calculate length for "metric_name:subsystem.name": */
+        mlen = 13 + cfl_sds_len(opts->name) + 2;
+        metric_name = cfl_sds_create_size(mlen);
+        cfl_sds_cat_safe(&metric_name, "\"metric_name:", 13);
+        cfl_sds_cat_safe(&metric_name, opts->name, cfl_sds_len(opts->name));
+    }
+    if (suffix != NULL) {
+        slen = strlen(suffix);
+        mlen += slen;
+        cfl_sds_cat_safe(&metric_name, suffix, slen);
+    }
+    cfl_sds_cat_safe(&metric_name, "\":", 2);
+    cfl_sds_cat_safe(buf, metric_name, mlen);
+    cfl_sds_destroy(metric_name);
+}
+
+static void format_metric_type(cfl_sds_t *buf, const char *metric_type_name)
+{
+    int len = 0;
+    char tmp[32];
+
+    len = snprintf(tmp, sizeof(tmp) - 1, ",\"metric_type\":\"%s\"", metric_type_name);
+    cfl_sds_cat_safe(buf, tmp, len);
+}
+
+static void append_metric_value(cfl_sds_t *buf, struct cmt_map *map,
+                                struct cmt_metric *metric)
+{
+    int len;
+    double val;
+    char tmp[128];
+    cfl_sds_t metric_val;
+
+    /* Retreive metric name */
+    format_metric_name(buf, map, NULL);
+
+    /* Retrieve metric value */
+    val = cmt_metric_get_value(metric);
+    metric_val = double_to_string(val);
+
+    len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_val);
+    cfl_sds_cat_safe(buf, tmp, len);
+    cfl_sds_destroy(metric_val);
+}
+
+static void format_context_common(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                                  struct cmt_metric *metric)
+{
+    int len, tlen;
+    char hostname[256], timestamp[128];
+    char *index = NULL, *source = NULL, *source_type = NULL;
+    struct timespec tms;
+    uint64_t ts;
+    int result = CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR;
+
+    /* Open parenthesis */
+    cfl_sds_cat_safe(buf, "{", 1);
+
+    /* host */
+    len = snprintf(hostname, sizeof(hostname) - 1, "\"host\":\"%s\",", context->host);
+    cfl_sds_cat_safe(buf, hostname, len);
+
+    /* timestamp (RFC3339Nano) */
+    ts = cmt_metric_get_timestamp(metric);
+    cmt_time_from_ns(&tms, ts);
+
+    /* timestamp (floting point) */
+    len = snprintf(timestamp, sizeof(timestamp) - 1, "\"time\":%09lu.%09lu,", tms.tv_sec, tms.tv_nsec);
+    cfl_sds_cat_safe(buf, timestamp, len);
+
+    /* event type: metric */
+    cfl_sds_cat_safe(buf, "\"event\":\"metric\",", 17);
+
+    /* index */
+    if (context->index != NULL) {
+        tlen = strlen(context->index) + 12; /* adding snprintf template character length */
+        index = malloc(tlen);
+        if (index == NULL) {
+            cmt_errno();
+            result = CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR;
+
+            goto cleanup;
+        }
+        len = snprintf(index, tlen, "\"index\":\"%s\",", context->index);
+        cfl_sds_cat_safe(buf, index, len);
+        free(index);
+    }
+
+    /* source */
+    if (context->source != NULL) {
+        tlen = strlen(context->source) + 13; /* adding snprintf template character length */
+        source = malloc(tlen);
+        if (source == NULL) {
+            cmt_errno();
+            result = CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR;
+
+            goto cleanup;
+        }
+        len = snprintf(source, tlen, "\"source\":\"%s\",", context->source);
+        cfl_sds_cat_safe(buf, source, len);
+        free(source);
+    }
+
+    /* sourcetype */
+    if (context->source_type != NULL) {
+        tlen = strlen(context->source_type) + 18; /* adding snprintf template character length */
+        source_type = malloc(tlen);
+        if (source == NULL) {
+            cmt_errno();
+            result = CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR;
+
+            goto cleanup;
+        }
+        len = snprintf(source_type, tlen, "\"sourcetype\":\"%s\",", context->source_type);
+        cfl_sds_cat_safe(buf, source_type, len);
+        free(source_type);
+    }
+
+    return;
+
+cleanup:
+    if (result != CMT_ENCODE_SPLUNK_HEC_SUCCESS) {
+        if (index != NULL) {
+            free(index);
+        }
+        if (source != NULL) {
+            free(source);
+        }
+        if (source_type != NULL) {
+            free(source_type);
+        }
+    }
+}
+
+static void format_metric_labels(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                                 struct cmt_metric *metric)
+{
+    int i;
+    int n;
+    int count = 0;
+    int static_labels = 0;
+
+    struct cmt_map_label *label_k;
+    struct cmt_map_label *label_v;
+    struct cfl_list *head;
+    struct cmt_label *slabel;
+
+    /* Static labels */
+    static_labels = cmt_labels_count(context->cmt->static_labels);
+    if (static_labels > 0) {
+        cfl_sds_cat_safe(buf, ",", 1);
+        cfl_list_foreach(head, &context->cmt->static_labels->list) {
+            count++;
+            cfl_sds_cat_safe(buf, "\"", 1);
+            slabel = cfl_list_entry(head, struct cmt_label, _head);
+            cfl_sds_cat_safe(buf, slabel->key, cfl_sds_len(slabel->key));
+            cfl_sds_cat_safe(buf, "\":\"", 3);
+            cfl_sds_cat_safe(buf, slabel->val, cfl_sds_len(slabel->val));
+            cfl_sds_cat_safe(buf, "\"", 1);
+
+            if (count < static_labels) {
+                cfl_sds_cat_safe(buf, ",", 1);
+            }
+        }
+    }
+
+    n = cfl_list_size(&metric->labels);
+    if (n > 0) {
+        cfl_sds_cat_safe(buf, ",", 1);
+        label_k = cfl_list_entry_first(&map->label_keys, struct cmt_map_label, _head);
+
+        i = 0;
+        cfl_list_foreach(head, &metric->labels) {
+            label_v = cfl_list_entry(head, struct cmt_map_label, _head);
+
+            cfl_sds_cat_safe(buf, "\"", 1);
+            cfl_sds_cat_safe(buf, label_k->name, cfl_sds_len(label_k->name));
+            cfl_sds_cat_safe(buf, "\":\"", 3);
+            cfl_sds_cat_safe(buf, label_v->name, cfl_sds_len(label_v->name));
+            cfl_sds_cat_safe(buf, "\"", 1);
+            i++;
+
+            label_k = cfl_list_entry_next(&label_k->_head, struct cmt_map_label,
+                                         _head, &map->label_keys);
+            if (i < n) {
+                cfl_sds_cat_safe(buf, ",", 1);
+            }
+        }
+    }
+}
+
+static void append_bucket_metric(cfl_sds_t *buf, struct cmt_map *map,
+                                 struct cmt_metric *metric, int index)
+{
+    int len = 0;
+    double val;
+    char tmp[128];
+    cfl_sds_t metric_val;
+
+    /* metric name for bucket */
+    format_metric_name(buf, map, "_bucket");
+
+    /* Retrieve metric value */
+    val = cmt_metric_hist_get_value(metric, index);
+    metric_val = double_to_string(val);
+
+    len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_val);
+    cfl_sds_cat_safe(buf, tmp, len);
+    cfl_sds_destroy(metric_val);
+}
+
+static void format_histogram_bucket(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                                    struct cmt_metric *metric)
+{
+    int index;
+    int len = 0;
+    char tmp[128];
+    cfl_sds_t val;
+    uint64_t metric_val;
+    struct cmt_histogram *histogram;
+    struct cmt_histogram_buckets *buckets;
+    cfl_sds_t metric_str;
+
+    histogram = (struct cmt_histogram *) map->parent;
+    buckets = histogram->buckets;
+
+    for (index = 0; index <= buckets->count; index++) {
+        /* Common fields */
+        format_context_common(context, buf, map, metric);
+
+        /* Other fields */
+        cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+        /* bucket metric */
+        append_bucket_metric(buf, map, metric, index);
+
+        /* upper bound */
+        cfl_sds_cat_safe(buf, ",\"le\":", 6);
+
+        if (index < buckets->count) {
+            cfl_sds_cat_safe(buf, "\"", 1);
+            val = double_to_string(buckets->upper_bounds[index]);
+            cfl_sds_cat_safe(buf, val, cfl_sds_len(val));
+            cfl_sds_destroy(val);
+            cfl_sds_cat_safe(buf, "\"", 1);
+        }
+        else {
+            cfl_sds_cat_safe(buf, "\"+Inf\"", 6);
+        }
+
+        /* Format labels */
+        format_metric_labels(context, buf, map, metric);
+
+        /* Format metric type */
+        format_metric_type(buf, "Histogram");
+
+        /* Close parenthesis for fields */
+        cfl_sds_cat_safe(buf, "}", 1);
+
+        /* Close parenthesis */
+        cfl_sds_cat_safe(buf, "}", 1);
+    }
+
+    /* Format histogram sum */
+    {
+        /* Common fields */
+        format_context_common(context, buf, map, metric);
+
+        /* Other fields */
+        cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+        /* metric name for bucket */
+        format_metric_name(buf, map, "_sum");
+
+        /* Retrieve metric value */
+        metric_val = cmt_metric_hist_get_sum_value(metric);
+        metric_str = double_to_string(metric_val);
+
+        len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_str);
+        cfl_sds_cat_safe(buf, tmp, len);
+        cfl_sds_destroy(metric_str);
+
+        /* Format labels */
+        format_metric_labels(context, buf, map, metric);
+
+        /* Format metric type */
+        format_metric_type(buf, "Histogram");
+
+        /* Close parenthesis for fields */
+        cfl_sds_cat_safe(buf, "}", 1);
+
+        /* Close parenthesis */
+        cfl_sds_cat_safe(buf, "}", 1);
+    }
+
+    /* Format histogram sum */
+    {
+        /* Common fields */
+        format_context_common(context, buf, map, metric);
+
+        /* Other fields */
+        cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+        /* metric name for bucket */
+        format_metric_name(buf, map, "_count");
+
+        /* Retrieve metric value */
+        metric_val = cmt_metric_hist_get_count_value(metric);
+        metric_str = double_to_string(metric_val);
+
+        len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_str);
+        cfl_sds_cat_safe(buf, tmp, len);
+        cfl_sds_destroy(metric_str);
+
+        /* Format labels */
+        format_metric_labels(context, buf, map, metric);
+
+        /* Format metric type */
+        format_metric_type(buf, "Histogram");
+
+        /* Close parenthesis for fields */
+        cfl_sds_cat_safe(buf, "}", 1);
+
+        /* Close parenthesis */
+        cfl_sds_cat_safe(buf, "}", 1);
+    }
+}
+
+static void append_quantiles_metric(cfl_sds_t *buf, struct cmt_map *map,
+                                    struct cmt_metric *metric, int index)
+{
+    int len = 0;
+    double val;
+    char tmp[128];
+    cfl_sds_t metric_val;
+
+    /* metric name for bucket */
+    format_metric_name(buf, map, NULL);
+
+    /* Retrieve metric value */
+    val = cmt_summary_quantile_get_value(metric, index);
+    metric_val = double_to_string(val);
+
+    len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_val);
+    cfl_sds_cat_safe(buf, tmp, len);
+    cfl_sds_destroy(metric_val);
+}
+
+static void format_summary_metric(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                                  struct cmt_metric *metric)
+{
+    int index;
+    int len = 0;
+    char tmp[128];
+    cfl_sds_t val;
+    uint64_t metric_val;
+    struct cmt_summary *summary;
+    cfl_sds_t metric_str;
+
+    summary = (struct cmt_summary *) map->parent;
+
+    if (metric->sum_quantiles_set) {
+        for (index = 0; index < summary->quantiles_count; index++) {
+            /* Common fields */
+            format_context_common(context, buf, map, metric);
+
+            /* Other fields */
+            cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+            /* bucket metric */
+            append_quantiles_metric(buf, map, metric, index);
+
+            /* quantiles */
+            cfl_sds_cat_safe(buf, ",\"qt\":\"", 7);
+            val = double_to_string(summary->quantiles[index]);
+            cfl_sds_cat_safe(buf, val, cfl_sds_len(val));
+            cfl_sds_destroy(val);
+            cfl_sds_cat_safe(buf, "\"", 1);
+
+            /* Format labels */
+            format_metric_labels(context, buf, map, metric);
+
+            /* Format metric type */
+            format_metric_type(buf, "Summary");
+
+            /* Close parenthesis for fields */
+            cfl_sds_cat_safe(buf, "}", 1);
+
+            /* Close parenthesis */
+            cfl_sds_cat_safe(buf, "}", 1);
+        }
+    }
+
+    /* Format Summary sum */
+    {
+        /* Common fields */
+        format_context_common(context, buf, map, metric);
+
+        /* Other fields */
+        cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+        /* metric name for bucket */
+        format_metric_name(buf, map, "_sum");
+
+        /* Retrieve metric value */
+        metric_val = cmt_summary_get_sum_value(metric);
+        metric_str = double_to_string(metric_val);
+
+        len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_str);
+        cfl_sds_cat_safe(buf, tmp, len);
+        cfl_sds_destroy(metric_str);
+
+        /* Format labels */
+        format_metric_labels(context, buf, map, metric);
+
+        /* Format metric type */
+        format_metric_type(buf, "Summary");
+
+        /* Close parenthesis for fields */
+        cfl_sds_cat_safe(buf, "}", 1);
+
+        /* Close parenthesis */
+        cfl_sds_cat_safe(buf, "}", 1);
+    }
+
+    /* Format summary count */
+    {
+        /* Common fields */
+        format_context_common(context, buf, map, metric);
+
+        /* Other fields */
+        cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+        /* metric name for bucket */
+        format_metric_name(buf, map, "_count");
+
+        /* Retrieve metric value */
+        metric_val = cmt_summary_get_count_value(metric);
+        metric_str = double_to_string(metric_val);
+
+        len = snprintf(tmp, sizeof(tmp) - 1, "%s", metric_str);
+        cfl_sds_cat_safe(buf, tmp, len);
+        cfl_sds_destroy(metric_str);
+
+        /* Format labels */
+        format_metric_labels(context, buf, map, metric);
+
+        /* Format metric type */
+        format_metric_type(buf, "Summary");
+
+        /* Close parenthesis for fields */
+        cfl_sds_cat_safe(buf, "}", 1);
+
+        /* Close parenthesis */
+        cfl_sds_cat_safe(buf, "}", 1);
+    }
+}
+
+static void format_metric_data_points(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                                      struct cmt_metric *metric)
+{
+    /* Common fields */
+    format_context_common(context, buf, map, metric);
+
+    /* Other fields */
+    cfl_sds_cat_safe(buf, "\"fields\":{", 10);
+
+    /* Metric name and value */
+    append_metric_value(buf, map, metric);
+
+    /* Format labels */
+    format_metric_labels(context, buf, map, metric);
+
+    /* Close parenthesis for fields */
+    cfl_sds_cat_safe(buf, "}", 1);
+
+    /* Close parenthesis */
+    cfl_sds_cat_safe(buf, "}", 1);
+}
+
+static void format_metric(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map,
+                          struct cmt_metric *metric)
+{
+    if (map->type == CMT_HISTOGRAM) {
+        return format_histogram_bucket(context, buf, map, metric);
+    }
+    else if (map->type == CMT_SUMMARY) {
+        return format_summary_metric(context, buf, map, metric);
+    }
+    else {
+        /* For Counter, Gauge, and Untyped types */
+        return format_metric_data_points(context, buf, map, metric);
+    }
+}
+
+static void format_metrics(struct cmt_splunk_hec_context *context, cfl_sds_t *buf, struct cmt_map *map)
+{
+    struct cfl_list *head;
+    struct cmt_metric *metric;
+
+    /* Simple metric, no labels */
+    if (map->metric_static_set == 1) {
+        format_metric(context, buf, map, &map->metric);
+    }
+
+    cfl_list_foreach(head, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        format_metric(context, buf, map, metric);
+    }
+}
+
+static void destroy_splunk_hec_context(struct cmt_splunk_hec_context *context)
+{
+    if (context != NULL) {
+        free(context);
+    }
+}
+
+static struct cmt_splunk_hec_context
+*initialize_splunk_hec_context(struct cmt *cmt, const char *host,
+                               const char *index, const char *source, const char *source_type)
+{
+    int result = CMT_ENCODE_SPLUNK_HEC_SUCCESS;
+    struct cmt_splunk_hec_context *context = NULL;
+
+    context = calloc(1, sizeof(struct cmt_splunk_hec_context));
+    if (context == NULL) {
+        result = CMT_ENCODE_SPLUNK_HEC_ALLOCATION_ERROR;
+
+        goto cleanup;
+    }
+
+    /* host parameter is mandatory. */
+    if (host == NULL) {
+        result = CMT_ENCODE_SPLUNK_HEC_INVALID_ARGUMENT_ERROR;
+
+        goto cleanup;
+    }
+
+    memset(context, 0, sizeof(struct cmt_splunk_hec_context));
+    context->cmt = cmt;
+    context->host = host;
+    context->index = NULL;
+    context->source = NULL;
+    context->source_type = NULL;
+
+    /* Setting up optional members. */
+    if (index != NULL) {
+        context->index = index;
+    }
+    if (source != NULL) {
+        context->source = source;
+    }
+    if (source_type != NULL) {
+        context->source_type = source_type;
+    }
+
+cleanup:
+    if (result != CMT_ENCODE_SPLUNK_HEC_SUCCESS) {
+        if (context != NULL) {
+            destroy_splunk_hec_context(context);
+
+            context = NULL;
+        }
+    }
+
+    return context;
+}
+
+/* Format all the registered metrics in Splunk HEC JSON format */
+cfl_sds_t cmt_encode_splunk_hec_create(struct cmt *cmt, const char *host,
+                                       const char *index, const char *source, const char *source_type)
+{
+    cfl_sds_t buf;
+    struct cfl_list *head;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_untyped *untyped;
+    struct cmt_summary *summary;
+    struct cmt_histogram *histogram;
+    struct cmt_splunk_hec_context *context;
+
+    context = initialize_splunk_hec_context(cmt, host, index, source, source_type);
+
+    if (context == NULL) {
+        return NULL;
+    }
+
+    /* Allocate a 1KB of buffer */
+    buf = cfl_sds_create_size(1024);
+    if (!buf) {
+        return NULL;
+    }
+
+    /* Counters */
+    cfl_list_foreach(head, &cmt->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+        format_metrics(context, &buf, counter->map);
+    }
+
+    /* Gauges */
+    cfl_list_foreach(head, &cmt->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+        format_metrics(context, &buf, gauge->map);
+    }
+
+    /* Summaries */
+    cfl_list_foreach(head, &cmt->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+        format_metrics(context, &buf, summary->map);
+    }
+
+    /* Histograms */
+    cfl_list_foreach(head, &cmt->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+        format_metrics(context, &buf, histogram->map);
+    }
+
+    /* Untyped */
+    cfl_list_foreach(head, &cmt->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+        format_metrics(context, &buf, untyped->map);
+    }
+
+    if (context != NULL) {
+      destroy_splunk_hec_context(context);
+    }
+
+    return buf;
+}
+
+void cmt_encode_splunk_hec_destroy(cfl_sds_t text)
+{
+    cfl_sds_destroy(text);
+}

--- a/lib/cmetrics/tests/encoding.c
+++ b/lib/cmetrics/tests/encoding.c
@@ -32,6 +32,7 @@
 #include <cmetrics/cmt_encode_opentelemetry.h>
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_encode_influx.h>
+#include <cmetrics/cmt_encode_splunk_hec.h>
 
 #include "cmt_tests.h"
 
@@ -727,6 +728,258 @@ void test_influx()
     cmt_destroy(cmt);
 }
 
+void test_splunk_hec()
+{
+    uint64_t ts;
+    cfl_sds_t text;
+    struct cmt *cmt;
+    struct cmt_counter *c1;
+    struct cmt_counter *c2;
+    const char *host = "localhost", *index = "fluent-bit-metrics", *source = "fluent-bit-cmetrics", *source_type = "cmetrics";
+
+    char *out1 = \
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:labels.test\":1.0}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:labels.test\":2.0,\"host\":\"calyptia.com\",\"app\":\"cmetrics\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:nosubsystem\":1.0,\"host\":\"aaa\",\"app\":\"bbb\"}}";
+
+    char *out2 = \
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"fields\":{\"metric_name:labels.test\":1.0,\"dev\":\"Calyptia\",\"lang\":\"C\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"fields\":{\"metric_name:labels.test\":2.0,\"dev\":\"Calyptia\",\"lang\":\"C\",\"host\":\"calyptia.com\",\"app\":\"cmetrics\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"fields\":{\"metric_name:nosubsystem\":1.0,\"dev\":\"Calyptia\",\"lang\":\"C\",\"host\":\"aaa\",\"app\":\"bbb\"}}";
+
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    c1 = cmt_counter_create(cmt, "cmt", "labels", "test", "Static labels test",
+                            2, (char *[]) {"host", "app"});
+
+    ts = 1435658235000000123;
+    cmt_counter_inc(c1, ts, 0, NULL);
+    cmt_counter_inc(c1, ts, 2, (char *[]) {"calyptia.com", "cmetrics"});
+    cmt_counter_inc(c1, ts, 2, (char *[]) {"calyptia.com", "cmetrics"});
+
+    c2 = cmt_counter_create(cmt, "cmt", "", "nosubsystem", "No subsystem",
+                            2, (char *[]) {"host", "app"});
+
+    cmt_counter_inc(c2, ts, 2, (char *[]) {"aaa", "bbb"});
+
+    /* Encode to splunk hec (no static labels) */
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out1) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    /* append static labels */
+    cmt_label_add(cmt, "dev", "Calyptia");
+    cmt_label_add(cmt, "lang", "C");
+
+    text = cmt_encode_splunk_hec_create(cmt, host, index, NULL, NULL);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out2) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    cmt_destroy(cmt);
+}
+
+/* values to observe in a histogram */
+double hist_observe_values[10] = {
+                                  0.0 , 1.02, 2.04, 3.06,
+                                  4.08, 5.10, 6.12, 7.14,
+                                  8.16, 9.18
+                                 };
+
+static int histogram_observe_all(struct cmt_histogram *h,
+                                 uint64_t timestamp,
+                                 int labels_count, char **labels_vals)
+{
+    int i;
+    double val;
+
+    for (i = 0; i < sizeof(hist_observe_values)/(sizeof(double)); i++) {
+        val = hist_observe_values[i];
+        cmt_histogram_observe(h, timestamp, val, labels_count, labels_vals);
+    }
+
+    return i;
+}
+
+void test_splunk_hec_histogram()
+{
+    uint64_t ts;
+    cfl_sds_t text;
+    struct cmt *cmt;
+    struct cmt_histogram *h;
+    struct cmt_histogram_buckets *buckets;
+    const char *host = "localhost", *index = "fluent-bit-metrics", *source = "fluent-bit-cmetrics", *source_type = "cmetrics";
+
+    char *out1 =
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.005\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.01\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.025\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.05\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.1\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.25\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.5\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"1.0\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":3.0,\"le\":\"2.5\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":5.0,\"le\":\"5.0\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":10.0,\"le\":\"10.0\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":10.0,\"le\":\"+Inf\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_sum\":45.0,\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_count\":10.0,\"metric_type\":\"Histogram\"}}";
+    char *out2 =
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.005\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.01\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.025\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.05\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.1\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.25\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"0.5\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":1.0,\"le\":\"1.0\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":3.0,\"le\":\"2.5\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":5.0,\"le\":\"5.0\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":10.0,\"le\":\"10.0\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_bucket\":10.0,\"le\":\"+Inf\",\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_sum\":45.0,\"static\":\"test\",\"metric_type\":\"Histogram\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_count\":10.0,\"static\":\"test\",\"metric_type\":\"Histogram\"}}";
+
+    cmt_initialize();
+
+    /* CMetrics context */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Timestamp */
+    ts = 1435658235000000123;
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(11,
+                                           0.005, 0.01, 0.025, 0.05,
+                                           0.1, 0.25, 0.5, 1.0, 2.5,
+                                           5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a gauge metric type */
+    h = cmt_histogram_create(cmt,
+                             "k8s", "network", "load", "Network load",
+                             buckets,
+                             1, (char *[]) {"my_label"});
+    TEST_CHECK(h != NULL);
+
+    /* no labels */
+    histogram_observe_all(h, ts, 0, NULL);
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out1) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    /* static label: register static label for the context */
+    cmt_label_add(cmt, "static", "test");
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out2) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    /* defined labels: add a custom label value */
+    histogram_observe_all(h, ts, 1, (char *[]) {"val"});
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    cmt_encode_splunk_hec_destroy(text);
+
+    cmt_destroy(cmt);
+}
+
+void test_splunk_hec_summary()
+{
+    double sum;
+    uint64_t count;
+    uint64_t ts;
+    double q[6];
+    double r[6];
+    cfl_sds_t text;
+    struct cmt *cmt;
+    struct cmt_summary *s;
+    const char *host = "localhost", *index = "fluent-bit-metrics", *source = "fluent-bit-cmetrics", *source_type = "cmetrics";
+
+    char *out1 =
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_sum\":51.0,\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_count\":10.0,\"metric_type\":\"Summary\"}}";
+    char *out2 =
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":1.0,\"qt\":\"0.1\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":2.0,\"qt\":\"0.2\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":3.0,\"qt\":\"0.3\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":4.0,\"qt\":\"0.4\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":5.0,\"qt\":\"0.5\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":6.0,\"qt\":\"1.0\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_sum\":51.0,\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_count\":10.0,\"metric_type\":\"Summary\"}}";
+    char *out3 =
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":1.0,\"qt\":\"0.1\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":2.0,\"qt\":\"0.2\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":3.0,\"qt\":\"0.3\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":4.0,\"qt\":\"0.4\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":5.0,\"qt\":\"0.5\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load\":6.0,\"qt\":\"1.0\",\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_sum\":51.0,\"static\":\"test\",\"metric_type\":\"Summary\"}}"
+        "{\"host\":\"localhost\",\"time\":1435658235.000000123,\"event\":\"metric\",\"index\":\"fluent-bit-metrics\",\"source\":\"fluent-bit-cmetrics\",\"sourcetype\":\"cmetrics\",\"fields\":{\"metric_name:network.load_count\":10.0,\"static\":\"test\",\"metric_type\":\"Summary\"}}";
+
+    cmt_initialize();
+
+    /* Timestamp */
+    ts = 1435658235000000123;
+
+    /* CMetrics context */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* set quantiles, no labels */
+    q[0] = 0.1;
+    q[1] = 0.2;
+    q[2] = 0.3;
+    q[3] = 0.4;
+    q[4] = 0.5;
+    q[5] = 1.0;
+
+    r[0] = 1;
+    r[1] = 2;
+    r[2] = 3;
+    r[3] = 4;
+    r[4] = 5;
+    r[5] = 6;
+
+    /* Create a gauge metric type */
+    s = cmt_summary_create(cmt,
+                           "k8s", "network", "load", "Network load",
+                           6, q,
+                           1, (char *[]) {"my_label"});
+    TEST_CHECK(s != NULL);
+
+    count = 10;
+    sum   = 51.612894511314444;
+
+    /* no quantiles, no labels */
+    cmt_summary_set_default(s, ts, NULL, sum, count, 0, NULL);
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out1) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    cmt_summary_set_default(s, ts, r, sum, count, 0, NULL);
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out2) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    /* static label: register static label for the context */
+    cmt_label_add(cmt, "static", "test");
+    text = cmt_encode_splunk_hec_create(cmt, host, index, source, source_type);
+    printf("%s\n", text);
+    TEST_CHECK(strcmp(text, out3) == 0);
+    cmt_encode_splunk_hec_destroy(text);
+
+    cmt_destroy(cmt);
+}
+
 TEST_LIST = {
     {"cmt_msgpack_cleanup_on_error",   test_cmt_to_msgpack_cleanup_on_error},
     {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
@@ -739,5 +992,8 @@ TEST_LIST = {
     {"prometheus",                     test_prometheus},
     {"text",                           test_text},
     {"influx",                         test_influx},
+    {"splunk_hec",                     test_splunk_hec},
+    {"splunk_hec_histogram",           test_splunk_hec_histogram},
+    {"splunk_hec_summary",             test_splunk_hec_summary},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
With cmetrics support of Splunk HEC encoding, we can handle metrics type of events on out_splunk.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
