### PR TITLE
tests: runtime: out_forward: Follow option order for fluent_signal

### DIFF
--- a/tests/runtime/out_forward.c
+++ b/tests/runtime/out_forward.c
@@ -143,8 +143,8 @@ static void cb_check_forward_mode(void *ctx, int ffd,
     TEST_CHECK(root.via.map.size == 2);
 
     /* Record */
-    key = root.via.map.ptr[0].key;
-    val = root.via.map.ptr[0].val;
+    key = root.via.map.ptr[1].key;
+    val = root.via.map.ptr[1].val;
 
     ret = strncmp(key.via.str.ptr, "fluent_signal", 13);
     TEST_CHECK(ret == 0);


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

From PR https://github.com/fluent/fluent-bit/pull/6298, the order of `fluent_signal` had been changed.
We should follow the option alignment. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
