### PR TITLE
in_tail: add file name context to inotify debug event mask

### DIFF
--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -43,21 +43,30 @@ static int debug_event_mask(struct flb_tail_config *ctx,
                             uint32_t mask)
 {
     flb_sds_t buf;
+    int buf_size = 256;
 
     /* Only enter this function if debug mode is allowed */
     if (flb_log_check(FLB_LOG_DEBUG) == 0) {
         return 0;
     }
 
+    if (file) {
+        buf_size = file->name_len + 64;
+    }
+    
+    if (buf_size < 256) {
+        buf_size = 256;
+    }
+
     /* Create buffer */
-    buf = flb_sds_create_size(256);
+    buf = flb_sds_create_size(buf_size);
     if (!buf) {
         return -1;
     }
 
     /* Print info into sds */
     if (file) {
-        flb_sds_printf(&buf, "inode=%"PRIu64" events: ", file->inode);
+        flb_sds_printf(&buf, "inode=%"PRIu64", %s, events: ", file->name, file->inode);
     }
     else {
         flb_sds_printf(&buf, "events: ");


### PR DESCRIPTION
These messages are useful for debugging except with only the inode, it you have to do work to match this with specific files.

Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
