### PR TITLE
dummy: up the sleep time in the tests so they pass.

### DIFF
--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -279,7 +279,7 @@ void do_test_records_single(char *system, void (*records_cb)(struct callback_rec
     TEST_CHECK(flb_start(ctx) == 0);
 
     /* 4 sec passed. It must have flushed */
-    sleep(2);
+    sleep(5);
 
     records_cb(records);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

The new dummy tests for copies do not pass on the CI systems due to latency or some other timing related reason. I also witnessed this on my M1 mac book. This is a patch to increment the sleep time taken by these tests from 2 to 5 seconds in the hopes that allows enough time for it to run on the CI systems.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
