### PR TITLE
log: implement log suppress feature

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_thread_storage.h>
 #include <fluent-bit/flb_worker.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_sds.h>
 #include <inttypes.h>
 #include <errno.h>
 
@@ -52,6 +53,9 @@ extern FLB_TLS_DEFINE(struct flb_log, flb_log_ctx)
 #define FLB_LOG_EVENT    MK_EVENT_NOTIFICATION
 #define FLB_LOG_MNG      1024
 
+#define FLB_LOG_CACHE_ENTRIES        10
+#define FLB_LOG_CACHE_TEXT_BUF_SIZE  1024
+
 /* Logging main context */
 struct flb_log {
     struct mk_event event;     /* worker event for manager */
@@ -67,6 +71,19 @@ struct flb_log {
     int pth_init;
     pthread_cond_t  pth_cond;
     pthread_mutex_t pth_mutex;
+};
+
+struct flb_log_cache_entry {
+    flb_sds_t buf;
+    uint64_t timestamp;
+    struct mk_list _head;
+};
+
+/* Structure to keep a reference of the last N number of entries */
+struct flb_log_cache {
+    int size;                       /* cache size       */
+    int timeout;                    /* cache timeout    */
+    struct mk_list entries;         /* list for entries */
 };
 
 /*
@@ -105,6 +122,15 @@ int flb_log_set_file(struct flb_config *config, char *out);
 int flb_log_destroy(struct flb_log *log, struct flb_config *config);
 void flb_log_print(int type, const char *file, int line, const char *fmt, ...);
 int flb_log_is_truncated(int type, const char *file, int line, const char *fmt, ...);
+
+struct flb_log_cache *flb_log_cache_create(int timeout_seconds, int size);
+void flb_log_cache_destroy(struct flb_log_cache *cache);
+struct flb_log_cache_entry *flb_log_cache_exists(struct flb_log_cache *cache, char *msg_buf, size_t msg_size);
+struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache, uint64_t ts);
+
+int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, size_t msg_size);
+
+
 
 /* Logging macros */
 #define flb_helper(fmt, ...)                                    \

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -237,6 +237,7 @@ struct flb_output_instance {
     int event_type;
     int id;                              /* instance id                  */
     int log_level;                       /* instance log level           */
+    int log_suppress_interval;           /* log suppression interval     */
     char name[32];                       /* numbered name (cpu -> cpu.0) */
     char *alias;                         /* alias name for the instance  */
     int flags;                           /* inherit flags from plugin    */

--- a/include/fluent-bit/flb_output_plugin.h
+++ b/include/fluent-bit/flb_output_plugin.h
@@ -27,30 +27,66 @@
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 
+#include <stdarg.h>
+
+static inline int flb_output_plugin_log_suppress_check(struct flb_output_instance *ins, const char *fmt, ...)
+{
+    int ret;
+    size_t size;
+    va_list args;
+    char buf[4096];
+    struct flb_worker *w;
+
+    if (ins->log_suppress_interval <= 0) {
+        return FLB_FALSE;
+    }
+
+    va_start(args, fmt);
+    size = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
+    va_end(args);
+
+    if (size == -1) {
+        return FLB_FALSE;
+    }
+
+    w = flb_worker_get();
+    if (!w) {
+        return FLB_FALSE;
+    }
+
+    ret = flb_log_cache_check_suppress(w->log_cache, buf, size);
+    return ret;
+}
+
 #define flb_plg_error(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_ERROR))             \
-        flb_log_print(FLB_LOG_ERROR, NULL, 0, "[output:%s:%s] " fmt,    \
-                      ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
+        if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_ERROR, NULL, 0, "[output:%s:%s] " fmt,     \
+                          ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_warn(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_WARN))              \
-        flb_log_print(FLB_LOG_WARN, NULL, 0, "[output:%s:%s] " fmt,     \
-                      ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
+        if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_WARN, NULL, 0, "[output:%s:%s] " fmt,     \
+                          ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_info(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_INFO))              \
-        flb_log_print(FLB_LOG_INFO, NULL, 0, "[output:%s:%s] " fmt,     \
-                      ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
+        if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_INFO, NULL, 0, "[output:%s:%s] " fmt,     \
+                          ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_debug(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_DEBUG))             \
-        flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[output:%s:%s] " fmt,    \
-                      ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
+        if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[output:%s:%s] " fmt,    \
+                          ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_trace(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
-        flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
-                      "[output:%s:%s at %s:%i] " fmt,                   \
-                      ctx->p->name, flb_output_name(ctx), __FLB_FILENAME__, \
-                      __LINE__, ##__VA_ARGS__)
+        if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
+                          "[output:%s:%s at %s:%i] " fmt,                   \
+                          ctx->p->name, flb_output_name(ctx), __FLB_FILENAME__, \
+                          __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_worker.h
+++ b/include/fluent-bit/flb_worker.h
@@ -33,6 +33,7 @@ struct flb_worker {
     pthread_t tid;             /* thread ID   */
 
     /* Logging */
+    struct flb_log_cache *log_cache;
 #ifdef _WIN32
     intptr_t log[2];
 #else

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -686,6 +686,9 @@ int flb_log_destroy(struct flb_log *log, struct flb_config *config)
     /* Release resources */
     mk_event_loop_destroy(log->evl);
     flb_pipe_destroy(log->ch_mng);
+    if (log->worker->log_cache) {
+        flb_log_cache_destroy(log->worker->log_cache);
+    }
     flb_free(log->worker);
     flb_free(log);
 

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -143,11 +143,172 @@ static void log_worker_collector(void *data)
     pthread_exit(NULL);
 }
 
+struct flb_log_cache *flb_log_cache_create(int timeout_seconds, int size)
+{
+    int i;
+    struct flb_log_cache *cache;
+    struct flb_log_cache_entry *entry;
+
+    if (size <= 0) {
+        return NULL;
+    }
+
+    cache = flb_calloc(1, sizeof(struct flb_log_cache));
+    if (!cache) {
+        flb_errno();
+        return NULL;
+    }
+    cache->timeout = timeout_seconds;
+    mk_list_init(&cache->entries);
+
+    for (i = 0; i < size; i++) {
+        entry = flb_calloc(1, sizeof(struct flb_log_cache_entry));
+        if (!entry) {
+            flb_errno();
+            flb_log_cache_destroy(cache);
+            return NULL;
+        }
+
+        entry->buf = flb_sds_create_size(FLB_LOG_CACHE_TEXT_BUF_SIZE);
+        if (!entry->buf) {
+            flb_errno();
+            flb_log_cache_destroy(cache);
+        }
+        entry->timestamp = 0; /* unset for now */
+        mk_list_add(&entry->_head, &cache->entries);
+    }
+
+    return cache;
+}
+
+void flb_log_cache_destroy(struct flb_log_cache *cache)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_log_cache_entry *entry;
+
+    if (!cache) {
+        return;
+    }
+
+    mk_list_foreach_safe(head, tmp, &cache->entries) {
+        entry = mk_list_entry(head, struct flb_log_cache_entry, _head);
+        flb_sds_destroy(entry->buf);
+        mk_list_del(&entry->_head);
+        flb_free(entry);
+    }
+    flb_free(cache);
+}
+
+struct flb_log_cache_entry *flb_log_cache_exists(struct flb_log_cache *cache, char *msg_buf, size_t msg_size)
+{
+    size_t size;
+    struct mk_list *head;
+    struct flb_log_cache_entry *entry;
+
+    if (msg_size <= 1) {
+        return NULL;
+    }
+
+    /* number of bytes to compare */
+    size = msg_size / 2;
+
+    mk_list_foreach(head, &cache->entries) {
+        entry = mk_list_entry(head, struct flb_log_cache_entry, _head);
+        if (entry->timestamp == 0) {
+            continue;
+        }
+
+        if (flb_sds_len(entry->buf) < size) {
+            continue;
+        }
+
+        if (strncmp(entry->buf, msg_buf, size) == 0) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+
+
+/* returns an unused entry or the oldest one */
+struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache, uint64_t ts)
+{
+    struct mk_list *head;
+    struct flb_log_cache_entry *entry;
+    struct flb_log_cache_entry *target = NULL;
+
+    mk_list_foreach(head, &cache->entries) {
+        entry = mk_list_entry(head, struct flb_log_cache_entry, _head);
+
+        /* unused entry */
+        if (entry->timestamp == 0) {
+            return entry;
+        }
+
+        /* expired entry */
+        if (entry->timestamp + cache->timeout < ts) {
+            return entry;
+        }
+
+        /* keep a reference to the oldest entry to sacrifice it */
+        if (!target || entry->timestamp < target->timestamp) {
+            target = entry;
+        }
+    }
+
+    return target;
+}
+
+/*
+ * should the incoming message to be suppressed because already one similar exists in
+ * the cache ?
+ *
+ * if no similar message exists, then the incoming message is added to the cache.
+ */
+int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, size_t msg_size)
+{
+    uint64_t now = 0;
+    struct flb_log_cache_entry *entry;
+
+    now = time(NULL);
+    entry = flb_log_cache_exists(cache, msg_buf, msg_size);
+
+    /* if no similar message found, add the incoming message to the cache */
+    if (!entry) {
+        /* look for an unused entry or the oldest one */
+        entry = flb_log_cache_get_target(cache, now);
+
+        /* if no target entry is available just return, do not suppress the message */
+        if (!entry) {
+            return FLB_FALSE;
+        }
+
+        /* add the message to the cache */
+        flb_sds_len_set(entry->buf, 0);
+        entry->buf = flb_sds_copy(entry->buf, msg_buf, msg_size);
+        entry->timestamp = now;
+        return FLB_FALSE;
+    }
+    else {
+        if (entry->timestamp + cache->timeout > now) {
+            return FLB_TRUE;
+        }
+        else {
+            entry->timestamp = now;
+            return FLB_FALSE;
+        }
+    }
+    return FLB_TRUE;
+}
+
 int flb_log_worker_init(struct flb_worker *worker)
 {
     int ret;
     struct flb_config *config = worker->config;
     struct flb_log *log = config->log;
+    struct flb_log_cache *cache;
 
     /* Pipe to communicate Thread with worker log-collector */
     ret = flb_pipe_create(worker->log);
@@ -165,6 +326,14 @@ int flb_log_worker_init(struct flb_worker *worker)
         return -1;
     }
 
+    /* Log cache to reduce noise */
+    cache = flb_log_cache_create(10, FLB_LOG_CACHE_ENTRIES);
+    if (!cache) {
+        close(worker->log[0]);
+        close(worker->log[1]);
+        return -1;
+    }
+    worker->log_cache = cache;
     return 0;
 }
 
@@ -458,6 +627,7 @@ int flb_log_is_truncated(int type, const char *file, int line, const char *fmt, 
 
 void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
 {
+    int n;
     int len;
     int ret;
     struct log_message msg = {0};
@@ -475,7 +645,7 @@ void flb_log_print(int type, const char *file, int line, const char *fmt, ...)
 
     w = flb_worker_get();
     if (w) {
-        int n = flb_pipe_write_all(w->log[1], &msg, sizeof(msg));
+        n = flb_pipe_write_all(w->log[1], &msg, sizeof(msg));
         if (n == -1) {
             fprintf(stderr, "%s", (char *) msg.msg);
             perror("write");

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -448,6 +448,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     }
     instance->config = config;
     instance->log_level = -1;
+    instance->log_suppress_interval = -1;
     instance->test_mode = FLB_FALSE;
     instance->is_threaded = FLB_FALSE;
     instance->tp_workers = plugin->workers;
@@ -598,6 +599,14 @@ int flb_output_set_property(struct flb_output_instance *ins,
             return -1;
         }
         ins->log_level = ret;
+    }
+    else if (prop_key_check("log_suppress_interval", k, len) == 0 && tmp) {
+        ret = flb_utils_time_to_seconds(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
+        }
+        ins->log_suppress_interval = ret;
     }
     else if (prop_key_check("host", k, len) == 0) {
         ins->host.name = tmp;

--- a/src/flb_worker.c
+++ b/src/flb_worker.c
@@ -142,6 +142,10 @@ void flb_worker_destroy(struct flb_worker *worker)
         return;
     }
 
+    if (worker->log_cache) {
+        flb_log_cache_destroy(worker->log_cache);
+    }
+
     mk_list_del(&worker->_head);
     flb_free(worker);
 }

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -35,6 +35,7 @@ set(UNIT_TESTS_FILES
   parser_ltsv.c
   parser_regex.c
   env.c
+  log.c
   )
 
 # Config format

--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -1,0 +1,124 @@
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
+
+#include "flb_tests_internal.h"
+
+#define TIMEOUT             5
+#define TEST_RECORD_01      "this is a test message"
+#define TEST_RECORD_01_SIZE sizeof(TEST_RECORD_01) - 1
+
+#define TEST_RECORD_02      "other type of message"
+#define TEST_RECORD_02_SIZE sizeof(TEST_RECORD_02) - 1
+
+static void cache_basic_timeout()
+{
+    int i;
+    int ret_1;
+    int ret_2;
+    struct flb_log_cache *cache;
+    struct flb_log_cache_entry *entry;
+
+    printf("\n");
+
+    cache = flb_log_cache_create(10, 0);
+    TEST_CHECK(cache == NULL);
+
+    cache = flb_log_cache_create(5, 4);
+    TEST_CHECK(cache != NULL);
+
+    /* cache must be empty */
+    entry = flb_log_cache_exists(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(entry == NULL);
+
+    /* upon trying to check for a suppress and if not found, it must be added */
+    ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(ret_1 == FLB_FALSE);
+
+    /* double check that it was added */
+    entry = flb_log_cache_exists(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(entry != NULL);
+
+    printf("------------------------\n");
+
+    /* reset */
+    flb_log_cache_destroy(cache);
+
+    /* create a new cache */
+    cache = flb_log_cache_create(5, 4);
+    TEST_CHECK(cache != NULL);
+
+    for (i = 0; i < 10; i++) {
+        ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+        ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+
+        if (i == 0) {
+            TEST_CHECK(ret_1 == FLB_FALSE);
+            TEST_CHECK(ret_2 == FLB_FALSE);
+        }
+        else if (i >= 1 && i < 5) {
+            TEST_CHECK(ret_1 == FLB_TRUE);
+            TEST_CHECK(ret_2 == FLB_TRUE);
+        }
+        else if (i == 5) {
+            TEST_CHECK(ret_1 == FLB_FALSE);
+            TEST_CHECK(ret_2 == FLB_FALSE);
+        }
+        else {
+            TEST_CHECK(ret_1 == FLB_TRUE);
+            TEST_CHECK(ret_2 == FLB_TRUE);
+        }
+
+        sleep(1);
+    }
+
+    ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(ret_1 == FLB_FALSE);
+
+    ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+    TEST_CHECK(ret_2 == FLB_FALSE);
+
+    flb_log_cache_destroy(cache);
+}
+
+static void cache_one_slot()
+{
+    int i;
+    int ret_1;
+    int ret_2;
+    struct flb_log_cache *cache;
+    struct flb_log_cache_entry *entry;
+
+    printf("\n");
+
+    cache = flb_log_cache_create(2, 1);
+    TEST_CHECK(cache != NULL);
+
+    for (i = 0; i < 10; i++) {
+
+        if (i == 0) {
+            ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+            TEST_CHECK(ret_1 == FLB_FALSE);
+
+            ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+            TEST_CHECK(ret_1 == FLB_TRUE);
+        }
+        else {
+            ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+            ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+
+            TEST_CHECK(ret_1 == FLB_FALSE);
+            TEST_CHECK(ret_2 == FLB_FALSE);
+        }
+
+        sleep(1);
+    }
+
+    flb_log_cache_destroy(cache);
+}
+
+TEST_LIST = {
+    { "cache_basic_timeout" , cache_basic_timeout },
+    { "cache_one_slot"      , cache_one_slot      },
+    { 0 }
+};


### PR DESCRIPTION
The following PR implements a new option called `log_suppress_interval` that allows the suppressing of log messages from output plugins that look similar within  an interval of time.

The current missing implementation is to allow dynamic config if the interval since internally is set to 10 seconds, but to enable it and test it, it must be set in the configuration, e.g:

```
[OUTPUT]
    name http
    match *
    log_suppress_interval 10s
```

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
