### PR TITLE
chunk_trace: minor fixes when tracing with rewrite_tag filters.

### DIFF
--- a/src/flb_chunk_trace.c
+++ b/src/flb_chunk_trace.c
@@ -451,33 +451,35 @@ int flb_chunk_trace_input(struct flb_chunk_trace *trace)
 
     msgpack_pack_str_with_body(&mp_pck, "records", strlen("records"));
 
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto sbuffer_error;
-        }
-        records++;
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+    if (buf_size > 0) {
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto sbuffer_error;
+            }
+            records++;
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
 
-    msgpack_pack_array(&mp_pck, records);
+        msgpack_pack_array(&mp_pck, records);
 
-    off = 0;
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto sbuffer_error;
-        }
-        flb_time_pop_from_msgpack(&tm, &result, &record);
+        off = 0;
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto sbuffer_error;
+            }
+            flb_time_pop_from_msgpack(&tm, &result, &record);
 
-        msgpack_pack_map(&mp_pck, 2);
-        msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
-        flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
-        msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
-        msgpack_pack_object(&mp_pck, *record);
+            msgpack_pack_map(&mp_pck, 2);
+            msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
+            flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
+            msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
+            msgpack_pack_object(&mp_pck, *record);
 
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+    }
 
     msgpack_pack_str_with_body(&mp_pck, "start_time", strlen("start_time"));
     flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
@@ -544,32 +546,34 @@ int flb_chunk_trace_pre_output(struct flb_chunk_trace *trace)
 
     msgpack_pack_str_with_body(&mp_pck, "records", strlen("records"));
 
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto sbuffer_error;
-        }
-        records++;
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+    if (buf_size > 0) {
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto sbuffer_error;
+            }
+            records++;
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
 
-    msgpack_pack_array(&mp_pck, records);
-    off = 0;
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto sbuffer_error;
-        }
-        flb_time_pop_from_msgpack(&tm, &result, &record);
+        msgpack_pack_array(&mp_pck, records);
+        off = 0;
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto sbuffer_error;
+            }
+            flb_time_pop_from_msgpack(&tm, &result, &record);
 
-        msgpack_pack_map(&mp_pck, 2);
-        msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
-        flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
-        msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
-        msgpack_pack_object(&mp_pck, *record);
+            msgpack_pack_map(&mp_pck, 2);
+            msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
+            flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
+            msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
+            msgpack_pack_object(&mp_pck, *record);
 
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+    }
 
     msgpack_pack_str_with_body(&mp_pck, "start_time", strlen("start_time"));
     flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
@@ -645,32 +649,35 @@ int flb_chunk_trace_filter(struct flb_chunk_trace *tracer, void *pfilter, struct
     msgpack_pack_str_with_body(&mp_pck, "records", strlen("records"));
 
     msgpack_unpacked_init(&result);
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto unpack_error;
-        }
-        records++;
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
 
-    msgpack_pack_array(&mp_pck, records);
-    off = 0;
-    do {
-        rc = msgpack_unpack_next(&result, buf, buf_size, &off);
-        if (rc != MSGPACK_UNPACK_SUCCESS) {
-            flb_error("unable to unpack record");
-            goto unpack_error;
-        }
-        flb_time_pop_from_msgpack(&tm, &result, &record);
+    if (buf_size > 0) {
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto unpack_error;
+            }
+            records++;
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
 
-        msgpack_pack_map(&mp_pck, 2);
-        msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
-        flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
-        msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
-        msgpack_pack_object(&mp_pck, *record);
+        msgpack_pack_array(&mp_pck, records);
+        off = 0;
+        do {
+            rc = msgpack_unpack_next(&result, buf, buf_size, &off);
+            if (rc != MSGPACK_UNPACK_SUCCESS) {
+                flb_error("unable to unpack record");
+                goto unpack_error;
+            }
+            flb_time_pop_from_msgpack(&tm, &result, &record);
 
-    } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+            msgpack_pack_map(&mp_pck, 2);
+            msgpack_pack_str_with_body(&mp_pck, "timestamp", strlen("timestamp"));
+            flb_time_append_to_msgpack(&tm, &mp_pck, FLB_TIME_ETFMT_INT);
+            msgpack_pack_str_with_body(&mp_pck, "record", strlen("record"));
+            msgpack_pack_object(&mp_pck, *record);
+
+        } while (rc == MSGPACK_UNPACK_SUCCESS && off < buf_size);
+    }
 
     in_emitter_add_record(tag, flb_sds_len(tag), mp_sbuf.data, mp_sbuf.size,
                           tracer->ctxt->input);

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -170,7 +170,7 @@ void flb_filter_do(struct flb_input_chunk *ic,
                     flb_input_chunk_write_at(ic, write_at, "", 0);
 #ifdef FLB_HAVE_CHUNK_TRACE
                     if (ic->trace) {
-                        flb_chunk_trace_filter(ic->trace, &tm_start, &tm_finish, (void *)f_ins, "", 0);
+                        flb_chunk_trace_filter(ic->trace, (void *)f_ins, &tm_start, &tm_finish, "", 0);
                     }
 #endif /* FLB_HAVE_CHUNK_TRACE */
 

--- a/src/http_server/api/v1/trace.c
+++ b/src/http_server/api/v1/trace.c
@@ -42,8 +42,10 @@ struct flb_input_instance *find_input(struct flb_hs *hs, const char *name)
         if (strcmp(name, in->name) == 0) {
             return in;
         }
-        if (strcmp(name, in->alias) == 0) {
-            return in;
+        if (in->alias) {
+            if (strcmp(name, in->alias) == 0) {
+                return in;
+            }
         }
     }
     return NULL;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Several minor fixes I applied while testing the rewrite_tag filter with traces:

  * check an alias is set for an input when searching for an input to activate a trace on.
  * improve handling for empty records (which rewrite_tag emits...).
  * fix arguments passed to trace filter.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
