### PR TITLE
tests: internal: utils: add test case for flb_utils_split

### DIFF
--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -3,7 +3,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_utils.h>
-
+#include <stdarg.h>
 #include "flb_tests_internal.h"
 
 
@@ -474,6 +474,84 @@ void test_proxy_url_split() {
     }
 }
 
+static int compare_split_entry(const char* input, int separator, int max_split, ...)
+{
+    va_list ap;
+    int count = 1;
+    char *expect;
+    struct mk_list *split = NULL;
+    struct mk_list *tmp_list = NULL;
+    struct mk_list *head = NULL;
+    struct flb_split_entry *entry = NULL;
+
+    split = flb_utils_split(input, separator, max_split);
+    if (!TEST_CHECK(split != NULL)) {
+        TEST_MSG("flb_utils_split failed. input=%s", input);
+        return -1;
+    }
+    if (!TEST_CHECK(mk_list_is_empty(split) != 0)) {
+        TEST_MSG("list is empty. input=%s", input);
+        return -1;
+    }
+
+    va_start(ap, max_split);
+    mk_list_foreach_safe(head, tmp_list, split) {
+        if (max_split > 0 && !TEST_CHECK(count <= max_split) ) {
+            TEST_MSG("count error. got=%d expect=%d input=%s", count, max_split, input);
+        }
+
+        expect = va_arg(ap, char*);
+        entry = mk_list_entry(head, struct flb_split_entry, _head);
+        if (!TEST_CHECK(entry != NULL)) {
+            TEST_MSG("entry is NULL. input=%s", input);
+            goto comp_end;
+        }
+        /*
+        printf("%d:%s\n", count, entry->value);
+        */
+        if (!TEST_CHECK(strcmp(expect, entry->value) == 0)) {
+            TEST_MSG("mismatch. got=%s expect=%s. input=%s", entry->value, expect, input);
+            goto comp_end;
+        }
+        count++;
+    }
+ comp_end:
+    if (split != NULL) {
+        flb_utils_split_free(split);
+    }
+    va_end(ap);
+    return 0;
+}
+
+void test_flb_utils_split()
+{
+    compare_split_entry("aa,bb", ',', 2, "aa","bb" );
+    compare_split_entry("localhost:12345", ':', 2, "localhost","12345" );
+    compare_split_entry("https://fluentbit.io/announcements/", '/', -1, "https:", "fluentbit.io","announcements" );
+
+    /* /proc/net/dev example */
+    compare_split_entry("enp0s3: 1955136    1768    0    0    0     0          0         0    89362     931    0    0    0     0       0          0",
+                        ' ', 256, 
+                        "enp0s3:", "1955136", "1768", "0", "0", "0", "0", "0", "0", "89362", "931", "0", "0", "0", "0", "0", "0", "0");
+
+    /* filter_grep configuration */
+    compare_split_entry("Regex test  *a*", ' ', 3, "Regex", "test", "*a*");
+
+    /* filter_modify configuration */
+    compare_split_entry("Condition Key_Value_Does_Not_Equal cpustats  KNOWN", ' ', 4, 
+                        "Condition", "Key_Value_Does_Not_Equal", "cpustats", "KNOWN");
+
+    /* nginx_exporter_metrics example */
+    compare_split_entry("Active connections: 1\nserver accepts handled requests\n 10 10 10\nReading: 0 Writing: 1 Waiting: 0", '\n', 4,
+                        "Active connections: 1", "server accepts handled requests", " 10 10 10","Reading: 0 Writing: 1 Waiting: 0");
+
+    /* out_cloudwatch_logs example */
+    compare_split_entry("dimension_1,dimension_2;dimension_3", ';', 256,
+                        "dimension_1,dimension_2", "dimension_3");
+    /* separator is not contained */
+    compare_split_entry("aa,bb", '/', 2, "aa,bb");
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "url_split", test_url_split },
@@ -484,5 +562,6 @@ TEST_LIST = {
     { "test_write_str_invalid_leading_byte_case_2", test_write_str_invalid_leading_byte_case_2 },
     { "test_write_str_buffer_overrun", test_write_str_buffer_overrun },
     { "proxy_url_split", test_proxy_url_split },
+    { "test_flb_utils_split", test_flb_utils_split },
     { 0 }
 };


### PR DESCRIPTION
This patch is to add test cases for `flb_utils_split`.
It is to check regressions of the function before merging https://github.com/fluent/fluent-bit/pull/6387


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --show-leak-kinds=all --leak-check=full bin/flb-it-utils 
==60252== Memcheck, a memory error detector
==60252== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==60252== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==60252== Command: bin/flb-it-utils
==60252== 

Test test_flb_utils_split...                    [ OK ]
==60261== Warning: invalid file descriptor -1 in syscall close()
==60261== 
==60261== HEAP SUMMARY:
==60261==     in use at exit: 144 bytes in 1 blocks
==60261==   total heap usage: 916 allocs, 915 frees, 87,176 bytes allocated
==60261== 
==60261== 144 bytes in 1 blocks are still reachable in loss record 1 of 1
==60261==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==60261==    by 0x141666: main (acutest.h:1632)
==60261== 
==60261== LEAK SUMMARY:
==60261==    definitely lost: 0 bytes in 0 blocks
==60261==    indirectly lost: 0 bytes in 0 blocks
==60261==      possibly lost: 0 bytes in 0 blocks
==60261==    still reachable: 144 bytes in 1 blocks
==60261==         suppressed: 0 bytes in 0 blocks
==60261== 
==60261== For lists of detected and suppressed errors, rerun with: -s
==60261== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==60252== 
==60252== HEAP SUMMARY:
==60252==     in use at exit: 0 bytes in 0 blocks
==60252==   total heap usage: 3 allocs, 3 frees, 1,205 bytes allocated
==60252== 
==60252== All heap blocks were freed -- no leaks are possible
==60252== 
==60252== For lists of detected and suppressed errors, rerun with: -s
==60252== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
