### PR TITLE
tests: internal: log: make cache_basic_timeout more stable

### DIFF
--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -11,11 +11,41 @@
 #define TEST_RECORD_02      "other type of message"
 #define TEST_RECORD_02_SIZE sizeof(TEST_RECORD_02) - 1
 
+static int check_interval(int timeout, int *interval)
+{
+    if (!TEST_CHECK( (*interval >= timeout - 1) && *interval <= timeout) ) {
+        TEST_MSG("interval error. got=%d expect=%d-%d", *interval, timeout -1 ,timeout);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int update_and_check_interval(int timeout, int ret, int *interval)
+{
+    int ret_val;
+
+    if (ret == FLB_TRUE) {
+        *interval += 1;
+        return 0;
+    }
+
+    /* false means timeout. check interval. */
+    ret_val = check_interval(timeout, interval);
+    *interval = 0; /* reset interval */
+
+    return ret_val;
+}
+
 static void cache_basic_timeout()
 {
     int i;
+    int ret;
     int ret_1;
     int ret_2;
+    int timeout = 5;
+    int interval1 = 0;
+    int interval2 = 0;
     struct flb_log_cache *cache;
     struct flb_log_cache_entry *entry;
 
@@ -45,32 +75,35 @@ static void cache_basic_timeout()
     flb_log_cache_destroy(cache);
 
     /* create a new cache */
-    cache = flb_log_cache_create(5, 4);
+    cache = flb_log_cache_create(timeout, 4);
     TEST_CHECK(cache != NULL);
 
-    for (i = 0; i < 10; i++) {
-        ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
-        ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+    ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+    TEST_CHECK(ret_1 == FLB_FALSE);
+    TEST_CHECK(ret_2 == FLB_FALSE);
+    sleep(1);
 
-        if (i == 0) {
-            TEST_CHECK(ret_1 == FLB_FALSE);
-            TEST_CHECK(ret_2 == FLB_FALSE);
+    for (i = 1; i < 10; i++) {
+        ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+        ret = update_and_check_interval(timeout, ret_1, &interval1);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("update_and_check_interval for TEST_RECORD_01 failed. i=%d", i);
         }
-        else if (i >= 1 && i < 5) {
-            TEST_CHECK(ret_1 == FLB_TRUE);
-            TEST_CHECK(ret_2 == FLB_TRUE);
-        }
-        else if (i == 5) {
-            TEST_CHECK(ret_1 == FLB_FALSE);
-            TEST_CHECK(ret_2 == FLB_FALSE);
-        }
-        else {
-            TEST_CHECK(ret_1 == FLB_TRUE);
-            TEST_CHECK(ret_2 == FLB_TRUE);
+
+        ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+        ret = update_and_check_interval(timeout, ret_2, &interval2);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("update_and_check_interval for TEST_RECORD_02 failed. i=%d", i);
         }
 
         sleep(1);
     }
+    ret = update_and_check_interval(timeout, ret_1, &interval1);
+    TEST_CHECK(ret == 0);
+
+    ret = update_and_check_interval(timeout, ret_2, &interval2);
+    TEST_CHECK(ret == 0);
 
     ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
     TEST_CHECK(ret_1 == FLB_FALSE);


### PR DESCRIPTION
This patch tries to fix following test error.
https://ci.appveyor.com/project/fluent/fluent-bit-2e87g/builds/45867890/job/u6f3mqnfwf2l45fd#L3761

```
31/38 Test #31: flb-it-log .......................***Failed   20.23 sec
Test cache_basic_timeout...                     
------------------------
[ FAILED ]
  log.c:60: Check ret_1 == FLB_TRUE... failed
  log.c:61: Check ret_2 == FLB_TRUE... failed
  log.c:64: Check ret_1 == FLB_FALSE... failed
  log.c:65: Check ret_2 == FLB_FALSE... failed
  log.c:68: Check ret_1 == FLB_TRUE... failed
  log.c:69: Check ret_2 == FLB_TRUE... failed
  log.c:76: Check ret_1 == FLB_FALSE... failed
  log.c:79: Check ret_2 == FLB_FALSE... failed
Test cache_one_slot...                          
[ OK ]
FAILED: 1 of 2 unit tests has failed.
```
The test checks at the 5th second to see if it timed out.
However timing may be off and the test may fail.

This patch is to check an interval between FLB_FALSE.
If the timeout is 5seconds,  4 < interval <= 5 is allowed. 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->


## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/flb-it-log 
==30761== Memcheck, a memory error detector
==30761== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==30761== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==30761== Command: bin/flb-it-log
==30761== 
Test cache_basic_timeout...                     
------------------------
[ OK ]
==30762== Warning: invalid file descriptor -1 in syscall close()
==30762== 
==30762== HEAP SUMMARY:
==30762==     in use at exit: 32 bytes in 1 blocks
==30762==   total heap usage: 849 allocs, 848 frees, 93,693 bytes allocated
==30762== 
==30762== 32 bytes in 1 blocks are still reachable in loss record 1 of 1
==30762==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30762==    by 0x1415F4: main (acutest.h:1632)
==30762== 
==30762== LEAK SUMMARY:
==30762==    definitely lost: 0 bytes in 0 blocks
==30762==    indirectly lost: 0 bytes in 0 blocks
==30762==      possibly lost: 0 bytes in 0 blocks
==30762==    still reachable: 32 bytes in 1 blocks
==30762==         suppressed: 0 bytes in 0 blocks
==30762== 
==30762== For lists of detected and suppressed errors, rerun with: -s
==30762== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test cache_one_slot...                          
[ OK ]
==30763== Warning: invalid file descriptor -1 in syscall close()
==30763== 
==30763== HEAP SUMMARY:
==30763==     in use at exit: 32 bytes in 1 blocks
==30763==   total heap usage: 834 allocs, 833 frees, 86,158 bytes allocated
==30763== 
==30763== 32 bytes in 1 blocks are still reachable in loss record 1 of 1
==30763==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==30763==    by 0x1415F4: main (acutest.h:1632)
==30763== 
==30763== LEAK SUMMARY:
==30763==    definitely lost: 0 bytes in 0 blocks
==30763==    indirectly lost: 0 bytes in 0 blocks
==30763==      possibly lost: 0 bytes in 0 blocks
==30763==    still reachable: 32 bytes in 1 blocks
==30763==         suppressed: 0 bytes in 0 blocks
==30763== 
==30763== For lists of detected and suppressed errors, rerun with: -s
==30763== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==30761== 
==30761== HEAP SUMMARY:
==30761==     in use at exit: 0 bytes in 0 blocks
==30761==   total heap usage: 3 allocs, 3 frees, 1,093 bytes allocated
==30761== 
==30761== All heap blocks were freed -- no leaks are possible
==30761== 
==30761== For lists of detected and suppressed errors, rerun with: -s
==30761== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
