### PR TITLE
cf_fluentbit: print config file load error

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -287,6 +287,8 @@ static int local_init(struct local_ctx *ctx, char *file)
         p = realpath(file, path);
 #endif
         if (!p) {
+            flb_errno();
+            flb_error("file=%s", file);
             return -1;
         }
     }


### PR DESCRIPTION
Currently fluent-bit exit silently when it fails to load config file.
This patch is to log it.
```
[2022/12/17 14:33:23] [error] [/home/taka/git/fluent-bit/src/config_format/flb_cf_fluentbit.c:290 errno=2] No such file or directory
[2022/12/17 14:33:23] [error] file=/home/taka/git/fluent-bit/build/issues/6547/aaa
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
## Configuration 
```
[SERVICE]
    parsers_file aaa

[INPUT]
    Name dummy

[OUTPUT]
    Name stdout
```

## Debug/Valgrind log

```
$ valgrind --leak-check=full ../../bin/fluent-bit -c b.conf 
==40432== Memcheck, a memory error detector
==40432== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==40432== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==40432== Command: ../../bin/fluent-bit -c b.conf
==40432== 
Fluent Bit v2.0.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/17 14:40:55] [error] [/home/taka/git/fluent-bit/src/config_format/flb_cf_fluentbit.c:290 errno=2] No such file or directory
[2022/12/17 14:40:55] [error] file=/home/taka/git/fluent-bit/build/issues/6547/aaa
[2022/12/17 14:40:55] [ info] [fluent bit] version=2.0.7, commit=8015b372fc, pid=40432
[2022/12/17 14:40:55] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/12/17 14:40:55] [ info] [cmetrics] version=0.5.7
[2022/12/17 14:40:55] [ info] [ctraces ] version=0.2.5
[2022/12/17 14:40:55] [ info] [input:dummy:dummy.0] initializing
[2022/12/17 14:40:55] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2022/12/17 14:40:55] [ info] [output:stdout:stdout.0] worker #0 started
[2022/12/17 14:40:55] [ info] [sp] stream processor started
^C[2022/12/17 14:40:56] [engine] caught signal (SIGINT)
[2022/12/17 14:40:56] [ warn] [engine] service will shutdown in max 5 seconds
[2022/12/17 14:40:56] [ info] [input] pausing dummy.0
[2022/12/17 14:40:56] [ info] [engine] service has stopped (0 pending tasks)
[2022/12/17 14:40:56] [ info] [input] pausing dummy.0
[2022/12/17 14:40:56] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/12/17 14:40:56] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==40432== 
==40432== HEAP SUMMARY:
==40432==     in use at exit: 0 bytes in 0 blocks
==40432==   total heap usage: 1,404 allocs, 1,404 frees, 246,428 bytes allocated
==40432== 
==40432== All heap blocks were freed -- no leaks are possible
==40432== 
==40432== For lists of detected and suppressed errors, rerun with: -s
==40432== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
