### PR TITLE
workflows: update unit test runner OS

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   run-ubuntu-unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -50,7 +50,7 @@ jobs:
       - name: Setup environment
         run: |
           sudo apt update
-          sudo apt install -yyq gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev
+          sudo apt install -y gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev
           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
       - uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,8 +49,8 @@ jobs:
     steps:
       - name: Setup environment
         run: |
-          sudo apt update
-          sudo apt install -y gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev
+          sudo apt-get update
+          sudo apt-get install -y gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev
           sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #6174 and the soon-to-be removal of Ubuntu 18 runners.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

https://github.com/fluent/fluent-bit/actions/runs/3515883866/jobs/5891709736

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
