### PR TITLE
packaging: librdkafka SASL_SCRAM and GZIP support on all targets

### DIFF
--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel && \
+    cmake3 libyaml-devel zlib-devel && \
     yum clean all
 
 # amazonlinux/2.arm64v8 base image
@@ -32,7 +32,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel && \
+    cmake3 libyaml-devel zlib-devel && \
     yum clean all
 
 FROM amazonlinux:2022 as amazonlinux-2022-base
@@ -43,7 +43,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel && \
+    cmake3 libyaml-devel zlib-devel && \
     yum clean all
 
 # hadolint ignore=DL3029
@@ -57,7 +57,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel && \
+    cmake3 libyaml-devel zlib-devel && \
     yum clean all
 
 # Common build for all distributions now

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -65,7 +65,8 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    libyaml-devel zlib-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -88,7 +89,8 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    libyaml-devel zlib-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -106,7 +108,8 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    libyaml-devel zlib-devel && \
     dnf clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -123,7 +126,8 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel  \
+    libyaml-devel zlib-devel && \
     dnf clean all
 
 ARG FLB_OUT_PGSQL=On

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
-    cyrus-sasl-lib openssl openss-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm -ivh epel-release-latest-7.noarch.rpm && \
@@ -65,7 +65,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -88,7 +88,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
     yum clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -106,7 +106,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
     dnf clean all
 
 ARG FLB_OUT_PGSQL=On
@@ -123,7 +123,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel && \
     dnf clean all
 
 ARG FLB_OUT_PGSQL=On

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev cmake \
     make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all software-properties-common \
-    software-properties-common libyaml-dev apt-transport-https && \
+    software-properties-common libyaml-dev apt-transport-https  \
+    pkg-config libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.0 zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common libyaml-dev apt-transport-https pkg-config && \
+    software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
@@ -61,7 +61,7 @@ RUN apt-get update && \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
-    software-properties-common libyaml-dev apt-transport-https pkg-config && \
+    software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
@@ -79,7 +79,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/20.04.arm64v8 base image
@@ -93,7 +93,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04 base image
@@ -105,7 +105,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04.arm64v8 base image
@@ -119,7 +119,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now


### PR DESCRIPTION
<!-- Provide summary of changes -->

I've found out that we don't have `cyrus-sasl-devel` dependency for CentOS targets, also I have added `libsasl`, `openssl` and `pkg-config` dependencies for Ubuntu 16.04. And I have added zlib-dev for CentOS and Amazon Linux targets for enabling GZIP support in librdkafka (Debian and Raspbian targets already had `zlib-1g-dev` dependency). 

I've checked that libfluent-bit.so in all x64 builds contains substring "CMAKE GNU GNU PKGCONFIG HDRHISTOGRAM ZLIB LIBDL PLUGINS SSL SASL_SCRAM SASL_OAUTHBEARER SASL_CYRUS C11THREADS CRC32C_HW SNAPPY SOCKEM". I think now we have the same set of enabled librdkafka features for every build target. I hope that arm64 targets fine too because they have the same package list as x64.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #632, #6086 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
