### PR TITLE
packaging: more changes for switchover

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -392,8 +392,8 @@ jobs:
           rm -f /tmp/my_cosign.key
         shell: bash
         env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.cosign_private_key }}
-          COSIGN_PASSWORD: ${{ secrets.cosign_private_key_password }} # optional
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }} # optional
 
       - name: Cosign keyless signing using Rektor public transparency log
         # This step uses the identity token to provision an ephemeral certificate
@@ -437,8 +437,8 @@ jobs:
           aws s3 cp ./cosign.pub "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/cosign.pub" --no-progress
         shell: bash
         env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.cosign_private_key }}
-          COSIGN_PASSWORD: ${{ secrets.cosign_private_key_password }} # optional
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }} # optional
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -204,7 +204,7 @@ jobs:
   # simpler plus tests the whole pipeline.
   # The assumption being we would remove this step eventually anyway.
   staging-release-packages-server:
-    if: inputs.legacy_server
+    if: gitub.event.inputs.legacy-server
     name: fluentbit.io - upload packages
     # Not required if using the staging bucket
     needs: staging-release-packages-s3

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -164,14 +164,24 @@ jobs:
         AWS_REGION: "us-east-1"
       shell: bash
 
-    - name: Download components from staging and setup
-      run:
+    - name: Get Appveyor binaries
+      continue-on-error: true
+      run: |
+        ./packaging/appveyor-download.sh
+      shell: bash
+      env:
+        TAG: v${{ github.event.inputs.version }}
+        OUTPUT_DIR: appveyor
+
+    - name: Move components from staging and setup
+      run: |
         ./packaging/update-source-packages.sh
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: "us-east-1"
         SOURCE_DIR: staging
+        WINDOWS_SOURCE_DIR: appveyor
         TARGET_DIR: release
         VERSION: ${{ github.event.inputs.version }}
         MAJOR_VERSION: ${{ needs.staging-release-version-check.outputs.major-version }}

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -19,6 +19,11 @@ on:
         description: Optionally override the image name to push to on Github Container Registry.
         default: fluent/fluent-bit
         required: false
+      legacy-server:
+        type: boolean
+        description: Indicate with a 'yes' that we are using the legacy packages server
+        default: true
+        required: true
 
 # We do not want a new staging build to run whilst we are releasing the current staging build.
 # We also do not want multiples to run for the same version.
@@ -71,7 +76,7 @@ jobs:
   # 5. Upload to release bucket.
   # Note we could resign all packages as well potentially if we wanted to update the key.
   staging-release-packages-s3:
-    name: S3 - create release
+    name: S3 - update packages bucket
     runs-on: ubuntu-22.04 # no createrepo on Ubuntu 20.04
     environment: release
     needs: staging-release-version-check
@@ -136,6 +141,51 @@ jobs:
         AWS_REGION: "us-east-1"
       shell: bash
 
+  staging-release-source-s3:
+    name: S3 - update source bucket
+    runs-on: ubuntu-latest
+    environment: release
+    needs: 
+      - staging-release-version-check
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Sync packages from buckets on S3
+      run: |
+        mkdir -p release staging 
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_RELEASE_SOURCES }}" release/ --no-progress
+        aws s3 sync "s3://${{ secrets.AWS_S3_BUCKET_STAGING }}/source/" staging/ --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: "us-east-1"
+      shell: bash
+
+    - name: Download components from staging and setup
+      run:
+        ./packaging/update-source-packages.sh
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: "us-east-1"
+        SOURCE_DIR: staging
+        TARGET_DIR: release
+        VERSION: ${{ github.event.inputs.version }}
+        MAJOR_VERSION: ${{ needs.staging-release-version-check.outputs.major-version }}
+      shell: bash
+      
+    - name: Sync to bucket on S3
+      run: |
+        aws s3 sync release/ "s3://${{ secrets.AWS_S3_BUCKET_RELEASE_SOURCES }}" --delete --follow-symlinks --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: "us-east-1"
+      shell: bash
+
   # We have two options here:
   # 1. Sync the signed packages direct from the release bucket.
   # 2. Sync the staged packages from the staging bucket, resign on the server.
@@ -144,6 +194,7 @@ jobs:
   # simpler plus tests the whole pipeline.
   # The assumption being we would remove this step eventually anyway.
   staging-release-packages-server:
+    if: inputs.legacy_server
     name: fluentbit.io - upload packages
     # Not required if using the staging bucket
     needs: staging-release-packages-s3

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -414,6 +414,35 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: true
 
+  staging-release-upload-cosign-key:
+    name: Upload Cosign public key for verification
+    needs:
+      - staging-release-images-sign
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2
+      
+      - name: Get public key and add to S3 bucket
+        # Only run if we have a key defined
+        if: ${{ env.COSIGN_PRIVATE_KEY }}
+        # The key needs to cope with newlines
+        run: |
+          echo -e "${COSIGN_PRIVATE_KEY}" > /tmp/my_cosign.key
+          cosign public-key --key /tmp/my_cosign.key > ./cosign.pub
+          rm -f /tmp/my_cosign.key
+          cat ./cosign.pub
+          aws s3 cp ./cosign.pub "s3://${{ secrets.AWS_S3_BUCKET_RELEASE }}/cosign.pub" --no-progress
+        shell: bash
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.cosign_private_key }}
+          COSIGN_PASSWORD: ${{ secrets.cosign_private_key_password }} # optional
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+
   # This will require a sign off so can be done after packages are updated to confirm
   # Until S3 bucket is set up as release will only test what is in the server from a prior release.
   # TODO: https://github.com/fluent/fluent-bit/issues/5098

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -204,7 +204,7 @@ jobs:
   # simpler plus tests the whole pipeline.
   # The assumption being we would remove this step eventually anyway.
   staging-release-packages-server:
-    if: gitub.event.inputs.legacy-server
+    if: github.event.inputs.legacy-server
     name: fluentbit.io - upload packages
     # Not required if using the staging bucket
     needs: staging-release-packages-s3

--- a/packaging/appveyor-download.sh
+++ b/packaging/appveyor-download.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -eux
+
+TAG=${TAG:?}
+URL=${URL:-https://ci.appveyor.com/api}
+PROJECT_SLUG=${PROJECT_SLUG:-fluent/fluent-bit-2e87g}
+OUTPUT_DIR=${OUTPUT_DIR:-$PWD}
+
+# Search the history for the version built using our tag
+APPVEYOR_BUILD_VERSION=$(curl -sSfL --header "Content-type: application/json" "$URL/projects/$PROJECT_SLUG/history?recordsNumber=100"|jq -cr ".builds[]|select(.isTag)|select(.tag == \"$TAG\").version")
+APPVEYOR_BUILD_INFO=$(curl -sSfL --header "Content-type: application/json" "$URL/projects/$PROJECT_SLUG/build/${APPVEYOR_BUILD_VERSION}")
+
+JOB_ID1=$(echo "$APPVEYOR_BUILD_INFO"| jq -cr .build.jobs[0].jobId)
+JOB_ID2=$(echo "$APPVEYOR_BUILD_INFO"| jq -cr .build.jobs[1].jobId)
+
+ARTIFACTS_JOB1=$(curl -sSfL --header "Content-type: application/json" "$URL/buildjobs/${JOB_ID1}/artifacts")
+ARTIFACTS_JOB2=$(curl -sSfL --header "Content-type: application/json" "$URL/buildjobs/${JOB_ID2}/artifacts")
+
+JOB1_FILE1=$(echo "$ARTIFACTS_JOB1"| jq -cr .[0].fileName)
+JOB1_FILE2=$(echo "$ARTIFACTS_JOB1"| jq -cr .[1].fileName)
+JOB2_FILE1=$(echo "$ARTIFACTS_JOB2"| jq -cr .[0].fileName)
+JOB2_FILE2=$(echo "$ARTIFACTS_JOB2"| jq -cr .[1].fileName)
+
+mkdir -p "$OUTPUT_DIR"
+pushd "$OUTPUT_DIR"
+curl -sSfLO "$URL/buildjobs/${JOB_ID1}/artifacts/$JOB1_FILE1"
+curl -sSfLO "$URL/buildjobs/${JOB_ID1}/artifacts/$JOB1_FILE2"
+curl -sSfLO "$URL/buildjobs/${JOB_ID2}/artifacts/$JOB2_FILE1"
+curl -sSfLO "$URL/buildjobs/${JOB_ID2}/artifacts/$JOB2_FILE2"
+popd

--- a/packaging/appveyor-download.sh
+++ b/packaging/appveyor-download.sh
@@ -10,17 +10,20 @@ OUTPUT_DIR=${OUTPUT_DIR:-$PWD}
 APPVEYOR_BUILD_VERSION=$(curl -sSfL --header "Content-type: application/json" "$URL/projects/$PROJECT_SLUG/history?recordsNumber=100"|jq -cr ".builds[]|select(.isTag)|select(.tag == \"$TAG\").version")
 APPVEYOR_BUILD_INFO=$(curl -sSfL --header "Content-type: application/json" "$URL/projects/$PROJECT_SLUG/build/${APPVEYOR_BUILD_VERSION}")
 
+# Assuming two jobs - Win32/64
 JOB_ID1=$(echo "$APPVEYOR_BUILD_INFO"| jq -cr .build.jobs[0].jobId)
 JOB_ID2=$(echo "$APPVEYOR_BUILD_INFO"| jq -cr .build.jobs[1].jobId)
 
 ARTIFACTS_JOB1=$(curl -sSfL --header "Content-type: application/json" "$URL/buildjobs/${JOB_ID1}/artifacts")
 ARTIFACTS_JOB2=$(curl -sSfL --header "Content-type: application/json" "$URL/buildjobs/${JOB_ID2}/artifacts")
 
+# Assuming two artefacts per job - fluent-bit (no td-agent-bit) zip/exe
 JOB1_FILE1=$(echo "$ARTIFACTS_JOB1"| jq -cr .[0].fileName)
 JOB1_FILE2=$(echo "$ARTIFACTS_JOB1"| jq -cr .[1].fileName)
 JOB2_FILE1=$(echo "$ARTIFACTS_JOB2"| jq -cr .[0].fileName)
 JOB2_FILE2=$(echo "$ARTIFACTS_JOB2"| jq -cr .[1].fileName)
 
+# Download all the artefacts now
 mkdir -p "$OUTPUT_DIR"
 pushd "$OUTPUT_DIR"
 curl -sSfLO "$URL/buildjobs/${JOB_ID1}/artifacts/$JOB1_FILE1"

--- a/packaging/server/publish-manual.sh
+++ b/packaging/server/publish-manual.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eux
+
+SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
+WINDOWS_SOURCE_DIR=${WINDOWS_SOURCE_DIR:-ignore}
+VERSION=${VERSION:-$1}
+MAJOR_VERSION=${MAJOR_VERSION:-}
+
+if [[ -z "$VERSION" ]]; then
+    echo "Missing VERSION value"
+    exit 1
+fi
+
+if [[ -z "$MAJOR_VERSION" ]]; then
+    MAJOR_VERSION=${VERSION%.*}
+fi
+
+echo "Publishing source and Windows packages for $VERSION (major: $MAJOR_VERSION)"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Missing source directory: $SOURCE_DIR"
+fi
+
+RELEASES_DIR=${RELEASES_DIR:-/var/www/releases.fluentbit.io}
+if [[ -d "$RELEASES_DIR/releases" ]]; then
+    echo "Using legacy releases linkage"
+    RELEASES_DIR="$RELEASES_DIR/releases" 
+fi
+
+# Handle the JSON schema by copying in the new versions (if they exist).
+echo "Updating JSON schema"
+find "$SOURCE_DIR/" -iname "fluent-bit-schema*$VERSION*.json" -exec cp -vf "{}" "$RELEASES_DIR/$MAJOR_VERSION/" \;
+
+# Intended for AppVeyor usage
+if [[ -d "$WINDOWS_SOURCE_DIR" ]]; then
+    echo "Using overridden Windows directory: $WINDOWS_SOURCE_DIR"
+    pushd "$WINDOWS_SOURCE_DIR"
+        for i in *.exe
+        do
+            echo "$i"
+            sha256sum "$i" > "$i".sha256
+        done
+
+        for i in *.zip
+        do
+            echo "$i"
+            sha256sum "$i" > "$i".sha256
+        done
+    popd
+    # shellcheck disable=SC2086
+    cp -vf "$WINDOWS_SOURCE_DIR"/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+else
+    # Windows - we do want word splitting and ensure some files exist
+    if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
+        echo "Copying Windows artefacts"
+        # shellcheck disable=SC2086
+        cp -vf "$SOURCE_DIR"/windows/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+    else
+        echo "Missing Windows builds"
+    fi
+fi
+
+# Source - we do want word splitting and ensure some files exist
+if compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
+    echo "Copying source artefacts"
+    # shellcheck disable=SC2086
+    cp -vf "$SOURCE_DIR"/source/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+else
+    echo "Missing source artefacts"
+fi

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -43,7 +43,7 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "apt-get update && apt-get install -y sudo gpg curl;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+        sh -c "apt-get update && apt-get install -y gpg curl;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
     check_version "$LOG_FILE"
     rm -f "$LOG_FILE"
 done
@@ -56,7 +56,7 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         "$IMAGE" \
-        sh -c "yum install -y sudo;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+        sh -c "curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
     check_version "$LOG_FILE"
     rm -f "$LOG_FILE"
 done

--- a/packaging/update-source-packages.sh
+++ b/packaging/update-source-packages.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -eux
 
-SOURCE_DIR=${SOURCE_DIR:-$HOME/apt}
 WINDOWS_SOURCE_DIR=${WINDOWS_SOURCE_DIR:-ignore}
 VERSION=${VERSION:-$1}
 MAJOR_VERSION=${MAJOR_VERSION:-}
+SOURCE_DIR=${SOURCE_DIR:?}
+TARGET_DIR=${TARGET_DIR:?}
 
 if [[ -z "$VERSION" ]]; then
     echo "Missing VERSION value"
@@ -15,21 +16,19 @@ if [[ -z "$MAJOR_VERSION" ]]; then
     MAJOR_VERSION=${VERSION%.*}
 fi
 
-echo "Publishing source and Windows packages for $VERSION (major: $MAJOR_VERSION)"
-
 if [[ ! -d "$SOURCE_DIR" ]]; then
     echo "Missing source directory: $SOURCE_DIR"
+    exit 1
 fi
 
-RELEASES_DIR=${RELEASES_DIR:-/var/www/releases.fluentbit.io}
-if [[ -d "$RELEASES_DIR/releases" ]]; then
-    echo "Using legacy releases linkage"
-    RELEASES_DIR="$RELEASES_DIR/releases" 
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Missing target directory: $TARGET_DIR"
+    exit 1
 fi
 
 # Handle the JSON schema by copying in the new versions (if they exist).
 echo "Updating JSON schema"
-find "$SOURCE_DIR/" -iname "fluent-bit-schema*$VERSION*.json" -exec cp -vf "{}" "$RELEASES_DIR/$MAJOR_VERSION/" \;
+find "$SOURCE_DIR/" -iname "fluent-bit-schema*$VERSION*.json" -exec cp -vf "{}" "$TARGET_DIR/$MAJOR_VERSION/" \;
 
 # Intended for AppVeyor usage
 if [[ -d "$WINDOWS_SOURCE_DIR" ]]; then
@@ -48,13 +47,13 @@ if [[ -d "$WINDOWS_SOURCE_DIR" ]]; then
         done
     popd
     # shellcheck disable=SC2086
-    cp -vf "$WINDOWS_SOURCE_DIR"/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+    cp -vf "$WINDOWS_SOURCE_DIR"/*$VERSION* "$TARGET_DIR/$MAJOR_VERSION/"
 else
     # Windows - we do want word splitting and ensure some files exist
     if compgen -G "$SOURCE_DIR/windows/*$VERSION*" > /dev/null; then
         echo "Copying Windows artefacts"
         # shellcheck disable=SC2086
-        cp -vf "$SOURCE_DIR"/windows/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+        cp -vf "$SOURCE_DIR"/windows/*$VERSION* "$TARGET_DIR/$MAJOR_VERSION/"
     else
         echo "Missing Windows builds"
     fi
@@ -64,7 +63,7 @@ fi
 if compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
     echo "Copying source artefacts"
     # shellcheck disable=SC2086
-    cp -vf "$SOURCE_DIR"/source/*$VERSION* "$RELEASES_DIR/$MAJOR_VERSION/"
+    cp -vf "$SOURCE_DIR"/source/*$VERSION* "$TARGET_DIR/$MAJOR_VERSION/"
 else
     echo "Missing source artefacts"
 fi


### PR DESCRIPTION
Various updates to handle the new server approach with a bucket.
Added automated AppVeyor download as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
