### PR TITLE
packaging: fix publish script

### DIFF
--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -33,10 +33,10 @@ if [[ -n "$CREATE_REPO_CMD" ]]; then
     echo "Using $CREATE_REPO_CMD"
 elif command -v createrepo &> /dev/null; then
     echo "Found createrepo"
-    CREATE_REPO_CMD="createrepo -dvp"
+    CREATE_REPO_CMD="createrepo"
 elif command -v createrepo_c &> /dev/null; then
     echo "Found createrepo_c"
-    CREATE_REPO_CMD="createrepo_c -dvp"
+    CREATE_REPO_CMD="createrepo_c"
 else
     echo "Unable to find a command equivalent to createrepo"
     exit 1

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -20,7 +20,8 @@ APT_TARGETS=("ubuntu:18.04"
 YUM_TARGETS=("centos:7"
     "rockylinux:8"
     "quay.io/centos/centos:stream9"
-    "amazonlinux:2")
+    "amazonlinux:2"
+    "amazonlinux:2022")
 
 for IMAGE in "${APT_TARGETS[@]}"
 do
@@ -39,5 +40,5 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "yum update -y curl sudo;curl $INSTALL_SCRIPT | sh"
+        sh -c "yum install -y sudo;curl $INSTALL_SCRIPT | sh"
 done


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves failures during publishing on the server side.
Adds AL2022 to test suite for releases and resolves issue with curl vs curl-minimal mismatch to resolve #6280 .

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Changes tested for 2.0.3 release process and also run the `test-release-packages.sh` script locally which failed for AL2022 prior to the updates in #6280 for the release server symlink.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
