### PR TITLE
fluent-bit: fix return type for flb_cf_section_property_add.

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -611,7 +611,7 @@ static int set_property(struct flb_cf *cf, struct flb_cf_section *s, char *kv)
     int sep;
     char *key;
     char *value;
-    struct cfl_array *tmp;
+    struct cfl_variant *tmp;
 
     len = strlen(kv);
     sep = mk_string_char_search(kv, '=', len);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fix a compiler warning which can cause some of our docker builds to fail.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
