### PR TITLE
workflows: tweak keyless container signing

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Cosign with a key
         # Only run if we have a key defined
-        if: secrets.cosign_private_key != ''
+        if: ${{ env.COSIGN_PRIVATE_KEY }}
         # The key needs to cope with newlines
         run: |
           echo -e "${COSIGN_PRIVATE_KEY}" > /tmp/my_cosign.key

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -80,6 +80,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      production-digest: ${{ steps.build_push.outputs.digest }}
+      debug-digest: ${{ steps.debug_build_push.outputs.digest }}
     steps:
       - name: Checkout code for modern style builds
         uses: actions/checkout@v3
@@ -110,6 +113,7 @@ jobs:
             raw,latest
 
       - name: Build the production images
+        id: build_push
         uses: docker/build-push-action@v3
         with:
           file: ./dockerfiles/Dockerfile
@@ -134,6 +138,7 @@ jobs:
             raw,latest-debug
 
       - name: Build the debug multi-arch images
+        id: debug_build_push
         uses: docker/build-push-action@v3
         with:
           file: ./dockerfiles/Dockerfile
@@ -239,34 +244,33 @@ jobs:
         run: |
           cosign sign --recursive \
             -a "repo=${{ github.repository }}" \
-            -a "workflow=${{ github.workflow }}" \
+            -a "workflow=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -a "ref=${{ github.sha }}" \
             -a "release=${{ inputs.version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:${{ needs.call-build-images-meta.outputs.major-version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:latest"
+            "${{ inputs.registry }}/${{ inputs.image }}@${{ needs.call-build-images.outputs.production-digest }}" \
+            "${{ inputs.registry }}/${{ inputs.image }}@${{ needs.call-build-images.outputs.debug-digest }}"
         shell: bash
         # Ensure we move on to key-based signing as well
         continue-on-error: true
         env:
-          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_EXPERIMENTAL: true
 
       - name: Cosign with a key
         # Only run if we have a key defined
-        if: ${{ env.COSIGN_PRIVATE_KEY }}
+        if: secrets.cosign_private_key != ''
         # The key needs to cope with newlines
         run: |
           echo -e "${COSIGN_PRIVATE_KEY}" > /tmp/my_cosign.key
           cosign sign --key /tmp/my_cosign.key --recursive \
             -a "repo=${{ github.repository }}" \
-            -a "workflow=${{ github.workflow }}" \
+            -a "workflow=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -a "ref=${{ github.sha }}" \
             -a "release=${{ inputs.version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:${{ needs.call-build-images-meta.outputs.major-version }}" \
-            "${{ inputs.registry }}/${{ inputs.image }}:latest"
+            "${{ inputs.registry }}/${{ inputs.image }}@${{ needs.call-build-images.outputs.production-digest }}"
+            "${{ inputs.registry }}/${{ inputs.image }}@${{ needs.call-build-images.outputs.debug-digest }}"
           rm -f /tmp/my_cosign.key
         shell: bash
+        continue-on-error: true
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.cosign_private_key }}
           COSIGN_PASSWORD: ${{ secrets.cosign_private_key_password }} # optional

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -350,12 +350,7 @@ jobs:
 
   staging-release-images-sign:
     name: Sign container image manifests
-    permissions:
-      contents: read
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
+    permissions: write-all
     runs-on: ubuntu-latest
     environment: release
     needs: 
@@ -407,7 +402,7 @@ jobs:
         #
         # We use recursive signing on the manifest to cover all the images.
         run: |
-          cosign sign --recursive \
+          cosign sign --yes --recursive \
             -a "repo=${{ github.repository }}" \
             -a "workflow=${{ github.workflow }}" \
             -a "release=${{ github.event.inputs.version }}" \
@@ -417,7 +412,7 @@ jobs:
             "$DH_RELEASE_IMAGE_NAME:${{ github.event.inputs.version }}-debug"
         shell: bash
         env:
-          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_EXPERIMENTAL: true
 
   # This will require a sign off so can be done after packages are updated to confirm
   # Until S3 bucket is set up as release will only test what is in the server from a prior release.


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Keyless container signing is currently blocking and timing out waiting for user authentication. It also needs to use image digests.

The fluentd-aggregator-image workflow uses keyless signing and works fine so adopting the necessary changes here from @stevehipwell:
https://github.com/fluent/fluentd-aggregator-docker-image/blob/a7057e9c4626c3ffef6346df4dead2e8196bdcd1/.github/workflows/release.yaml#L11

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
