### PR TITLE
out_pgsql: pass connection options to postgresql client

### DIFF
--- a/plugins/out_pgsql/pgsql.c
+++ b/plugins/out_pgsql/pgsql.c
@@ -92,6 +92,9 @@ static int cb_pgsql_init(struct flb_output_instance *ins,
         ctx->db_table = flb_sds_create(FLB_PGSQL_TABLE);
     }
 
+    /* connection options */
+    ctx->conn_options = flb_output_get_property("connection_options", ins);
+
     if (!ctx->db_table) {
         flb_errno();
         pgsql_conf_destroy(ctx);

--- a/plugins/out_pgsql/pgsql.h
+++ b/plugins/out_pgsql/pgsql.h
@@ -67,6 +67,9 @@ struct flb_pgsql_config {
     /* instance reference */
     struct flb_output_instance *ins;
 
+    /* connections */
+    const char *conn_options;
+
     /* connections pool */
     struct mk_list conn_queue;
     struct mk_list _head;

--- a/plugins/out_pgsql/pgsql_connections.c
+++ b/plugins/out_pgsql/pgsql_connections.c
@@ -54,9 +54,12 @@ void *pgsql_create_connection(struct flb_pgsql_config *ctx)
         flb_errno();
         return NULL;
     }
+
+    flb_plg_debug(ctx->ins, "connection_options: %s", ctx->conn_options);
     conn->conn = PQsetdbLogin(ctx->db_hostname,
                               ctx->db_port,
-                              NULL, NULL,
+                              ctx->conn_options,
+                              NULL,
                               ctx->db_name,
                               ctx->db_user,
                               ctx->db_passwd);


### PR DESCRIPTION
libpq supports connection options on the postgresql plugin. Passing connection options to client are basic functionality but the plugin cannot pass connection options. I patched it.

#6836 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [X] Backport to latest stable release.


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
