### PR TITLE
tests: runtime: in_tail: remove unused var

### DIFF
--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -287,7 +287,6 @@ void wait_with_timeout(uint32_t timeout_ms, struct tail_test_result *result, int
     struct flb_time end_time;
     struct flb_time diff_time;
     uint64_t elapsed_time_flb = 0;
-    int64_t ret = 0;
 
     flb_time_get(&start_time);
 


### PR DESCRIPTION
This patch is to remove unused variable.
```
Consolidate compiler generated dependencies of target flb-rt-in_tail
[ 81%] Building C object tests/runtime/CMakeFiles/flb-rt-in_tail.dir/in_tail.c.o
/home/taka/git/fluent-bit/tests/runtime/in_tail.c: In function ‘wait_with_timeout’:
/home/taka/git/fluent-bit/tests/runtime/in_tail.c:290:13: warning: unused variable ‘ret’ [-Wunused-variable]
  290 |     int64_t ret = 0;
      |             ^~~
[ 81%] Linking C executable ../../bin/flb-rt-in_tail
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
