### PR TITLE
input_chunk: info level instead of debug for chunk removal msg

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -602,9 +602,9 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
             FS_CHUNK_SIZE_DEBUG_MOD(o_ins, old_ic, -old_ic_bytes);
             o_ins->fs_chunks_size -= old_ic_bytes;
 
-            flb_debug("[input chunk] remove route of chunk %s with size %ld bytes to output plugin %s "
-                      "to place the incoming data with size %ld bytes", flb_input_chunk_get_name(old_ic),
-                      old_ic_bytes, o_ins->name, chunk_size);
+            flb_debug("[input chunk] consider route removal for chunk %s with size %zd bytes from input plugin %s to output plugin %s "
+                      "to place the incoming data with size %zu bytes, total_limit_size=%zu", flb_input_chunk_get_name(old_ic),
+                      old_ic_bytes, ic->in->name, o_ins->name, chunk_size, o_ins->total_limit_size);
 
             if (flb_routes_mask_is_empty(old_ic->routes_mask)) {
                 if (old_ic->task != NULL) {
@@ -615,12 +615,18 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
                     if (old_ic->task->users == 0) {
                         flb_debug("[task] drop task_id %d with no active route from input plugin %s",
                                   old_ic->task->id, ic->in->name);
+                        /* end-user friendly message */
+                        flb_info("[input chunk] remove chunk %s with size %zd bytes from input plugin %s to output plugin %s "
+                                 "to place the incoming data with size %zu bytes, total_limit_size=%zu, task_id=%d",
+                                 flb_input_chunk_get_name(old_ic), old_ic_bytes, ic->in->name, o_ins->name, chunk_size, 
+                                 o_ins->total_limit_size, old_ic->task->id);
                         flb_task_destroy(old_ic->task, FLB_TRUE);
                     }
                 }
                 else {
-                    flb_debug("[input chunk] drop chunk %s with no output route from input plugin %s",
-                              flb_input_chunk_get_name(old_ic), ic->in->name);
+                    flb_info("[input chunk] remove chunk %s with size %zd bytes from input plugin %s to output plugin %s "
+                             "to place the incoming data with size %zu bytes, total_limit_size=%zu", flb_input_chunk_get_name(old_ic),
+                             old_ic_bytes, ic->in->name, o_ins->name, chunk_size, o_ins->total_limit_size);
                     flb_input_chunk_destroy(old_ic, FLB_TRUE);
                 }
             }


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
