### PR TITLE
tiger: 1.8.15: 20221220

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -329,6 +329,9 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
         }
     }
     else if (ret == FLB_ERROR) {
+        flb_error("[engine] output '%s' could not process chunk '%s'. Chunk will not be retried.",
+                  flb_output_name(ins), flb_input_chunk_get_name(task->ic));
+
         /* cmetrics */
         cmt_counter_inc(ins->cmt_errors, ts, 1, (char *[]) {name});
         cmt_counter_add(ins->cmt_dropped_records, ts, task->records,


### PR DESCRIPTION
changes:

- engine now log FLB_ERROR from output plugins
- out_splunk: print as a log the chunks that could not be processed (e.g: HTTP 400 error)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
