### PR TITLE
build: wasm: Disable WASM for *BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -lutil")
 endif()
 
+# *BSD is not supported platform for wasm-micro-runtime. Now, we should be disabled for these platforms.
+if(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+  message(STATUS "This platform is not supported for WASM feature so disabled.")
+  set(FLB_WASM OFF)
+endif()
+
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)


### PR DESCRIPTION
wasm-micro-runtime(WAMR) does not support *BSD platforms. We should disable Wasm feature on them.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

With this patch, cmake's configuration can be passed but still not buildable due to incompatible pointer type:

```
[ 45%] Building C object src/CMakeFiles/fluent-bit-static.dir/flb_engine_dispatch.c.o
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:516:17: warning: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
            str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
                ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:1796:18: error: variable has incomplete type 'struct ucred'
    struct ucred peer_credentials;
                 ^
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:1796:12: note: forward declaration of 'struct ucred'
    struct ucred peer_credentials;
           ^
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:1813:29: error: invalid application of 'sizeof' to an incomplete type 'struct ucred'
    peer_credentials_size = sizeof(struct ucred);
                            ^     ~~~~~~~~~~~~~~
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:1796:12: note: forward declaration of 'struct ucred'
    struct ucred peer_credentials;
           ^
/home/cosmo/GitHub/fluent-bit/src/flb_network.c:1817:25: error: use of undeclared identifier 'SO_PEERCRED'
                        SO_PEERCRED,
                        ^
1 warning and 3 errors generated.
--- src/CMakeFiles/fluent-bit-static.dir/flb_network.c.o ---
*** [src/CMakeFiles/fluent-bit-static.dir/flb_network.c.o] Error code 1

```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Related to #6289.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
