### PR TITLE
out_forward: Put chunk key as the first key of the option map

### DIFF
--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -95,12 +95,6 @@ static int append_options(struct flb_forward *ctx,
     /* options is map, use the dynamic map type */
     flb_mp_map_header_init(&mh, mp_pck);
 
-    /* event type (FLB_EVENT_TYPE_LOGS, FLB_EVENT_TYPE_METRICS, FLB_EVENT_TYPE_TRACES) */
-    flb_mp_map_header_append(&mh);
-    msgpack_pack_str(mp_pck, 13);
-    msgpack_pack_str_body(mp_pck, "fluent_signal", 13);
-    msgpack_pack_int64(mp_pck, event_type);
-
     if (fc->require_ack_response == FLB_TRUE) {
         /*
          * for ack we calculate  sha512 of context, take 16 bytes,
@@ -148,6 +142,12 @@ static int append_options(struct flb_forward *ctx,
         msgpack_pack_str(mp_pck, 4);
         msgpack_pack_str_body(mp_pck, "gzip", 4);
     }
+
+    /* event type (FLB_EVENT_TYPE_LOGS, FLB_EVENT_TYPE_METRICS, FLB_EVENT_TYPE_TRACES) */
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(mp_pck, 13);
+    msgpack_pack_str_body(mp_pck, "fluent_signal", 13);
+    msgpack_pack_int64(mp_pck, event_type);
 
     flb_mp_map_header_end(&mh);
 


### PR DESCRIPTION
Since fluent-bit 2.0.0, we start to add `fluent_signal` to represent event_type for logs, metrics, and traces.
However, out_forward still wants to be chunk key as the first key of the option.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/6290

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

client:

```ini
[SERVICE]
    Flush                1
    Daemon               Off
    Log_Level            debug
    Parsers_File         ../conf/parsers.conf

[INPUT]
    Name                 tcp
    Listen               0.0.0.0
    Port                 5170
    Format               none
    Separator            \n

[OUTPUT]
    Name                 forward
    Match                *
    Host                 127.0.0.1
    Port                 24224
    Require_ack_response True
    Retry_Limit          no_limits

[OUTPUT]
    Name                 stdout
    Match                *
```

server:

```ini
[SERVICE]
    Flush                     1
    Daemon                    Off
    Log_Level                 debug
    Parsers_File              ../conf/parsers.conf

[INPUT]
    Name                      forward
    Port                      24224

[OUTPUT]
    Name                      stdout
    Match                     *
```

- [x] Debug log output from testing the change

client:

```log
Fluent Bit v2.0.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/28 18:05:42] [ info] Configuration:
[2022/10/28 18:05:42] [ info]  flush time     | 1.000000 seconds
[2022/10/28 18:05:42] [ info]  grace          | 5 seconds
[2022/10/28 18:05:42] [ info]  daemon         | 0
[2022/10/28 18:05:42] [ info] ___________
[2022/10/28 18:05:42] [ info]  inputs:
[2022/10/28 18:05:42] [ info]      tcp
[2022/10/28 18:05:42] [ info] ___________
[2022/10/28 18:05:42] [ info]  filters:
[2022/10/28 18:05:42] [ info] ___________
[2022/10/28 18:05:42] [ info]  outputs:
[2022/10/28 18:05:42] [ info]      forward.0
[2022/10/28 18:05:42] [ info]      stdout.1
[2022/10/28 18:05:42] [ info] ___________
[2022/10/28 18:05:42] [ info]  collectors:
[2022/10/28 18:05:42] [ info] [fluent bit] version=2.0.2, commit=81c84b75e8, pid=137958
[2022/10/28 18:05:42] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/10/28 18:05:42] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/28 18:05:42] [ info] [cmetrics] version=0.5.4
[2022/10/28 18:05:42] [ info] [ctraces ] version=0.2.5
[2022/10/28 18:05:42] [ info] [input:tcp:tcp.0] initializing
[2022/10/28 18:05:42] [ info] [input:tcp:tcp.0] storage_strategy='memory' (memory only)
[2022/10/28 18:05:42] [debug] [tcp:tcp.0] created event channels: read=21 write=22
[2022/10/28 18:05:42] [debug] [downstream] listening on 0.0.0.0:5170
[2022/10/28 18:05:42] [debug] [forward:forward.0] created event channels: read=24 write=25
[2022/10/28 18:05:42] [debug] [stdout:stdout.1] created event channels: read=36 write=37
[2022/10/28 18:05:42] [ info] [output:forward:forward.0] worker #0 started
[2022/10/28 18:05:42] [ info] [output:forward:forward.0] worker #1 started
[2022/10/28 18:05:42] [debug] [router] match rule tcp.0:forward.0
[2022/10/28 18:05:42] [debug] [router] match rule tcp.0:stdout.1
[2022/10/28 18:05:42] [ info] [sp] stream processor started
[2022/10/28 18:05:42] [ info] [output:stdout:stdout.1] worker #0 started
[2022/10/28 18:05:52] [debug] [input chunk] update output instances with new chunk size diff=31
[2022/10/28 18:05:52] [debug] [task] created task=0x7f1c1c01dce0 id=0 OK
[2022/10/28 18:05:52] [debug] [output:forward:forward.0] task_id=0 assigned to thread #0
[2022/10/28 18:05:52] [debug] [output:stdout:stdout.1] task_id=0 assigned to thread #0
[2022/10/28 18:05:52] [debug] [output:forward:forward.0] request 31 bytes to flush
[0] tcp.0: [1666947952.610070018, {"log"=>"msg fluent-bit"}]
[2022/10/28 18:05:52] [debug] [out flush] cb_destroy coro_id=0
[2022/10/28 18:05:52] [debug] [output:forward:forward.0] send options records=1 chunk='ec61082e9f818ccc6465efe15663455f'
[2022/10/28 18:05:52] [debug] [output:forward:forward.0] protocol: received ACK ec61082e9f818ccc6465efe15663455f
[2022/10/28 18:05:52] [debug] [out flush] cb_destroy coro_id=0
[2022/10/28 18:05:52] [debug] [task] destroy task=0x7f1c1c01dce0 (task_id=0)
^C[2022/10/28 18:06:11] [engine] caught signal (SIGINT)
[2022/10/28 18:06:11] [ warn] [engine] service will shutdown in max 5 seconds
[2022/10/28 18:06:11] [ info] [engine] service has stopped (0 pending tasks)
[2022/10/28 18:06:11] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2022/10/28 18:06:11] [ info] [output:forward:forward.0] thread worker #0 stopped
[2022/10/28 18:06:11] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2022/10/28 18:06:11] [ info] [output:forward:forward.0] thread worker #1 stopped
[2022/10/28 18:06:11] [ info] [output:stdout:stdout.1] thread worker #0 stopping...
[2022/10/28 18:06:11] [ info] [output:stdout:stdout.1] thread worker #0 stopped
```

server:

```log
Fluent Bit v2.0.2
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/10/28 19:33:10] [ info] Configuration:
[2022/10/28 19:33:10] [ info]  flush time     | 1.000000 seconds
[2022/10/28 19:33:10] [ info]  grace          | 5 seconds
[2022/10/28 19:33:10] [ info]  daemon         | 0
[2022/10/28 19:33:10] [ info] ___________
[2022/10/28 19:33:10] [ info]  inputs:
[2022/10/28 19:33:10] [ info]      forward
[2022/10/28 19:33:10] [ info] ___________
[2022/10/28 19:33:10] [ info]  filters:
[2022/10/28 19:33:10] [ info] ___________
[2022/10/28 19:33:10] [ info]  outputs:
[2022/10/28 19:33:10] [ info]      stdout.0
[2022/10/28 19:33:10] [ info] ___________
[2022/10/28 19:33:10] [ info]  collectors:
[2022/10/28 19:33:10] [ info] [fluent bit] version=2.0.2, commit=81c84b75e8, pid=147393
[2022/10/28 19:33:10] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/10/28 19:33:10] [ info] [storage] ver=1.3.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/10/28 19:33:10] [ info] [cmetrics] version=0.5.4
[2022/10/28 19:33:10] [ info] [ctraces ] version=0.2.5
[2022/10/28 19:33:10] [ info] [input:forward:forward.0] initializing
[2022/10/28 19:33:10] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2022/10/28 19:33:10] [debug] [forward:forward.0] created event channels: read=21 write=22
[2022/10/28 19:33:10] [debug] [in_fw] Listen='0.0.0.0' TCP_Port=24224
[2022/10/28 19:33:10] [debug] [downstream] listening on 0.0.0.0:24224
[2022/10/28 19:33:10] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/10/28 19:33:10] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2022/10/28 19:33:10] [ info] [sp] stream processor started
[2022/10/28 19:33:10] [ info] [output:stdout:stdout.0] worker #0 started
[2022/10/28 19:33:21] [debug] [input chunk] update output instances with new chunk size diff=20
[2022/10/28 19:33:22] [debug] [task] created task=0x7f737400f4c0 id=0 OK
[2022/10/28 19:33:22] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] tcp.0: [1666953201.815383880, {"log"=>"msg"}]
[2022/10/28 19:33:22] [debug] [out flush] cb_destroy coro_id=0
[2022/10/28 19:33:22] [debug] [task] destroy task=0x7f737400f4c0 (task_id=0)
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
