### PR TITLE
tests: internal: parser: fix warnings

### DIFF
--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -181,7 +181,7 @@ void test_parser_time_lookup()
     struct flb_parser *p;
     struct flb_config *config;
     struct time_check *t;
-    struct tm tm;
+    struct flb_tm tm;
 
     config = flb_config_init();
 


### PR DESCRIPTION
This patch is to fix below warnings.

```
[ 97%] Building C object tests/internal/CMakeFiles/flb-it-parser.dir/parser.c.o
/home/taka/git/fluent-bit/tests/internal/parser.c: In function ‘test_parser_time_lookup’:
/home/taka/git/fluent-bit/tests/internal/parser.c:228:67: warning: passing argument 5 of ‘flb_parser_time_lookup’ from incompatible pointer type [-Wincompatible-pointer-types]
  228 |         ret = flb_parser_time_lookup(t->time_string, len, now, p, &tm, &ns);
      |                                                                   ^~~
      |                                                                   |
      |                                                                   struct tm *
In file included from /home/taka/git/fluent-bit/tests/internal/parser.c:5:
/home/taka/git/fluent-bit/include/fluent-bit/flb_parser.h:108:43: note: expected ‘struct flb_tm *’ but argument is of type ‘struct tm *’
  108 |                            struct flb_tm *tm, double *ns);
      |                            ~~~~~~~~~~~~~~~^~
/home/taka/git/fluent-bit/tests/internal/parser.c:234:36: warning: passing argument 1 of ‘flb_parser_tm2time’ from incompatible pointer type [-Wincompatible-pointer-types]
  234 |         epoch = flb_parser_tm2time(&tm);
      |                                    ^~~
      |                                    |
      |                                    struct tm *
In file included from /home/taka/git/fluent-bit/tests/internal/parser.c:5:
/home/taka/git/fluent-bit/include/fluent-bit/flb_parser.h:76:62: note: expected ‘const struct flb_tm *’ but argument is of type ‘struct tm *’
   76 | static inline time_t flb_parser_tm2time(const struct flb_tm *src)
      |                                         ~~~~~~~~~~~~~~~~~~~~~^~~
[ 97%] Linking C executable ../../bin/flb-it-parser
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/flb-it-parser
==110978== Memcheck, a memory error detector
==110978== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==110978== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==110978== Command: bin/flb-it-parser
==110978== 
Test tzone_offset...                            [ OK ]
==110979== Warning: invalid file descriptor -1 in syscall close()
==110979== 
==110979== HEAP SUMMARY:
==110979==     in use at exit: 80 bytes in 1 blocks
==110979==   total heap usage: 831 allocs, 830 frees, 84,477 bytes allocated
==110979== 
==110979== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==110979==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==110979==    by 0x1655A1: main (acutest.h:1632)
==110979== 
==110979== LEAK SUMMARY:
==110979==    definitely lost: 0 bytes in 0 blocks
==110979==    indirectly lost: 0 bytes in 0 blocks
==110979==      possibly lost: 0 bytes in 0 blocks
==110979==    still reachable: 80 bytes in 1 blocks
==110979==         suppressed: 0 bytes in 0 blocks
==110979== 
==110979== For lists of detected and suppressed errors, rerun with: -s
==110979== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test time_lookup...                             ==110980== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==110980== Warning: invalid file descriptor -1 in syscall close()
==110980== 
==110980== HEAP SUMMARY:
==110980==     in use at exit: 80 bytes in 1 blocks
==110980==   total heap usage: 2,743 allocs, 2,742 frees, 210,649 bytes allocated
==110980== 
==110980== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==110980==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==110980==    by 0x1655A1: main (acutest.h:1632)
==110980== 
==110980== LEAK SUMMARY:
==110980==    definitely lost: 0 bytes in 0 blocks
==110980==    indirectly lost: 0 bytes in 0 blocks
==110980==      possibly lost: 0 bytes in 0 blocks
==110980==    still reachable: 80 bytes in 1 blocks
==110980==         suppressed: 0 bytes in 0 blocks
==110980== 
==110980== For lists of detected and suppressed errors, rerun with: -s
==110980== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test json_time_lookup...                        ==110981== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==110981== Warning: invalid file descriptor -1 in syscall close()
==110981== 
==110981== HEAP SUMMARY:
==110981==     in use at exit: 80 bytes in 1 blocks
==110981==   total heap usage: 2,899 allocs, 2,898 frees, 1,117,529 bytes allocated
==110981== 
==110981== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==110981==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==110981==    by 0x1655A1: main (acutest.h:1632)
==110981== 
==110981== LEAK SUMMARY:
==110981==    definitely lost: 0 bytes in 0 blocks
==110981==    indirectly lost: 0 bytes in 0 blocks
==110981==      possibly lost: 0 bytes in 0 blocks
==110981==    still reachable: 80 bytes in 1 blocks
==110981==         suppressed: 0 bytes in 0 blocks
==110981== 
==110981== For lists of detected and suppressed errors, rerun with: -s
==110981== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test regex_time_lookup...                       ==110982== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==110982== Warning: invalid file descriptor -1 in syscall close()
==110982== 
==110982== HEAP SUMMARY:
==110982==     in use at exit: 80 bytes in 1 blocks
==110982==   total heap usage: 3,802 allocs, 3,801 frees, 491,472 bytes allocated
==110982== 
==110982== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==110982==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==110982==    by 0x1655A1: main (acutest.h:1632)
==110982== 
==110982== LEAK SUMMARY:
==110982==    definitely lost: 0 bytes in 0 blocks
==110982==    indirectly lost: 0 bytes in 0 blocks
==110982==      possibly lost: 0 bytes in 0 blocks
==110982==    still reachable: 80 bytes in 1 blocks
==110982==         suppressed: 0 bytes in 0 blocks
==110982== 
==110982== For lists of detected and suppressed errors, rerun with: -s
==110982== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test mysql_unquoted...                          ==110983== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==110983== Warning: invalid file descriptor -1 in syscall close()
==110983== 
==110983== HEAP SUMMARY:
==110983==     in use at exit: 80 bytes in 1 blocks
==110983==   total heap usage: 3,815 allocs, 3,814 frees, 571,893 bytes allocated
==110983== 
==110983== 80 bytes in 1 blocks are still reachable in loss record 1 of 1
==110983==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==110983==    by 0x1655A1: main (acutest.h:1632)
==110983== 
==110983== LEAK SUMMARY:
==110983==    definitely lost: 0 bytes in 0 blocks
==110983==    indirectly lost: 0 bytes in 0 blocks
==110983==      possibly lost: 0 bytes in 0 blocks
==110983==    still reachable: 80 bytes in 1 blocks
==110983==         suppressed: 0 bytes in 0 blocks
==110983== 
==110983== For lists of detected and suppressed errors, rerun with: -s
==110983== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==110978== 
==110978== HEAP SUMMARY:
==110978==     in use at exit: 0 bytes in 0 blocks
==110978==   total heap usage: 3 allocs, 3 frees, 1,141 bytes allocated
==110978== 
==110978== All heap blocks were freed -- no leaks are possible
==110978== 
==110978== For lists of detected and suppressed errors, rerun with: -s
==110978== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
