### PR TITLE
out_kinesis_firehose: used function create_time_format_string for time output can support millisecond and nanosecond by adding %F or %L to time_key_format.

### DIFF
--- a/plugins/out_kinesis_firehose/firehose_api.c
+++ b/plugins/out_kinesis_firehose/firehose_api.c
@@ -165,6 +165,7 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
     size_t len;
     size_t tmp_size;
     void *compressed_tmp_buf;
+    char *out_buff;
 
     tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
     ret = flb_msgpack_to_json(tmp_buf_ptr,
@@ -216,8 +217,8 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
                          ctx->delivery_stream);
             return 2;
         }
-        /* guess space needed to write time_key */
-        len = 6 + strlen(ctx->time_key) + 6 * strlen(ctx->time_key_format);
+        /* format time output and get the length */
+        create_time_format_string(&out_buff, &len, ctx->time_key_format, tms);
         /* how much space do we have left */
         tmp_size = (buf->tmp_buf_size - buf->tmp_buf_offset) - written;
         if (len > tmp_size) {
@@ -235,11 +236,10 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
         time_key_ptr += 3;
         tmp_size = buf->tmp_buf_size - buf->tmp_buf_offset;
         tmp_size -= (time_key_ptr - tmp_buf_ptr);
-        len = strftime(time_key_ptr, tmp_size, ctx->time_key_format, &time_stamp);
-        if (len <= 0) {
-            /* ran out of space - should not happen because of check above */
-            return 1;
-        }
+        /* merge out_buff to time_key_ptr */
+        len = snprintf(time_key_ptr, strlen(out_buff) + 1,
+                       "%s", out_buff);
+        free(out_buff);
         time_key_ptr += len;
         memcpy(time_key_ptr, "\"}", 2);
         time_key_ptr += 2;


### PR DESCRIPTION
Signed-off-by: Clay Cheng chaych@amazon.com

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
