### PR TITLE
config_format: fluentbit: call stat again when resolve real path(#6281)

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -446,6 +446,12 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
                 snprintf(tmp, PATH_MAX, "%s/%s", ctx->root_path, cfg_file);
                 cfg_file = tmp;
             }
+            /* stat again */
+            ret = stat(cfg_file, &st);
+            if (ret < 0) {
+                flb_errno();
+                return -1;
+            }
         }
 #ifndef _WIN32
         /* check if readed file */

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -16,6 +16,7 @@
 #define FLB_001 FLB_TESTS_DATA_PATH "/data/config_format/classic/issue_5880.conf"
 #define FLB_002 FLB_TESTS_DATA_PATH "/data/config_format/classic/indent_level_error.conf"
 #define FLB_003 FLB_TESTS_DATA_PATH "/data/config_format/classic/recursion.conf"
+#define FLB_004 FLB_TESTS_DATA_PATH "/data/config_format/classic/issue6281.conf"
 
 #define ERROR_LOG "fluentbit_conf_error.log"
 
@@ -224,10 +225,44 @@ void recursion()
     /* No SIGSEGV means success */
 }
 
+
+/*
+ *  https://github.com/fluent/fluent-bit/issues/6281
+ *
+ *  Fluent-bit loads issue6281.conf that loads issue6281_input/output.conf.
+ *
+ *    config dir -+-- issue6281.conf
+ *                |
+ *                +-- issue6281_input.conf
+ *                |
+ *                +-- issue6281_output.conf
+ */
+void not_current_dir_files()
+{
+    struct flb_cf *cf;
+
+    cf = flb_cf_create();
+    if (!TEST_CHECK(cf != NULL)) {
+        TEST_MSG("flb_cf_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    cf = flb_cf_fluentbit_create(cf, FLB_004, NULL, 0);
+    if (!TEST_CHECK(cf != NULL)) {
+        TEST_MSG("flb_cf_fluentbit_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (cf != NULL) {
+        flb_cf_destroy(cf);
+    }
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
     { "missing_value_issue5880" , missing_value},
     { "indent_level_error" , indent_level_error},
     { "recursion" , recursion},
+    { "not_current_dir_files", not_current_dir_files},
     { 0 }
 };

--- a/tests/internal/data/config_format/classic/issue6281.conf
+++ b/tests/internal/data/config_format/classic/issue6281.conf
@@ -1,0 +1,2 @@
+@INCLUDE issue6281_input.conf
+@INCLUDE issue6281_output.conf

--- a/tests/internal/data/config_format/classic/issue6281_input.conf
+++ b/tests/internal/data/config_format/classic/issue6281_input.conf
@@ -1,0 +1,2 @@
+[INPUT]
+    Name dummy

--- a/tests/internal/data/config_format/classic/issue6281_output.conf
+++ b/tests/internal/data/config_format/classic/issue6281_output.conf
@@ -1,0 +1,2 @@
+[OUTPUT]
+    Name stdout


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/blob/v2.0.0/src/config_format/flb_cf_fluentbit.c#L439
In this case, fluent-bit tries to resolve the real path.
However `st` will not be updated using new real path.
Then `st.st_ino` will be 0 and fluent-bit will abort.
https://github.com/fluent/fluent-bit/blob/v2.0.0/src/config_format/flb_cf_fluentbit.c#L453

This issue was caused by https://github.com/fluent/fluent-bit/pull/6213
It will happen using following command.
```
fluent-bit -c <absolute path to configuration file>
```

This patch is to fix it calling stat for new real path to get real inode.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

issue6281.conf:
```
@INCLUDE issue6281_input.conf
@INCLUDE issue6281_output.conf
```
issue6281_input.conf:
```
[INPUT]
    Name dummy
```

issue6281_output.conf:
```
[OUTPUT]
    Name stdout
```

## Debug/Valgrind output
```
$ valgrind --leak-check=full bin/fluent-bit -c ~/git/WORKTREE/fix_6281/tests/internal/data/config_format/classic/issue6281.conf 
==111408== Memcheck, a memory error detector
==111408== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==111408== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==111408== Command: bin/fluent-bit -c /home/taka/git/WORKTREE/fix_6281/tests/internal/data/config_format/classic/issue6281.conf
==111408== 
Fluent Bit v2.0.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/27 05:27:32] [ info] [fluent bit] version=2.0.0, commit=58b0214f02, pid=111408
[2022/10/27 05:27:32] [ info] [storage] ver=1.3.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/27 05:27:32] [ info] [cmetrics] version=0.5.3
[2022/10/27 05:27:32] [ info] [ctraces ] version=0.2.5
[2022/10/27 05:27:32] [ info] [input:dummy:dummy.0] initializing
[2022/10/27 05:27:32] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/10/27 05:27:33] [ info] [sp] stream processor started
[2022/10/27 05:27:33] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [1666816053.535887407, {"message"=>"dummy"}]
[0] dummy.0: [1666816054.510309454, {"message"=>"dummy"}]
^C[2022/10/27 05:27:35] [engine] caught signal (SIGINT)
[0] dummy.0: [1666816055.447874557, {"message"=>"dummy"}]
[2022/10/27 05:27:35] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/27 05:27:35] [ info] [input] pausing dummy.0
[2022/10/27 05:27:36] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/27 05:27:36] [ info] [input] pausing dummy.0
[2022/10/27 05:27:36] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/10/27 05:27:36] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==111408== 
==111408== HEAP SUMMARY:
==111408==     in use at exit: 0 bytes in 0 blocks
==111408==   total heap usage: 1,478 allocs, 1,478 frees, 1,275,432 bytes allocated
==111408== 
==111408== All heap blocks were freed -- no leaks are possible
==111408== 
==111408== For lists of detected and suppressed errors, rerun with: -s
==111408== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
