### PR TITLE
added variable for "FLUENT_BIT_PACKAGES_URL"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -e
 
 # Provided primarily to simplify testing for staging, etc.
 RELEASE_URL=${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}
+FLUENT_BIT_PACKAGES_URL=${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}
 RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-$FLUENT_BIT_PACKAGES_URL/fluentbit.key}
 
 echo "================================"


### PR DESCRIPTION
The current script is failing installation of fluent-bit as its not able to find the RELEASE_KEY in the script. So added variable for "FLUENT_BIT_PACKAGES_URL" as $FLUENT_BIT_PACKAGES_URL value is not being put into the RELEASE_KEY resulting it to be rendered as "/fluentbit.key" whereas it should be "https://packages.fluentbit.io/fluentbit.key". 

If not this, then we should revert the release key to "RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" this.

Resolves #6679 

Signed-off-by: dextercrypt <36314791+dextercrypt@users.noreply.github.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
