### PR TITLE
node_exporter_metrics: Support individual on/off and intervals for metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -40,6 +40,127 @@
 #include "ne_vmstat_linux.h"
 #include "ne_netdev.h"
 
+static int ne_timer_cpu_metrics_cb(struct flb_input_instance *ins,
+                                   struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_cpu_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_cpufreq_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_cpufreq_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_meminfo_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_meminfo_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_diskstats_metrics_cb(struct flb_input_instance *ins,
+                                         struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_diskstats_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_filesystem_metrics_cb(struct flb_input_instance *ins,
+                                          struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_filesystem_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_uname_metrics_cb(struct flb_input_instance *ins,
+                                     struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_uname_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_stat_metrics_cb(struct flb_input_instance *ins,
+                                    struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_stat_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_time_metrics_cb(struct flb_input_instance *ins,
+                                    struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_time_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_loadavg_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_loadavg_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_vmstat_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_vmstat_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_netdev_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_netdev_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_filefd_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_filefd_update(ctx);
+
+    return 0;
+}
+
+
 struct flb_ne_callback {
     char *name;
     void (*func)(char *, void *, void *);
@@ -62,7 +183,7 @@ static void update_metrics(struct flb_input_instance *ins, struct flb_ne *ctx)
                 ne_update_cb(ctx, entry->str);
             }
             else {
-                flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
+                flb_plg_debug(ctx->ins, "Callback for metrics '%s' is not registered", entry->str);
             }
         }
     }
@@ -205,7 +326,7 @@ static int in_ne_init(struct flb_input_instance *in,
                       struct flb_config *config, void *data)
 {
     int ret;
-    int metric_idx = 0;
+    int metric_idx = -1;
     struct flb_ne *ctx;
     struct mk_list *head;
     struct flb_slist_entry *entry;
@@ -217,6 +338,21 @@ static int in_ne_init(struct flb_input_instance *in,
         flb_errno();
         return -1;
     }
+
+    /* Initialize fds */
+    ctx->coll_fd = -1;
+    ctx->coll_cpu_fd = -1;
+    ctx->coll_cpufreq_fd = -1;
+    ctx->coll_meminfo_fd = -1;
+    ctx->coll_diskstats_fd = -1;
+    ctx->coll_filesystem_fd = -1;
+    ctx->coll_uname_fd = -1;
+    ctx->coll_stat_fd = -1;
+    ctx->coll_time_fd = -1;
+    ctx->coll_loadavg_fd = -1;
+    ctx->coll_vmstat_fd = -1;
+    ctx->coll_netdev_fd = -1;
+    ctx->coll_filefd_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -239,22 +375,7 @@ static int in_ne_init(struct flb_input_instance *in,
     }
     ctx->coll_fd = ret;
 
-    /* Initialize node metric collectors */
-    ne_cpu_init(ctx);
-    ne_cpufreq_init(ctx);
-    ne_meminfo_init(ctx);
-    ne_diskstats_init(ctx);
-    ne_filesystem_init(ctx);
-    ne_uname_init(ctx);
-    ne_stat_init(ctx);
-    ne_time_init(ctx);
-    ne_loadavg_init(ctx);
-    ne_vmstat_init(ctx);
-    ne_netdev_init(ctx);
-    ne_filefd_init(ctx);
-
-    /* Check enabled metrics */
-        /* Update our metrics */
+    /* Check and initialize enabled metrics */
     if (ctx->metrics) {
         mk_list_foreach(head, ctx->metrics) {
             entry = mk_list_entry(head, struct flb_slist_entry, _head);
@@ -262,52 +383,244 @@ static int in_ne_init(struct flb_input_instance *in,
 
             if (ret == FLB_FALSE) {
                 if (strncmp(entry->str, "cpufreq", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 0;
+                    if (ctx->cpu_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 0;
+                    }
+                    else if (ctx->cpufreq_scrape_interval > 0) {
+                        /* Create the cpufreq collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_cpufreq_metrics_cb,
+                                                           ctx->cpufreq_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set cpufreq collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_cpufreq_fd = ret;
+                    }
+                    ne_cpufreq_init(ctx);
                 }
                 else if (strncmp(entry->str, "cpu", 3) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 1;
+                    if (ctx->cpufreq_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 1;
+                    }
+                    else if (ctx->cpu_scrape_interval > 0) {
+                        /* Create the cpu collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_cpu_metrics_cb,
+                                                           ctx->cpu_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set cpu collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_cpu_fd = ret;
+                    }
+                    ne_cpu_init(ctx);
                 }
                 else if (strncmp(entry->str, "meminfo", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 2;
+                    if (ctx->meminfo_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 2;
+                    }
+                    else if (ctx->meminfo_scrape_interval > 0) {
+                        /* Create the meminfo collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_meminfo_metrics_cb,
+                                                           ctx->meminfo_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set meminfo collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_meminfo_fd = ret;
+                    }
+                    ne_meminfo_init(ctx);
                 }
                 else if (strncmp(entry->str, "diskstats", 9) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 3;
+                    if (ctx->diskstats_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 3;
+                    }
+                    else if (ctx->diskstats_scrape_interval > 0) {
+                        /* Create the diskstats collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_diskstats_metrics_cb,
+                                                           ctx->diskstats_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set diskstats collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_diskstats_fd = ret;
+                    }
+                    ne_diskstats_init(ctx);
                 }
                 else if (strncmp(entry->str, "filesystem", 10) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 4;
+                    if (ctx->diskstats_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 4;
+                    }
+                    else if (ctx->filesystem_scrape_interval > 0) {
+                        /* Create the diskstats collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_filesystem_metrics_cb,
+                                                           ctx->filesystem_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set filesystem collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_filesystem_fd = ret;
+                    }
+                    ne_filesystem_init(ctx);
                 }
                 else if (strncmp(entry->str, "uname", 5) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 5;
+                    if (ctx->uname_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 5;
+                    }
+                    else if (ctx->uname_scrape_interval > 0) {
+                        /* Create the uname collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_uname_metrics_cb,
+                                                           ctx->uname_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set uname collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_uname_fd = ret;
+                    }
+                    ne_uname_init(ctx);
                 }
                 else if (strncmp(entry->str, "stat", 4) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 6;
+                    if (ctx->stat_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 6;
+                    }
+                    else if (ctx->stat_scrape_interval > 0) {
+                        /* Create the meminfo collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_stat_metrics_cb,
+                                                           ctx->stat_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set meminfo collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_stat_fd = ret;
+                    }
+                    ne_stat_init(ctx);
                 }
                 else if (strncmp(entry->str, "time", 4) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 7;
+                    if (ctx->time_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 7;
+                    }
+                    else if (ctx->time_scrape_interval > 0) {
+                        /* Create the time collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_time_metrics_cb,
+                                                           ctx->time_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set time collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_time_fd = ret;
+                    }
+                    ne_time_init(ctx);
                 }
                 else if (strncmp(entry->str, "loadavg", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 8;
+                    if (ctx->loadavg_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 8;
+                    }
+                    else if (ctx->loadavg_scrape_interval > 0) {
+                        /* Create the loadavg collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_loadavg_metrics_cb,
+                                                           ctx->loadavg_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set loadavg collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_loadavg_fd = ret;
+                    }
+                    ne_loadavg_init(ctx);
                 }
                 else if (strncmp(entry->str, "vmstat", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 9;
+                    if (ctx->vmstat_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 9;
+                    }
+                    else if (ctx->vmstat_scrape_interval > 0) {
+                        /* Create the vmstat collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_vmstat_metrics_cb,
+                                                           ctx->vmstat_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set vmstat collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_vmstat_fd = ret;
+                    }
+                    ne_vmstat_init(ctx);
                 }
                 else if (strncmp(entry->str, "netdev", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 10;
+                    if (ctx->netdev_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 10;
+                    }
+                    else if (ctx->netdev_scrape_interval > 0) {
+                        /* Create the netdev collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_netdev_metrics_cb,
+                                                           ctx->netdev_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set netdev collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_netdev_fd = ret;
+                    }
+                    ne_netdev_init(ctx);
                 }
                 else if (strncmp(entry->str, "filefd", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 11;
+                    if (ctx->filefd_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 11;
+                    }
+                    else if (ctx->filefd_scrape_interval > 0) {
+                        /* Create the filefd collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_filefd_metrics_cb,
+                                                           ctx->filefd_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set filefd collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_filefd_fd = ret;
+                    }
+                    ne_filefd_init(ctx);
                 }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
@@ -336,17 +649,81 @@ static int in_ne_init(struct flb_input_instance *in,
 
 static int in_ne_exit(void *data, struct flb_config *config)
 {
+    int ret;
     struct flb_ne *ctx = data;
+    struct mk_list *head;
+    struct flb_slist_entry *entry;
 
     if (!ctx) {
         return 0;
     }
 
-    ne_diskstats_exit(ctx);
-    ne_filesystem_exit(ctx);
-    ne_meminfo_exit(ctx);
-    ne_vmstat_exit(ctx);
-    ne_netdev_exit(ctx);
+    /* Teardown for callback tied up resources */
+    if (ctx->metrics) {
+        mk_list_foreach(head, ctx->metrics) {
+            entry = mk_list_entry(head, struct flb_slist_entry, _head);
+            ret = flb_callback_exists(ctx->callback, entry->str);
+
+            if (ret == FLB_TRUE) {
+                if (strncmp(entry->str, "cpufreq", 7) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "cpu", 3) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "meminfo", 7) == 0) {
+                    ne_meminfo_exit(ctx);
+                }
+                else if (strncmp(entry->str, "diskstats", 9) == 0) {
+                    ne_diskstats_exit(ctx);
+                }
+                else if (strncmp(entry->str, "filesystem", 10) == 0) {
+                    ne_filesystem_exit(ctx);
+                }
+                else if (strncmp(entry->str, "uname", 5) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "stat", 4) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "time", 4) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "loadavg", 7) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "vmstat", 6) == 0) {
+                    ne_vmstat_exit(ctx);
+                }
+                else if (strncmp(entry->str, "netdev", 6) == 0) {
+                    ne_netdev_exit(ctx);
+                }
+                else if (strncmp(entry->str, "filefd", 6) == 0) {
+                    /* nop */
+                }
+                else {
+                    flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
+                }
+            }
+        }
+    }
+
+    /* Teardown for timer tied up resources */
+    if (ctx->coll_meminfo_fd != -1) {
+        ne_meminfo_exit(ctx);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        ne_diskstats_exit(ctx);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        ne_filesystem_exit(ctx);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        ne_vmstat_exit(ctx);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        ne_netdev_exit(ctx);
+    }
 
     flb_ne_config_destroy(ctx);
     /* destroy callback context */
@@ -362,6 +739,42 @@ static void in_ne_pause(void *data, struct flb_config *config)
     struct flb_ne *ctx = data;
 
     flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+    if (ctx->coll_cpu_fd != -1) {
+        flb_input_collector_pause(ctx->coll_cpu_fd, ctx->ins);
+    }
+    if (ctx->coll_cpufreq_fd != -1) {
+        flb_input_collector_pause(ctx->coll_cpufreq_fd, ctx->ins);
+    }
+    if (ctx->coll_meminfo_fd != -1) {
+        flb_input_collector_pause(ctx->coll_meminfo_fd, ctx->ins);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        flb_input_collector_pause(ctx->coll_diskstats_fd, ctx->ins);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        flb_input_collector_pause(ctx->coll_filesystem_fd, ctx->ins);
+    }
+    if (ctx->coll_uname_fd != -1) {
+        flb_input_collector_pause(ctx->coll_uname_fd, ctx->ins);
+    }
+    if (ctx->coll_stat_fd != -1) {
+        flb_input_collector_pause(ctx->coll_stat_fd, ctx->ins);
+    }
+    if (ctx->coll_time_fd != -1) {
+        flb_input_collector_pause(ctx->coll_time_fd, ctx->ins);
+    }
+    if (ctx->coll_loadavg_fd != -1) {
+        flb_input_collector_pause(ctx->coll_loadavg_fd, ctx->ins);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        flb_input_collector_pause(ctx->coll_vmstat_fd, ctx->ins);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        flb_input_collector_pause(ctx->coll_netdev_fd, ctx->ins);
+    }
+    if (ctx->coll_filefd_fd != -1) {
+        flb_input_collector_pause(ctx->coll_filefd_fd, ctx->ins);
+    }
 }
 
 static void in_ne_resume(void *data, struct flb_config *config)
@@ -369,6 +782,42 @@ static void in_ne_resume(void *data, struct flb_config *config)
     struct flb_ne *ctx = data;
 
     flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+    if (ctx->coll_cpu_fd != -1) {
+        flb_input_collector_resume(ctx->coll_cpu_fd, ctx->ins);
+    }
+    if (ctx->coll_cpufreq_fd != -1) {
+        flb_input_collector_resume(ctx->coll_cpufreq_fd, ctx->ins);
+    }
+    if (ctx->coll_meminfo_fd != -1) {
+        flb_input_collector_resume(ctx->coll_meminfo_fd, ctx->ins);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        flb_input_collector_resume(ctx->coll_diskstats_fd, ctx->ins);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        flb_input_collector_resume(ctx->coll_filesystem_fd, ctx->ins);
+    }
+    if (ctx->coll_uname_fd != -1) {
+        flb_input_collector_resume(ctx->coll_uname_fd, ctx->ins);
+    }
+    if (ctx->coll_stat_fd != -1) {
+        flb_input_collector_resume(ctx->coll_stat_fd, ctx->ins);
+    }
+    if (ctx->coll_time_fd != -1) {
+        flb_input_collector_resume(ctx->coll_time_fd, ctx->ins);
+    }
+    if (ctx->coll_loadavg_fd != -1) {
+        flb_input_collector_resume(ctx->coll_loadavg_fd, ctx->ins);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        flb_input_collector_resume(ctx->coll_vmstat_fd, ctx->ins);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        flb_input_collector_resume(ctx->coll_netdev_fd, ctx->ins);
+    }
+    if (ctx->coll_filefd_fd != -1) {
+        flb_input_collector_resume(ctx->coll_filefd_fd, ctx->ins);
+    }
 }
 
 /* Configuration properties map */
@@ -377,6 +826,78 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "scrape_interval", "5",
      0, FLB_TRUE, offsetof(struct flb_ne, scrape_interval),
      "scrape interval to collect metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.cpu.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, cpu_scrape_interval),
+     "scrape interval to collect cpu metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.cpufreq.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, cpufreq_scrape_interval),
+     "scrape interval to collect cpufreq metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.meminfo.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, meminfo_scrape_interval),
+     "scrape interval to collect meminfo metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.diskstats.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, diskstats_scrape_interval),
+     "scrape interval to collect diskstats metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.filesystem.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, filesystem_scrape_interval),
+     "scrape interval to collect filesystem metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.uname.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, uname_scrape_interval),
+     "scrape interval to collect uname metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.stat.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, stat_scrape_interval),
+     "scrape interval to collect stat metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.time.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, time_scrape_interval),
+     "scrape interval to collect time metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.loadavg.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, loadavg_scrape_interval),
+     "scrape interval to collect loadavg metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.vmstat.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, vmstat_scrape_interval),
+     "scrape interval to collect vmstat metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.netdev.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, netdev_scrape_interval),
+     "scrape interval to collect netdev metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.filefd.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, filefd_scrape_interval),
+     "scrape interval to collect filefd metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -708,6 +708,11 @@ static int in_ne_exit(void *data, struct flb_config *config)
         }
     }
 
+    /* destroy callback context */
+    if (ctx->callback) {
+        flb_callback_destroy(ctx->callback);
+    }
+
     /* Teardown for timer tied up resources */
     if (ctx->coll_meminfo_fd != -1) {
         ne_meminfo_exit(ctx);
@@ -726,10 +731,6 @@ static int in_ne_exit(void *data, struct flb_config *config)
     }
 
     flb_ne_config_destroy(ctx);
-    /* destroy callback context */
-    if (ctx->callback) {
-        flb_callback_destroy(ctx->callback);
-    }
 
     return 0;
 }

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -39,6 +39,8 @@ struct flb_ne {
     int coll_fd;                                      /* collector fd     */
     struct cmt *cmt;                                  /* cmetrics context */
     struct flb_input_instance *ins;                   /* input instance   */
+    struct flb_callback *callback;                    /* metric callback */
+    struct mk_list *metrics;                          /* enabled metrics */
 
     /*
      * Metrics Contexts

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -42,6 +42,33 @@ struct flb_ne {
     struct flb_callback *callback;                    /* metric callback */
     struct mk_list *metrics;                          /* enabled metrics */
 
+    /* Individual intervals for metrics */
+    int cpu_scrape_interval;
+    int cpufreq_scrape_interval;
+    int meminfo_scrape_interval;
+    int diskstats_scrape_interval;
+    int filesystem_scrape_interval;
+    int uname_scrape_interval;
+    int stat_scrape_interval;
+    int time_scrape_interval;
+    int loadavg_scrape_interval;
+    int vmstat_scrape_interval;
+    int netdev_scrape_interval;
+    int filefd_scrape_interval;
+
+    int coll_cpu_fd;                                    /* collector fd (cpu)    */
+    int coll_cpufreq_fd;                                /* collector fd (cpufreq)  */
+    int coll_meminfo_fd;                                /* collector fd (meminfo)  */
+    int coll_diskstats_fd;                              /* collector fd (diskstat) */
+    int coll_filesystem_fd;                             /* collector fd (filesystem) */
+    int coll_uname_fd;                                  /* collector fd (uname)    */
+    int coll_stat_fd;                                   /* collector fd (stat)    */
+    int coll_time_fd;                                   /* collector fd (time)    */
+    int coll_loadavg_fd;                                /* collector fd (loadavg)    */
+    int coll_vmstat_fd;                                 /* collector fd (vmstat)    */
+    int coll_netdev_fd;                                 /* collector fd (netdev)    */
+    int coll_filefd_fd;                                 /* collector fd (filefd)    */
+
     /*
      * Metrics Contexts
      * ----------------


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, node_exporter_metrics does not support switch on/off for each of metrics and support each of intervals of scrapiong metrics neither. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
    flush           1
    log_level       info

[INPUT]
    name            node_exporter_metrics
    tag             fluentbit.metrics.${HOSTNAME}
    scrape_interval 5
    collector.cpu.scrape_interval 5
    collector.cpufreq.scrape_interval 15
    collector.meminfo.scrape_interval 5
    collector.diskstats.scrape_interval 30
    collector.filesystem.scrape_interval 25
    collector.uname.scrape_interval 50
    collector.stat.scrape_interval 35
    collector.time.scrape_interval 55
    collector.loadavg.scrape_interval 20
    collector.vmstat.scrape_interval 40
    collector.netdev.scrape_interval 60
    collector.filefd.scrape_interval 70

[OUTPUT]
    name stdout
    Match *
```
- [x] Debug log output from testing the change

<details>

```
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/01/26 16:56:13] [ info] [fluent bit] version=2.0.9, commit=16eae10786, pid=468078
[2023/01/26 16:56:13] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/01/26 16:56:13] [ info] [cmetrics] version=0.5.8
[2023/01/26 16:56:13] [ info] [ctraces ] version=0.2.7
[2023/01/26 16:56:13] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/01/26 16:56:13] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/01/26 16:56:13] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/01/26 16:56:13] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/01/26 16:56:13] [ info] [output:stdout:stdout.0] worker #0 started
[2023/01/26 16:56:13] [ info] [sp] stream processor started
1970-01-01T00:00:00.000000000Z node_intr_total = 0
1970-01-01T00:00:00.000000000Z node_context_switches_total = 0
1970-01-01T00:00:00.000000000Z node_forks_total = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgpgin = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgpgout = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pswpin = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pswpout = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgfault = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgmajfault = 0
1970-01-01T00:00:00.000000000Z node_vmstat_oom_kill = 0
1970-01-01T00:00:00.000000000Z node_memory_MemTotal_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_MemFree_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_MemAvailable_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Buffers_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Cached_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_SwapCached_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Active_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Inactive_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Active_anon_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Inactive_anon_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Active_file_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Inactive_file_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Unevictable_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Mlocked_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_SwapTotal_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_SwapFree_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Dirty_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Writeback_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_AnonPages_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Mapped_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Shmem_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_KReclaimable_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Slab_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_SReclaimable_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_SUnreclaim_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_KernelStack_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_PageTables_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_NFS_Unstable_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Bounce_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_WritebackTmp_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_CommitLimit_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Committed_AS_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_VmallocTotal_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_VmallocUsed_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_VmallocChunk_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Percpu_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_HardwareCorrupted_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_AnonHugePages_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_ShmemHugePages_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_ShmemPmdMapped_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_FileHugePages_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_FilePmdMapped_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_HugePages_Total = 0
1970-01-01T00:00:00.000000000Z node_memory_HugePages_Free = 0
1970-01-01T00:00:00.000000000Z node_memory_HugePages_Rsvd = 0
1970-01-01T00:00:00.000000000Z node_memory_HugePages_Surp = 0
1970-01-01T00:00:00.000000000Z node_memory_Hugepagesize_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_Hugetlb_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_DirectMap4k_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_DirectMap2M_bytes = 0
1970-01-01T00:00:00.000000000Z node_memory_DirectMap1G_bytes = 0
1970-01-01T00:00:00.000000000Z node_boot_time_seconds = 0
1970-01-01T00:00:00.000000000Z node_procs_running = 0
1970-01-01T00:00:00.000000000Z node_procs_blocked = 0
1970-01-01T00:00:00.000000000Z node_time_seconds = 0
1970-01-01T00:00:00.000000000Z node_load1 = 0
1970-01-01T00:00:00.000000000Z node_load5 = 0
1970-01-01T00:00:00.000000000Z node_load15 = 0
1970-01-01T00:00:00.000000000Z node_filefd_allocated = 0
1970-01-01T00:00:00.000000000Z node_filefd_maximum = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="idle"} = 104132.46000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="iowait"} = 268.00999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="nice"} = 13.32
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="softirq"} = 1207.3299999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="system"} = 2438.0500000000002
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="0",mode="user"} = 5879.3999999999996
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="idle"} = 21159.650000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="iowait"} = 30.5
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="nice"} = 9.5399999999999991
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="softirq"} = 1713.21
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="system"} = 2469.8899999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="1",mode="user"} = 6275.2600000000002
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="idle"} = 21795.369999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="iowait"} = 27.41
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="nice"} = 9.6999999999999993
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="softirq"} = 28.109999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="system"} = 2505.1199999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="2",mode="user"} = 6550.5
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="idle"} = 21960.639999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="iowait"} = 52.659999999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="nice"} = 16.210000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="softirq"} = 5.7599999999999998
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="system"} = 2331.5500000000002
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="3",mode="user"} = 6311.4200000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="idle"} = 21772.98
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="iowait"} = 33.530000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="nice"} = 12.67
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="softirq"} = 6.8899999999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="system"} = 2483.0500000000002
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="4",mode="user"} = 6632.3599999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="idle"} = 21964.439999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="iowait"} = 34.409999999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="nice"} = 7.6100000000000003
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="softirq"} = 4
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="system"} = 2398.9400000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="5",mode="user"} = 6597.71
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="idle"} = 21839.110000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="iowait"} = 29.879999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="nice"} = 11.48
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="softirq"} = 3.52
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="system"} = 2525.5500000000002
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="6",mode="user"} = 6717.9700000000003
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="idle"} = 21806.389999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="iowait"} = 28.690000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="nice"} = 7.1799999999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="softirq"} = 1.47
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="system"} = 2520.8299999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="7",mode="user"} = 6621.0699999999997
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="idle"} = 21937.279999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="iowait"} = 30.879999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="nice"} = 6.3099999999999996
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="softirq"} = 4.8399999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="system"} = 2451.6199999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="8",mode="user"} = 6408.1199999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="idle"} = 21829.759999999998
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="iowait"} = 30.370000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="nice"} = 7.7199999999999998
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="softirq"} = 1.1200000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="system"} = 4706.79
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="9",mode="user"} = 3915.1199999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="idle"} = 21965.18
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="iowait"} = 32.289999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="nice"} = 12.710000000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="softirq"} = 7.7300000000000004
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="system"} = 2485.1700000000001
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="10",mode="user"} = 6243.7700000000004
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="idle"} = 21905.73
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="iowait"} = 35.649999999999999
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="irq"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="nice"} = 13.48
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="softirq"} = 126.12
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="steal"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="system"} = 2456.6999999999998
2023-01-26T07:56:18.271001386Z node_cpu_seconds_total{cpu="11",mode="user"} = 6433.1999999999998
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="0",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="0",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="1",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="1",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="2",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="2",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="3",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="3",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="4",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="4",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="5",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="5",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="6",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="6",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="7",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="7",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="8",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="8",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="9",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="9",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="10",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="10",mode="nice"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="11",mode="user"} = 0
2023-01-26T07:56:18.271001386Z node_cpu_guest_seconds_total{cpu="11",mode="nice"} = 0
1970-01-01T00:00:00.000000000Z node_intr_total = 0
1970-01-01T00:00:00.000000000Z node_context_switches_total = 0
1970-01-01T00:00:00.000000000Z node_forks_total = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgpgin = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgpgout = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pswpin = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pswpout = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgfault = 0
1970-01-01T00:00:00.000000000Z node_vmstat_pgmajfault = 0
1970-01-01T00:00:00.000000000Z node_vmstat_oom_kill = 0
2023-01-26T07:56:18.298807727Z node_memory_MemTotal_bytes = 67356889088
2023-01-26T07:56:18.298807727Z node_memory_MemFree_bytes = 40800112640
2023-01-26T07:56:18.298807727Z node_memory_MemAvailable_bytes = 60581879808
2023-01-26T07:56:18.298807727Z node_memory_Buffers_bytes = 548032512
2023-01-26T07:56:18.298807727Z node_memory_Cached_bytes = 17622319104
2023-01-26T07:56:18.298807727Z node_memory_SwapCached_bytes = 65536
2023-01-26T07:56:18.298807727Z node_memory_Active_bytes = 6049935360
2023-01-26T07:56:18.298807727Z node_memory_Inactive_bytes = 17123610624
2023-01-26T07:56:18.298807727Z node_memory_Active_anon_bytes = 9625600
2023-01-26T07:56:18.298807727Z node_memory_Inactive_anon_bytes = 5022892032
2023-01-26T07:56:18.298807727Z node_memory_Active_file_bytes = 6040309760
2023-01-26T07:56:18.298807727Z node_memory_Inactive_file_bytes = 12100718592
2023-01-26T07:56:18.298807727Z node_memory_Unevictable_bytes = 13524992
2023-01-26T07:56:18.298807727Z node_memory_Mlocked_bytes = 13524992
2023-01-26T07:56:18.298807727Z node_memory_SwapTotal_bytes = 8538550272
2023-01-26T07:56:18.298807727Z node_memory_SwapFree_bytes = 8536190976
2023-01-26T07:56:18.298807727Z node_memory_Dirty_bytes = 98304
2023-01-26T07:56:18.298807727Z node_memory_Writeback_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_AnonPages_bytes = 5016838144
2023-01-26T07:56:18.298807727Z node_memory_Mapped_bytes = 1534320640
2023-01-26T07:56:18.298807727Z node_memory_Shmem_bytes = 126562304
2023-01-26T07:56:18.298807727Z node_memory_KReclaimable_bytes = 2383560704
2023-01-26T07:56:18.298807727Z node_memory_Slab_bytes = 2751250432
2023-01-26T07:56:18.298807727Z node_memory_SReclaimable_bytes = 2383560704
2023-01-26T07:56:18.298807727Z node_memory_SUnreclaim_bytes = 367689728
2023-01-26T07:56:18.298807727Z node_memory_KernelStack_bytes = 31326208
2023-01-26T07:56:18.298807727Z node_memory_PageTables_bytes = 66166784
2023-01-26T07:56:18.298807727Z node_memory_NFS_Unstable_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_Bounce_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_WritebackTmp_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_CommitLimit_bytes = 42216992768
2023-01-26T07:56:18.298807727Z node_memory_Committed_AS_bytes = 16481423360
2023-01-26T07:56:18.298807727Z node_memory_VmallocTotal_bytes = 35184372087808
2023-01-26T07:56:18.298807727Z node_memory_VmallocUsed_bytes = 120168448
2023-01-26T07:56:18.298807727Z node_memory_VmallocChunk_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_Percpu_bytes = 35258368
2023-01-26T07:56:18.298807727Z node_memory_HardwareCorrupted_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_AnonHugePages_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_ShmemHugePages_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_ShmemPmdMapped_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_FileHugePages_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_FilePmdMapped_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_HugePages_Total = 0
2023-01-26T07:56:18.298807727Z node_memory_HugePages_Free = 0
2023-01-26T07:56:18.298807727Z node_memory_HugePages_Rsvd = 0
2023-01-26T07:56:18.298807727Z node_memory_HugePages_Surp = 0
2023-01-26T07:56:18.298807727Z node_memory_Hugepagesize_bytes = 2097152
2023-01-26T07:56:18.298807727Z node_memory_Hugetlb_bytes = 0
2023-01-26T07:56:18.298807727Z node_memory_DirectMap4k_bytes = 2825691136
2023-01-26T07:56:18.298807727Z node_memory_DirectMap2M_bytes = 26086473728
2023-01-26T07:56:18.298807727Z node_memory_DirectMap1G_bytes = 39728447488
1970-01-01T00:00:00.000000000Z node_boot_time_seconds = 0
1970-01-01T00:00:00.000000000Z node_procs_running = 0
1970-01-01T00:00:00.000000000Z node_procs_blocked = 0
1970-01-01T00:00:00.000000000Z node_time_seconds = 0
1970-01-01T00:00:00.000000000Z node_load1 = 0
1970-01-01T00:00:00.000000000Z node_load5 = 0
1970-01-01T00:00:00.000000000Z node_load15 = 0
1970-01-01T00:00:00.000000000Z node_filefd_allocated = 0
1970-01-01T00:00:00.000000000Z node_filefd_maximum = 0
^C[2023/01/26 16:56:27] [engine] caught signal (SIGINT)
[2023/01/26 16:56:27] [ warn] [engine] service will shutdown in max 5 seconds
[2023/01/26 16:56:27] [ info] [input] pausing node_exporter_metrics.0
```

</details>

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==474863== 
==474863== HEAP SUMMARY:
==474863==     in use at exit: 0 bytes in 0 blocks
==474863==   total heap usage: 21,879 allocs, 21,879 frees, 15,551,313 bytes allocated
==474863== 
==474863== All heap blocks were freed -- no leaks are possible
==474863== 
==474863== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

~~Documentation is needed.~~ https://github.com/fluent/fluent-bit-docs/pull/1034

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
