### PR TITLE
packaging: resolve legacy Bullseye setup issue

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -487,8 +487,8 @@ jobs:
         shell: bash
         env:
           VERSION_TO_CHECK_FOR: ${{ github.event.inputs.version }}
-          FLUENT_BIT_PACKAGES_URL: https://${{ secrets.AWS_S3_BUCKET_RELEASE }}.s3.amazonaws.com
-          FLUENT_BIT_PACKAGES_KEY: https://${{ secrets.AWS_S3_BUCKET_RELEASE }}.s3.amazonaws.com/fluentbit.key
+          FLUENT_BIT_PACKAGES_URL: http://${{ secrets.AWS_S3_BUCKET_RELEASE }}.s3.amazonaws.com
+          FLUENT_BIT_PACKAGES_KEY: http://${{ secrets.AWS_S3_BUCKET_RELEASE }}.s3.amazonaws.com/fluentbit.key
 
   staging-release-smoke-test-containers:
     name: Run container smoke tests

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -53,10 +53,10 @@ do
     echo "Testing $IMAGE"
     LOG_FILE=$(mktemp)
 
-    FLUENT_BIT_INSTALL_COMMAND_PREFIX=${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}
+    UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX=${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}
     # For AL2022 we currently want a fixed 2022 version instead of build timestamps
     if [[ "$IMAGE" == "amazonlinux:2022" ]]; then
-        FLUENT_BIT_INSTALL_COMMAND_PREFIX="sed -i 's|\$releasever/|2022/|g' /etc/yum.repos.d/fluent-bit.repo;$FLUENT_BIT_INSTALL_COMMAND_PREFIX"
+        UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX="sed -i 's|\$releasever/|2022/|g' /etc/yum.repos.d/fluent-bit.repo;${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}"
     fi
 
     # We do want word splitting for EXTRA_MOUNTS
@@ -65,7 +65,7 @@ do
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         -e FLUENT_BIT_RELEASE_VERSION="${FLUENT_BIT_RELEASE_VERSION:-}" \
-        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}" \
+        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="$UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX" \
         -e FLUENT_BIT_INSTALL_PACKAGE_NAME="${FLUENT_BIT_INSTALL_PACKAGE_NAME:-fluent-bit}" \
         -e FLUENT_BIT_INSTALL_YUM_PARAMETERS="${FLUENT_BIT_INSTALL_YUM_PARAMETERS:-}" \
         $EXTRA_MOUNTS \

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -93,10 +93,12 @@ for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do
     # The origin and label fields seem to cover the base directory for the repo and codename.
     # The docs seems to suggest these fields are optional and free-form: https://wiki.debian.org/DebianRepository/Format#Origin
     # They are security checks to verify if they have changed so we match the legacy server.
-    APTLY_PUBLISH_ARGS="-origin=\". $CODENAME\" -label=\". $CODENAME\""
+    APTLY_ORIGIN=". $CODENAME"
+    APTLY_LABEL=". $CODENAME"
     if [[ "$DEB_REPO" == "debian/bullseye" ]]; then
         # For Bullseye, the legacy server had a slightly different setup we try to reproduce here
-        APTLY_PUBLISH_ARGS='-origin="bullseye bullseye" -label="bullseye bullseye"'
+        APTLY_ORIGIN="bullseye bullseye"
+        APTLY_LABEL="bullseye bullseye"
     fi
 
     cat << EOF > "$APTLY_CONFIG"
@@ -120,9 +122,9 @@ EOF
     fi
     aptly -config="$APTLY_CONFIG" repo show "$APTLY_REPO_NAME"
     if [[ "$DISABLE_SIGNING" != "true" ]]; then
-        aptly -config="$APTLY_CONFIG" publish repo -gpg-key="$GPG_KEY" "${APTLY_PUBLISH_ARGS[@]}" "$APTLY_REPO_NAME"
+        aptly -config="$APTLY_CONFIG" publish repo -gpg-key="$GPG_KEY" -origin="$APTLY_ORIGIN" -label="$APTLY_LABEL" "$APTLY_REPO_NAME"
     else
-        aptly -config="$APTLY_CONFIG" publish repo --skip-signing "${APTLY_PUBLISH_ARGS[@]}" "$APTLY_REPO_NAME"
+        aptly -config="$APTLY_CONFIG" publish repo --skip-signing -origin="$APTLY_ORIGIN" -label="$APTLY_LABEL" "$APTLY_REPO_NAME"
     fi
     rsync -av "$APTLY_ROOTDIR"/public/* "$REPO_DIR"
     # Remove unnecessary files


### PR DESCRIPTION
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Fixes #6732 to ensure the bucket repo data matches the legacy server for Debian Bullseye.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Spun up new server.
Sync'd bucket.
Checked the files (repeated for `Label`):
```shell
$ find bucket/ -name "Release" -exec cat {} \;|grep Origin
Origin: . bookworm
Origin: . bookworm
Origin: . bookworm
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . bullseye
Origin: . bullseye
Origin: . bullseye
```

Ran the update-repos.sh script in this PR with appropriate config.
Checked the files (repeated for `Label`):
```shell
$ find bucket/ -name "Release" -exec cat {} \;|grep Origin
Origin: . bookworm
Origin: . bookworm
Origin: . bookworm
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
```

Repeating this on the old server shows only Bullseye with the difference:
```shell
$ find ./apt.fluentbit.io/ -name "Release" -exec cat {} \;|grep Origin
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . buster
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jammy
Origin: . jammy
Origin: . jammy
Origin: . jammy
Origin: . jammy
Origin: . xenial
Origin: . xenial
Origin: . xenial
Origin: . xenial
Origin: . xenial
Origin: . focal
Origin: . focal
Origin: . focal
Origin: . focal
Origin: . focal
Origin: . bionic
Origin: . bionic
Origin: . bionic
Origin: . bionic
Origin: . bionic
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . buster
Origin: . bookworm
Origin: . bookworm
Origin: . bookworm
Origin: . bookworm
Origin: . bookworm
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . stretch
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: . jessie
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
Origin: bullseye bullseye
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
