### PR TITLE
in_tail: fixed argument order that caused a segfault in issue 6797

### DIFF
--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -66,7 +66,7 @@ static int debug_event_mask(struct flb_tail_config *ctx,
 
     /* Print info into sds */
     if (file) {
-        flb_sds_printf(&buf, "inode=%"PRIu64", %s, events: ", file->name, file->inode);
+        flb_sds_printf(&buf, "inode=%"PRIu64", %s, events: ", file->inode, file->name);
     }
     else {
         flb_sds_printf(&buf, "events: ");


### PR DESCRIPTION
As a side note, if the attributes in the mask are composable (as the code suggests) there could be combinations that exceed the filename + 64 assumption causing a buffer overflow.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>