### PR TITLE
install: resolve various niggles

### DIFF
--- a/.github/workflows/pr-install-script.yaml
+++ b/.github/workflows/pr-install-script.yaml
@@ -1,0 +1,29 @@
+name: Test install script for all targets
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'packaging/test-release-packages.sh'
+      - 'install.sh'
+
+  workflow_dispatch:
+jobs:
+  test-install-script:
+    name: Run install tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Fluent Bit code
+        uses: actions/checkout@v3
+
+      - name: Run install tests
+        run: |
+          ./packaging/test-release-packages.sh
+        shell: bash
+        env:
+          INSTALL_SCRIPT: ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ else
 fi
 
 SUDO=sudo
-if [[ $(id -u) -eq 0 ]]; then
+if [ "$(id -u)" -eq 0 ]; then
     SUDO=''
 else
     # Clear any previous sudo permission

--- a/install.sh
+++ b/install.sh
@@ -48,15 +48,12 @@ cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 name = Fluent Bit
 # Legacy server style
 baseurl = $RELEASE_URL/amazonlinux/VERSION_ARCH_SUBSTR
-# IaC server style
-baseurl = $RELEASE_URL/amazonlinux/VERSION_SUBSTR
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
 enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
-sed -i 's|VERSION_SUBSTR|\$releasever/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
 yum -y install fluent-bit
 SCRIPT
@@ -69,15 +66,12 @@ cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 name = Fluent Bit
 # Legacy server style
 baseurl = $RELEASE_URL/centos/VERSION_ARCH_SUBSTR
-# IaC server style
-baseurl = $RELEASE_URL/centos/VERSION_SUBSTR
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
 enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
-sed -i 's|VERSION_SUBSTR|\$releasever/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
 yum -y install fluent-bit
 SCRIPT

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -11,6 +11,14 @@ fi
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 INSTALL_SCRIPT=${INSTALL_SCRIPT:-https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh}
 
+INSTALL_CMD="curl $INSTALL_SCRIPT|sh"
+EXTRA_MOUNTS=""
+if [[ -f "$INSTALL_SCRIPT" ]]; then
+    ABSOLUTE_PATH=$(realpath "$INSTALL_SCRIPT")
+    EXTRA_MOUNTS="-v $ABSOLUTE_PATH:/install.sh:ro"
+    INSTALL_CMD="/install.sh"
+fi
+
 # Optional check for specific version
 VERSION_TO_CHECK_FOR=${VERSION_TO_CHECK_FOR:-}
 function check_version() {
@@ -35,28 +43,34 @@ YUM_TARGETS=("centos:7"
     "amazonlinux:2"
     "amazonlinux:2022")
 
-for IMAGE in "${APT_TARGETS[@]}"
-do
-    echo "Testing $IMAGE"
-    LOG_FILE=$(mktemp)
-    $CONTAINER_RUNTIME run --rm -t \
-        -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
-        -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
-        "$IMAGE" \
-        sh -c "apt-get update && apt-get install -y gpg curl;curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
-    check_version "$LOG_FILE"
-    rm -f "$LOG_FILE"
-done
-
 for IMAGE in "${YUM_TARGETS[@]}"
 do
     echo "Testing $IMAGE"
     LOG_FILE=$(mktemp)
+    # We do want word splitting for EXTRA_MOUNTS
+    # shellcheck disable=SC2086
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
+        $EXTRA_MOUNTS \
         "$IMAGE" \
-        sh -c "curl $INSTALL_SCRIPT | sh && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+        sh -c "$INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+    check_version "$LOG_FILE"
+    rm -f "$LOG_FILE"
+done
+
+for IMAGE in "${APT_TARGETS[@]}"
+do
+    echo "Testing $IMAGE"
+    LOG_FILE=$(mktemp)
+    # We do want word splitting for EXTRA_MOUNTS
+    # shellcheck disable=SC2086
+    $CONTAINER_RUNTIME run --rm -t \
+        -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
+        -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
+        $EXTRA_MOUNTS \
+        "$IMAGE" \
+        sh -c "apt-get update && apt-get install -y gpg curl;$INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
     check_version "$LOG_FILE"
     rm -f "$LOG_FILE"
 done


### PR DESCRIPTION
Resolves various problems introduced on some platforms and also introduces a PR workflow to verify it.

- Incorrect usage of bash specific test syntax
- Multiple base urls fail if not available for Yum targets

```shell
$ ./packaging/test-release-packages.sh
...
================================
 Fluent Bit Installation Script 
================================
This script requires superuser access to install packages.
You will be prompted for your password by sudo.
sh: 31: [[: not found
sh: 35: sudo: not found
...

===============================
 Fluent Bit Installation Script 
================================
This script requires superuser access to install packages.
You will be prompted for your password by sudo.
[fluent-bit]
name = Fluent Bit
# Legacy server style
baseurl = https://packages.fluentbit.io/centos/$releasever/$basearch/
# IaC server style
baseurl = https://packages.fluentbit.io/centos/$releasever/
gpgcheck=1
repo_gpgcheck=1
gpgkey=https://packages.fluentbit.io/fluentbit.key
enabled=1
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
 * base: mirrors.coreix.net
 * extras: mirror.quickhost.uk
 * updates: mirror.as29550.net
base                                                     | 3.6 kB     00:00     
extras                                                   | 2.9 kB     00:00     
https://packages.fluentbit.io/centos/7/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

```shell
$ export INSTALL_SCRIPT=https://raw.githubusercontent.com/fluent/fluent-bit/b39bdc3187bddd8d1ece5d946c043a0a6d14ae9b/install.sh
$ ./packaging/test-release-packages.sh
...
```
Everything is fine.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
