### PR TITLE
CMakeLists.txt: Miniz: compile as a static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,7 @@ add_definitions(-DMPACK_EXTENSIONS=1)
 add_subdirectory(${FLB_PATH_LIB_MPACK} EXCLUDE_FROM_ALL)
 
 # Miniz (zip)
+FLB_OPTION(BUILD_SHARED_LIBS OFF)
 add_subdirectory(${FLB_PATH_LIB_MINIZ} EXCLUDE_FROM_ALL)
 
 # ring buffer library


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/6711

Buildroot enforces globally wide that all packages are dynamically linked (if BR2_SHARED_LIBS), so that means that these options slept through the subdirectories. The libminiz.so is not installed by cmake, causing the fluent-bit to crash. This patch forces libminiz to be compiled statically.

Note that this option doesn't have a dedicated prefix, adding one would require a change in libminiz. That is not the scope of this PR, if someone can take this up, feel free to do so.

Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com>