### PR TITLE
in_opentelemetry: refactor json logs parsing

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -35,6 +35,12 @@
 static int otlp_pack_any_value(msgpack_packer *mp_pck,
                                Opentelemetry__Proto__Common__V1__AnyValue *body);
 
+static int pack_msgpack_any_value_object(msgpack_packer *mp_pck,
+                                         msgpack_object *obj);
+
+static int pack_msgpack_kvlist(msgpack_packer *mp_pck,
+                               msgpack_object *obj);
+
 static int send_response(struct http_conn *conn, int http_status, char *message)
 {
     int len;
@@ -395,107 +401,486 @@ static int binary_payload_to_msgpack(msgpack_packer *mp_pck,
     return 0;
 }
 
-static int get_token_length(jsmntok_t token){
-    return token.end - token.start;
+static int pack_resource(msgpack_packer *mp_pck,
+                         msgpack_object_map resource)
+{
+    int ret;
+
+    if (resource.size != 1 ||
+        resource.ptr[0].key.type != MSGPACK_OBJECT_STR ||
+        strncasecmp("attributes", resource.ptr[0].key.via.str.ptr, resource.ptr[0].key.via.str.size) != 0) {
+        flb_error("[otel] Invalid JSON payload, incorrect resource definition");
+        return -1;
+    }
+
+    if (resource.ptr[0].val.type != MSGPACK_OBJECT_ARRAY) {
+        flb_error("[otel] Invalid JSON payload, attribute list must be an array");
+    }
+
+    ret = pack_msgpack_kvlist(mp_pck, &resource.ptr[0].val);
+
+    return ret;
 }
 
-static char *get_value_from_token(jsmntok_t *tokens,
-                                  const char *body,
-                                  int pos){
-    char *tmp;
-    jsmntok_t token;
-    int token_len;
+static int pack_msgpack_bytes(msgpack_packer *mp_pck,
+                              msgpack_object *obj)
+{
+    return msgpack_pack_bin_with_body(mp_pck, obj->via.bin.ptr, obj->via.bin.size);
+}
 
-    token = tokens[pos];
-    token_len = get_token_length(token);
+static int pack_msgpack_string(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    return msgpack_pack_str_with_body(mp_pck, obj->via.str.ptr, obj->via.str.size);
+}
 
-    tmp = flb_calloc(1, token_len + 1);
-    tmp =  memcpy(tmp, body+token.start, token_len);
+static int pack_msgpack_double(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    return msgpack_pack_double(mp_pck, obj->via.f64);
+}
 
-    return tmp;
+static int pack_msgpack_int(msgpack_packer *mp_pck,
+                            msgpack_object *obj)
+{
+    return msgpack_pack_int(mp_pck, obj->via.i64);
+}
+
+static int pack_msgpack_boolean(msgpack_packer *mp_pck,
+                                msgpack_object *obj)
+{
+    return msgpack_pack_double(mp_pck, obj->via.boolean);
+}
+
+static int pack_msgpack_array(msgpack_packer *mp_pck,
+                              msgpack_object *obj)
+{
+    size_t arr_index;
+    msgpack_object_array arr;
+    int ret = 0;
+
+    arr = obj->via.array;
+
+    msgpack_pack_array(mp_pck, arr.size);
+
+    for (arr_index = 0;
+         arr_index < arr.size && ret == 0;
+         arr_index++) {
+
+        ret = pack_msgpack_any_value_object(mp_pck, &arr.ptr[arr_index]);
+
+    }
+
+    return ret;
+}
+
+static int pack_msgpack_kvpair(msgpack_packer *mp_pck,
+                               msgpack_object_map *obj)
+{
+    size_t kvpair_index;
+    msgpack_object k;
+    msgpack_object v;
+    int ret = 0;
+
+    if (obj->size != 2) {
+        flb_error("[otel] Invalid kvpair");
+        return -1;
+    }
+
+    msgpack_pack_map(mp_pck, 1);
+
+    // pack key as string and value as anyValue
+    for (kvpair_index = 0;
+         kvpair_index < obj->size && ret == 0;
+         kvpair_index++) {
+
+        k = obj->ptr[kvpair_index].key;
+        v = obj->ptr[kvpair_index].val;
+
+        if (k.type != MSGPACK_OBJECT_STR) {
+            flb_error("[otel] Invalid kvpair");
+            return -1;
+        }
+
+        if (strncasecmp("key", k.via.str.ptr, k.via.str.size) == 0) {
+            ret = msgpack_pack_str_with_body(mp_pck, v.via.str.ptr, v.via.str.size);
+        }
+        else if (strncasecmp("value", k.via.str.ptr, k.via.str.size) == 0) {
+            ret = pack_msgpack_any_value_object(mp_pck, &v);
+        }
+    }
+
+    return ret;
+}
+
+static int pack_msgpack_kvlist(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    int ret = 0;
+    msgpack_object_array arr;
+    msgpack_object_map kvpair;
+    size_t arr_index;
+
+    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+        flb_error("[otel] Kvlist value must be an array");
+        return ret;
+    }
+
+    arr = obj->via.array;
+
+    msgpack_pack_array(mp_pck, arr.size);
+
+    for (arr_index = 0; arr_index < arr.size && ret == 0; arr_index++) {
+
+        if (arr.ptr[arr_index].type != MSGPACK_OBJECT_MAP ||
+            arr.ptr[arr_index].via.map.size % 2 != 0) {
+
+            flb_error("[otel] Invalid kvlist value");
+            return ret;
+
+        }
+
+        kvpair = arr.ptr[arr_index].via.map;
+        ret = pack_msgpack_kvpair(mp_pck, &kvpair);
+
+    }
+
+    return ret;
+}
+
+/*
+ * Any value format: {"kvlistValue":{"values":[{"key":"k","value":{"stringValue":"v"}}]}
+ * obj.key contains the value type and obj.val contains the value
+ * In case of kvlist or array we need to get rid of extra information
+ */
+static int pack_msgpack_any_value_object(msgpack_packer *mp_pck,
+                                         msgpack_object *obj)
+{
+    int ret = -1;
+    msgpack_object_kv map_value;
+
+    if (obj->type != MSGPACK_OBJECT_MAP || obj->via.map.size != 1) {
+        flb_error("[otel] Invalid map size in json to msgpack conversion");
+        return ret;
+    }
+
+    map_value = obj->via.map.ptr[0];
+
+    if (strncasecmp(map_value.key.via.str.ptr,
+                    "bytesvalue",
+                    map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_bytes(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                    "kvlistvalue",
+                    map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_kvlist(mp_pck, &map_value.val.via.map.ptr->val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "arrayvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_array(mp_pck, &map_value.val.via.map.ptr->val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "doublevalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_double(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "intvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_int(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "boolvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_boolean(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "stringvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_string(mp_pck, &map_value.val);
+
+    }
+
+    return ret;
+}
+
+static int pack_log_record(msgpack_packer *mp_pck,
+                           msgpack_object_map *resource,
+                           char *schema_url,
+                           msgpack_object_map *scope,
+                           msgpack_object_map *log_record)
+{
+    size_t log_field_index;
+    msgpack_object_kv field;
+    int ret = 0;
+
+    /*
+     * start a new log record here
+     * need confirmation on format [[timestamp, {metadata}], {log record}] or [timestamp, {log record}]
+     * As of now, we pack it in the regular format, [timestamp, {log record}]
+     */
+
+    msgpack_pack_array(mp_pck, 2);
+    flb_pack_time_now(mp_pck);
+
+    for (log_field_index = 0;
+         log_field_index < log_record->size && ret == 0;
+         log_field_index++) {
+
+            field = log_record->ptr[log_field_index];
+
+            if (field.key.type != MSGPACK_OBJECT_STR) {
+                flb_error("[otel] Invalid JSON payload, key must be a string");
+                return -1;
+            }
+
+            if (field.key.via.str.size == 4 &&
+                strncasecmp(field.key.via.str.ptr, "body", 4) == 0) {
+
+                    ret = pack_msgpack_any_value_object(mp_pck, &field.val);
+
+                }
+        }
+
+    return ret;
+}
+
+static int parse_log_records(msgpack_packer *mp_pck,
+                             msgpack_object_map *resource,
+                             char *schema_url,
+                             msgpack_object_map *scope,
+                             msgpack_object_array log_records)
+{
+    size_t log_records_index;
+    msgpack_object_map *log_record;
+    int ret = 0;
+
+    for (log_records_index = 0;
+         log_records_index < log_records.size && ret == 0;
+         log_records_index++) {
+
+            log_record = &log_records.ptr[log_records_index].via.map;
+
+            ret = pack_log_record(mp_pck, resource, schema_url, scope, log_record);
+        }
+
+    return ret;
+}
+
+static int parse_scope_logs(msgpack_packer *mp_pck,
+                            msgpack_object_map *resource,
+                            msgpack_object_array scope_logs)
+{
+    size_t scope_logs_index;
+    size_t scope_log_index;
+    msgpack_object_map scope_log;
+    msgpack_object_map *scope;
+    char *schema_url;
+    int ret;
+
+    schema_url = NULL;
+    scope = NULL;
+    ret = 0;
+
+    for (scope_logs_index = 0;
+         scope_logs_index < scope_logs.size;
+         scope_logs_index++) {
+
+        scope_log = scope_logs.ptr[scope_logs_index].via.map;
+
+        if (scope_log.size > 3) {
+            flb_error("[otel] Invalid JSON payload, a scope log can have at most 3 fields: scope, log records, & schema_url");
+            return -1;
+        }
+
+        for (scope_log_index = 0;
+             scope_log_index < scope_log.size;
+             scope_log_index++) {
+
+            if (strncasecmp("schemaurl",
+                            scope_log.ptr[scope_log_index].key.via.str.ptr,
+                            scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                    memcpy(schema_url,
+                        scope_log.ptr[scope_log_index].val.via.str.ptr,
+                        scope_log.ptr[scope_log_index].val.via.str.size);
+
+                }
+
+            else if (strncasecmp("scope",
+                                  scope_log.ptr[scope_log_index].key.via.str.ptr,
+                                  scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                    scope = &scope_log.ptr[scope_log_index].val.via.map;
+
+                }
+
+            }
+
+        for (scope_log_index = 0;
+             scope_log_index < scope_log.size;
+             scope_log_index++) {
+
+            if (strncasecmp("logrecords",
+                            scope_log.ptr[scope_log_index].key.via.str.ptr,
+                            scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                if (scope_log.ptr[scope_log_index].val.type != MSGPACK_OBJECT_ARRAY) {
+                    flb_error("[otel] Invalid JSON payload, log records must be an array");
+                }
+
+                ret = parse_log_records(mp_pck, resource, schema_url, scope, scope_log.ptr[scope_log_index].val.via.array);
+                if (ret != 0) {
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+static int parse_resource_logs(msgpack_packer *mp_pck,
+                               msgpack_object_array resource_logs)
+{
+    size_t resource_logs_index;
+    size_t resource_log_index;
+    msgpack_object_map resource_log;
+    msgpack_object_map *resource;
+    int ret;
+
+    resource = NULL;
+    ret = 0;
+
+    for (resource_logs_index = 0;
+         resource_logs_index < resource_logs.size;
+         resource_logs_index++) {
+
+        resource_log = resource_logs.ptr[resource_logs_index].via.map;
+
+        if (resource_log.size > 3) {
+            flb_error("[otel] Invalid JSON payload, a resource log can have at most 3 fields: resource, scope logs, & schema_url");
+            return -1;
+        }
+
+        /*
+         * First iterate through the keys and set the values of resource,
+         * because this needs to be propogated to the log records, and JSON can be unordered.
+         * In the next iteration, scan the scope logs and pass these values to it.
+         */
+
+        for (resource_log_index = 0;
+             resource_log_index < resource_log.size;
+             resource_log_index++) {
+
+            if (strncasecmp("resource",
+                            resource_log.ptr[resource_log_index].key.via.str.ptr,
+                            resource_log.ptr[resource_log_index].key.via.str.size) == 0) {
+
+                resource = &resource_log.ptr[resource_log_index].val.via.map;
+
+            }
+        }
+
+        for (resource_log_index = 0;
+             resource_log_index < resource_log.size;
+             resource_log_index++) {
+            if (strncasecmp("scopelogs",
+                            resource_log.ptr[resource_log_index].key.via.str.ptr,
+                            resource_log.ptr[resource_log_index].key.via.str.size) == 0) {
+
+                if (resource_log.ptr[resource_log_index].val.type != MSGPACK_OBJECT_ARRAY) {
+                    flb_error("[otel] Invalid JSON payload, scope logs must be an array");
+                    return -1;
+                }
+
+                ret = parse_scope_logs(mp_pck, resource, resource_log.ptr[resource_log_index].val.via.array);
+                if (ret != 0) {
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+/*
+ * Process the JSON payload.
+ * A valid payload must be in the form defined in the OpenTelemetry proto file:
+ * https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto
+ */
+static int process_json_export_service_request(msgpack_packer *mp_pck,
+                                               char *buf,
+                                               size_t buf_size)
+{
+    size_t off = 0;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object_map resource_logs_map;
+    int ret = 0;
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, buf, buf_size, &off) == MSGPACK_UNPACK_SUCCESS && ret == 0) {
+        root = result.data;
+        resource_logs_map = root.via.map;
+
+        if (root.type != MSGPACK_OBJECT_MAP ||
+            resource_logs_map.size != 1 ||
+            strncasecmp(resource_logs_map.ptr[0].key.via.str.ptr, "resourcelogs", resource_logs_map.ptr[0].key.via.str.size)) {
+                flb_error("[otel] Invalid JSON payload");
+                return -1;
+        }
+
+        ret = parse_resource_logs(mp_pck, resource_logs_map.ptr[0].val.via.array);
+
+    }
+
+    return ret;
 }
 
 static int json_payload_to_msgpack(msgpack_packer *mp_pck,
                                    const char *body,
                                    size_t len)
 {
-    int n_tokens;
-    int token_index;
-    int kv_index;
-    int result;
+    size_t buf_size;
+    int root_type;
+    int ret;
+    char *buf;
 
-    char *key;
-    char *otel_value_type;
-    char *otel_log_record;
+    /*
+     * Convert the json to msgpack to make parsing easier
+     */
 
-    jsmn_parser parser;
-    jsmntok_t tokens[1024];
-    jsmntok_t token;
-
-    result = 0;
-
-    jsmn_init(&parser);
-    n_tokens = jsmn_parse(&parser, body, len, tokens, 1024);
-
-    if (n_tokens < 0) {
-        flb_error("[otel] Failed to parse JSON payload, jsmn error %d", n_tokens);
+    ret = flb_pack_json(body, len, &buf, &buf_size, &root_type);
+    if (ret == FLB_ERR_JSON_PART) {
+        printf("data incomplete");
+        return -1;
+    }
+    else if (ret == FLB_ERR_JSON_INVAL) {
+        printf("invalid JSON message, skipping");
         return -1;
     }
 
-    // position 0 is the root object, skip it
-    for (token_index = 1; token_index < n_tokens; token_index++) {
-        token = tokens[token_index];
+    ret = process_json_export_service_request(mp_pck, buf, buf_size);
+    flb_free(buf);
 
-        switch (token.type) {
-
-            case JSMN_OBJECT:
-                for (kv_index=0; kv_index < token.size; kv_index++) {
-                    key = get_value_from_token(tokens, body, token_index+kv_index+1);
-
-                    if (strcmp(key, "body") == 0) {
-                        otel_value_type = get_value_from_token(tokens, body, token_index+kv_index+3);
-                        otel_log_record = get_value_from_token(tokens, body, token_index+kv_index+4);
-
-                        msgpack_pack_array(mp_pck, 2);
-                        flb_pack_time_now(mp_pck);
-
-                        if (strcasecmp(otel_value_type, "stringvalue") == 0) {
-                            result = otel_pack_string(mp_pck, otel_log_record);
-                        }
-
-                        else if (strcasecmp(otel_value_type, "intvalue") == 0) {
-                            result = otel_pack_int(mp_pck, atoi(otel_log_record));
-                        }
-
-                        else if (strcasecmp(otel_value_type, "doublevalue") == 0) {
-                            result = otel_pack_double(mp_pck, atof(otel_log_record));
-                        }
-
-                        else if (strcasecmp(otel_value_type, "boolvalue") == 0) {
-                            if (strcasecmp(otel_log_record, "true") == 0) {
-                                result = otel_pack_bool(mp_pck, true);
-                            } else {
-                                result = otel_pack_bool(mp_pck, false);
-                            }
-                        }
-
-                        else if (strcasecmp(otel_value_type, "bytesvalue") == 0){
-                            result = otel_pack_string(mp_pck, otel_log_record);
-                        }
-
-                        flb_free(otel_value_type);
-                        flb_free(otel_log_record);
-                    }
-
-                    flb_free(key);
-                }
-                break;
-
-            default:
-                break;
-        }
-    }
-    return result;
+    return ret;
 }
 
 static int process_payload_logs(struct flb_opentelemetry *ctx, struct http_conn *conn,

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -715,7 +715,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
     struct flb_time tm;
     int res = FLB_OK;
 
-    log_record_list = (Opentelemetry__Proto__Logs__V1__LogRecord *) flb_calloc(ctx->batch_size, sizeof(Opentelemetry__Proto__Logs__V1__LogRecord *));
+    log_record_list = flb_calloc(ctx->batch_size, sizeof(Opentelemetry__Proto__Logs__V1__LogRecord *));
     if (!log_record_list) {
         flb_errno();
         return -1;
@@ -728,7 +728,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
         return -1;
     }
 
-    log_bodies = (Opentelemetry__Proto__Common__V1__AnyValue *) flb_calloc(ctx->batch_size, sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
+    log_bodies = flb_calloc(ctx->batch_size, sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
     if (!log_bodies) {
         flb_free(log_record_list);
         flb_free(log_records);
@@ -761,10 +761,6 @@ static int process_logs(struct flb_event_chunk *event_chunk,
 
         /* unpack the array of [timestamp, map] */
         flb_time_pop_from_msgpack(&tm, &result, &obj);
-
-        if (obj->type != MSGPACK_OBJECT_MAP) {
-            continue;
-        }
 
         log_object = msgpack_object_to_otlp_any_value(obj);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
convert json to msgpack using Fluent Bit API to make parsing easier (instead of directly using jsmn)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[INPUT]
	name opentelemetry
	host 0.0.0.0
	port 4318

[OUTPUT]
	name opentelemetry
	match *
	host 0.0.0.0
	port 3434
	logs_uri /v1/logs
	metrics_uri /v1/metrics
	traces_uri /v1/traces
	batch_size 4
```

- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
root@72be08b8372b:/fluent-bit/build# valgrind --leak-check=full ./bin/fluent-bit -c  ../dev-files/confs/logs-otel-pipeline.conf -v
==131932== Memcheck, a memory error detector
==131932== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==131932== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==131932== Command: ./bin/fluent-bit -c ../dev-files/confs/logs-otel-pipeline.conf -v
==131932==
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/01 06:20:53] [ info] Configuration:
[2023/02/01 06:20:53] [ info]  flush time     | 1.000000 seconds
[2023/02/01 06:20:53] [ info]  grace          | 5 seconds
[2023/02/01 06:20:53] [ info]  daemon         | 0
[2023/02/01 06:20:53] [ info] ___________
[2023/02/01 06:20:53] [ info]  inputs:
[2023/02/01 06:20:53] [ info]      opentelemetry
[2023/02/01 06:20:53] [ info] ___________
[2023/02/01 06:20:53] [ info]  filters:
[2023/02/01 06:20:53] [ info] ___________
[2023/02/01 06:20:53] [ info]  outputs:
[2023/02/01 06:20:53] [ info]      opentelemetry.0
[2023/02/01 06:20:53] [ info] ___________
[2023/02/01 06:20:53] [ info]  collectors:
[2023/02/01 06:20:54] [ info] [fluent bit] version=2.0.9, commit=92ced68b60, pid=131932
[2023/02/01 06:20:54] [debug] [engine] coroutine stack size: 196608 bytes (192.0K)
[2023/02/01 06:20:54] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/01 06:20:54] [ info] [cmetrics] version=0.5.8
[2023/02/01 06:20:54] [ info] [ctraces ] version=0.2.7
[2023/02/01 06:20:54] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/02/01 06:20:54] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/02/01 06:20:54] [debug] [opentelemetry:opentelemetry.0] created event channels: read=21 write=22
[2023/02/01 06:20:54] [debug] [downstream] listening on 0.0.0.0:4318
[2023/02/01 06:20:54] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:4318
[2023/02/01 06:20:54] [debug] [opentelemetry:opentelemetry.0] created event channels: read=24 write=25
[2023/02/01 06:20:54] [ info] [sp] stream processor started
[2023/02/01 06:21:05] [debug] [input chunk] update output instances with new chunk size diff=35
[2023/02/01 06:21:05] [debug] [task] created task=0x54788a0 id=0 OK
[2023/02/01 06:21:05] [debug] [http_client] not using http_proxy for header
[2023/02/01 06:21:05] [ info] [output:opentelemetry:opentelemetry.0] 0.0.0.0:3434, HTTP status=200


[2023/02/01 06:21:05] [debug] [out flush] cb_destroy coro_id=0
[2023/02/01 06:21:05] [debug] [task] destroy task=0x54788a0 (task_id=0)
^C[2023/02/01 06:21:08] [engine] caught signal (SIGINT)
[2023/02/01 06:21:08] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/01 06:21:09] [ info] [engine] service has stopped (0 pending tasks)
==131932==
==131932== HEAP SUMMARY:
==131932==     in use at exit: 0 bytes in 0 blocks
==131932==   total heap usage: 1,670 allocs, 1,670 frees, 1,775,935 bytes allocated
==131932==
==131932== All heap blocks were freed -- no leaks are possible
==131932==
==131932== For lists of detected and suppressed errors, rerun with: -s
==131932== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
