### PR TITLE
tests: runtime: add missing fabs() to compare DBL_EPSILON

### DIFF
--- a/tests/runtime/out_http.c
+++ b/tests/runtime/out_http.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_time.h>
 #include <float.h>
+#include <math.h>
 #include <msgpack.h>
 #include "flb_tests_runtime.h"
 
@@ -139,7 +140,7 @@ static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
     case MSGPACK_OBJECT_FLOAT64:
         {
             double val = strtod(str, NULL);
-            if ((val - obj.via.f64) < DBL_EPSILON) {
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
                 ret = 0;
             }
         }

--- a/tests/runtime/out_lib.c
+++ b/tests/runtime/out_lib.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_time.h>
 #include <float.h>
+#include <math.h>
 #include "flb_tests_runtime.h"
 
 struct test_ctx {
@@ -162,7 +163,7 @@ static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
     case MSGPACK_OBJECT_FLOAT64:
         {
             double val = strtod(str, NULL);
-            if ((val - obj.via.f64) < DBL_EPSILON) {
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
                 ret = 0;
             }
         }

--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_downstream.h>
 #include <string.h>
 #include <float.h>
+#include <math.h>
 #include <msgpack.h>
 #include "flb_tests_runtime.h"
 
@@ -146,7 +147,7 @@ static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
     case MSGPACK_OBJECT_FLOAT64:
         {
             double val = strtod(str, NULL);
-            if ((val - obj.via.f64) < DBL_EPSILON) {
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
                 ret = 0;
             }
         }


### PR DESCRIPTION
DBL_EPSILON should compare with absolute value since (0.0 - 1.0) < DBL_EPSILON always true.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug log

```
taka@taka-VirtualBox:~/git/fluent-bit/build$ bin/flb-rt-out_tcp 
Test tcp_with_tls...                            [ OK ]
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
Test tcp_exit_workers...                        [ OK ]
Test tcp_exit_no_workers...                     [ OK ]
SUCCESS: All unit tests have passed.
taka@taka-VirtualBox:~/git/fluent-bit/build$ bin/flb-rt-out_http 
Test format_msgpack...                          [ OK ]
Test format_json...                             [ OK ]
Test format_json_stream...                      [ OK ]
Test format_json_lines...                       [ OK ]
Test format_gelf...                             [ OK ]
Test format_gelf_host_key...                    [ OK ]
Test format_gelf_timestamp_key...               [ OK ]
Test format_gelf_full_message_key...            [ OK ]
Test format_gelf_level_key...                   [ OK ]
Test set_json_date_key...                       [ OK ]
Test disable_json_date_key...                   [ OK ]
Test json_date_format_epoch...                  [ OK ]
Test json_date_format_iso8601...                [ OK ]
Test json_date_format_java_sql_timestamp...     [ OK ]
SUCCESS: All unit tests have passed.
taka@taka-VirtualBox:~/git/fluent-bit/build$ bin/flb-rt-out_lib 
Test metrics_msgpack...                         [ OK ]
Test metrics_json...                            [ OK ]
Test format_json...                             [ OK ]
Test format_msgpack...                          [ OK ]
Test max_records...                             [ OK ]
SUCCESS: All unit tests have passed.
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
