### PR TITLE
packaging: add extra repo creation details

### DIFF
--- a/packaging/server/aptly.conf
+++ b/packaging/server/aptly.conf
@@ -17,6 +17,16 @@
   "ppaCodename": "",
   "skipContentsPublishing": false,
   "FileSystemPublishEndpoints": {
+    "debian/bookworm": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/bookworm",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "debian/bullseye": {
+      "rootDir": "/var/www/apt.fluentbit.io/debian/bullseye",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
     "debian/jessie": {
       "rootDir": "/var/www/apt.fluentbit.io/debian/jessie",
       "linkMethod": "copy",

--- a/packaging/server/create-aptly-repo.sh
+++ b/packaging/server/create-aptly-repo.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Distro and codename
+DISTRO=${DISTRO:?}
+CODENAME=${CODENAME:?}
+
+# Package version to add
+VERSION=${VERSION:?}
+# Packages location
+SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
+# Aptly config file
+APTLY_CONFIG=${APTLY_CONFIG:-/etc/aptly.conf}
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Missing source directory: $SOURCE_DIR"
+    exit 1
+fi
+
+REPO_NAME="flb-${DISTRO}-${CODENAME}"
+
+if aptly -config="$APTLY_CONFIG" repo show "$REPO_NAME" 2>/dev/null; then 
+    echo "Existing repo found for $REPO_NAME"
+    exit 1
+fi
+
+mkdir -p "/var/www/apt.fluentbit.io/${DISTRO}/${CODENAME}/"
+
+if ! grep -q "debian/bookworm" "$APTLY_CONFIG"; then
+    echo "Please update the aptly config file with the following:"
+    echo
+    echo '   "FileSystemPublishEndpoints": {'
+    echo "+    \"${DISTRO}/${CODENAME}\": {"
+    echo "+      \"rootDir\": \"/var/www/apt.fluentbit.io/${DISTRO}/${CODENAME}\","
+    echo '+      "linkMethod": "copy",'
+    echo '+      "verifyMethod": "md5"'
+    echo '+    },'
+    exit 1
+fi
+
+echo "First time publishing ${DISTRO} ${CODENAME}"
+
+# Create repo and add packages
+aptly -config=/etc/aptly.conf repo create -distribution="$CODENAME" -component=main "$REPO_NAME"
+find "$SOURCE_DIR/${DISTRO}/${CODENAME}/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add "$REPO_NAME" {} \;
+
+# Snapshot and publish
+SNAPSHOT_NAME="fluent-bit-${DISTRO}-${CODENAME}-${VERSION}"
+aptly -config="$APTLY_CONFIG" snapshot create "$SNAPSHOT_NAME" from repo "$REPO_NAME"
+aptly -config="$APTLY_CONFIG" publish snapshot -gpg-key=releases@fluentbit.io "$SNAPSHOT_NAME" "filesystem:${DISTRO}/${COMPONENT}:"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #6442.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

```shell
$ docker run --rm -it debian:bookworm /bin/sh -c 'apt-get update && apt-get install -y sudo gpg curl && curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh'
...
Preparing to unpack .../fluent-bit_2.0.6_amd64.deb ...
Unpacking fluent-bit (2.0.6) ...
Setting up libyaml-0-2:amd64 (0.2.5-1) ...
Setting up libpq5:amd64 (15.1-1) ...
Setting up fluent-bit (2.0.6) ...
Processing triggers for libc-bin (2.36-4) ...

Installation completed. Happy Logging!
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
