### PR TITLE
networking: added a flag to diferentiate input plugins that listen for connections 

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -61,6 +61,10 @@
 #define FLB_INPUT_PRIVATE    256   /* plugin is not published/exposed       */
 #define FLB_INPUT_NOTAG      512   /* plugin might don't have tags          */
 #define FLB_INPUT_THREADED  1024   /* plugin must run in a separate thread  */
+#define FLB_INPUT_NET_SERVER   8   /* Input address may set host and port.
+                                    * In addition, if TLS is enabled then a
+                                    * private key and certificate are required.
+                                    */
 
 /* Input status */
 #define FLB_INPUT_RUNNING     1

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -319,5 +319,5 @@ struct flb_input_plugin in_forward_plugin = {
     .cb_pause     = in_fw_pause,
     .cb_exit      = in_fw_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -194,5 +194,5 @@ struct flb_input_plugin in_http_plugin = {
     .cb_resume    = NULL,
     .cb_exit      = in_http_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS,
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_mqtt/mqtt.c
+++ b/plugins/in_mqtt/mqtt.c
@@ -154,5 +154,5 @@ struct flb_input_plugin in_mqtt_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_mqtt_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS,
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -196,5 +196,5 @@ struct flb_input_plugin in_opentelemetry_plugin = {
     .cb_resume    = NULL,
     .cb_exit      = in_opentelemetry_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS,
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -240,5 +240,5 @@ struct flb_input_plugin in_syslog_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_syslog_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -180,5 +180,5 @@ struct flb_input_plugin in_tcp_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_tcp_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS,
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/plugins/in_udp/udp.c
+++ b/plugins/in_udp/udp.c
@@ -188,5 +188,5 @@ struct flb_input_plugin in_udp_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_udp_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET,
+    .flags        = FLB_INPUT_NET_SERVER,
 };

--- a/plugins/in_unix_socket/unix_socket.c
+++ b/plugins/in_unix_socket/unix_socket.c
@@ -316,5 +316,5 @@ struct flb_input_plugin in_unix_socket_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_unix_socket_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET | FLB_IO_OPT_TLS, // | FLB_IO_ASYNC
+    .flags        = FLB_INPUT_NET_SERVER | FLB_IO_OPT_TLS
 };

--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -242,21 +242,21 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
         config_map = flb_config_map_create(ins->config, ins->p->config_map);
         options_size = mk_list_size(config_map);
 
-        if (ins->flags & FLB_INPUT_NET) {
+        if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
             options_size += 2;
         }
-        if (ins->flags & FLB_IO_OPT_TLS && 0) {
+        if (ins->flags & FLB_IO_OPT_TLS) {
             tls_config = flb_tls_get_config_map(ins->config);
             options_size += mk_list_size(tls_config);
         }
 
         msgpack_pack_array(&mp_pck, options_size);
 
-        if (ins->flags & FLB_INPUT_NET) {
+        if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
             pack_config_map_entry(&mp_pck, &m_input_net_listen);
             pack_config_map_entry(&mp_pck, &m_input_net_port);
         }
-        if (ins->flags & FLB_IO_OPT_TLS && 0) {
+        if (ins->flags & FLB_IO_OPT_TLS) {
             mk_list_foreach(head, tls_config) {
                 m = mk_list_entry(head, struct flb_config_map, _head);
                 pack_config_map_entry(&mp_pck, m);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -271,7 +271,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         flb_kv_init(&instance->net_properties);
 
         /* Plugin use networking */
-        if (plugin->flags & FLB_INPUT_NET) {
+        if (plugin->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) {
             ret = flb_net_host_set(plugin->name, &instance->host, input);
             if (ret != 0) {
                 flb_free(instance);
@@ -1014,7 +1014,8 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     }
 
 #ifdef FLB_HAVE_TLS
-    if (ins->use_tls == FLB_TRUE) {
+    if (ins->use_tls == FLB_TRUE &&
+        (p->flags & FLB_INPUT_NET_SERVER) != 0) {
         if (ins->tls_crt_file == NULL) {
             tls_error_message = "certificate file missing";
 


### PR DESCRIPTION
This PR adds the `FLB_INPUT_NET_SERVER` flag meant to be used in input plugins that start listeners in order to differentiate them from those that actively fetch information from remote sources while enforcing TLS setting correctness.

Additionally, the `FLB_IO_OPT_TLS` flag was added to some plugins that should have it but didn't.