### PR TITLE
CMakeLists: use FLB_DEFINTION for FLB_HAVE_*(#6519)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if(FLB_TRACE)
 endif()
 
 if(FLB_CHUNK_TRACE)
-  add_definitions(-DFLB_HAVE_CHUNK_TRACE=1)
+  FLB_DEFINITION(FLB_HAVE_CHUNK_TRACE)
 endif()
 
 # SSL/TLS: add encryption support


### PR DESCRIPTION
Fixes #6519 
This patch is to fix to use `FLB_DEFINITION` to define `FLB_HAVE_*`.

`FLB_HAVE_CHUNK_TRACE` should be defined in flb_info.h.
However it isn't defined since it is defined using `add_definitions`.

It causes struct size mismatch between fluent-bit and fluent-bit-plugin since the size will be changed `FLB_HAVE_CHUNK_TRACE` is defined or not.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Dockerfile 

It is to test issue #6519 

```dockerfile
FROM ubuntu:jammy

RUN apt update -qq && apt install -y cmake make g++ vim tree pkg-config libyaml-dev flex bison git libssl-dev
#RUN git clone https://github.com/fluent/fluent-bit.git && cd /fluent-bit/build && cmake .. && make
RUN git clone https://github.com/nokute78/fluent-bit.git && cd /fluent-bit/build && git checkout use_flb_definition_for_flb_have && cmake .. && make
RUN cd / && git clone https://github.com/brisa-robotics/fluent-bit-plugin && cd fluent-bit-plugin && git checkout in_bug && mkdir build && cp -r /fluent-bit/build/lib/monkey/include/monkey/mk_core/ /fluent-bit/include/
RUN cd /fluent-bit-plugin/build && cmake -DFLB_SOURCE=/fluent-bit -DPLUGIN_NAME=in_dummy2 ../ && make 
```

```
$ sudo docker run -it --rm <created container image id>
# /fluent-bit/build/bin/fluent-bit -e /fluent-bit-plugin/build/flb-in_dummy2.so -i dummy2 -o stdout
Fluent Bit v2.0.8
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/23 01:33:54] [ info] [fluent bit] version=2.0.8, commit=64c3f2cfd0, pid=13
[2022/12/23 01:33:54] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/12/23 01:33:54] [ info] [cmetrics] version=0.5.7
[2022/12/23 01:33:54] [ info] [ctraces ] version=0.2.5
[2022/12/23 01:33:54] [ info] [input:dummy2:dummy2.0] initializing
[2022/12/23 01:33:54] [ info] [input:dummy2:dummy2.0] storage_strategy='memory' (memory only)
[2022/12/23 01:33:54] [ info] [sp] stream processor started
[2022/12/23 01:33:54] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy2.0: [1671759234.951397405, {"message"=>"dummy"}]
^C[2022/12/23 01:33:56] [engine] caught signal (SIGINT)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
