### PR TITLE
filter_ecs: only attach metadata keys if their values are non-empty

### DIFF
--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -1431,7 +1431,7 @@ static int is_tag_marked_failed(struct flb_filter_ecs *ctx,
                        tag, tag_len,
                        (void **) &val, &val_size);
     if (ret != -1) {
-        if (*val >= ctx->agent_endpoint_retries) {
+        if (*val > ctx->agent_endpoint_retries) {
             return FLB_TRUE;
         }
     }
@@ -1616,7 +1616,6 @@ static int cb_ecs_filter(const void *data, size_t bytes,
                                     len);
             }
         }
-
     }
     msgpack_unpacked_destroy(&result);
 

--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -1325,7 +1325,7 @@ static int get_metadata_by_id(struct flb_filter_ecs *ctx,
     /* get metadata for this container */
     ret = flb_hash_get(ctx->container_hash_table,
                        container_short_id, flb_sds_len(container_short_id),
-                       (void *) metadata_buffer, &size);
+                       (void **) metadata_buffer, &size);
 
     if (ret == -1) {
         /* try fetch metadata */
@@ -1339,7 +1339,7 @@ static int get_metadata_by_id(struct flb_filter_ecs *ctx,
         /* get from hash table */
         ret = flb_hash_get(ctx->container_hash_table,
                            container_short_id, flb_sds_len(container_short_id),
-                           (void *) metadata_buffer, &size);
+                           (void **) metadata_buffer, &size);
     }
 
     flb_sds_destroy(container_short_id);
@@ -1369,14 +1369,14 @@ static int is_tag_marked_failed(struct flb_filter_ecs *ctx,
                                 const char *tag, int tag_len)
 {
     int ret;
-    int val = 0;
+    int *val = NULL;
     size_t val_size;
 
     ret = flb_hash_get(ctx->failed_metadata_request_tags,
                        tag, tag_len,
-                       (void *) &val, &val_size);
+                       (void **) &val, &val_size);
     if (ret != -1) {
-        if (val >= FLB_ECS_FILTER_METADATA_RETRIES) {
+        if (*val >= FLB_ECS_FILTER_METADATA_RETRIES) {
             return FLB_TRUE;
         }
     }
@@ -1393,7 +1393,7 @@ static void mark_tag_failed(struct flb_filter_ecs *ctx,
 
     ret = flb_hash_get(ctx->failed_metadata_request_tags,
                        tag, tag_len,
-                       (void *) val, &val_size);
+                       (void **) &val, &val_size);
 
     if (ret == -1) {
         /* hash table copies memory to new heap block */

--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -1376,7 +1376,7 @@ static int is_tag_marked_failed(struct flb_filter_ecs *ctx,
                        tag, tag_len,
                        (void **) &val, &val_size);
     if (ret != -1) {
-        if (*val >= FLB_ECS_FILTER_METADATA_RETRIES) {
+        if (*val >= ctx->agent_endpoint_retries) {
             return FLB_TRUE;
         }
     }
@@ -1417,7 +1417,7 @@ static void mark_tag_failed(struct flb_filter_ecs *ctx,
         flb_plg_info(ctx->ins, "Failed to get ECS Metadata for tag %s %d times. "
                     "This might be because the logs for this tag do not come from an ECS Task Container. "
                     "This plugin will retry metadata requests at most %d times total for this tag.",
-                    tag, *val, FLB_ECS_FILTER_METADATA_RETRIES);
+                    tag, *val, ctx->agent_endpoint_retries);
 
     }
 }
@@ -1467,7 +1467,7 @@ static int cb_ecs_filter(const void *data, size_t bytes,
     if (check == FLB_TRUE) {
         flb_plg_debug(ctx->ins, "Failed to get ECS Metadata for tag %s %d times. "
                       "Will not attempt to retry the metadata request. Will attach cluster metadata only.",
-                      tag, FLB_ECS_FILTER_METADATA_RETRIES);
+                      tag, ctx->agent_endpoint_retries);
     }
 
     if (check == FLB_FALSE && ctx->cluster_metadata_only == FLB_FALSE) {
@@ -1692,6 +1692,15 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_filter_ecs, ecs_port),
      "The port at which the ECS Agent Introspection endpoint is reachable. "
      "Defaults to 51678"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "agent_endpoint_retries", FLB_ECS_FILTER_METADATA_RETRIES,
+     0, FLB_TRUE, offsetof(struct flb_filter_ecs, agent_endpoint_retries),
+     "Number of retries for failed metadata requests to ECS Agent Introspection "
+     "endpoint. The most common cause of failed metadata requests is that the "
+     "container the metadata request was made for is not part of an ECS Task. "
+     "Check if you have non-task containers and docker dual logging enabled."
     },
 
     {0}

--- a/plugins/filter_ecs/ecs.h
+++ b/plugins/filter_ecs/ecs.h
@@ -49,20 +49,28 @@ struct flb_ecs_metadata_key {
     struct mk_list _head;
 };
 
+/* metadata processed into KV pair ready to add to log record */
+struct flb_ecs_metadata_keypair {
+    /* key is just a reference to the flb_ecs_metadata_key.key */
+    flb_sds_t key;
+    flb_sds_t val;
+
+    struct mk_list _head;
+};
+
 struct flb_ecs_metadata_buffer {
     /* msgpack_sbuffer */
     char *buf;
     size_t size;
 
-    /* unpacked object to use with flb_ra_translate */
-    msgpack_unpacked unpacked;
-    msgpack_object obj;
-    int free_packer;
-
     /* the hash table only stores a pointer- we need the list to track and free these */
     struct mk_list _head;
     /* we clean up the memory for these once ecs_meta_cache_ttl has expired */
     time_t last_used_time;
+
+    /* List of processed metadata keys and values */
+    struct mk_list metadata_keypairs;
+    int keypairs_len;
 
     /* 
      * To remove from the hash table on TTL expiration, we need the ID 

--- a/plugins/filter_ecs/ecs.h
+++ b/plugins/filter_ecs/ecs.h
@@ -30,7 +30,7 @@
 #define FLB_ECS_FILTER_PORT                       "51678"
 #define FLB_ECS_FILTER_CLUSTER_PATH               "/v1/metadata"
 #define FLB_ECS_FILTER_TASK_PATH_FORMAT           "/v1/tasks?dockerid=%s"
-#define FLB_ECS_FILTER_METADATA_RETRIES           "2"
+#define FLB_ECS_FILTER_METADATA_RETRIES           "3"
 
 /*
  * Kubernetes recommends not running more than 110 pods per node

--- a/plugins/filter_ecs/ecs.h
+++ b/plugins/filter_ecs/ecs.h
@@ -30,7 +30,7 @@
 #define FLB_ECS_FILTER_PORT                       "51678"
 #define FLB_ECS_FILTER_CLUSTER_PATH               "/v1/metadata"
 #define FLB_ECS_FILTER_TASK_PATH_FORMAT           "/v1/tasks?dockerid=%s"
-#define FLB_ECS_FILTER_METADATA_RETRIES           2
+#define FLB_ECS_FILTER_METADATA_RETRIES           "2"
 
 /*
  * Kubernetes recommends not running more than 110 pods per node
@@ -108,6 +108,8 @@ struct flb_filter_ecs {
 
     flb_sds_t ecs_host;
     int ecs_port;
+
+    int agent_endpoint_retries;
 
     /* 
      * This field is used when we build new container metadata objects


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is rebased on top of: https://github.com/fluent/fluent-bit/pull/6589

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

## ECS Metadata Empty metadata fix and performance optimization

### Problem Statement

The ECS Filter was first released in AWS for Fluent Bit 2.29.0. The first version works, but has a non-ideal experience when metadata lookups for a log fails, and the code is very inefficient. 


#### Problem 1: Filter can attache metadata keypairs with empty values

When customers configure the ECS filter, they provide a list of metadata key value pairs they want added to logs. The filter looks up metadata from the ECS Agent introspection endpoint. 

However, the metadata fetch can fail, for one of two reasons:

1. ECS Agent introspection endpoint is unreachable. 
2. The filter is trying to attach metadata for a container that is not running as part of an ECS Task. The ECS Agent introspection endpoint only returns metadata for containers that are running as part of ECS Tasks. However, customers can have other containers running on their host. One key example is the ECS Agent, which is itself a container that is not part of an ECS Task. When customers customers collect the log files from `/var/lib/docker/containers` they will get logs for all containers running on that host. This is due in part to the recent Docker[dual logging feature](https://docs.docker.com/config/containers/logging/dual-logging/)which will always write a containers stdout/stderr to `/var/lib/docker/containers`. While customers can disable dual logging in the Docker `daemon.json` config file, it is enabled by default on the ECS optimized AMI and in all vanilla Docker installs. Thus, Fluent Bit would collect logs for the ECS Agent and any other containers that are not part of an ECS Task. When the ECS Filter tries to lookup these containers in the ECS Agent introspection endpoint, it will get an error response. 


When either of the above issues occur, the currently released ECS Filter will attach metadata values that are empty. For example, consider the following config. 


```
[FILTER]
    Name              ecs
    Match             task.var.lib.docker.containers.*
    ECS_Tag_Prefix    task.var.lib.docker.containers.
    ADD               container    $ECSContainerName
    ADD               ecs_task_id  $TaskID
    ADD               ecs_family   $TaskDefinitionFamily
```

If the above errors occur, a customer would get a log like:


```
{
    "log": "log line from the container..."
    # empty metadata values
    "container": "",
    "ecs_task_id": "",
    "ecs_family": ""
}
```
<img width="1792" alt="Screen Shot 2022-12-18 at 8 55 50 PM" src="https://user-images.githubusercontent.com/29443996/209296862-6edb8ed6-9339-4644-8e88-02993eb33b0c.png">


#### Problem 2: Current ECS Filter is inefficient

If N is the number of metadata key value pairs the customers has configured. Currently, in the filter callback, the ECS Filter calls `flb_ra_translate` to template the metadata for every single log record it processes times N: https://github.com/fluent/fluent-bit/blob/v2.0.6/plugins/filter_ecs/ecs.c#L1533

Each call requires going through the metadata msgpack object and at least one `flb_sds` string allocation. 

### 
Root Cause of Problems

As explained above, the root cause is the inefficient code contributed in the first version of the filter.

* The outgoing msgpack buffer is packed with the configured number of metadata keys, with no check for whether or not we failed to obtain the metadata: https://github.com/fluent/fluent-bit/blob/v2.0.6/plugins/filter_ecs/ecs.c#L1520
* `flb_ra_translate` is called for every log record in the filter callback times the number of metadata keys: https://github.com/fluent/fluent-bit/blob/v2.0.6/plugins/filter_ecs/ecs.c#L1533

### Solution

1. The key value pairs configured by the customer are static during runtime, so the filter can store a list of key value pairs for each container metadata buffer. 
2. The outgoing msgpack buffer returned by the filter can be packed with the actual number of metadata keys successfully processed.



### Estimates

|Task	|Estimate	|Planned Start date	|Completion date	|
|---	|---	|---	|---	|
|Metadata Filter Fixes code implementation	|1	|12/19/2022	|12/20/2022	|
|Testing	|0.5	|12/20/2022	|12/23/2022	|
|PR Review and Release	|🤷‍♂️	|🤷‍♂️	|	|
|	|	|	|	|
|	|	|	|	|



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
