### PR TITLE
out_s3: updated for getting upload time from timestamp.

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -46,7 +46,7 @@ static int construct_request_buffer(struct flb_s3 *ctx, flb_sds_t new_data,
                                     struct s3_file *chunk,
                                     char **out_buf, size_t *out_size);
 
-static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time,
+static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_log_time,
                          char *body, size_t body_size);
 
 static int put_all_chunks(struct flb_s3 *ctx);
@@ -57,7 +57,8 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
                                            const char *tag, int tag_len);
 
 static struct multipart_upload *create_upload(struct flb_s3 *ctx,
-                                              const char *tag, int tag_len);
+                                              const char *tag, int tag_len,
+                                              time_t file_first_log_time);
 
 static void remove_from_queue(struct upload_queue *entry);
 
@@ -986,11 +987,21 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
     int size_check = FLB_FALSE;
     int part_num_check = FLB_FALSE;
     int timeout_check = FLB_FALSE;
-    time_t create_time;
     int ret;
     void *payload_buf = NULL;
     size_t payload_size = 0;
     size_t preCompress_size = 0;
+    time_t file_first_log_time = time(NULL);
+
+    /*
+     * When chunk does not exist, file_first_log_time will be the current time.
+     * This is only for unit tests and prevents unit tests from segfaulting when chunk is
+     * NULL because if so chunk->first_log_time will be NULl either and will cause
+     * segfault during the process of put_object upload or mutipart upload.
+     */
+    if (chunk != NULL) {
+        file_first_log_time = chunk->first_log_time;
+    }
 
     if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
         /* Map payload */
@@ -1057,14 +1068,7 @@ put_object:
      * remove chunk from buffer list- needed for async http so that the
      * same chunk won't be sent more than once
      */
-    if (chunk) {
-        create_time = chunk->create_time;
-    }
-    else {
-        create_time = time(NULL);
-    }
-
-    ret = s3_put_object(ctx, tag, create_time, body, body_size);
+    ret = s3_put_object(ctx, tag, file_first_log_time, body, body_size);
     if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
         flb_free(payload_buf);
     }
@@ -1086,7 +1090,7 @@ put_object:
 multipart:
 
     if (init_upload == FLB_TRUE) {
-        m_upload = create_upload(ctx, tag, tag_len);
+        m_upload = create_upload(ctx, tag, tag_len, file_first_log_time);
         if (!m_upload) {
             flb_plg_error(ctx->ins, "Could not find or create upload for tag %s", tag);
             if (chunk) {
@@ -1325,7 +1329,7 @@ static int construct_request_buffer(struct flb_s3 *ctx, flb_sds_t new_data,
     return 0;
 }
 
-static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time,
+static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_log_time,
                          char *body, size_t body_size)
 {
     flb_sds_t s3_key = NULL;
@@ -1342,8 +1346,8 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t create_time
     flb_sds_t tmp;
     char final_body_md5[25];
 
-    s3_key = flb_get_s3_key(ctx->s3_key_format, create_time, tag, ctx->tag_delimiters,
-                            ctx->seq_index);
+    s3_key = flb_get_s3_key(ctx->s3_key_format, file_first_log_time, tag,
+                            ctx->tag_delimiters, ctx->seq_index);
     if (!s3_key) {
         flb_plg_error(ctx->ins, "Failed to construct S3 Object Key for %s", tag);
         return -1;
@@ -1517,8 +1521,8 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
     return m_upload;
 }
 
-static struct multipart_upload *create_upload(struct flb_s3 *ctx,
-                                              const char *tag, int tag_len)
+static struct multipart_upload *create_upload(struct flb_s3 *ctx, const char *tag,
+                                              int tag_len, time_t file_first_log_time)
 {
     int ret;
     struct multipart_upload *m_upload = NULL;
@@ -1531,8 +1535,8 @@ static struct multipart_upload *create_upload(struct flb_s3 *ctx,
         flb_errno();
         return NULL;
     }
-    s3_key = flb_get_s3_key(ctx->s3_key_format, time(NULL), tag, ctx->tag_delimiters,
-                            ctx->seq_index);
+    s3_key = flb_get_s3_key(ctx->s3_key_format, file_first_log_time, tag,
+                            ctx->tag_delimiters, ctx->seq_index);
     if (!s3_key) {
         flb_plg_error(ctx->ins, "Failed to construct S3 Object Key for %s", tag);
         flb_free(m_upload);
@@ -1672,13 +1676,16 @@ static int send_upload_request(void *out_context, flb_sds_t chunk,
     return ret;
 }
 
-static int buffer_chunk(void *out_context, struct s3_file *upload_file, flb_sds_t chunk,
-                        int chunk_size, const char *tag, int tag_len)
+static int buffer_chunk(void *out_context, struct s3_file *upload_file,
+                        flb_sds_t chunk, int chunk_size,
+                        const char *tag, int tag_len,
+                        time_t file_first_log_time)
 {
     int ret;
     struct flb_s3 *ctx = out_context;
 
-    ret = s3_store_buffer_put(ctx, upload_file, tag, tag_len, chunk, (size_t) chunk_size);
+    ret = s3_store_buffer_put(ctx, upload_file, tag,
+                              tag_len, chunk, (size_t) chunk_size, file_first_log_time);
     flb_sds_destroy(chunk);
     if (ret < 0) {
         flb_plg_warn(ctx->ins, "Could not buffer chunk. Data order preservation "
@@ -2025,14 +2032,16 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
 
 static void unit_test_flush(void *out_context, struct s3_file *upload_file,
                             const char *tag, int tag_len, flb_sds_t chunk,
-                            int chunk_size, struct multipart_upload *m_upload_file)
+                            int chunk_size, struct multipart_upload *m_upload_file,
+                            time_t file_first_log_time)
 {
     int ret;
     char *buffer;
     size_t buffer_size;
     struct flb_s3 *ctx = out_context;
 
-    s3_store_buffer_put(ctx, upload_file, tag, tag_len, chunk, (size_t) chunk_size);
+    s3_store_buffer_put(ctx, upload_file, tag, tag_len,
+                        chunk, (size_t) chunk_size, file_first_log_time);
     ret = construct_request_buffer(ctx, chunk, upload_file, &buffer, &buffer_size);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Could not construct request buffer for %s",
@@ -2112,6 +2121,11 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
     struct s3_file *upload_file = NULL;
     struct flb_s3 *ctx = out_context;
     struct multipart_upload *m_upload_file = NULL;
+    msgpack_unpacked result;
+    msgpack_object *obj;
+    size_t off = 0;
+    struct flb_time tms;
+    time_t file_first_log_time = 0;
 
     /* Cleanup old buffers and initialize upload timer */
     flush_init(ctx);
@@ -2140,11 +2154,38 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                                     event_chunk->tag,
                                     flb_sds_len(event_chunk->tag));
 
+    if (upload_file == NULL) {
+        /* unpack msgpack */
+        msgpack_unpacked_init(&result);
+
+        /* Get the first record timestamp */
+        while (msgpack_unpack_next(&result,
+                                   event_chunk->data,
+                                   event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
+            flb_time_pop_from_msgpack(&tms, &result, &obj);
+            if (&tms.tm.tv_sec != 0) {
+                file_first_log_time = tms.tm.tv_sec;
+                break;
+            }
+        }
+
+        msgpack_unpacked_destroy(&result);
+    }
+    else {
+        /* Get file_first_log_time from upload_file */
+        file_first_log_time = upload_file->first_log_time;
+    }
+
+    if (file_first_log_time == 0) {
+        file_first_log_time = time(NULL);
+    }
+
     /* Specific to unit tests, will not get called normally */
     if (s3_plugin_under_test() == FLB_TRUE) {
         unit_test_flush(ctx, upload_file,
                         event_chunk->tag, flb_sds_len(event_chunk->tag),
-                        chunk, chunk_size, m_upload_file);
+                        chunk, chunk_size,
+                        m_upload_file, file_first_log_time);
     }
 
     /* Discard upload_file if it has failed to upload MAX_UPLOAD_ERRORS times */
@@ -2178,12 +2219,14 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
         total_file_size_check = FLB_TRUE;
     }
 
-    /* File is ready for upload */
-    if (upload_timeout_check == FLB_TRUE || total_file_size_check == FLB_TRUE) {
+    /* File is ready for upload, upload_file != NULL prevents from segfaulting. */
+    if ((upload_file != NULL) && (upload_timeout_check == FLB_TRUE || total_file_size_check == FLB_TRUE)) {
         if (ctx->preserve_data_ordering == FLB_TRUE) {
             /* Buffer last chunk in file and lock file to prevent further changes */
             ret = buffer_chunk(ctx, upload_file, chunk, chunk_size,
-                               event_chunk->tag, flb_sds_len(event_chunk->tag));
+                               event_chunk->tag, flb_sds_len(event_chunk->tag),
+                               file_first_log_time);
+
             if (ret < 0) {
                 FLB_OUTPUT_RETURN(FLB_RETRY);
             }
@@ -2218,7 +2261,9 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
 
     /* Buffer current chunk in filesystem and wait for next chunk from engine */
     ret = buffer_chunk(ctx, upload_file, chunk, chunk_size,
-                       event_chunk->tag, flb_sds_len(event_chunk->tag));
+                       event_chunk->tag, flb_sds_len(event_chunk->tag),
+                       file_first_log_time);
+
     if (ret < 0) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -125,7 +125,8 @@ struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
 /* Append data to a new or existing fstore file */
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
-                        char *data, size_t bytes)
+                        char *data, size_t bytes,
+                        time_t file_first_log_time)
 {
     int ret;
     flb_sds_t name;
@@ -168,6 +169,7 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
             return -1;
         }
         s3_file->fsf = fsf;
+        s3_file->first_log_time = file_first_log_time;
         s3_file->create_time = time(NULL);
 
         /* Use fstore opaque 'data' reference to keep our context */
@@ -223,6 +225,7 @@ static int set_files_context(struct flb_s3 *ctx)
                 continue;
             }
             s3_file->fsf = fsf;
+            s3_file->first_log_time = time(NULL);
             s3_file->create_time = time(NULL);
 
             /* Use fstore opaque 'data' reference to keep our context */

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -28,13 +28,15 @@ struct s3_file {
     int failures;                    /* delivery failures */
     size_t size;                     /* file size */
     time_t create_time;              /* creation time */
+    time_t first_log_time;           /* first log time */
     flb_sds_t file_path;             /* file path */
     struct flb_fstore_file *fsf;     /* reference to parent flb_fstore_file */
 };
 
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
-                        char *data, size_t bytes);
+                        char *data, size_t bytes,
+                        time_t file_first_log_time);
 
 int s3_store_init(struct flb_s3 *ctx);
 int s3_store_exit(struct flb_s3 *ctx);


### PR DESCRIPTION
Signed-off-by: Clay Cheng <claychen@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[OUTPUT]
     Name s3
     Match *
     bucket clay-s3-timestamp
     region us-east-1
     total_file_size 1M
     upload_timeout 1m
     use_put_object On
```
- [x] Debug log output from testing the change
***Upload timeout + put object used***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 50M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 1000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:05:45] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:05:45] [ info] [sp] stream processor started
[2023/01/04 00:06:38] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:06:39] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/04/47-objecth4lHpX0O
[2023/01/04 00:06:50] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:06:51] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/04/58-objectr2dk4WDH
[2023/01/04 00:07:02] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:07:03] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/05/10-objectd1yH71IC
[2023/01/04 00:07:14] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:07:15] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/05/23-objectLGJCZYcW
```

***NO Upload timeout + Multipart***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 50M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 100000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:19:17] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:17] [ info] [output:s3:s3.0] Successfully uploaded part #2 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=78af9cbb127bf654817f0f8273fe7bdb
[2023/01/04 00:19:18] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:18] [ info] [output:s3:s3.0] Successfully uploaded part #3 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=9c2bd3405a7011ce397e382bd54fb88c
[2023/01/04 00:19:19] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:19] [ info] [output:s3:s3.0] Successfully uploaded part #4 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=705e5449d950fa76e99b0f40c49a7bfc
[2023/01/04 00:19:21] [ info] [output:s3:s3.0] UploadPart http status=200
```

***Upload timeout + multipart***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 6G
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 100000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:20:21] [ info] [sp] stream processor started
[2023/01/04 00:20:21] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] Successfully initiated multipart upload for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] Successfully uploaded part #1 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=3d3e0fa00c7aa5ac7d48b7412d37c1fa
[2023/01/04 00:20:55] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:55] [ info] [output:s3:s3.0] Successfully uploaded part #2 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=9dd63db9450ad383a90a4dc77fbbaa67
[2023/01/04 00:20:57] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:57] [ info] [output:s3:s3.0] Successfully uploaded part #3 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=ec14e35d5f7ab37780a029d63b536bec
[2023/01/04 00:20:58] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:58] [ info] [output:s3:s3.0] Successfully uploaded part #4 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=b95a4fc49cb23d3521978deafcaed2f3
[2023/01/04 00:20:59] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:59] [ info] [output:s3:s3.0] Successfully uploaded part #5 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=2f579891b3254356e78b69da5de94488
```

***No Upload Timeout + Single put object***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 1M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 1000000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:22:24] [ info] [sp] stream processor started
[2023/01/04 00:22:24] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectVubURfP2
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-object08fXmltw
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectMPpfA1ef
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectzZkbV6ul
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectVgFIjmn8
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectqx3KzVt3
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-object6nv6J7f4
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectpUwoeaFc
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==10338== LEAK SUMMARY:
==10338==    definitely lost: 0 bytes in 0 blocks
==10338==    indirectly lost: 0 bytes in 0 blocks
==10338==      possibly lost: 0 bytes in 0 blocks
==10338==    still reachable: 102,912 bytes in 3,432 blocks
==10338==         suppressed: 0 bytes in 0 blocks
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
