### PR TITLE
workflows: update packaging to remove Ubuntu 18 runners

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -206,7 +206,7 @@ jobs:
     # Only upload for staging
     if: inputs.environment == 'staging'
     # Need to use 18.04 as 20.04 has no createrepo available
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     needs:
       - call-build-linux-packages
@@ -214,7 +214,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo aptly
+          sudo apt-get install -y createrepo_c aptly
 
       - name: Checkout code for repo metadata construction - always latest
         uses: actions/checkout@v3

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo_c aptly
+          sudo apt-get install -y createrepo-c aptly
 
       - name: Checkout code for repo metadata construction - always latest
         uses: actions/checkout@v3

--- a/.github/workflows/remove-release.yaml
+++ b/.github/workflows/remove-release.yaml
@@ -14,7 +14,7 @@ jobs:
 
   remove-release-packages-s3:
     name: S3 - remove release
-    runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
+    runs-on: ubuntu-22.04 # no createrepo on Ubuntu 20.04
     environment: release
     steps:
     - name: Checkout code
@@ -22,7 +22,7 @@ jobs:
 
     - name: Setup runner
       run: |
-        sudo apt-get install debsigs createrepo aptly rsync
+        sudo apt-get install debsigs createrepo_c aptly rsync
       shell: bash
 
     - name: Import GPG key for signing
@@ -68,7 +68,7 @@ jobs:
   remove-release-packages-server:
     name: fluentbit.io - remove packages
     needs: remove-release-packages-s3
-    runs-on: ubuntu-18.04 # failures with AWS client on latest
+    runs-on: ubuntu-22.04 # failures with AWS client on latest
     environment: release
     steps:
     - name: Checkout code

--- a/.github/workflows/remove-release.yaml
+++ b/.github/workflows/remove-release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Setup runner
       run: |
-        sudo apt-get install debsigs createrepo_c aptly rsync
+        sudo apt-get install debsigs createrepo-c aptly rsync
       shell: bash
 
     - name: Import GPG key for signing

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -83,7 +83,8 @@ jobs:
 
     - name: Setup runner
       run: |
-        sudo apt-get install debsigs createrepo_c aptly rsync
+        sudo apt-get update
+        sudo apt-get install -y debsigs createrepo-c aptly rsync
       shell: bash
 
     - name: Import GPG key for signing

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -72,7 +72,7 @@ jobs:
   # Note we could resign all packages as well potentially if we wanted to update the key.
   staging-release-packages-s3:
     name: S3 - create release
-    runs-on: ubuntu-18.04 # no createrepo on Ubuntu 20.04
+    runs-on: ubuntu-22.04 # no createrepo on Ubuntu 20.04
     environment: release
     needs: staging-release-version-check
     permissions:
@@ -83,7 +83,7 @@ jobs:
 
     - name: Setup runner
       run: |
-        sudo apt-get install debsigs createrepo aptly rsync
+        sudo apt-get install debsigs createrepo_c aptly rsync
       shell: bash
 
     - name: Import GPG key for signing
@@ -146,7 +146,7 @@ jobs:
     name: fluentbit.io - upload packages
     # Not required if using the staging bucket
     needs: staging-release-packages-s3
-    runs-on: ubuntu-18.04 # failures with AWS client on latest
+    runs-on: ubuntu-22.04 # failures with AWS client on latest
     environment: release
     permissions:
       contents: read


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #6174 by switching to Ubuntu 22.04 for packaging as this provides `createrepo_c`. Packaging scripts already updated to support it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

https://github.com/fluent/fluent-bit/actions/runs/3515729290

Looks good: https://github.com/fluent/fluent-bit/actions/runs/3515729290/jobs/5891540361

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
