### PR TITLE
network: freebsd: Don't use linux like struct ucred on freebsd

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -153,6 +153,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
 /* use for locking the use of the chunk trace context. */
 #ifdef FLB_HAVE_CHUNK_TRACE
     pthread_mutexattr_t attr = {0};
+    pthread_mutexattr_init(&attr);
 #endif
 
     if (!input) {

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1791,7 +1791,7 @@ static int net_address_unix_socket_peer_pid_raw(flb_sockfd_t fd,
                                                 int output_buffer_size,
                                                 size_t *output_data_size)
 {
-#ifndef FLB_SYSTEM_MACOS    
+#if !defined(FLB_SYSTEM_MACOS) && !defined(FLB_SYSTEM_FREEBSD)
     unsigned int peer_credentials_size;
     struct ucred peer_credentials;
 #endif
@@ -1809,7 +1809,7 @@ static int net_address_unix_socket_peer_pid_raw(flb_sockfd_t fd,
         return -1;
     }
 
-#ifndef FLB_SYSTEM_MACOS    
+#if !defined(FLB_SYSTEM_MACOS) && !defined(FLB_SYSTEM_FREEBSD)
     peer_credentials_size = sizeof(struct ucred);
 
     result = getsockopt(fd,


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

In FreeBSD, `struct ucred` is incomplete strust type like as macOS.
We should avoid to use it on FreeBSD.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Related to https://github.com/fluent/fluent-bit/issues/6289.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
