### PR TITLE
openssl: add SSL_ERROR_SYSCALL case

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -429,6 +429,11 @@ static int tls_net_read(struct flb_tls_session *session,
         else if (ret == SSL_ERROR_WANT_WRITE) {
             ret = FLB_TLS_WANT_WRITE;
         }
+        else if (ret == SSL_ERROR_SYSCALL) {
+            flb_errno();
+            ERR_error_string_n(ret, err_buf, sizeof(err_buf)-1);
+            flb_error("[tls] syscall error: %s", err_buf);
+        }
         else if (ret < 0) {
             ERR_error_string_n(ret, err_buf, sizeof(err_buf)-1);
             flb_error("[tls] error: %s", err_buf);
@@ -476,6 +481,13 @@ static int tls_net_write(struct flb_tls_session *session,
         }
         else if (ret == SSL_ERROR_WANT_READ) {
             ret = FLB_TLS_WANT_READ;
+        }
+        else if (ret == SSL_ERROR_SYSCALL) {
+            flb_errno();
+            ERR_error_string_n(ret, err_buf, sizeof(err_buf)-1);
+            flb_error("[tls] syscall error: %s", err_buf);
+
+            ret = -1;
         }
         else {
             ERR_error_string_n(ret, err_buf, sizeof(err_buf)-1);


### PR DESCRIPTION
This patch is to print errno when openssl API returns `SSL_ERROR_SYSCALL`.
There are several issues that `SSL_ERROR_SYSCALL`(=5) returned. #6431 #5705

## Example SSL error log
```
[2022/11/21 11:57:45] [error] [tls] error: error:00000005:lib(0):func(0):DH lib
```

## The value of `SSL_ERROR_SYSCALL`
```
$ grep SSL_ERROR_SYSCALL /usr/include/openssl/*
/usr/include/openssl/ssl.h:# define SSL_ERROR_SYSCALL               5/* look at error stack/return
```

## OpenSSL man page

https://www.openssl.org/docs/man3.1/man3/SSL_get_error.html
```
SSL_ERROR_SYSCALL
Some non-recoverable, fatal I/O error occurred. The OpenSSL error queue may contain more information on the error. 
For socket I/O on Unix systems, consult errno for details. 
If this error occurs then no further I/O operations should be performed on the connection and SSL_shutdown() must not be called.

This value can also be returned for other errors, check the error queue for details.
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
