### PR TITLE
calyptia: concatenate configuration as raw strings.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -96,13 +96,13 @@ static void pipeline_config_add_properties(flb_sds_t *buf, struct mk_list *props
             flb_sds_printf(buf, "    %s ", kv->key);
 
             if (is_sensitive_property(kv->key)) {
-                flb_sds_cat(*buf, "--redacted--", strlen("--redacted--"));
+                flb_sds_cat_safe(*buf, "--redacted--", strlen("--redacted--"));
             }
             else {
-                flb_sds_cat(*buf, kv->val, strlen(kv->val));
+                flb_sds_cat_safe(*buf, kv->val, strlen(kv->val));
             }
 
-            flb_sds_cat(*buf, "\n", 1);
+            flb_sds_cat_safe(*buf, "\n", 1);
         }
     }
 }

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -96,13 +96,13 @@ static void pipeline_config_add_properties(flb_sds_t *buf, struct mk_list *props
             flb_sds_printf(buf, "    %s ", kv->key);
 
             if (is_sensitive_property(kv->key)) {
-                flb_sds_printf(buf, "--redacted--");
+                flb_sds_cat(*buf, "--redacted--", strlen("--redacted--"));
             }
             else {
-                flb_sds_printf(buf, kv->val);
+                flb_sds_cat(*buf, kv->val, strlen(kv->val));
             }
 
-            flb_sds_printf(buf, "\n");
+            flb_sds_cat(*buf, "\n", 1);
         }
     }
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Concatenate values from the configuration as strings instead of fmt strings via flb_sds_printf. This avoids issues where values have format strings in them.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
