### PR TITLE
in_tail: remove extra fstat() syscall and remove unused function

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -747,31 +747,6 @@ static int tag_compose(char *tag, char *fname, char *out_buf, size_t *out_size,
     return 0;
 }
 
-static inline int flb_tail_file_exists_old(struct stat *st,
-                                       struct flb_tail_config *ctx)
-{
-    struct mk_list *head;
-    struct flb_tail_file *file;
-
-    /* Iterate static list */
-    mk_list_foreach(head, &ctx->files_static) {
-        file = mk_list_entry(head, struct flb_tail_file, _head);
-        if (file->inode == st->st_ino) {
-            return FLB_TRUE;
-        }
-    }
-
-    /* Iterate dynamic list */
-    mk_list_foreach(head, &ctx->files_event) {
-        file = mk_list_entry(head, struct flb_tail_file, _head);
-        if (file->inode == st->st_ino) {
-            return FLB_TRUE;
-        }
-    }
-
-    return FLB_FALSE;
-}
-
 static inline int flb_tail_file_exists(struct stat *st,
                                        struct flb_tail_config *ctx)
 {
@@ -1292,7 +1267,6 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
     size_t capacity;
     size_t processed_bytes;
     ssize_t bytes;
-    struct stat st;
     struct flb_tail_config *ctx;
 
     /* Check if we the engine issued a pause */
@@ -1383,15 +1357,9 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         }
 #endif
 
-        ret = fstat(file->fd, &st);
-        if (ret == -1) {
-            flb_errno();
-            return FLB_TAIL_ERROR;
-        }
-        else {
-            /* adjust file counters, returns FLB_TAIL_OK or FLB_TAIL_ERROR */
-            ret = adjust_counters(ctx, file);
-        }
+        /* adjust file counters, returns FLB_TAIL_OK or FLB_TAIL_ERROR */
+        ret = adjust_counters(ctx, file);
+
         /* Data was consumed but likely some bytes still remain */
         return ret;
     }


### PR DESCRIPTION
When consuming data from a file, fstat() is being invoked twice upon reading the content and then adjusting the internal counters, this patch simply remove the first check and let the adjust_counters() function perform the fstat().

This patch also removes an unused function.

Signed-off-by: Eduardo Silva <eduardo@calyptia.com>
