### PR TITLE
build: wamrc: Make buildable with LLVM 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,11 @@ if (FLB_TESTS_OSSFUZZ)
   set(FLB_CONFIG_YAML Off)
 endif()
 
+if (FLB_WASM)
+  # For Linking libedit adjustments on LLVM 15.
+  include(cmake/FindLibEdit.cmake)
+endif()
+
 # Set Fluent Bit dependency libraries path
 include(cmake/libraries.cmake)
 

--- a/cmake/FindLibEdit.cmake
+++ b/cmake/FindLibEdit.cmake
@@ -1,0 +1,72 @@
+# FindLibEdit
+# -----------
+#
+# Find libedit library and headers
+#
+# The module defines the following variables:
+#
+# ::
+#
+#   libedit_FOUND         - true if libedit was found
+#   libedit_INCLUDE_DIRS  - include search path
+#   libedit_LIBRARIES     - libraries to link
+#   libedit_VERSION       - version number
+
+# This cmake file is based on LLVM Project one's.
+#
+# Copyright (c) 2018-2022 LLVM Project
+#
+
+if(libedit_INCLUDE_DIRS AND libedit_LIBRARIES)
+  set(libedit_FOUND TRUE)
+else()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_LIBEDIT QUIET libedit)
+
+  find_path(libedit_INCLUDE_DIRS
+            NAMES
+              histedit.h
+            HINTS
+              ${PC_LIBEDIT_INCLUDEDIR}
+              ${PC_LIBEDIT_INCLUDE_DIRS}
+              ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  find_library(libedit_LIBRARIES
+               NAMES
+                 edit libedit
+               HINTS
+                 ${PC_LIBEDIT_LIBDIR}
+                 ${PC_LIBEDIT_LIBRARY_DIRS}
+                 ${CMAKE_INSTALL_FULL_LIBDIR})
+
+  if(libedit_INCLUDE_DIRS AND EXISTS "${libedit_INCLUDE_DIRS}/histedit.h")
+    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_major_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MAJOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MAJOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MAJOR_VERSION "${libedit_major_version_str}")
+
+    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_minor_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MINOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MINOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MINOR_VERSION "${libedit_minor_version_str}")
+
+    set(libedit_VERSION_STRING "${libedit_major_version}.${libedit_minor_version}")
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LibEdit
+                                    REQUIRED_VARS
+                                      libedit_INCLUDE_DIRS
+                                      libedit_LIBRARIES
+                                    VERSION_VAR
+                                      libedit_VERSION_STRING)
+  mark_as_advanced(libedit_INCLUDE_DIRS libedit_LIBRARIES)
+endif()
+
+if (libedit_INCLUDE_DIRS AND libedit_LIBRARIES AND NOT TARGET LibEdit::LibEdit)
+  add_library(LibEdit::LibEdit UNKNOWN IMPORTED)
+  set_target_properties(LibEdit::LibEdit PROPERTIES
+                        IMPORTED_LOCATION ${libedit_LIBRARIES}
+                        INTERFACE_INCLUDE_DIRECTORIES ${libedit_INCLUDE_DIRS})
+endif()


### PR DESCRIPTION
Since LLVM 15, libedit will be linked with cmake functionality. We have to find out where libedit is installed in the building boxes.

see: https://reviews.llvm.org/rG9426358ea1fa84bac7b85f550f9efce12349c9da

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
