### PR TITLE
wasm: Fix wasm load error

### DIFF
--- a/plugins/filter_wasm/filter_wasm.c
+++ b/plugins/filter_wasm/filter_wasm.c
@@ -190,7 +190,7 @@ static int filter_wasm_config_read(struct flb_filter_wasm *ctx,
 
     /* function_name setting */
     if (ctx->wasm_function_name == NULL) {
-        flb_plg_error(f_ins, "no WASM 'program path' was given");
+        flb_plg_error(f_ins, "no WASM 'function name' was given");
         return -1;
     }
 

--- a/plugins/filter_wasm/filter_wasm.c
+++ b/plugins/filter_wasm/filter_wasm.c
@@ -214,7 +214,7 @@ static int cb_wasm_init(struct flb_filter_instance *f_ins,
     int ret = -1;
 
     /* Allocate space for the configuration */
-    ctx = flb_malloc(sizeof(struct flb_filter_wasm));
+    ctx = flb_calloc(1, sizeof(struct flb_filter_wasm));
     if (!ctx) {
         return -1;
     }

--- a/src/wasm/flb_wasm.c
+++ b/src/wasm/flb_wasm.c
@@ -70,6 +70,9 @@ static int flb_wasm_load_wasm_binary(const char *wasm_path, int8_t **out_buf, ui
     return buffer != NULL;
 
 error:
+    if (buffer != NULL) {
+        BH_FREE(buffer);
+    }
 
     return FLB_FALSE;
 }
@@ -106,6 +109,7 @@ struct flb_wasm *flb_wasm_instantiate(struct flb_config *config, const char *was
     wasi_dir_list = flb_malloc(sizeof(char *) * accessible_dir_list_size);
     if (!wasi_dir_list) {
         flb_errno();
+        flb_free(fw);
         return NULL;
     }
     mk_list_foreach(head, accessible_dir_list) {

--- a/src/wasm/flb_wasm.c
+++ b/src/wasm/flb_wasm.c
@@ -71,7 +71,7 @@ static int flb_wasm_load_wasm_binary(const char *wasm_path, int8_t **out_buf, ui
 
 error:
 
-    return -1;
+    return FLB_FALSE;
 }
 
 struct flb_wasm *flb_wasm_instantiate(struct flb_config *config, const char *wasm_path,
@@ -190,6 +190,9 @@ error:
     }
     if (buffer != NULL) {
         BH_FREE(buffer);
+    }
+    if (fw != NULL) {
+        flb_free(fw);
     }
 
     wasm_runtime_destroy();


### PR DESCRIPTION
This patch is to fix some memory errors when fluent-bit fails to load wasm.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[INPUT]
    Name dummy

[FILTER]
    Name wasm
    Match *
    Wasm_Path a
    Function_Name go_filter

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c wasm.conf 
==14189== Memcheck, a memory error detector
==14189== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==14189== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==14189== Command: bin/fluent-bit -c wasm.conf
==14189== 
Fluent Bit v2.0.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/26 07:53:06] [ info] [fluent bit] version=2.0.7, commit=b913c38bc2, pid=14189
[2022/11/26 07:53:07] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/11/26 07:53:07] [ info] [cmetrics] version=0.5.7
[2022/11/26 07:53:07] [ info] [ctraces ] version=0.2.5
[2022/11/26 07:53:07] [ info] [input:dummy:dummy.0] initializing
[2022/11/26 07:53:07] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/11/26 07:53:07] [ info] [output:stdout:stdout.0] worker #0 started
[2022/11/26 07:53:07] [ info] [sp] stream processor started
==14189== Warning: client switching stacks?  SP change: 0x5804a50 --> 0x5ff8f10
==14189==          to suppress, use: --max-stackframe=8340672 or greater
Read file to buffer failed: open file a failed.
[2022/11/26 07:53:08] [error] Open wasm file [a] failed.
==14189== Warning: client switching stacks?  SP change: 0x6ffb6f8 --> 0x54ac0d0
==14189==          to suppress, use: --max-stackframe=28636712 or greater
==14189== Warning: client switching stacks?  SP change: 0x54ac028 --> 0x6ffb6f8
==14189==          to suppress, use: --max-stackframe=28636880 or greater
==14189==          further instances of this message will not be shown.
[0] dummy.0: [1669416787.980347562, {"message"=>"dummy"}]
Read file to buffer failed: open file a failed.
[2022/11/26 07:53:08] [error] Open wasm file [a] failed.
^C[2022/11/26 07:53:09] [engine] caught signal (SIGINT)
[2022/11/26 07:53:09] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [1669416788.970731257, {"message"=>"dummy"}]
[2022/11/26 07:53:09] [ info] [input] pausing dummy.0
[2022/11/26 07:53:09] [ info] [engine] service has stopped (0 pending tasks)
[2022/11/26 07:53:09] [ info] [input] pausing dummy.0
[2022/11/26 07:53:09] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/11/26 07:53:10] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==14189== 
==14189== HEAP SUMMARY:
==14189==     in use at exit: 0 bytes in 0 blocks
==14189==   total heap usage: 1,589 allocs, 1,589 frees, 943,885 bytes allocated
==14189== 
==14189== All heap blocks were freed -- no leaks are possible
==14189== 
==14189== For lists of detected and suppressed errors, rerun with: -s
==14189== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
