### PR TITLE
proxy: plugin_proxy: Clean up allocated resources correctly

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -90,9 +90,6 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
         }
 
         flb_input_log_append(ins, NULL, 0, data, len);
-        if (!data) {
-            free(data);
-        }
 
         ret = proxy_go_input_cleanup(ctx->proxy, data);
         if (ret == -1) {

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -255,6 +255,13 @@ int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
     if (plugin->cb_cleanup) {
         ret = plugin->cb_cleanup(allocated_data);
     }
+    else {
+        /* If cleanup callback is not registered, we need to cleanup
+         * allocated memory on fluent-bit side. */
+        if (!allocated_data) {
+            free(allocated_data);
+        }
+    }
 
     return ret;
 }

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -258,7 +258,7 @@ int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
     else {
         /* If cleanup callback is not registered, we need to cleanup
          * allocated memory on fluent-bit side. */
-        if (!allocated_data) {
+        if (allocated_data != NULL) {
             free(allocated_data);
         }
     }


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

<!-- Provide summary of changes -->

Currently, fluent-bit frees allocated memory on every time even if a clean up callback is registered.
However, freeing allocated memory in every time is not good behavior for resource handling on Golang shared object (input plugin) side.

Also, we should keep the behavior when cleanup callback is not registered.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
