### PR TITLE
packaging: add version check in release package tests

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -389,6 +389,8 @@ jobs:
         run: |
           ./packaging/test-release-packages.sh
         shell: bash
+        env:
+          VERSION_TO_CHECK_FOR: ${{ github.event.inputs.version }}
 
   staging-release-smoke-test-containers:
     name: Run container smoke tests

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -11,6 +11,18 @@ fi
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 INSTALL_SCRIPT=${INSTALL_SCRIPT:-https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh}
 
+# Optional check for specific version
+VERSION_TO_CHECK_FOR=${VERSION_TO_CHECK_FOR:-}
+function check_version() {
+    if [[ -n "$VERSION_TO_CHECK_FOR" ]]; then
+        local LOG_FILE=$1
+        if ! grep -q "$VERSION_TO_CHECK_FOR" "$LOG_FILE"; then
+            echo "WARNING: Not using expected version: $VERSION_TO_CHECK_FOR"
+            exit 1
+        fi
+    fi
+}
+
 APT_TARGETS=("ubuntu:18.04"
     "ubuntu:20.04"
     "ubuntu:22.04"
@@ -26,19 +38,25 @@ YUM_TARGETS=("centos:7"
 for IMAGE in "${APT_TARGETS[@]}"
 do
     echo "Testing $IMAGE"
+    LOG_FILE=$(mktemp)
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "apt-get update && apt-get install -y sudo gpg curl;curl $INSTALL_SCRIPT | sh"
+        sh -c "apt-get update && apt-get install -y sudo gpg curl;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+    check_version "$LOG_FILE"
+    rm -f "$LOG_FILE"
 done
 
 for IMAGE in "${YUM_TARGETS[@]}"
 do
     echo "Testing $IMAGE"
+    LOG_FILE=$(mktemp)
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "yum install -y sudo;curl $INSTALL_SCRIPT | sh"
+        sh -c "yum install -y sudo;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+    check_version "$LOG_FILE"
+    rm -f "$LOG_FILE"
 done


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Minor improvement to release process to verify the version we're expecting is installed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Checking for latest works:

```shell
$ VERSION_TO_CHECK_FOR=2.0.5 ./test-release-packages.sh 
...
Installation completed. Happy Logging!

Fluent Bit v2.0.5
Git commit: 
+ check_version /tmp/tmp.WAOUgMtLHG
+ [[ -n 2.0.5 ]]
+ local LOG_FILE=/tmp/tmp.WAOUgMtLHG
+ grep -q 2.0.5 /tmp/tmp.WAOUgMtLHG
+ rm -f /tmp/tmp.WAOUgMtLHG
...
$ echo $?
0
```

Failure case works:

```shell
$ VERSION_TO_CHECK_FOR=2.0.4 ./test-release-packages.sh
...
Installation completed. Happy Logging!

Fluent Bit v2.0.5
Git commit: 
+ check_version /tmp/tmp.RwYk6CfwuJ
+ [[ -n 2.0.4 ]]
+ local LOG_FILE=/tmp/tmp.RwYk6CfwuJ
+ grep -q 2.0.4 /tmp/tmp.RwYk6CfwuJ
+ echo 'WARNING: Not using expected version: 2.0.4'
WARNING: Not using expected version: 2.0.4
+ exit 1
$ echo $?
1
```

No version also passes:

```shell
$ ./test-release-packages.sh 
...
$ echo $?
0
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
