### PR TITLE
CMakeLists.txt: only require a C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fluent-bit)
+project(fluent-bit C)
 
 # CMP0069 ensures that LTO is enabled for all compilers
 cmake_policy(SET CMP0069 NEW)


### PR DESCRIPTION
Fluent-bit is mostly written in C,
so don't require CXX in the top-level project.

Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com>

Seen while debugging fluent-bit on https://github.com/buildroot/buildroot/commit/6a0f7c39bcb48fc13aa2ce3fc4996baf1be66483 with c-only toolchains.
https://patchwork.ozlabs.org/project/buildroot/patch/20230130121930.3472747-1-thomas@devoogdt.com/


<!-- Provide summary of changes -->

Fluent-bit is mainly written in C,
so don't require CXX in the top-level project.

https://cmake.org/cmake/help/latest/command/project.html
 - Optional. Can also be specified without LANGUAGES keyword per the first, short signature.
 - By default C and CXX are enabled if no language options are given. 

No mention of "New in version", so I guess that older cmake versions can handle this.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.