### PR TITLE
windows_exporter_metrics: Support individual on/off and intervals for metrics

### DIFF
--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -193,6 +193,27 @@ struct flb_we {
     struct flb_callback *callback;                    /* metric callback */
     struct mk_list *metrics;                          /* enabled metrics */
 
+    /* Individual intervals for metrics */
+    int cpu_scrape_interval;
+    int net_scrape_interval;
+    int logical_disk_scrape_interval;
+    int cs_scrape_interval;
+    int os_scrape_interval;
+    int wmi_thermalzone_scrape_interval;
+    int wmi_cpu_info_scrape_interval;
+    int wmi_logon_scrape_interval;
+    int wmi_system_scrape_interval;
+
+    int coll_cpu_fd;                                    /* collector fd (cpu)    */
+    int coll_net_fd;                                    /* collector fd (net)  */
+    int coll_logical_disk_fd;                           /* collector fd (logical_disk) */
+    int coll_cs_fd;                                     /* collector fd (cs) */
+    int coll_os_fd;                                     /* collector fd (os)    */
+    int coll_wmi_thermalzone_fd;                        /* collector fd (wmi_thermalzone) */
+    int coll_wmi_cpu_info_fd;                           /* collector fd (wmi_cpu_info) */
+    int coll_wmi_logon_fd;                              /* collector fd (wmi_logon)    */
+    int coll_wmi_system_fd;                             /* collector fd (wmi_system)    */
+
     /*
      * Metrics Contexts
      * ----------------

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -190,6 +190,9 @@ struct flb_we {
 
     float windows_version;
 
+    struct flb_callback *callback;                    /* metric callback */
+    struct mk_list *metrics;                          /* enabled metrics */
+
     /*
      * Metrics Contexts
      * ----------------


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, windows_exporter_metrics does not support switch on/off for each of metrics and support each of intervals of scrapiong metrics neither.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```python
[INPUT]
    Name windows_exporter_metrics
    Tag             windows_metrics
    scrape_interval 5
    we.logical_disk.allow_disk_regex /(C|D)/
    we.logical_disk.deny_disk_regex /^HarddiskVolume.*/
    collector.cpu.scrape_interval 10
    collector.cpu_info.scrape_interval 50
    collector.os.scrape_interval 30
    collector.net.scrape_interval 40
    collector.logical_disk.scrape_interval 35
    collector.cs.scrape_interval 60
    collector.thermalzone.scrape_interval 55
    collector.logon.scrape_interval 15
    collector.system.scrape_interval 65
    metrics cpu,cpu_info,os,net,logical_disk,cs,thermalzone,logon,system

[OUTPUT]
    Name stdout
```
- [x] Debug log output from testing the change

<details>

```log
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/01 13:40:14] [ info] Configuration:
[2023/02/01 13:40:14] [ info]  flush time     | 1.000000 seconds
[2023/02/01 13:40:14] [ info]  grace          | 5 seconds
[2023/02/01 13:40:14] [ info]  daemon         | 0
[2023/02/01 13:40:14] [ info] ___________
[2023/02/01 13:40:14] [ info]  inputs:
[2023/02/01 13:40:14] [ info]      windows_exporter_metrics
[2023/02/01 13:40:14] [ info] ___________
[2023/02/01 13:40:14] [ info]  filters:
[2023/02/01 13:40:14] [ info] ___________
[2023/02/01 13:40:14] [ info]  outputs:
[2023/02/01 13:40:14] [ info]      stdout.0
[2023/02/01 13:40:14] [ info] ___________
[2023/02/01 13:40:14] [ info]  collectors:
[2023/02/01 13:40:14] [ info] [fluent bit] version=2.0.9, commit=abef2d6ec7, pid=11836
[2023/02/01 13:40:14] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/02/01 13:40:14] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/01 13:40:14] [ info] [cmetrics] version=0.5.8
[2023/02/01 13:40:14] [ info] [ctraces ] version=0.2.7
[2023/02/01 13:40:14] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2023/02/01 13:40:14] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/02/01 13:40:14] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=852 write=856
[2023/02/01 13:40:15] [debug] [stdout:stdout.0] created event channels: read=1232 write=1236
[2023/02/01 13:40:15] [ info] [sp] stream processor started
[2023/02/01 13:40:15] [ info] [output:stdout:stdout.0] worker #0 started
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu_info' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'os' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'net' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logical_disk' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cs' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'thermalzone' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logon' is not registered
[2023/02/01 13:40:20] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'system' is not registered
[2023/02/01 13:40:20] [debug] [input chunk] update output instances with new chunk size diff=9118
[2023/02/01 13:40:21] [debug] [task] created task=000001D2D3071A80 id=0 OK
[2023/02/01 13:40:21] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1970-01-01T00:00:00.000000000Z windows_system_exception_dispatches_total = 0
1970-01-01T00:00:00.000000000Z windows_os_physical_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_time = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes_limit = 0
1970-01-01T00:00:00.000000000Z windows_os_process_memory_limit_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes = 0
1970-01-01T00:00:00.000000000Z windows_os_users = 0
1970-01-01T00:00:00.000000000Z windows_os_visible_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_cs_logical_processors = 0
1970-01-01T00:00:00.000000000Z windows_cs_physical_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_system_context_switches_total = 0
1970-01-01T00:00:00.000000000Z windows_system_processor_queue = 0
1970-01-01T00:00:00.000000000Z windows_system_system_calls_total = 0
1970-01-01T00:00:00.000000000Z windows_system_system_up_time = 0
1970-01-01T00:00:00.000000000Z windows_system_threads = 0
[2023/02/01 13:40:21] [debug] [out flush] cb_destroy coro_id=0
[2023/02/01 13:40:21] [debug] [task] destroy task=000001D2D3071A80 (task_id=0)
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu_info' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'os' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'net' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logical_disk' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cs' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'thermalzone' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logon' is not registered
[2023/02/01 13:40:25] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'system' is not registered
[2023/02/01 13:40:25] [debug] [input chunk] update output instances with new chunk size diff=9118
[2023/02/01 13:40:26] [debug] [task] created task=000001D2D3087D60 id=0 OK
[2023/02/01 13:40:26] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1970-01-01T00:00:00.000000000Z windows_system_exception_dispatches_total = 0
1970-01-01T00:00:00.000000000Z windows_os_physical_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_time = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes_limit = 0
1970-01-01T00:00:00.000000000Z windows_os_process_memory_limit_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes = 0
1970-01-01T00:00:00.000000000Z windows_os_users = 0
1970-01-01T00:00:00.000000000Z windows_os_visible_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_cs_logical_processors = 0
1970-01-01T00:00:00.000000000Z windows_cs_physical_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_system_context_switches_total = 0
1970-01-01T00:00:00.000000000Z windows_system_processor_queue = 0
1970-01-01T00:00:00.000000000Z windows_system_system_calls_total = 0
1970-01-01T00:00:00.000000000Z windows_system_system_up_time = 0
1970-01-01T00:00:00.000000000Z windows_system_threads = 0
[2023/02/01 13:40:26] [debug] [out flush] cb_destroy coro_id=1
[2023/02/01 13:40:26] [debug] [task] destroy task=000001D2D3087D60 (task_id=0)
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cpu_info' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'os' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'net' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logical_disk' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'cs' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'thermalzone' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'logon' is not registered
[2023/02/01 13:40:30] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] Callback for metrics 'system' is not registered
[2023/02/01 13:40:30] [debug] [input chunk] update output instances with new chunk size diff=20217
[2023/02/01 13:40:31] [debug] [task] created task=000001D2D309FB70 id=0 OK
[2023/02/01 13:40:31] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,0",state="c1"} = 1199.4281711000001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,0",state="c2"} = 1204.9490053
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,0",state="c3"} = 1351475.6676934001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,1",state="c1"} = 452.16040520000001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,1",state="c2"} = 515.13840990000006
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,1",state="c3"} = 1362186.5813227
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,2",state="c1"} = 1557.4036355999999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,2",state="c2"} = 1141.2416701
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,2",state="c3"} = 1350338.8757032999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,3",state="c1"} = 562.21088169999996
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,3",state="c2"} = 523.80280170000003
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,3",state="c3"} = 1361722.1372688999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,4",state="c1"} = 472.6561686
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,4",state="c2"} = 833.70947220000005
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,4",state="c3"} = 1363024.2635842001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,5",state="c1"} = 358.60226490000002
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,5",state="c2"} = 563.3986817
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,5",state="c3"} = 1366480.3488425
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,6",state="c1"} = 269.27584519999999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,6",state="c2"} = 416.51383270000002
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,6",state="c3"} = 1367925.1882155
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,7",state="c1"} = 249.80578980000001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,7",state="c2"} = 373.09551329999999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,7",state="c3"} = 1368454.7990804
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,8",state="c1"} = 455.84735389999997
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,8",state="c2"} = 802.53385749999995
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,8",state="c3"} = 1362834.5629213999
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,9",state="c1"} = 318.79846099999997
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,9",state="c2"} = 545.82524420000004
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,9",state="c3"} = 1366444.5347418
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,10",state="c1"} = 266.6737048
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,10",state="c2"} = 454.7032643
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,10",state="c3"} = 1367568.2936895001
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,11",state="c1"} = 240.7581869
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,11",state="c2"} = 401.0384449
2023-02-01T04:40:25.058745200Z windows_cpu_cstate_seconds_total{core="0,11",state="c3"} = 1367994.5977694001
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,0",mode="idle"} = 1366329
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,0",mode="interrupt"} = 201.421875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,0",mode="dpc"} = 141.046875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,0",mode="privileged"} = 3617.40625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,0",mode="user"} = 3009.46875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,1",mode="idle"} = 1369418.09375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,1",mode="interrupt"} = 100.96875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,1",mode="dpc"} = 61.5
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,1",mode="privileged"} = 1964.078125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,1",mode="user"} = 1573.140625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,2",mode="idle"} = 1366007.671875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,2",mode="interrupt"} = 134.71875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,2",mode="dpc"} = 59.296875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,2",mode="privileged"} = 3595.828125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,2",mode="user"} = 3351.8125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,3",mode="idle"} = 1369134.375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,3",mode="interrupt"} = 87.671875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,3",mode="dpc"} = 42.046875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,3",mode="privileged"} = 2040.90625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,3",mode="user"} = 1780
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,4",mode="idle"} = 1368985.578125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,4",mode="interrupt"} = 44.8125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,4",mode="dpc"} = 33.65625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,4",mode="privileged"} = 2233.765625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,4",mode="user"} = 1735.96875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,5",mode="idle"} = 1370554.859375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,5",mode="interrupt"} = 25.359375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,5",mode="dpc"} = 16.90625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,5",mode="privileged"} = 1244.0625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,5",mode="user"} = 1156.34375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,6",mode="idle"} = 1371127.8125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,6",mode="interrupt"} = 25.828125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,6",mode="dpc"} = 14
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,6",mode="privileged"} = 1047.65625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,6",mode="user"} = 779.8125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,7",mode="idle"} = 1371261.484375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,7",mode="interrupt"} = 22.28125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,7",mode="dpc"} = 13.46875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,7",mode="privileged"} = 935.328125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,7",mode="user"} = 758.46875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,8",mode="idle"} = 1368768.015625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,8",mode="interrupt"} = 47.734375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,8",mode="dpc"} = 44.21875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,8",mode="privileged"} = 2435.5
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,8",mode="user"} = 1751.765625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,9",mode="idle"} = 1370498.5
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,9",mode="interrupt"} = 26.390625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,9",mode="dpc"} = 21.890625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,9",mode="privileged"} = 1328.296875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,9",mode="user"} = 1128.5
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,10",mode="idle"} = 1370902.890625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,10",mode="interrupt"} = 21.6875
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,10",mode="dpc"} = 15.375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,10",mode="privileged"} = 1110.625
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,10",mode="user"} = 941.78125
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,11",mode="idle"} = 1370978.9375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,11",mode="interrupt"} = 19.75
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,11",mode="dpc"} = 16.234375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,11",mode="privileged"} = 1063.109375
2023-02-01T04:40:25.058745200Z windows_cpu_time_total{core="0,11",mode="user"} = 913.234375
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,0"} = 120941941
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,1"} = 53590741
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,2"} = 104371786
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,3"} = 48458151
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,4"} = 37978476
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,5"} = 26750498
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,6"} = 24932587
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,7"} = 21767165
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,8"} = 39044719
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,9"} = 26340972
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,10"} = 21643681
2023-02-01T04:40:25.058745200Z windows_cpu_interrupts_total{core="0,11"} = 19408696
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,0"} = 22962669
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,1"} = 10385600
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,2"} = 15372487
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,3"} = 8480155
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,4"} = 3677831
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,5"} = 2686704
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,6"} = 2320108
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,7"} = 2006141
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,8"} = 3927972
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,9"} = 2601729
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,10"} = 2146070
2023-02-01T04:40:25.058745200Z windows_cpu_dpcs_total{core="0,11"} = 2047442
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,0"} = 18510387
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,1"} = 9133614
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,2"} = 18782736
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,3"} = 9360287
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,4"} = 3322666
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,5"} = 2265582
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,6"} = 1606186
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,7"} = 1475928
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,8"} = 2885675
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,9"} = 1826643
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,10"} = 1487628
2023-02-01T04:40:25.058745200Z windows_cpu_clock_interrupts_total{core="0,11"} = 1404993
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,0"} = 80316690
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,1"} = 33549490
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,2"} = 72663180
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,3"} = 31076764
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,4"} = 21498001
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,5"} = 16060594
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,6"} = 13905565
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,7"} = 12623316
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,8"} = 22199991
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,9"} = 15640528
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,10"} = 13004262
2023-02-01T04:40:25.058745200Z windows_cpu_idle_break_events_total{core="0,11"} = 11638534
1970-01-01T00:00:00.000000000Z windows_system_exception_dispatches_total = 0
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,0"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,1"} = 0
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,2"} = 0
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,3"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,4"} = 0
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,5"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,6"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,7"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,8"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,9"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,10"} = 0
2023-02-01T04:40:25.058745200Z windows_cpu_parkings_status{core="0,11"} = 1
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,0"} = 1700
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,1"} = 1700
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,2"} = 1700
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,3"} = 1700
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,4"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,5"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,6"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,7"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,8"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,9"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,10"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_core_frequency_mhz{core="0,11"} = 1200
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,0"} = 1686026995319
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,1"} = 813567399299
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,2"} = 1797966164816
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,3"} = 849514032615
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,4"} = 635632585143
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,5"} = 426954655310
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,6"} = 341458802129
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,7"} = 306435258631
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,8"} = 657548281053
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,9"} = 435921654209
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,10"} = 362330150148
2023-02-01T04:40:25.058745200Z windows_cpu_processor_performance{core="0,11"} = 334075451337
1970-01-01T00:00:00.000000000Z windows_os_physical_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_time = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes_limit = 0
1970-01-01T00:00:00.000000000Z windows_os_process_memory_limit_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_processes = 0
1970-01-01T00:00:00.000000000Z windows_os_users = 0
1970-01-01T00:00:00.000000000Z windows_os_visible_memory_bytes = 0
1970-01-01T00:00:00.000000000Z windows_os_virtual_memory_free_bytes = 0
1970-01-01T00:00:00.000000000Z windows_cs_logical_processors = 0
1970-01-01T00:00:00.000000000Z windows_cs_physical_memory_bytes = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="system"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="interactive"} = 2
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="network"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="batch"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="service"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="proxy"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="unlock"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="network_clear_text"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="new_credentials"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="remote_interactive"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="cached_interactive"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="cached_remote_interactive"} = 0
2023-02-01T04:40:30.066054500Z windows_logon_logon_type{status="cached_unlock"} = 0
1970-01-01T00:00:00.000000000Z windows_system_context_switches_total = 0
1970-01-01T00:00:00.000000000Z windows_system_processor_queue = 0
1970-01-01T00:00:00.000000000Z windows_system_system_calls_total = 0
1970-01-01T00:00:00.000000000Z windows_system_system_up_time = 0
1970-01-01T00:00:00.000000000Z windows_system_threads = 0
[2023/02/01 13:40:31] [debug] [out flush] cb_destroy coro_id=2
[2023/02/01 13:40:31] [debug] [task] destroy task=000001D2D309FB70 (task_id=0)
[2023/02/01 13:40:32] [engine] caught signal (SIGINT)
[2023/02/01 13:40:32] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/01 13:40:32] [ info] [input] pausing windows_exporter_metrics.0
[2023/02/01 13:40:33] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/01 13:40:33] [ info] [input] pausing windows_exporter_metrics.0
[2023/02/01 13:40:33] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/01 13:40:33] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

</details>

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

~~TBD~~ https://github.com/fluent/fluent-bit-docs/pull/1037

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
