### PR TITLE
wix: windows: Tweak wix installer for fluent-bit 2.0

### DIFF
--- a/cpack/wix/WIX.template.in.cmakein
+++ b/cpack/wix/WIX.template.in.cmakein
@@ -79,11 +79,11 @@
 
         <Property Id="CreateFluentBitWinSvc" Value=" "/>
         <CustomAction Id="SetCreateFluentBitWinSvcCommand" Property="CreateFluentBitWinSvc" Value="&quot;sc.exe&quot; create @FLB_OUT_NAME@ binpath= &quot;\&quot;[INSTALL_ROOT]bin\@FLB_OUT_NAME@.exe\&quot; -c \&quot;[INSTALL_ROOT]conf\@FLB_OUT_NAME@.conf\&quot;&quot; start= delayed-auto" Execute="immediate" />
-        <CustomAction Id="CreateFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
+        <CustomAction Id="CreateFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
 
         <Property Id="LaunchFluentBitWinSvc" Value=" "/>
         <CustomAction Id="SetLaunchFluentBitWinSvcCommand" Property="LaunchFluentBitWinSvc" Value="&quot;sc.exe&quot; start @FLB_OUT_NAME@" Execute="immediate" />
-        <CustomAction Id="LaunchFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
+        <CustomAction Id="LaunchFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
 
         <Property Id="StopFluentBitWinSvc" Value=" "/>
         <CustomAction Id="SetStopFluentBitWinSvcCommand" Property="StopFluentBitWinSvc" Value="&quot;sc.exe&quot; stop @FLB_OUT_NAME@" Execute="immediate" />

--- a/cpack/wix/WIX.template.in.cmakein
+++ b/cpack/wix/WIX.template.in.cmakein
@@ -77,6 +77,11 @@
         <?include "properties.wxi"?>
         <?include "product_fragment.wxi"?>
 
+        <Property Id="LAUNCHSERVICE" Value="1"/>
+        <SetProperty Id="LAUNCHSERVICE" Value="0" After="LaunchConditions" Sequence="first">
+          <![CDATA[%NOT_FLB_SVC_LAUNCH <> ""]]>
+        </SetProperty>
+
         <Property Id="CreateFluentBitWinSvc" Value=" "/>
         <CustomAction Id="SetCreateFluentBitWinSvcCommand" Property="CreateFluentBitWinSvc" Value="&quot;sc.exe&quot; create @FLB_OUT_NAME@ binpath= &quot;\&quot;[INSTALL_ROOT]bin\@FLB_OUT_NAME@.exe\&quot; -c \&quot;[INSTALL_ROOT]conf\@FLB_OUT_NAME@.conf\&quot;&quot; start= delayed-auto" Execute="immediate" />
         <CustomAction Id="CreateFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
@@ -91,13 +96,13 @@
 
         <Property Id="DeleteFluentBitWinSvc" Value=" "/>
         <CustomAction Id="SetDeleteFluentBitWinSvcCommand" Property="DeleteFluentBitWinSvc" Value="&quot;sc.exe&quot; delete @FLB_OUT_NAME@" Execute="immediate" />
-        <CustomAction Id="DeleteFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="check" Impersonate="no" />
+        <CustomAction Id="DeleteFluentBitWinSvc" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
 
         <InstallExecuteSequence>
             <Custom Action="SetCreateFluentBitWinSvcCommand" After="InstallFiles">NOT Installed</Custom>
             <Custom Action="CreateFluentBitWinSvc" After="SetCreateFluentBitWinSvcCommand">NOT Installed</Custom>
-            <Custom Action="SetLaunchFluentBitWinSvcCommand" After="CreateFluentBitWinSvc">NOT Installed</Custom>
-            <Custom Action="LaunchFluentBitWinSvc" After="SetLaunchFluentBitWinSvcCommand">NOT Installed</Custom>
+            <Custom Action="SetLaunchFluentBitWinSvcCommand" After="CreateFluentBitWinSvc">LAUNCHSERVICE="1" AND NOT Installed</Custom>
+            <Custom Action="LaunchFluentBitWinSvc" After="SetLaunchFluentBitWinSvcCommand">LAUNCHSERVICE="1" AND NOT Installed</Custom>
 
             <Custom Action="SetStopFluentBitWinSvcCommand" After="InstallInitialize">REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
             <Custom Action="StopFluentBitWinSvc" After="SetStopFluentBitWinSvcCommand">REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>


### PR DESCRIPTION
<!-- Provide summary of changes -->

* In fluent-bit 2.0, some of cases leads installation failure due to strictly checking on returning values.
* Introduce environment variables to skip service launching for orchestration tools.

Managing with Ansible or Chef or else cases, automatic service launch is not preferable for such cases.
Because Windows does not permit file replacement during someone is using.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
