### PR TITLE
upstream: fix the stuck issue happened in Windows Server 2016 and 2019.

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -435,11 +435,16 @@ static int prepare_destroy_conn(struct flb_upstream_conn *u_conn)
     }
 
     if (u_conn->fd > 0) {
+#ifdef FLB_HAVE_TLS
+        if (u_conn->tls_session) {
+            flb_tls_session_destroy(u_conn->tls, u_conn);
+        }
+#endif
+        shutdown(u_conn->fd, SHUT_RDWR);
         flb_socket_close(u_conn->fd);
         u_conn->fd = -1;
         u_conn->event.fd = -1;
     }
-
     /* remove connection from the queue */
     mk_list_del(&u_conn->_head);
 
@@ -483,11 +488,6 @@ static int destroy_conn(struct flb_upstream_conn *u_conn)
         return 0;
     }
 
-#ifdef FLB_HAVE_TLS
-    if (u_conn->tls_session) {
-        flb_tls_session_destroy(u_conn->tls, u_conn);
-    }
-#endif
     mk_list_del(&u_conn->_head);
     flb_free(u_conn);
 
@@ -855,10 +855,6 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
         mk_list_foreach_safe(u_head, tmp, &uq->av_queue) {
             u_conn = mk_list_entry(u_head, struct flb_upstream_conn, _head);
             if ((now - u_conn->ts_available) >= u->net.keepalive_idle_timeout) {
-                if (u_conn->fd != -1) {
-                    shutdown(u_conn->fd, SHUT_RDWR);
-                }
-
                 prepare_destroy_conn(u_conn);
                 flb_debug("[upstream] drop keepalive connection #%i to %s:%i "
                           "(keepalive idle timeout)",


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch fix the issue https://github.com/fluent/fluent-bit/issues/6163. It moves the close socket function from prepare_destroy_conn to destroy_conn function. In the old way, prepare_destroy_conn or flb_upstream_conn_timeouts will close or shutdown the socket, then call flb_tls_session_destroy to shutdown ssl, which causes failure of SSL_shutdown. And randomly fluent-bit is stuck at the second SSL_shutdown call in Windows Server 2016 or 2019. After this change, SSL_shutdown works correctly.

Signed-off-by: Richard Su sudahang@hotmail.com
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
https://github.com/fluent/fluent-bit/issues/6163
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
