### PR TITLE
out_s3: update for getting upload time from timestamp.

### DIFF
--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -125,7 +125,8 @@ struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
 /* Append data to a new or existing fstore file */
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
-                        char *data, size_t bytes)
+                        char *data, size_t bytes,
+                        time_t file_first_log_time)
 {
     int ret;
     flb_sds_t name;
@@ -175,6 +176,7 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
             return -1;
         }
         s3_file->fsf = fsf;
+        s3_file->first_log_time = file_first_log_time;
         s3_file->create_time = time(NULL);
 
         /* Use fstore opaque 'data' reference to keep our context */
@@ -241,6 +243,7 @@ static int set_files_context(struct flb_s3 *ctx)
                 continue;
             }
             s3_file->fsf = fsf;
+            s3_file->first_log_time = time(NULL);
             s3_file->create_time = time(NULL);
 
             /* Use fstore opaque 'data' reference to keep our context */

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -28,13 +28,15 @@ struct s3_file {
     int failures;                    /* delivery failures */
     size_t size;                     /* file size */
     time_t create_time;              /* creation time */
+    time_t first_log_time;           /* first log time */
     flb_sds_t file_path;             /* file path */
     struct flb_fstore_file *fsf;     /* reference to parent flb_fstore_file */
 };
 
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
-                        char *data, size_t bytes);
+                        char *data, size_t bytes,
+                        time_t file_first_log_time);
 
 int s3_store_init(struct flb_s3 *ctx);
 int s3_store_exit(struct flb_s3 *ctx);


### PR DESCRIPTION
Signed-off-by: Clay Cheng <claychen@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224
[OUTPUT]
     Name s3
     Match *
     bucket s3-time-1
     region us-east-1
     use_put_object On
     total_file_size 10M
     retry_limit 2
     upload_timeout 5s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 100000,
            "batchSize": 1
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "logStream": "stderr",
            "port": 24224
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 1000
    }
}
```
- [x] Debug log output from testing the change
***Upload timeout + put object used***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 50M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 1000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:05:45] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:05:45] [ info] [sp] stream processor started
[2023/01/04 00:06:38] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:06:39] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/04/47-objecth4lHpX0O
[2023/01/04 00:06:50] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:06:51] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/04/58-objectr2dk4WDH
[2023/01/04 00:07:02] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:07:03] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/05/10-objectd1yH71IC
[2023/01/04 00:07:14] [ info] [output:s3:s3.0] upload_timeout reached for tag_prefix
[2023/01/04 00:07:15] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/05/23-objectLGJCZYcW
```
****first log time and key format****
<img width="657" alt="image" src="https://user-images.githubusercontent.com/111381953/210470261-fb6def84-828a-4d91-865b-25935fefe329.png">


***NO Upload timeout + Multipart***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 50M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 100000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:19:17] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:17] [ info] [output:s3:s3.0] Successfully uploaded part #2 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=78af9cbb127bf654817f0f8273fe7bdb
[2023/01/04 00:19:18] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:18] [ info] [output:s3:s3.0] Successfully uploaded part #3 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=9c2bd3405a7011ce397e382bd54fb88c
[2023/01/04 00:19:19] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:19:19] [ info] [output:s3:s3.0] Successfully uploaded part #4 for /fluent-bit-logs/tag_prefix/2023/01/04/00/17/33, UploadId=mdox3F3JsR80CA1R4eDhz3Yp88AM25FyJKxlECaahYpoQwlnQlTgEpF3FPkc8AYk4p_2Cpmi0uNaQrM.adNlDYQ8ahBcU6ToAZBex47ht7GZINBdAY_xwYp0VFmit0ZG, ETag=705e5449d950fa76e99b0f40c49a7bfc
[2023/01/04 00:19:21] [ info] [output:s3:s3.0] UploadPart http status=200
```
****first log time and key format****
<img width="568" alt="image" src="https://user-images.githubusercontent.com/111381953/210470157-d535fd62-d8a4-4564-87bc-fef15bc1a171.png">


***Upload timeout + multipart***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 6G
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 100000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:20:21] [ info] [sp] stream processor started
[2023/01/04 00:20:21] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] Successfully initiated multipart upload for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:54] [ info] [output:s3:s3.0] Successfully uploaded part #1 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=3d3e0fa00c7aa5ac7d48b7412d37c1fa
[2023/01/04 00:20:55] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:55] [ info] [output:s3:s3.0] Successfully uploaded part #2 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=9dd63db9450ad383a90a4dc77fbbaa67
[2023/01/04 00:20:57] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:57] [ info] [output:s3:s3.0] Successfully uploaded part #3 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=ec14e35d5f7ab37780a029d63b536bec
[2023/01/04 00:20:58] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:58] [ info] [output:s3:s3.0] Successfully uploaded part #4 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=b95a4fc49cb23d3521978deafcaed2f3
[2023/01/04 00:20:59] [ info] [output:s3:s3.0] UploadPart http status=200
[2023/01/04 00:20:59] [ info] [output:s3:s3.0] Successfully uploaded part #5 for /fluent-bit-logs/tag_prefix/2023/01/04/00/19/12, UploadId=pRC2DikdUL6ZEzWPYCR7WLE.JJnJgdizkPFV8AoJ8JTnFnRAG9Kj2gKJQnG1DPMgV8cdJQ13ly.2M_z5X02gFnMGF8yuI8MnI5ZRCJMXoEEmHJG7RlwycF04zUccNAOq, ETag=2f579891b3254356e78b69da5de94488
```
****first log time and key format****
<img width="727" alt="image" src="https://user-images.githubusercontent.com/111381953/210470002-68e268c8-7301-4074-89ed-51d3484343c4.png">

***No Upload Timeout + Single put object***
```
[INPUT]
     Name                         forward
     Listen                       0.0.0.0
     Port                         24224

[OUTPUT]
     Name s3
     Match *
     bucket s3-time-test
     region us-east-1
#     use_put_object On
     total_file_size 1M
     retry_limit 2
     upload_timeout 10s
```
```
{
    "generator": {
        "name": "basic",
        "config": {
            "contentLength": 1000000
        }
    },
    "datajet": {
        "name": "forward",
        "config": {
            "batchSize": 1,
            "timeOffset": -100
        }
    },
    "stage": {
        "batchRate": 5,
        "maxBatches": 10000000
    }
}
```
```
[2023/01/04 00:22:24] [ info] [sp] stream processor started
[2023/01/04 00:22:24] [ info] [output:s3:s3.0] worker #0 started
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectVubURfP2
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-object08fXmltw
[2023/01/04 00:22:36] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectMPpfA1ef
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/55-objectzZkbV6ul
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectVgFIjmn8
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectqx3KzVt3
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-object6nv6J7f4
[2023/01/04 00:22:37] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/tag_prefix/2023/01/04/00/20/56-objectpUwoeaFc
```
****first log time and time format****
<img width="642" alt="image" src="https://user-images.githubusercontent.com/111381953/210469650-eeea91fe-a0b8-471e-a956-e4f65b68b4e9.png">




<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==10338== LEAK SUMMARY:
==10338==    definitely lost: 0 bytes in 0 blocks
==10338==    indirectly lost: 0 bytes in 0 blocks
==10338==      possibly lost: 0 bytes in 0 blocks
==10338==    still reachable: 102,912 bytes in 3,432 blocks
==10338==         suppressed: 0 bytes in 0 blocks
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
