### PR TITLE
upstream_conn: fix ordering of mk_event_inject and prepare_conn_destroy

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -794,6 +794,7 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
 {
     time_t now;
     int drop;
+    int inject;
     struct mk_list *head;
     struct mk_list *u_head;
     struct mk_list *tmp;
@@ -842,13 +843,21 @@ int flb_upstream_conn_timeouts(struct mk_list *list)
             }
 
             if (drop == FLB_TRUE) {
+                inject = FLB_FALSE;
                 if (u_conn->event.status != MK_EVENT_NONE) {
+                    inject = FLB_TRUE;
+                }
+                u_conn->net_error = ETIMEDOUT;
+                prepare_destroy_conn(u_conn);
+                /* 
+                 * prepare_destroy_conn calls mk_list_del on the event in the 
+                 * priority bucket queue, so for safety, we inject it afterwards
+                 */
+                if (inject == FLB_TRUE) {
                     mk_event_inject(u_conn->evl, &u_conn->event,
                                     MK_EVENT_READ | MK_EVENT_WRITE,
                                     FLB_TRUE);
                 }
-                u_conn->net_error = ETIMEDOUT;
-                prepare_destroy_conn(u_conn);
             }
         }
 


### PR DESCRIPTION
prepare_destroy_conn calls mk_list_del on the event in the priority bucket queue, so for safety, we inject it after this covers us against the case where the event was triggered and waiting, but we also reached the timeout.

Addresses this issue on 1.9: https://github.com/fluent/fluent-bit/issues/6822

**See the issue for a design doc on why this is needed**

Signed-off-by: Wesley Pettit <wppttt@amazon.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
