### PR TITLE
example: wasm: Fix typos

### DIFF
--- a/examples/filter_rust/README.md
+++ b/examples/filter_rust/README.md
@@ -49,7 +49,7 @@ Create fluent-bit configuration file as follows:
 [FILTER]
     Name wasm
     Tag  dummy.*
-    WASI_Path /path/to/filter_rust.wasm
+    WASM_Path /path/to/filter_rust.wasm
     Function_Name rust_filter
     accessible_paths .,/path/to/fluent-bit
 

--- a/examples/filter_rust_clib/README.md
+++ b/examples/filter_rust_clib/README.md
@@ -67,7 +67,7 @@ Create fluent-bit configuration file as follows:
 [FILTER]
     Name wasm
     Tag  dummy.*
-    WASI_Path /path/to/rust_clib_filter.wasm
+    WASM_Path /path/to/rust_clib_filter.wasm
     Function_Name rust_clib_filter
     accessible_paths .,/path/to/fluent-bit
 


### PR DESCRIPTION
filter_wasm handles `WASM_Path` instead of `WASI_Path`.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
