### PR TITLE
workflows: update for new packages server workflow

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -414,6 +414,35 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: true
 
+  staging-release-upload-cosign-key:
+    name: Upload Cosign public key for verification
+    needs:
+      - staging-release-images-sign
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2
+      
+      - name: Get public key and add to S3 bucket
+        # Only run if we have a key defined
+        if: ${{ env.COSIGN_PRIVATE_KEY }}
+        # The key needs to cope with newlines
+        run: |
+          echo -e "${COSIGN_PRIVATE_KEY}" > /tmp/my_cosign.key
+          cosign public-key --key /tmp/my_cosign.key > ./cosign.pub
+          rm -f /tmp/my_cosign.key
+          cat ./cosign.pub
+          aws s3 cp ./cosign.pub "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/cosign.pub" --no-progress
+        shell: bash
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.cosign_private_key }}
+          COSIGN_PASSWORD: ${{ secrets.cosign_private_key_password }} # optional
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+
   # This will require a sign off so can be done after packages are updated to confirm
   # Until S3 bucket is set up as release will only test what is in the server from a prior release.
   # TODO: https://github.com/fluent/fluent-bit/issues/5098

--- a/packaging/server/publish-manual.sh
+++ b/packaging/server/publish-manual.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eux
+
+SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
+WINDOWS_SOURCE_DIR=${WINDOWS_SOURCE_DIR:-ignore}
+VERSION=${VERSION:-$1}
+MAJOR_VERSION=${MAJOR_VERSION:-}
+
+if [[ -z "$VERSION" ]]; then
+    echo "Missing VERSION value"
+    exit 1
+fi
+
+if [[ -z "$MAJOR_VERSION" ]]; then
+    MAJOR_VERSION=${VERSION%.*}
+fi
+
+echo "Publishing source and Windows packages for $VERSION (major: $MAJOR_VERSION)"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Missing source directory: $SOURCE_DIR"
+fi
+
+RELEASES_DIR=${RELEASES_DIR:-/var/www/releases.fluentbit.io}
+if [[ -d "$RELEASES_DIR/releases" ]]; then
+    echo "Using legacy releases linkage"
+    RELEASES_DIR="$RELEASES_DIR/releases" 
+fi
+
+# Handle the JSON schema by copying in the new versions (if they exist).
+echo "Updating JSON schema"
+find "$SOURCE_DIR/" -iname "fluent-bit-schema*$VERSION*.json" -exec cp -vf "{}" "$RELEASES_DIR/$MAJOR_VERSION/" \;
+
+# Intended for AppVeyor usage
+if [[ -d "$WINDOWS_SOURCE_DIR" ]]; then
+    echo "Using overridden Windows directory: $WINDOWS_SOURCE_DIR"
+    pushd "$WINDOWS_SOURCE_DIR"
+        for i in *.exe
+        do
+            echo "$i"
+            sha256sum "$i" > "$i".sha256
+        done
+
+        for i in *.zip
+        do
+            echo "$i"
+            sha256sum "$i" > "$i".sha256
+        done
+    popd
+    # shellcheck disable=SC2086
+    cp -vf "$WINDOWS_SOURCE_DIR"/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+else
+    # Windows - we do want word splitting and ensure some files exist
+    if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
+        echo "Copying Windows artefacts"
+        # shellcheck disable=SC2086
+        cp -vf "$SOURCE_DIR"/windows/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+    else
+        echo "Missing Windows builds"
+    fi
+fi
+
+# Source - we do want word splitting and ensure some files exist
+if compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
+    echo "Copying source artefacts"
+    # shellcheck disable=SC2086
+    cp -vf "$SOURCE_DIR"/source/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+else
+    echo "Missing source artefacts"
+fi


### PR DESCRIPTION
Addresses #6665 by adding the Cosign key and updating the manual steps we will do on the new server.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
