### PR TITLE
env: increase temp buffer size(#6313)

### DIFF
--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -168,7 +168,7 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
     const char *env_var = NULL;
     char *v_start = NULL;
     char *v_end = NULL;
-    char tmp[64];
+    char tmp[4096];
     flb_sds_t buf;
     flb_sds_t s;
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -31,6 +31,7 @@ set(UNIT_TESTS_FILES
   bucket_queue.c
   flb_event_loop.c
   ring_buffer.c
+  env.c
   )
 
 # Config format

--- a/tests/internal/env.c
+++ b/tests/internal/env.c
@@ -1,0 +1,78 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_sds.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "flb_tests_internal.h"
+
+/* https://github.com/fluent/fluent-bit/issues/6313 */
+void test_translate_long_env()
+{
+    struct flb_env *env;
+    flb_sds_t buf = NULL;
+    char *long_env = "ABC_APPLICATION_TEST_TEST_ABC_FLUENT_BIT_SECRET_FLUENTD_HTTP_HOST";
+    char long_env_ra[4096] = {0};
+    char *env_val = "aaaaa";
+    size_t ret_size;
+    int ret;
+
+    ret_size = snprintf(&long_env_ra[0], sizeof(long_env_ra), "${%s}", long_env);
+    if (!TEST_CHECK(ret_size < sizeof(long_env_ra))) {
+        TEST_MSG("long_env_ra size error");
+        exit(1);
+    }
+
+    env = flb_env_create();
+    if (!TEST_CHECK(env != NULL)) {
+        TEST_MSG("flb_env_create failed");
+        exit(1);
+    }
+
+    ret = setenv(long_env, env_val, 0);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("setenv failed");
+        flb_env_destroy(env);
+        exit(1);
+    }
+
+    buf = flb_env_var_translate(env, &long_env_ra[0]);
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("flb_env_var_translate failed");
+        unsetenv(long_env);
+        flb_env_destroy(env);
+        exit(1);
+    }
+
+    if (!TEST_CHECK(strlen(buf) == strlen(env_val) && 0 == strcmp(buf, env_val))) {
+        TEST_MSG("mismatch. Got=%s expect=%s", buf, env_val);
+    }
+    flb_sds_destroy(buf);
+    unsetenv(long_env);
+    flb_env_destroy(env);
+}
+
+
+TEST_LIST = {
+    { "translate_long_env"           , test_translate_long_env},
+    { NULL, NULL }
+};


### PR DESCRIPTION
Fixes #6313 

The issue exposed by strict checking patch https://github.com/fluent/fluent-bit/pull/6152 
However the root cause is small temporary buffer size.(=64 bytes)
If a size of environment value name  exceeds the buffer size, the variable is not translated.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy

[FILTER]
    Name record_modifier
    Match *
    Record env ${ABC_APPLICATION_TEST_TEST_ABC_FLUENT_BIT_SECRET_FLUENTD_HTTP_HOST}

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

```
$ ABC_APPLICATION_TEST_TEST_ABC_FLUENT_BIT_SECRET_FLUENTD_HTTP_HOST=hoge valgrind --leak-check=full ../../bin/fluent-bit -c a.conf 
==79927== Memcheck, a memory error detector
==79927== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==79927== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==79927== Command: ../../bin/fluent-bit -c a.conf
==79927== 
Fluent Bit v2.0.4
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/06 10:02:34] [ info] [fluent bit] version=2.0.4, commit=326c0c1f94, pid=79927
[2022/11/06 10:02:34] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/11/06 10:02:34] [ info] [cmetrics] version=0.5.5
[2022/11/06 10:02:34] [ info] [ctraces ] version=0.2.5
[2022/11/06 10:02:34] [ info] [input:dummy:dummy.0] initializing
[2022/11/06 10:02:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/11/06 10:02:34] [ info] [output:stdout:stdout.0] worker #0 started
[2022/11/06 10:02:34] [ info] [sp] stream processor started
==79927== Warning: client switching stacks?  SP change: 0x6ffb8b8 --> 0x54a7630
==79927==          to suppress, use: --max-stackframe=28656264 or greater
==79927== Warning: client switching stacks?  SP change: 0x54a7588 --> 0x6ffb8b8
==79927==          to suppress, use: --max-stackframe=28656432 or greater
==79927== Warning: client switching stacks?  SP change: 0x6ffb8b8 --> 0x54a7588
==79927==          to suppress, use: --max-stackframe=28656432 or greater
==79927==          further instances of this message will not be shown.
[0] dummy.0: [1667696554.979545764, {"message"=>"dummy", "env"=>"hoge"}]
[0] dummy.0: [1667696555.969476691, {"message"=>"dummy", "env"=>"hoge"}]
^C[2022/11/06 10:02:37] [engine] caught signal (SIGINT)
[2022/11/06 10:02:37] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [1667696556.947309086, {"message"=>"dummy", "env"=>"hoge"}]
[2022/11/06 10:02:37] [ info] [input] pausing dummy.0
[2022/11/06 10:02:37] [ info] [engine] service has stopped (0 pending tasks)
[2022/11/06 10:02:37] [ info] [input] pausing dummy.0
[2022/11/06 10:02:38] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/11/06 10:02:38] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==79927== 
==79927== HEAP SUMMARY:
==79927==     in use at exit: 0 bytes in 0 blocks
==79927==   total heap usage: 1,607 allocs, 1,607 frees, 1,337,103 bytes allocated
==79927== 
==79927== All heap blocks were freed -- no leaks are possible
==79927== 
==79927== For lists of detected and suppressed errors, rerun with: -s
==79927== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
