### PR TITLE
upstream_ha: Fixed extra parameters storage

### DIFF
--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -241,7 +241,7 @@ static struct flb_upstream_node *create_node(int id,
         key[klen] = '\0';
 
         /* Add the key and value to the hash table */
-        ret = flb_hash_table_add(ht, key, klen, entry->val, vlen);
+        ret = flb_hash_table_add(ht, key, klen, entry->val->data.as_string, vlen);
         if (ret == -1) {
             flb_error("[upstream_ha] cannot add key %s to hash table",
                       entry->key);


### PR DESCRIPTION
The extra parameters of an upstream were stored as cfl_variant, but retrieved as strings (char *) in out_forward.

This would lead to errors when using "Compress gzip" in an upstream configuration file for out_forward, for example:
[error] [output:forward:forward.0] invalid compress mode: ☺
Yes, I swear we really did have a smiley instead of "compress" by pure (bad) luck.
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
