### PR TITLE
build: input_chunk_raw does not depend on FLB_IN_STORAGE_BACKLOG

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -50,8 +50,6 @@
 #define FLB_INPUT_CHUNK_RELEASE_SCOPE_LOCAL  0
 #define FLB_INPUT_CHUNK_RELEASE_SCOPE_GLOBAL 1
 
-#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
-
 struct input_chunk_raw {
     struct flb_input_instance *ins;
     int event_type;
@@ -61,6 +59,7 @@ struct input_chunk_raw {
     size_t buf_size;
 };
 
+#ifdef FLB_HAVE_IN_STORAGE_BACKLOG
 
 extern ssize_t sb_get_releasable_output_queue_space(struct flb_output_instance *output_plugin,
                                                     size_t                      required_space);


### PR DESCRIPTION
The struct input_chunk_raw definition does not need to be conditional on FLB_IN_STORAGE_BACKLOG

Relates to one of the build problems mention in #6464

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
- [N/A] Documentation required for this feature


**Backporting**

- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
