### PR TITLE
sds: check flb_sds_printf() format and arguments at compile time

### DIFF
--- a/include/fluent-bit/flb_sds.h
+++ b/include/fluent-bit/flb_sds.h
@@ -33,6 +33,12 @@
 
 #define FLB_SDS_HEADER_SIZE (sizeof(uint64_t) + sizeof(uint64_t))
 
+#if defined(__GNUC__) || defined(__clang__)
+#define FLB_SDS_FORMAT_PRINTF __attribute__ ((format (printf, 2, 3)))
+#else
+#define FLB_SDS_FORMAT_PRINTF
+#endif
+
 typedef char *flb_sds_t;
 
 #pragma pack(push, 1)
@@ -107,7 +113,7 @@ int flb_sds_cat_safe(flb_sds_t *buf, const char *str, int len);
 flb_sds_t flb_sds_increase(flb_sds_t s, size_t len);
 flb_sds_t flb_sds_copy(flb_sds_t s, const char *str, int len);
 void flb_sds_destroy(flb_sds_t s);
-flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...);
+flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...) FLB_SDS_FORMAT_PRINTF;
 int flb_sds_snprintf(flb_sds_t *str, size_t size, const char *fmt, ...);
 
 #endif


### PR DESCRIPTION
Check are done only on GCC/Clang.

Signed-off-by: Benoît GARNIER <bunch@orange.fr>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
