### PR TITLE
data_dog: partially revert recent datadog PR to avoid segfault

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -256,11 +256,8 @@ static int datadog_format(struct flb_config *config,
              * (so they won't be packed as attr)
              */
             if (ctx->remap && (ind = dd_attr_need_remapping(k, v)) >=0 ) {
-                ret = remapping[ind].remap_to_tag(remapping[ind].remap_tag_name, v,
-                                                  &remapped_tags);
-                if (ret < 0) {
-                    flb_plg_error(ctx->ins, "Failed to remap tag: %s, skipping", remapping[ind].remap_tag_name);
-                }
+                remapping[ind].remap_to_tag(remapping[ind].remap_tag_name, v,
+                                            remapped_tags);
                 continue;
             }
 
@@ -282,25 +279,9 @@ static int datadog_format(struct flb_config *config,
         /* here we concatenate ctx->dd_tags and remapped_tags, depending on their presence */
         if (remap_cnt) {
             if (ctx->dd_tags != NULL) {
-                tmp = flb_sds_cat(remapped_tags, FLB_DATADOG_TAG_SEPERATOR,
-                                  strlen(FLB_DATADOG_TAG_SEPERATOR));
-                if (!tmp) {
-                    flb_errno();
-                    flb_sds_destroy(remapped_tags);
-                    msgpack_sbuffer_destroy(&mp_sbuf);
-                    msgpack_unpacked_destroy(&result);
-                    return -1;
-                }
-                remapped_tags = tmp;
+                flb_sds_cat(remapped_tags, FLB_DATADOG_TAG_SEPERATOR,
+                            strlen(FLB_DATADOG_TAG_SEPERATOR));
                 flb_sds_cat(remapped_tags, ctx->dd_tags, strlen(ctx->dd_tags));
-                if (!tmp) {
-                    flb_errno();
-                    flb_sds_destroy(remapped_tags);
-                    msgpack_sbuffer_destroy(&mp_sbuf);
-                    msgpack_unpacked_destroy(&result);
-                    return -1;
-                }
-                remapped_tags = tmp;
             }
             dd_msgpack_pack_key_value_str(&mp_pck,
                                           FLB_DATADOG_DD_TAGS_KEY,

--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -33,7 +33,6 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     struct flb_upstream *upstream;
     const char *api_key;
     const char *tmp;
-    flb_sds_t tmp_sds;
 
     int ret;
     char *protocol = NULL;
@@ -76,18 +75,12 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     /* use TLS ? */
     if (ins->use_tls == FLB_TRUE) {
         io_flags = FLB_IO_TLS;
-        tmp_sds = flb_sds_create("https://");
+        ctx->scheme = flb_sds_create("https://");
     }
     else {
         io_flags = FLB_IO_TCP;
-        tmp_sds = flb_sds_create("http://");
+        ctx->scheme = flb_sds_create("http://");
     }
-    if (!tmp_sds) {
-        flb_errno();
-        flb_datadog_conf_destroy(ctx);
-        return NULL;
-    }
-    ctx->scheme = tmp_sds;
     flb_plg_debug(ctx->ins, "scheme: %s", ctx->scheme);
 
     /* configure URI */
@@ -133,17 +126,11 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
 
     /* Get network configuration */
     if (!ins->host.name) {
-        tmp_sds = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
+        ctx->host = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
     }
     else {
-        tmp_sds = flb_sds_create(ins->host.name);
+        ctx->host = flb_sds_create(ins->host.name);
     }
-    if (!tmp_sds) {
-        flb_errno();
-        flb_datadog_conf_destroy(ctx);
-        return NULL;
-    }
-    ctx->host = tmp_sds;
     flb_plg_debug(ctx->ins, "host: %s", ctx->host);
 
     if (ins->host.port != 0) {

--- a/plugins/out_datadog/datadog_remap.h
+++ b/plugins/out_datadog/datadog_remap.h
@@ -22,12 +22,10 @@
 
 #include "datadog.h"
 
-typedef int (*dd_attr_remap_to_tag_fn)(const char*, msgpack_object, flb_sds_t*);
-
 struct dd_attr_tag_remapping {
     char* origin_attr_name; /* original attribute name */
     char* remap_tag_name;   /* tag name to remap to */
-    dd_attr_remap_to_tag_fn remap_to_tag;  /* remapping function */
+    void (*remap_to_tag) (const char*, msgpack_object, flb_sds_t);  /* remapping function */
 };
 
 extern const struct dd_attr_tag_remapping remapping[];


### PR DESCRIPTION
See 1.9 PR: https://github.com/fluent/fluent-bit/pull/6785

We noticed that the recent datadog pr triggers a segfault when `provider` option is set to `ecs`. After a lot of investigation, we were unable to find the root cause of the segfault, but discovers that it exists during a some random network call, which has nothing to do with the error handling code added in the PR, that when removed, resolves the segfault.

As a solution, we partially revert the recent Datadog pr that mysteriously triggers this segfault. It is just some simple error handling code that was recently added. We also add the data buffer resize fix from here: https://github.com/fluent/fluent-bit/pull/6570

Partial revert provider ecs code of Datadog recent pr that triggers segfaults:
https://github.com/fluent/fluent-bit/pull/5930
https://github.com/fluent/fluent-bit/pull/5929

See the segfault reports in aws-for-fluent-bit repo here:
https://github.com/aws/aws-for-fluent-bit/issues/491

Signed-off-by: Matthew Fala <falamatt@amazon.com>

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
