### PR TITLE
out_loki: add missing flb_sds_cat for float value

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1012,6 +1012,7 @@ static void pack_format_line_value(flb_sds_t *buf, msgpack_object *val)
         else {
             len = snprintf(temp, sizeof(temp)-1, "%.16g", val->via.f64);
         }
+        safe_sds_cat(buf, temp, len);
     }
     else if (val->type == MSGPACK_OBJECT_ARRAY) {
         safe_sds_cat(buf, "\"[", 2);

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -547,6 +547,67 @@ void flb_test_label_map_path()
     flb_destroy(ctx);
 }
 
+static void cb_check_float_value(void *ctx, int ffd,
+                                 int res_ret, void *res_data, size_t res_size,
+                                 void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "\"float=1.3\"";
+
+    p = strstr(out_js, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out_js);
+    }
+
+    flb_sds_destroy(out_js);
+}
+
+#define JSON_FLOAT "[12345678, {\"float\":1.3}]"
+void flb_test_float_value()
+{
+    int ret;
+    int size = sizeof(JSON_FLOAT) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "line_format", "key_value",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_float_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_FLOAT, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
 /* Test list */
 TEST_LIST = {
     {"remove_keys_remove_map" , flb_test_remove_map},
@@ -557,5 +618,6 @@ TEST_LIST = {
     {"label_keys"       , flb_test_label_keys },
     {"line_format"      , flb_test_line_format },
     {"label_map_path"   , flb_test_label_map_path},
+    {"float_value"      , flb_test_float_value},
     {NULL, NULL}
 };


### PR DESCRIPTION
out_loki doesn't append floating point value using following configuration.
```
[INPUT]
    Name dummy
    Dummy {"value":1.3}

[OUTPUT]
    Name loki
    Match *
    Line_Format key_value
```


```
$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 89
User-Agent: Fluent-Bit
Content-Type: application/json

{"streams":[{"stream":{"job":"fluent-bit"},"values":[["1676170056677523154","value="]]}]}^C
```

This patch is to fix it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[INPUT]
    Name dummy
    Dummy {"value":1.3}

[OUTPUT]
    Name loki
    Match *
    Line_Format key_value
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-out_loki 
==51995== Memcheck, a memory error detector
==51995== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==51995== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==51995== Command: bin/flb-rt-out_loki
==51995== 
Test remove_keys_remove_map...                  [ OK ]
Test labels_ra...                               [ OK ]
Test remove_keys...                             [ OK ]
Test basic...                                   [ OK ]
Test labels...                                  [ OK ]
Test label_keys...                              [ OK ]
Test line_format...                             [ OK ]
Test label_map_path...                          [ OK ]
Test float_value...                             [ OK ]
SUCCESS: All unit tests have passed.
==51995== 
==51995== HEAP SUMMARY:
==51995==     in use at exit: 0 bytes in 0 blocks
==51995==   total heap usage: 13,002 allocs, 13,002 frees, 6,006,621 bytes allocated
==51995== 
==51995== All heap blocks were freed -- no leaks are possible
==51995== 
==51995== For lists of detected and suppressed errors, rerun with: -s
==51995== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
