### PR TITLE
tests: internal: fuzzers: add fstore fuzzer

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(UNIT_TESTS_FILES
   signv4_fuzzer.c
   flb_json_fuzzer.c
   filter_stdout_fuzzer.c
+  fstore_fuzzer.c
   parser_fuzzer.c
   parse_json_fuzzer.c
   parse_logfmt_fuzzer.c

--- a/tests/internal/fuzzers/fstore_fuzzer.c
+++ b/tests/internal/fuzzers/fstore_fuzzer.c
@@ -1,0 +1,69 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_fstore.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_compat.h>
+
+#include <chunkio/chunkio.h>
+#include <chunkio/cio_utils.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+
+#define FSF_STORE_PATH "/tmp/flb-fstore"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int ret;
+    void *out_buf;
+    size_t out_size;
+    struct stat st_data;
+    struct flb_fstore *fs;
+    struct flb_fstore_stream *st;
+    struct flb_fstore_file *fsf;
+
+    cio_utils_recursive_delete(FSF_STORE_PATH);
+    fs = flb_fstore_create(FSF_STORE_PATH, FLB_FSTORE_FS);
+    st = flb_fstore_stream_create(fs, "abc");
+    if (st != NULL) {
+        fsf = flb_fstore_file_create(fs, st, "example.txt", size);
+
+        if (fsf != NULL) {
+            ret = flb_fstore_file_append(fsf, data, size);
+            if (ret == 0) {
+                ret = flb_fstore_file_content_copy(fs, fsf, &out_buf, &out_size);
+                if (ret == 0) {
+                    assert(memcmp(out_buf, data, size) == 0);
+                }
+                flb_free(out_buf);
+            }
+        }
+    }
+
+    flb_fstore_dump(fs);
+    flb_fstore_destroy(fs);
+    return 0;
+}


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
