### PR TITLE
ring_buffer: add mutex to prevent data race

### DIFF
--- a/include/fluent-bit/flb_ring_buffer.h
+++ b/include/fluent-bit/flb_ring_buffer.h
@@ -42,5 +42,6 @@ int flb_ring_buffer_add_event_loop(struct flb_ring_buffer *rb, void *evl, uint8_
 
 int flb_ring_buffer_write(struct flb_ring_buffer *rb, void *ptr, size_t size);
 int flb_ring_buffer_read(struct flb_ring_buffer *rb, void *ptr, size_t size);
+void flb_ring_buffer_set_flush_pending(struct flb_ring_buffer *rb, int val);
 
 #endif

--- a/include/fluent-bit/flb_ring_buffer.h
+++ b/include/fluent-bit/flb_ring_buffer.h
@@ -21,6 +21,7 @@
 #define FLB_RING_BUFFER_H
 
 #include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_pthread.h>
 
 struct flb_ring_buffer {
     void *ctx;                        /* pointer to backend context */
@@ -30,6 +31,7 @@ struct flb_ring_buffer {
     flb_pipefd_t signal_channels[2];  /* flush request signaling channel */
     uint64_t data_window;             /* 0% - 100% occupancy window flush request */
     uint64_t data_size;               /* ring buffer size */
+    pthread_mutex_t pth_mutex;        /* mutex */
     void *data_buf;                   /* ring buffer */
 };
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1945,8 +1945,7 @@ void flb_input_chunk_ring_buffer_collector(struct flb_config *ctx, void *data)
             }
             cr = NULL;
         }
-
-        ins->rb->flush_pending = FLB_FALSE;
+        flb_ring_buffer_set_flush_pending(ins->rb, FLB_FALSE);
     }
 }
 

--- a/src/flb_ring_buffer.c
+++ b/src/flb_ring_buffer.c
@@ -209,4 +209,9 @@ int flb_ring_buffer_read(struct flb_ring_buffer *rb, void *ptr, size_t size)
     return 0;
 }
 
-
+void flb_ring_buffer_set_flush_pending(struct flb_ring_buffer *rb, int bool_val)
+{
+    pthread_mutex_lock(&rb->pth_mutex);
+    rb->flush_pending = bool_val;
+    pthread_mutex_unlock(&rb->pth_mutex);
+}

--- a/src/flb_ring_buffer.c
+++ b/src/flb_ring_buffer.c
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_pthread.h>
 #include <fluent-bit/flb_ring_buffer.h>
 #include <fluent-bit/flb_engine_macros.h>
 
@@ -52,6 +53,7 @@ struct flb_ring_buffer *flb_ring_buffer_create(uint64_t size)
         return NULL;
     }
     rb->data_size = size;
+    pthread_mutex_init(&rb->pth_mutex, NULL);
 
     /* lwrb context */
     lwrb = flb_malloc(sizeof(lwrb_t));
@@ -165,15 +167,19 @@ int flb_ring_buffer_write(struct flb_ring_buffer *rb, void *ptr, size_t size)
     size_t ret;
     size_t av;
 
+    pthread_mutex_lock(&rb->pth_mutex);
+
     /* make sure there is enough space available */
     av = lwrb_get_free(rb->ctx);
     if (av < size) {
+        pthread_mutex_unlock(&rb->pth_mutex);
         return -1;
     }
 
     /* write the content */
     ret = lwrb_write(rb->ctx, ptr, size);
     if (ret == 0) {
+        pthread_mutex_unlock(&rb->pth_mutex);
         return -1;
     }
 
@@ -186,15 +192,16 @@ int flb_ring_buffer_write(struct flb_ring_buffer *rb, void *ptr, size_t size)
             flb_pipe_write_all(rb->signal_channels[1], ".", 1);
         }
     }
-
+    pthread_mutex_unlock(&rb->pth_mutex);
     return 0;
 }
 
 int flb_ring_buffer_read(struct flb_ring_buffer *rb, void *ptr, size_t size)
 {
     size_t ret;
-
+    pthread_mutex_lock(&rb->pth_mutex);
     ret = lwrb_read(rb->ctx, ptr, size);
+    pthread_mutex_unlock(&rb->pth_mutex);
     if (ret == 0) {
         return -1;
     }


### PR DESCRIPTION
This patch is to add pthread_mutex_t to prevent following data race.

<details>

```
    ==================
    WARNING: ThreadSanitizer: data race (pid=4506)
      Read of size 8 at 0x7b9400000010 by thread T1:
        #0 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827 (libtsan.so.0+0x6243e)
        #1 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:819 (libtsan.so.0+0x6243e)
        #2 lwrb_read /home/taka/git/fluent-bit/lib/lwrb/lwrb/src/lwrb/lwrb.c:199 (fluent-bit+0x8d3d1)
        #3 flb_ring_buffer_read /home/taka/git/fluent-bit/src/flb_ring_buffer.c:197 (fluent-bit+0x176143)
        #4 flb_input_chunk_ring_buffer_collector /home/taka/git/fluent-bit/src/flb_input_chunk.c:1930 (fluent-bit+0x209432)
        #5 flb_sched_event_handler /home/taka/git/fluent-bit/src/flb_scheduler.c:428 (fluent-bit+0x139c76)
        #6 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:937 (fluent-bit+0x12615a)
        #7 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:629 (fluent-bit+0xa0ced)
    
      Previous write of size 8 at 0x7b9400000010 by thread T3:
        #0 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827 (libtsan.so.0+0x6243e)
        #1 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:819 (libtsan.so.0+0x6243e)
        #2 lwrb_write /home/taka/git/fluent-bit/lib/lwrb/lwrb/src/lwrb/lwrb.c:145 (fluent-bit+0x8d13d)
        #3 flb_ring_buffer_write /home/taka/git/fluent-bit/src/flb_ring_buffer.c:175 (fluent-bit+0x176025)
        #4 append_to_ring_buffer /home/taka/git/fluent-bit/src/flb_input_chunk.c:1904 (fluent-bit+0x20914f)
        #5 flb_input_chunk_append_raw /home/taka/git/fluent-bit/src/flb_input_chunk.c:1966 (fluent-bit+0x20954c)
        #6 input_log_append /home/taka/git/fluent-bit/src/flb_input_log.c:33 (fluent-bit+0x20e8d2)
        #7 flb_input_log_append /home/taka/git/fluent-bit/src/flb_input_log.c:47 (fluent-bit+0x20e955)
        #8 ml_stream_buffer_flush /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:356 (fluent-bit+0x348975)
        #9 process_content /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:575 (fluent-bit+0x3494cf)
        #10 flb_tail_file_chunk /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:1341 (fluent-bit+0x34d428)
        #11 in_tail_collect_event /home/taka/git/fluent-bit/plugins/in_tail/tail.c:328 (fluent-bit+0x32bec0)
        #12 tail_fs_event /home/taka/git/fluent-bit/plugins/in_tail/tail_fs_inotify.c:267 (fluent-bit+0x3329f6)
        #13 input_collector_fd /home/taka/git/fluent-bit/src/flb_input_thread.c:168 (fluent-bit+0xe0395)
        #14 engine_handle_event /home/taka/git/fluent-bit/src/flb_input_thread.c:183 (fluent-bit+0xe1111)
        #15 input_thread /home/taka/git/fluent-bit/src/flb_input_thread.c:384 (fluent-bit+0xe1111)
        #16 step_callback /home/taka/git/fluent-bit/src/flb_worker.c:43 (fluent-bit+0x157a2e)
    
      Location is heap block of size 8193 at 0x7b9400000000 allocated by main thread:
        #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:672 (libtsan.so.0+0x31edc)
        #1 flb_calloc /home/taka/git/fluent-bit/include/fluent-bit/flb_mem.h:89 (fluent-bit+0x175969)
        #2 flb_ring_buffer_create /home/taka/git/fluent-bit/src/flb_ring_buffer.c:67 (fluent-bit+0x175ab2)
        #3 flb_input_new /home/taka/git/fluent-bit/src/flb_input.c:326 (fluent-bit+0xd3c48)
        #4 service_configure_plugin /home/taka/git/fluent-bit/src/fluent-bit.c:710 (fluent-bit+0x8540d)
        #5 service_configure /home/taka/git/fluent-bit/src/fluent-bit.c:878 (fluent-bit+0x8625f)
        #6 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1182 (fluent-bit+0x87038)
        #7 main /home/taka/git/fluent-bit/src/fluent-bit.c:1257 (fluent-bit+0x8734e)
    
      Thread T1 'flb-pipeline' (tid=4508, running) created by main thread at:
        #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
        #1 mk_utils_worker_spawn /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_utils.c:284 (fluent-bit+0xc06aa0)
        #2 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1231 (fluent-bit+0x871f1)
        #3 main /home/taka/git/fluent-bit/src/fluent-bit.c:1257 (fluent-bit+0x8734e)
    
      Thread T3 'flb-in-tail.0-w' (tid=4510, running) created by thread T1 at:
        #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
        #1 mk_utils_worker_spawn /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_utils.c:284 (fluent-bit+0xc06aa0)
        #2 flb_tp_thread_start /home/taka/git/fluent-bit/src/flb_thread_pool.c:123 (fluent-bit+0x170263)
        #3 flb_input_thread_instance_init /home/taka/git/fluent-bit/src/flb_input_thread.c:543 (fluent-bit+0xe1cf6)
        #4 flb_input_instance_init /home/taka/git/fluent-bit/src/flb_input.c:1130 (fluent-bit+0xd73d0)
        #5 flb_input_init_all /home/taka/git/fluent-bit/src/flb_input.c:1217 (fluent-bit+0xd78a3)
        #6 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:717 (fluent-bit+0x12532a)
        #7 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:629 (fluent-bit+0xa0ced)
    
    SUMMARY: ThreadSanitizer: data race /home/taka/git/fluent-bit/lib/lwrb/lwrb/src/lwrb/lwrb.c:199 in lwrb_read
    ==================
```

```
    ==================
    WARNING: ThreadSanitizer: data race (pid=31138)
      Read of size 4 at 0x7b1c000002b0 by thread T3 (mutexes: write M12):
        #0 flb_ring_buffer_write /home/taka/git/fluent-bit/src/flb_ring_buffer.c:186 (fluent-bit+0x17608f)
        #1 append_to_ring_buffer /home/taka/git/fluent-bit/src/flb_input_chunk.c:1904 (fluent-bit+0x2091c4)
        #2 flb_input_chunk_append_raw /home/taka/git/fluent-bit/src/flb_input_chunk.c:1966 (fluent-bit+0x2095c1)
        #3 input_log_append /home/taka/git/fluent-bit/src/flb_input_log.c:33 (fluent-bit+0x20e947)
        #4 flb_input_log_append /home/taka/git/fluent-bit/src/flb_input_log.c:47 (fluent-bit+0x20e9ca)
        #5 ml_stream_buffer_flush /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:356 (fluent-bit+0x3489ea)
        #6 process_content /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:575 (fluent-bit+0x349544)
        #7 flb_tail_file_chunk /home/taka/git/fluent-bit/plugins/in_tail/tail_file.c:1341 (fluent-bit+0x34d49d)
        #8 in_tail_collect_static /home/taka/git/fluent-bit/plugins/in_tail/tail.c:188 (fluent-bit+0x32b489)
        #9 input_collector_fd /home/taka/git/fluent-bit/src/flb_input_thread.c:168 (fluent-bit+0xe0395)
        #10 engine_handle_event /home/taka/git/fluent-bit/src/flb_input_thread.c:183 (fluent-bit+0xe1111)
        #11 input_thread /home/taka/git/fluent-bit/src/flb_input_thread.c:384 (fluent-bit+0xe1111)
        #12 step_callback /home/taka/git/fluent-bit/src/flb_worker.c:43 (fluent-bit+0x157a2e)
    
      Previous write of size 4 at 0x7b1c000002b0 by thread T1:
        #0 flb_input_chunk_ring_buffer_collector /home/taka/git/fluent-bit/src/flb_input_chunk.c:1949 (fluent-bit+0x2094dd)
        #1 flb_sched_event_handler /home/taka/git/fluent-bit/src/flb_scheduler.c:428 (fluent-bit+0x139c76)
        #2 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:937 (fluent-bit+0x12615a)
        #3 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:629 (fluent-bit+0xa0ced)
    
      Location is heap block of size 104 at 0x7b1c000002a0 allocated by main thread:
        #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:672 (libtsan.so.0+0x31edc)
        #1 flb_calloc /home/taka/git/fluent-bit/include/fluent-bit/flb_mem.h:89 (fluent-bit+0x175969)
        #2 flb_ring_buffer_create /home/taka/git/fluent-bit/src/flb_ring_buffer.c:50 (fluent-bit+0x1759d2)
        #3 flb_input_new /home/taka/git/fluent-bit/src/flb_input.c:326 (fluent-bit+0xd3c48)
        #4 service_configure_plugin /home/taka/git/fluent-bit/src/fluent-bit.c:710 (fluent-bit+0x8540d)
        #5 service_configure /home/taka/git/fluent-bit/src/fluent-bit.c:878 (fluent-bit+0x8625f)
        #6 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1182 (fluent-bit+0x87038)
        #7 main /home/taka/git/fluent-bit/src/fluent-bit.c:1257 (fluent-bit+0x8734e)
    
      Mutex M12 (0x7b1c000002d8) created at:
        #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1227 (libtsan.so.0+0x4bee1)
        #1 flb_ring_buffer_create /home/taka/git/fluent-bit/src/flb_ring_buffer.c:56 (fluent-bit+0x175a40)
        #2 flb_input_new /home/taka/git/fluent-bit/src/flb_input.c:326 (fluent-bit+0xd3c48)
        #3 service_configure_plugin /home/taka/git/fluent-bit/src/fluent-bit.c:710 (fluent-bit+0x8540d)
        #4 service_configure /home/taka/git/fluent-bit/src/fluent-bit.c:878 (fluent-bit+0x8625f)
        #5 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1182 (fluent-bit+0x87038)
        #6 main /home/taka/git/fluent-bit/src/fluent-bit.c:1257 (fluent-bit+0x8734e)
    
      Thread T3 'flb-in-tail.0-w' (tid=31142, running) created by thread T1 at:
        #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
        #1 mk_utils_worker_spawn /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_utils.c:284 (fluent-bit+0xc06b10)
        #2 flb_tp_thread_start /home/taka/git/fluent-bit/src/flb_thread_pool.c:123 (fluent-bit+0x170263)
        #3 flb_input_thread_instance_init /home/taka/git/fluent-bit/src/flb_input_thread.c:543 (fluent-bit+0xe1cf6)
        #4 flb_input_instance_init /home/taka/git/fluent-bit/src/flb_input.c:1130 (fluent-bit+0xd73d0)
        #5 flb_input_init_all /home/taka/git/fluent-bit/src/flb_input.c:1217 (fluent-bit+0xd78a3)
        #6 flb_engine_start /home/taka/git/fluent-bit/src/flb_engine.c:717 (fluent-bit+0x12532a)
        #7 flb_lib_worker /home/taka/git/fluent-bit/src/flb_lib.c:629 (fluent-bit+0xa0ced)
    
      Thread T1 'flb-pipeline' (tid=31140, running) created by main thread at:
        #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
        #1 mk_utils_worker_spawn /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_utils.c:284 (fluent-bit+0xc06b10)
        #2 flb_main /home/taka/git/fluent-bit/src/fluent-bit.c:1231 (fluent-bit+0x871f1)
        #3 main /home/taka/git/fluent-bit/src/fluent-bit.c:1257 (fluent-bit+0x8734e)
    
    SUMMARY: ThreadSanitizer: data race /home/taka/git/fluent-bit/src/flb_ring_buffer.c:186 in flb_ring_buffer_write
    ==================
```

</details>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration


1. Run some container
1. Build fluent-bit with -DSANITIZE_THREAD=on
2. Run fluent-bit with following configuration


```
[SERVICE]
     Storage.path hoge

[INPUT]
     Name tail
     Alias container-logs
#     Path /var/log/syslog
     Path /var/lib/docker/containers/63e1107469fd01febb7e667a3cae782e87a54d46592f683ca39c91417b75216a/63e1107469fd01febb7e667a3cae782e87a54d46592f683ca39c91417b75216a-json.log
     multiline.parser docker, cri
     Tag kube.*
     threaded on
     Buffer_Chunk_Size 64KB
     Buffer_Max_Size 128KB
     Mem_Buf_Limit 10MB
     storage.type filesystem
     storage.pause_on_chunks_overlimit On
     Skip_Long_Lines On
     DB a.db
     DB.locking true
     Read_From_Head on

[OUTPUT]
     Name stdout
     Match *
```

## Debug/Valgrind output

```
# valgrind --leak-check=full ../../bin/fluent-bit -c b.conf 
==56790== Memcheck, a memory error detector
==56790== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==56790== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==56790== Command: ../../bin/fluent-bit -c b.conf
==56790== 
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/02 09:57:36] [ info] [fluent bit] version=2.0.9, commit=d55530fa80, pid=56790
[2023/02/02 09:57:36] [ info] [storage] created root path hoge
[2023/02/02 09:57:36] [ info] [storage] ver=1.2.0, type=memory+filesystem, sync=normal, checksum=off, max_chunks_up=128
[2023/02/02 09:57:36] [ info] [storage] backlog input plugin: storage_backlog.1
[2023/02/02 09:57:36] [ info] [cmetrics] version=0.5.8
[2023/02/02 09:57:36] [ info] [ctraces ] version=0.2.7
[2023/02/02 09:57:36] [ info] [input:tail:container-logs] initializing
[2023/02/02 09:57:36] [ info] [input:tail:container-logs] storage_strategy='filesystem' (memory + filesystem)
[2023/02/02 09:57:37] [ info] [input:tail:container-logs] multiline core started
[2023/02/02 09:57:37] [ info] [input:tail:container-logs] thread instance initialized
(snip)
[2023/02/02 09:57:40] [ info] [input:tail:container-logs] inotify_fs_remove(): inode=5133186 watch_fd=1
[2023/02/02 09:57:40] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/02 09:57:40] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==56790== 
==56790== HEAP SUMMARY:
==56790==     in use at exit: 0 bytes in 0 blocks
==56790==   total heap usage: 36,434 allocs, 36,434 frees, 146,724,432 bytes allocated
==56790== 
==56790== All heap blocks were freed -- no leaks are possible
==56790== 
==56790== For lists of detected and suppressed errors, rerun with: -s
==56790== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
