### PR TITLE
filter_record_modifier: support uuid_key

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.h
+++ b/plugins/filter_record_modifier/filter_modifier.h
@@ -21,6 +21,7 @@
 #define FLB_FILTER_RECORD_MODIFIER_H
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_filter.h>
 
 struct modifier_record {
@@ -42,6 +43,9 @@ struct record_modifier_ctx {
     int records_num;
     int remove_keys_num;
     int allowlist_keys_num;
+
+    flb_sds_t uuid_key;
+
     /* config map */
     struct mk_list *records_map;
     struct mk_list *remove_keys_map;

--- a/tests/runtime/filter_record_modifier.c
+++ b/tests/runtime/filter_record_modifier.c
@@ -20,6 +20,7 @@
 
 #include <fluent-bit.h>
 #include <fluent-bit/flb_time.h>
+#include <msgpack.h>
 #include "flb_tests_runtime.h"
 #include "data/common/json_long.h"    /* JSON_LONG    */
 
@@ -27,6 +28,7 @@ struct filter_test {
     flb_ctx_t *flb;    /* Fluent Bit library context */
     int i_ffd;         /* Input fd  */
     int f_ffd;         /* Filter fd */
+    int o_ffd;         /* Output fd */
 };
 
 struct expect_str {
@@ -119,8 +121,8 @@ static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
     TEST_CHECK(o_ffd >= 0);
     flb_output_set(ctx->flb, o_ffd,
                    "match", "test",
-                   "format", "json",
                    NULL);
+    ctx->o_ffd = o_ffd;
 
     return ctx;
 }
@@ -158,6 +160,11 @@ static void flb_records()
     ret = flb_filter_set(ctx->flb, ctx->f_ffd,
                          "record", "new_key new_val",
                          "record", "add_key add_val",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -206,6 +213,11 @@ static void flb_allowlist_keys()
                          NULL);
     TEST_CHECK(ret == 0);
 
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
     /* Prepare output callback with expected result */
     cb_data.cb = cb_check_result;
     cb_data.data = &expect;
@@ -249,6 +261,11 @@ static void flb_whitelist_keys()
     ret = flb_filter_set(ctx->flb, ctx->f_ffd,
                          "whitelist_key", "aaa",
                          "whitelist_key", "bbb",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -299,6 +316,11 @@ static void flb_remove_keys()
                          NULL);
     TEST_CHECK(ret == 0);
 
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
     /* Prepare output callback with expected result */
     cb_data.cb = cb_check_result;
     cb_data.data = &expect;
@@ -343,6 +365,11 @@ static void flb_multiple()
                          "record",     "new_key new_val",
                          "allowlist_key", "new_key",
                          "allowlist_key", "aaa",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
                          NULL);
     TEST_CHECK(ret == 0);
 
@@ -443,9 +470,116 @@ void flb_exclusive_setting()
     /* It should be error since "allowlist_key" and "remove_key" are exclusive */
     TEST_CHECK(ret != 0);
 
-     flb_stop(ctx);
+    flb_stop(ctx);
     flb_destroy(ctx);
 }
+
+#define UUID_KEY_NAME "uuid"
+static int cb_check_uuid(void *record, size_t size, void *data)
+{
+    char uuid[256] = {0};
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+    int ret;
+    int i_map;
+    int map_size;
+    int uuid_found = FLB_FALSE;
+    char uuid_part[5][16];
+
+#ifndef FLB_HAVE_OPENSSL
+    if (!TEST_CHECK(1 == 0)) {
+        /* flb_utils_uuid_v4_gen function needs openssl */
+        TEST_MSG("uuid_key needs OpenSSL");
+        return -1;
+    }
+#endif
+
+    if (!TEST_CHECK(record != NULL)) {
+        TEST_MSG("data is null");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, record, size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        obj = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_ARRAY && obj.via.array.size == 2)) {
+            TEST_MSG("array error. type = %d", obj.type);
+            continue;
+        }
+        obj = obj.via.array.ptr[1];
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_MAP)) {
+            TEST_MSG("map error. type = %d", obj.type);
+            continue;
+        }
+        map_size = obj.via.map.size;
+        for (i_map=0; i_map<map_size; i_map++) {
+            if (obj.via.map.ptr[i_map].key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+            if (strncmp(UUID_KEY_NAME, obj.via.map.ptr[i_map].key.via.str.ptr, strlen(UUID_KEY_NAME)) == 0) {
+                memcpy(&uuid[0], obj.via.map.ptr[i_map].val.via.str.ptr, obj.via.map.ptr[i_map].val.via.str.size);
+                ret = sscanf(&uuid[0], "%8s-%4s-%4s-%4s-%12s", &uuid_part[0][0], &uuid_part[1][0], &uuid_part[2][0], &uuid_part[3][0], &uuid_part[4][0]);
+                if (!TEST_CHECK(ret == 5)) {
+                    TEST_MSG("ret should be 5. ret=%d", ret);
+                }
+                uuid_found = FLB_TRUE;
+            }
+        }
+    }
+
+    if (!TEST_CHECK(uuid_found == FLB_TRUE)) {
+        TEST_MSG("uuid not found");
+    }
+
+    msgpack_unpacked_destroy(&result);
+    flb_free(record);
+
+    return 0;
+}
+
+static void flb_uuid_key()
+{
+    int len;
+    int ret;
+    int bytes;
+    int not_used;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_uuid;
+    cb_data.data = &not_used;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "uuid_key", UUID_KEY_NAME,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data samples */
+    p = "[0, {\"key_name\":\"sample\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    filter_test_destroy(ctx);
+}
+
 
 /* test list */
 TEST_LIST = {
@@ -456,5 +590,6 @@ TEST_LIST = {
     {"whitelist_keys"      , flb_whitelist_keys},
     {"multiple"            , flb_multiple},
     {"exclusive_setting"   , flb_exclusive_setting},
+    {"uuid_key"            , flb_uuid_key},
     {NULL, NULL}
 };


### PR DESCRIPTION
This patch is to append UUID to each record.
Requested at #5571 

|Name|Description|
|---|---|
|uuid_key| If set, the plugin generates uuid per record.|

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy

[FILTER]
    Name record_modifier
    Match *
    uuid_key uuid

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c uuid.conf 
==73886== Memcheck, a memory error detector
==73886== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==73886== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==73886== Command: bin/fluent-bit -c uuid.conf
==73886== 
Fluent Bit v2.0.6
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/20 09:12:32] [ info] [fluent bit] version=2.0.6, commit=2049e320eb, pid=73886
[2022/11/20 09:12:32] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/11/20 09:12:32] [ info] [cmetrics] version=0.5.7
[2022/11/20 09:12:32] [ info] [ctraces ] version=0.2.5
[2022/11/20 09:12:32] [ info] [input:dummy:dummy.0] initializing
[2022/11/20 09:12:32] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/11/20 09:12:32] [ info] [output:stdout:stdout.0] worker #0 started
[2022/11/20 09:12:32] [ info] [sp] stream processor started
==73886== Warning: client switching stacks?  SP change: 0x6ffb6f8 --> 0x55ffa30
==73886==          to suppress, use: --max-stackframe=27245768 or greater
==73886== Warning: client switching stacks?  SP change: 0x55ff988 --> 0x6ffb6f8
==73886==          to suppress, use: --max-stackframe=27245936 or greater
==73886== Warning: client switching stacks?  SP change: 0x6ffb6f8 --> 0x55ff988
==73886==          to suppress, use: --max-stackframe=27245936 or greater
==73886==          further instances of this message will not be shown.
[0] dummy.0: [1668903153.547521855, {"message"=>"dummy", "uuid"=>"441b94a3-ff3b-44b9-9578-10bee7d749d7"}]
[0] dummy.0: [1668903154.546527567, {"message"=>"dummy", "uuid"=>"a8e901b0-236b-4231-8e96-bef6e395d1cc"}]
[0] dummy.0: [1668903155.519441622, {"message"=>"dummy", "uuid"=>"da3197a6-7b30-4ee5-9edc-9ad7b06fe27c"}]
^C[2022/11/20 09:12:36] [engine] caught signal (SIGINT)
[2022/11/20 09:12:36] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [1668903156.517244770, {"message"=>"dummy", "uuid"=>"58bb95d2-a666-4e08-8d49-f05864e65d2f"}]
[2022/11/20 09:12:36] [ info] [input] pausing dummy.0
[2022/11/20 09:12:37] [ info] [engine] service has stopped (0 pending tasks)
[2022/11/20 09:12:37] [ info] [input] pausing dummy.0
[2022/11/20 09:12:37] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/11/20 09:12:37] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==73886== 
==73886== HEAP SUMMARY:
==73886==     in use at exit: 542,739 bytes in 4,232 blocks
==73886==   total heap usage: 8,297 allocs, 4,065 frees, 2,616,893 bytes allocated
==73886== 
==73886== LEAK SUMMARY:
==73886==    definitely lost: 0 bytes in 0 blocks
==73886==    indirectly lost: 0 bytes in 0 blocks
==73886==      possibly lost: 0 bytes in 0 blocks
==73886==    still reachable: 542,739 bytes in 4,232 blocks
==73886==         suppressed: 0 bytes in 0 blocks
==73886== Reachable blocks (those to which a pointer was found) are not shown.
==73886== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==73886== 
==73886== For lists of detected and suppressed errors, rerun with: -s
==73886== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
