### PR TITLE
chunk-trace: add a warning to enable tracing when it is not enabled.

### DIFF
--- a/src/flb_chunk_trace.c
+++ b/src/flb_chunk_trace.c
@@ -163,6 +163,8 @@ struct flb_chunk_trace_context *flb_chunk_trace_context_new(void *trace_input,
     int ret;
 
     if (config->enable_chunk_trace == FLB_FALSE) {
+        flb_warn("[chunk trace] enable chunk tracing via the configuration or "
+                 " command line to be able to activate tracing.");
         return NULL;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This happens enough that I decided to add a warning. Warn people to enable chunk tracing when it is disabled and they attempt to activate it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
