### PR TITLE
event_decoder: add flb_event_decoder

### DIFF
--- a/include/fluent-bit/flb_event_decoder.h
+++ b/include/fluent-bit/flb_event_decoder.h
@@ -1,0 +1,94 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_EVENT_DECODER_H
+#define FLB_EVENT_DECODER_H
+
+#include <msgpack.h>
+#include <mpack/mpack.h>
+
+
+#include <fluent-bit/flb_time.h>
+#include <msgpack.h>
+
+typedef enum _flb_event_lib_type {
+    FLB_EVENT_LIB_TYPE_MSGPACK = 1, /* msgpack-c */
+    FLB_EVENT_LIB_TYPE_MPACK , /* mpack */
+    FLB_EVENT_LIB_TYPE_UNKNOWN,
+} flb_event_lib_type;
+
+struct flb_fluent_record {
+    flb_event_lib_type type;
+    union {
+        msgpack_object *msgpack;
+        mpack_reader_t *mpack;
+    }reader;
+};
+
+typedef enum _flb_event_fmt {
+    FLB_EVENT_FMT_TIME_RECORD = 1, /* [TIMESTAMP, {RECORD}] */
+    FLB_EVENT_FMT_UNKNOWN,
+}flb_event_fmt;
+
+/* 
+ * A struct to represent fluent event.
+ * https://docs.fluentbit.io/manual/concepts/key-concepts#event-or-record
+ */
+struct flb_event {
+    flb_event_fmt format;
+    struct flb_time timestamp;
+    struct flb_fluent_record record;
+    /* TODO: metadata ?*/
+};
+
+static inline void flb_event_set_default(struct flb_event *event)
+{
+    event->format = FLB_EVENT_FMT_UNKNOWN;
+    event->record.type = FLB_EVENT_LIB_TYPE_UNKNOWN;
+}
+
+
+struct flb_event_decoder_msgpack {
+    msgpack_unpacked upk;
+};
+
+struct flb_event_decoder_mpack {
+    mpack_reader_t reader;
+};
+
+struct flb_event_decoder {
+    flb_event_lib_type type;
+    size_t offset;
+    void *raw_data;
+    size_t raw_data_size;
+    union {
+        struct flb_event_decoder_msgpack msgpack;
+        struct flb_event_decoder_mpack mpack;
+    }decoder;
+};
+
+/* decoder option */
+#define FLB_EVENT_DECODER_OPT_USE_MPACK (1<<1)
+
+struct flb_event_decoder *flb_event_decoder_create(void *input_buf, size_t input_size, int decoder_opt);
+int flb_event_decoder_destroy(struct flb_event_decoder *dec);
+int flb_event_decoder_next(struct flb_event_decoder *dec,
+                                  struct flb_event *event);
+int flb_event_decoder_reuse(struct flb_event_decoder *dec, void *input_buf, size_t input_size);
+#endif

--- a/include/fluent-bit/flb_fluent_event.h
+++ b/include/fluent-bit/flb_fluent_event.h
@@ -1,0 +1,62 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FLUENT_EVENT_H
+#define FLB_FLUENT_EVENT_H
+
+#include <fluent-bit/flb_time.h>
+#include <msgpack.h>
+
+typedef enum _flb_fluent_event_lib_type {
+    FLB_FLUENT_EVENT_LIB_TYPE_MSGPACK = 1, /* msgpack-c */
+    FLB_FLUENT_EVENT_LIB_TYPE_MPACK , /* mpack */
+    FLB_FLUENT_EVENT_LIB_TYPE_UNKNOWN,
+} flb_fluent_event_lib_type;
+
+struct flb_fluent_record {
+    flb_fluent_event_lib_type type;
+    union {
+        msgpack_object *msgpack;
+        mpack_reader_t *mpack;
+    }reader;
+};
+
+typedef enum _flb_fluent_event_fmt {
+    FLB_FLUENT_EVENT_FMT_TIME_RECORD = 1, /* [TIMESTAMP, {RECORD}] */
+    FLB_FLUENT_EVENT_FMT_UNKNOWN,
+}flb_fluent_event_fmt;
+
+/* 
+ * A struct to represent fluent event.
+ * https://docs.fluentbit.io/manual/concepts/key-concepts#event-or-record
+ */
+struct flb_fluent_event {
+    flb_fluent_event_fmt format;
+    struct flb_time timestamp;
+    struct flb_fluent_record record;
+    /* TODO: metadata ?*/
+};
+
+static inline void flb_fluent_event_set_default(struct flb_fluent_event *event)
+{
+    event->format = FLB_FLUENT_EVENT_FMT_UNKNOWN;
+    event->record.type = FLB_FLUENT_EVENT_LIB_TYPE_UNKNOWN;
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ set(src
   flb_typecast.c
   flb_event.c
   flb_base64.c
+  flb_event_decoder.c
   flb_ring_buffer.c
   )
 

--- a/src/flb_event_decoder.c
+++ b/src/flb_event_decoder.c
@@ -270,10 +270,8 @@ static int event_decoder_next_mpack(struct flb_event_decoder *dec,
     int i_ret;
 
     event->record.reader.mpack = NULL;
-    if (((void*)dec->decoder.mpack.reader.data - dec->raw_data) >= dec->raw_data_size) {
+    if (((char*)dec->decoder.mpack.reader.data - (char*)dec->raw_data) >= dec->raw_data_size) {
         /* no data */
-        printf("reader=%p raw_data=%p diff=%ld\n", dec->decoder.mpack.reader.data, dec->raw_data,
-               (void*)dec->decoder.mpack.reader.data - dec->raw_data);
         return -1;
     }
 

--- a/src/flb_event_decoder.c
+++ b/src/flb_event_decoder.c
@@ -1,0 +1,351 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_event_decoder.h>
+#include <msgpack.h>
+
+static int event_decoder_destroy_mpack(struct flb_event_decoder *dec)
+{
+    mpack_reader_destroy(&(dec->decoder.mpack.reader));
+    return 0;
+}
+static int event_decoder_destroy_msgpack(struct flb_event_decoder *dec)
+{
+    msgpack_unpacked_destroy(&(dec->decoder.msgpack.upk));
+    return 0;
+}
+
+int flb_event_decoder_clear(struct flb_event_decoder *dec)
+{
+    int ret = 0;
+
+    if (dec == NULL) {
+        flb_error("%s: dec is NULL", __FUNCTION__);
+        return -1;
+    }
+
+    switch (dec->type) {
+    case FLB_EVENT_LIB_TYPE_MSGPACK:
+        ret = event_decoder_destroy_msgpack(dec);
+        break;
+
+    case FLB_EVENT_LIB_TYPE_MPACK:
+        ret = event_decoder_destroy_mpack(dec);
+        break;
+
+    default:
+        flb_error("%s: unknown type %d", __FUNCTION__, dec->type);
+        return -1;
+    }
+    return ret;
+}
+
+int flb_event_decoder_destroy(struct flb_event_decoder *dec)
+{
+    int ret = 0;
+
+    ret = flb_event_decoder_clear(dec);
+    flb_free(dec);
+
+    return ret;
+}
+
+static int event_decoder_create_mpack(struct flb_event_decoder *dec)
+{
+    mpack_reader_init_data(&(dec->decoder.mpack.reader), dec->raw_data, dec->raw_data_size);
+    dec->offset = 0;
+    return 0;
+}
+
+static int event_decoder_create_msgpack(struct flb_event_decoder *dec)
+{
+    msgpack_unpacked_init(&(dec->decoder.msgpack.upk));
+    dec->offset = 0;
+    return 0;
+}
+
+static int event_decoder_init(struct flb_event_decoder *dec, void *input_buf, size_t input_size)
+{
+    int ret;
+
+    dec->raw_data = input_buf;
+    dec->raw_data_size = input_size;
+
+    switch (dec->type) {
+    case FLB_EVENT_LIB_TYPE_MSGPACK:
+        ret = event_decoder_create_msgpack(dec);
+        break;
+
+    case FLB_EVENT_LIB_TYPE_MPACK:
+        ret = event_decoder_create_mpack(dec);
+        break;
+
+    default:
+        flb_error("%s: unknown type %d", __FUNCTION__, dec->type);
+        return -1;
+    }
+
+    return ret;
+}
+
+struct flb_event_decoder *flb_event_decoder_create(void *input_buf, size_t input_size, int decoder_opt)
+{
+    int ret;
+    struct flb_event_decoder *dec = NULL;
+
+    dec = flb_calloc(1, sizeof(struct flb_event_decoder));
+    if (dec == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    /* check decoder option */
+    dec->type = FLB_EVENT_LIB_TYPE_MSGPACK;
+    if (decoder_opt & FLB_EVENT_DECODER_OPT_USE_MPACK) {
+        dec->type = FLB_EVENT_LIB_TYPE_MPACK;
+    }
+
+    ret = event_decoder_init(dec, input_buf, input_size);
+    if (ret < 0) {
+        flb_event_decoder_destroy(dec);
+        return NULL;
+    }
+
+    return dec;
+}
+
+static int time_pop_from_mpack(struct flb_event *event, mpack_reader_t *reader)
+{
+    int ret = -1;
+
+    switch(event->format) {
+    case FLB_EVENT_FMT_TIME_RECORD:
+        ret = flb_time_pop_from_mpack(&(event->timestamp), reader);
+        break;
+    default:
+        flb_error("format=%d is not supported", event->format);
+    }
+    return ret;
+}
+
+static int time_pop_from_msgpack(struct flb_event *event, msgpack_unpacked *upk)
+{
+    int ret = -1;
+    msgpack_object *obj;
+
+    switch(event->format) {
+    case FLB_EVENT_FMT_TIME_RECORD:
+        ret = flb_time_pop_from_msgpack(&(event->timestamp), upk, &obj);
+        event->record.reader.msgpack = obj;
+        break;
+    default:
+        flb_error("format=%d is not supported", event->format);
+    }
+    return ret;
+}
+
+static int time_pop(struct flb_event_decoder *dec, struct flb_event *event)
+{
+    switch (dec->type) {
+    case FLB_EVENT_LIB_TYPE_MSGPACK:
+        return time_pop_from_msgpack(event, &(dec->decoder.msgpack.upk));
+    case FLB_EVENT_LIB_TYPE_MPACK:
+        return time_pop_from_mpack(event, &(dec->decoder.mpack.reader));
+    default:
+        flb_error("%s: unknown type %d", __FUNCTION__, dec->type);
+    }
+    return FLB_FALSE;
+}
+
+static int is_event_format_time_record_mpack(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+    const char *start_addr = reader->data;
+    int ret = FLB_FALSE;
+
+    tag = mpack_read_tag(reader);
+
+    /* check if format is [TIMESTAMP, {RECORD}] */
+    if (mpack_tag_type(&tag) != mpack_type_array) {
+        flb_trace("%s: object is not array", __FUNCTION__);
+        goto is_event_format_time_record_mpack_end;
+    }
+    if (mpack_tag_array_count(&tag) != 2) {
+        flb_trace("%s: array size is not 2", __FUNCTION__);
+        goto is_event_format_time_record_mpack_end;
+    }
+
+    /* TODO: is second element of array a map */
+
+    ret = FLB_TRUE;
+ is_event_format_time_record_mpack_end:
+    /* reset pointer */
+    reader->data = start_addr;
+    return ret;
+}
+
+static int is_event_format_time_record_msgpack(msgpack_object *obj)
+{
+    /* check if format is [TIMESTAMP, {RECORD}] */
+    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+        flb_trace("%s: object is not array", __FUNCTION__);
+        return FLB_FALSE;
+    }
+    if (obj->via.array.size != 2) {
+        flb_trace("%s: array size is not 2", __FUNCTION__);
+        return FLB_FALSE;
+    }
+    if (obj->via.array.ptr[1].type != MSGPACK_OBJECT_MAP) {
+        flb_trace("%s: object is not map", __FUNCTION__);
+        return FLB_FALSE;
+    }
+    return FLB_TRUE;
+}
+
+static int is_event_format_time_record(struct flb_event_decoder *dec, struct flb_event *event)
+{
+    switch (dec->type) {
+    case FLB_EVENT_LIB_TYPE_MSGPACK:
+        return is_event_format_time_record_msgpack(&(dec->decoder.msgpack.upk.data));
+    case FLB_EVENT_LIB_TYPE_MPACK:
+        return is_event_format_time_record_mpack(&(dec->decoder.mpack.reader));
+    default:
+        flb_error("%s: unknown type %d", __FUNCTION__, dec->type);
+    }
+    return FLB_FALSE;
+}
+
+static int decode_event_format(struct flb_event_decoder *dec, struct flb_event *event)
+{
+    /* check if format is [TIMESTAMP, {RECORD}] */
+    if (is_event_format_time_record(dec, event)) {
+        event->format = FLB_EVENT_FMT_TIME_RECORD;
+        return 0;
+    }
+
+    event->format = FLB_EVENT_FMT_UNKNOWN;
+    return -1;
+}
+
+static int event_decode(struct flb_event_decoder *dec, struct flb_event *event)
+{
+    int ret;
+
+    flb_event_set_default(event);
+
+    ret = decode_event_format(dec, event);
+    if (ret < 0) {
+        flb_error("%s: Fluent event format is invalid", __FUNCTION__);
+        return -1;
+    }
+
+    ret = time_pop(dec, event);
+    if (ret < 0) {
+        flb_error("%s: failed to get timestamp from event", __FUNCTION__);
+    }
+    event->record.type = FLB_EVENT_LIB_TYPE_MSGPACK;
+
+    return 0;
+}
+
+static int event_decoder_next_mpack(struct flb_event_decoder *dec,
+                                    struct flb_event *event)
+{
+    int i_ret;
+
+    event->record.reader.mpack = NULL;
+    if (((void*)dec->decoder.mpack.reader.data - dec->raw_data) >= dec->raw_data_size) {
+        /* no data */
+        printf("reader=%p raw_data=%p diff=%ld\n", dec->decoder.mpack.reader.data, dec->raw_data,
+               (void*)dec->decoder.mpack.reader.data - dec->raw_data);
+        return -1;
+    }
+
+    i_ret = event_decode(dec, event);
+    event->record.reader.mpack = &(dec->decoder.mpack.reader);
+
+    return i_ret;
+}
+
+static int event_decoder_next_msgpack(struct flb_event_decoder *dec,
+                                      struct flb_event *event)
+{
+    msgpack_unpack_return m_ret;
+    int i_ret;
+
+    m_ret = msgpack_unpack_next(&(dec->decoder.msgpack.upk), dec->raw_data, dec->raw_data_size,
+                              &(dec->offset));
+    switch (m_ret) {
+    case MSGPACK_UNPACK_SUCCESS:
+        i_ret = event_decode(dec, event);
+        break;
+    case MSGPACK_UNPACK_EXTRA_BYTES:
+        flb_trace("%s:MSGPACK_UNPACK_EXTRA_BYTES", __FUNCTION__);
+        return 1;
+    case MSGPACK_UNPACK_CONTINUE:
+        flb_trace("%s:MSGPACK_UNPACK_CONTINUE", __FUNCTION__);
+        return 1;
+    case MSGPACK_UNPACK_PARSE_ERROR:
+        flb_error("%s:MSGPACK_UNPACK_PARSE_ERROR", __FUNCTION__);
+        return -1;
+    case MSGPACK_UNPACK_NOMEM_ERROR:
+        flb_error("%s:MSGPACK_UNPACK_NOMEM_ERROR", __FUNCTION__);
+        return -1;
+    }
+
+    return i_ret;
+}
+
+int flb_event_decoder_next(struct flb_event_decoder *dec,
+                           struct flb_event *event)
+{
+    int ret = -1;
+
+    if (dec == NULL || event == NULL) {
+        flb_error("%s: input and/or NULL. dec=%p event=%p", __FUNCTION__, dec, event);
+        return -1;
+    }
+
+    switch (dec->type) {
+    case FLB_EVENT_LIB_TYPE_MSGPACK:
+        ret = event_decoder_next_msgpack(dec, event);
+        break;
+
+    case FLB_EVENT_LIB_TYPE_MPACK:
+        ret = event_decoder_next_mpack(dec, event);
+        break;
+
+    default:
+        flb_error("%s: unknown type %d",__FUNCTION__, dec->type);
+        return -1;
+    }
+
+    return ret;
+}
+
+int flb_event_decoder_reuse(struct flb_event_decoder *dec, void *input_buf, size_t input_size)
+{
+    int ret;
+
+    ret = flb_event_decoder_clear(dec);
+    if (ret < 0) {
+        return -1;
+    }
+    return event_decoder_init(dec, input_buf, input_size);
+}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -23,6 +23,7 @@ set(UNIT_TESTS_FILES
   mp.c
   input_chunk.c
   flb_time.c
+  flb_event_decoder.c
   file.c
   csv.c
   multiline.c

--- a/tests/internal/flb_event_decoder.c
+++ b/tests/internal/flb_event_decoder.c
@@ -1,0 +1,360 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2023 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_event_decoder.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_internal.h"
+#include <string.h>
+#include <msgpack.h>
+
+static int create_test_msgpack(struct flb_time *tm, msgpack_packer *mp_pck, msgpack_sbuffer *mp_sbuf, int val1, int val2)
+{
+    tm->tm.tv_sec  = 123456;
+    tm->tm.tv_nsec = 987654;
+
+    msgpack_pack_array(mp_pck, 2);
+    flb_time_append_to_msgpack(tm, mp_pck, FLB_TIME_ETFMT_V1_FIXEXT);
+    msgpack_pack_map(mp_pck, 2);
+
+    msgpack_pack_str(mp_pck, 4);
+    msgpack_pack_str_body(mp_pck, "key1", 4);
+    msgpack_pack_int64(mp_pck, val1);
+
+    msgpack_pack_str(mp_pck, 4);
+    msgpack_pack_str_body(mp_pck, "key2", 4);
+    msgpack_pack_int64(mp_pck, val2);
+
+    return 0;
+}
+
+static int compare_char_key_int_val(msgpack_object_kv kv, char *key, size_t key_size,int val)
+{
+
+    if (!TEST_CHECK(kv.key.type == MSGPACK_OBJECT_STR)) {
+        TEST_MSG("type error. type=%d", kv.key.type);
+        return -1;
+    }
+    if(!TEST_CHECK(strncmp(kv.key.via.str.ptr, key, key_size) == 0)) {
+        TEST_MSG("str error got=%.*s expect=%s", 
+                 kv.key.via.str.size, kv.key.via.str.ptr, key);
+        return -1;
+    }
+    if (!TEST_CHECK(kv.val.type == MSGPACK_OBJECT_POSITIVE_INTEGER)) {
+        TEST_MSG("type error. type=%d", kv.val.type);
+        return -1;
+    }
+    if(!TEST_CHECK(kv.val.via.i64 == val)) {
+        TEST_MSG("str error got=%"PRId64 " expect=%d", 
+                 kv.val.via.i64, val);
+        return -1;
+    }
+
+    return 0;
+}
+
+void event_decoder_msgpack()
+{
+    int ret;
+    struct flb_time tm;
+    struct flb_event event;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct flb_event_decoder *dec = NULL;
+
+    msgpack_object *obj = NULL;
+
+    /* encode msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    create_test_msgpack(&tm, &mp_pck, &mp_sbuf, 123, 456);
+
+    /* unpack */
+    dec = flb_event_decoder_create(mp_sbuf.data, mp_sbuf.size,0);
+    if (!TEST_CHECK(dec != NULL)) {
+        TEST_MSG("flb_event_decoder_create failed");
+        goto event_decode_msgpack_end;
+    }
+
+    ret = flb_event_decoder_next(dec, &event);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_event_decoder_next failed");
+        goto event_decode_msgpack_end;
+    }
+
+    if (!TEST_CHECK(event.timestamp.tm.tv_sec == tm.tm.tv_sec && event.timestamp.tm.tv_nsec == tm.tm.tv_nsec)) {
+        TEST_MSG("timestamp error. got=%ld.%ld expect=%ld.%ld",
+                 event.timestamp.tm.tv_sec,
+                 event.timestamp.tm.tv_nsec , tm.tm.tv_sec, tm.tm.tv_nsec);
+        goto event_decode_msgpack_end;
+    }
+
+    /* check record */
+    obj = event.record.reader.msgpack;
+    ret = compare_char_key_int_val(obj->via.map.ptr[0], "key1", 4, 123);
+    if (ret < 0) {
+        TEST_MSG("key1 error");
+        goto event_decode_msgpack_end;
+    }
+    ret = compare_char_key_int_val(obj->via.map.ptr[1], "key2", 4, 456);
+    if (ret < 0) {
+        TEST_MSG("key2 error");
+        goto event_decode_msgpack_end;
+    }
+
+ event_decode_msgpack_end:
+    if (dec != NULL) {
+        flb_event_decoder_destroy(dec);
+    }
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
+void event_decoder_next_msgpack()
+{
+    int ret;
+    struct flb_time tm;
+    struct flb_event event;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct flb_event_decoder *dec = NULL;
+    int val1 = 123;
+    int val2 = 456;
+    int val3 = 234;
+    int val4 = 567;
+
+    msgpack_object *obj = NULL;
+
+    /* encode msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    create_test_msgpack(&tm, &mp_pck, &mp_sbuf, val1, val2);
+    create_test_msgpack(&tm, &mp_pck, &mp_sbuf, val3, val4);
+
+    /* unpack */
+    dec = flb_event_decoder_create(mp_sbuf.data, mp_sbuf.size,0);
+    if (!TEST_CHECK(dec != NULL)) {
+        TEST_MSG("flb_event_decoder_create failed");
+        goto event_decode_next_msgpack_end;
+    }
+
+    ret = flb_event_decoder_next(dec, &event);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_event_decoder_next failed");
+        goto event_decode_next_msgpack_end;
+    }
+
+    if (!TEST_CHECK(event.timestamp.tm.tv_sec == tm.tm.tv_sec && event.timestamp.tm.tv_nsec == tm.tm.tv_nsec)) {
+        TEST_MSG("timestamp error. got=%ld.%ld expect=%ld.%ld",
+                 event.timestamp.tm.tv_sec,
+                 event.timestamp.tm.tv_nsec , tm.tm.tv_sec, tm.tm.tv_nsec);
+        goto event_decode_next_msgpack_end;
+    }
+
+    /* check record */
+    obj = event.record.reader.msgpack;
+    ret = compare_char_key_int_val(obj->via.map.ptr[0], "key1", 4, val1);
+    if (ret < 0) {
+        TEST_MSG("1. key1 error");
+        goto event_decode_next_msgpack_end;
+    }
+    ret = compare_char_key_int_val(obj->via.map.ptr[1], "key2", 4, val2);
+    if (ret < 0) {
+        TEST_MSG("1. key2 error");
+        goto event_decode_next_msgpack_end;
+    }
+
+    ret = flb_event_decoder_next(dec, &event);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_event_decoder_next failed");
+        goto event_decode_next_msgpack_end;
+    }
+
+    if (!TEST_CHECK(event.timestamp.tm.tv_sec == tm.tm.tv_sec && event.timestamp.tm.tv_nsec == tm.tm.tv_nsec)) {
+        TEST_MSG("timestamp error. got=%ld.%ld expect=%ld.%ld",
+                 event.timestamp.tm.tv_sec,
+                 event.timestamp.tm.tv_nsec , tm.tm.tv_sec, tm.tm.tv_nsec);
+        goto event_decode_next_msgpack_end;
+    }
+
+    /* check record */
+    obj = event.record.reader.msgpack;
+    ret = compare_char_key_int_val(obj->via.map.ptr[0], "key1", 4, val3);
+    if (ret < 0) {
+        TEST_MSG("2. key1 error");
+        goto event_decode_next_msgpack_end;
+    }
+    ret = compare_char_key_int_val(obj->via.map.ptr[1], "key2", 4, val4);
+    if (ret < 0) {
+        TEST_MSG("2. key2 error");
+        goto event_decode_next_msgpack_end;
+    }
+
+ event_decode_next_msgpack_end:
+    if (dec != NULL) {
+        flb_event_decoder_destroy(dec);
+    }
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
+void event_decoder_mpack()
+{
+    int ret;
+    struct flb_time tm;
+    struct flb_event event;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct flb_event_decoder *dec = NULL;
+
+    mpack_reader_t *reader;
+    mpack_tag_t tag;
+
+    /* encode msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    create_test_msgpack(&tm, &mp_pck, &mp_sbuf, 123, 456);
+
+    /* unpack */
+    dec = flb_event_decoder_create(mp_sbuf.data, mp_sbuf.size, FLB_EVENT_DECODER_OPT_USE_MPACK);
+    if (!TEST_CHECK(dec != NULL)) {
+        TEST_MSG("flb_event_decoder_create failed");
+        goto event_decode_mpack_end;
+    }
+
+    ret = flb_event_decoder_next(dec, &event);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_event_decoder_next failed. ret=%d", ret);
+        goto event_decode_mpack_end;
+    }
+
+    if (!TEST_CHECK(event.timestamp.tm.tv_sec == tm.tm.tv_sec && event.timestamp.tm.tv_nsec == tm.tm.tv_nsec)) {
+        TEST_MSG("timestamp error. got=%ld.%ld expect=%ld.%ld",
+                 event.timestamp.tm.tv_sec,
+                 event.timestamp.tm.tv_nsec , tm.tm.tv_sec, tm.tm.tv_nsec);
+        goto event_decode_mpack_end;
+    }
+
+    reader = event.record.reader.mpack;
+    if (!TEST_CHECK(reader != NULL)) {
+        TEST_MSG("reader is NULL");
+        goto event_decode_mpack_end;
+    }
+
+    tag = mpack_read_tag(reader);
+    if (!TEST_CHECK(mpack_tag_type(&tag) == mpack_type_map)) {
+        TEST_MSG("type error. It should be map. type=%d", mpack_tag_type(&tag));
+        goto event_decode_mpack_end;
+    }
+
+    /* TODO: check kv */
+
+ event_decode_mpack_end:
+    if (dec != NULL) {
+        flb_event_decoder_destroy(dec);
+    }
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
+void reuse_decoder_msgpack()
+{
+    int ret;
+    int i;
+    int val1;
+    int val2;
+    struct flb_time tm;
+    struct flb_event event;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    struct flb_event_decoder *dec = NULL;
+
+    msgpack_object *obj = NULL;
+
+    /* encode msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    create_test_msgpack(&tm, &mp_pck, &mp_sbuf, 123, 456);
+
+    /* unpack */
+    dec = flb_event_decoder_create(mp_sbuf.data, mp_sbuf.size,0);
+    if (!TEST_CHECK(dec != NULL)) {
+        TEST_MSG("flb_event_decoder_create failed");
+        goto reuse_decoder_msgpack_end;
+    }
+
+    for (i=0; i<10; i++) {
+        /* encode msgpack */
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        val1 = 123 + 10 * i;
+        val2 = 456 + 10 * i;
+
+        msgpack_sbuffer_init(&mp_sbuf);
+        msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+        create_test_msgpack(&tm, &mp_pck, &mp_sbuf, val1, val2);
+
+        ret = flb_event_decoder_reuse(dec, mp_sbuf.data, mp_sbuf.size);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("flb_event_decoder_reuse failed");
+            goto reuse_decoder_msgpack_end;
+        }
+
+        ret = flb_event_decoder_next(dec, &event);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("flb_event_decoder_next failed");
+            goto reuse_decoder_msgpack_end;
+        }
+
+        if (!TEST_CHECK(event.timestamp.tm.tv_sec == tm.tm.tv_sec && event.timestamp.tm.tv_nsec == tm.tm.tv_nsec)) {
+            TEST_MSG("timestamp error. got=%ld.%ld expect=%ld.%ld",
+                     event.timestamp.tm.tv_sec,
+                     event.timestamp.tm.tv_nsec , tm.tm.tv_sec, tm.tm.tv_nsec);
+            goto reuse_decoder_msgpack_end;
+        }
+
+        /* check record */
+        obj = event.record.reader.msgpack;
+        ret = compare_char_key_int_val(obj->via.map.ptr[0], "key1", 4, val1);
+        if (ret < 0) {
+            TEST_MSG("key1 error");
+            goto reuse_decoder_msgpack_end;
+        }
+        ret = compare_char_key_int_val(obj->via.map.ptr[1], "key2", 4, val2);
+        if (ret < 0) {
+            TEST_MSG("key2 error");
+            goto reuse_decoder_msgpack_end;
+        }
+
+    }
+ reuse_decoder_msgpack_end:
+    if (dec != NULL) {
+        flb_event_decoder_destroy(dec);
+    }
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
+TEST_LIST = {
+    {"event_decoder_msgpack", event_decoder_msgpack},
+    {"event_decoder_next_msgpack", event_decoder_next_msgpack},
+    {"event_decoder_mpack", event_decoder_mpack},
+    {"reuse_decoder_msgpack", reuse_decoder_msgpack},
+    {NULL, NULL}
+};


### PR DESCRIPTION
Currently, every filter/output plugin implement following routine processing.
This patch is to add a common way to decode fluent-bit event.

It also support changing event format like https://github.com/fluent/fluent-bit/issues/6666#issue-1527777877.
This decoder is to hide decoding way from filter/output plugins.

This patch also changes out_stdout as an example using decoder.

## Routine processing
1. Check if incoming msgpack data is an array
2. Pop timestamp from the array. Timestamp should be integer or ext format.
3. Decode second element as a record.


## Example
```c
    struct flb_event_decoder *dec = NULL;
    struct flb_event event;

    dec = flb_event_decoder_create((char*)event_chunk->data, event_chunk->size, 0);
    if (dec == NULL) {
        flb_plg_error(ctx->ins, "flb_event_decoder_create failed");
        FLB_OUTPUT_RETURN(FLB_ERROR);
    }

    while (flb_event_decoder_next(dec, &event) == 0) {
        // timestamp is event.timestamp
        // record is event.record.reader.msgpack
    }
        
    flb_event_decoder_destroy(dec);
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o stdout
==58371== Memcheck, a memory error detector
==58371== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==58371== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==58371== Command: bin/fluent-bit -i cpu -o stdout
==58371== 
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/01/16 20:48:26] [ info] [fluent bit] version=2.0.9, commit=ee30c5822f, pid=58371
[2023/01/16 20:48:27] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/01/16 20:48:27] [ info] [cmetrics] version=0.5.8
[2023/01/16 20:48:27] [ info] [ctraces ] version=0.2.7
[2023/01/16 20:48:27] [ info] [input:cpu:cpu.0] initializing
[2023/01/16 20:48:27] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/01/16 20:48:27] [ info] [output:stdout:stdout.0] worker #0 started
[2023/01/16 20:48:27] [ info] [sp] stream processor started
[0] cpu.0: [1673869708.280814123, {"cpu_p"=>24.000000, "user_p"=>23.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>24.000000, "cpu0.p_user"=>23.000000, "cpu0.p_system"=>1.000000}]
[0] cpu.0: [1673869709.350102779, {"cpu_p"=>22.000000, "user_p"=>20.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>22.000000, "cpu0.p_user"=>20.000000, "cpu0.p_system"=>2.000000}]
[0] cpu.0: [1673869710.236699779, {"cpu_p"=>9.000000, "user_p"=>7.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>9.000000, "cpu0.p_user"=>7.000000, "cpu0.p_system"=>2.000000}]
^C[2023/01/16 20:48:31] [engine] caught signal (SIGINT)
[0] cpu.0: [1673869711.237081320, {"cpu_p"=>12.000000, "user_p"=>11.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>12.000000, "cpu0.p_user"=>11.000000, "cpu0.p_system"=>1.000000}]
[2023/01/16 20:48:31] [ warn] [engine] service will shutdown in max 5 seconds
[2023/01/16 20:48:31] [ info] [input] pausing cpu.0
[2023/01/16 20:48:32] [ info] [engine] service has stopped (0 pending tasks)
[2023/01/16 20:48:32] [ info] [input] pausing cpu.0
[2023/01/16 20:48:32] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/01/16 20:48:32] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==58371== 
==58371== HEAP SUMMARY:
==58371==     in use at exit: 0 bytes in 0 blocks
==58371==   total heap usage: 1,536 allocs, 1,536 frees, 1,583,576 bytes allocated
==58371== 
==58371== All heap blocks were freed -- no leaks are possible
==58371== 
==58371== For lists of detected and suppressed errors, rerun with: -s
==58371== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
