### PR TITLE
trace: remove unused variable

### DIFF
--- a/src/http_server/api/v1/trace.c
+++ b/src/http_server/api/v1/trace.c
@@ -224,7 +224,6 @@ static int http_enable_trace(mk_request_t *request, void *data, const char *inpu
     struct flb_hs *hs = data;
     flb_sds_t prefix = NULL;
     flb_sds_t output_name = NULL;
-    int toggled_on = -1;
     msgpack_object *key;
     msgpack_object *val;
     struct mk_list *props = NULL;


### PR DESCRIPTION
This patch is to remove following warning.
```
/home/taka/git/fluent-bit/src/http_server/api/v1/trace.c: In function ‘http_enable_trace’:
/home/taka/git/fluent-bit/src/http_server/api/v1/trace.c:227:9: warning: unused variable ‘toggled_on’ [-Wunused-variable]
  227 |     int toggled_on = -1;
      |         ^~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
