### PR TITLE
in_syslog: added option to set receiving socket buffer size

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -143,6 +143,7 @@ int flb_net_socket_reset(flb_sockfd_t fd);
 int flb_net_socket_tcp_nodelay(flb_sockfd_t fd);
 int flb_net_socket_blocking(flb_sockfd_t fd);
 int flb_net_socket_nonblocking(flb_sockfd_t fd);
+int flb_net_socket_rcv_buffer(flb_sockfd_t fd, int rcvbuf);
 int flb_net_socket_tcp_fastopen(flb_sockfd_t sockfd);
 
 /* Socket handling */

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -228,8 +228,8 @@ static struct flb_config_map config_map[] = {
      "Set the parser"
     },
     {
-      FLB_CONFIG_MAP_SIZE, "buffer_rcv_size", (char *)NULL,
-      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_rcv_size),
+      FLB_CONFIG_MAP_SIZE, "receive_buffer_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_syslog, receive_buffer_size),
       "Set the socket receiving buffer size"
     },
     /* EOF */

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -227,6 +227,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_syslog, parser_name),
      "Set the parser"
     },
+    {
+      FLB_CONFIG_MAP_SIZE, "buffer_rcv_size", (char *)NULL,
+      0, FLB_TRUE, offsetof(struct flb_syslog, buffer_rcv_size),
+      "Set the socket receiving buffer size"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -49,6 +49,7 @@ struct flb_syslog {
     flb_sds_t unix_path;
     flb_sds_t unix_perm_str;
     unsigned int unix_perm;
+    size_t buffer_rcv_size;
 
     /* UDP buffer, data length and buffer size */
         // char *buffer_data;

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -49,7 +49,7 @@ struct flb_syslog {
     flb_sds_t unix_path;
     flb_sds_t unix_perm_str;
     unsigned int unix_perm;
-    size_t buffer_rcv_size;
+    size_t receive_buffer_size;
 
     /* UDP buffer, data length and buffer size */
         // char *buffer_data;

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -116,6 +116,13 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
         ctx->buffer_max_size = ctx->buffer_chunk_size;
     }
 
+    /* Socket rcv buffer size */
+    if (ctx->buffer_rcv_size == -1 || ctx->buffer_rcv_size>INT_MAX) {
+        flb_plg_error(ins, "invalid buffer_rcv_size");
+        flb_free(ctx);
+        return NULL;
+    }
+
     /* Parser */
     if (ctx->parser_name) {
         ctx->parser = flb_parser_get(ctx->parser_name, config);

--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -117,8 +117,8 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
     }
 
     /* Socket rcv buffer size */
-    if (ctx->buffer_rcv_size == -1 || ctx->buffer_rcv_size>INT_MAX) {
-        flb_plg_error(ins, "invalid buffer_rcv_size");
+    if (ctx->receive_buffer_size == -1 || ctx->receive_buffer_size>INT_MAX) {
+        flb_plg_error(ins, "invalid receive_buffer_size");
         flb_free(ctx);
         return NULL;
     }

--- a/plugins/in_syslog/syslog_server.c
+++ b/plugins/in_syslog/syslog_server.c
@@ -166,6 +166,14 @@ static int syslog_server_net_create(struct flb_syslog *ctx)
         return -1;
     }
 
+    if (ctx->buffer_rcv_size) {
+        if (flb_net_socket_rcv_buffer(ctx->downstream->server_fd, ctx->buffer_rcv_size)) {
+            flb_error("[in_syslog] could not set rcv buffer to %ld. Aborting",
+                      ctx->buffer_rcv_size);
+            return -1;
+        }
+    }
+
     flb_net_socket_nonblocking(ctx->downstream->server_fd);
 
     return 0;

--- a/plugins/in_syslog/syslog_server.c
+++ b/plugins/in_syslog/syslog_server.c
@@ -166,10 +166,11 @@ static int syslog_server_net_create(struct flb_syslog *ctx)
         return -1;
     }
 
-    if (ctx->buffer_rcv_size) {
-        if (flb_net_socket_rcv_buffer(ctx->downstream->server_fd, ctx->buffer_rcv_size)) {
+    if (ctx->receive_buffer_size) {
+        if (flb_net_socket_rcv_buffer(ctx->downstream->server_fd,
+                                      ctx->receive_buffer_size)) {
             flb_error("[in_syslog] could not set rcv buffer to %ld. Aborting",
-                      ctx->buffer_rcv_size);
+                      ctx->receive_buffer_size);
             return -1;
         }
     }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -212,6 +212,16 @@ int flb_net_socket_nonblocking(flb_sockfd_t fd)
     return 0;
 }
 
+int flb_net_socket_rcv_buffer(flb_sockfd_t fd, int rcvbuf)
+{
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) != 0) {
+        flb_errno();
+        return -1;
+    }
+
+    return 0;
+}
+
 int flb_net_socket_blocking(flb_sockfd_t fd)
 {
 #ifdef _WIN32


### PR DESCRIPTION
This PR adds an option to set receiving socket buffer size on syslog.

This avoids losing packets on an datagram listening socket in case of a burst of incoming packet when the default buffer size (/proc/sys/net/core/rmem_default) is too low.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
