### PR TITLE
in_node_exporter_metrics: fix set vmstat metrics as counter metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
@@ -43,7 +43,7 @@ static int vmstat_configure(struct flb_ne *ctx)
     struct mk_list split_list;
     struct flb_slist_entry *line;
     struct flb_slist_entry *key;
-    struct cmt_untyped *u;
+    struct cmt_counter *c;
 
     /* Initialize regex for skipped devices */
     ctx->vml_regex_fields = flb_regex_create(VMSTAT_ENTRIES);
@@ -96,16 +96,16 @@ static int vmstat_configure(struct flb_ne *ctx)
 
         snprintf(tmp, sizeof(tmp) - 1,
                  "/proc/vmstat information field %s.", key->str);
-        u = cmt_untyped_create(ctx->cmt, "node", "vmstat", key->str,
+        c = cmt_counter_create(ctx->cmt, "node", "vmstat", key->str,
                                tmp, 0, NULL);
-        if (!u) {
+        if (!c) {
             flb_slist_destroy(&split_list);
             flb_slist_destroy(&list);
             return -1;
         }
 
         ret = flb_hash_table_add(ctx->vml_ht,
-                                 key->str, flb_sds_len(key->str), u, 0);
+                                 key->str, flb_sds_len(key->str), c, 0);
         if (ret == -1) {
             flb_plg_error(ctx->ins,
                           "could not add hash for vmstat metric: %s", key->str);


### PR DESCRIPTION
Vmstat metrics seems to be of counter types: https://github.com/torvalds/linux/blob/master/mm/vmstat.c
The goal of this MR is to change vmstat metrics type int the in_node_exporter_metrics from untyped to counter.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [  ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
