### PR TITLE
tests: runtime: out_tcp: remove unused variables

### DIFF
--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -900,7 +900,6 @@ static void cb_check_basic(void *ctx, int ffd,
 void flb_test_tcp_exit_workers(void)
 {
     int ret;
-    int bytes;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -945,7 +944,6 @@ void flb_test_tcp_exit_workers(void)
 void flb_test_tcp_exit_no_workers(void)
 {
     int ret;
-    int bytes;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;


### PR DESCRIPTION
This patch is to remove below warnings.

```
[ 87%] Building C object tests/runtime/CMakeFiles/flb-rt-out_tcp.dir/out_tcp.c.o
/home/taka/git/fluent-bit/tests/runtime/out_tcp.c: In function ‘flb_test_tcp_exit_workers’:
/home/taka/git/fluent-bit/tests/runtime/out_tcp.c:903:9: warning: unused variable ‘bytes’ [-Wunused-variable]
  903 |     int bytes;
      |         ^~~~~
/home/taka/git/fluent-bit/tests/runtime/out_tcp.c: In function ‘flb_test_tcp_exit_no_workers’:
/home/taka/git/fluent-bit/tests/runtime/out_tcp.c:948:9: warning: unused variable ‘bytes’ [-Wunused-variable]
  948 |     int bytes;
      |         ^~~~~
[ 87%] Linking C executable ../../bin/flb-rt-out_tcp
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/flb-rt-out_tcp 
==106040== Memcheck, a memory error detector
==106040== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==106040== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==106040== Command: bin/flb-rt-out_tcp
==106040== 
Test tcp_with_tls...                            ==106041== Warning: client switching stacks?  SP change: 0x6fdb6f8 --> 0x5718310
==106041==          to suppress, use: --max-stackframe=25965544 or greater
==106041== Warning: client switching stacks?  SP change: 0x5718268 --> 0x6fdb6f8
==106041==          to suppress, use: --max-stackframe=25965712 or greater
==106041== Warning: client switching stacks?  SP change: 0x6fdb6f8 --> 0x5718268
==106041==          to suppress, use: --max-stackframe=25965712 or greater
==106041==          further instances of this message will not be shown.
[ OK ]
==106041== 
==106041== HEAP SUMMARY:
==106041==     in use at exit: 192 bytes in 1 blocks
==106041==   total heap usage: 19,449 allocs, 19,448 frees, 3,012,306 bytes allocated
==106041== 
==106041== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106041==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106041==    by 0x165531: main (acutest.h:1632)
==106041== 
==106041== LEAK SUMMARY:
==106041==    definitely lost: 0 bytes in 0 blocks
==106041==    indirectly lost: 0 bytes in 0 blocks
==106041==      possibly lost: 0 bytes in 0 blocks
==106041==    still reachable: 192 bytes in 1 blocks
==106041==         suppressed: 0 bytes in 0 blocks
==106041== 
==106041== For lists of detected and suppressed errors, rerun with: -s
==106041== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test format_msgpack...                          [ OK ]
==106046== 
==106046== HEAP SUMMARY:
==106046==     in use at exit: 192 bytes in 1 blocks
==106046==   total heap usage: 1,384 allocs, 1,383 frees, 612,666 bytes allocated
==106046== 
==106046== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106046==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106046==    by 0x165531: main (acutest.h:1632)
==106046== 
==106046== LEAK SUMMARY:
==106046==    definitely lost: 0 bytes in 0 blocks
==106046==    indirectly lost: 0 bytes in 0 blocks
==106046==      possibly lost: 0 bytes in 0 blocks
==106046==    still reachable: 192 bytes in 1 blocks
==106046==         suppressed: 0 bytes in 0 blocks
==106046== 
==106046== For lists of detected and suppressed errors, rerun with: -s
==106046== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test format_json...                             [ OK ]
==106051== 
==106051== HEAP SUMMARY:
==106051==     in use at exit: 192 bytes in 1 blocks
==106051==   total heap usage: 1,393 allocs, 1,392 frees, 662,086 bytes allocated
==106051== 
==106051== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106051==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106051==    by 0x165531: main (acutest.h:1632)
==106051== 
==106051== LEAK SUMMARY:
==106051==    definitely lost: 0 bytes in 0 blocks
==106051==    indirectly lost: 0 bytes in 0 blocks
==106051==      possibly lost: 0 bytes in 0 blocks
==106051==    still reachable: 192 bytes in 1 blocks
==106051==         suppressed: 0 bytes in 0 blocks
==106051== 
==106051== For lists of detected and suppressed errors, rerun with: -s
==106051== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test format_json_stream...                      [ OK ]
==106056== 
==106056== HEAP SUMMARY:
==106056==     in use at exit: 192 bytes in 1 blocks
==106056==   total heap usage: 1,395 allocs, 1,394 frees, 645,948 bytes allocated
==106056== 
==106056== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106056==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106056==    by 0x165531: main (acutest.h:1632)
==106056== 
==106056== LEAK SUMMARY:
==106056==    definitely lost: 0 bytes in 0 blocks
==106056==    indirectly lost: 0 bytes in 0 blocks
==106056==      possibly lost: 0 bytes in 0 blocks
==106056==    still reachable: 192 bytes in 1 blocks
==106056==         suppressed: 0 bytes in 0 blocks
==106056== 
==106056== For lists of detected and suppressed errors, rerun with: -s
==106056== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test format_json_lines...                       [ OK ]
==106061== 
==106061== HEAP SUMMARY:
==106061==     in use at exit: 192 bytes in 1 blocks
==106061==   total heap usage: 1,398 allocs, 1,397 frees, 670,523 bytes allocated
==106061== 
==106061== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106061==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106061==    by 0x165531: main (acutest.h:1632)
==106061== 
==106061== LEAK SUMMARY:
==106061==    definitely lost: 0 bytes in 0 blocks
==106061==    indirectly lost: 0 bytes in 0 blocks
==106061==      possibly lost: 0 bytes in 0 blocks
==106061==    still reachable: 192 bytes in 1 blocks
==106061==         suppressed: 0 bytes in 0 blocks
==106061== 
==106061== For lists of detected and suppressed errors, rerun with: -s
==106061== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test set_json_date_key...                       [ OK ]
==106066== 
==106066== HEAP SUMMARY:
==106066==     in use at exit: 192 bytes in 1 blocks
==106066==   total heap usage: 1,394 allocs, 1,393 frees, 653,866 bytes allocated
==106066== 
==106066== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106066==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106066==    by 0x165531: main (acutest.h:1632)
==106066== 
==106066== LEAK SUMMARY:
==106066==    definitely lost: 0 bytes in 0 blocks
==106066==    indirectly lost: 0 bytes in 0 blocks
==106066==      possibly lost: 0 bytes in 0 blocks
==106066==    still reachable: 192 bytes in 1 blocks
==106066==         suppressed: 0 bytes in 0 blocks
==106066== 
==106066== For lists of detected and suppressed errors, rerun with: -s
==106066== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test disable_json_date_key...                   [ OK ]
==106071== 
==106071== HEAP SUMMARY:
==106071==     in use at exit: 192 bytes in 1 blocks
==106071==   total heap usage: 1,394 allocs, 1,393 frees, 653,824 bytes allocated
==106071== 
==106071== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106071==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106071==    by 0x165531: main (acutest.h:1632)
==106071== 
==106071== LEAK SUMMARY:
==106071==    definitely lost: 0 bytes in 0 blocks
==106071==    indirectly lost: 0 bytes in 0 blocks
==106071==      possibly lost: 0 bytes in 0 blocks
==106071==    still reachable: 192 bytes in 1 blocks
==106071==         suppressed: 0 bytes in 0 blocks
==106071== 
==106071== For lists of detected and suppressed errors, rerun with: -s
==106071== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test json_date_format_epoch...                  [ OK ]
==106076== 
==106076== HEAP SUMMARY:
==106076==     in use at exit: 192 bytes in 1 blocks
==106076==   total heap usage: 1,391 allocs, 1,390 frees, 629,263 bytes allocated
==106076== 
==106076== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106076==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106076==    by 0x165531: main (acutest.h:1632)
==106076== 
==106076== LEAK SUMMARY:
==106076==    definitely lost: 0 bytes in 0 blocks
==106076==    indirectly lost: 0 bytes in 0 blocks
==106076==      possibly lost: 0 bytes in 0 blocks
==106076==    still reachable: 192 bytes in 1 blocks
==106076==         suppressed: 0 bytes in 0 blocks
==106076== 
==106076== For lists of detected and suppressed errors, rerun with: -s
==106076== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test json_date_format_iso8601...                [ OK ]
==106083== 
==106083== HEAP SUMMARY:
==106083==     in use at exit: 192 bytes in 1 blocks
==106083==   total heap usage: 1,401 allocs, 1,400 frees, 658,669 bytes allocated
==106083== 
==106083== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106083==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106083==    by 0x165531: main (acutest.h:1632)
==106083== 
==106083== LEAK SUMMARY:
==106083==    definitely lost: 0 bytes in 0 blocks
==106083==    indirectly lost: 0 bytes in 0 blocks
==106083==      possibly lost: 0 bytes in 0 blocks
==106083==    still reachable: 192 bytes in 1 blocks
==106083==         suppressed: 0 bytes in 0 blocks
==106083== 
==106083== For lists of detected and suppressed errors, rerun with: -s
==106083== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test json_date_format_java_sql_timestamp...     [ OK ]
==106088== 
==106088== HEAP SUMMARY:
==106088==     in use at exit: 192 bytes in 1 blocks
==106088==   total heap usage: 1,401 allocs, 1,400 frees, 658,678 bytes allocated
==106088== 
==106088== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106088==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106088==    by 0x165531: main (acutest.h:1632)
==106088== 
==106088== LEAK SUMMARY:
==106088==    definitely lost: 0 bytes in 0 blocks
==106088==    indirectly lost: 0 bytes in 0 blocks
==106088==      possibly lost: 0 bytes in 0 blocks
==106088==    still reachable: 192 bytes in 1 blocks
==106088==         suppressed: 0 bytes in 0 blocks
==106088== 
==106088== For lists of detected and suppressed errors, rerun with: -s
==106088== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test tcp_exit_workers...                        [ OK ]
==106093== 
==106093== HEAP SUMMARY:
==106093==     in use at exit: 192 bytes in 1 blocks
==106093==   total heap usage: 1,390 allocs, 1,389 frees, 267,017 bytes allocated
==106093== 
==106093== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106093==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106093==    by 0x165531: main (acutest.h:1632)
==106093== 
==106093== LEAK SUMMARY:
==106093==    definitely lost: 0 bytes in 0 blocks
==106093==    indirectly lost: 0 bytes in 0 blocks
==106093==      possibly lost: 0 bytes in 0 blocks
==106093==    still reachable: 192 bytes in 1 blocks
==106093==         suppressed: 0 bytes in 0 blocks
==106093== 
==106093== For lists of detected and suppressed errors, rerun with: -s
==106093== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test tcp_exit_no_workers...                     [ OK ]
==106098== 
==106098== HEAP SUMMARY:
==106098==     in use at exit: 192 bytes in 1 blocks
==106098==   total heap usage: 1,357 allocs, 1,356 frees, 226,875 bytes allocated
==106098== 
==106098== 192 bytes in 1 blocks are still reachable in loss record 1 of 1
==106098==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==106098==    by 0x165531: main (acutest.h:1632)
==106098== 
==106098== LEAK SUMMARY:
==106098==    definitely lost: 0 bytes in 0 blocks
==106098==    indirectly lost: 0 bytes in 0 blocks
==106098==      possibly lost: 0 bytes in 0 blocks
==106098==    still reachable: 192 bytes in 1 blocks
==106098==         suppressed: 0 bytes in 0 blocks
==106098== 
==106098== For lists of detected and suppressed errors, rerun with: -s
==106098== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==106040== 
==106040== HEAP SUMMARY:
==106040==     in use at exit: 0 bytes in 0 blocks
==106040==   total heap usage: 3 allocs, 3 frees, 1,253 bytes allocated
==106040== 
==106040== All heap blocks were freed -- no leaks are possible
==106040== 
==106040== For lists of detected and suppressed errors, rerun with: -s
==106040== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
