### PR TITLE
in_tail: Fix multiline + Path_Key emitting empty logs

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -866,8 +866,8 @@ static int ml_flush_callback(struct flb_ml_parser *parser,
     else {
         /* adjust the records in a new buffer */
         record_append_custom_keys(file,
-                                  file->mult_sbuf.data,
-                                  file->mult_sbuf.size,
+                                  buf_data,
+                                  buf_size,
                                   &mult_buf, &mult_size);
 
         ml_stream_buffer_append(file, mult_buf, mult_size);


### PR DESCRIPTION
When appending Path_Key or Offset_Key in multiline mode, append the keys to the correct buffer.

Fixes #6240

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [x] Backport to latest stable release.

* Backport PR: https://github.com/fluent/fluent-bit/pull/6244

## Configuration
**main.conf**
```
[INPUT]
    Name              tail
    Key               message
    Path              ./test.log
    Path_Key          path
    Read_from_Head    True
    Tag               json_log
    multiline.parser  multiline_parser

[OUTPUT]
    Match *
    Name stdout
```
**parser.conf**
```
[MULTILINE_PARSER]
    flush_timeout 5000
    name          multiline_parser
    type          regex
    rule          "start_state"    "^{.*"    "cont"
    rule          "cont"    "^[^{]"    "cont"
```
**test.log**
```
{"message": "test_message"}
{"message": "test_message2"}
{
 "message": "multi-line-message"
}

```

## Valgrind output
```
$ valgrind bin/fluent-bit --config main.conf --parser parser.conf --verbose
==73203== Memcheck, a memory error detector
==73203== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==73203== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==73203== Command: bin/fluent-bit --config main.conf --parser parser.conf --verbose
==73203== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/19 22:55:42] [ info] Configuration:
[2022/10/19 22:55:42] [ info]  flush time     | 1.000000 seconds
[2022/10/19 22:55:42] [ info]  grace          | 5 seconds
[2022/10/19 22:55:42] [ info]  daemon         | 0
[2022/10/19 22:55:42] [ info] ___________
[2022/10/19 22:55:42] [ info]  inputs:
[2022/10/19 22:55:42] [ info]      tail
[2022/10/19 22:55:42] [ info] ___________
[2022/10/19 22:55:42] [ info]  filters:
[2022/10/19 22:55:42] [ info] ___________
[2022/10/19 22:55:42] [ info]  outputs:
[2022/10/19 22:55:42] [ info]      stdout.0
[2022/10/19 22:55:42] [ info] ___________
[2022/10/19 22:55:42] [ info]  collectors:
[2022/10/19 22:55:43] [ info] [fluent bit] version=2.0.0, commit=19690076e6, pid=73203
[2022/10/19 22:55:43] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/10/19 22:55:43] [ info] [storage] ver=1.3.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/19 22:55:43] [ info] [cmetrics] version=0.5.2
[2022/10/19 22:55:43] [ info] [input:tail:tail.0] initializing
[2022/10/19 22:55:43] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2022/10/19 22:55:43] [ info] [output:stdout:stdout.0] worker #0 started
[2022/10/19 22:55:43] [debug] [tail:tail.0] created event channels: read=21 write=22
[2022/10/19 22:55:43] [ info] [input:tail:tail.0] multiline core started
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] inotify watch fd=28
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] scanning path ./test.log
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] inode=5511413 with offset=0 appended as ./test.log
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] scan_glob add(): ./test.log, inode 5511413
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] 1 new files found on path './test.log'
[2022/10/19 22:55:43] [debug] [stdout:stdout.0] created event channels: read=30 write=31
[2022/10/19 22:55:43] [debug] [router] match rule tail.0:stdout.0
[2022/10/19 22:55:43] [ info] [sp] stream processor started
[2022/10/19 22:55:43] [debug] [input chunk] update output instances with new chunk size diff=131
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] [static files] processed 94b
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] inode=5511413 file=./test.log promote to TAIL_EVENT
[2022/10/19 22:55:43] [ info] [input:tail:tail.0] inotify_fs_add(): inode=5511413 watch_fd=1 name=./test.log
[2022/10/19 22:55:43] [debug] [input:tail:tail.0] [static files] processed 0b, done
==73203== Warning: client switching stacks?  SP change: 0x6b779d8 --> 0x5043850
==73203==          to suppress, use: --max-stackframe=28524936 or greater
==73203== Warning: client switching stacks?  SP change: 0x50437a8 --> 0x6b779d8
==73203==          to suppress, use: --max-stackframe=28525104 or greater
==73203== Warning: client switching stacks?  SP change: 0x6b779d8 --> 0x50437a8
==73203==          to suppress, use: --max-stackframe=28525104 or greater
==73203==          further instances of this message will not be shown.
[0] json_log: [1666234543.169631261, {"log"=>"{"message": "test_message"}
[2022/10/19 22:55:44] [debug] [task] created task=0x50372e0 id=0 OK
", "path"=>"./test.log"}]
[1] json_log: [1666234543.176461997, {"log"=>"{"message": "test_message2"}
", "path"=>"./test.log"}]
[2022/10/19 22:55:44] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2022/10/19 22:55:44] [debug] [out flush] cb_destroy coro_id=0
[2022/10/19 22:55:44] [debug] [task] destroy task=0x50372e0 (task_id=0)
[2022/10/19 22:55:53] [debug] [input chunk] update output instances with new chunk size diff=75
[2022/10/19 22:55:53] [debug] [task] created task=0x50c2b40 id=0 OK
[2022/10/19 22:55:53] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] json_log: [1666234543.191564117, {"log"=>"{
 "message": "multi-line-message"
}
", "path"=>"./test.log"}]
[2022/10/19 22:55:53] [debug] [out flush] cb_destroy coro_id=1
[2022/10/19 22:55:53] [debug] [task] destroy task=0x50c2b40 (task_id=0)
^C[2022/10/19 22:55:55] [engine] caught signal (SIGINT)
[2022/10/19 22:55:55] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/19 22:55:55] [ info] [input] pausing tail.0
[2022/10/19 22:55:56] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/19 22:55:56] [ info] [input] pausing tail.0
[2022/10/19 22:55:56] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
==73203== 
==73203== HEAP SUMMARY:
==73203==     in use at exit: 0 bytes in 0 blocks
==73203==   total heap usage: 1,801 allocs, 1,801 frees, 1,345,447 bytes allocated
==73203== 
==73203== All heap blocks were freed -- no leaks are possible
==73203== 
==73203== For lists of detected and suppressed errors, rerun with: -s
==73203== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
