### PR TITLE
install: Base RELEASE_KEY default off RELEASE_URL which will have a default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Provided primarily to simplify testing for staging, etc.
 RELEASE_URL=${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}
-RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-$FLUENT_BIT_PACKAGES_URL/fluentbit.key}
+RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-$RELEASE_URL/fluentbit.key}
 
 echo "================================"
 echo " Fluent Bit Installation Script "


### PR DESCRIPTION
If FLUENT_BIT_PACKAGES_URL is not provided, RELEASE_KEY will fail validation

`error: /fluentbit.key: import read failed(2).`

* Base default value for RELEASE_KEY off RELEASE_URL which has a default. FLUENT_BIT_PACKAGES_URL is optional

Fixes #6679 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
