### PR TITLE
stream: fixed an condition that caused concurrency issues

### DIFF
--- a/include/fluent-bit/flb_stream.h
+++ b/include/fluent-bit/flb_stream.h
@@ -168,10 +168,10 @@ static inline int flb_stream_acquire_lock(struct flb_stream *stream,
 
     if (stream->thread_safety_flag) {
         if (wait_flag) {
-            result = pthread_mutex_trylock(&stream->list_mutex);
+            result = pthread_mutex_lock(&stream->list_mutex);
         }
         else {
-            result = pthread_mutex_lock(&stream->list_mutex);
+            result = pthread_mutex_trylock(&stream->list_mutex);
         }
     }
 


### PR DESCRIPTION
When an output plugin runs with in multi worker mode the upstream is set to thread safe mode which means flb_stream_acquire_lock and flb_stream_release_lock are used to manipulate the underlying mutex.

There was an error in flb_stream_acquire_lock where the wait_flag condition was inverted and because of that, a second thread could unknowingly access the resources while they shouldn't be able to.

An unrelated but somewhat similar in nature error could be present in flb_upstream_conn_get since the upstream lock is acquired inside the keepalive available queue loop so the locking code / strategy should be reviewed.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>