### PR TITLE
packaging: enable kafka SASL mechanisms support for Debian and Ubuntu

### DIFF
--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/buster.arm64v8 base image
@@ -34,7 +34,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bullseye base image
@@ -47,7 +47,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bullseye.arm64v8 base image
@@ -62,7 +62,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bookworm base image
@@ -75,7 +75,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bookworm.arm64v8 base image
@@ -90,7 +90,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common libyaml-dev apt-transport-https && \
+    software-properties-common libyaml-dev apt-transport-https pkg-config && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
@@ -60,7 +60,7 @@ RUN apt-get update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common libyaml-dev apt-transport-https && \
+    software-properties-common libyaml-dev apt-transport-https pkg-config && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
@@ -78,7 +78,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/20.04.arm64v8 base image
@@ -92,7 +92,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04 base image
@@ -104,7 +104,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04.arm64v8 base image
@@ -118,7 +118,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now


### PR DESCRIPTION
Signed-off-by: Nikita Kozlovsky <nikitka@gmail.com>

This pull request adds SASL mechanisms support. I added pkg-config as a dependency, because without it librdkafka's cmake unable to find libsasl2 and disables SASL support. 

Without pkg-config I got error `failed to create producer: No provider for SASL mechanism SCRAM-SHA-512: recompile librdkafka with libsasl2 or openssl support. Current build options: PLAIN`. After I've added pkg-config and have recompiled package error is gone and I've successfully connected to kafka with SCRAM-SHA-512 SASL mechanism.


I think this pull requests fixes #632.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->



**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
