### PR TITLE
out_syslog: add allow_longer_sd_id property

### DIFF
--- a/plugins/out_syslog/syslog_conf.c
+++ b/plugins/out_syslog/syslog_conf.c
@@ -125,6 +125,10 @@ struct flb_syslog *flb_syslog_config_create(struct flb_output_instance *ins,
         }
     }
 
+    if (ctx->parsed_format == FLB_SYSLOG_RFC5424 && ctx->allow_longer_sd_id == FLB_TRUE) {
+        flb_plg_warn(ctx->ins, "Allow longer SD-ID. It may violate RFC5424.");
+    }
+
     /* validate preset values */
     ret = is_valid_severity(ctx->ins, ctx->severity_preset, ctx->parsed_format);
     if (ret != 0) {

--- a/plugins/out_syslog/syslog_conf.h
+++ b/plugins/out_syslog/syslog_conf.h
@@ -46,6 +46,7 @@ struct flb_syslog {
     flb_sds_t procid_key;
     flb_sds_t msgid_key;
     struct mk_list *sd_keys;
+    int allow_longer_sd_id;
     flb_sds_t message_key;
 
     /* Preset */


### PR DESCRIPTION
Fixes #6787 

RFC 5424 limits a size of SD-ID and PARAM-NAME to 32 characters. 
https://www.rfc-editor.org/rfc/rfc5424#section-6

If 'sd_allow_longer_sd_id' is true,
Fluent-bit allows a SD-ID and PARAM-NAME that is longer than 32 characters.

|Name|Description|Default|
|--|--|--|
|allow_longer_sd_id|If true, Fluent-bit allows SD-ID that is longer than 32 characters. Such long SD-ID violates RFC 5424.|`false`|

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration
```
[INPUT]
    Name dummy
    Dummy {"msg":"hello world", "sd_key_that_is_longer_than_32_characters": {"logtype_that_is_longer_than_32_characters": "access","clustername": "mycluster","namespace": "mynamespace"}}

[OUTPUT]
    Name syslog
    syslog_sd_key sd_key_that_is_longer_than_32_characters
    allow_longer_sd_id true
```



## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/b
==37485== Memcheck, a memory error detector
==37485== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==37485== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==37485== Command: bin/fluent-bit -c /home/taka/b
==37485== 
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/05 14:52:43] [ info] [fluent bit] version=2.0.9, commit=4c0ca4fc5f, pid=37485
[2023/02/05 14:52:44] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/05 14:52:44] [ info] [cmetrics] version=0.5.8
[2023/02/05 14:52:44] [ info] [ctraces ] version=0.2.7
[2023/02/05 14:52:44] [ info] [input:dummy:dummy.0] initializing
[2023/02/05 14:52:44] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/02/05 14:52:44] [ warn] [output:syslog:syslog.0] Allow longer SD-ID. It may violate RFC5424.
[2023/02/05 14:52:44] [ info] [output:syslog:syslog.0] setup done for 127.0.0.1:514 (TLS=off)
[2023/02/05 14:52:44] [ info] [sp] stream processor started
^C[2023/02/05 14:52:46] [engine] caught signal (SIGINT)
[2023/02/05 14:52:46] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/05 14:52:46] [ info] [input] pausing dummy.0
[2023/02/05 14:52:46] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/05 14:52:46] [ info] [input] pausing dummy.0
==37485== 
==37485== HEAP SUMMARY:
==37485==     in use at exit: 0 bytes in 0 blocks
==37485==   total heap usage: 1,543 allocs, 1,543 frees, 943,414 bytes allocated
==37485== 
==37485== All heap blocks were freed -- no leaks are possible
==37485== 
==37485== For lists of detected and suppressed errors, rerun with: -s
==37485== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ sudo nc -lu 514
[sudo] password for taka: 
<14>1 2023-02-05T05:50:54.680906Z - - - - [sd_key_that_is_longer_than_32_characters logtype_that_is_longer_than_32_characters="access" clustername="mycluster" namespace="mynamespace"]<14>1 2023-02-05T05:50:55.680719Z - - - - [sd_key_that_is_longer_than_32_characters logtype_that_is_longer_than_32_characters="access" clustername="mycluster" namespace="mynamespace"]<14>1 2023-02-05T05:50:56.680828Z - - - - [sd_key_that_is_longer_than_32_characters logtype_that_is_longer_than_32_characters="access" clustername="mycluster" namespace="mynamespace"]^
```

```
$ valgrind --leak-check=full bin/flb-rt-out_syslog 
==37326== Memcheck, a memory error detector
==37326== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==37326== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==37326== Command: bin/flb-rt-out_syslog
==37326== 
Test format_severity_key_rfc3164...             [ OK ]
Test format_facility_key_rfc3164...             [ OK ]
Test format_severity_facility_key_rfc3164...    [ OK ]
Test format_hostname_key_rfc3164...             [ OK ]
Test format_appname_key_rfc3164...              [ OK ]
Test format_severity_preset_rfc3164...          [ OK ]
Test format_facility_preset_rfc3164...          [ OK ]
Test format_hostname_preset_rfc3164...          [ OK ]
Test format_appname_preset_rfc3164...           [ OK ]
Test format_syslog_rfc5424...                   [ OK ]
Test format_severity_key_rfc5424...             [ OK ]
Test format_facility_key_rfc5424...             [ OK ]
Test format_severity_facility_key_rfc5424...    [ OK ]
Test format_hostname_key_rfc5424...             [ OK ]
Test format_appname_key_rfc5424...              [ OK ]
Test format_procid_key_rfc5424...               [ OK ]
Test format_msgid_key_rfc5424...                [ OK ]
Test format_sd_key_rfc5424...                   [ OK ]
Test format_severity_preset_rfc5424...          [ OK ]
Test format_facility_preset_rfc5424...          [ OK ]
Test format_hostname_preset_rfc5424...          [ OK ]
Test format_appname_preset_rfc5424...           [ OK ]
Test format_procid_preset_rfc5424...            [ OK ]
Test format_msgid_preset_rfc5424...             [ OK ]
Test allow_longer_sd_id_rfc5424...              [ OK ]
Test malformed_longer_sd_id_rfc5424...          [ OK ]
SUCCESS: All unit tests have passed.
==37326== 
==37326== HEAP SUMMARY:
==37326==     in use at exit: 0 bytes in 0 blocks
==37326==   total heap usage: 37,102 allocs, 37,102 frees, 16,088,295 bytes allocated
==37326== 
==37326== All heap blocks were freed -- no leaks are possible
==37326== 
==37326== For lists of detected and suppressed errors, rerun with: -s
==37326== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
