### PR TITLE
tests: internal: fuzzers: make parse_logfmt fuzzer able to fail malloc

### DIFF
--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -11,24 +11,39 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     struct flb_config *fuzz_config;
     struct flb_parser *fuzz_parser;
 
-    /* Set fuzzer-malloc chance of failure */
-    flb_malloc_mod = 25000;
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
+    if (size < 4) {
+        return 0;
+    }
     flb_malloc_p = 0;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
 
     /* logfmt parser */
     fuzz_config = flb_config_init();
+    if (fuzz_config == NULL) {
+        return 0;
+    }
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE,
                                     MK_TRUE, FLB_FALSE, NULL, 0, NULL,
                                     fuzz_config);
-    flb_parser_do(fuzz_parser, (char*)data, size,
-                  &out_buf, &out_size, &out_time);
+    if (fuzz_parser) {
+        flb_parser_do(fuzz_parser, (char*)data, size,
+                      &out_buf, &out_size, &out_time);
 
-    if (out_buf != NULL) {
-        free(out_buf);
+        if (out_buf != NULL) {
+            free(out_buf);
+        }
+        flb_parser_destroy(fuzz_parser);
     }
 
-    flb_parser_destroy(fuzz_parser);
     flb_config_exit(fuzz_config);
 
     return 0;


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
