### PR TITLE
in_tcp: support '\0' separator(#6526)

### DIFF
--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -257,6 +257,10 @@ int flb_unescape_string(const char *buf, int buf_len, char **unesc_buf)
                     p[j++] = '\r';
                     i++;
                 }
+                else if (n == '0') {
+                    p[j++] = '\0';
+                    i++;
+                }
                 else if (n == '\\') {
                     p[j++] = '\\';
                     i++;


### PR DESCRIPTION
Fixes #6526 

This patch is to 
- unescape: support '\0'
- in_tcp: allow '\0' as a separator

I added `strstr_sep` since `strstr(buf, '\0')` always returns buf.
`strstr_sep` is to seek '\0' in a string.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
  Flush                       10
  Log_Level                   debug

[INPUT]
  Tag                 gelf
  Name                tcp
  Listen              0.0.0.0
  Port                12201
  Format              none
  Separator           \0

[OUTPUT]
  Match                     *
  Name                      stdout
```

## Debug/Valgrind output

1. Run fluent-bit -c a.conf
2. Send message using `printf '{ "version": "1.1", "host": "example.org", "short_message": "A short message", "level": 5, "_some_info": "foo" }\x00{ "version": "1.1", "host": "example.org", "short_message": "A short message2", "level": 5, "_some_info": "foo" }\x00' | nc -w0 localhost 12201`

```
$ valgrind --leak-check=full ../../bin/fluent-bit -c a.conf 
==72099== Memcheck, a memory error detector
==72099== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==72099== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==72099== Command: ../../bin/fluent-bit -c a.conf
==72099== 
Fluent Bit v2.0.8
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/12/24 11:12:23] [ info] Configuration:
[2022/12/24 11:12:23] [ info]  flush time     | 10.000000 seconds
[2022/12/24 11:12:23] [ info]  grace          | 5 seconds
[2022/12/24 11:12:23] [ info]  daemon         | 0
[2022/12/24 11:12:23] [ info] ___________
[2022/12/24 11:12:23] [ info]  inputs:
[2022/12/24 11:12:23] [ info]      tcp
[2022/12/24 11:12:23] [ info] ___________
[2022/12/24 11:12:23] [ info]  filters:
[2022/12/24 11:12:23] [ info] ___________
[2022/12/24 11:12:23] [ info]  outputs:
[2022/12/24 11:12:23] [ info]      stdout.0
[2022/12/24 11:12:23] [ info] ___________
[2022/12/24 11:12:23] [ info]  collectors:
[2022/12/24 11:12:23] [ info] [fluent bit] version=2.0.8, commit=9444fdc5ee, pid=72099
[2022/12/24 11:12:23] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/12/24 11:12:23] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2022/12/24 11:12:23] [ info] [cmetrics] version=0.5.8
[2022/12/24 11:12:23] [ info] [ctraces ] version=0.2.7
[2022/12/24 11:12:23] [ info] [input:tcp:tcp.0] initializing
[2022/12/24 11:12:23] [ info] [input:tcp:tcp.0] storage_strategy='memory' (memory only)
[2022/12/24 11:12:23] [debug] [tcp:tcp.0] created event channels: read=21 write=22
[2022/12/24 11:12:23] [debug] [downstream] listening on 0.0.0.0:12201
[2022/12/24 11:12:23] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2022/12/24 11:12:23] [ info] [output:stdout:stdout.0] worker #0 started
[2022/12/24 11:12:23] [ info] [sp] stream processor started
[2022/12/24 11:12:29] [debug] [input chunk] update output instances with new chunk size diff=261
[2022/12/24 11:12:33] [debug] [task] created task=0x54ccf50 id=0 OK
[2022/12/24 11:12:33] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] gelf: [1671847949.913843898, {"log"=>"{ "version": "1.1", "host": "example.org", "short_message": "A short message", "level": 5, "_some_info": "foo" }"}]
[1] gelf: [1671847949.920680548, {"log"=>"{ "version": "1.1", "host": "example.org", "short_message": "A short message2", "level": 5, "_some_info": "foo" }"}]
[2022/12/24 11:12:33] [debug] [out flush] cb_destroy coro_id=0
[2022/12/24 11:12:33] [debug] [task] destroy task=0x54ccf50 (task_id=0)
^C[2022/12/24 11:12:34] [engine] caught signal (SIGINT)
[2022/12/24 11:12:34] [ warn] [engine] service will shutdown in max 5 seconds
[2022/12/24 11:12:35] [ info] [engine] service has stopped (0 pending tasks)
[2022/12/24 11:12:35] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2022/12/24 11:12:35] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==72099== 
==72099== HEAP SUMMARY:
==72099==     in use at exit: 0 bytes in 0 blocks
==72099==   total heap usage: 1,504 allocs, 1,504 frees, 862,562 bytes allocated
==72099== 
==72099== All heap blocks were freed -- no leaks are possible
==72099== 
==72099== For lists of detected and suppressed errors, rerun with: -s
==72099== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
