### PR TITLE
signv4: handle error case

### DIFF
--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -497,6 +497,9 @@ void headers_sanitize(struct mk_list *in_list, struct mk_list *out_list)
         kv = flb_kv_item_create_len(&out_tmp,
                                     kv->key, flb_sds_len(kv->key),
                                     v_start, v_end - v_start);
+        if (kv == NULL) {
+            continue;
+        }
         for (x = 0; x < flb_sds_len(kv->key); x++) {
             kv->key[x] = tolower(kv->key[x]);
         }


### PR DESCRIPTION
`flb_kv_item_create_len` may fail and this should be handled.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
