### PR TITLE
tests: internal: fuzzers: make malloc failable

### DIFF
--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -51,10 +51,11 @@
  * Return 1 or 0 based on a probability.
  */
 int flb_malloc_p;
+int flb_malloc_mod;
 
 static inline int flb_fuzz_get_probability(int val) {
   flb_malloc_p += 1;
-  flb_malloc_p = flb_malloc_p % 25000;
+  flb_malloc_p = flb_malloc_p % flb_malloc_mod;
   if (val > flb_malloc_p) {
     return 1;
   }

--- a/tests/internal/fuzzers/base64_fuzzer.c
+++ b/tests/internal/fuzzers/base64_fuzzer.c
@@ -1,11 +1,17 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <fluent-bit/flb_base64.h>
+#include <fluent-bit/flb_mem.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     char out[100];
     size_t olen;
+
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
     flb_base64_encode((unsigned char *) out, 100,
                       &olen, (unsigned char *)data, size);
     flb_base64_decode((unsigned char *) out, 100,

--- a/tests/internal/fuzzers/config_fuzzer.c
+++ b/tests/internal/fuzzers/config_fuzzer.c
@@ -320,7 +320,10 @@ char conf_file[] = "# Parser: no_year\n"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
     /* Limit the size of the config files to 32KB. */
     if (size > 32768) {
         return 0;

--- a/tests/internal/fuzzers/config_map_fuzzer.c
+++ b/tests/internal/fuzzers/config_map_fuzzer.c
@@ -155,7 +155,9 @@ struct flb_config_map *configs[] = {config_map_mult, config_map};
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
     if (size < 40) {
         return 0;
     }

--- a/tests/internal/fuzzers/config_random_fuzzer.c
+++ b/tests/internal/fuzzers/config_random_fuzzer.c
@@ -24,7 +24,9 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
 
     /* Limit the size of the config files to 32KB. */
     if (size > 32768) {

--- a/tests/internal/fuzzers/ctrace_fuzzer.c
+++ b/tests/internal/fuzzers/ctrace_fuzzer.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <fluent-bit/flb_mem.h>
 #include <ctraces/ctraces.h>
 #include <ctraces/ctr_decode_msgpack.h>
 
@@ -7,6 +8,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct ctrace *ctr = NULL;
     size_t msgpack_text_size;
     char *msgpack_text_buffer = NULL;
+
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
 
     ctr_decode_msgpack_create(&ctr, data, size, &off);
     if (ctr != NULL) {

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -15,9 +15,12 @@ struct flb_parser *parser;
 int filter_ffd;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (size < 100) { 
+    if (size < 100) {
         return 0;
     }
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
 
     uint8_t ud = data[0];
     MOVE_INPUT(1);
@@ -85,7 +88,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                             flb_input_chunk_flush(ic, &flushed);
                         }
                     }
-                } 
+                }
             }
             break;
         case 6:
@@ -122,9 +125,12 @@ struct flb_lib_out_cb cb;
 
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
     ctx = flb_create();
-    flb_service_set(ctx, "Flush", "0", "Grace", 
+    flb_service_set(ctx, "Flush", "0", "Grace",
                     "0", "Log_Level", "debug", NULL);
 
     in_ffd = flb_input(ctx, (char *) "lib", NULL);

--- a/tests/internal/fuzzers/filter_stdout_fuzzer.c
+++ b/tests/internal/fuzzers/filter_stdout_fuzzer.c
@@ -27,7 +27,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
+
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
+
     ctx = flb_create();
     flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
     in_ffd = flb_input(ctx, (char *) "lib", NULL);

--- a/tests/internal/fuzzers/flb_json_fuzzer.c
+++ b/tests/internal/fuzzers/flb_json_fuzzer.c
@@ -24,7 +24,10 @@
 int LLVMFuzzerTestOneInput(unsigned char *data, size_t size)
 {
     TIMEOUT_GUARD
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
     if (size < 1) {
         return 0;
     }

--- a/tests/internal/fuzzers/http_fuzzer.c
+++ b/tests/internal/fuzzers/http_fuzzer.c
@@ -16,7 +16,10 @@ extern int fuzz_check_connection(struct flb_http_client *c);
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    /* Set fuzzer-malloc chance of failure */
     flb_malloc_p = 0;
+    flb_malloc_mod = 25000;
+
     struct flb_upstream *u;
     struct flb_connection *u_conn = NULL;
     struct flb_http_client *c;

--- a/tests/internal/fuzzers/msgpack_parse_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_parse_fuzzer.c
@@ -4,7 +4,10 @@
 #include <fluent-bit/flb_pack.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
+
     if (size != 512)
         return 0;
 

--- a/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
+++ b/tests/internal/fuzzers/msgpack_to_gelf_fuzzer.c
@@ -4,6 +4,8 @@
 #include <fluent-bit/flb_pack.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
     if (size != 512)
         return 0;

--- a/tests/internal/fuzzers/multiline_fuzzer.c
+++ b/tests/internal/fuzzers/multiline_fuzzer.c
@@ -133,6 +133,8 @@ void test_multiline_parser(msgpack_object *root2, int rand_val) {
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     TIMEOUT_GUARD
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
     /* Ensure there's enough data */
     if (size < 250) {

--- a/tests/internal/fuzzers/pack_json_state_fuzzer.c
+++ b/tests/internal/fuzzers/pack_json_state_fuzzer.c
@@ -6,6 +6,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     int out_size= 0;
     char *out_buf = NULL;
     struct flb_pack_state state;
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     /* Exit early to avoid timeouts due to excessive size */

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -29,6 +29,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_time out_time;
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     /* json parser */

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -11,6 +11,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     /* logfmt parser */

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -11,6 +11,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     /* ltsvc parser */

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -42,6 +42,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     int time_keep = 0;
     int types_len = 0;
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     if (size < 100) {

--- a/tests/internal/fuzzers/record_ac_fuzzer.c
+++ b/tests/internal/fuzzers/record_ac_fuzzer.c
@@ -22,6 +22,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     size_t off = 0;
     msgpack_object map;
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     if (size < 100) {

--- a/tests/internal/fuzzers/signv4_fuzzer.c
+++ b/tests/internal/fuzzers/signv4_fuzzer.c
@@ -15,11 +15,20 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    if (size < 55) { 
+    if (size < 59) {
         return 0;
     }
 
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
     flb_malloc_p = 0;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
 
     char s3_mode = data[0];
     MOVE_INPUT(1)
@@ -58,37 +67,38 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     http_u = flb_upstream_create(http_config, "127.0.0.1", 8001, 0, NULL);
-    http_u_conn = flb_malloc(sizeof(struct flb_connection));
-    if (http_u_conn == NULL) {
-        flb_free(config);
-        return 0;
-    }
-    http_u_conn->upstream = http_u;
+    if (http_u != NULL) {
+        http_u_conn = flb_malloc(sizeof(struct flb_connection));
+        if (http_u_conn != NULL) {
+            http_u_conn->upstream = http_u;
 
-    http_c = flb_http_client(http_u_conn, method, uri, 
-                 null_terminated, size, "127.0.0.1", 8001, NULL, 0);
-
-    /* Call into the main target flb_signv4_do*/
-    time_t t = 1440938160;
-    char *region = "us-east-1";
-    char *access_key = "AKIDEXAMPLE";
-    char *service = "service";
-    char *secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";	
-    int ret = setenv(AWS_ACCESS_KEY_ID, access_key, 1);
-    if (ret >= 0) {
-        ret = setenv(AWS_SECRET_ACCESS_KEY, secret_key, 1);
-        if (ret >= 0) {
-            flb_sds_t signature = flb_signv4_do(http_c, FLB_TRUE, FLB_FALSE, t,
-                        region, service, s3_mode, provider);
-            if (signature) {
-              flb_sds_destroy(signature);
+            http_c = flb_http_client(http_u_conn, method, uri,
+                         null_terminated, size, "127.0.0.1", 8001, NULL, 0);
+            if (http_c) {
+                /* Call into the main target flb_signv4_do*/
+                time_t t = 1440938160;
+                char *region = "us-east-1";
+                char *access_key = "AKIDEXAMPLE";
+                char *service = "service";
+                char *secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+                int ret = setenv(AWS_ACCESS_KEY_ID, access_key, 1);
+                if (ret >= 0) {
+                    ret = setenv(AWS_SECRET_ACCESS_KEY, secret_key, 1);
+                    if (ret >= 0) {
+                        flb_sds_t signature = flb_signv4_do(http_c, FLB_TRUE, FLB_FALSE,
+                                    t, region, service, s3_mode, provider);
+                        if (signature) {
+                          flb_sds_destroy(signature);
+                        }
+                    }
+                }
+                flb_http_client_destroy(http_c);
             }
         }
+        flb_upstream_destroy(http_u);
     }
 
     /* Cleanup */
-    flb_http_client_destroy(http_c);
-    flb_upstream_destroy(http_u);
     flb_config_exit(http_config);
     flb_aws_provider_destroy(provider);
     flb_free(config);

--- a/tests/internal/fuzzers/strp_fuzzer.c
+++ b/tests/internal/fuzzers/strp_fuzzer.c
@@ -19,6 +19,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     char *fmt = get_null_terminated(size - 30, &data, &size);

--- a/tests/internal/fuzzers/utils_fuzzer.c
+++ b/tests/internal/fuzzers/utils_fuzzer.c
@@ -38,6 +38,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
+    /* Set fuzzer-malloc chance of failure */
+    flb_malloc_mod = 25000;
     flb_malloc_p = 0;
 
     uint64_t ran_hash = *(uint64_t *)data;


### PR DESCRIPTION
This modifies the logic for making flb_malloc failable with more control in the fuzzer for how often it should fail. The signv4 fuzzer sets the necessary flb_malloc_mod param to a value dependent on the fuzz-data, which means the value can be arbitrary. The consequence is that eventually we should have all flb_mallocs reached by the signv4 fuzzer tested for erroneous malloc calls. From local runs, this has led to fixes e.g.:
- https://github.com/fluent/fluent-bit/pull/6654
- https://github.com/fluent/fluent-bit/pull/6652
- https://github.com/fluent/fluent-bit/pull/6653
- https://github.com/fluent/fluent-bit/pull/6655

Eventually, the same change will be applied to all the other fuzzers but am taking them one by one to avoid spamming the oss-fuzz log.

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
