### PR TITLE
filter_kubernetes: add improved error message for meta tag parsing.

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -1265,7 +1265,10 @@ static inline int extract_meta(struct flb_kube *ctx,
     }
 
     if (n <= 0) {
-        flb_plg_warn(ctx->ins, "invalid pattern for given tag %s", tag);
+        flb_plg_error(ctx->ins, 
+                      "unable to extract metadata using regular expression "
+                      "pattern from the given tag: %s", 
+                      tag);
         return -1;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Improve the somewhat obscure warning message that is thrown when parsing the tag in the kubernetes filter fails. Also promote it to an error message.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
