### PR TITLE
in_forward: fixed memory leak when sending ACK

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -156,6 +156,8 @@ static int send_ack(struct flb_input_instance *in, struct fw_conn *conn,
                              mp_sbuf.size,
                              &sent);
 
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
     if (bytes == -1) {
         flb_plg_error(in, "cannot send ACK response: %.*s",
                       chunk.via.str.size, chunk.via.str.ptr);


### PR DESCRIPTION
The leak is huge: 8k per ACK sent.

Signed-off-by: Benoît GARNIER <bunch@orange.fr>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
