### PR TITLE
calyptia: fix segfault when concatenating custom configuration.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -96,13 +96,13 @@ static void pipeline_config_add_properties(flb_sds_t *buf, struct mk_list *props
             flb_sds_printf(buf, "    %s ", kv->key);
 
             if (is_sensitive_property(kv->key)) {
-                flb_sds_cat_safe(*buf, "--redacted--", strlen("--redacted--"));
+                flb_sds_cat_safe(buf, "--redacted--", strlen("--redacted--"));
             }
             else {
-                flb_sds_cat_safe(*buf, kv->val, strlen(kv->val));
+                flb_sds_cat_safe(buf, kv->val, strlen(kv->val));
             }
 
-            flb_sds_cat_safe(*buf, "\n", 1);
+            flb_sds_cat_safe(buf, "\n", 1);
         }
     }
 }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -113,6 +113,11 @@ if(FLB_IN_LIB)
   endif()
   FLB_RT_TEST(FLB_OUT_S3                "out_s3.c")
   FLB_RT_TEST(FLB_OUT_TD                "out_td.c")
+
+endif()
+
+if (FLB_CUSTOM_CALYPTIA)
+  FLB_RT_TEST(FLB_CUSTOM_CALYPTIA "custom_calyptia_test.c")
 endif()
 
 

--- a/tests/runtime/custom_calyptia_test.c
+++ b/tests/runtime/custom_calyptia_test.c
@@ -1,0 +1,57 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_custom.h>
+#include "flb_tests_runtime.h"
+
+flb_sds_t custom_calyptia_pipeline_config_get(struct flb_config *ctx);
+
+void flb_custom_calyptia_pipeline_config_get_test()
+{
+    const char *cfg_str = "[INPUT]\n    name cpu.0\n[INPUT]\n    name fluentbit_metrics.1\n    tag _calyptia_cloud\n    scrape_on_start true\n    scrape_interval 30\n\n\n[OUTPUT]\n    name  stdout.0\n    match *\n    retry_limit 1\n\n";
+    flb_ctx_t *ctx;
+    int in_ffd_cpu;
+    int in_ffd_metrics;
+    int out_ffd;
+    struct flb_custom_instance *calyptia;
+    flb_sds_t cfg;
+
+    ctx = flb_create();
+
+    in_ffd_cpu = flb_input(ctx, (char *) "cpu", NULL);
+    TEST_CHECK(in_ffd_cpu >= 0);
+
+    in_ffd_metrics = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd_metrics >= 0);
+    flb_input_set(ctx, in_ffd_metrics,
+                  "tag", "_calyptia_cloud",
+                  "scrape_on_start", "true",
+                  "scrape_interval", "30",
+                  NULL);
+
+    out_ffd = flb_output(ctx, (char *) "stdout", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    calyptia = flb_custom_new(ctx->config, (char *)"calyptia", NULL);
+    TEST_CHECK(calyptia != NULL);
+    flb_custom_set_property(calyptia, "api_key", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");    
+    flb_custom_set_property(calyptia, "log_level", "debug");
+    flb_custom_set_property(calyptia, "log_level", "7DDD2941-3ED6-4B8C-9F84-DD04C4A018A4");
+    flb_custom_set_property(calyptia, "add_label", "pipeline_id 7DDD2941-3ED6-4B8C-9F84-DD04C4A018A4");
+    flb_custom_set_property(calyptia, "calyptia_host", "cloud-api.calyptia.com");
+    flb_custom_set_property(calyptia, "calyptia_port", "443");
+    flb_custom_set_property(calyptia, "tls", "on");
+    flb_custom_set_property(calyptia, "tls_verify", "on");
+
+    cfg = custom_calyptia_pipeline_config_get(ctx->config);
+    TEST_CHECK(strcmp(cfg, cfg_str) == 0);
+    flb_sds_destroy(cfg);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"get_config_test", flb_custom_calyptia_pipeline_config_get_test},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fix addressing for the call to `flb_sds_cat_safe`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
