### PR TITLE
input: Fixed memory leak in configuration

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -600,6 +600,7 @@ int flb_input_set_property(struct flb_input_instance *ins,
     else if (prop_key_check("storage.pause_on_chunks_overlimit", k, len) == 0 && tmp) {
         if (ins->storage_type == FLB_STORAGE_FS) {
             ret = flb_utils_bool(tmp);
+            flb_sds_destroy(tmp);
             if (ret == -1) {
                 return -1;
             }


### PR DESCRIPTION
Signed-off-by: Benoît GARNIER <bunch@orange.fr>

Some temporaries were not freed during configuration load.

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
