### PR TITLE
engine: added retry cleanup when a task cannot be retried

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -229,7 +229,9 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
                      flb_input_name(task->i_ins),
                      flb_output_name(ins), out_id);
         }
+
         flb_task_retry_clean(task, ins);
+
         flb_task_users_dec(task, FLB_TRUE);
     }
     else if (ret == FLB_RETRY && config->is_running && !config->is_shutting_down) {
@@ -248,7 +250,11 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
                      task_id,
                      flb_input_name(task->i_ins),
                      flb_output_name(ins), out_id);
+
+            flb_task_retry_clean(task, ins);
+
             flb_task_users_dec(task, FLB_TRUE);
+
             return 0;
         }
 
@@ -280,7 +286,10 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
                      flb_input_name(task->i_ins),
                      flb_output_name(ins));
 
+            flb_task_retry_clean(task, ins);
+
             flb_task_users_dec(task, FLB_TRUE);
+
             return 0;
         }
 
@@ -342,6 +351,9 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
         flb_metrics_sum(FLB_METRIC_OUT_ERROR, 1, ins->metrics);
         flb_metrics_sum(FLB_METRIC_OUT_DROPPED_RECORDS, task->records, ins->metrics);
 #endif
+
+        flb_task_retry_clean(task, ins);
+
         flb_task_users_dec(task, FLB_TRUE);
     }
 


### PR DESCRIPTION
Due to how flb_task_users_release determines if it can drop the involved chunk and how entries in the retries list are handled by flb_task_retry_create we need to explicitly remove the retry entries related to the failed task and plugin instance before calling flb_task_users_dec to ensure that chunks linked to tasks that had at least one retry but are deemed not retriable afterwards can be properly disposed of.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>