### PR TITLE
flb_aws_util: added function flb_aws_strftime_precision for time output

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -22,6 +22,7 @@
 #ifndef FLB_AWS_UTIL_H
 
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_time.h>
 
 #define FLB_AWS_UTIL_H
 
@@ -176,6 +177,14 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size);
 //* Constructs S3 object key as per the format. */
 flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
                          char *tag_delimiter, uint64_t seq_index);
+
+/*
+ * This function is an extension to strftime which can support milliseconds with %3N,
+ * support nanoseconds with %9N or %L. The return value is the length of formatted
+ * time string.
+ */
+size_t flb_aws_strftime_precision(char **out_buf, const char *time_format,
+                                  struct flb_time *tms);
 
 #endif
 #endif /* FLB_HAVE_AWS */

--- a/plugins/out_kinesis_firehose/firehose_api.c
+++ b/plugins/out_kinesis_firehose/firehose_api.c
@@ -165,6 +165,7 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
     size_t len;
     size_t tmp_size;
     void *compressed_tmp_buf;
+    char *out_buf;
 
     tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
     ret = flb_msgpack_to_json(tmp_buf_ptr,
@@ -216,34 +217,48 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
                          ctx->delivery_stream);
             return 2;
         }
-        /* guess space needed to write time_key */
-        len = 6 + strlen(ctx->time_key) + 6 * strlen(ctx->time_key_format);
+
+        /* format time output and return the length */
+        len = flb_aws_strftime_precision(&out_buf, ctx->time_key_format, tms);
+
         /* how much space do we have left */
         tmp_size = (buf->tmp_buf_size - buf->tmp_buf_offset) - written;
         if (len > tmp_size) {
-            /* not enough space- tell caller to retry */
+            /* not enough space - tell caller to retry */
+            flb_free(out_buf);
             return 1;
         }
-        time_key_ptr = tmp_buf_ptr + written - 1;
-        memcpy(time_key_ptr, ",", 1);
-        time_key_ptr++;
-        memcpy(time_key_ptr, "\"", 1);
-        time_key_ptr++;
-        memcpy(time_key_ptr, ctx->time_key, strlen(ctx->time_key));
-        time_key_ptr += strlen(ctx->time_key);
-        memcpy(time_key_ptr, "\":\"", 3);
-        time_key_ptr += 3;
-        tmp_size = buf->tmp_buf_size - buf->tmp_buf_offset;
-        tmp_size -= (time_key_ptr - tmp_buf_ptr);
-        len = strftime(time_key_ptr, tmp_size, ctx->time_key_format, &time_stamp);
-        if (len <= 0) {
-            /* ran out of space - should not happen because of check above */
-            return 1;
+
+        if (len == 0) {
+            /*
+             * when the length of out_buf is not enough for time_key_format,
+             * time_key will not be added to record.
+             */
+            flb_plg_error(ctx->ins, "Failed to add time_key %s to record, %s",
+                          ctx->time_key, ctx->delivery_stream);
+            flb_free(out_buf);
         }
-        time_key_ptr += len;
-        memcpy(time_key_ptr, "\"}", 2);
-        time_key_ptr += 2;
-        written = (time_key_ptr - tmp_buf_ptr);
+        else {
+            time_key_ptr = tmp_buf_ptr + written - 1;
+            memcpy(time_key_ptr, ",", 1);
+            time_key_ptr++;
+            memcpy(time_key_ptr, "\"", 1);
+            time_key_ptr++;
+            memcpy(time_key_ptr, ctx->time_key, strlen(ctx->time_key));
+            time_key_ptr += strlen(ctx->time_key);
+            memcpy(time_key_ptr, "\":\"", 3);
+            time_key_ptr += 3;
+            tmp_size = buf->tmp_buf_size - buf->tmp_buf_offset;
+            tmp_size -= (time_key_ptr - tmp_buf_ptr);
+
+            /* merge out_buf to time_key_ptr */
+            memcpy(time_key_ptr, out_buf, len);
+            flb_free(out_buf);
+            time_key_ptr += len;
+            memcpy(time_key_ptr, "\"}", 2);
+            time_key_ptr += 2;
+            written = (time_key_ptr - tmp_buf_ptr);
+        }
     }
 
     /* is (written + 1) because we still have to append newline */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[INPUT]
    Name                         forward
    Listen                       0.0.0.0
    Port                         24224
[OUTPUT]
    Name                         kinesis_streams
    Match                        *
    region                       us-east-1
    stream                       test-clay-firehose
    time_key                     @timestamp
    time_key_format              %Y-%m-%dT%H:%M:%S.%3N.%L.%L
```
- [x] Debug log output from testing the change
***Normal time_key_format***
```
[INPUT]
    Name                         forward
    Listen                       0.0.0.0
    Port                         24224

[OUTPUT]
    Name                         kinesis_streams
    Match                        *
    region                       us-east-1
    stream              test-clay-firehose
    time_key                     @timestamp
    time_key_format              %Y-%m-%dT%H:%M:%S.%3N.%L.%L
```
```
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.250.250161647.250161647.250161647"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.250.250229597.250229597.250229597"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.250.250403404.250403404.250403404"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.251.251213550.251213550.251213550"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.251.251456260.251456260.251456260"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.251.251516580.251516580.251516580"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.251.251573085.251573085.251573085"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.251.251810073.251810073.251810073"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.252.252052307.252052307.252052307"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.252.252310276.252310276.252310276"}
{"from":"userA","to":"userB","@timestamp":"2023-01-04T00:39:14.253.253333330.253333330.253333330"}
```
***Wrong time_key_format***
```
[INPUT]
    Name                         forward
    Listen                       0.0.0.0
    Port                         24224

[OUTPUT]
    Name                         kinesis_streams
    Match                        *
    region                       us-east-1
    stream              test-clay-firehose
    time_key                     @timestamp
    time_key_format              %Y-%m-%dT%H:%M:%S.%3N.%L.%L-%9N-9N~%9N-99N~%99N-99NN~%9%9NN-9NL~%9N%L
```
****fluent-bit log****
```
[2023/01/04 01:05:02] [ info] [output:kinesis_streams:kinesis_streams.0] worker #0 started
[2023/01/04 01:05:19] [error] [output:kinesis_streams:kinesis_streams.0] Failed to add time_key @timestamp to record, test-clay-firehose
[2023/01/04 01:05:19] [error] [output:kinesis_streams:kinesis_streams.0] Failed to add time_key @timestamp to record, test-clay-firehose
[2023/01/04 01:05:19] [error] [output:kinesis_streams:kinesis_streams.0] Failed to add time_key @timestamp to record, test-clay-firehose
[2023/01/04 01:05:19] [error] [output:kinesis_streams:kinesis_streams.0] Failed to add time_key @timestamp to record, test-clay-firehose
[2023/01/04 01:05:19] [error] [output:kinesis_streams:kinesis_streams.0] Failed to add time_key @timestamp to record, test-clay-firehose
```
```
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
{"from":"userA","to":"userB"}
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==8834== 
==8834== LEAK SUMMARY:
==8834==    definitely lost: 0 bytes in 0 blocks
==8834==    indirectly lost: 0 bytes in 0 blocks
==8834==      possibly lost: 0 bytes in 0 blocks
==8834==    still reachable: 102,912 bytes in 3,432 blocks
==8834==         suppressed: 0 bytes in 0 blocks
==8834== 
==8834== For lists of detected and suppressed errors, rerun with: -s
==8834== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/981 https://github.com/fluent/fluent-bit-docs/pull/980
**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
