### PR TITLE
opensearch: fix '(null)' index when using record accessor and id_key/generate_id.

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -507,8 +507,6 @@ static int opensearch_format(struct flb_config *config,
 
             flb_sds_destroy(ra_index);
             ra_index = NULL;
-            index = NULL;
-
         }
 
         /* Tag Key */

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -479,6 +479,10 @@ static int opensearch_format(struct flb_config *config,
             index = index_formatted;
         }
         else if (ctx->ra_index) {
+            // free any previous ra_index to avoid memory leaks.
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             /* a record accessor pattern exists for the index */
             ra_index = flb_ra_translate(ctx->ra_index,
                                            (char *) tag, tag_len,
@@ -504,9 +508,6 @@ static int opensearch_format(struct flb_config *config,
                                              ctx->action,
                                              index, ctx->type);
             }
-
-            flb_sds_destroy(ra_index);
-            ra_index = NULL;
         }
 
         /* Tag Key */
@@ -530,6 +531,9 @@ static int opensearch_format(struct flb_config *config,
             msgpack_sbuffer_destroy(&tmp_sbuf);
             flb_sds_destroy(bulk);
             flb_sds_destroy(j_index);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             return -1;
         }
 
@@ -587,7 +591,9 @@ static int opensearch_format(struct flb_config *config,
             msgpack_unpacked_destroy(&result);
             flb_sds_destroy(bulk);
             flb_sds_destroy(j_index);
-            flb_sds_destroy(ra_index);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             return -1;
         }
 
@@ -598,8 +604,10 @@ static int opensearch_format(struct flb_config *config,
             flb_sds_destroy(bulk);
             flb_sds_destroy(j_index);
             flb_sds_destroy(out_buf);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             return -1;
-
         }
 
         if (strcasecmp(ctx->write_operation, FLB_OS_WRITE_OP_UPDATE) == 0) {
@@ -628,6 +636,9 @@ static int opensearch_format(struct flb_config *config,
             flb_sds_destroy(bulk);
             flb_sds_destroy(j_index);
             flb_sds_destroy(out_buf);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             return -1;
         }
 
@@ -645,6 +656,9 @@ static int opensearch_format(struct flb_config *config,
     *out_data = bulk;
     *out_size = flb_sds_len(bulk);
 
+    if (ra_index != NULL) {
+        flb_sds_destroy(ra_index);
+    }
     /*
      * Note: we don't destroy the bulk as we need to keep the allocated
      * buffer with the data. Instead we just release the bulk context and

--- a/tests/runtime/out_opensearch.c
+++ b/tests/runtime/out_opensearch.c
@@ -112,6 +112,50 @@ static void cb_check_index_record_accessor_suppress_type(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_index_record_accessor_id_key(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"abc\",\"_type\":\"def\",\"_id\":\"something\"}}";
+
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_index_record_accessor_generate_id(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"code\",\"_type\":\"def\",\"_id\":\"";
+    char *id = NULL;
+    char c;
+    int i;
+
+    // check that index is working
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    // check that we have a UUID
+    id = p + strlen(index_line);
+    TEST_CHECK(strlen(id) > 36);
+    for (i = 0; i < strlen(id) && i < 36; i++) {
+        c = (*(id+i));
+        TEST_CHECK(
+            (c >= 'A' && c <= 'F') ||
+            (*(id+i)) == '-' ||
+            (c >= '0' && c <= '9')
+        );
+    }
+
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_logstash_format(void *ctx, int ffd,
                                      int res_ret, void *res_data, size_t res_size,
                                      void *data)
@@ -481,6 +525,98 @@ void flb_test_index_record_accessor_suppress_type()
     /* Enable test mode */
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
                               cb_check_index_record_accessor_suppress_type,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor_with_id_key()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"something\", \"myindex\": \"abc\"}]";
+
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "opensearch", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "type", "def",
+                   "id_key", "key",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor_id_key,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor_with_generate_id()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"xul\", \"myindex\": \"code\"}]";
+
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "opensearch", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "type", "def",
+                   "generate_id", "true",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor_generate_id,
                               NULL, NULL);
 
     /* Start */
@@ -867,6 +1003,8 @@ TEST_LIST = {
     {"index_type"            , flb_test_index_type },
     {"index_record_accessor" , flb_test_index_record_accessor},
     {"index_record_accessor_suppress_type" , flb_test_index_record_accessor_suppress_type},
+    {"index_record_accessor_id_key", flb_test_index_record_accessor_with_id_key},
+    {"index_record_accessor_generate_id", flb_test_index_record_accessor_with_generate_id},
     {"logstash_format"       , flb_test_logstash_format },
     {"logstash_format_nanos" , flb_test_logstash_format_nanos },
     {"tag_key"               , flb_test_tag_key },


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add tests to make sure the combination of using an `index` with record accessor in combination with either  `id_key` or `generate_id` does not result in generating a packet with an index of '(null)'.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
