### PR TITLE
in_syslog: new raw_message_key option

### DIFF
--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -233,8 +233,8 @@ static struct flb_config_map config_map[] = {
       "Set the socket receiving buffer size"
     },
     {
-     FLB_CONFIG_MAP_STR, "message_raw_key", (char *)NULL,
-     0, FLB_TRUE, offsetof(struct flb_syslog, message_raw_key),
+     FLB_CONFIG_MAP_STR, "raw_message_key", (char *) NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, raw_message_key),
      "Key where the raw message will be preserved"
     },
 

--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -232,6 +232,13 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct flb_syslog, receive_buffer_size),
       "Set the socket receiving buffer size"
     },
+    {
+     FLB_CONFIG_MAP_STR, "message_raw_key", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, message_raw_key),
+     "Key where the raw message will be preserved"
+    },
+
+
     /* EOF */
     {0}
 };

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -63,6 +63,7 @@ struct flb_syslog {
     /* Configuration */
     flb_sds_t parser_name;
     struct flb_parser *parser;
+    flb_sds_t message_raw_key;
 
     int dgram_mode_flag;
     int collector_id;

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -63,7 +63,7 @@ struct flb_syslog {
     /* Configuration */
     flb_sds_t parser_name;
     struct flb_parser *parser;
-    flb_sds_t message_raw_key;
+    flb_sds_t raw_message_key;
 
     int dgram_mode_flag;
     int collector_id;

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -33,29 +33,23 @@ static inline void consume_bytes(char *buf, int bytes, int length)
 
 static int append_raw_message_to_record_data(char **result_buffer,
                                              size_t *result_size,
-                                             char *raw_message_key_name,
+                                             flb_sds_t raw_message_key_name,
                                              char *base_object_buffer,
                                              size_t base_object_size,
                                              char *raw_message_buffer,
                                              size_t raw_message_size)
 {
-    size_t             new_entry_index;
-    msgpack_unpacked   unpacked_buffer;
-    size_t             unpacker_offset;
-    size_t             new_object_size;
-    msgpack_object    *resized_object;
-    msgpack_sbuffer    packer_buffer;
-    msgpack_object_kv *new_entry;
-    msgpack_packer     packer;
+    int                i;
     int                result;
-
+    size_t             unpacker_offset;
+    msgpack_sbuffer    mp_sbuf;
+    msgpack_packer     mp_pck;
+    msgpack_unpacked   unpacked_buffer;
     *result_buffer = NULL;
     *result_size = 0;
 
     unpacker_offset = 0;
-
     msgpack_unpacked_init(&unpacked_buffer);
-
     result = msgpack_unpack_next(&unpacked_buffer,
                                  base_object_buffer,
                                  base_object_size,
@@ -67,68 +61,33 @@ static int append_raw_message_to_record_data(char **result_buffer,
 
     if (unpacker_offset != base_object_size) {
         msgpack_unpacked_destroy(&unpacked_buffer);
-
         return -2;
     }
 
     if (unpacked_buffer.data.type != MSGPACK_OBJECT_MAP) {
         msgpack_unpacked_destroy(&unpacked_buffer);
-
         return -3;
     }
 
-    new_object_size = base_object_size + sizeof(msgpack_object);
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-    resized_object = flb_calloc(1, new_object_size);
+    msgpack_pack_map(&mp_pck, unpacked_buffer.data.via.map.size + 1);
 
-    if (resized_object == NULL) {
-        flb_errno();
-
-        return -4;
+    for (i = 0; i < unpacked_buffer.data.via.map.size; i++) {
+        msgpack_pack_object(&mp_pck, unpacked_buffer.data.via.map.ptr[i].key);
+        msgpack_pack_object(&mp_pck, unpacked_buffer.data.via.map.ptr[i].val);
     }
 
-    memcpy(resized_object, &unpacked_buffer.data, base_object_size);
+    msgpack_pack_str(&mp_pck, flb_sds_len(raw_message_key_name));
+    msgpack_pack_str_body(&mp_pck, raw_message_key_name, flb_sds_len(raw_message_key_name));
+    msgpack_pack_str(&mp_pck, raw_message_size);
+    msgpack_pack_str_body(&mp_pck, raw_message_buffer, raw_message_size);
 
-    new_entry_index = resized_object->via.map.size;
-    resized_object->via.map.size++;
-
-    new_entry = &resized_object->via.map.ptr[new_entry_index];
-
-    new_entry->key.type = MSGPACK_OBJECT_STR;
-    new_entry->key.via.str.size = strlen(raw_message_key_name);
-    new_entry->key.via.str.ptr  = raw_message_key_name;
-
-    new_entry->val.type = MSGPACK_OBJECT_BIN;
-    new_entry->val.via.bin.size = raw_message_size;
-    new_entry->val.via.bin.ptr  = raw_message_buffer;
-
-    msgpack_sbuffer_init(&packer_buffer);
-
-    msgpack_packer_init(&packer, &packer_buffer, msgpack_sbuffer_write);
-
-    msgpack_pack_object(&packer, *resized_object);
-
-    *result_buffer = flb_calloc(1, packer_buffer.size);
-
-    if (*result_buffer == NULL) {
-        flb_errno();
-
-        result = -4;
-    }
-    else {
-        memcpy(*result_buffer, packer_buffer.data, packer_buffer.size);
-
-        *result_size = packer_buffer.size;
-
-        result = 0;
-    }
-
-    msgpack_sbuffer_destroy(&packer_buffer);
+    *result_buffer = mp_sbuf.data;
+    *result_size = mp_sbuf.size;
 
     msgpack_unpacked_destroy(&unpacked_buffer);
-
-    flb_free(resized_object);
-
     return result;
 }
 
@@ -145,10 +104,10 @@ static inline int pack_line(struct flb_syslog *ctx,
 
     modified_data_buffer = NULL;
 
-    if (ctx->message_raw_key != NULL) {
+    if (ctx->raw_message_key != NULL) {
         result = append_raw_message_to_record_data(&modified_data_buffer,
                                                    &modified_data_size,
-                                                   ctx->message_raw_key,
+                                                   ctx->raw_message_key,
                                                    data,
                                                    data_size,
                                                    raw_data,


### PR DESCRIPTION
implements #6476 by adding a new option called `raw_message_key`, based on #6477.  e.g:

```
[SERVICE]
    parsers_file parsers.conf

[INPUT]
    name            syslog
    mode            udp
    parser          syslog-rfc5424
    raw_message_key raw

[OUTPUT]
    name   stdout
    match  *
    format json_lines
```

testing a message:

```json
{
	"date": 1669778120.283024,
	"pri": "14",
	"time": "2022-11-29T21:15:20.283024-06:00",
	"host": "monox-2.lan",
	"ident": "syslogtest",
	"pid": "23551",
	"msgid": "some_unique_msgid",
	"extradata": "-",
	"message": "This is an interesting message",
	"raw": "<14>1 2022-11-29T21:15:20.283024-06:00 monox-2.lan syslogtest 23551 some_unique_msgid - This is an interesting message"
}
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
