### PR TITLE
input: TLS parameter verification fix

### DIFF
--- a/plugins/in_health/health.c
+++ b/plugins/in_health/health.c
@@ -135,6 +135,7 @@ static int in_health_init(struct flb_input_instance *in,
                           struct flb_config *config, void *data)
 {
     int ret;
+    int upstream_flags;
     struct flb_in_health_config *ctx;
     (void) data;
 
@@ -166,8 +167,15 @@ static int in_health_init(struct flb_input_instance *in,
         return -1;
     }
 
+    upstream_flags = FLB_IO_TCP;
+
+    if (in->use_tls) {
+        upstream_flags |= FLB_IO_TLS;
+    }
+
     ctx->u = flb_upstream_create(config, in->host.name, in->host.port,
-                                 FLB_IO_TCP, NULL);
+                                 upstream_flags, in->tls);
+
     if (!ctx->u) {
         flb_plg_error(ctx->ins, "could not initialize upstream");
         flb_free(ctx);

--- a/plugins/in_nginx_exporter_metrics/nginx.c
+++ b/plugins/in_nginx_exporter_metrics/nginx.c
@@ -1505,6 +1505,7 @@ struct nginx_ctx *nginx_ctx_init(struct flb_input_instance *ins,
                                         struct flb_config *config)
 {
     int ret;
+    int upstream_flags;
     struct nginx_ctx *ctx;
     struct flb_upstream *upstream;
 
@@ -1538,8 +1539,15 @@ struct nginx_ctx *nginx_ctx_init(struct flb_input_instance *ins,
         return NULL;
     }
 
+    upstream_flags = FLB_IO_TCP;
+
+    if (ins->use_tls) {
+        upstream_flags |= FLB_IO_TLS;
+    }
+
     upstream = flb_upstream_create(config, ins->host.name, ins->host.port,
-                                   FLB_IO_TCP, NULL);
+                                   upstream_flags, ins->tls);
+
     if (!upstream) {
         flb_plg_error(ins, "upstream initialization error");
         return NULL;

--- a/plugins/in_prometheus_scrape/prom_scrape.c
+++ b/plugins/in_prometheus_scrape/prom_scrape.c
@@ -29,6 +29,7 @@ static struct prom_scrape *prom_scrape_create(struct flb_input_instance *ins,
                                               struct flb_config *config)
 {
     int ret;
+    int upstream_flags;
     struct prom_scrape *ctx;
     struct flb_upstream *upstream;
 
@@ -53,8 +54,15 @@ static struct prom_scrape *prom_scrape_create(struct flb_input_instance *ins,
         return NULL;
     }
 
+    upstream_flags = FLB_IO_TCP;
+
+    if (ins->use_tls) {
+        upstream_flags |= FLB_IO_TLS;
+    }
+
     upstream = flb_upstream_create(config, ins->host.name, ins->host.port,
-                                   FLB_IO_TCP, NULL);
+                                   upstream_flags, ins->tls);
+
     if (!upstream) {
         flb_plg_error(ins, "upstream initialization error");
         return NULL;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -840,7 +840,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     struct flb_config *ctx = ins->config;
     struct mk_list *config_map;
     struct flb_input_plugin *p = ins->p;
-    const char *tls_error_message;
+    int tls_session_mode;
 
     if (ins->log_level == -1 && config->log != NULL) {
         ins->log_level = config->log->level;
@@ -1014,41 +1014,46 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     }
 
 #ifdef FLB_HAVE_TLS
-    if (ins->use_tls == FLB_TRUE &&
-        (p->flags & FLB_INPUT_NET_SERVER) != 0) {
-        if (ins->tls_crt_file == NULL) {
-            tls_error_message = "certificate file missing";
+    if (ins->use_tls == FLB_TRUE) {
+        if ((p->flags & FLB_INPUT_NET_SERVER) != 0) {
+            if (ins->tls_crt_file == NULL) {
+                flb_error("[input %s] error initializing TLS context "
+                          "(certificate file missing)",
+                          ins->name);
 
-            ins->tls = NULL;
-        }
-        else if (ins->tls_key_file == NULL) {
-            tls_error_message = "private key file missing";
+                flb_input_instance_destroy(ins);
 
-            ins->tls = NULL;
+                return -1;
+            }
+            else if (ins->tls_key_file == NULL) {
+                flb_error("[input %s] error initializing TLS context "
+                          "(private key file missing)",
+                          ins->name);
+
+                flb_input_instance_destroy(ins);
+
+                return -1;
+            }
+
+            tls_session_mode = FLB_TLS_SERVER_MODE;
         }
         else {
-            tls_error_message = NULL;
-
-            ins->tls = flb_tls_create(FLB_TLS_SERVER_MODE,
-                                      ins->tls_verify,
-                                      ins->tls_debug,
-                                      ins->tls_vhost,
-                                      ins->tls_ca_path,
-                                      ins->tls_ca_file,
-                                      ins->tls_crt_file,
-                                      ins->tls_key_file,
-                                      ins->tls_key_passwd);
+            tls_session_mode = FLB_TLS_CLIENT_MODE;
         }
 
+        ins->tls = flb_tls_create(tls_session_mode,
+                                  ins->tls_verify,
+                                  ins->tls_debug,
+                                  ins->tls_vhost,
+                                  ins->tls_ca_path,
+                                  ins->tls_ca_file,
+                                  ins->tls_crt_file,
+                                  ins->tls_key_file,
+                                  ins->tls_key_passwd);
+
         if (ins->tls == NULL) {
-            if (tls_error_message != NULL) {
-                flb_error("[input %s] error initializing TLS context (%s)",
-                          ins->name, tls_error_message);
-            }
-            else {
-                flb_error("[input %s] error initializing TLS context",
-                          ins->name);
-            }
+            flb_error("[input %s] error initializing TLS context",
+                      ins->name);
 
             flb_input_instance_destroy(ins);
 


### PR DESCRIPTION
This PR fixes the TLS parameter verification and TLS session initialization for those input plugins that actively scrape remote endpoints. Additionally, this enables those plugins to connect to TLS endpoints which was not an option (regardless of the parameter verification issue).