### PR TITLE
workflows: windows OCI image release

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -273,11 +273,17 @@ jobs:
 
   # This takes a long time...
   call-build-windows-container:
-    name: Windows container image
-    runs-on: windows-2019
+    name: Windows container images
+    runs-on: windows-${{ matrix.windows-base-version }}
     environment: ${{ inputs.environment }}
     needs:
       - call-build-images-meta
+    strategy:
+      fail-fast: true
+      matrix:
+        windows-base-version: 
+          - '2019'
+          - '2022'
     permissions:
       contents: read
       packages: write
@@ -296,8 +302,9 @@ jobs:
 
       - name: Build the production images
         run: |
-          docker build -t ${{ inputs.registry }}/${{ inputs.image }}:windows-2019-${{ inputs.version }} --build-arg FLB_NIGHTLY_BUILD=${{ inputs.unstable }} --build-arg WINDOWS_VERSION=ltsc2019 -f ./dockerfiles/Dockerfile.windows .
-          docker push ${{ inputs.registry }}/${{ inputs.image }}:windows-2019-${{ inputs.version }}
+          docker build -t ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-${{ inputs.version }} --build-arg FLB_NIGHTLY_BUILD=${{ inputs.unstable }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/Dockerfile.windows .
+          docker push ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-${{ inputs.version }}
+        
         # We cannot use this action as it requires privileged mode
         # uses: docker/build-push-action@v3
         # with:

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -164,17 +164,16 @@ jobs:
       access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  # MacOS is currently not officially supported and under "flux" so do not fail a build for it
-  # staging-build-macos-packages:
-  #   needs:
-  #     - staging-build-get-meta
-  #   uses: ./.github/workflows/call-build-macos.yaml
-  #   with:
-  #     version: ${{ needs.staging-build-get-meta.outputs.version }}
-  #     ref: ${{ inputs.version || github.ref_name }}
-  #     environment: staging
-  #   secrets:
-  #     token: ${{ secrets.GITHUB_TOKEN }}
-  #     bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
-  #     access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  staging-build-macos-packages:
+    needs:
+      - staging-build-get-meta
+    uses: ./.github/workflows/call-build-macos.yaml
+    with:
+      version: ${{ needs.staging-build-get-meta.outputs.version }}
+      ref: ${{ inputs.version || github.ref_name }}
+      environment: staging
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      bucket: ${{ secrets.AWS_S3_BUCKET_STAGING }}
+      access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -175,7 +175,9 @@ jobs:
           "latest",
           "${{ github.event.inputs.version }}-debug",
           "${{ needs.staging-release-version-check.outputs.major-version }}-debug",
-          "latest-debug"
+          "latest-debug",
+          "windows-2019-${{ github.event.inputs.version }}",
+          "windows-2022-${{ github.event.inputs.version }}"
         ]
     steps:
       # Primarily because the skopeo errors are hard to parse and non-obvious


### PR DESCRIPTION
Addresses #6278 by pushing the current staging Windows OCI images to release registries and also builds for Windows Server 2022.

We re-enable the MacOS build as well for staging (it is stable now).

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Test run of this branch: https://github.com/fluent/fluent-bit/actions/runs/3360667316

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
