### PR TITLE
workflows: handle windows container release

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -24,6 +24,9 @@ on:
 # We also do not want multiples to run for the same version.
 concurrency: staging-build-release
 
+env:
+  STAGING_IMAGE_NAME: ghcr.io/${{ github.repository }}/staging
+
 jobs:
 
   staging-release-version-check:
@@ -163,8 +166,6 @@ jobs:
     needs:
       - staging-release-version-check
     environment: release
-    env:
-      STAGING_IMAGE_NAME: ghcr.io/${{ github.repository }}/staging
     strategy:
       fail-fast: false
       matrix:
@@ -218,6 +219,59 @@ jobs:
         env:
           RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
           RELEASE_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+  staging-release-images-windows:
+    name: Release Windows images
+    # Cannot be done by Skopeo on a Linux runner unfortunately
+    runs-on: windows-latest
+    needs:
+      - staging-release-version-check
+    environment: release
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: [
+          "windows-2019-${{ github.event.inputs.version }}",
+          "windows-2022-${{ github.event.inputs.version }}"
+        ]
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check the image exists
+        run: |
+          docker pull "$STAGING_IMAGE_NAME:$TAG"
+        env:
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+      - name: Promote container images from staging to GHCR.io
+        run: |
+          docker push "$STAGING_IMAGE_NAME:$TAG" $RELEASE_IMAGE_NAME:$TAG"
+        env:
+          RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
+          RELEASE_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Promote container images from staging to Dockerhub
+        run: |
+          docker push "$STAGING_IMAGE_NAME:$TAG" $RELEASE_IMAGE_NAME:$TAG"
+        env:
+          RELEASE_IMAGE_NAME: docker.io/${{ github.event.inputs.docker-image || secrets.DOCKERHUB_ORGANIZATION }}
+          RELEASE_CREDS: ${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}
           TAG: ${{ matrix.tag }}
         shell: bash
 

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -158,7 +158,7 @@ jobs:
   # Simple skopeo copy jobs to transfer image from staging to release registry with optional GPG key signing.
   # Unfortunately skopeo currently does not support Cosign: https://github.com/containers/skopeo/issues/1533
   staging-release-images:
-    name: Release ${{ matrix.tag }} container images
+    name: Release ${{ matrix.tag }} Linux container images
     runs-on: ubuntu-latest
     needs:
       - staging-release-version-check
@@ -175,9 +175,7 @@ jobs:
           "latest",
           "${{ github.event.inputs.version }}-debug",
           "${{ needs.staging-release-version-check.outputs.major-version }}-debug",
-          "latest-debug",
-          "windows-2019-${{ github.event.inputs.version }}",
-          "windows-2022-${{ github.event.inputs.version }}"
+          "latest-debug"
         ]
     steps:
       # Primarily because the skopeo errors are hard to parse and non-obvious

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -366,8 +366,8 @@ jobs:
   # This will require a sign off so can be done after packages are updated to confirm
   # Until S3 bucket is set up as release will only test what is in the server from a prior release.
   # TODO: https://github.com/fluent/fluent-bit/issues/5098
-  staging-release-smoke-test:
-    name: Run smoke tests on release artefacts
+  staging-release-smoke-test-packages:
+    name: Run package smoke tests
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -379,10 +379,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up dependencies - podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+        shell: bash
+
       - name: Test release packages
         run: |
           ./packaging/test-release-packages.sh
         shell: bash
+
+  staging-release-smoke-test-containers:
+    name: Run container smoke tests
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-latest
+    environment: release
+    needs:
+      - staging-release-images
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Test containers
         run: |

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       major-version: ${{ steps.get_major_version.outputs.value }}
+    permissions:
+      contents: none
     steps:
     - name: Get the version on staging
       run: |
@@ -73,6 +75,8 @@ jobs:
     runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
     environment: release
     needs: staging-release-version-check
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -144,6 +148,8 @@ jobs:
     needs: staging-release-packages-s3
     runs-on: ubuntu-18.04 # failures with AWS client on latest
     environment: release
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -178,6 +184,8 @@ jobs:
           "${{ needs.staging-release-version-check.outputs.major-version }}-debug",
           "latest-debug"
         ]
+    permissions:
+      packages: write
     steps:
       # Primarily because the skopeo errors are hard to parse and non-obvious
       - name: Check the image exists
@@ -229,6 +237,8 @@ jobs:
     needs:
       - staging-release-version-check
     environment: release
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=dokken/amazonlinux-2
+ARG STAGING_BASE=docker.io/dokken/amazonlinux-2
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/amazonlinux-2 as official-install
+FROM docker.io/dokken/amazonlinux-2 as official-install
 
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}

--- a/packaging/testing/smoke/packages/Dockerfile.amazonlinux2022
+++ b/packaging/testing/smoke/packages/Dockerfile.amazonlinux2022
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=dokken/amazonlinux-2022
+ARG STAGING_BASE=docker.io/dokken/amazonlinux-2022
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/amazonlinux-2022 as official-install
+FROM docker.io/dokken/amazonlinux-2022 as official-install
 
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}

--- a/packaging/testing/smoke/packages/Dockerfile.centos7
+++ b/packaging/testing/smoke/packages/Dockerfile.centos7
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=dokken/centos-7
+ARG STAGING_BASE=docker.io/dokken/centos-7
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/centos-7 as official-install
+FROM docker.io/dokken/centos-7 as official-install
 
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}

--- a/packaging/testing/smoke/packages/Dockerfile.centos8
+++ b/packaging/testing/smoke/packages/Dockerfile.centos8
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=dokken/centos-8
+ARG STAGING_BASE=docker.io/dokken/centos-8
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/centos-8 as official-install
+FROM docker.io/dokken/centos-8 as official-install
 # CentOS is now EOL so have to use the vault repos
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*

--- a/packaging/testing/smoke/packages/Dockerfile.centos9
+++ b/packaging/testing/smoke/packages/Dockerfile.centos9
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=docker.io/dokken/centos-9
+ARG STAGING_BASE=docker.io/dokken/centos-stream-9
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM docker.io/dokken/centos-9 as official-install
+FROM docker.io/dokken/centos-stream-9 as official-install
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}
 

--- a/packaging/testing/smoke/packages/Dockerfile.centos9
+++ b/packaging/testing/smoke/packages/Dockerfile.centos9
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'staging-upgrade-prep' as the base
-ARG STAGING_BASE=dokken/centos-9
+ARG STAGING_BASE=docker.io/dokken/centos-9
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/centos-9 as official-install
+FROM docker.io/dokken/centos-9 as official-install
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}
 

--- a/packaging/testing/smoke/packages/Dockerfile.debian10
+++ b/packaging/testing/smoke/packages/Dockerfile.debian10
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'official-install' as the base
-ARG STAGING_BASE=dokken/debian-10
+ARG STAGING_BASE=docker.io/dokken/debian-10
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/debian-10 as official-install
+FROM docker.io/dokken/debian-10 as official-install
 
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}

--- a/packaging/testing/smoke/packages/Dockerfile.debian11
+++ b/packaging/testing/smoke/packages/Dockerfile.debian11
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'official-install' as the base
-ARG STAGING_BASE=dokken/debian-11
+ARG STAGING_BASE=docker.io/dokken/debian-11
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/debian-11 as official-install
+FROM docker.io/dokken/debian-11 as official-install
 
 ARG RELEASE_URL
 ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu1804
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'official-install' as the base
-ARG STAGING_BASE=dokken/ubuntu-18.04
+ARG STAGING_BASE=docker.io/dokken/ubuntu-18.04
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/ubuntu-18.04 as official-install
+FROM docker.io/dokken/ubuntu-18.04 as official-install
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG RELEASE_URL

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2004
@@ -1,11 +1,11 @@
 # For staging upgrade we use the 'official-install' as the base
-ARG STAGING_BASE=dokken/ubuntu-20.04
+ARG STAGING_BASE=docker.io/dokken/ubuntu-20.04
 
 ARG RELEASE_URL=https://packages.fluentbit.io
 ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
 
 # hadolint ignore=DL3006
-FROM dokken/ubuntu-20.04 as official-install
+FROM docker.io/dokken/ubuntu-20.04 as official-install
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG RELEASE_URL

--- a/packaging/testing/smoke/packages/Dockerfile.ubuntu2204
+++ b/packaging/testing/smoke/packages/Dockerfile.ubuntu2204
@@ -1,7 +1,7 @@
 # For staging upgrade we use the 'official-install' as the base
 
 # hadolint ignore=DL3007
-FROM dokken/ubuntu-22.04:latest as official-install
+FROM docker.io/dokken/ubuntu-22.04:latest as official-install
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Use the one-line install
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
@@ -14,7 +14,7 @@ FROM official-install as staging-upgrade-prep
 RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
 
 # hadolint ignore=DL3007
-FROM dokken/ubuntu-22.04:latest as staging-install
+FROM docker.io/dokken/ubuntu-22.04:latest as staging-install
 ARG STAGING_URL
 ARG STAGING_VERSION
 ENV STAGING_VERSION=${STAGING_VERSION}
@@ -23,8 +23,8 @@ RUN wget -qO - $STAGING_URL/fluentbit.key | apt-key add -
 RUN echo "deb $STAGING_URL/ubuntu/jammy jammy main" >> /etc/apt/sources.list
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y fluent-bit \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN systemctl enable fluent-bit
 
 COPY ./test.sh /test.sh

--- a/packaging/testing/smoke/packages/run-package-tests.sh
+++ b/packaging/testing/smoke/packages/run-package-tests.sh
@@ -21,6 +21,9 @@ RELEASE_KEY=${RELEASE_KEY:-https://packages.fluentbit.io/fluentbit.key}
 STAGING_URL=${STAGING_URL:-https://fluentbit-staging.s3.amazonaws.com}
 STAGING_KEY=${STAGING_KEY:-https://fluentbit-staging.s3.amazonaws.com/fluentbit.key}
 
+# Podman is preferred as better systemd support and cgroups handling
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
+
 if [[ ! -f "$SCRIPT_DIR/Dockerfile.$PACKAGE_TEST" ]]; then
     echo "No definition for $SCRIPT_DIR/Dockerfile.$PACKAGE_TEST"
     exit 1
@@ -38,11 +41,11 @@ do
 
     CONTAINER_NAME="package-verify-$PACKAGE_TEST-$TARGET"
 
-    docker rm -f "$CONTAINER_NAME"
+    "${CONTAINER_RUNTIME}" rm --force --ignore --volumes "$CONTAINER_NAME"
 
     # We do want splitting for build args
     # shellcheck disable=SC2086
-    docker build \
+    "${CONTAINER_RUNTIME}" build \
                 --build-arg STAGING_KEY=$STAGING_KEY \
                 --build-arg STAGING_URL=$STAGING_URL \
                 --build-arg RELEASE_KEY=$RELEASE_KEY \
@@ -51,13 +54,11 @@ do
                 -t "$CONTAINER_NAME" \
                 -f "$SCRIPT_DIR/Dockerfile.$PACKAGE_TEST" "$SCRIPT_DIR/"
 
-    docker run --rm -d \
-        --privileged \
-        -v /sys/fs/cgroup/:/sys/fs/cgroup:ro \
+    "${CONTAINER_RUNTIME}" run --rm -d \
         --name "$CONTAINER_NAME" \
         "$CONTAINER_NAME"
 
-    docker exec -t "$CONTAINER_NAME" /test.sh
+    "${CONTAINER_RUNTIME}" exec -t "$CONTAINER_NAME" /test.sh
 
-    docker rm -f "$CONTAINER_NAME"
+    "${CONTAINER_RUNTIME}" rm --force --ignore --volumes "$CONTAINER_NAME"
 done

--- a/packaging/testing/smoke/packages/run-package-tests.sh
+++ b/packaging/testing/smoke/packages/run-package-tests.sh
@@ -55,6 +55,7 @@ do
                 -f "$SCRIPT_DIR/Dockerfile.$PACKAGE_TEST" "$SCRIPT_DIR/"
 
     "${CONTAINER_RUNTIME}" run --rm -d \
+        --timeout 120 \
         --name "$CONTAINER_NAME" \
         "$CONTAINER_NAME"
 

--- a/packaging/testing/smoke/packages/test.sh
+++ b/packaging/testing/smoke/packages/test.sh
@@ -13,6 +13,9 @@ echo "Check service enabled"
 systemctl is-enabled fluent-bit
 
 until systemctl is-system-running; do
+    # On more recent systems we may see degrade when running
+    [ "$(systemctl is-system-running)" = "degraded" ] && break
+    systemctl --failed
     sleep 10
 done
 


### PR DESCRIPTION
Resolves #6356 by providing a separate job to do the Windows container release so this can run on a Windows runner.
Resolves #6357 by using podman which handles systemd and cgroupsv2 much better.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
