### PR TITLE
out_prometheus_exporter: add content-type(#6554)

### DIFF
--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -18,7 +18,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
-
+#include <fluent-bit/flb_http_server.h>
 #include "prom.h"
 #include "prom_http.h"
 
@@ -173,6 +173,7 @@ static void cb_metrics(mk_request_t *request, void *data)
     buf->users++;
 
     mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_PROMETHEUS);
     mk_http_send(request, buf->buf_data, buf->buf_size, NULL);
     mk_http_done(request);
 


### PR DESCRIPTION
Fixes #6554 

This patch is to add following content-type to a response of out_prometheus_exporter.
```
Content-Type: text/plain; version=0.0.4
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
# Fluent Bit Metrics + Prometheus Exporter
# -------------------------------------------
# The following example collects Fluent Bit metrics and exposes
# them through a Prometheus HTTP end-point.
#
# After starting the service try it with:
#
# $ curl http://127.0.0.1:2021/metrics
#
[SERVICE]
    flush           1
    log_level       info

[INPUT]
    name            fluentbit_metrics
    tag             internal_metrics
    scrape_interval 2

[OUTPUT]
    name            prometheus_exporter
    match           internal_metrics
    host            0.0.0.0
    port            2021
```

## Debug/Valgrind output

```
$ curl -i http://127.0.0.1:2021/metrics
HTTP/1.1 200 OK
Server: Monkey/1.7.0
Date: Fri, 16 Dec 2022 23:40:52 GMT
Transfer-Encoding: chunked
Content-Type: text/plain; version=0.0.4

# HELP fluentbit_uptime Number of seconds that Fluent Bit has been running.
# TYPE fluentbit_uptime counter
fluentbit_uptime{hostname="taka-VirtualBox"} 5
# HELP fluentbit_input_bytes_total Number of input bytes.
# TYPE fluentbit_input_bytes_total counter
fluentbit_input_bytes_total{name="fluentbit_metrics.0"} 0
# HELP fluentbit_input_records_total Number of input records.
```

Following error is not related this PR since it is also reported on [current master](https://github.com/fluent/fluent-bit/tree/7c5edc3793bf627b7f863413ca512c9e89969631)
```
$ valgrind --leak-check=full ../../bin/fluent-bit -c a.conf 
==25299== Memcheck, a memory error detector
==25299== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25299== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==25299== Command: ../../bin/fluent-bit -c a.conf
==25299== 
Fluent Bit v2.0.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/17 08:40:46] [ info] [fluent bit] version=2.0.7, commit=8015b372fc, pid=25299
[2022/12/17 08:40:46] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/12/17 08:40:46] [ info] [cmetrics] version=0.5.7
[2022/12/17 08:40:46] [ info] [ctraces ] version=0.2.5
[2022/12/17 08:40:46] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2022/12/17 08:40:46] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2022/12/17 08:40:46] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2022/12/17 08:40:46] [ info] [sp] stream processor started
==25299== Warning: client switching stacks?  SP change: 0x7ffd148 --> 0x54c2470
==25299==          to suppress, use: --max-stackframe=45329624 or greater
==25299== Warning: client switching stacks?  SP change: 0x54c23d8 --> 0x7ffd148
==25299==          to suppress, use: --max-stackframe=45329776 or greater
==25299== Warning: client switching stacks?  SP change: 0x7ffd208 --> 0x54c23d8
==25299==          to suppress, use: --max-stackframe=45329968 or greater
==25299==          further instances of this message will not be shown.
^C[2022/12/17 08:40:54] [engine] caught signal (SIGINT)
[2022/12/17 08:40:54] [ warn] [engine] service will shutdown in max 5 seconds
[2022/12/17 08:40:54] [ info] [input] pausing fluentbit_metrics.0
[2022/12/17 08:40:55] [ info] [engine] service has stopped (0 pending tasks)
[2022/12/17 08:40:55] [ info] [input] pausing fluentbit_metrics.0
==25299== 
==25299== HEAP SUMMARY:
==25299==     in use at exit: 56 bytes in 1 blocks
==25299==   total heap usage: 8,624 allocs, 8,623 frees, 12,109,031 bytes allocated
==25299== 
==25299== 56 bytes in 1 blocks are definitely lost in loss record 1 of 1
==25299==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25299==    by 0xCBE4C3: mk_mem_alloc_z (mk_memory.h:70)
==25299==    by 0xCBE63A: thread_get_libco_params (mk_http_thread.c:60)
==25299==    by 0xCBE828: thread_params_set (mk_http_thread.c:168)
==25299==    by 0xCBEA40: mk_http_thread_create (mk_http_thread.c:226)
==25299==    by 0xCBABCB: mk_http_init (mk_http.c:748)
==25299==    by 0xCB9A0A: mk_http_request_prepare (mk_http.c:232)
==25299==    by 0xCBCA2A: mk_http_sched_read (mk_http.c:1576)
==25299==    by 0xCB85FC: mk_sched_event_read (mk_scheduler.c:695)
==25299==    by 0xCC1578: mk_server_worker_loop (mk_server.c:525)
==25299==    by 0xCB7F33: mk_sched_launch_worker_loop (mk_scheduler.c:417)
==25299==    by 0x4FD6B42: start_thread (pthread_create.c:442)
==25299== 
==25299== LEAK SUMMARY:
==25299==    definitely lost: 56 bytes in 1 blocks
==25299==    indirectly lost: 0 bytes in 0 blocks
==25299==      possibly lost: 0 bytes in 0 blocks
==25299==    still reachable: 0 bytes in 0 blocks
==25299==         suppressed: 0 bytes in 0 blocks
==25299== 
==25299== For lists of detected and suppressed errors, rerun with: -s
==25299== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
