### PR TITLE
tests: internal: parser_regex: add test for parser_regex

### DIFF
--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -31,6 +31,7 @@ set(UNIT_TESTS_FILES
   bucket_queue.c
   flb_event_loop.c
   ring_buffer.c
+  parser_regex.c
   )
 
 # Config format

--- a/tests/internal/parser_regex.c
+++ b/tests/internal/parser_regex.c
@@ -1,0 +1,491 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_format.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_parser_decoder.h>
+#include <msgpack.h>
+#include <float.h>
+#include <math.h>
+#include "flb_tests_internal.h"
+
+static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
+{
+    int ret = -1;
+
+    if (str == NULL) {
+        flb_error("str is NULL");
+        return -1;
+    }
+
+    switch (obj.type)  {
+    case MSGPACK_OBJECT_STR:
+        if (obj.via.str.size != str_len) {
+            return -1;
+        }
+        ret = strncmp(str, obj.via.str.ptr, str_len);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            unsigned long val = strtoul(str, NULL, 10);
+            if (val == (unsigned long)obj.via.u64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            long long val = strtoll(str, NULL, 10);
+            if (val == (unsigned long)obj.via.i64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            double val = strtod(str, NULL);
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            if (str_len != 4 /*true*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "true", 4);
+        }
+        else {
+            if (str_len != 5 /*false*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "false", 5);
+        }
+        break;
+    default:
+        flb_error("not supported");
+    }
+
+    return ret;
+}
+
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+static int compare_msgpack(void *msgpack_data, size_t msgpack_size, struct str_list *l)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+    int map_size;
+    int i_map;
+    int i_list;
+    int num = 0;
+
+    if (!TEST_CHECK(msgpack_data != NULL)) {
+        TEST_MSG("msgpack_data is NULL");
+        return -1;
+    }
+    else if (!TEST_CHECK(msgpack_size > 0)) {
+        TEST_MSG("msgpack_size is 0");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, msgpack_data, msgpack_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        obj = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_MAP)) {
+            TEST_MSG("map error. type = %d", obj.type);
+            continue;
+        }
+        map_size = obj.via.map.size;
+        for (i_map=0; i_map<map_size; i_map++) {
+            if (!TEST_CHECK(obj.via.map.ptr[i_map].key.type == MSGPACK_OBJECT_STR)) {
+                TEST_MSG("key is not string. type =%d", obj.via.map.ptr[i_map].key.type);
+                continue;
+            }
+            for (i_list=0; i_list< l->size/2; i_list++)  {
+                if (msgpack_strncmp(l->lists[i_list*2], strlen(l->lists[i_list*2]),
+                                    obj.via.map.ptr[i_map].key) == 0 &&
+                    msgpack_strncmp(l->lists[i_list*2+1], strlen(l->lists[i_list*2+1]),
+                                    obj.via.map.ptr[i_map].val) == 0) {
+                    num++;
+                }
+            }
+        }
+    }
+    msgpack_unpacked_destroy(&result);
+    if (!TEST_CHECK(num == l->size/2)) {
+        msgpack_object_print(stdout, obj);
+        putchar('\n');
+        TEST_MSG("compare failed. matched_num=%d expect=%lu", num, l->size/2);
+        return -1;
+    }
+    return 0;
+}
+
+void test_basic()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret = 0;
+    char *input = "text 100 1.23 true";
+    char *regex = "(?<str>[a-z]+) (?<int>\\d+) (?<double>\\d+\\.\\d+) (?<bool>true)";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"str", "text", "int", "100", "double","1.23", "bool", "true"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+
+    parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+    }
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_time_key()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret = 0;
+    char *input = "text 100 1.23 true 2022-10-31T12:00:01.123";
+    char *regex = "(?<str>[a-z]+) (?<int>\\d+) (?<double>\\d+\\.\\d+) (?<bool>true) (?<time>.+)";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"str", "text", "int", "100", "double","1.23", "bool", "true"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    out_time.tm.tv_sec = 0;
+    out_time.tm.tv_nsec = 0;
+
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+
+    parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
+                               FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+        flb_free(out_buf);
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    if (!TEST_CHECK(out_time.tm.tv_sec == 1667217601 && out_time.tm.tv_nsec == 123000000)) {
+        TEST_MSG("timestamp error. sec  Got=%ld Expect=1667217601", out_time.tm.tv_sec);
+        TEST_MSG("timestamp error. nsec Got=%ld Expect=123000000", out_time.tm.tv_nsec);
+    }
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_time_keep()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret = 0;
+    char *input = "text 100 1.23 true 2022-10-31T12:00:01.123";
+    char *regex = "(?<str>[a-z]+) (?<int>\\d+) (?<double>\\d+\\.\\d+) (?<bool>true) (?<time>.+)";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"str", "text", "int", "100", "double","1.23", "bool", "true", "time", "2022-10-31T12:00:01.123"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    out_time.tm.tv_sec = 0;
+    out_time.tm.tv_nsec = 0;
+
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+
+    parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
+                               FLB_TRUE /*time_keep */, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+        flb_free(out_buf);
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    if (!TEST_CHECK(out_time.tm.tv_sec == 1667217601 && out_time.tm.tv_nsec == 123000000)) {
+        TEST_MSG("timestamp error. sec  Got=%ld Expect=1667217601", out_time.tm.tv_sec);
+        TEST_MSG("timestamp error. nsec Got=%ld Expect=123000000", out_time.tm.tv_nsec);
+    }
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_types()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret = 0;
+    char *input = "text 100 1.23 true";
+    char *regex = "(?<str>[a-z]+) (?<int>\\d+) (?<double>\\d+\\.\\d+) (?<bool>true)";
+    struct flb_parser_types *types = NULL;
+
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"str", "text", "int", "256" /*= 0x100 */, "double","1.23", "bool", "true"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+
+    /* Note: types will be released by flb_parser_destroy */
+    types = flb_malloc(sizeof(struct flb_parser_types));
+    if (!TEST_CHECK(types != NULL)) {
+        TEST_MSG("flb_malloc failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+    types->key = flb_malloc(strlen("int")+1);
+    if (!TEST_CHECK(types->key != NULL)) {
+        TEST_MSG("flb_malloc failed");
+        flb_free(types);
+        flb_config_exit(config);
+        exit(1);
+    }
+    strcpy(types->key, "int");
+    types->key_len = 3;
+    types->type = FLB_PARSER_TYPE_HEX;
+
+    parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE,
+                               types, 1, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create failed");
+        flb_free(types->key);
+        flb_free(types);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+    }
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_decode_field_json()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    struct cfl_variant *var = NULL;
+    int ret = 0;
+    char *input = "{\"str\":\"text\", \"int\":100, \"double\":1.23, \"bool\":true}";
+    char *regex = "(?<json_str>.+)";
+    struct flb_cf *cf = NULL;
+    struct flb_cf_section *section = NULL;
+    struct mk_list *decoder = NULL;
+
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"str", "text", "int", "100", "double","1.23", "bool", "true"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+    cf = flb_cf_create();
+    if (!TEST_CHECK(cf != NULL)) {
+        TEST_MSG("flb_cf_create failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    section = flb_cf_section_create(cf, "TEST", 4);
+    if (!TEST_CHECK(section != NULL)) {
+        TEST_MSG("flb_cf_section_create failed");
+        flb_cf_destroy(cf);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+	var = flb_cf_section_property_add(cf, section->properties, "decode_field", 12, "json json_str", 13);
+	if(!TEST_CHECK(var != NULL)) {
+        TEST_MSG("flb_cf_section_property_add failed");
+        flb_cf_destroy(cf);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    decoder = flb_parser_decoder_list_create(section);
+    if (!TEST_CHECK(decoder != NULL)) {
+        TEST_MSG("flb_parser_decoder_list_create failed");
+        flb_cf_destroy(cf);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE,
+                               NULL, 0, decoder, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create failed");
+        flb_cf_destroy(cf);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_cf_destroy(cf);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+    }
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_cf_destroy(cf);
+    flb_config_exit(config);
+}
+
+
+TEST_LIST = {
+    { "basic", test_basic},
+    { "time_key", test_time_key},
+    { "time_keep", test_time_keep},
+    { "types", test_types},
+    { "decode_field_json", test_decode_field_json},
+    { 0 }
+};


### PR DESCRIPTION
This patch is to add internal test for regex parser.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/flb-it-parser_regex 
==37283== Memcheck, a memory error detector
==37283== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==37283== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==37283== Command: bin/flb-it-parser_regex
==37283== 
Test basic...                                   ==37284== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==37284== Warning: invalid file descriptor -1 in syscall close()
==37284== 
==37284== HEAP SUMMARY:
==37284==     in use at exit: 80 bytes in 1 blocks
==37284==   total heap usage: 1,736 allocs, 1,735 frees, 191,568 bytes allocated
==37284== 
==37284== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==37284==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==37284==    by 0x144FA8: main (acutest.h:1632)
==37284== 
==37284== LEAK SUMMARY:
==37284==    definitely lost: 0 bytes in 0 blocks
==37284==    indirectly lost: 0 bytes in 0 blocks
==37284==      possibly lost: 0 bytes in 0 blocks
==37284==    still reachable: 80 bytes in 1 blocks
==37284==         suppressed: 0 bytes in 0 blocks
==37284== 
==37284== For lists of detected and suppressed errors, rerun with: -s
==37284== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test time_key...                                ==37285== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==37285== Warning: invalid file descriptor -1 in syscall close()
==37285== 
==37285== HEAP SUMMARY:
==37285==     in use at exit: 80 bytes in 1 blocks
==37285==   total heap usage: 1,755 allocs, 1,754 frees, 196,966 bytes allocated
==37285== 
==37285== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==37285==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==37285==    by 0x144FA8: main (acutest.h:1632)
==37285== 
==37285== LEAK SUMMARY:
==37285==    definitely lost: 0 bytes in 0 blocks
==37285==    indirectly lost: 0 bytes in 0 blocks
==37285==      possibly lost: 0 bytes in 0 blocks
==37285==    still reachable: 80 bytes in 1 blocks
==37285==         suppressed: 0 bytes in 0 blocks
==37285== 
==37285== For lists of detected and suppressed errors, rerun with: -s
==37285== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test time_keep...                               ==37286== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==37286== Warning: invalid file descriptor -1 in syscall close()
==37286== 
==37286== HEAP SUMMARY:
==37286==     in use at exit: 80 bytes in 1 blocks
==37286==   total heap usage: 1,755 allocs, 1,754 frees, 196,966 bytes allocated
==37286== 
==37286== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==37286==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==37286==    by 0x144FA8: main (acutest.h:1632)
==37286== 
==37286== LEAK SUMMARY:
==37286==    definitely lost: 0 bytes in 0 blocks
==37286==    indirectly lost: 0 bytes in 0 blocks
==37286==      possibly lost: 0 bytes in 0 blocks
==37286==    still reachable: 80 bytes in 1 blocks
==37286==         suppressed: 0 bytes in 0 blocks
==37286== 
==37286== For lists of detected and suppressed errors, rerun with: -s
==37286== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test types...                                   ==37287== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==37287== Warning: invalid file descriptor -1 in syscall close()
==37287== 
==37287== HEAP SUMMARY:
==37287==     in use at exit: 80 bytes in 1 blocks
==37287==   total heap usage: 1,739 allocs, 1,738 frees, 191,592 bytes allocated
==37287== 
==37287== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==37287==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==37287==    by 0x144FA8: main (acutest.h:1632)
==37287== 
==37287== LEAK SUMMARY:
==37287==    definitely lost: 0 bytes in 0 blocks
==37287==    indirectly lost: 0 bytes in 0 blocks
==37287==      possibly lost: 0 bytes in 0 blocks
==37287==    still reachable: 80 bytes in 1 blocks
==37287==         suppressed: 0 bytes in 0 blocks
==37287== 
==37287== For lists of detected and suppressed errors, rerun with: -s
==37287== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test decode_field_json...                       ==37288== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==37288== Warning: invalid file descriptor -1 in syscall close()
==37288== 
==37288== HEAP SUMMARY:
==37288==     in use at exit: 80 bytes in 1 blocks
==37288==   total heap usage: 1,712 allocs, 1,711 frees, 262,095 bytes allocated
==37288== 
==37288== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==37288==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==37288==    by 0x144FA8: main (acutest.h:1632)
==37288== 
==37288== LEAK SUMMARY:
==37288==    definitely lost: 0 bytes in 0 blocks
==37288==    indirectly lost: 0 bytes in 0 blocks
==37288==      possibly lost: 0 bytes in 0 blocks
==37288==    still reachable: 80 bytes in 1 blocks
==37288==         suppressed: 0 bytes in 0 blocks
==37288== 
==37288== For lists of detected and suppressed errors, rerun with: -s
==37288== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==37283== 
==37283== HEAP SUMMARY:
==37283==     in use at exit: 0 bytes in 0 blocks
==37283==   total heap usage: 3 allocs, 3 frees, 1,141 bytes allocated
==37283== 
==37283== All heap blocks were freed -- no leaks are possible
==37283== 
==37283== For lists of detected and suppressed errors, rerun with: -s
==37283== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
