### PR TITLE
workflows: ensure 1.9 containers do not update latest tag

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -180,9 +180,69 @@ jobs:
         tag: [
           "${{ github.event.inputs.version }}",
           "${{ needs.staging-release-version-check.outputs.major-version }}",
-          "latest",
           "${{ github.event.inputs.version }}-debug",
           "${{ needs.staging-release-version-check.outputs.major-version }}-debug",
+        ]
+    permissions:
+      packages: write
+    steps:
+      # Primarily because the skopeo errors are hard to parse and non-obvious
+      - name: Check the image exists
+        run: |
+          docker pull "$STAGING_IMAGE_NAME:$TAG"
+        env:
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+      # Use the container to prevent any rootless issues and we do not need to use GPG signing as DockerHub does not support it.
+      - name: Promote container images from staging to Dockerhub
+        run: |
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$RELEASE_CREDS" \
+              "docker://$STAGING_IMAGE_NAME:$TAG" \
+              "docker://$RELEASE_IMAGE_NAME:$TAG"
+        env:
+          RELEASE_IMAGE_NAME: docker.io/${{ github.event.inputs.docker-image || secrets.DOCKERHUB_ORGANIZATION }}
+          RELEASE_CREDS: ${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+      - name: Promote container images from staging to GHCR.io
+        if: ${{ startsWith(github.event.inputs.version, '2.0') || ! startsWith(matrix.tag, 'latest') }}
+        run: |
+          docker run --rm  \
+            quay.io/skopeo/stable:latest \
+            copy \
+              --all \
+              --retry-times 10 \
+              --src-no-creds \
+              --dest-creds "$RELEASE_CREDS" \
+              "docker://$STAGING_IMAGE_NAME:$TAG" \
+              "docker://$RELEASE_IMAGE_NAME:$TAG"
+        env:
+          RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
+          RELEASE_CREDS: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ matrix.tag }}
+        shell: bash
+
+  staging-release-images-latest-tags:
+    # Only update latest tags for 2.0 releases
+    if: startsWith(github.event.inputs.version, '2.0') 
+    name: Release latest Linux container images
+    runs-on: ubuntu-latest
+    needs:
+      - staging-release-images
+    environment: release
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: [
+          "latest",
           "latest-debug"
         ]
     permissions:
@@ -298,7 +358,8 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     environment: release
-    needs: staging-release-images
+    needs: 
+      - staging-release-images
     env:
       DH_RELEASE_IMAGE_NAME: docker.io/${{ github.event.inputs.docker-image || secrets.DOCKERHUB_ORGANIZATION }}
       GHCR_RELEASE_IMAGE_NAME: ghcr.io/${{ github.event.inputs.github-image || github.repository }}
@@ -331,12 +392,8 @@ jobs:
             -a "release=${{ github.event.inputs.version }}" \
             "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
             "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
-            "$GHCR_RELEASE_IMAGE_NAME:latest" \
-            "$GHCR_RELEASE_IMAGE_NAME:latest-debug" \
             "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
-            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
-            "$DH_RELEASE_IMAGE_NAME:latest" \
-            "$DH_RELEASE_IMAGE_NAME:latest-debug"
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" 
           rm -f /tmp/my_cosign.key
         shell: bash
         env:
@@ -356,12 +413,8 @@ jobs:
             -a "release=${{ github.event.inputs.version }}" \
             "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
             "$GHCR_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
-            "$GHCR_RELEASE_IMAGE_NAME:latest" \
-            "$GHCR_RELEASE_IMAGE_NAME:latest-debug" \
             "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}" \
-            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug" \
-            "$DH_RELEASE_IMAGE_NAME:latest" \
-            "$DH_RELEASE_IMAGE_NAME:latest-debug"
+            "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug"
         shell: bash
         env:
           COSIGN_EXPERIMENTAL: "true"


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves #6466 by ensuring we do not overwrite `latest` tags for 1.9 container releases.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
