### PR TITLE
core: minimal synchronous scheduler

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -59,8 +59,9 @@
 #define FLB_OUTPUT_NET            32  /* output address may set host and port */
 #define FLB_OUTPUT_PLUGIN_CORE     0
 #define FLB_OUTPUT_PLUGIN_PROXY    1
-#define FLB_OUTPUT_NO_MULTIPLEX  512
+#define FLB_OUTPUT_NO_MULTIPLEX  512  /* run one task at a time, one task per flush */
 #define FLB_OUTPUT_PRIVATE      1024
+#define FLB_OUTPUT_SYNCHRONOUS  2048  /* run one task at a time, no flush cycle limit */
 
 
 /* Event type handlers */
@@ -357,6 +358,7 @@ struct flb_output_instance {
      * loaded (in backlog)
      */
     size_t fs_backlog_chunks_size;
+
     /*
      * Buffer limit: optional limit set by configuration so this output instance
      * cannot buffer more than total_limit_size (bytes unit).
@@ -366,6 +368,9 @@ struct flb_output_instance {
      * filesystem as buffer type.
      */
     size_t total_limit_size;
+
+    /* Queue for singleplexed tasks */
+    struct flb_task_queue *singleplex_queue;
 
     /* Thread Pool: this is optional for the caller */
     int tp_workers;
@@ -721,6 +726,12 @@ struct flb_output_instance *flb_output_get_instance(struct flb_config *config,
                                                     int out_id);
 int flb_output_flush_finished(struct flb_config *config, int out_id);
 
+int flb_output_task_singleplex_enqueue(struct flb_task_queue *queue,
+                                       struct flb_task_retry *retry,
+                                       struct flb_task *task,
+                                       struct flb_output_instance *out_ins,
+                                       struct flb_config *config);
+int flb_output_task_singleplex_flush_next(struct flb_task_queue *queue);
 struct flb_output_instance *flb_output_new(struct flb_config *config,
                                            const char *output, void *data,
                                            int public_only);

--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -88,6 +88,34 @@ struct flb_task {
     struct flb_config *config;           /* parent flb config             */
 };
 
+/*
+ * A queue of flb_task_enqueued tasks
+ *
+ * This structure is currently used to track pending flushes when FLB_OUTPUT_SYNCHRONOUS
+ * is used.
+ */
+struct flb_task_queue {
+    struct mk_list pending;
+    struct mk_list in_progress;
+};
+
+/*
+ * An enqueued task is a task that is not yet dispatched to a thread
+ * or started on the engine.
+ *
+ * There may be multiple enqueued instances of the same task on different out instances.
+ *
+ * This structure is currently used to track pending flushes when FLB_OUTPUT_SYNCHRONOUS
+ * is used.
+ */
+struct flb_task_enqueued {
+    struct flb_task *task;
+    struct flb_task_retry *retry;
+    struct flb_output_instance *out_instance;
+    struct flb_config *config;
+    struct mk_list _head;
+};
+
 int flb_task_running_count(struct flb_config *config);
 int flb_task_running_print(struct flb_config *config);
 
@@ -104,6 +132,8 @@ void flb_task_add_coro(struct flb_task *task, struct flb_coro *coro);
 
 void flb_task_destroy(struct flb_task *task, int del);
 
+struct flb_task_queue* flb_task_queue_create();
+void flb_task_queue_destroy(struct flb_task_queue *queue);
 struct flb_task_retry *flb_task_retry_create(struct flb_task *task,
                                              struct flb_output_instance *ins);
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -344,13 +344,6 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
         goto error;
     }
 
-    /*
-     * Remove async flag from upstream
-     * CW output runs in sync mode; because the CW API currently requires
-     * PutLogEvents requests to a log stream to be made serially
-     */
-    upstream->flags &= ~(FLB_IO_ASYNC);
-
     ctx->cw_client->upstream = upstream;
     flb_output_upstream_set(upstream, ctx->ins);
     ctx->cw_client->host = ctx->endpoint;
@@ -666,7 +659,12 @@ struct flb_output_plugin out_cloudwatch_logs_plugin = {
     .cb_init      = cb_cloudwatch_init,
     .cb_flush     = cb_cloudwatch_flush,
     .cb_exit      = cb_cloudwatch_exit,
-    .flags        = 0,
+
+    /*
+     * Allow cloudwatch to use async network stack synchronously by opting into
+     * FLB_OUTPUT_SYNCHRONOUS synchronous task scheduler
+     */
+    .flags        = FLB_OUTPUT_SYNCHRONOUS,
     .workers      = 1,
 
     /* Configuration */

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -224,6 +224,13 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
     }
     name = (char *) flb_output_name(ins);
 
+    /* If we are in synchronous mode, flush the next waiting task */
+    if (ins->flags & FLB_OUTPUT_SYNCHRONOUS) {
+        if (ret == FLB_OK || ret == FLB_RETRY || ret == FLB_ERROR) {
+            flb_output_task_singleplex_flush_next(ins->singleplex_queue);
+        }
+    }
+
     /* A task has finished, delete it */
     if (ret == FLB_OK) {
         /* cmetrics */

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -75,11 +75,25 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     flb_event_chunk_update(task->event_chunk, buf_data, buf_size);
 
     /* flush the task */
-    ret = flb_output_task_flush(task, retry->o_ins, config);
-    if (ret == -1) {
-        flb_task_retry_destroy(retry);
-        return -1;
+    if (retry->o_ins->flags & FLB_OUTPUT_SYNCHRONOUS) {
+        /*
+         * If the plugin doesn't allow for multiplexing.
+         * singleplex_enqueue deletes retry context on flush or delayed flush failure
+         */
+        ret = flb_output_task_singleplex_enqueue(retry->o_ins->singleplex_queue, retry,
+                                                 task, retry->o_ins, config);
+        if (ret == -1) {
+            return -1;
+        }
     }
+    else {
+        ret = flb_output_task_flush(task, retry->o_ins, config);
+        if (ret == -1) {
+            flb_task_retry_destroy(retry);
+            return -1;
+        }
+    }
+
     return 0;
 }
 
@@ -183,10 +197,20 @@ static int tasks_start(struct flb_input_instance *in,
             hits++;
 
             /*
-             * We have the Task and the Route, created a thread context for the
-             * data handling.
+             * If the plugin is in synchronous mode, enqueue the task and flush
+             * when appropriate.
              */
-            flb_output_task_flush(task, route->out, config);
+            if (out->flags & FLB_OUTPUT_SYNCHRONOUS) {
+                flb_output_task_singleplex_enqueue(route->out->singleplex_queue, NULL,
+                                                   task, route->out, config);
+            }
+            else {
+                /*
+                 * We have the Task and the Route, created a thread context for the
+                 * data handling.
+                 */
+                flb_output_task_flush(task, route->out, config);
+            }
 
             /*
             th = flb_output_thread(task,

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -174,6 +174,125 @@ void flb_output_coro_add(struct flb_output_instance *ins, struct flb_coro *coro)
 }
 
 /*
+ * Queue a task to be flushed at a later time
+ * Deletes retry context if enqueue fails
+ */
+static int flb_output_task_queue_enqueue(struct flb_task_queue *queue,
+                                         struct flb_task_retry *retry,
+                                         struct flb_task *task,
+                                         struct flb_output_instance *out_ins,
+                                         struct flb_config *config)
+{
+    struct flb_task_enqueued *queued_task;
+
+    queued_task = flb_malloc(sizeof(struct flb_task_enqueued));
+    if (!queued_task) {
+        flb_errno();
+        if (retry) {
+            flb_task_retry_destroy(retry);
+        }
+        return -1;
+    }
+    queued_task->retry = retry;
+    queued_task->out_instance = out_ins;
+    queued_task->task = task;
+    queued_task->config = config;
+
+    mk_list_add(&queued_task->_head, &queue->pending);
+    return 0;
+}
+
+/*
+ * Pop task from pending queue and flush it
+ * Will delete retry context if flush fails
+ */
+static int flb_output_task_queue_flush_one(struct flb_task_queue *queue)
+{
+    struct flb_task_enqueued *queued_task;
+    int ret;
+    int is_empty;
+
+    is_empty = mk_list_is_empty(&queue->pending) == 0;
+    if (is_empty) {
+        flb_error("Attempting to flush task from an empty in_progress queue");
+        return -1;
+    }
+
+    queued_task = mk_list_entry_first(&queue->pending, struct flb_task_enqueued, _head);
+    mk_list_del(&queued_task->_head);
+    mk_list_add(&queued_task->_head, &queue->in_progress);
+    ret = flb_output_task_flush(queued_task->task,
+                                queued_task->out_instance,
+                                queued_task->config);
+
+    /* Destroy retry context if needed */
+    if (ret == -1) {
+        if (queued_task->retry) {
+            flb_task_retry_destroy(queued_task->retry);
+        }
+        /* Flush the next task */
+        flb_output_task_singleplex_flush_next(queue);
+        return -1;
+    }
+
+    return ret;
+}
+
+/*
+ * Will either run or queue running a single task
+ * Deletes retry context if enqueue fails
+ */
+int flb_output_task_singleplex_enqueue(struct flb_task_queue *queue,
+                                       struct flb_task_retry *retry,
+                                       struct flb_task *task,
+                                       struct flb_output_instance *out_ins,
+                                       struct flb_config *config)
+{
+    int ret;
+    int is_empty;
+
+    /* Enqueue task */
+    ret = flb_output_task_queue_enqueue(queue, retry, task, out_ins, config);
+    if (ret == -1) {
+        return -1;
+    }
+
+    /* Launch task if nothing is running */
+    is_empty = mk_list_is_empty(&out_ins->singleplex_queue->in_progress) == 0;
+    if (is_empty) {
+        return flb_output_task_queue_flush_one(out_ins->singleplex_queue);
+    }
+    
+    return 0;
+}
+
+/*
+ * Clear in progress task and flush a single queued task if exists
+ * Deletes retry context on next flush if flush fails
+ */
+int flb_output_task_singleplex_flush_next(struct flb_task_queue *queue)
+{
+    int is_empty;
+    struct flb_task_enqueued *ended_task;
+
+    /* Remove in progress task */
+    is_empty = mk_list_is_empty(&queue->in_progress) == 0;
+    if (!is_empty) {
+        ended_task = mk_list_entry_first(&queue->in_progress,
+                                        struct flb_task_enqueued, _head);
+        mk_list_del(&ended_task->_head);
+        flb_free(ended_task);
+    }
+    
+    /* Flush if there is a pending task queued */
+    is_empty = mk_list_is_empty(&queue->pending) == 0;
+    if (!is_empty) {
+        return flb_output_task_queue_flush_one(queue);
+    }
+    return 0;
+}
+
+/*
  * Flush a task through the output plugin, either using a worker thread + coroutine
  * or a simple co-routine in the current thread.
  */
@@ -191,6 +310,11 @@ int flb_output_task_flush(struct flb_task *task,
         ret = flb_output_thread_pool_flush(task, out_ins, config);
         if (ret == -1) {
             flb_task_users_dec(task, FLB_FALSE);
+
+            /* If we are in synchronous mode, flush one waiting task */
+            if (out_ins->flags & FLB_OUTPUT_SYNCHRONOUS) {
+                flb_output_task_singleplex_flush_next(out_ins->singleplex_queue);
+            }
         }
     }
     else {
@@ -208,6 +332,14 @@ int flb_output_task_flush(struct flb_task *task,
                         sizeof(struct flb_output_flush*));
         if (ret == -1) {
             flb_errno();
+            flb_output_flush_destroy(out_flush);
+            flb_task_users_dec(task, FLB_FALSE);
+
+            /* If we are in synchronous mode, flush one waiting task */
+            if (out_ins->flags & FLB_OUTPUT_SYNCHRONOUS) {
+                flb_output_task_singleplex_flush_next(out_ins->singleplex_queue);
+            }
+
             return -1;
         }
     }
@@ -284,6 +416,11 @@ int flb_output_instance_destroy(struct flb_output_instance *ins)
 
     /* release properties */
     flb_output_free_properties(ins);
+
+    /* free singleplex queue */
+    if (ins->flags & FLB_OUTPUT_SYNCHRONOUS) {
+        flb_task_queue_destroy(ins->singleplex_queue);
+    }
 
     mk_list_del(&ins->_head);
     flb_free(ins);
@@ -461,6 +598,9 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->p = plugin;
     instance->callback = flb_callback_create(instance->name);
     if (!instance->callback) {
+        if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+            flb_task_queue_destroy(instance->singleplex_queue);
+        }
         flb_free(instance);
         return NULL;
     }
@@ -474,6 +614,9 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
         ctx = flb_calloc(1, sizeof(struct flb_plugin_proxy_context));
         if (!ctx) {
             flb_errno();
+            if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+                flb_task_queue_destroy(instance->singleplex_queue);
+            }
             flb_free(instance);
             return NULL;
         }
@@ -527,7 +670,21 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     if (plugin->flags & FLB_OUTPUT_NET) {
         ret = flb_net_host_set(plugin->name, &instance->host, output);
         if (ret != 0) {
+            if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+                flb_task_queue_destroy(instance->singleplex_queue);
+            }
             flb_free(instance);
+            return NULL;
+        }
+    }
+
+    /* Create singleplex queue if SYNCHRONOUS mode is used */
+    instance->singleplex_queue = NULL;
+    if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+        instance->singleplex_queue = flb_task_queue_create();
+        if (!instance->singleplex_queue) {
+            flb_free(instance);
+            flb_errno();
             return NULL;
         }
     }

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -483,3 +483,35 @@ void flb_task_destroy(struct flb_task *task, int del)
     }
     flb_free(task);
 }
+
+struct flb_task_queue* flb_task_queue_create() {
+    struct flb_task_queue *tq;
+    tq = flb_malloc(sizeof(struct flb_task_queue));
+    if (!tq) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(&tq->pending);
+    mk_list_init(&tq->in_progress);
+    return tq;
+}
+
+void flb_task_queue_destroy(struct flb_task_queue *queue) {
+    struct flb_task_enqueued *queued_task;
+    struct mk_list *tmp;
+    struct mk_list *head;
+
+    mk_list_foreach_safe(head, tmp, &queue->pending) {
+        queued_task = mk_list_entry(head, struct flb_task_enqueued, _head);
+        mk_list_del(&queued_task->_head);
+        flb_free(queued_task);
+    }
+
+    mk_list_foreach_safe(head, tmp, &queue->in_progress) {
+        queued_task = mk_list_entry(head, struct flb_task_enqueued, _head);
+        mk_list_del(&queued_task->_head);
+        flb_free(queued_task);
+    }
+
+    flb_free(queue);
+}


### PR DESCRIPTION
# Minimal Synchronous Scheduler - 1.9x
>Master branch PR https://github.com/fluent/fluent-bit/pull/6413
Please leave review comments on this 1.9x branch.
## Summary
Implement a synchronous task scheduler plugin option allowing for the cloudwatch_logs plugin to opt into to allow for migrate to the Async Network stack.

## Issue
Due to limitations of the CloudWatch API in processing PutLogEvents network requests synchronously, Fluent Bit sends data to CloudWatch using a less supported “synchronous” networking stack. This stack is prone to indefinite hangs and segfaults and only works well when used with a fine tuned configuration.
See: https://github.com/fluent/fluent-bit/issues/6140 and https://github.com/fluent/fluent-bit/issues/6329

## Investigative Efforts
While at first we tried to resolve the networking hang issues found in the synchronous network stack by adding OpenSSL error handling, DNS Timeouts, and enabling unidirectional TLS shutdowns, these efforts only made fluent bit go from failing once in 5 minutes without the changes to once in 5 hours with the changes - when tested under a high load failure case. We determined that it would take too much effort to isolate synchronous network stack issues and decided to invest efforts switching to the widely used Fluent Bit asynchronous network stack.

* [Open SSL error handling](https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer) (https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer)
* [Remove bidirectional tcp shutdown](https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer) (https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer)
* Switch to [async DNS](https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer) (https://github.com/matthewfala/fluent-bit/commits/instrument-1.9.8-net-layer)


## Solution
Our proposed solution is to migrate the Cloudwatch Logs output plugin to Fluent Bit’s asynchronous network stack.

## Switching to Async Network Stack

*CloudWatch API Synchronous Usage Requirements*
CloudWatch relies on the Synchronous networking to ensure that CloudWatch Logs PutLogEvents requests are done sequentially.

Normally when the asynchronous network stack is used, Fluent Bit context switches in the next batch of logs into processing when the previous batch yields on a network call. This defeats the desired sequential PutLogEvents execution required by CloudWatch.

*Existing Core Synchronous Scheduler*
In order to enforce sequential processing of log data when the asynchronous network stack is used, we opt our CloudWatch Logs plugin into a Fluent Bit Core synchronous task scheduler which limits one batch of logs to be processed at a time, essentially using the asynchronous networking stack in a synchronous manner.

A bottleneck was discovered in the Fluent Bit Core Synchronous scheduler, which limits processing logs to 1 batch per second (or per flush interval).

*New Performant Core Synchronous Scheduler*
A performant new core scheduler was written by the FireLens team that removes this 1 batch per second restriction while keeping the one batch at a time processing restriction in place. The CloudWatch Plugin opts into the performant Synchronous Scheduler implementation and uses the asynchronous network stack.



For plugins that opt into FLB_OUTPUT_SYNCHRONOUS by setting that as a plugin flag, there will be a limit of 1 task per output_instance worker group.


## Testing and Results

#### Unit Testing

A series of 24 hour tests were conducted on Fluent Bit 1.9x with the patch with and without Valgrind. No network hangs were observed on 1.9 and no memory leaks were introduced by the patch.

A 24 hour test was conducted on Fluent Bit 2.0x with the patch. No network hangs were observed.

#### Parallel Long Running Durability Tests

To simulate the customer’s long running execution of Fluent Bit, 40-100 ECS FireLens test tasks per test were run in parallel to accumulate cumulative running time and gain confidence in the patch.

The following is a stability matrix outlining the patches impact on Fluent Bit’s durability rating which is described lowerbounded average hours to failure (HTF)

Fluent 1.9x (AWS For Fluent Bit Official Release)

_ | Patch | No Patch
-- |-- | --
Keepalive On | [2] Very Stable (+3500h) | [1,8] Segfault on some network errors after throttling limits (~80h)
Keepalive Off | [3] Somewhat stable (~2000h) | Cloudwatch Hang(~0.08h)



Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
