### PR TITLE
workflows: update package testing to use same approach as builds

### DIFF
--- a/.github/workflows/pr-package-tests.yaml
+++ b/.github/workflows/pr-package-tests.yaml
@@ -6,24 +6,69 @@ on:
       - opened
       - reopened
       - synchronize
+    branches:
+      - master
 
 jobs:
-  pr-package-test-build:
-    name: PR - packages build
+  pr-package-test-build-generate-matrix:
+    name: PR - packages build matrix
     # This is a long test to run so only on-demand for certain PRs
     if: contains(github.event.pull_request.labels.*.name, 'ok-package-test')
+    needs:
+      - pr-package-test-build-get-meta
     runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+    environment: pr
+    permissions:
+      contents: read
     steps:
-      - name: Checkout code
+      - name: Checkout repository, always latest for action
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      # Set up the list of target to build so we can pass the JSON to the reusable job
+      - uses: ./.github/actions/generate-package-build-matrix
+        id: set-matrix
+        with:
+          ref: master
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+  pr-package-test-build-packages:
+    name: PR - packages build Linux
+    needs:
+      - pr-package-test-build-get-meta
+      - pr-package-test-build-generate-matrix
+    uses: ./.github/workflows/call-build-linux-packages.yaml
+    with:
+      version: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      ref: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      build_matrix: ${{ needs.pr-package-test-build-generate-matrix.outputs.build-matrix }}
+      environment: pr
+      unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run build of all locally
-        run: ./local-build-all.sh
-        shell: bash
-        working-directory: packaging
+  pr-package-test-build-windows-package:
+    name: PR - packages build Windows
+    needs:
+      - pr-package-test-build-get-meta
+    uses: ./.github/workflows/call-build-windows.yaml
+    with:
+      version: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      ref: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      environment: pr
+      unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  pr-package-test-build-macos-package:
+    name: PR - packages build MacOS
+    needs:
+      - pr-package-test-build-get-meta
+    uses: ./.github/workflows/call-build-macos.yaml
+    with:
+      version: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      ref: ${{ needs.pr-package-test-build-get-meta.outputs.branch }}
+      environment: pr-package-test
+      unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Updated workflow to run package builds exactly as they normally are rather than via the local script which times out.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

See checks here.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
