### PR TITLE
security policy: update supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.9.x   | :white_check_mark: |
-| 1.8.x   | :white_check_mark: |
-| < 1.8   | :x:                |
+| 2.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
remove 1.8 and 1.9

Signed-off-by: José Lecaros <lecaros@calyptia.com>

remove 1.8 and 1.9


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
