### PR TITLE
filter_grep: support logical_op property

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -53,6 +53,7 @@ static void delete_rules(struct grep_ctx *ctx)
 
 static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
 {
+    int first_rule = GREP_NO_RULE;
     flb_sds_t tmp;
     struct mk_list *head;
     struct mk_list *split;
@@ -79,11 +80,21 @@ static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
             rule->type = GREP_EXCLUDE;
         }
         else {
-            flb_plg_error(ctx->ins, "unknown rule type '%s'", kv->key);
-            delete_rules(ctx);
+            /* Other property. Skip */
             flb_free(rule);
-            return -1;
+            continue;
         }
+
+        if (ctx->logical_op != GREP_LOGICAL_OP_NOT_SET && first_rule != GREP_NO_RULE) {
+            /* 'AND'/'OR' case */
+            if (first_rule != rule->type) {
+                flb_plg_error(ctx->ins, "Both 'regex' and 'exclude' are set.");
+                delete_rules(ctx);
+                flb_free(rule);
+                return -1;
+            }
+        }
+        first_rule = rule->type;
 
         /* As a value we expect a pair of field name and a regular expression */
         split = flb_utils_split(kv->val, ' ', 1);
@@ -185,6 +196,8 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
                         void *data)
 {
     int ret;
+    size_t len;
+    const char* val;
     struct grep_ctx *ctx;
 
     /* Create context */
@@ -202,6 +215,20 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
     mk_list_init(&ctx->rules);
     ctx->ins = f_ins;
 
+    ctx->logical_op = GREP_LOGICAL_OP_NOT_SET;
+    val = flb_filter_get_property("logical_op", f_ins);
+    if (val != NULL) {
+        len = strlen(val);
+        if (len == 3 && strncasecmp("AND", val, len) == 0) {
+            flb_plg_info(ctx->ins, "AND mode");
+            ctx->logical_op = GREP_LOGICAL_OP_AND;
+        }
+        else if (len == 2 && strncasecmp("OR", val, len) == 0) {
+            flb_plg_info(ctx->ins, "OR mode");
+            ctx->logical_op = GREP_LOGICAL_OP_OR;
+        }
+    }
+
     /* Load rules */
     ret = set_rules(ctx, f_ins);
     if (ret == -1) {
@@ -212,6 +239,42 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
     /* Set our context */
     flb_filter_set_context(f_ins, ctx);
     return 0;
+}
+
+static inline int grep_filter_data_and_or(msgpack_object map, struct grep_ctx *ctx)
+{
+    ssize_t ra_ret;
+    int found = FLB_FALSE;
+    struct mk_list *head;
+    struct grep_rule *rule;
+
+    /* For each rule, validate against map fields */
+    mk_list_foreach(head, &ctx->rules) {
+        found = FLB_FALSE;
+        rule = mk_list_entry(head, struct grep_rule, _head);
+
+        ra_ret = flb_ra_regex_match(rule->ra, map, rule->regex, NULL);
+        if (ra_ret > 0) {
+            found = FLB_TRUE;
+        }
+
+        if (ctx->logical_op == GREP_LOGICAL_OP_OR && found == FLB_TRUE) {
+            /* OR case: One rule is matched. */
+            goto grep_filter_data_and_or_end;
+        }
+        else if (ctx->logical_op == GREP_LOGICAL_OP_AND && found == FLB_FALSE) {
+            /* AND case: One rule is not matched */
+            goto grep_filter_data_and_or_end;
+        }
+    }
+
+ grep_filter_data_and_or_end:
+    if (rule->type == GREP_REGEX) {
+        return found ? GREP_RET_KEEP : GREP_RET_EXCLUDE;
+    }
+
+    /* rule is exclude */
+    return found ? GREP_RET_EXCLUDE : GREP_RET_KEEP;
 }
 
 static int cb_grep_filter(const void *data, size_t bytes,
@@ -225,6 +288,7 @@ static int cb_grep_filter(const void *data, size_t bytes,
     int ret;
     int old_size = 0;
     int new_size = 0;
+    struct grep_ctx *ctx = context;
     msgpack_unpacked result;
     msgpack_object map;
     msgpack_object root;
@@ -252,7 +316,13 @@ static int cb_grep_filter(const void *data, size_t bytes,
         /* get time and map */
         map  = root.via.array.ptr[1];
 
-        ret = grep_filter_data(map, context);
+        if (ctx->logical_op == GREP_LOGICAL_OP_NOT_SET) {
+            ret = grep_filter_data(map, ctx);
+        }
+        else {
+            ret = grep_filter_data_and_or(map, ctx);
+        }
+
         if (ret == GREP_RET_KEEP) {
             msgpack_pack_object(&tmp_pck, root);
             new_size++;
@@ -300,6 +370,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "exclude", NULL,
      FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
      "Exclude records in which the content of KEY matches the regular expression."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logical_op", NULL,
+     0, FLB_FALSE, 0,
+     "Specify whether to use logical conjuciton or disjunction. AND and OR are allowed."
     },
     {0}
 };

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -85,7 +85,7 @@ static int set_rules(struct grep_ctx *ctx, struct flb_filter_instance *f_ins)
             continue;
         }
 
-        if (ctx->logical_op != GREP_LOGICAL_OP_NOT_SET && first_rule != GREP_NO_RULE) {
+        if (ctx->logical_op != GREP_LOGICAL_OP_LEGACY && first_rule != GREP_NO_RULE) {
             /* 'AND'/'OR' case */
             if (first_rule != rule->type) {
                 flb_plg_error(ctx->ins, "Both 'regex' and 'exclude' are set.");
@@ -215,7 +215,7 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
     mk_list_init(&ctx->rules);
     ctx->ins = f_ins;
 
-    ctx->logical_op = GREP_LOGICAL_OP_NOT_SET;
+    ctx->logical_op = GREP_LOGICAL_OP_LEGACY;
     val = flb_filter_get_property("logical_op", f_ins);
     if (val != NULL) {
         len = strlen(val);
@@ -226,6 +226,10 @@ static int cb_grep_init(struct flb_filter_instance *f_ins,
         else if (len == 2 && strncasecmp("OR", val, len) == 0) {
             flb_plg_info(ctx->ins, "OR mode");
             ctx->logical_op = GREP_LOGICAL_OP_OR;
+        }
+        else if (len == 6 && strncasecmp("legacy", val, len) == 0) {
+            flb_plg_info(ctx->ins, "legacy mode");
+            ctx->logical_op = GREP_LOGICAL_OP_LEGACY;
         }
     }
 
@@ -316,7 +320,7 @@ static int cb_grep_filter(const void *data, size_t bytes,
         /* get time and map */
         map  = root.via.array.ptr[1];
 
-        if (ctx->logical_op == GREP_LOGICAL_OP_NOT_SET) {
+        if (ctx->logical_op == GREP_LOGICAL_OP_LEGACY) {
             ret = grep_filter_data(map, ctx);
         }
         else {
@@ -372,9 +376,9 @@ static struct flb_config_map config_map[] = {
      "Exclude records in which the content of KEY matches the regular expression."
     },
     {
-     FLB_CONFIG_MAP_STR, "logical_op", NULL,
+     FLB_CONFIG_MAP_STR, "logical_op", "legacy",
      0, FLB_FALSE, 0,
-     "Specify whether to use logical conjuciton or disjunction. AND and OR are allowed."
+     "Specify whether to use logical conjuciton or disjunction. legacy, AND and OR are allowed."
     },
     {0}
 };

--- a/plugins/filter_grep/grep.h
+++ b/plugins/filter_grep/grep.h
@@ -35,7 +35,7 @@
 #define GREP_RET_EXCLUDE  1
 
 enum _logical_op{
-    GREP_LOGICAL_OP_NOT_SET,
+    GREP_LOGICAL_OP_LEGACY,
     GREP_LOGICAL_OP_OR,
     GREP_LOGICAL_OP_AND
 } logical_op;

--- a/plugins/filter_grep/grep.h
+++ b/plugins/filter_grep/grep.h
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_record_accessor.h>
 
 /* rule types */
+#define GREP_NO_RULE  0
 #define GREP_REGEX    1
 #define GREP_EXCLUDE  2
 
@@ -33,8 +34,15 @@
 #define GREP_RET_KEEP     0
 #define GREP_RET_EXCLUDE  1
 
+enum _logical_op{
+    GREP_LOGICAL_OP_NOT_SET,
+    GREP_LOGICAL_OP_OR,
+    GREP_LOGICAL_OP_AND
+} logical_op;
+
 struct grep_ctx {
     struct mk_list rules;
+    int logical_op;
     struct flb_filter_instance *ins;
 };
 

--- a/tests/runtime/filter_grep.c
+++ b/tests/runtime/filter_grep.c
@@ -375,11 +375,89 @@ void flb_test_issue_5209(void)
     flb_destroy(ctx);
 }
 
+
+/* filter_grep supports multiple 'Regex's.
+ * If user sets multiple 'Regex's, fluent-bit uses as AND conditions.
+ */
+void flb_test_filter_grep_multi_regex(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char p[512];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    int got;
+    int n_loop = 256;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Regex", "log deprecated",
+                         "Regex", "log option",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Ingest 2 records per loop. One of them should be excluded. */
+    for (i = 0; i < n_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        /* Below record will be included */
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using deprecated option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+
+        /* Below record will be excluded */
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got == n_loop)) {
+        TEST_MSG("expect: %d got: %d", n_loop, got);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"regex",   flb_test_filter_grep_regex   },
     {"exclude", flb_test_filter_grep_exclude },
     {"invalid", flb_test_filter_grep_invalid },
+    {"multi_regex", flb_test_filter_grep_multi_regex },
     {"multi_exclude", flb_test_filter_grep_multi_exclude },
     {"unknown_property", flb_test_filter_grep_unknown_property },
     {"issue_5209", flb_test_issue_5209 },

--- a/tests/runtime/filter_grep.c
+++ b/tests/runtime/filter_grep.c
@@ -452,6 +452,374 @@ void flb_test_filter_grep_multi_regex(void)
     flb_destroy(ctx);
 }
 
+void flb_test_error_AND_regex_exclude(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "stdout", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Regex",   "val 1",
+                         "Exclude", "val2 3",
+                         "Logical_Op", "AND",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_error_OR_regex_exclude(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "stdout", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Regex",   "val 1",
+                         "Exclude", "val2 3",
+                         "Logical_Op", "OR",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_AND_regex(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char p[512];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    int got;
+    int n_loop = 256;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Regex", "log deprecated",
+                         "Regex", "log option",
+                         "Logical_Op", "AND",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Ingest 2 records per loop. One of them should be excluded. */
+    for (i = 0; i < n_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        /* Below record will be included */
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using deprecated option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+
+        /* Below record will be excluded */
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got == n_loop)) {
+        TEST_MSG("expect: %d got: %d", n_loop, got);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_OR_regex(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char p[512];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    int got;
+    int n_loop = 256;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Regex", "log deprecated",
+                         "Regex", "log option",
+                         "Logical_Op", "OR",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Ingest 2 records per loop. One of them should be excluded. */
+    for (i = 0; i < n_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        /* Below record will be included */
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using deprecated option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+
+        /* Below record will be excluded */
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got == n_loop * 2)) {
+        TEST_MSG("expect: %d got: %d", n_loop * 2, got);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_AND_exclude(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char p[512];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    int got;
+    int n_loop = 256;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Exclude", "log deprecated",
+                         "Exclude", "log option",
+                         "Logical_Op", "AND",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Ingest 2 records per loop. One of them should be excluded. */
+    for (i = 0; i < n_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        /* Below record will be included */
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using deprecated option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+
+        /* Below record will be excluded */
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got == n_loop)) {
+        TEST_MSG("expect: %d got: %d", n_loop, got);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_OR_exclude(void)
+{
+    int i;
+    int ret;
+    int bytes;
+    char p[512];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    int got;
+    int n_loop = 256;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "grep", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Exclude", "log deprecated",
+                         "Exclude", "log other",
+                         "Logical_Op", "OR",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Ingest 2 records per loop. One of them should be excluded. */
+    for (i = 0; i < n_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        /* Below record will be included */
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using deprecated option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+
+        /* Below record will be excluded */
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"log\": \"Using option\"}]", i, (i * i));
+        bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got == n_loop)) {
+        TEST_MSG("expect: %d got: %d", n_loop, got);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"regex",   flb_test_filter_grep_regex   },
@@ -460,6 +828,13 @@ TEST_LIST = {
     {"multi_regex", flb_test_filter_grep_multi_regex },
     {"multi_exclude", flb_test_filter_grep_multi_exclude },
     {"unknown_property", flb_test_filter_grep_unknown_property },
+    {"AND_regex", flb_test_AND_regex},
+    {"OR_regex", flb_test_OR_regex},
+    {"AND_exclude", flb_test_AND_exclude},
+    {"OR_exclude", flb_test_OR_exclude},
+    {"error_OR_regex_exclude", flb_test_error_OR_regex_exclude},
+    {"error_AND_regex_exclude", flb_test_error_AND_regex_exclude},
+    {"error_OR_regex_exclude", flb_test_error_OR_regex_exclude},
     {"issue_5209", flb_test_issue_5209 },
     {NULL, NULL}
 };


### PR DESCRIPTION
Doc PR: https://github.com/fluent/fluent-bit-docs/pull/1031
EDIT: update default value.

This patch is to support 'logical_op' to handle multiple conditions like Fluentd's `and`/`or` directive.
https://docs.fluentd.org/filter/grep
User requests: #6708 #6245

|Key|Description|
|---|----|
|Logical_Op|Specify whether to use logical conjuciton or disjunction. `AND` and `OR` are allowed. Default is `legacy`.|

Note: Default is none for backward  backward compatibility.
Because filter_grep treats 'AND' when multi `Regex`s are set.
When multi `Exclude`s are set, filter_grep treats 'OR'.  Please see test case `flb_test_filter_grep_multi_regex` and `flb_test_filter_grep_multi_exclude`


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[INPUT]
    Name dummy
    Dummy {"endpoint":"localhost", "value":"something"}
    Tag dummy

[FILTER]
    Name grep
    Match *
    Logical_Op or
    Regex value something
    Regex value error

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==33268== Memcheck, a memory error detector
==33268== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33268== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==33268== Command: bin/fluent-bit -c a.conf
==33268== 
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/01/22 09:46:49] [ info] [fluent bit] version=2.0.9, commit=16eae10786, pid=33268
[2023/01/22 09:46:49] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/01/22 09:46:49] [ info] [cmetrics] version=0.5.8
[2023/01/22 09:46:49] [ info] [ctraces ] version=0.2.7
[2023/01/22 09:46:49] [ info] [input:dummy:dummy.0] initializing
[2023/01/22 09:46:49] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/01/22 09:46:49] [ info] [filter:grep:grep.0] OR mode
[2023/01/22 09:46:49] [ info] [sp] stream processor started
[2023/01/22 09:46:49] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy: [1674348410.558341857, {"endpoint"=>"localhost", "value"=>"something"}]
[0] dummy: [1674348411.546425499, {"endpoint"=>"localhost", "value"=>"something"}]
^C[2023/01/22 09:46:52] [engine] caught signal (SIGINT)
[0] dummy: [1674348412.496432201, {"endpoint"=>"localhost", "value"=>"something"}]
[2023/01/22 09:46:52] [ warn] [engine] service will shutdown in max 5 seconds
[2023/01/22 09:46:52] [ info] [input] pausing dummy.0
[2023/01/22 09:46:53] [ info] [engine] service has stopped (0 pending tasks)
[2023/01/22 09:46:53] [ info] [input] pausing dummy.0
[2023/01/22 09:46:53] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/01/22 09:46:53] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==33268== 
==33268== HEAP SUMMARY:
==33268==     in use at exit: 0 bytes in 0 blocks
==33268==   total heap usage: 1,737 allocs, 1,737 frees, 1,373,190 bytes allocated
==33268== 
==33268== All heap blocks were freed -- no leaks are possible
==33268== 
==33268== For lists of detected and suppressed errors, rerun with: -s
==33268== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
