### PR TITLE
in_winevtlog: Fix ignoring non-existent channel handling

### DIFF
--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -612,16 +612,14 @@ struct mk_list *winevtlog_open_all(const char *channels, int read_existing_event
     channel = strtok_s(tmp , ",", &state);
     while (channel) {
         ch = winevtlog_subscribe(channel, read_existing_events, NULL);
-        if (ignore_missing_channels) {
-            if (ch) {
-                mk_list_add(&ch->_head, list);
-            }
-            else {
-                flb_debug("[in_winevtlog] channel '%s' does not exist", channel);
-            }             
+        if (ch) {
+            mk_list_add(&ch->_head, list);
         }
         else {
-            if (!ch) {
+            if (ignore_missing_channels) {
+                flb_debug("[in_winevtlog] channel '%s' does not exist", channel);
+            }
+            else {
                 flb_free(tmp);
                 winevtlog_close_all(list);
                 return NULL;


### PR DESCRIPTION
With previous implementation, winevtlog plugin does not handle any channels when ignore_missing_channels parameter is not true.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
