### PR TITLE
workflows: automatically create release during the release process

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -377,7 +377,6 @@ jobs:
     environment: release
     needs:
       - staging-release-packages-server
-      - staging-release-images
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -414,3 +413,34 @@ jobs:
         shell: bash
         env:
           IMAGE_TAG: ${{ github.event.inputs.version }}
+
+  staging-release-create-release:
+    name: Create the Github Release once packages and containers are up
+    needs:
+      - staging-release-images
+      - staging-release-packages-server
+    permissions:
+      contents: write
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release 1.9 - not latest
+        uses: softprops/action-gh-release@v1
+        if: startsWith(inputs.version, '1.9')
+        with:
+          body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
+          draft: false
+          generate_release_notes: false
+          name: "Fluent Bit ${{ inputs.version }}"
+          tag_name: v${{ inputs.version }}
+          target_commitish: '1.9'
+
+      - name: Release 2.0 and latest
+        uses: softprops/action-gh-release@v1
+        if: startsWith(inputs.version, '2.0')
+        with:
+          body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
+          draft: false
+          generate_release_notes: false
+          name: "Fluent Bit ${{ inputs.version }}"
+          tag_name: v${{ inputs.version }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Will create a valid Github release as soon as the release process is successful - this will link out to the announcement.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
