### PR TITLE
http_server: add new /api/v2 endpoint with new metrics

### DIFF
--- a/include/fluent-bit/flb_http_server.h
+++ b/include/fluent-bit/flb_http_server.h
@@ -22,6 +22,7 @@
 
 #ifndef FLB_HTTP_SERVER_H
 #define FLB_HTTP_SERVER_H
+
 #include "http_server/flb_hs.h"
 #include "http_server/flb_hs_utils.h"
 #include "http_server/flb_hs_endpoints.h"

--- a/include/fluent-bit/http_server/flb_hs.h
+++ b/include/fluent-bit/http_server/flb_hs.h
@@ -32,7 +32,7 @@
 struct flb_hs_buf {
     int users;
     flb_sds_t data;
-    char *raw_data;
+    void *raw_data;
     size_t raw_size;
     struct mk_list _head;
 };
@@ -41,6 +41,7 @@ struct flb_hs {
     mk_ctx_t *ctx;             /* Monkey HTTP Context */
     int vid;                   /* Virtual Host ID     */
     int qid_metrics;           /* Metrics Message Queue ID    */
+    int qid_metrics_v2;        /* Metrics Message Queue ID for /api/v2 */
     int qid_storage;           /* Storage Message Queue ID    */
     int qid_health;            /* health Message Queue ID    */
 
@@ -56,6 +57,7 @@ struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config);
 int flb_hs_push_health_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_pipeline_metrics(struct flb_hs *hs, void *data, size_t size);
+int flb_hs_push_metrics(struct flb_hs *hs, void *data, size_t size);
 int flb_hs_push_storage_metrics(struct flb_hs *hs, void *data, size_t size);
 
 int flb_hs_destroy(struct flb_hs *ctx);

--- a/src/flb_metrics_exporter.c
+++ b/src/flb_metrics_exporter.c
@@ -148,9 +148,17 @@ static int collect_outputs(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
 
 static int collect_metrics(struct flb_me *me)
 {
+    int ret;
     int keys;
+    char *buf_data;
+    size_t buf_size;
     struct flb_config *ctx = me->config;
+    struct cmt *cmt;
 
+    /*
+     * msgpack buffer for old-style /v1/metrics
+     * ----------------------------------------
+     */
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
 
@@ -166,15 +174,36 @@ static int collect_metrics(struct flb_me *me)
     collect_filters(&mp_sbuf, &mp_pck, me->config);
     collect_outputs(&mp_sbuf, &mp_pck, me->config);
 
+    /*
+     * If the built-in HTTP server is enabled, push metrics and health checks
+     * ---------------------------------------------------------------------
+     */
+
 #ifdef FLB_HAVE_HTTP_SERVER
     if (ctx->http_server == FLB_TRUE) {
-        /* v1 metrics (old) */
+        /* /v1/metrics (old) */
         flb_hs_push_pipeline_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
+
+        /* /v1/health */
         if (ctx->health_check == FLB_TRUE) {
             flb_hs_push_health_metrics(ctx->http_ctx, mp_sbuf.data, mp_sbuf.size);
         }
+
+        /* /v2/metrics: retrieve a CMetrics context with internal metrics */
+        cmt = flb_me_get_cmetrics(ctx);
+        if (cmt) {
+            /* encode context to msgpack */
+            ret = cmt_encode_msgpack_create(cmt, &buf_data, &buf_size);
+            if (ret == 0) {
+                flb_hs_push_metrics(ctx->http_ctx, buf_data, buf_size);
+                cmt_encode_msgpack_destroy(buf_data);
+            }
+            cmt_destroy(cmt);
+        }
     }
 #endif
+
+    /* destroy msgpack buffer for old-style /v1/metrics */
     msgpack_sbuffer_destroy(&mp_sbuf);
 
 

--- a/src/http_server/CMakeLists.txt
+++ b/src/http_server/CMakeLists.txt
@@ -12,6 +12,9 @@ set(src
 # api/v1
 add_subdirectory(api/v1)
 
+# api/v2
+add_subdirectory(api/v2)
+
 include_directories(${MONKEY_INCLUDE_DIR})
 add_library(flb-http-server STATIC ${src})
-target_link_libraries(flb-http-server monkey-core-static api-v1)
+target_link_libraries(flb-http-server monkey-core-static api-v1 api-v2)

--- a/src/http_server/api/v2/CMakeLists.txt
+++ b/src/http_server/api/v2/CMakeLists.txt
@@ -1,0 +1,9 @@
+# api/v2
+set(src
+  metrics.c
+  register.c
+  )
+
+include_directories(${MONKEY_INCLUDE_DIR})
+add_library(api-v2 STATIC ${src})
+target_link_libraries(api-v2 monkey-core-static fluent-bit-static)

--- a/src/http_server/api/v2/metrics.c
+++ b/src/http_server/api/v2/metrics.c
@@ -1,0 +1,259 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_version.h>
+#include <fluent-bit/flb_time.h>
+#include "metrics.h"
+
+#include <fluent-bit/flb_http_server.h>
+
+#define null_check(x) do { if (!x) { goto error; } else {sds = x;} } while (0)
+
+pthread_key_t hs_metrics_v2_key;
+
+static struct mk_list *hs_metrics_v2_key_create()
+{
+    struct mk_list *metrics_list = NULL;
+
+    metrics_list = flb_malloc(sizeof(struct mk_list));
+    if (metrics_list == NULL) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(metrics_list);
+    pthread_setspecific(hs_metrics_v2_key, metrics_list);
+
+    return metrics_list;
+}
+
+static void hs_metrics_v2_key_destroy(void *data)
+{
+    struct mk_list *metrics_list = (struct mk_list*) data;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_hs_buf *entry;
+
+    if (metrics_list == NULL) {
+        return;
+    }
+    mk_list_foreach_safe(head, tmp, metrics_list) {
+        entry = mk_list_entry(head, struct flb_hs_buf, _head);
+        if (entry != NULL) {
+            if (entry->raw_data != NULL) {
+                cmt_destroy(entry->raw_data);
+                entry->raw_data = NULL;
+            }
+            mk_list_del(&entry->_head);
+            flb_free(entry);
+        }
+    }
+
+    flb_free(metrics_list);
+}
+
+/* Return the newest metrics buffer */
+static struct flb_hs_buf *metrics_get_latest()
+{
+    struct flb_hs_buf *buf;
+    struct mk_list *metrics_list;
+
+    metrics_list = pthread_getspecific(hs_metrics_v2_key);
+    if (!metrics_list) {
+        return NULL;
+    }
+
+    if (mk_list_size(metrics_list) == 0) {
+        return NULL;
+    }
+
+    buf = mk_list_entry_last(metrics_list, struct flb_hs_buf, _head);
+    return buf;
+}
+
+/* Delete unused metrics, note that we only care about the latest node */
+static int cleanup_metrics()
+{
+    int c = 0;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct mk_list *metrics_list;
+    struct flb_hs_buf *last;
+    struct flb_hs_buf *entry;
+
+    metrics_list = pthread_getspecific(hs_metrics_v2_key);
+    if (!metrics_list) {
+        return -1;
+    }
+
+    last = metrics_get_latest();
+    if (!last) {
+        return -1;
+    }
+
+    mk_list_foreach_safe(head, tmp, metrics_list) {
+        entry = mk_list_entry(head, struct flb_hs_buf, _head);
+        if (entry != last && entry->users == 0) {
+            mk_list_del(&entry->_head);
+            cmt_destroy(entry->raw_data);
+            flb_free(entry);
+            c++;
+        }
+    }
+
+    return c;
+}
+
+/*
+ * Callback invoked every time some metrics are received through a message queue channel.
+ * This function runs in a Monkey HTTP thread worker and it purpose is to take the metrics
+ * data and store it somewhere so then it can be available by the end-points upon
+ * HTTP client requests.
+ */
+static void cb_mq_metrics(mk_mq_t *queue, void *data, size_t size)
+{
+    int ret;
+    size_t off = 0;
+    struct cmt *cmt;
+    struct flb_hs_buf *buf;
+    struct mk_list *metrics_list = NULL;
+
+    metrics_list = pthread_getspecific(hs_metrics_v2_key);
+    if (!metrics_list) {
+        metrics_list = hs_metrics_v2_key_create();
+        if (metrics_list == NULL) {
+            return;
+        }
+    }
+
+    /* decode cmetrics */
+    ret = cmt_decode_msgpack_create(&cmt, data, size, &off);
+    if (ret != 0) {
+        return;
+    }
+
+    buf = flb_malloc(sizeof(struct flb_hs_buf));
+    if (!buf) {
+        flb_errno();
+        return;
+    }
+    buf->users = 0;
+    buf->data = NULL;
+
+    /* Store CMetrics context as the raw_data */
+    buf->raw_data = cmt;
+    buf->raw_size = 0;
+
+    mk_list_add(&buf->_head, metrics_list);
+    cleanup_metrics();
+}
+
+/* API: expose metrics in Prometheus format /api/v2/metrics/prometheus */
+static void cb_metrics_prometheus(mk_request_t *request, void *data)
+{
+    struct cmt *cmt;
+    struct flb_hs_buf *buf;
+    cfl_sds_t payload;
+
+    buf = metrics_get_latest();
+    if (!buf) {
+        mk_http_status(request, 404);
+        mk_http_done(request);
+        return;
+    }
+
+    cmt = (struct cmt *) buf->raw_data;
+
+    /* convert CMetrics to text */
+    payload = cmt_encode_prometheus_create(cmt, CMT_FALSE);
+    if (!payload) {
+        mk_http_status(request, 500);
+        mk_http_done(request);
+        return;
+    }
+
+    buf->users++;
+
+    mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_PROMETHEUS);
+    mk_http_send(request, payload, cfl_sds_len(payload), NULL);
+    mk_http_done(request);
+
+    cmt_encode_prometheus_destroy(payload);
+
+    buf->users--;
+}
+
+/* API: expose built-in metrics /api/v1/metrics (JSON format) */
+static void cb_metrics(mk_request_t *request, void *data)
+{
+    struct cmt *cmt;
+    struct flb_hs_buf *buf;
+    cfl_sds_t payload;
+
+    buf = metrics_get_latest();
+    if (!buf) {
+        mk_http_status(request, 404);
+        mk_http_done(request);
+        return;
+    }
+
+    cmt = (struct cmt *) buf->raw_data;
+
+    /* convert CMetrics to text */
+    payload = cmt_encode_text_create(cmt);
+    if (!payload) {
+        mk_http_status(request, 500);
+        mk_http_done(request);
+        return;
+    }
+
+    buf->users++;
+
+    mk_http_status(request, 200);
+    mk_http_send(request, payload, cfl_sds_len(payload), NULL);
+    mk_http_done(request);
+
+    cmt_encode_text_destroy(payload);
+
+    buf->users--;
+}
+
+/* Perform registration */
+int api_v2_metrics(struct flb_hs *hs)
+{
+
+    pthread_key_create(&hs_metrics_v2_key, hs_metrics_v2_key_destroy);
+
+    /* Create a message queue */
+    hs->qid_metrics_v2 = mk_mq_create(hs->ctx, "/metrics_v2",
+                                      cb_mq_metrics, NULL);
+    /* HTTP end-points */
+    mk_vhost_handler(hs->ctx, hs->vid, "/api/v2/metrics/prometheus",
+                     cb_metrics_prometheus, hs);
+
+    mk_vhost_handler(hs->ctx, hs->vid, "/api/v2/metrics", cb_metrics, hs);
+
+    return 0;
+}

--- a/src/http_server/api/v2/metrics.h
+++ b/src/http_server/api/v2/metrics.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_HS_API_V2_METRICS_H
+#define FLB_HS_API_V2_METRICS_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_server.h>
+
+int api_v2_metrics(struct flb_hs *hs);
+
+#endif

--- a/src/http_server/api/v2/register.c
+++ b/src/http_server/api/v2/register.c
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_server.h>
+
+#include "metrics.h"
+
+int api_v2_registration(struct flb_hs *hs)
+{
+    api_v2_metrics(hs);
+    return 0;
+}

--- a/src/http_server/api/v2/register.h
+++ b/src/http_server/api/v2/register.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_API_V2_REG_H
+#define FLB_API_V2_REG_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_http_server.h>
+
+int api_v2_registration(struct flb_hs *hs);
+
+#endif


### PR DESCRIPTION
The following PR, introduces the new endpoint `/api/v2/` which exposes by default the internal metrics of Fluent Bit:

| endpoint | description | 
|--|--|
| `/api/v2/metrics` | expose internal metrics in text format |
| `/api/v2/metrics/prometheus` | expose internal metrics in Prometheus text format |

note: there is no changes to the `/api/v1` endpoint, this is just the beginning of a next version, both will be available. 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
