### PR TITLE
tests: internal: log: remove unused variable

### DIFF
--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -115,7 +115,6 @@ int flb_cf_plugin_property_add(struct flb_cf *cf,
                                char *k_buf, size_t k_len,
                                char *v_buf, size_t v_len)
 {
-    int i;
     int ret;
     flb_sds_t key;
     flb_sds_t val;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1039,7 +1039,6 @@ int flb_input_chunk_destroy_corrupted(struct flb_input_chunk *ic,
                                       const char *tag_buf, int tag_len,
                                       int del)
 {
-    int ret;
     ssize_t bytes;
     struct mk_list *head;
     struct flb_output_instance *o_ins;

--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -87,7 +87,6 @@ static void cache_one_slot()
     int ret_1;
     int ret_2;
     struct flb_log_cache *cache;
-    struct flb_log_cache_entry *entry;
 
     printf("\n");
 

--- a/tests/runtime/core_chunk_trace.c
+++ b/tests/runtime/core_chunk_trace.c
@@ -70,7 +70,6 @@ void do_test_records_trace(void (*records_cb)(struct callback_records *))
     flb_ctx_t    *ctx    = NULL;
     struct flb_input_instance *input;
     struct flb_output_instance *output;
-    struct flb_output_instance *trace_output;
     int i;
     struct flb_lib_out_cb cb;
     struct callback_records *records;

--- a/tests/runtime/filter_kubernetes.c
+++ b/tests/runtime/filter_kubernetes.c
@@ -32,7 +32,6 @@ void wait_with_timeout(uint32_t timeout_ms, struct kube_test_result *result, int
     struct flb_time end_time;
     struct flb_time diff_time;
     uint64_t elapsed_time_flb = 0;
-    int64_t ret = 0;
 
     flb_time_get(&start_time);
 


### PR DESCRIPTION
This patch is to solve unused variable warnings.
- tests/internal/log.c
- src/flb_input_chunk.c
- src/config_format/flb_config_format.c
- tests/runtime/core_chunk_trace.c
- tests/runtime/filter_kubernetes.c

```
[ 94%] Building C object tests/internal/CMakeFiles/flb-it-log.dir/log.c.o
/home/taka/git/fluent-bit/tests/internal/log.c: In function ‘cache_one_slot’:
/home/taka/git/fluent-bit/tests/internal/log.c:90:33: warning: unused variable ‘entry’ [-Wunused-variable]
   90 |     struct flb_log_cache_entry *entry;
      |                                 ^~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
d$ valgrind --leak-check=full bin/flb-it-log 
==47267== Memcheck, a memory error detector
==47267== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==47267== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==47267== Command: bin/flb-it-log
==47267== 
Test cache_basic_timeout...                     
------------------------
[ OK ]
==47268== Warning: invalid file descriptor -1 in syscall close()
==47268== 
==47268== HEAP SUMMARY:
==47268==     in use at exit: 32 bytes in 1 blocks
==47268==   total heap usage: 849 allocs, 848 frees, 93,693 bytes allocated
==47268== 
==47268== LEAK SUMMARY:
==47268==    definitely lost: 0 bytes in 0 blocks
==47268==    indirectly lost: 0 bytes in 0 blocks
==47268==      possibly lost: 0 bytes in 0 blocks
==47268==    still reachable: 32 bytes in 1 blocks
==47268==         suppressed: 0 bytes in 0 blocks
==47268== Reachable blocks (those to which a pointer was found) are not shown.
==47268== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==47268== 
==47268== For lists of detected and suppressed errors, rerun with: -s
==47268== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test cache_one_slot...                          
[ OK ]
==47269== Warning: invalid file descriptor -1 in syscall close()
==47269== 
==47269== HEAP SUMMARY:
==47269==     in use at exit: 32 bytes in 1 blocks
==47269==   total heap usage: 834 allocs, 833 frees, 86,158 bytes allocated
==47269== 
==47269== LEAK SUMMARY:
==47269==    definitely lost: 0 bytes in 0 blocks
==47269==    indirectly lost: 0 bytes in 0 blocks
==47269==      possibly lost: 0 bytes in 0 blocks
==47269==    still reachable: 32 bytes in 1 blocks
==47269==         suppressed: 0 bytes in 0 blocks
==47269== Reachable blocks (those to which a pointer was found) are not shown.
==47269== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==47269== 
==47269== For lists of detected and suppressed errors, rerun with: -s
==47269== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==47267== 
==47267== HEAP SUMMARY:
==47267==     in use at exit: 0 bytes in 0 blocks
==47267==   total heap usage: 3 allocs, 3 frees, 1,093 bytes allocated
==47267== 
==47267== All heap blocks were freed -- no leaks are possible
==47267== 
==47267== For lists of detected and suppressed errors, rerun with: -s
==47267== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
