### PR TITLE
opensearch: aoss support - 1.9

### DIFF
--- a/include/fluent-bit/flb_signv4.h
+++ b/include/fluent-bit/flb_signv4.h
@@ -40,6 +40,7 @@ flb_sds_t flb_signv4_do(struct flb_http_client *c, int normalize_uri,
                         time_t t_now,
                         char *region, char *service,
                         int s3_mode,
+                        struct mk_list *unsigned_headers,  /* flb_slist */
                         struct flb_aws_provider *provider);
 
 #endif

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -260,7 +260,7 @@ static flb_sds_t add_aws_signature(struct flb_http_client *c, struct flb_bigquer
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ctx->aws_region, "sts",
-                              0, ctx->aws_provider);
+                              0, NULL, ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "Could not sign the request with AWS SigV4");
         return NULL;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -62,8 +62,8 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
-                              ctx->aws_region, "es",
-                              0, NULL,
+                              ctx->aws_region, ctx->aws_service_name,
+                              S3_MODE_SIGNED_PAYLOAD, ctx->aws_unsigned_headers,
                               ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
@@ -1010,6 +1010,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "aws_external_id", NULL,
      0, FLB_FALSE, 0,
      "External ID for the AWS IAM Role specified with `aws_role_arn`"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "aws_service_name", "es",
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_service_name),
+     "AWS Service Name"
     },
 #endif
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -63,7 +63,7 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ctx->aws_region, "es",
-                              0,
+                              0, NULL,
                               ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -61,6 +61,8 @@ struct flb_elasticsearch {
     /* one for the standard chain provider, one for sts assume role */
     struct flb_tls *aws_sts_tls;
     char *aws_session_name;
+    char *aws_service_name;
+    struct mk_list *aws_unsigned_headers;
 #endif
 
     /* HTTP Client Setup */

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -294,6 +294,18 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     }
 
 #ifdef FLB_HAVE_AWS
+    /* AWS Auth Unsigned Headers */
+    ctx->aws_unsigned_headers = flb_malloc(sizeof(struct mk_list));
+    if (ret != 0) {
+        flb_es_conf_destroy(ctx);
+    }
+    flb_slist_create(ctx->aws_unsigned_headers);
+    ret = flb_slist_add(ctx->aws_unsigned_headers, "Content-Length");
+    if (ret != 0) {
+        flb_es_conf_destroy(ctx);
+        return NULL;
+    }
+
     /* AWS Auth */
     ctx->has_aws_auth = FLB_FALSE;
     tmp = flb_output_get_property("aws_auth", ins);
@@ -443,6 +455,11 @@ int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 
     if (ctx->aws_sts_tls) {
         flb_tls_destroy(ctx->aws_sts_tls);
+    }
+
+    if (ctx->aws_unsigned_headers) {
+        flb_slist_destroy(ctx->aws_unsigned_headers);
+        flb_free(ctx->aws_unsigned_headers);
     }
 #endif
 

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -232,7 +232,7 @@ static int http_post(struct flb_out_http *ctx,
                                   time(NULL),
                                   (char *) ctx->aws_region,
                                   (char *) ctx->aws_service,
-                                  0,
+                                  0, NULL,
                                   ctx->aws_provider);
 
         if (!signature) {

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -59,8 +59,8 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
-                              ctx->aws_region, "es",
-                              0, NULL,
+                              ctx->aws_region, ctx->aws_service_name,
+                              S3_MODE_SIGNED_PAYLOAD, ctx->aws_unsigned_headers,
                               ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
@@ -1015,6 +1015,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "aws_external_id", NULL,
      0, FLB_FALSE, 0,
      "External ID for the AWS IAM Role specified with `aws_role_arn`"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "aws_service_name", "es",
+     0, FLB_TRUE, offsetof(struct flb_opensearch, aws_service_name),
+     "AWS Service Name"
     },
 #endif
 

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -60,7 +60,7 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ctx->aws_region, "es",
-                              0,
+                              0, NULL,
                               ctx->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -73,6 +73,8 @@ struct flb_opensearch {
     /* one for the standard chain provider, one for sts assume role */
     struct flb_tls *aws_sts_tls;
     char *aws_session_name;
+    char *aws_service_name;
+    struct mk_list *aws_unsigned_headers;
 #endif
 
     /* HTTP Client Setup */

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -201,6 +201,19 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
     }
 
 #ifdef FLB_HAVE_AWS
+    /* AWS Auth Unsigned Headers */
+    ctx->aws_unsigned_headers = flb_malloc(sizeof(struct mk_list));
+    if (!ctx->aws_unsigned_headers) {
+        flb_os_conf_destroy(ctx);
+        return NULL;
+    }
+    flb_slist_create(ctx->aws_unsigned_headers);
+    ret = flb_slist_add(ctx->aws_unsigned_headers, "Content-Length");
+    if (ret != 0) {
+        flb_os_conf_destroy(ctx);
+        return NULL;
+    }
+
     /* AWS Auth */
     ctx->has_aws_auth = FLB_FALSE;
     tmp = flb_output_get_property("aws_auth", ins);
@@ -347,6 +360,11 @@ int flb_os_conf_destroy(struct flb_opensearch *ctx)
 
     if (ctx->aws_sts_tls) {
         flb_tls_destroy(ctx->aws_sts_tls);
+    }
+
+    if (ctx->aws_unsigned_headers) {
+        flb_slist_destroy(ctx->aws_unsigned_headers);
+        flb_free(ctx->aws_unsigned_headers);
     }
 #endif
 

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -455,7 +455,7 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
         }
         signature = flb_signv4_do(c, normalize_uri, FLB_TRUE, time(NULL),
                                   aws_client->region, aws_client->service,
-                                  aws_client->s3_mode,
+                                  aws_client->s3_mode, NULL,
                                   aws_client->provider);
         if (!signature) {
             if (aws_client->debug_only == FLB_TRUE) {

--- a/tests/internal/fuzzers/signv4_fuzzer.c
+++ b/tests/internal/fuzzers/signv4_fuzzer.c
@@ -79,7 +79,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         ret = setenv(AWS_SECRET_ACCESS_KEY, secret_key, 1);
         if (ret >= 0) {
             flb_sds_t signature = flb_signv4_do(http_c, FLB_TRUE, FLB_FALSE, t,
-                        region, service, s3_mode, provider);
+                        region, service, s3_mode, NULL, provider);
             if (signature) {
               flb_sds_destroy(signature);
             }

--- a/tests/internal/signv4.c
+++ b/tests/internal/signv4.c
@@ -604,7 +604,7 @@ static void aws_test_suite()
                                   FLB_TRUE,  /* normalize URI ? */
                                   FLB_FALSE, /* add x-amz-date header ? */
                                   t, region, service,
-                                  0,
+                                  0, NULL,
                                   provider);
         TEST_CHECK(signature != NULL);
         if (signature) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
master pr: https://github.com/fluent/fluent-bit/pull/6612

# OpenSearch and ElasticSearch improvements:
Several minor changes:
- Add payload hash to authenticated request headers as:
```
x-amz-content-sha256
```
- Allow for configurable service name where "es" is used by default.
- Add Excluded_Headers parameter to aws sigv4 function.
- Exclude content_length from OpenSearch & ES headers


# Testing

### Configuration Files
Tested by FireLens team on Amazon AWS Opensearch with the following plugin configurations
```
[SERVICE]
    Flush 1
    Grace 30

[INPUT]
    Name cpu
    Tag cpu

[OUTPUT]
    Name  es
    Match *
    Index cpu
    Host my.es.amazonaws.com
    port 443
    aws_auth on
    aws_region us-west-2
    tls on
```

```
[SERVICE]
    Flush 1
    Grace 30

[INPUT]
    Name cpu
    Tag cpu

[OUTPUT]
    Name  opensearch
    Match *
    Index cpu
    Host my.es.amazonaws.com
    port 443
    aws_auth on
    aws_region us-west-2
    tls on
```

### Test Results
No error messages were detected. Logs are successfully received at the Opensearch cluster.

```
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/20 04:14:12] [ info] [fluent bit] version=1.9.10, commit=062d4c1144, pid=6382
[2022/12/20 04:14:12] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/12/20 04:14:12] [ info] [cmetrics] version=0.3.7
[2022/12/20 04:14:12] [ info] [sp] stream processor started
```


### Test Valgrind Results
`valgrind --leak-check=full ./fluent-bit -c ../../.vscode/fluent-bit-config/fluent-bit.conf`

### Opensearch
```
==13015== Memcheck, a memory error detector
==13015== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==13015== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==13015== Command: ./fluent-bit -c ../../.vscode/fluent-bit-config/fluent-bit.conf
==13015== 
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/20 04:24:05] [ info] [fluent bit] version=1.9.10, commit=c0e20d18dd, pid=13015
[2022/12/20 04:24:05] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/12/20 04:24:05] [ info] [cmetrics] version=0.3.7
[2022/12/20 04:24:06] [ info] [sp] stream processor started
==13015== Warning: client switching stacks?  SP change: 0x76fe8a8 --> 0x84fef80
==13015==          to suppress, use: --max-stackframe=14681816 or greater
==13015== Warning: client switching stacks?  SP change: 0x84feef8 --> 0x76fe8a8
==13015==          to suppress, use: --max-stackframe=14681680 or greater
==13015== Warning: client switching stacks?  SP change: 0x76fead8 --> 0x84feef8
==13015==          to suppress, use: --max-stackframe=14681120 or greater
==13015==          further instances of this message will not be shown.
^C[2022/12/20 04:24:10] [engine] caught signal (SIGINT)
[2022/12/20 04:24:10] [ info] [input] pausing cpu.0
[2022/12/20 04:24:10] [ warn] [engine] service will shutdown in max 30 seconds
[2022/12/20 04:24:10] [ info] [engine] service has stopped (0 pending tasks)
==13015== 
==13015== HEAP SUMMARY:
==13015==     in use at exit: 110,402 bytes in 3,763 blocks
==13015==   total heap usage: 60,332 allocs, 56,569 frees, 6,568,634 bytes allocated
==13015== 
==13015== LEAK SUMMARY:
==13015==    definitely lost: 0 bytes in 0 blocks
==13015==    indirectly lost: 0 bytes in 0 blocks
==13015==      possibly lost: 0 bytes in 0 blocks
==13015==    still reachable: 110,402 bytes in 3,763 blocks
==13015==         suppressed: 0 bytes in 0 blocks
==13015== Reachable blocks (those to which a pointer was found) are not shown.
==13015== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==13015== 
==13015== For lists of detected and suppressed errors, rerun with: -s
==13015== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### ElasticSearch
Unfortunately, es on both 1.9 and aoss-1.9 (this pr's branch) have numerous networking invalid read errors. This may need to be further investigated. There are no memory leaks introduced though:


**es 1.9**
```
==17772== Memcheck, a memory error detector
==17772== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==17772== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==17772== Command: ./fluent-bit -c ../../.vscode/fluent-bit-config/fluent-bit.conf
==17772== 
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/20 04:29:02] [ info] [fluent bit] version=1.9.10, commit=760956f50c, pid=17772
[2022/12/20 04:29:02] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/12/20 04:29:02] [ info] [cmetrics] version=0.3.7
[2022/12/20 04:29:03] [ info] [sp] stream processor started
[2022/12/20 04:29:03] [ info] [output:es:es.0] worker #0 started
[2022/12/20 04:29:03] [ info] [output:es:es.0] worker #1 started
==17772== Warning: client switching stacks?  SP change: 0x8f009c8 --> 0x9949270
==17772==          to suppress, use: --max-stackframe=10782888 or greater
==17772== Warning: client switching stacks?  SP change: 0x99491e8 --> 0x8f009c8
==17772==          to suppress, use: --max-stackframe=10782752 or greater
==17772== Warning: client switching stacks?  SP change: 0x8f009c8 --> 0x99491e8
==17772==          to suppress, use: --max-stackframe=10782752 or greater
==17772==          further instances of this message will not be shown.
==17772== Thread 5 flb-out-es.0-w1:
==17772== Invalid write of size 8
==17772==    at 0x7CC1C7: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902500 is in a rw- anonymous segment
==17772== 
==17772== Invalid write of size 8
==17772==    at 0x7CC1CB: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902508 is in a rw- anonymous segment
==17772== 
==17772== Invalid write of size 8
==17772==    at 0x7CC1CF: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902510 is in a rw- anonymous segment
==17772== 
==17772== Invalid write of size 8
==17772==    at 0x7CC1D3: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902518 is in a rw- anonymous segment
==17772== 
==17772== Invalid write of size 8
==17772==    at 0x7CC1D7: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902520 is in a rw- anonymous segment
==17772== 
==17772== Invalid write of size 8
==17772==    at 0x7CC1DB: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9902528 is in a rw- anonymous segment
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1DF: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322a8 is 8 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1E3: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322b0 is 16 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1E7: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322b8 is 24 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1EB: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322c0 is 32 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1EF: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322c8 is 40 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x7CC1F3: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==17772==  Address 0x9a322d0 is 48 bytes inside a block of size 25,088 alloc'd
==17772==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==17772==    by 0x7CD2E0: co_create (amd64.c:142)
==17772==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==17772==    by 0x460323: output_thread (flb_output_thread.c:288)
==17772==    by 0x477A70: step_callback (flb_worker.c:43)
==17772==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==17772==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==17772== 
==17772== Invalid read of size 8
==17772==    at 0x45F84C: output_pre_cb_flush (flb_output.h:497)
==17772==  Address 0x9902700 is in a rw- anonymous segment
==17772== 

...

==17772== 
==17772== HEAP SUMMARY:
==17772==     in use at exit: 110,402 bytes in 3,763 blocks
==17772==   total heap usage: 73,309 allocs, 69,546 frees, 48,019,335 bytes allocated
==17772== 
==17772== LEAK SUMMARY:
==17772==    definitely lost: 0 bytes in 0 blocks
==17772==    indirectly lost: 0 bytes in 0 blocks
==17772==      possibly lost: 0 bytes in 0 blocks
==17772==    still reachable: 110,402 bytes in 3,763 blocks
==17772==         suppressed: 0 bytes in 0 blocks
==17772== Reachable blocks (those to which a pointer was found) are not shown.
==17772== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==17772== 
==17772== Use --track-origins=yes to see where uninitialised values come from
==17772== For lists of detected and suppressed errors, rerun with: -s
```


**es aoss-1.9**
```

Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/20 04:32:42] [ info] [fluent bit] version=1.9.10, commit=f22e8b90c1, pid=21318
[2022/12/20 04:32:42] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/12/20 04:32:42] [ info] [cmetrics] version=0.3.7
[2022/12/20 04:32:43] [ info] [sp] stream processor started
[2022/12/20 04:32:43] [ info] [output:es:es.0] worker #1 started
[2022/12/20 04:32:43] [ info] [output:es:es.0] worker #0 started
==21318== Warning: client switching stacks?  SP change: 0x8f009c8 --> 0x9949270
==21318==          to suppress, use: --max-stackframe=10782888 or greater
==21318== Warning: client switching stacks?  SP change: 0x99491e8 --> 0x8f009c8
==21318==          to suppress, use: --max-stackframe=10782752 or greater
==21318== Warning: client switching stacks?  SP change: 0x8f009c8 --> 0x99491e8
==21318==          to suppress, use: --max-stackframe=10782752 or greater
==21318==          further instances of this message will not be shown.
==21318== Thread 5 flb-out-es.0-w1:
==21318== Invalid write of size 8
==21318==    at 0x7CC547: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902500 is in a rw- anonymous segment
==21318== 
==21318== Invalid write of size 8
==21318==    at 0x7CC54B: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902508 is in a rw- anonymous segment
==21318== 
==21318== Invalid write of size 8
==21318==    at 0x7CC54F: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902510 is in a rw- anonymous segment
==21318== 
==21318== Invalid write of size 8
==21318==    at 0x7CC553: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902518 is in a rw- anonymous segment
==21318== 
==21318== Invalid write of size 8
==21318==    at 0x7CC557: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902520 is in a rw- anonymous segment
==21318== 
==21318== Invalid write of size 8
==21318==    at 0x7CC55B: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x9902528 is in a rw- anonymous segment
==21318== 
==21318== Invalid read of size 8
==21318==    at 0x7CC55F: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x99efbf8 is 8 bytes inside a block of size 25,088 alloc'd
==21318==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==21318==    by 0x7CD660: co_create (amd64.c:142)
==21318==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==21318==    by 0x460323: output_thread (flb_output_thread.c:288)
==21318==    by 0x477A70: step_callback (flb_worker.c:43)
==21318==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==21318==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)
==21318== 
==21318== Invalid read of size 8
==21318==    at 0x7CC563: co_swap_function (in /home/ec2-user/fala-forks/fluent-bit/build/bin/fluent-bit)
==21318==  Address 0x99efc00 is 16 bytes inside a block of size 25,088 alloc'd
==21318==    at 0x4C2D065: malloc (vg_replace_malloc.c:381)
==21318==    by 0x7CD660: co_create (amd64.c:142)
==21318==    by 0x460323: flb_output_flush_create (flb_output.h:569)
==21318==    by 0x460323: output_thread (flb_output_thread.c:288)
==21318==    by 0x477A70: step_callback (flb_worker.c:43)
==21318==    by 0x4E4444A: start_thread (in /usr/lib64/libpthread-2.26.so)
==21318==    by 0x642C52E: clone (in /usr/lib64/libc-2.26.so)

...


[2022/12/20 04:33:02] [ info] [output:es:es.0] thread worker #0 stopped
[2022/12/20 04:33:02] [ info] [output:es:es.0] thread worker #1 stopping...
[2022/12/20 04:33:02] [ info] [output:es:es.0] thread worker #1 stopped
==21318== 
==21318== HEAP SUMMARY:
==21318==     in use at exit: 110,402 bytes in 3,763 blocks
==21318==   total heap usage: 61,959 allocs, 58,196 frees, 11,855,407 bytes allocated
==21318== 
==21318== LEAK SUMMARY:
==21318==    definitely lost: 0 bytes in 0 blocks
==21318==    indirectly lost: 0 bytes in 0 blocks
==21318==      possibly lost: 0 bytes in 0 blocks
==21318==    still reachable: 110,402 bytes in 3,763 blocks
==21318==         suppressed: 0 bytes in 0 blocks
==21318== Reachable blocks (those to which a pointer was found) are not shown.
==21318== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==21318== 
==21318== Use --track-origins=yes to see where uninitialised values come from
==21318== For lists of detected and suppressed errors, rerun with: -s
==21318== ERROR SUMMARY: 11634 errors from 1000 contexts (suppressed: 0 from 0)
```

### Interpretation of Valgrind Results
It's not clear why the invalid reads only appear in es and not the opensearch plugin which have nearly identical code.


### CloudWatch_logs Plugin Regression Testing
CloudWatch_logs plugin is also tested with this PR to ensure that aws auth still works for other plugins.
CloudWatch receives logs successfully.
```
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/20 04:37:32] [ info] [fluent bit] version=1.9.10, commit=f22e8b90c1, pid=23324
[2022/12/20 04:37:32] [ info] [storage] version=1.2.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/12/20 04:37:32] [ info] [cmetrics] version=0.3.7
[2022/12/20 04:37:33] [ info] [sp] stream processor started
[2022/12/20 04:37:33] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] worker #0 started
==23324== Warning: client switching stacks?  SP change: 0x93009c8 --> 0x87472f0
==23324==          to suppress, use: --max-stackframe=12293848 or greater
==23324== Warning: client switching stacks?  SP change: 0x8747268 --> 0x93009c8
==23324==          to suppress, use: --max-stackframe=12293984 or greater
==23324== Warning: client switching stacks?  SP change: 0x93009c8 --> 0x8747268
==23324==          to suppress, use: --max-stackframe=12293984 or greater
==23324==          further instances of this message will not be shown.
[2022/12/20 04:37:34] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream test2_test in log group fluent_test
[2022/12/20 04:37:36] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Log Group fluent_test not found. Will attempt to create it.
[2022/12/20 04:37:36] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log group fluent_test
[2022/12/20 04:37:44] [ warn] [net] getaddrinfo(host='logs.us-west-2.amazonaws.com', err=12): Timeout while contacting DNS servers
[2022/12/20 04:37:44] [error] [aws_client] connection initialization error
[2022/12/20 04:37:45] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Created log group fluent_test
[2022/12/20 04:37:45] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream test2_test in log group fluent_test
[2022/12/20 04:37:45] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Created log stream test2_test
^C[2022/12/20 04:38:46] [engine] caught signal (SIGINT)
[2022/12/20 04:38:46] [ warn] [engine] service will shutdown in max 30 seconds
[2022/12/20 04:38:46] [ info] [engine] service has stopped (0 pending tasks)
[2022/12/20 04:38:46] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] thread worker #0 stopping...
[2022/12/20 04:38:46] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] thread worker #0 stopped
==23324== 
==23324== HEAP SUMMARY:
==23324==     in use at exit: 110,402 bytes in 3,763 blocks
==23324==   total heap usage: 67,457 allocs, 63,694 frees, 33,207,221 bytes allocated
==23324== 
==23324== LEAK SUMMARY:
==23324==    definitely lost: 0 bytes in 0 blocks
==23324==    indirectly lost: 0 bytes in 0 blocks
==23324==      possibly lost: 0 bytes in 0 blocks
==23324==    still reachable: 110,402 bytes in 3,763 blocks
==23324==         suppressed: 0 bytes in 0 blocks
==23324== Reachable blocks (those to which a pointer was found) are not shown.
==23324== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==23324== 
==23324== For lists of detected and suppressed errors, rerun with: -s
==23324== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
