### PR TITLE
multiline: do not permanently set ml group time to the first log time.

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -1018,6 +1018,8 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
     msgpack_packer mp_pck;
     msgpack_unpacked result;
     struct flb_ml_parser_ins *parser_i = mst->parser;
+    struct flb_time *group_time;
+    struct flb_time now;
 
     breakline_prepare(parser_i, group);
     len = flb_sds_len(group->buf);
@@ -1028,7 +1030,10 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
 
     /* if the group don't have a time set, use current time */
     if (flb_time_to_nanosec(&group->mp_time) == 0L) {
-        flb_time_get(&group->mp_time);
+        flb_time_get(&now);
+        group_time = &now;
+    } else {
+        group_time = &group->mp_time;
     }
 
     /* compose final record if we have a first line context */
@@ -1054,7 +1059,7 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
 
         /* Take the first line keys and repack */
         msgpack_pack_array(&mp_pck, 2);
-        flb_time_append_to_msgpack(&group->mp_time, &mp_pck, 0);
+        flb_time_append_to_msgpack(group_time, &mp_pck, 0);
 
         len = flb_sds_len(parser_i->key_content);
         size = map.via.map.size;
@@ -1093,7 +1098,7 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
     else if (len > 0) {
         /* Pack raw content as Fluent Bit record */
         msgpack_pack_array(&mp_pck, 2);
-        flb_time_append_to_msgpack(&group->mp_time, &mp_pck, 0);
+        flb_time_append_to_msgpack(group_time, &mp_pck, 0);
         msgpack_pack_map(&mp_pck, 1);
 
         /* key */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Use a local variable instead of setting the ml group time when flushing multiline groups with a zeroed log time. This avoids a problem where log times get stuck as the first log time when an actual time is not parsed from the logs.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
