### PR TITLE
out_loki: get tenant_id before removing keys(#6207)

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1120,6 +1120,14 @@ static int pack_record(struct flb_loki *ctx,
     msgpack_unpacked mp_buffer;
     size_t off = 0;
 
+    /*
+     * Get tenant id from record before removing keys.
+     * https://github.com/fluent/fluent-bit/issues/6207
+     */
+    if (ctx->ra_tenant_id_key && rec->type == MSGPACK_OBJECT_MAP) {
+        get_tenant_id_from_record(ctx, rec);
+    }
+
     /* Remove keys in remove_keys */
     msgpack_unpacked_init(&mp_buffer);
     if (ctx->remove_mpa) {
@@ -1134,11 +1142,6 @@ static int pack_record(struct flb_loki *ctx,
             }
             rec = &mp_buffer.data;
         }
-    }
-
-    // Get tenant id from record.
-    if (ctx->ra_tenant_id_key && rec->type == MSGPACK_OBJECT_MAP) {
-        get_tenant_id_from_record(ctx, rec);
     }
 
     /* Drop single key */


### PR DESCRIPTION
Fixes #6207 

Refer to #6207, user wants to get tenant_id from record to use as a http header and remove it from record.
This patch is to call `get_tenant_id_from_record` before removing keys.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
## Configuration

```
[INPUT]
    Name dummy
    Dummy {"namespace":"NAME", "container":"CONTAINER", "host":"HOST", "app":"APP", "stream":"STREAM", "tenant_id":"TENANT_ID"}

[OUTPUT]
    Name loki
    Match *
    Host localhost
    label_keys $namespace,$container,$host,$app,$stream
    drop_single_key On
    line_format key_value
    tenant_id_key tenant_id
    remove_keys namespace,container,host,app,stream,tenant_id
```

## Debug /Valgrind output

Following log is output of `nc -l 3100`
```
taka@taka-VirtualBox:~$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: localhost:3100
Content-Length: 151
User-Agent: Fluent-Bit
Content-Type: application/json
X-Scope-OrgID: TENANT_ID

{"streams":[{"stream":{"namespace":"NAME","container":"CONTAINER","host":"HOST","app":"APP","stream":"STREAM"},"values":[["1666266446578005773",""]]}]}
```

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==3540== Memcheck, a memory error detector
==3540== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3540== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==3540== Command: bin/fluent-bit -c a.conf
==3540== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/20 20:49:13] [ info] [fluent bit] version=2.0.0, commit=3000f699f2, pid=3540
[2022/10/20 20:49:13] [ info] [storage] ver=1.3.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/20 20:49:13] [ info] [cmetrics] version=0.5.2
[2022/10/20 20:49:13] [ info] [input:dummy:dummy.0] initializing
[2022/10/20 20:49:13] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/10/20 20:49:13] [ info] [output:loki:loki.0] configured, hostname=localhost:3100
[2022/10/20 20:49:13] [ info] [sp] stream processor started
^C[2022/10/20 20:49:24] [engine] caught signal (SIGINT)
[2022/10/20 20:49:24] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/20 20:49:24] [ info] [input] pausing dummy.0
[2022/10/20 20:49:25] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/20 20:49:25] [ info] [input] pausing dummy.0
==3540== 
==3540== HEAP SUMMARY:
==3540==     in use at exit: 0 bytes in 0 blocks
==3540==   total heap usage: 2,966 allocs, 2,966 frees, 5,980,795 bytes allocated
==3540== 
==3540== All heap blocks were freed -- no leaks are possible
==3540== 
==3540== For lists of detected and suppressed errors, rerun with: -s
==3540== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
