### PR TITLE
upstream: fixed memory leaks in configuration

### DIFF
--- a/include/fluent-bit/flb_upstream_node.h
+++ b/include/fluent-bit/flb_upstream_node.h
@@ -62,8 +62,8 @@ struct flb_upstream_node {
 };
 
 
-struct flb_upstream_node *flb_upstream_node_create(const char *name, const char *host,
-                                                   const char *port,
+struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t host,
+                                                   flb_sds_t port,
                                                    int tls, int tls_verify,
                                                    int tls_debug,
                                                    const char *tls_vhost,

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -170,18 +170,21 @@ static struct flb_upstream_node *create_node(int id,
     tmp = flb_cf_section_property_get_string(cf, s, "tls");
     if (tmp) {
         tls = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
     }
 
     /* tls.verify */
     tmp = flb_cf_section_property_get_string(cf, s, "tls.verify");
     if (tmp) {
         tls_verify = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
     }
 
     /* tls.debug */
     tmp = flb_cf_section_property_get_string(cf, s, "tls.debug");
     if (tmp) {
         tls_debug = atoi(tmp);
+        flb_sds_destroy(tmp);
     }
 
     /* tls.vhost */
@@ -314,6 +317,7 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
     }
 
     ups = flb_upstream_ha_create(tmp);
+    flb_sds_destroy(tmp);
     if (!ups) {
         flb_error("[upstream_ha] cannot create context");
         flb_cf_destroy(cf);

--- a/src/flb_upstream_node.c
+++ b/src/flb_upstream_node.c
@@ -27,8 +27,8 @@
 #include <fluent-bit/flb_upstream_node.h>
 
 /* Create a new Upstream Node context */
-struct flb_upstream_node *flb_upstream_node_create(const char *name, const char *host,
-                                                   const char *port,
+struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t host,
+                                                   flb_sds_t port,
                                                    int tls, int tls_verify,
                                                    int tls_debug,
                                                    const char *tls_vhost,
@@ -66,18 +66,18 @@ struct flb_upstream_node *flb_upstream_node_create(const char *name, const char 
         node->name = flb_sds_create(tmp);
     }
     else {
-        node->name = flb_sds_create(name);
+        node->name = name;
     }
 
     /* host */
-    node->host = flb_sds_create(host);
+    node->host = host;
     if (!node->host) {
         flb_upstream_node_destroy(node);
         return NULL;
     }
 
     /* port */
-    node->port = flb_sds_create(port);
+    node->port = port;
     if (!node->port) {
         flb_upstream_node_destroy(node);
         return NULL;


### PR DESCRIPTION
Some temporaries were not freed, and some allocation strings were reallocated and freed once.

Signed-off-by: Benoît GARNIER <bunch@orange.fr>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
