### PR TITLE
out_opentelemetry: fix memory leak and invalid free

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -295,7 +295,6 @@ static void clear_array(Opentelemetry__Proto__Logs__V1__LogRecord **logs,
 
     for (index = 0 ; index < log_count ; index++) {
         otlp_any_value_destroy(logs[index]->body);
-        flb_free(logs[index]);
     }
 
     flb_free(logs);
@@ -781,6 +780,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
                                 log_record_count);
 
             clear_array(log_record_list, log_record_count);
+            flb_free(log_records);
 
             log_record_count = 0;
 
@@ -797,6 +797,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
                             log_record_count);
 
         clear_array(log_record_list, log_record_count);
+        flb_free(log_records);
 
         log_record_count = 0;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Remove an invalid free and fix a memory leak.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This fixes #6720.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
