### PR TITLE
dockerfiles: Fix to work correctly for Windows container

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -90,7 +90,7 @@ COPY --from=builder /fluent-bit /fluent-bit
 
 RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
 
-ENTRYPOINT [ "C:\fluent-bit\bin\fluent-bit.exe" ]
+ENTRYPOINT [ "fluent-bit.exe" ]
 # Hadolint gets confused by Windows it seems
 # hadolint ignore=DL3025
-CMD [ "C:\fluent-bit\bin\fluent-bit.exe", "-c", "C:\fluent-bit\etc\fluent-bit.conf" ]
+CMD [ "fluent-bit.exe", "-c", "/fluent-bit/etc/fluent-bit.conf" ]


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

Currently, Dockerfile for windows in fluent-bit's master is not working correctly on Windows.
This PR should fix this issue.

With this fix, we can run fluent-bit 2.0 included Windows container on Windows:

```log
PS> docker build . -t fluent/fluent-bit:<<fluent-bit-built-tag>> -f .\dockerfiles\Dockerfile.windows
# Take a long time to build fluent-bit container....
PS> docker run -it --rm fluent/fluent-bit:<<fluent-bit-built-tag>>
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/25 17:02:34] [ info] [fluent bit] version=2.0.0, commit=, pid=1308
[2022/10/25 17:02:34] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/25 17:02:34] [ info] [cmetrics] version=0.5.3
[2022/10/25 17:02:34] [ info] [ctraces ] version=0.2.5
[2022/10/25 17:02:34] [ info] [input:winlog:winlog.0] initializing
[2022/10/25 17:02:34] [ info] [input:winlog:winlog.0] storage_strategy='memory' (memory only)
[2022/10/25 17:02:34] [ info] [sp] stream processor started
[2022/10/25 17:02:34] [ info] [output:stdout:stdout.0] worker #0 started
```
 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
