### PR TITLE
fix various object destroy calls (wrong/missing)

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -152,7 +152,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
             if (sec == 0 && nsec == 0) {
                 flb_plg_error(ctx->ins, "invalid 'refresh_interval' config "
                               "value (%s)", tmp);
-                flb_free(ctx);
+                flb_tail_config_destroy(ctx);
                 return NULL;
             }
 
@@ -174,7 +174,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     /* Config: seconds interval to monitor file after rotation */
     if (ctx->rotate_wait <= 0) {
         flb_plg_error(ctx->ins, "invalid 'rotate_wait' config value");
-        flb_free(ctx);
+        flb_tail_config_destroy(ctx);
         return NULL;
     }
 
@@ -201,7 +201,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     /* Validate buffer limit */
     if (ctx->buf_chunk_size > ctx->buf_max_size) {
         flb_plg_error(ctx->ins, "buffer_max_size must be >= buffer_chunk");
-        flb_free(ctx);
+        flb_tail_config_destroy(ctx);
         return NULL;
     }
 
@@ -438,10 +438,8 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
 #endif
 
     /* Close pipe ends */
-    flb_pipe_close(config->ch_manager[0]);
-    flb_pipe_close(config->ch_manager[1]);
-    flb_pipe_close(config->ch_pending[0]);
-    flb_pipe_close(config->ch_pending[1]);
+    flb_pipe_destroy(config->ch_manager);
+    flb_pipe_destroy(config->ch_pending);
 
 #ifdef FLB_HAVE_REGEX
     if (config->tag_regex) {

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1336,6 +1336,14 @@ static flb_sds_t loki_compose_payload(struct flb_loki *ctx,
 
          /* Iterate each record and pack it */
          while (msgpack_unpack_next(&result, data, bytes, &off) == mp_ok) {
+             if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+                 continue;
+             }
+
+             if (result.data.via.array.size != 2) {
+                 continue;
+             }
+
              /* Retrive timestamp of the record */
              flb_time_pop_from_msgpack(&tms, &result, &obj);
 
@@ -1356,6 +1364,14 @@ static flb_sds_t loki_compose_payload(struct flb_loki *ctx,
 
          /* Iterate each record and pack it */
          while (msgpack_unpack_next(&result, data, bytes, &off) == mp_ok) {
+             if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+                 continue;
+             }
+
+             if (result.data.via.array.size != 2) {
+                 continue;
+             }
+
              /* Retrive timestamp of the record */
              flb_time_pop_from_msgpack(&tms, &result, &obj);
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -380,8 +380,10 @@ void flb_config_exit(struct flb_config *config)
     }
 
     /* Pipe */
-    if (config->ch_data[0]) {
+    if (config->ch_data[0 > 0]) {
         mk_event_closesocket(config->ch_data[0]);
+    }
+    if (config->ch_data[1] > 0) {
         mk_event_closesocket(config->ch_data[1]);
     }
 

--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -554,7 +554,7 @@ struct flb_sched *flb_sched_create(struct flb_config *config,
     event->status = MK_EVENT_NONE;
 
     /* Create the frame timer */
-    fd = mk_event_timeout_create(evl, FLB_SCHED_REQUEST_FRAME, 0,
+    fd = mk_event_timeout_create(sched->evl, FLB_SCHED_REQUEST_FRAME, 0,
                                  event);
     event->priority = FLB_ENGINE_PRIORITY_CB_SCHED;
     if (fd == -1) {

--- a/src/flb_worker.c
+++ b/src/flb_worker.c
@@ -146,6 +146,10 @@ void flb_worker_destroy(struct flb_worker *worker)
         flb_log_cache_destroy(worker->log_cache);
     }
 
+    if (worker->log) {
+        flb_pipe_destroy(worker->log);
+    }
+
     mk_list_del(&worker->_head);
     flb_free(worker);
 }


### PR DESCRIPTION
This provides various fixes for incorrect/missing object destroy calls in various places during investigation of issue #6748 .


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
