### PR TITLE
in_tail: fix st_mtime timestamp format

### DIFF
--- a/plugins/in_tail/win32/stat.c
+++ b/plugins/in_tail/win32/stat.c
@@ -35,8 +35,8 @@
  */
 
 #define UINT64(high, low) ((uint64_t) (high) << 32 | (low))
-#define LDAP_TO_SECONDS_DIVISOR 10000000
-#define LDAP_TO_EPOCH_DIFF_SECONDS 11644473600
+#define WINDOWS_TICKS_TO_SECONDS_RATIO 10000000
+#define WINDOWS_EPOCH_TO_UNIX_EPOCH_DELTA 11644473600
 
 static int get_mode(unsigned int attr)
 {
@@ -48,16 +48,16 @@ static int get_mode(unsigned int attr)
 
 static int64_t filetime_to_epoch(FILETIME ft)
 {
-    ULARGE_INTEGER ldap;
+    ULARGE_INTEGER timestamp;
 
     /*
-     * The LDAP timestamp represents the number of
-     * 100-nanosecond intervals since Jan 1, 1601 UTC.
+     * The FILETIME represents the number of
+     * 100-nanosecond intervals (ticks) since Jan 1, 1601 UTC.
      */
-    ldap.HighPart = ft.dwHighDateTime;
-    ldap.LowPart = ft.dwLowDateTime;
+    timestamp.HighPart = ft.dwHighDateTime;
+    timestamp.LowPart = ft.dwLowDateTime;
 
-    return ((int64_t) ldap.QuadPart / LDAP_TO_SECONDS_DIVISOR) - LDAP_TO_EPOCH_DIFF_SECONDS;
+    return ((int64_t) timestamp.QuadPart / WINDOWS_TICKS_TO_SECONDS_RATIO) - WINDOWS_EPOCH_TO_UNIX_EPOCH_DELTA;
 }
 
 static int is_symlink(const char *path)

--- a/plugins/in_tail/win32/stat.c
+++ b/plugins/in_tail/win32/stat.c
@@ -48,14 +48,16 @@ static int get_mode(unsigned int attr)
 
 static int64_t filetime_to_epoch(FILETIME ft)
 {
-    int64_t ldap;
+    ULARGE_INTEGER ldap;
 
     /*
      * The LDAP timestamp represents the number of
      * 100-nanosecond intervals since Jan 1, 1601 UTC.
      */
-    ldap = UINT64(ft.dwHighDateTime, ft.dwLowDateTime);
-    return (ldap / LDAP_TO_SECONDS_DIVISOR) - LDAP_TO_EPOCH_DIFF_SECONDS;
+    ldap.HighPart = ft.dwHighDateTime;
+    ldap.LowPart = ft.dwLowDateTime;
+
+    return ((int64_t) ldap.QuadPart / LDAP_TO_SECONDS_DIVISOR) - LDAP_TO_EPOCH_DIFF_SECONDS;
 }
 
 static int is_symlink(const char *path)

--- a/plugins/in_tail/win32/stat.c
+++ b/plugins/in_tail/win32/stat.c
@@ -49,7 +49,7 @@
  *
  * Note: Even though this does not account for leap seconds it should be
  * accurate enough.
-*/
+ */
 
 static uint64_t filetime_to_epoch(FILETIME *ft)
 {

--- a/plugins/in_tail/win32/stat.c
+++ b/plugins/in_tail/win32/stat.c
@@ -59,8 +59,8 @@ static uint64_t filetime_to_epoch(FILETIME *ft)
         return 0;
     }
 
-    timestamp.HighPart = ft.dwHighDateTime;
-    timestamp.LowPart = ft.dwLowDateTime;
+    timestamp.HighPart = ft->dwHighDateTime;
+    timestamp.LowPart = ft->dwLowDateTime;
 
     timestamp.QuadPart /= WINDOWS_TICKS_TO_SECONDS_RATIO;
     timestamp.QuadPart -= WINDOWS_EPOCH_TO_UNIX_EPOCH_DELTA;


### PR DESCRIPTION
<!-- Provide summary of changes -->

This patch fixes an issue where st_mtime for Windows platforms was set directly from `ftLastWriteTime` without converting it to a Unix epoch timestamp first. This caused checks against `st_mtime` to not behave as expected.

For instance, this caused the `Ignore_Older` configuration option for in_tail to not work properly as it still registered files that it shouldn't have. 

How to reproduce the issue on Windows without this fix: Using in_tail, if you add a new file that matches the `Path` pattern you will see while debugging the application that [this](https://github.com/fluent/fluent-bit/blob/master/plugins/in_tail/tail_file.h#L46) line does not *"return the file modification time in seconds since epoch"* as expected, but rather an 18-digit long LDAP timestamp.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #6294

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
