### PR TITLE
out_kafka: fix segmentation fault issue while produce_message

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -478,6 +478,14 @@ static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
     while (msgpack_unpack_next(&result,
                                event_chunk->data,
                                event_chunk->size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+
+        if (result.data.via.array.size != 2) {
+            continue;
+        }
+
         flb_time_pop_from_msgpack(&tms, &result, &obj);
 
         ret = produce_message(&tms, obj, ctx, config);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix segmentation fault in out_kafka.

Stacktrace:
```
Nov 23, 2022 @ 00:53:23.362 | [2022/11/22 15:53:23] [engine] caught signal (SIGSEGV)
-- | --

  | Nov 23, 2022 @ 00:53:23.473 | #0  0xaaaad87abb10      in  produce_message() at plugins/out_kafka/kafka.c:189

  | Nov 23, 2022 @ 00:53:23.473 | #1  0xaaaad87ac50b      in  cb_kafka_flush() at plugins/out_kafka/kafka.c:483

  | Nov 23, 2022 @ 00:53:23.473 | #2  0xaaaad84a4a17      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:519

  | Nov 23, 2022 @ 00:53:23.473 | #3  0xaaaad8ede3fb      in  co_switch() at lib/monkey/deps/flb_libco/aarch64.c:133

  | Nov 23, 2022 @ 00:53:23.473 | #4  0xffffffffffffffff  in  ???() at ???:0
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fix #6451 

Thank you @Jinmo , for kindly helping me troubleshooting !

----
**Testing**
We tested this change by deploying custom-build to our production application. Segmentation fault is not being caused.

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
