### PR TITLE
in_docker: prepare to support cgroup v2

### DIFF
--- a/plugins/in_docker/CMakeLists.txt
+++ b/plugins/in_docker/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   docker.c
+  cgroup_v1.c
   )
 
 FLB_PLUGIN(in_docker "${src}" "")

--- a/plugins/in_docker/cgroup_v1.c
+++ b/plugins/in_docker/cgroup_v1.c
@@ -1,0 +1,397 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include <dirent.h>
+#include <string.h>
+#include "docker.h"
+
+/* This method returns list of currently running docker ids. */
+static struct mk_list *get_active_dockers()
+{
+    DIR *dp;
+    struct dirent *ep;
+    struct mk_list *list;
+
+    list = flb_malloc(sizeof(struct mk_list));
+    if (!list) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(list);
+
+    dp = opendir(DOCKER_CGROUP_V1_CPU_DIR);
+    if (dp != NULL) {
+        ep = readdir(dp);
+
+        while(ep != NULL) {
+            if (ep->d_type == OS_DIR_TYPE) {
+                if (strcmp(ep->d_name, CURRENT_DIR) != 0
+                    && strcmp(ep->d_name, PREV_DIR) != 0
+                    && strlen(ep->d_name) == DOCKER_LONG_ID_LEN) { /* precautionary check */
+
+                    docker_info *docker = in_docker_init_docker_info(ep->d_name);
+                    mk_list_add(&docker->_head, list);
+                }
+            }
+            ep = readdir(dp);
+        }
+        closedir(dp);
+    }
+
+    return list;
+}
+
+static char *read_line(FILE *fin)
+{
+    char *buffer;
+    char *tmp;
+    int read_chars = 0;
+    int bufsize = 1215;
+    char *line;
+
+    line = (char *) flb_calloc(bufsize, sizeof(char));
+    if (!line) {
+        flb_errno();
+        return NULL;
+    }
+
+    buffer = line;
+
+    while (fgets(buffer, bufsize - read_chars, fin)) {
+        read_chars = strlen(line);
+
+        if (line[read_chars - 1] == '\n') {
+            line[read_chars - 1] = '\0';
+            return line;
+        }
+        else {
+            bufsize = 2 * bufsize;
+            tmp = flb_realloc(line, bufsize);
+            if (!tmp) {
+                flb_errno();
+                return NULL;
+            }
+            else {
+                line = tmp;
+                buffer = line + read_chars;
+            }
+        }
+    }
+
+    flb_free(line);
+    return NULL;
+}
+
+/* This routine returns path to docker's cgroup CPU usage file. */
+static char *get_cpu_used_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(105, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+
+    strcat(path, DOCKER_CGROUP_V1_CPU_DIR);
+    strcat(path, "/");
+    strcat(path, id);
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V1_CPU_USAGE_FILE);
+
+    return path;
+}
+
+/* This routine returns path to docker's cgroup memory limit file. */
+static char *get_mem_limit_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(116, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_CGROUP_V1_MEM_DIR);
+    strcat(path, "/");
+    strcat(path, id);
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V1_MEM_LIMIT_FILE);
+
+    return path;
+}
+
+/* This routine returns path to docker's cgroup memory used file. */
+static char *get_mem_used_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(116, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_CGROUP_V1_MEM_DIR);
+    strcat(path, "/");
+    strcat(path, id);
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V1_MEM_USAGE_FILE);
+
+    return path;
+}
+
+static char *get_config_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(107, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_LIB_ROOT);
+    strcat(path, "/");
+    strcat(path, id);
+    strcat(path, "/");
+    strcat(path, DOCKER_CONFIG_JSON);
+
+    return path;
+}
+
+static char *extract_name(char *line, char *start)
+{
+    int skip = 9;
+    int len = 0;
+    char *name;
+    char buff[256];
+    char *curr;
+
+    if (start != NULL) {
+        curr = start + skip;
+        while (*curr != '"') {
+            buff[len++] = *curr;
+            curr++;
+        }
+
+        if (len > 0) {
+            name = (char *) flb_calloc(len + 1, sizeof(char));
+            if (!name) {
+                flb_errno();
+                return NULL;
+            }
+            memcpy(name, buff, len);
+
+            return name;
+        }
+    }
+
+    return NULL;
+}
+
+static char *get_container_name(struct flb_docker *ctx, char *id)
+{
+    char *container_name = NULL;
+    char *config_file;
+    FILE *f = NULL;
+    char *line;
+
+    config_file = get_config_file(id);
+    if (!config_file) {
+        return NULL;
+    }
+
+    f = fopen(config_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "cannot open %s", config_file);
+        flb_free(config_file);
+        return NULL;
+    }
+
+    while ((line = read_line(f))) {
+        char *index = strstr(line, DOCKER_NAME_ARG);
+        if (index != NULL) {
+            container_name = extract_name(line, index);
+            flb_free(line);
+            break;
+        }
+        flb_free(line);
+    }
+
+    flb_free(config_file);
+    fclose(f);
+
+    return container_name;
+}
+
+/* Returns CPU metrics for docker id. */
+static cpu_snapshot *get_docker_cpu_snapshot(struct flb_docker *ctx, char *id)
+{
+    int c;
+    unsigned long cpu_used = 0;
+    char *usage_file;
+    cpu_snapshot *snapshot = NULL;
+    FILE *f;
+
+    usage_file = get_cpu_used_file(id);
+    if (!usage_file) {
+        return NULL;
+    }
+
+    f = fopen(usage_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "error gathering CPU data from %s",
+                      usage_file);
+        flb_free(usage_file);
+        return NULL;
+    }
+
+    c = fscanf(f, "%ld", &cpu_used);
+    if (c != 1) {
+        flb_plg_error(ctx->ins, "error scanning used CPU value from %s",
+                      usage_file);
+        flb_free(usage_file);
+        fclose(f);
+        return NULL;
+    }
+
+    snapshot = (cpu_snapshot *) flb_calloc(1, sizeof(cpu_snapshot));
+    if (!snapshot) {
+        flb_errno();
+        fclose(f);
+        flb_free(usage_file);
+        return NULL;
+    }
+
+    snapshot->used = cpu_used;
+
+    flb_free(usage_file);
+    fclose(f);
+    return snapshot;
+}
+
+/* Returns memory used by a docker in bytes. */
+static uint64_t get_docker_mem_used(struct flb_docker *ctx, char *id)
+{
+    int c;
+    char *usage_file = NULL;
+    uint64_t mem_used = 0;
+    FILE *f;
+
+    usage_file = get_mem_used_file(id);
+    if (!usage_file) {
+        return 0;
+    }
+
+    f = fopen(usage_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "cannot retrieve memory used from %s",
+                      usage_file);
+        flb_free(usage_file);
+        return 0;
+    }
+
+    c = fscanf(f, "%ld", &mem_used);
+    if (c != 1) {
+        flb_plg_error(ctx->ins, "cannot scan memory usage value from %s",
+                      usage_file);
+        flb_free(usage_file);
+        fclose(f);
+        return 0;
+    }
+
+    flb_free(usage_file);
+    fclose(f);
+
+    return mem_used;
+}
+
+/* Returns memory limit for a docker in bytes. */
+static uint64_t get_docker_mem_limit(char *id)
+{
+    char *limit_file = get_mem_limit_file(id);
+    uint64_t mem_limit = 0;
+    FILE *f;
+
+    if (!limit_file) {
+        return 0;
+    }
+
+    f = fopen(limit_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_free(limit_file);
+        return 0;
+    }
+
+    fscanf(f, "%ld", &mem_limit);
+    flb_free(limit_file);
+    fclose(f);
+
+    return mem_limit;
+}
+
+/* Get memory snapshot for a docker id. */
+static mem_snapshot *get_docker_mem_snapshot(struct flb_docker *ctx, char *id)
+{
+    mem_snapshot *snapshot = NULL;
+
+    snapshot = (mem_snapshot *) flb_calloc(1, sizeof(mem_snapshot));
+    if (!snapshot) {
+        flb_errno();
+        return NULL;
+    }
+
+    snapshot->used = get_docker_mem_used(ctx, id);
+    snapshot->limit = get_docker_mem_limit(id);
+
+    return snapshot;
+}
+
+int in_docker_set_cgroup_api_v1(struct cgroup_api *api)
+{
+    api->cgroup_version = 1;
+    api->get_active_docker_ids = get_active_dockers;
+    api->get_container_name = get_container_name;
+    api->get_cpu_snapshot = get_docker_cpu_snapshot;
+    api->get_mem_snapshot = get_docker_mem_snapshot;
+
+    return 0;
+}

--- a/plugins/in_docker/docker.h
+++ b/plugins/in_docker/docker.h
@@ -31,11 +31,11 @@
 #define OS_DIR_TYPE           4
 #define DOCKER_LONG_ID_LEN    64
 #define DOCKER_SHORT_ID_LEN   12
-#define DOCKER_CGROUP_MEM_DIR "/sys/fs/cgroup/memory/docker"
-#define DOCKER_CGROUP_CPU_DIR "/sys/fs/cgroup/cpu/docker"
-#define DOCKER_MEM_LIMIT_FILE "memory.limit_in_bytes"
-#define DOCKER_MEM_USAGE_FILE "memory.usage_in_bytes"
-#define DOCKER_CPU_USAGE_FILE "cpuacct.usage"
+#define DOCKER_CGROUP_V1_MEM_DIR "/sys/fs/cgroup/memory/docker"
+#define DOCKER_CGROUP_V1_CPU_DIR "/sys/fs/cgroup/cpu/docker"
+#define DOCKER_CGROUP_V1_MEM_LIMIT_FILE "memory.limit_in_bytes"
+#define DOCKER_CGROUP_V1_MEM_USAGE_FILE "memory.usage_in_bytes"
+#define DOCKER_CGROUP_V1_CPU_USAGE_FILE "cpuacct.usage"
 #define DOCKER_LIB_ROOT       "/var/lib/docker/containers"
 #define DOCKER_CONFIG_JSON    "config.v2.json"
 #define DOCKER_NAME_ARG       "\"Name\""
@@ -64,6 +64,17 @@ typedef struct docker_snapshot {
     struct mk_list _head;
 } docker_snapshot;
 
+struct flb_docker;
+
+struct cgroup_api {
+    int cgroup_version;
+    struct mk_list* (*get_active_docker_ids) ();
+    char*           (*get_container_name) (struct flb_docker *, char *);
+    cpu_snapshot*   (*get_cpu_snapshot)   (struct flb_docker *, char *);
+    mem_snapshot*   (*get_mem_snapshot)   (struct flb_docker *, char *);
+};
+int in_docker_set_cgroup_api_v1(struct cgroup_api *api);
+
 /* Docker Input configuration & context */
 struct flb_docker {
     int coll_fd;                /* collector id/fd */
@@ -71,10 +82,11 @@ struct flb_docker {
     int interval_nsec;          /* interval collection time (Nanosecond) */
     struct mk_list *whitelist;  /* dockers to monitor */
     struct mk_list *blacklist;  /* dockers to exclude */
+    struct cgroup_api cgroup_api;
     struct flb_input_instance *ins;
 };
 
 int in_docker_collect(struct flb_input_instance *i_ins,
                       struct flb_config *config, void *in_context);
-
+docker_info *in_docker_init_docker_info(char *id);
 #endif


### PR DESCRIPTION
This patch is to prepare to support cgroup v2.
NOTE: in_docker doesn't support cgroup v2 with this patch. Just preparing and no functionality changes.

- Add `struct cgroup_api` to support cgroup function pointers
- Move cgroup v1 depended API to cgroup_v1.c
- Rename defines to clarify for cgroup v1

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

I tested on Ubuntu 20.04 which using cgroup v1.

```
# valgrind --leak-check=full bin/fluent-bit -i docker -o stdout
==89408== Memcheck, a memory error detector
==89408== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==89408== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==89408== Command: bin/fluent-bit -i docker -o stdout
==89408== 
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/01/09 11:14:40] [ info] [fluent bit] version=2.0.9, commit=14f8871d69, pid=89408
[2023/01/09 11:14:40] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/01/09 11:14:40] [ info] [cmetrics] version=0.5.8
[2023/01/09 11:14:40] [ info] [ctraces ] version=0.2.7
[2023/01/09 11:14:40] [ info] [input:docker:docker.0] initializing
[2023/01/09 11:14:40] [ info] [input:docker:docker.0] storage_strategy='memory' (memory only)
[2023/01/09 11:14:40] [ info] [output:stdout:stdout.0] worker #0 started
[2023/01/09 11:14:40] [ info] [sp] stream processor started
[0] docker.0: [1673230480.999810319, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>829830127, "mem_used"=>5894144, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1673230482.166036212, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>937004521, "mem_used"=>6078464, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1673230482.904621318, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>1103054851, "mem_used"=>6078464, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1673230483.911950519, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>1160862396, "mem_used"=>5894144, "mem_limit"=>9223372036854771712}]
[0] docker.0: [1673230484.969345201, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>1160862396, "mem_used"=>5894144, "mem_limit"=>9223372036854771712}]
^C[2023/01/09 11:14:46] [engine] caught signal (SIGINT)
[2023/01/09 11:14:46] [ warn] [engine] service will shutdown in max 5 seconds
[0] docker.0: [1673230485.903953907, {"id"=>"bbfaa9a60de0", "name"=>"exciting_cohen", "cpu_used"=>1160862396, "mem_used"=>5894144, "mem_limit"=>9223372036854771712}]
[2023/01/09 11:14:46] [ info] [input] pausing docker.0
[2023/01/09 11:14:46] [ info] [engine] service has stopped (0 pending tasks)
[2023/01/09 11:14:46] [ info] [input] pausing docker.0
[2023/01/09 11:14:46] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/01/09 11:14:46] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==89408== 
==89408== HEAP SUMMARY:
==89408==     in use at exit: 0 bytes in 0 blocks
==89408==   total heap usage: 1,711 allocs, 1,711 frees, 2,592,661 bytes allocated
==89408== 
==89408== All heap blocks were freed -- no leaks are possible
==89408== 
==89408== For lists of detected and suppressed errors, rerun with: -s
==89408== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
