### PR TITLE
tests: internal: fuzzers: extend ctrace fuzzer

### DIFF
--- a/tests/internal/fuzzers/ctrace_fuzzer.c
+++ b/tests/internal/fuzzers/ctrace_fuzzer.c
@@ -5,8 +5,14 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     size_t off = 0;
     struct ctrace *ctr = NULL;
+    size_t msgpack_text_size;
+    char *msgpack_text_buffer = NULL;
+
     ctr_decode_msgpack_create(&ctr, data, size, &off);
     if (ctr != NULL) {
+        ctr_encode_msgpack_create(ctr, &msgpack_text_buffer, &msgpack_text_size);
+        ctr_encode_msgpack_destroy(msgpack_text_buffer);
+
         ctr_destroy(ctr);
     }
     return 0;


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->
Extend the fuzzing target for ctrace lib so it hits encoding logic as well.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
