### PR TITLE
config: fix memory freeing in error handling

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -202,14 +202,15 @@ struct flb_config *flb_config_init()
     /* Initialize config_format context */
     cf = flb_cf_create();
     if (!cf) {
-        flb_config_exit(config);
+        flb_free(config);
         return NULL;
     }
     config->cf_main = cf;
 
     section = flb_cf_section_create(cf, "service", 0);
     if (!section) {
-        flb_config_exit(config);
+        flb_cf_destroy(cf);
+        flb_free(config);
         return NULL;
     }
 


### PR DESCRIPTION
Calling `flb_config_exit(config);` at these lines causes issues becase a lot of the config struct has not been been initialised, in particular the various lists. This will cause crashes of various sort. We should only call `flb_config_exit` after all the fields relying on `mk_list_init` has been initilised.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
