### PR TITLE
packaging: fix server publishing for Debian Bookworm

### DIFF
--- a/packaging/server/create-aptly-repo.sh
+++ b/packaging/server/create-aptly-repo.sh
@@ -25,7 +25,7 @@ fi
 
 mkdir -p "/var/www/apt.fluentbit.io/${DISTRO}/${CODENAME}/"
 
-if ! grep -q "debian/bookworm" "$APTLY_CONFIG"; then
+if ! grep -q "${DISTRO}/${CODENAME}" "$APTLY_CONFIG"; then
     echo "Please update the aptly config file with the following:"
     echo
     echo '   "FileSystemPublishEndpoints": {'

--- a/packaging/server/publish-all.sh
+++ b/packaging/server/publish-all.sh
@@ -112,7 +112,7 @@ fi
 echo "Publishing Debian 12 Bookworm"
 find "$SOURCE_DIR/debian/bookworm/" -iname "*-bit_$VERSION*.deb" -exec aptly -config="$APTLY_CONFIG" repo add flb-debian-bookworm {} \;
 aptly -config="$APTLY_CONFIG" snapshot create "fluent-bit-debian-bookworm-${VERSION}" from repo flb-debian-bookworm
-if ! aptly -config="$APTLY_CONFIG" publish switch -gpg-key="releases@fluentbit.io" bookworm filesystem:debian/bookworm:bookworm "fluent-bit-debian-bookworm-${VERSION}"; then
+if ! aptly -config="$APTLY_CONFIG" publish switch -gpg-key="releases@fluentbit.io" bookworm filesystem:debian/bookworm: "fluent-bit-debian-bookworm-${VERSION}"; then
     # Cleanup snapshot in case we want to retry later
     aptly -config="$APTLY_CONFIG" snapshot drop "fluent-bit-debian-bookworm-${VERSION}"
     exit 1


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Resolves an issue with publishing for the new Aptly Bookworm repo.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Confirmed to work.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
