### PR TITLE
fluent-bit: fix command line parsing with new config format API.

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -627,7 +627,7 @@ static int set_property(struct flb_cf *cf, struct flb_cf_section *s, char *kv)
     }
 
     tmp = flb_cf_section_property_add(cf, s->properties, key, 0, value, 0);
-    if (tmp != 0) {
+    if (tmp == NULL) {
         fprintf(stderr, "[error] setting up section '%s' plugin property '%s'\n",
                 s->name, key);
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Minor bug fix to update the usage of the new config format API from the command line.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
