### PR TITLE
tests: internal: fuzzers: add ctrace fuzzer

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_FILES
   engine_fuzzer.c
   config_fuzzer.c
   config_random_fuzzer.c
+  ctrace_fuzzer.c
   signv4_fuzzer.c
   flb_json_fuzzer.c
   filter_stdout_fuzzer.c

--- a/tests/internal/fuzzers/ctrace_fuzzer.c
+++ b/tests/internal/fuzzers/ctrace_fuzzer.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_decode_msgpack.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    size_t off;
+    struct ctrace *ctr = NULL;
+    ctr_decode_msgpack_create(&ctr, data, size, &off);
+    if (ctr != NULL) {
+        ctr_destroy(ctr);
+    }
+    return 0;
+}


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
