### PR TITLE
aws: fix freeing arbitrary memory

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -611,7 +611,7 @@ struct flb_aws_credentials *get_credentials_fn_environment(struct
         return NULL;
     }
 
-    creds = flb_malloc(sizeof(struct flb_aws_credentials));
+    creds = flb_calloc(1, sizeof(struct flb_aws_credentials));
     if (!creds) {
         flb_errno();
         return NULL;


### PR DESCRIPTION
The memory is currently non-nullified since malloc is used. However, shortly after malloc is used `flb_aws_credentials_destroy` is called in the event an error occurs. `flb_aws_credentials_destroy` will treat some of the memory in the malloced memory as pointers and use the memory as arguments to `free` if the given memory is non-null. This causes issues since non-null memory returned by malloc is not guaranteed to be safe to free. To avoid this use `calloc` instead as `flb_aws_credentials_destroy` will not call `free` on NULL bytes.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
