### PR TITLE
install: specify version to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,9 @@ set -e
 RELEASE_URL=${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}
 RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-$RELEASE_URL/fluentbit.key}
 
+# Optionally specify the version to install
+RELEASE_VERSION=${FLUENT_BIT_RELEASE_VERSION:-}
+
 echo "================================"
 echo " Fluent Bit Installation Script "
 echo "================================"
@@ -35,6 +38,14 @@ else
     sudo -k
 fi
 
+# Set up version pinning
+APT_VERSION=''
+YUM_VERSION=''
+if [[ -n "${RELEASE_VERSION}" ]]; then
+    APT_VERSION="=$RELEASE_VERSION"
+    YUM_VERSION="-$RELEASE_VERSION"
+fi
+
 # Now set up repos and install dependent on OS, version, etc.
 # Will require sudo
 case ${OS} in
@@ -55,7 +66,7 @@ enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
-yum -y install fluent-bit
+yum -y install fluent-bit$YUM_VERSION
 SCRIPT
     ;;
     centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
@@ -73,7 +84,7 @@ enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
-yum -y install fluent-bit
+yum -y install fluent-bit$YUM_VERSION
 SCRIPT
     ;;
     ubuntu|debian)
@@ -88,7 +99,7 @@ deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] $RELEASE_URL/${OS}/${C
 EOF
 cat /etc/apt/sources.list.d/fluent-bit.list
 apt-get -y update
-apt-get -y install fluent-bit
+apt-get -y install fluent-bit$APT_VERSION
 SCRIPT
     ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ RELEASE_KEY=${FLUENT_BIT_PACKAGES_KEY:-$RELEASE_URL/fluentbit.key}
 
 # Optionally specify the version to install
 RELEASE_VERSION=${FLUENT_BIT_RELEASE_VERSION:-}
+# Optionally prefix install commands, e.g. use 'echo ' here to prevent installation after repo set up.
+INSTALL_CMD_PREFIX=${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}
 
 echo "================================"
 echo " Fluent Bit Installation Script "
@@ -66,7 +68,7 @@ enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
-yum -y install fluent-bit$YUM_VERSION
+$INSTALL_CMD_PREFIX yum -y install fluent-bit$YUM_VERSION
 SCRIPT
     ;;
     centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
@@ -84,7 +86,7 @@ enabled=1
 EOF
 sed -i 's|VERSION_ARCH_SUBSTR|\$releasever/\$basearch/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
-yum -y install fluent-bit$YUM_VERSION
+$INSTALL_CMD_PREFIX yum -y install fluent-bit$YUM_VERSION
 SCRIPT
     ;;
     ubuntu|debian)
@@ -99,7 +101,7 @@ deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] $RELEASE_URL/${OS}/${C
 EOF
 cat /etc/apt/sources.list.d/fluent-bit.list
 apt-get -y update
-apt-get -y install fluent-bit$APT_VERSION
+$INSTALL_CMD_PREFIX apt-get -y install fluent-bit$APT_VERSION
 SCRIPT
     ;;
     *)

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -52,6 +52,8 @@ do
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
+        -e FLUENT_BIT_RELEASE_VERSION="${FLUENT_BIT_RELEASE_VERSION:-}" \
+        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}" \
         $EXTRA_MOUNTS \
         "$IMAGE" \
         sh -c "$INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
@@ -68,6 +70,8 @@ do
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
+        -e FLUENT_BIT_RELEASE_VERSION="${FLUENT_BIT_RELEASE_VERSION:-}" \
+        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}" \
         $EXTRA_MOUNTS \
         "$IMAGE" \
         sh -c "apt-get update && apt-get install -y gpg curl;$INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"


### PR DESCRIPTION
Resolves #6692 by adding options to specify version to install as well as disabling install entirely (or adding some other prefix command).

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Verified we can install version 2.0.6 (as indicated in the original issue):
```shell
$ export INSTALL=https://raw.githubusercontent.com/fluent/fluent-bit/1db6cc0de8ce8f79a0188b6769e5178c3e1d1297/install.sh
$ export VERSION_TO_CHECK_FOR=2.0.6
$ export FLUENT_BIT_RELEASE_VERSION=2.0.6
./packaging/test-release-packages.sh
...
Setting up fluent-bit (2.0.6) ...
Processing triggers for libc-bin (2.31-13+deb11u5) ...

Installation completed. Happy Logging!

Fluent Bit v2.0.6
...
```

Also verified it installs the latest (2.0.8) when not set.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
