### PR TITLE
input_chunk: use total_chunks_up in overlimit warn message

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1372,7 +1372,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
             in->p->cb_resume(in->context, in->config);
             flb_info("[input] %s resume (storage buf overlimit %d/%d)",
                       in->name,
-                      ((struct flb_storage_input *)in->storage)->cio->total_chunks,
+                      ((struct flb_storage_input *)in->storage)->cio->total_chunks_up,
                       ((struct flb_storage_input *)in->storage)->cio->max_chunks_up);
         }
     }
@@ -1391,7 +1391,7 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i)
     if (flb_input_chunk_is_storage_overlimit(i) == FLB_TRUE) {
         flb_warn("[input] %s paused (storage buf overlimit %d/%d)",
                  i->name,
-                 storage->cio->total_chunks,
+                 storage->cio->total_chunks_up,
                  storage->cio->max_chunks_up);
         flb_input_pause(i);
         i->storage_buf_status = FLB_INPUT_PAUSED;


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

This is a bug related to: https://github.com/fluent/fluent-bit/issues/6663

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
