### PR TITLE
packaging: add pkg-config dependency for the Raspbian builds

### DIFF
--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
@@ -31,7 +31,7 @@ RUN apt-get update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev && \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now


### PR DESCRIPTION
Signed-off-by: Nikita Kozlovsky <nikitka@gmail.com>

<!-- Provide summary of changes -->

Add pkg-config as a dependency for the Raspbian builds, same as PR #6734. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #632

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
