### PR TITLE
out_forward: Make forwardable for msgpack payloads of ctraces and cmetrics

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1054,7 +1054,7 @@ static int pack_metricses_payload(msgpack_packer *mp_pck, const void *data, size
     int entries;
     struct flb_time tm;
 
-    /* Format with forward mode representation of entries: [time, [{entries map}] */
+    /* Format with event stream format of entries: [[time, [{entries map}]]] */
     msgpack_pack_array(mp_pck, 1);
     msgpack_pack_array(mp_pck, 2);
     flb_time_get(&tm);

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1049,7 +1049,7 @@ static int flush_message_mode(struct flb_forward *ctx,
     return FLB_OK;
 }
 
-/* pack payloads of cmetrics or ctraces */
+/* pack payloads of cmetrics or ctraces with Fluentd compat format */
 static int pack_metricses_payload(msgpack_packer *mp_pck, const void *data, size_t bytes) {
     int entries;
     struct flb_time tm;
@@ -1132,7 +1132,12 @@ static int flush_forward_mode(struct flb_forward *ctx,
         }
         else {
             /* FLB_EVENT_TYPE_METRICS and FLB_EVENT_TYPE_TRACES */
-            pack_metricses_payload(&mp_pck, data, bytes);
+            if (fc->fluentd_compat) {
+                pack_metricses_payload(&mp_pck, data, bytes);
+            }
+            else {
+                msgpack_pack_bin(&mp_pck, bytes);
+            }
         }
     }
 
@@ -1485,6 +1490,12 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Compression mode"
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "fluentd_compat", "false",
+     0, FLB_TRUE, offsetof(struct flb_forward_config, fluentd_compat),
+     "Send cmetrics and ctreaces with Fluentd compatible format"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1049,6 +1049,22 @@ static int flush_message_mode(struct flb_forward *ctx,
     return FLB_OK;
 }
 
+/* pack payloads of cmetrics or ctraces */
+static int pack_metricses_payload(msgpack_packer *mp_pck, const void *data, size_t bytes) {
+    int entries;
+    struct flb_time tm;
+
+    /* Format with forward mode representation of entries: [time, [{entries map}] */
+    msgpack_pack_array(mp_pck, 1);
+    msgpack_pack_array(mp_pck, 2);
+    flb_time_get(&tm);
+    flb_time_append_to_msgpack(&tm, mp_pck, 0);
+    entries = flb_mp_count(data, bytes);
+    msgpack_pack_array(mp_pck, entries);
+
+    return 0;
+}
+
 #include <fluent-bit/flb_pack.h>
 /*
  * Forward Mode: this is the generic mechanism used in Fluent Bit, it takes
@@ -1116,7 +1132,7 @@ static int flush_forward_mode(struct flb_forward *ctx,
         }
         else {
             /* FLB_EVENT_TYPE_METRICS and FLB_EVENT_TYPE_TRACES */
-            msgpack_pack_bin(&mp_pck, bytes);
+            pack_metricses_payload(&mp_pck, data, bytes);
         }
     }
 

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -69,6 +69,8 @@ struct flb_forward_config {
     int secured;              /* Using Secure Forward mode ?  */
     int compress;             /* Using compression ? */
     int time_as_integer;      /* Use backward compatible timestamp ? */
+    int fluentd_compat;       /* Use Fluentd compatible payload for
+                               * metrics and ctraces */
 
     /* config */
     flb_sds_t shared_key;        /* shared key                   */


### PR DESCRIPTION
Just using to pack `msgpack_pack_bin` is not suitable for them. Instead, we should format as forward mode compatible array with:

```
[[time, [{map of msgpack payloads}]]]
```

to be able to handle with ordinary msgpack handler for format of forward mode.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

### Client

```ini
[SERVICE]
    flush           1
    log_level       info

[INPUT]
    Name dummy
    Tag  dummy.local
    Dummy {"message":"ok"},{"message":"ng"}

[INPUT]
    name            fluentbit_metrics
    tag             internal_metrics
    scrape_interval 2

[OUTPUT]
    name forward
    host 127.0.0.1
    port 24224
    Match *
```

### Server

```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    info
    HTTP_Monitor Off
    HTTP_Port    2020

[INPUT]
    Name forward
    Listen 0.0.0.0
    Port 24224

[OUTPUT]
    Name  stdout
    Match **
```

- [x] Debug log output from testing the change

### Client

```log
Fluent Bit v2.0.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/01 18:30:09] [ info] [fluent bit] version=2.0.4, commit=9cc8113e9c, pid=61998
[2022/11/01 18:30:09] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/11/01 18:30:09] [ info] [cmetrics] version=0.5.4
[2022/11/01 18:30:09] [ info] [ctraces ] version=0.2.5
[2022/11/01 18:30:09] [ info] [output:forward:forward.0] worker #0 started
[2022/11/01 18:30:09] [ info] [output:forward:forward.0] worker #1 started
[2022/11/01 18:30:09] [ info] [input:dummy:dummy.0] initializing
[2022/11/01 18:30:09] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/11/01 18:30:09] [ info] [input:fluentbit_metrics:fluentbit_metrics.1] initializing
[2022/11/01 18:30:09] [ info] [input:fluentbit_metrics:fluentbit_metrics.1] storage_strategy='memory' (memory only)
[2022/11/01 18:30:09] [ info] [sp] stream processor started
^C[2022/11/01 18:30:16] [engine] caught signal (SIGINT)
[2022/11/01 18:30:16] [ warn] [engine] service will shutdown in max 5 seconds
[2022/11/01 18:30:16] [ info] [input] pausing dummy.0
[2022/11/01 18:30:16] [ info] [input] pausing fluentbit_metrics.1
[2022/11/01 18:30:16] [ info] [engine] service has stopped (0 pending tasks)
[2022/11/01 18:30:16] [ info] [input] pausing dummy.0
[2022/11/01 18:30:16] [ info] [input] pausing fluentbit_metrics.1
[2022/11/01 18:30:16] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2022/11/01 18:30:16] [ info] [output:forward:forward.0] thread worker #0 stopped
[2022/11/01 18:30:16] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2022/11/01 18:30:16] [ info] [output:forward:forward.0] thread worker #1 stopped
```

### Server

<details>

```ini
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/01 18:32:36] [ info] [fluent bit] version=2.0.4, commit=9cc8113e9c, pid=62296
[2022/11/01 18:32:36] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/11/01 18:32:36] [ info] [cmetrics] version=0.5.4
[2022/11/01 18:32:36] [ info] [ctraces ] version=0.2.5
[2022/11/01 18:32:36] [ info] [input:forward:forward.0] initializing
[2022/11/01 18:32:36] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2022/11/01 18:32:36] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2022/11/01 18:32:36] [ info] [sp] stream processor started
[2022/11/01 18:32:36] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.local: [1667295165.256291531, {"message"=>"ok"}]
[1] dummy.local: [1667295165.256296156, {"message"=>"ng"}]
[2] dummy.local: [1667295166.256894654, {"message"=>"ok"}]
[3] dummy.local: [1667295166.256898424, {"message"=>"ng"}]
[4] dummy.local: [1667295167.256330110, {"message"=>"ok"}]
[5] dummy.local: [1667295167.256334789, {"message"=>"ng"}]
[6] dummy.local: [1667295168.256977670, {"message"=>"ok"}]
[7] dummy.local: [1667295168.256982484, {"message"=>"ng"}]
[0] internal_metrics: [1667295167.257295534, [{"meta"=>{"cmetrics"=>{}, "external"=>{}, "processing"=>{"static_labels"=>[]}}, "metrics"=>[{"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"uptime", "desc"=>"Number of seconds that Fluent Bit has been running."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295166256299369, "value"=>2.000000, "labels"=>["cosmo-desktop2"], "hash"=>664066640404586629}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295165256387450, "value"=>46.000000, "labels"=>["dummy.0"], "hash"=>6783070066932086793}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295165256387450, "value"=>2.000000, "labels"=>["dummy.0"], "hash"=>16968241896094814569}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4946779648672010914}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15794832464412949418}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input_metrics", "name"=>"scrapes_total", "desc"=>"Number of total metrics scrapes"}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295166256285320, "value"=>1.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15030326482682587993}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_records_total", "desc"=>"Number of processed output records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>15661751111138614745}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_bytes_total", "desc"=>"Number of processed output bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>5465725391715919844}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"errors_total", "desc"=>"Number of output errors."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>13882354849639886681}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_total", "desc"=>"Number of output retries."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>6972050182517516939}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_failed_total", "desc"=>"Number of abandoned batches because the maximum number of re-tries was reached."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>5387944126978579888}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"dropped_records_total", "desc"=>"Number of dropped records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>10810607203038655654}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retried_records_total", "desc"=>"Number of retried records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>15641256103080011587}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"process_start_time_seconds", "desc"=>"Start time of the process since unix epoch in seconds."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295166256299369, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2"], "hash"=>9279690240191828959}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"build", "name"=>"info", "desc"=>"Build version information."}, "labels"=>["hostname", "version", "os"]}, "values"=>[{"ts"=>1667295166256299369, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2", "2.0.4", "linux"], "hash"=>9737196133976564598}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"chunks", "desc"=>"Total number of chunks in the storage layer."}, "labels"=>[]}, "values"=>[{"ts"=>1667295166256350150, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"mem_chunks", "desc"=>"Total number of memory chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295166256350150, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks", "desc"=>"Total number of filesystem chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295166256350150, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_up", "desc"=>"Total number of filesystem chunks up in memory."}, "labels"=>[]}, "values"=>[{"ts"=>1667295166256350150, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_down", "desc"=>"Total number of filesystem chunks down."}, "labels"=>[]}, "values"=>[{"ts"=>1667295166256350150, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>345147461112778720}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>7167725341110359014}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>18341432182238133750}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>7615278731212785254}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>16633914220152489335}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>14493782051985305177}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>15464840571236558416}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>13307571446852634075}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>16257654226546430846}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>5864526819762515360}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>3018828969657996730}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>7545927422868403483}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4070106569836085253}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>11761437835054501844}]}]}]]
[1] internal_metrics: [1667295169.257168815, [{"meta"=>{"cmetrics"=>{}, "external"=>{}, "processing"=>{"static_labels"=>[]}}, "metrics"=>[{"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"uptime", "desc"=>"Number of seconds that Fluent Bit has been running."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295168256331618, "value"=>4.000000, "labels"=>["cosmo-desktop2"], "hash"=>664066640404586629}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295167256552283, "value"=>138.000000, "labels"=>["dummy.0"], "hash"=>6783070066932086793}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295167256552283, "value"=>6.000000, "labels"=>["dummy.0"], "hash"=>16968241896094814569}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4946779648672010914}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15794832464412949418}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input_metrics", "name"=>"scrapes_total", "desc"=>"Number of total metrics scrapes"}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295168256318471, "value"=>2.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15030326482682587993}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_records_total", "desc"=>"Number of processed output records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295167257874653, "value"=>4.000000, "labels"=>["forward.0"], "hash"=>15661751111138614745}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_bytes_total", "desc"=>"Number of processed output bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295167257874653, "value"=>6619.000000, "labels"=>["forward.0"], "hash"=>5465725391715919844}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"errors_total", "desc"=>"Number of output errors."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>13882354849639886681}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_total", "desc"=>"Number of output retries."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>6972050182517516939}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_failed_total", "desc"=>"Number of abandoned batches because the maximum number of re-tries was reached."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>5387944126978579888}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"dropped_records_total", "desc"=>"Number of dropped records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>10810607203038655654}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retried_records_total", "desc"=>"Number of retried records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>15641256103080011587}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"process_start_time_seconds", "desc"=>"Start time of the process since unix epoch in seconds."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295168256331618, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2"], "hash"=>9279690240191828959}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"build", "name"=>"info", "desc"=>"Build version information."}, "labels"=>["hostname", "version", "os"]}, "values"=>[{"ts"=>1667295168256331618, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2", "2.0.4", "linux"], "hash"=>9737196133976564598}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"chunks", "desc"=>"Total number of chunks in the storage layer."}, "labels"=>[]}, "values"=>[{"ts"=>1667295168256368623, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"mem_chunks", "desc"=>"Total number of memory chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295168256368623, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks", "desc"=>"Total number of filesystem chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295168256368623, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_up", "desc"=>"Total number of filesystem chunks up in memory."}, "labels"=>[]}, "values"=>[{"ts"=>1667295168256368623, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_down", "desc"=>"Total number of filesystem chunks down."}, "labels"=>[]}, "values"=>[{"ts"=>1667295168256368623, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>345147461112778720}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>7167725341110359014}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>18341432182238133750}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>7615278731212785254}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>16633914220152489335}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>14493782051985305177}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849463666, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>15464840571236558416}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>13307571446852634075}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>16257654226546430846}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>5864526819762515360}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>3018828969657996730}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>7545927422868403483}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4070106569836085253}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>11761437835054501844}]}]}]]
[0] dummy.local: [1667295169.256407128, {"message"=>"ok"}]
[1] dummy.local: [1667295169.256413183, {"message"=>"ng"}]
[2] dummy.local: [1667295170.257178232, {"message"=>"ok"}]
[3] dummy.local: [1667295170.257182186, {"message"=>"ng"}]
[0] internal_metrics: [1667295170.788789411, [{"meta"=>{"cmetrics"=>{}, "external"=>{}, "processing"=>{"static_labels"=>[]}}, "metrics"=>[{"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"uptime", "desc"=>"Number of seconds that Fluent Bit has been running."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295170256341080, "value"=>6.000000, "labels"=>["cosmo-desktop2"], "hash"=>664066640404586629}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256457637, "value"=>230.000000, "labels"=>["dummy.0"], "hash"=>6783070066932086793}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256457637, "value"=>10.000000, "labels"=>["dummy.0"], "hash"=>16968241896094814569}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"bytes_total", "desc"=>"Number of input bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4946779648672010914}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"records_total", "desc"=>"Number of input records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849757645, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15794832464412949418}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"input_metrics", "name"=>"scrapes_total", "desc"=>"Number of total metrics scrapes"}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295170256326458, "value"=>3.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>15030326482682587993}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_records_total", "desc"=>"Number of processed output records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169257596556, "value"=>8.000000, "labels"=>["forward.0"], "hash"=>15661751111138614745}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"proc_bytes_total", "desc"=>"Number of processed output bytes."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169257596556, "value"=>13238.000000, "labels"=>["forward.0"], "hash"=>5465725391715919844}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"errors_total", "desc"=>"Number of output errors."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>13882354849639886681}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_total", "desc"=>"Number of output retries."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>6972050182517516939}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retries_failed_total", "desc"=>"Number of abandoned batches because the maximum number of re-tries was reached."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>5387944126978579888}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"dropped_records_total", "desc"=>"Number of dropped records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>10810607203038655654}]}, {"meta"=>{"ver"=>2, "type"=>0, "opts"=>{"ns"=>"fluentbit", "ss"=>"output", "name"=>"retried_records_total", "desc"=>"Number of retried records."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295164849914044, "value"=>0.000000, "labels"=>["forward.0"], "hash"=>15641256103080011587}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"", "name"=>"process_start_time_seconds", "desc"=>"Start time of the process since unix epoch in seconds."}, "labels"=>["hostname"]}, "values"=>[{"ts"=>1667295170256341080, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2"], "hash"=>9279690240191828959}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"build", "name"=>"info", "desc"=>"Build version information."}, "labels"=>["hostname", "version", "os"]}, "values"=>[{"ts"=>1667295170256341080, "value"=>1667295164.000000, "labels"=>["cosmo-desktop2", "2.0.4", "linux"], "hash"=>9737196133976564598}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"chunks", "desc"=>"Total number of chunks in the storage layer."}, "labels"=>[]}, "values"=>[{"ts"=>1667295170256378286, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"mem_chunks", "desc"=>"Total number of memory chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295170256378286, "value"=>1.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks", "desc"=>"Total number of filesystem chunks."}, "labels"=>[]}, "values"=>[{"ts"=>1667295170256378286, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_up", "desc"=>"Total number of filesystem chunks up in memory."}, "labels"=>[]}, "values"=>[{"ts"=>1667295170256378286, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"storage", "name"=>"fs_chunks_down", "desc"=>"Total number of filesystem chunks down."}, "labels"=>[]}, "values"=>[{"ts"=>1667295170256378286, "value"=>0.000000, "hash"=>0}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>345147461112778720}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>46.000000, "labels"=>["dummy.0"], "hash"=>7167725341110359014}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["dummy.0"], "hash"=>18341432182238133750}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["dummy.0"], "hash"=>7615278731212785254}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>0.000000, "labels"=>["dummy.0"], "hash"=>16633914220152489335}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["dummy.0"], "hash"=>14493782051985305177}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>46.000000, "labels"=>["dummy.0"], "hash"=>15464840571236558416}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_overlimit", "desc"=>"Is the input memory usage overlimit ?."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>13307571446852634075}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_memory_bytes", "desc"=>"Memory bytes used by the chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>6527.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>16257654226546430846}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks", "desc"=>"Total number of chunks."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>5864526819762515360}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_up", "desc"=>"Total number of chunks up in memory."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>3018828969657996730}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_down", "desc"=>"Total number of chunks down."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>0.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>7545927422868403483}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy", "desc"=>"Total number of chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>1.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>4070106569836085253}]}, {"meta"=>{"ver"=>2, "type"=>1, "opts"=>{"ns"=>"fluentbit", "ss"=>"input", "name"=>"storage_chunks_busy_bytes", "desc"=>"Total number of bytes used by chunks in a busy state."}, "labels"=>["name"]}, "values"=>[{"ts"=>1667295169256282683, "value"=>6527.000000, "labels"=>["fluentbit_metrics.1"], "hash"=>11761437835054501844}]}]}]]
```

</details>

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==61998== 
==61998== HEAP SUMMARY:
==61998==     in use at exit: 0 bytes in 0 blocks
==61998==   total heap usage: 3,933 allocs, 3,933 frees, 4,289,171 bytes allocated
==61998== 
==61998== All heap blocks were freed -- no leaks are possible
==61998== 
==61998== For lists of detected and suppressed errors, rerun with: -s
==61998== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
