### PR TITLE
packaging: disable ARM build for AL2022 due to time

### DIFF
--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -3,7 +3,6 @@
         "amazonlinux/2",
         "amazonlinux/2.arm64v8",
         "amazonlinux/2022",
-        "amazonlinux/2022.arm64v8",
         "centos/7",
         "centos/7.arm64v8",
         "centos/8",


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Related to #6300 but disable the ARM build due to the excessive time until we can resolve.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
