### PR TITLE
network: test: internal: Prevent Infinite loop for no IPv6 environment

### DIFF
--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -63,6 +63,10 @@ static void test_client_server(int is_ipv6)
 
     /* Create client and server sockets */
     fd_client = flb_net_socket_create(family, FLB_TRUE);
+    if (errno == EAFNOSUPPORT) {
+        TEST_MSG("This protocol is not supported in this platform");
+        return;
+    }
     TEST_CHECK(fd_client != -1);
 
     fd_server = flb_net_server(TEST_PORT, host);
@@ -94,6 +98,10 @@ static void test_client_server(int is_ipv6)
 
     /* Event loop */
     while (1) {
+        /* Break immediately for invalid status */
+        if (fd_client == -1 || fd_server == -1) {
+            break;
+        }
         mk_event_wait(evl);
         mk_event_foreach(e_item, evl) {
             if (e_item->type == TEST_EV_CLIENT) {


### PR DESCRIPTION
With no IPv6 supported environment, the current implementation causes infinite loop to wait ev events for network testing. We should prevent such protocol glitching issue on test to prevent stucking test cases.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
