### PR TITLE
out_kafka: support iso8601_ns format

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -160,18 +160,27 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
                 break;
 
             case FLB_JSON_DATE_ISO8601:
+            case FLB_JSON_DATE_ISO8601_NS:
                 {
                 size_t date_len;
                 int len;
                 struct tm _tm;
-                char time_formatted[32];
+                char time_formatted[36];
+
                 /* Format the time; use microsecond precision (not nanoseconds). */
                 gmtime_r(&tm->tm.tv_sec, &_tm);
                 date_len = strftime(time_formatted, sizeof(time_formatted) - 1,
                              FLB_JSON_DATE_ISO8601_FMT, &_tm);
 
-                len = snprintf(time_formatted + date_len, sizeof(time_formatted) - 1 - date_len,
-                               ".%06" PRIu64 "Z", (uint64_t) tm->tm.tv_nsec / 1000);
+                if (ctx->timestamp_format == FLB_JSON_DATE_ISO8601) {
+                    len = snprintf(time_formatted + date_len, sizeof(time_formatted) - 1 - date_len,
+                                   ".%06" PRIu64 "Z", (uint64_t) tm->tm.tv_nsec / 1000);
+                }
+                else {
+                    /* FLB_JSON_DATE_ISO8601_NS */
+                    len = snprintf(time_formatted + date_len, sizeof(time_formatted) - 1 - date_len,
+                                   ".%09" PRIu64 "Z", (uint64_t) tm->tm.tv_nsec);
+                }
                 date_len += len;
 
                 msgpack_pack_str(&mp_pck, date_len);

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -124,6 +124,9 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
         if (strcasecmp(ctx->timestamp_format_str, "iso8601") == 0) {
             ctx->timestamp_format = FLB_JSON_DATE_ISO8601;
         }
+        else if (strcasecmp(ctx->timestamp_format_str, "iso8601_ns") == 0) {
+            ctx->timestamp_format = FLB_JSON_DATE_ISO8601_NS;
+        }
     }
 
     /* set number of retries: note that if the number is zero, means forever */

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -49,6 +49,7 @@
 
 #define FLB_JSON_DATE_DOUBLE      0
 #define FLB_JSON_DATE_ISO8601     1
+#define FLB_JSON_DATE_ISO8601_NS  2
 #define FLB_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
 
 struct flb_kafka_topic {


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/6132

This patch is to support nanosecond timestamp format `iso8601_ns`.
I want a user feed back since I'm not familiar with kafka.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
