### PR TITLE
stackdriver: cache token expiration and use it when using cached tokens

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -46,6 +46,7 @@
 
 pthread_key_t oauth2_type;
 pthread_key_t oauth2_token;
+pthread_key_t oauth2_token_expires;
 
 static void oauth2_cache_exit(void *ptr)
 {
@@ -59,10 +60,11 @@ static void oauth2_cache_init()
     /* oauth2 pthread key */
     pthread_key_create(&oauth2_type, oauth2_cache_exit);
     pthread_key_create(&oauth2_token, oauth2_cache_exit);
+    pthread_key_create(&oauth2_token_expires, oauth2_cache_exit);
 }
 
 /* Set oauth2 type and token in pthread keys */
-static void oauth2_cache_set(char *type, char *token)
+static void oauth2_cache_set(char *type, char *token, time_t expires)
 {
     flb_sds_t tmp;
 
@@ -81,6 +83,29 @@ static void oauth2_cache_set(char *type, char *token)
     }
     tmp = flb_sds_create(token);
     pthread_setspecific(oauth2_token, tmp);
+
+    /* oauth2 access toke expiration */
+    tmp = pthread_getspecific(oauth2_token_expires);
+    if (tmp) {
+        flb_sds_destroy(tmp);
+    }
+    tmp = flb_calloc(1, sizeof(time_t));
+    if (!tmp) {
+        flb_errno();
+        return;
+    }
+    *tmp = expires;
+    pthread_setspecific(oauth2_token, tmp);
+}
+
+/* By using pthread keys cached values, compose the authorizatoin token */
+static time_t oauth2_cache_get_expiration()
+{
+    time_t *expires = pthread_getspecific(oauth2_token_expires);
+    if (expires) {
+        return *expires;
+    }
+    return 0;
 }
 
 /* By using pthread keys cached values, compose the authorizatoin token */
@@ -321,6 +346,7 @@ static flb_sds_t get_google_token(struct flb_stackdriver *ctx)
 {
     int ret = 0;
     flb_sds_t output = NULL;
+    time_t cached_expiration = 0;
 
     ret = pthread_mutex_trylock(&ctx->token_mutex);
     if (ret == EBUSY) {
@@ -331,7 +357,17 @@ static flb_sds_t get_google_token(struct flb_stackdriver *ctx)
          * If the routine fails it will return NULL and the caller will just
          * issue a FLB_RETRY.
          */
-        return oauth2_cache_to_token();
+        output = oauth2_cache_to_token();
+        cached_expiration = oauth2_cache_get_expiration();
+        if (time(NULL) >= cached_expiration) {
+            return output;
+        } else {
+            /* 
+             * Cached token is expired. Wait on lock to use up-to-date token
+             * by either waiting for it to be refreshed or refresh it ourselves.
+             */
+            ret = pthread_mutex_lock(&ctx->token_mutex);
+        }
     }
     else if (ret != 0) {
         flb_plg_error(ctx->ins, "error locking mutex");
@@ -345,7 +381,7 @@ static flb_sds_t get_google_token(struct flb_stackdriver *ctx)
     /* Copy string to prevent race conditions (get_oauth2 can free the string) */
     if (ret == 0) {
         /* Update pthread keys cached values */
-        oauth2_cache_set(ctx->o->token_type, ctx->o->access_token);
+        oauth2_cache_set(ctx->o->token_type, ctx->o->access_token, ctx->o->expires);
 
         /* Compose outgoing buffer using cached values */
         output = oauth2_cache_to_token();


### PR DESCRIPTION
This change makes it so we don't attempt any request to Cloud Logging if we know that an expired token is being used.