### PR TITLE
out_tcp: new 'raw_message_key' option

### DIFF
--- a/plugins/out_tcp/tcp.h
+++ b/plugins/out_tcp/tcp.h
@@ -20,9 +20,14 @@
 #ifndef FLB_OUT_TCP_H
 #define FLB_OUT_TCP_H
 
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_record_accessor.h>
+
 struct flb_out_tcp {
     /* Output format */
     int out_format;
+    flb_sds_t raw_message_key;
+    struct flb_record_accessor *ra_raw_message_key;
 
     char *host;
     int port;

--- a/plugins/out_tcp/tcp_conf.c
+++ b/plugins/out_tcp/tcp_conf.c
@@ -67,6 +67,16 @@ struct flb_out_tcp *flb_tcp_conf_create(struct flb_output_instance *ins,
         io_flags |= FLB_IO_IPV6;
     }
 
+    /* raw message key mode */
+    if (ctx->raw_message_key) {
+        ctx->ra_raw_message_key = flb_ra_create(ctx->raw_message_key, FLB_TRUE);
+        if (!ctx->ra_raw_message_key) {
+            flb_plg_error(ctx->ins, "could not create record accessor for raw_message_key");
+            flb_free(ctx);
+            return NULL;
+        }
+    }
+
     /* Upstream context */
     upstream = flb_upstream_create(config,
                                    ins->host.name,
@@ -129,6 +139,10 @@ void flb_tcp_conf_destroy(struct flb_out_tcp *ctx)
 {
     if (!ctx) {
         return;
+    }
+
+    if (ctx->ra_raw_message_key) {
+        flb_ra_destroy(ctx->ra_raw_message_key);
     }
 
     if (ctx->u) {


### PR DESCRIPTION
add new `raw_message_key` option, this option allows to send records raw content of a specific key, this mode is incompatible with format. Usage:

__client__
```
fluent-bit -i dummy -p "dummy={\"key\": \"abc\", \"real\": \"good\"}" -o tcp -p port=55441 -p "raw_message_key=\$real"
```

__server__
```
nc -l 55441
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
