### PR TITLE
out_s3: use retry_limit in fluent-bit to replace MAX_UPLOAD_ERROR …

### DIFF
--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -401,18 +401,6 @@ int s3_store_has_uploads(struct flb_s3 *ctx)
     return FLB_FALSE;
 }
 
-int s3_store_file_inactive(struct flb_s3 *ctx, struct s3_file *s3_file)
-{
-    int ret;
-    struct flb_fstore_file *fsf;
-
-    fsf = s3_file->fsf;
-    flb_free(s3_file);
-    ret = flb_fstore_file_inactive(ctx->fs, fsf);
-
-    return ret;
-}
-
 int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file)
 {
     struct flb_fstore_file *fsf;

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -26,6 +26,7 @@
 struct s3_file {
     int locked;                      /* locked chunk is busy, cannot write to it */
     int failures;                    /* delivery failures */
+    char *input_name;                /* for s3_retry_warn output message gets input name */
     size_t size;                     /* file size */
     time_t create_time;              /* creation time */
     time_t first_log_time;           /* first log time */
@@ -44,7 +45,6 @@ int s3_store_exit(struct flb_s3 *ctx);
 int s3_store_has_data(struct flb_s3 *ctx);
 int s3_store_has_uploads(struct flb_s3 *ctx);
 
-int s3_store_file_inactive(struct flb_s3 *ctx, struct s3_file *s3_file);
 struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
                                   int tag_len);
 int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file);


### PR DESCRIPTION
Signed-off-by: Clay Cheng <chaych@amazon.com>

<!-- Replace MAX_UPLOAD_ERRORS to fluent bit retry_limit -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
[OUTPUT]
    Name                         s3
    Match                        *
    bucket                       clay-bucket-5-s3-test
    region                       us-east-1
    total_file_size              60M
    auto_retry_requests          true
    use_put_object               off
    upload_chunk_size            5M 
- [x] Debug log output from testing the change
<img width="1009" alt="Screen Shot 2022-10-13 at 1 48 19 PM" src="https://user-images.githubusercontent.com/111381953/195708094-67f455b4-bb6f-4a2d-b1ba-498b5f0ae86f.png">

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
**Test result when connected with s3:**
![image](https://user-images.githubusercontent.com/111381953/195703771-113d7b7e-c69b-4931-8b56-f2c2b1d63eed.png)

**Test results when disconnected from s3:**
![image](https://user-images.githubusercontent.com/111381953/195703413-3b9accbb-47e6-4499-ab4f-52f5bc9e1a51.png)


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
