### PR TITLE
in_cpu: fix pointer to v_cpuid

### DIFF
--- a/plugins/in_cpu/cpu.c
+++ b/plugins/in_cpu/cpu.c
@@ -135,7 +135,7 @@ static inline double proc_cpu_load(int cpus, struct cpu_stats *cstats)
                 fmt = " %s %lu %lu %lu %lu %lu";
                 ret = sscanf(line,
                              fmt,
-                             &s->v_cpuid,
+                             s->v_cpuid,
                              &s->v_user,
                              &s->v_nice,
                              &s->v_system,


### PR DESCRIPTION
Inlining the format string produces this warning:

    format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘char (*)[8]’

`v_cpuid` is already a `char[8]`, so it can be passed directly.

Signed-off-by: Tobias Nießen <tniessen@tnie.de>
