### PR TITLE
packaging: handle change in location of JSON schema for release

### DIFF
--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -183,19 +183,9 @@ fi
 # Sign YUM repo meta-data
 find "/var/www/apt.fluentbit.io" -name repomd.xml -exec gpg --detach-sign --armor --yes -u "releases@fluentbit.io" {} \;
 
-# Handle the JSON schema by copying in the new versions (if they exist) and then updating the symlinks that point at the latest.
-if compgen -G "$SOURCE_DIR/fluent-bit-schema*.json" > /dev/null; then
-    echo "Updating JSON schema"
-    cp -vf "$SOURCE_DIR"/fluent-bit-schema*.json /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION/"
-
-    # Simpler than 'ln --relative --target-directory=/var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION"'
-    pushd /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION"
-        ln -sf "fluent-bit-schema-$VERSION.json" fluent-bit-schema.json
-        ln -sf "fluent-bit-schema-pretty-$VERSION.json" fluent-bit-schema-pretty.json
-    popd
-else
-    echo "Missing JSON schema"
-fi
+# Handle the JSON schema by copying in the new versions (if they exist).
+echo "Updating JSON schema"
+find "$SOURCE_DIR/" -iname "fluent-bit-schema*$VERSION*.json" -exec cp -vf "{}" /var/www/releases.fluentbit.io/releases/"$MAJOR_VERSION/" \;
 
 # Windows - we do want word splitting and ensure some files exist
 if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Addresses #6442 failure with JSON schema publishing. 
Command ran manually to confirm on release server.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
