### PR TITLE
in_windows_exporter_metrics: cpu: Don't compare float values directly

### DIFF
--- a/plugins/in_windows_exporter_metrics/we_cpu.c
+++ b/plugins/in_windows_exporter_metrics/we_cpu.c
@@ -24,6 +24,8 @@
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_pack.h>
 
+#include <float.h>
+
 #include "we.h"
 #include "we_cpu.h"
 #include "we_util.h"
@@ -221,7 +223,7 @@ int we_cpu_init(struct flb_we *ctx)
         return -2;
     }
 
-    if (ctx->windows_version >= 6.05) {
+    if (fabsf(ctx->windows_version - 6.05) > FLT_EPSILON) {
         metric_sources = full_metric_sources;
         ctx->cpu.query = (char *) "Processor Information";
     }


### PR DESCRIPTION
We should compare via fabsf and FLB_EPLISON for two float values. Otherwise, we encountered missing metrics for the newer Windows platform.

This is because floating point values cannot compare directly in C.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
