### PR TITLE
filter_throttle: Fix print_status being partially uninitialized

### DIFF
--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -160,7 +160,7 @@ static int cb_throttle_init(struct flb_filter_instance *f_ins,
     pthread_mutex_init(&throttle_mut, NULL);
 
     /* Create context */
-    ctx = flb_malloc(sizeof(struct flb_filter_throttle_ctx));
+    ctx = flb_calloc(1, sizeof(struct flb_filter_throttle_ctx));
     if (!ctx) {
         flb_errno();
         return -1;


### PR DESCRIPTION
<!-- Provide summary of changes -->

When running with Valgrind with the throttle filter, you can see a warning:

```
==1== Thread 4:
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x34E701: time_ticker (throttle.c:84)
==1==    by 0x4854EA6: start_thread (pthread_create.c:477)
==1==    by 0x4FBDA2E: clone (clone.S:95)
==1==  Uninitialised value was created by a heap allocation
==1==    at 0x483877F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1==    by 0x34E58A: flb_malloc (flb_mem.h:79)
==1==    by 0x34EAC7: cb_throttle_init (throttle.c:163)
==1==    by 0x2394B5: flb_filter_init_all (flb_filter.c:480)
==1==    by 0x24C585: flb_engine_start (flb_engine.c:666)
==1==    by 0x22B9B4: flb_lib_worker (flb_lib.c:626)
==1==    by 0x4854EA6: start_thread (pthread_create.c:477)
==1==    by 0x4FBDA2E: clone (clone.S:95)
```

(when run with the following change to `conf/fluent-bit.conf`)
```diff
diff --git a/conf/fluent-bit.conf b/conf/fluent-bit.conf
index bf3269f38..6f5a20ec8 100644
--- a/conf/fluent-bit.conf
+++ b/conf/fluent-bit.conf
@@ -88,6 +88,15 @@
     # Read interval (sec) Default: 1
     interval_sec 1

+[FILTER]
+    name throttle
+    match *
+    rate 10000
+    window 5
+    interval 1s
+    print_status false
+    alias rl.observability
+
 [OUTPUT]
     name  stdout
     match *
```

This manifests as the filter sometimes printing a status message every second even when explicitly configured not to (depending on chance).

I believe this happens because `print_status` is an int (4 bytes), but the config framework writes one char of data (1 byte). Before this change, the throttle filter did not initialize `print_status` to anything, so if by chance the 3 uninitialized bytes the config framework _isn’t_ writing to are nonzero, the boolean is permanently true, no matter what you configure it to.

This fixes the unwanted status prints showing up in my deployment and makes the Valgrind error go away.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.