### PR TITLE
opentelemetry: refactor json logs input and set metadata using record accessor

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -35,6 +35,12 @@
 static int otlp_pack_any_value(msgpack_packer *mp_pck,
                                Opentelemetry__Proto__Common__V1__AnyValue *body);
 
+static int pack_msgpack_any_value_object(msgpack_packer *mp_pck,
+                                         msgpack_object *obj);
+
+static int pack_msgpack_kvlist(msgpack_packer *mp_pck,
+                               msgpack_object *obj);
+
 static int send_response(struct http_conn *conn, int http_status, char *message)
 {
     int len;
@@ -395,107 +401,486 @@ static int binary_payload_to_msgpack(msgpack_packer *mp_pck,
     return 0;
 }
 
-static int get_token_length(jsmntok_t token){
-    return token.end - token.start;
+static int pack_resource(msgpack_packer *mp_pck,
+                         msgpack_object_map resource)
+{
+    int ret;
+
+    if (resource.size != 1 ||
+        resource.ptr[0].key.type != MSGPACK_OBJECT_STR ||
+        strncasecmp("attributes", resource.ptr[0].key.via.str.ptr, resource.ptr[0].key.via.str.size) != 0) {
+        flb_error("[otel] Invalid JSON payload, incorrect resource definition");
+        return -1;
+    }
+
+    if (resource.ptr[0].val.type != MSGPACK_OBJECT_ARRAY) {
+        flb_error("[otel] Invalid JSON payload, attribute list must be an array");
+    }
+
+    ret = pack_msgpack_kvlist(mp_pck, &resource.ptr[0].val);
+
+    return ret;
 }
 
-static char *get_value_from_token(jsmntok_t *tokens,
-                                  const char *body,
-                                  int pos){
-    char *tmp;
-    jsmntok_t token;
-    int token_len;
+static int pack_msgpack_bytes(msgpack_packer *mp_pck,
+                              msgpack_object *obj)
+{
+    return msgpack_pack_bin_with_body(mp_pck, obj->via.bin.ptr, obj->via.bin.size);
+}
 
-    token = tokens[pos];
-    token_len = get_token_length(token);
+static int pack_msgpack_string(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    return msgpack_pack_str_with_body(mp_pck, obj->via.str.ptr, obj->via.str.size);
+}
 
-    tmp = flb_calloc(1, token_len + 1);
-    tmp =  memcpy(tmp, body+token.start, token_len);
+static int pack_msgpack_double(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    return msgpack_pack_double(mp_pck, obj->via.f64);
+}
 
-    return tmp;
+static int pack_msgpack_int(msgpack_packer *mp_pck,
+                            msgpack_object *obj)
+{
+    return msgpack_pack_int(mp_pck, obj->via.i64);
+}
+
+static int pack_msgpack_boolean(msgpack_packer *mp_pck,
+                                msgpack_object *obj)
+{
+    return msgpack_pack_double(mp_pck, obj->via.boolean);
+}
+
+static int pack_msgpack_array(msgpack_packer *mp_pck,
+                              msgpack_object *obj)
+{
+    size_t arr_index;
+    msgpack_object_array arr;
+    int ret = 0;
+
+    arr = obj->via.array;
+
+    msgpack_pack_array(mp_pck, arr.size);
+
+    for (arr_index = 0;
+         arr_index < arr.size && ret == 0;
+         arr_index++) {
+
+        ret = pack_msgpack_any_value_object(mp_pck, &arr.ptr[arr_index]);
+
+    }
+
+    return ret;
+}
+
+static int pack_msgpack_kvpair(msgpack_packer *mp_pck,
+                               msgpack_object_map *obj)
+{
+    size_t kvpair_index;
+    msgpack_object k;
+    msgpack_object v;
+    int ret = 0;
+
+    if (obj->size != 2) {
+        flb_error("[otel] Invalid kvpair");
+        return -1;
+    }
+
+    msgpack_pack_map(mp_pck, 1);
+
+    // pack key as string and value as anyValue
+    for (kvpair_index = 0;
+         kvpair_index < obj->size && ret == 0;
+         kvpair_index++) {
+
+        k = obj->ptr[kvpair_index].key;
+        v = obj->ptr[kvpair_index].val;
+
+        if (k.type != MSGPACK_OBJECT_STR) {
+            flb_error("[otel] Invalid kvpair");
+            return -1;
+        }
+
+        if (strncasecmp("key", k.via.str.ptr, k.via.str.size) == 0) {
+            ret = msgpack_pack_str_with_body(mp_pck, v.via.str.ptr, v.via.str.size);
+        }
+        else if (strncasecmp("value", k.via.str.ptr, k.via.str.size) == 0) {
+            ret = pack_msgpack_any_value_object(mp_pck, &v);
+        }
+    }
+
+    return ret;
+}
+
+static int pack_msgpack_kvlist(msgpack_packer *mp_pck,
+                               msgpack_object *obj)
+{
+    int ret = 0;
+    msgpack_object_array arr;
+    msgpack_object_map kvpair;
+    size_t arr_index;
+
+    if (obj->type != MSGPACK_OBJECT_ARRAY) {
+        flb_error("[otel] Kvlist value must be an array");
+        return ret;
+    }
+
+    arr = obj->via.array;
+
+    msgpack_pack_array(mp_pck, arr.size);
+
+    for (arr_index = 0; arr_index < arr.size && ret == 0; arr_index++) {
+
+        if (arr.ptr[arr_index].type != MSGPACK_OBJECT_MAP ||
+            arr.ptr[arr_index].via.map.size % 2 != 0) {
+
+            flb_error("[otel] Invalid kvlist value");
+            return ret;
+
+        }
+
+        kvpair = arr.ptr[arr_index].via.map;
+        ret = pack_msgpack_kvpair(mp_pck, &kvpair);
+
+    }
+
+    return ret;
+}
+
+/*
+ * Any value format: {"kvlistValue":{"values":[{"key":"k","value":{"stringValue":"v"}}]}
+ * obj.key contains the value type and obj.val contains the value
+ * In case of kvlist or array we need to get rid of extra information
+ */
+static int pack_msgpack_any_value_object(msgpack_packer *mp_pck,
+                                         msgpack_object *obj)
+{
+    int ret = -1;
+    msgpack_object_kv map_value;
+
+    if (obj->type != MSGPACK_OBJECT_MAP || obj->via.map.size != 1) {
+        flb_error("[otel] Invalid map size in json to msgpack conversion");
+        return ret;
+    }
+
+    map_value = obj->via.map.ptr[0];
+
+    if (strncasecmp(map_value.key.via.str.ptr,
+                    "bytesvalue",
+                    map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_bytes(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                    "kvlistvalue",
+                    map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_kvlist(mp_pck, &map_value.val.via.map.ptr->val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "arrayvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_array(mp_pck, &map_value.val.via.map.ptr->val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "doublevalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_double(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "intvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_int(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "boolvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_boolean(mp_pck, &map_value.val);
+
+    }
+    else if (strncasecmp(map_value.key.via.str.ptr,
+                         "stringvalue",
+                         map_value.key.via.str.size) == 0) {
+
+        ret = pack_msgpack_string(mp_pck, &map_value.val);
+
+    }
+
+    return ret;
+}
+
+static int pack_log_record(msgpack_packer *mp_pck,
+                           msgpack_object_map *resource,
+                           char *schema_url,
+                           msgpack_object_map *scope,
+                           msgpack_object_map *log_record)
+{
+    size_t log_field_index;
+    msgpack_object_kv field;
+    int ret = 0;
+
+    /*
+     * start a new log record here
+     * need confirmation on format [[timestamp, {metadata}], {log record}] or [timestamp, {log record}]
+     * As of now, we pack it in the regular format, [timestamp, {log record}]
+     */
+
+    msgpack_pack_array(mp_pck, 2);
+    flb_pack_time_now(mp_pck);
+
+    for (log_field_index = 0;
+         log_field_index < log_record->size && ret == 0;
+         log_field_index++) {
+
+            field = log_record->ptr[log_field_index];
+
+            if (field.key.type != MSGPACK_OBJECT_STR) {
+                flb_error("[otel] Invalid JSON payload, key must be a string");
+                return -1;
+            }
+
+            if (field.key.via.str.size == 4 &&
+                strncasecmp(field.key.via.str.ptr, "body", 4) == 0) {
+
+                    ret = pack_msgpack_any_value_object(mp_pck, &field.val);
+
+                }
+        }
+
+    return ret;
+}
+
+static int parse_log_records(msgpack_packer *mp_pck,
+                             msgpack_object_map *resource,
+                             char *schema_url,
+                             msgpack_object_map *scope,
+                             msgpack_object_array log_records)
+{
+    size_t log_records_index;
+    msgpack_object_map *log_record;
+    int ret = 0;
+
+    for (log_records_index = 0;
+         log_records_index < log_records.size && ret == 0;
+         log_records_index++) {
+
+            log_record = &log_records.ptr[log_records_index].via.map;
+
+            ret = pack_log_record(mp_pck, resource, schema_url, scope, log_record);
+        }
+
+    return ret;
+}
+
+static int parse_scope_logs(msgpack_packer *mp_pck,
+                            msgpack_object_map *resource,
+                            msgpack_object_array scope_logs)
+{
+    size_t scope_logs_index;
+    size_t scope_log_index;
+    msgpack_object_map scope_log;
+    msgpack_object_map *scope;
+    char *schema_url;
+    int ret;
+
+    schema_url = NULL;
+    scope = NULL;
+    ret = 0;
+
+    for (scope_logs_index = 0;
+         scope_logs_index < scope_logs.size;
+         scope_logs_index++) {
+
+        scope_log = scope_logs.ptr[scope_logs_index].via.map;
+
+        if (scope_log.size > 3) {
+            flb_error("[otel] Invalid JSON payload, a scope log can have at most 3 fields: scope, log records, & schema_url");
+            return -1;
+        }
+
+        for (scope_log_index = 0;
+             scope_log_index < scope_log.size;
+             scope_log_index++) {
+
+            if (strncasecmp("schemaurl",
+                            scope_log.ptr[scope_log_index].key.via.str.ptr,
+                            scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                    memcpy(schema_url,
+                        scope_log.ptr[scope_log_index].val.via.str.ptr,
+                        scope_log.ptr[scope_log_index].val.via.str.size);
+
+                }
+
+            else if (strncasecmp("scope",
+                                  scope_log.ptr[scope_log_index].key.via.str.ptr,
+                                  scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                    scope = &scope_log.ptr[scope_log_index].val.via.map;
+
+                }
+
+            }
+
+        for (scope_log_index = 0;
+             scope_log_index < scope_log.size;
+             scope_log_index++) {
+
+            if (strncasecmp("logrecords",
+                            scope_log.ptr[scope_log_index].key.via.str.ptr,
+                            scope_log.ptr[scope_log_index].key.via.str.size) == 0) {
+
+                if (scope_log.ptr[scope_log_index].val.type != MSGPACK_OBJECT_ARRAY) {
+                    flb_error("[otel] Invalid JSON payload, log records must be an array");
+                }
+
+                ret = parse_log_records(mp_pck, resource, schema_url, scope, scope_log.ptr[scope_log_index].val.via.array);
+                if (ret != 0) {
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+static int parse_resource_logs(msgpack_packer *mp_pck,
+                               msgpack_object_array resource_logs)
+{
+    size_t resource_logs_index;
+    size_t resource_log_index;
+    msgpack_object_map resource_log;
+    msgpack_object_map *resource;
+    int ret;
+
+    resource = NULL;
+    ret = 0;
+
+    for (resource_logs_index = 0;
+         resource_logs_index < resource_logs.size;
+         resource_logs_index++) {
+
+        resource_log = resource_logs.ptr[resource_logs_index].via.map;
+
+        if (resource_log.size > 3) {
+            flb_error("[otel] Invalid JSON payload, a resource log can have at most 3 fields: resource, scope logs, & schema_url");
+            return -1;
+        }
+
+        /*
+         * First iterate through the keys and set the values of resource,
+         * because this needs to be propogated to the log records, and JSON can be unordered.
+         * In the next iteration, scan the scope logs and pass these values to it.
+         */
+
+        for (resource_log_index = 0;
+             resource_log_index < resource_log.size;
+             resource_log_index++) {
+
+            if (strncasecmp("resource",
+                            resource_log.ptr[resource_log_index].key.via.str.ptr,
+                            resource_log.ptr[resource_log_index].key.via.str.size) == 0) {
+
+                resource = &resource_log.ptr[resource_log_index].val.via.map;
+
+            }
+        }
+
+        for (resource_log_index = 0;
+             resource_log_index < resource_log.size;
+             resource_log_index++) {
+            if (strncasecmp("scopelogs",
+                            resource_log.ptr[resource_log_index].key.via.str.ptr,
+                            resource_log.ptr[resource_log_index].key.via.str.size) == 0) {
+
+                if (resource_log.ptr[resource_log_index].val.type != MSGPACK_OBJECT_ARRAY) {
+                    flb_error("[otel] Invalid JSON payload, scope logs must be an array");
+                    return -1;
+                }
+
+                ret = parse_scope_logs(mp_pck, resource, resource_log.ptr[resource_log_index].val.via.array);
+                if (ret != 0) {
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+/*
+ * Process the JSON payload.
+ * A valid payload must be in the form defined in the OpenTelemetry proto file:
+ * https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto
+ */
+static int process_json_export_service_request(msgpack_packer *mp_pck,
+                                               char *buf,
+                                               size_t buf_size)
+{
+    size_t off = 0;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object_map resource_logs_map;
+    int ret = 0;
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, buf, buf_size, &off) == MSGPACK_UNPACK_SUCCESS && ret == 0) {
+        root = result.data;
+        resource_logs_map = root.via.map;
+
+        if (root.type != MSGPACK_OBJECT_MAP ||
+            resource_logs_map.size != 1 ||
+            strncasecmp(resource_logs_map.ptr[0].key.via.str.ptr, "resourcelogs", resource_logs_map.ptr[0].key.via.str.size)) {
+                flb_error("[otel] Invalid JSON payload");
+                return -1;
+        }
+
+        ret = parse_resource_logs(mp_pck, resource_logs_map.ptr[0].val.via.array);
+
+    }
+
+    return ret;
 }
 
 static int json_payload_to_msgpack(msgpack_packer *mp_pck,
                                    const char *body,
                                    size_t len)
 {
-    int n_tokens;
-    int token_index;
-    int kv_index;
-    int result;
+    size_t buf_size;
+    int root_type;
+    int ret;
+    char *buf;
 
-    char *key;
-    char *otel_value_type;
-    char *otel_log_record;
+    /*
+     * Convert the json to msgpack to make parsing easier
+     */
 
-    jsmn_parser parser;
-    jsmntok_t tokens[1024];
-    jsmntok_t token;
-
-    result = 0;
-
-    jsmn_init(&parser);
-    n_tokens = jsmn_parse(&parser, body, len, tokens, 1024);
-
-    if (n_tokens < 0) {
-        flb_error("[otel] Failed to parse JSON payload, jsmn error %d", n_tokens);
+    ret = flb_pack_json(body, len, &buf, &buf_size, &root_type);
+    if (ret == FLB_ERR_JSON_PART) {
+        printf("data incomplete");
+        return -1;
+    }
+    else if (ret == FLB_ERR_JSON_INVAL) {
+        printf("invalid JSON message, skipping");
         return -1;
     }
 
-    // position 0 is the root object, skip it
-    for (token_index = 1; token_index < n_tokens; token_index++) {
-        token = tokens[token_index];
+    ret = process_json_export_service_request(mp_pck, buf, buf_size);
+    flb_free(buf);
 
-        switch (token.type) {
-
-            case JSMN_OBJECT:
-                for (kv_index=0; kv_index < token.size; kv_index++) {
-                    key = get_value_from_token(tokens, body, token_index+kv_index+1);
-
-                    if (strcmp(key, "body") == 0) {
-                        otel_value_type = get_value_from_token(tokens, body, token_index+kv_index+3);
-                        otel_log_record = get_value_from_token(tokens, body, token_index+kv_index+4);
-
-                        msgpack_pack_array(mp_pck, 2);
-                        flb_pack_time_now(mp_pck);
-
-                        if (strcasecmp(otel_value_type, "stringvalue") == 0) {
-                            result = otel_pack_string(mp_pck, otel_log_record);
-                        }
-
-                        else if (strcasecmp(otel_value_type, "intvalue") == 0) {
-                            result = otel_pack_int(mp_pck, atoi(otel_log_record));
-                        }
-
-                        else if (strcasecmp(otel_value_type, "doublevalue") == 0) {
-                            result = otel_pack_double(mp_pck, atof(otel_log_record));
-                        }
-
-                        else if (strcasecmp(otel_value_type, "boolvalue") == 0) {
-                            if (strcasecmp(otel_log_record, "true") == 0) {
-                                result = otel_pack_bool(mp_pck, true);
-                            } else {
-                                result = otel_pack_bool(mp_pck, false);
-                            }
-                        }
-
-                        else if (strcasecmp(otel_value_type, "bytesvalue") == 0){
-                            result = otel_pack_string(mp_pck, otel_log_record);
-                        }
-
-                        flb_free(otel_value_type);
-                        flb_free(otel_log_record);
-                    }
-
-                    flb_free(key);
-                }
-                break;
-
-            default:
-                break;
-        }
-    }
-    return result;
+    return ret;
 }
 
 static int process_payload_logs(struct flb_opentelemetry *ctx, struct http_conn *conn,

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -21,6 +21,7 @@
 #define FLB_OUT_OPENTELEMETRY_H
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-otel-proto/fluent-otel.h>
 
 #define FLB_OPENTELEMETRY_CONTENT_TYPE_HEADER_NAME "Content-Type"
 #define FLB_OPENTELEMETRY_MIME_PROTOBUF_LITERAL    "application/x-protobuf"
@@ -32,6 +33,11 @@
  * including the ones that succeeded. This is not ideal.
  */
 #define DEFAULT_LOG_RECORD_BATCH_SIZE "1000"
+
+struct otel_kvpair_list {
+    size_t n_attributes;
+    Opentelemetry__Proto__Common__V1__KeyValue **kvlist;
+};
 
 /* Plugin context */
 struct opentelemetry_context {
@@ -50,6 +56,38 @@ struct opentelemetry_context {
     char *logs_uri;
     char *host;
     int port;
+
+    /* trace id key */
+    flb_sds_t trace_id_key;
+    struct flb_record_accessor *ra_trace_id_key;
+
+    /* span id key */
+    flb_sds_t span_id_key;
+    struct flb_record_accessor *ra_span_id_key;
+
+    /* severity text key */
+    flb_sds_t severity_text_key;
+    struct flb_record_accessor *ra_severity_text_key;
+
+    /* severity number key */
+    flb_sds_t severity_number_key;
+    struct flb_record_accessor *ra_severity_number_key;
+
+    /* time_unix_nano key */
+    flb_sds_t time_unix_nano_key;
+    struct flb_record_accessor *ra_time_unix_nano_key;
+
+    /* attributes key */
+    flb_sds_t attributes_key;
+    struct flb_record_accessor *ra_attributes_key;
+
+    /* resource key */
+    flb_sds_t resource_key;
+    struct flb_record_accessor *ra_resource_key;
+
+    /* body key */
+    flb_sds_t body_key;
+    struct flb_record_accessor *ra_body_key;
 
     /* Number of logs to flush at a time */
     int batch_size;

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_record_accessor.h>
 
 #include "opentelemetry.h"
 #include "opentelemetry_conf.h"
@@ -117,6 +118,229 @@ static char *sanitize_uri(char *uri){
     /* This function could return NULL if flb_calloc fails */
 
     return uri;
+}
+
+static int set_trace_id_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_trace_id_key = flb_ra_create(ctx->trace_id_key, FLB_TRUE);
+
+    if (!ctx->ra_trace_id_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for trace_id_key pattern: '%s'",
+                        ctx->trace_id_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_span_id_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_span_id_key = flb_ra_create(ctx->span_id_key, FLB_TRUE);
+
+    if (!ctx->ra_span_id_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for span_id_key pattern: '%s'",
+                        ctx->span_id_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_severity_text_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_severity_text_key = flb_ra_create(ctx->severity_text_key, FLB_TRUE);
+
+    if (!ctx->ra_severity_text_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for severity_text_key pattern: '%s'",
+                        ctx->severity_text_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_severity_number_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_severity_number_key = flb_ra_create(ctx->severity_number_key, FLB_TRUE);
+
+    if (!ctx->ra_severity_number_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for severity_number_key pattern: '%s'",
+                        ctx->severity_number_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_attributes_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_attributes_key = flb_ra_create(ctx->attributes_key, FLB_TRUE);
+
+    if (!ctx->ra_attributes_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for attributes_key pattern: '%s'",
+                        ctx->attributes_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_body_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_body_key = flb_ra_create(ctx->body_key, FLB_TRUE);
+
+    if (!ctx->ra_body_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for body_key pattern: '%s'",
+                        ctx->body_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_resource_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_resource_key = flb_ra_create(ctx->resource_key, FLB_TRUE);
+
+    if (!ctx->ra_resource_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for resource_key pattern: '%s'",
+                        ctx->resource_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_time_unix_nano_key(struct opentelemetry_context *ctx)
+{
+
+    ctx->ra_time_unix_nano_key = flb_ra_create(ctx->time_unix_nano_key, FLB_TRUE);
+
+    if (!ctx->ra_time_unix_nano_key) {
+        flb_plg_error(ctx->ins,
+                        "cannot create record accessor for time_unix_nano_key pattern: '%s'",
+                        ctx->time_unix_nano_key);
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_ra_fields(struct opentelemetry_context *ctx)
+{
+    int ret = 0;
+
+    if (ctx->trace_id_key && ret == 0) {
+
+        if (ctx->trace_id_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid trace_id_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_trace_id_key(ctx);
+    }
+
+    if (ctx->span_id_key && ret == 0) {
+
+        if (ctx->span_id_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid span_id_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_span_id_key(ctx);
+    }
+
+    if (ctx->severity_text_key && ret == 0) {
+
+        if (ctx->severity_text_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid severity_text_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_severity_text_key(ctx);
+    }
+
+    if (ctx->severity_number_key && ret == 0) {
+
+        if (ctx->severity_number_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid severity_number_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_severity_number_key(ctx);
+    }
+
+    if (ctx->time_unix_nano_key && ret == 0) {
+
+        if (ctx->time_unix_nano_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid time_unix_nano_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_time_unix_nano_key(ctx);
+    }
+
+    if (ctx->attributes_key && ret == 0) {
+
+        if (ctx->attributes_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid attributes_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_attributes_key(ctx);
+    }
+
+    if (ctx->body_key && ret == 0) {
+
+        if (ctx->body_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid body_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_body_key(ctx);
+    }
+
+    if (ctx->resource_key && ret == 0) {
+
+        if (ctx->resource_key[0] != '$') {
+            flb_plg_error(ctx->ins,
+                            "invalid resource_key pattern, it must start with '$'");
+            flb_opentelemetry_context_destroy(ctx);
+            return -1;
+        }
+        ret = set_resource_key(ctx);
+    }
+
+    return ret;
 }
 
 struct opentelemetry_context *flb_opentelemetry_context_create(
@@ -229,6 +453,10 @@ struct opentelemetry_context *flb_opentelemetry_context_create(
         ctx->metrics_uri = metrics_uri;
     }
 
+    ret = set_ra_fields(ctx);
+    if (ret < 0) {
+        return NULL;
+    }
 
     /* Set instance flags into upstream */
     flb_output_upstream_set(ctx->u, ins);
@@ -255,6 +483,39 @@ void flb_opentelemetry_context_destroy(
 
     if (ctx->u) {
         flb_upstream_destroy(ctx->u);
+    }
+
+    if (ctx->ra_trace_id_key) {
+        flb_ra_destroy(ctx->ra_trace_id_key);
+    }
+
+    if (ctx->ra_span_id_key) {
+        flb_ra_destroy(ctx->ra_span_id_key);
+    }
+
+    if (ctx->ra_severity_text_key) {
+        flb_ra_destroy(ctx->ra_severity_text_key);
+    }
+
+
+    if (ctx->ra_severity_number_key) {
+        flb_ra_destroy(ctx->ra_severity_number_key);
+    }
+
+    if (ctx->ra_time_unix_nano_key) {
+        flb_ra_destroy(ctx->ra_time_unix_nano_key);
+    }
+
+    if (ctx->ra_body_key) {
+        flb_ra_destroy(ctx->ra_body_key);
+    }
+
+    if (ctx->ra_resource_key) {
+        flb_ra_destroy(ctx->ra_resource_key);
+    }
+
+    if (ctx->ra_attributes_key) {
+        flb_ra_destroy(ctx->ra_attributes_key);
     }
 
     flb_free(ctx->proxy_host);

--- a/src/flb_ra_key.c
+++ b/src/flb_ra_key.c
@@ -62,7 +62,7 @@ static int msgpack_object_to_ra_value(msgpack_object o,
         }
         return 0;
     }
-    else if (o.type == MSGPACK_OBJECT_MAP) {
+    else if (o.type == MSGPACK_OBJECT_MAP || o.type == MSGPACK_OBJECT_ARRAY) {
         /* return boolean 'true', just denoting the existence of the key */
         result->type = FLB_RA_BOOL;
         result->val.boolean = true;

--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -544,8 +544,8 @@ static flb_sds_t ra_translate_keymap(struct flb_ra_parser *rp, flb_sds_t buf,
 
     /* Based on data type, convert to it string representation */
     if (v->type == FLB_RA_BOOL) {
-        /* Check if is a map or a real bool */
-        if (v->o.type == MSGPACK_OBJECT_MAP) {
+        /* Check if is a map/array or a real bool */
+        if (v->o.type == MSGPACK_OBJECT_MAP || v->o.type == MSGPACK_OBJECT_ARRAY) {
             /* Convert msgpack map to JSON string */
             js = flb_msgpack_to_json_str(1024, &v->o);
             if (js) {
@@ -607,7 +607,7 @@ flb_sds_t flb_ra_translate(struct flb_record_accessor *ra,
  *
  * For safety, the function returns a newly created string that needs
  * to be destroyed by the caller.
- * 
+ *
  * Returns NULL if `check` is FLB_TRUE and any key lookup in the record failed
  */
 flb_sds_t flb_ra_translate_check(struct flb_record_accessor *ra,


### PR DESCRIPTION
<!-- Provide summary of changes -->

in_opentelemetry: convert json to msgpack using Fluent Bit API to make parsing easier (instead of directly using jsmn)

out_opentelemetry: use record accessor to set metadata fields like trace_id, span_is, etc... 


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #6323 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[INPUT]
  Name   dummy
  Tag    dummy.log
  Rate 1
  Samples 1
  Dummy {"severity_text":"very severe text", "severity_number": "2", "resource":[{"resource-attr":"resource-val1"}],"body":{"testbody": "bod"},"traceid":"2e9ab9abb4fca54cfda61ffea37e429d","spanid":"804df3bd74eb09e2","attributes":[{"testkey":"testval"}]}

[OUTPUT]
  Name stdout
  Match *

[OUTPUT]
  Match *
  Name opentelemetry
  Host 0.0.0.0
  Port 3434
  Logs_uri /v1/logs
  attributes_key $attributes
  resource_key $resource
  trace_id_key $traceid
  span_id_key $spanid
  body_key $body
  severity_number_key $severity_number
  severity_text_key $severity_text
```

- [x] Debug log output from testing the change

```
root@72be08b8372b:/fluent-bit/build# ./bin/fluent-bit -c  ../dev-files/confs/ra_test.conf -v
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/14 11:00:31] [ info] Configuration:
[2023/02/14 11:00:31] [ info]  flush time     | 1.000000 seconds
[2023/02/14 11:00:31] [ info]  grace          | 5 seconds
[2023/02/14 11:00:31] [ info]  daemon         | 0
[2023/02/14 11:00:31] [ info] ___________
[2023/02/14 11:00:31] [ info]  inputs:
[2023/02/14 11:00:31] [ info]      dummy
[2023/02/14 11:00:31] [ info] ___________
[2023/02/14 11:00:31] [ info]  filters:
[2023/02/14 11:00:31] [ info] ___________
[2023/02/14 11:00:31] [ info]  outputs:
[2023/02/14 11:00:31] [ info]      stdout.0
[2023/02/14 11:00:31] [ info]      opentelemetry.1
[2023/02/14 11:00:31] [ info] ___________
[2023/02/14 11:00:31] [ info]  collectors:
[2023/02/14 11:00:31] [ info] [fluent bit] version=2.0.9, commit=7bcb502ebd, pid=252312
[2023/02/14 11:00:31] [debug] [engine] coroutine stack size: 196608 bytes (192.0K)
[2023/02/14 11:00:31] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/14 11:00:31] [ info] [cmetrics] version=0.5.8
[2023/02/14 11:00:31] [ info] [ctraces ] version=0.2.7
[2023/02/14 11:00:31] [ info] [input:dummy:dummy.0] initializing
[2023/02/14 11:00:31] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/02/14 11:00:31] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2023/02/14 11:00:31] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2023/02/14 11:00:31] [debug] [opentelemetry:opentelemetry.1] created event channels: read=30 write=31
[2023/02/14 11:00:31] [ info] [output:stdout:stdout.0] worker #0 started
[2023/02/14 11:00:31] [debug] [router] match rule dummy.0:stdout.0
[2023/02/14 11:00:31] [debug] [router] match rule dummy.0:opentelemetry.1
[2023/02/14 11:00:31] [ info] [sp] stream processor started
[2023/02/14 11:00:31] [debug] [input chunk] update output instances with new chunk size diff=214
[2023/02/14 11:00:32] [debug] [task] created task=0xffff9401de40 id=0 OK
[2023/02/14 11:00:32] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.log: [1676372431.277538465, {"severity_text"=>"very severe text", "severity_number"=>"2", "resource"=>[{"resource-attr"=>"resource-val1"}], "body"=>{"testbody"=>"bod"}, "traceid"=>"2e9ab9abb4fca54cfda61ffea37e429d", "spanid"=>"804df3bd74eb09e2", "attributes"=>[{"testkey"=>"testval"}]}]
[2023/02/14 11:00:32] [debug] [out flush] cb_destroy coro_id=0
[2023/02/14 11:00:32] [debug] [http_client] not using http_proxy for header
[2023/02/14 11:00:32] [ info] [output:opentelemetry:opentelemetry.1] 0.0.0.0:3434, HTTP status=200


[2023/02/14 11:00:32] [debug] [out flush] cb_destroy coro_id=0
[2023/02/14 11:00:32] [debug] [task] destroy task=0xffff9401de40 (task_id=0)
^C[2023/02/14 11:00:36] [engine] caught signal (SIGINT)
[2023/02/14 11:00:36] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/14 11:00:36] [ info] [input] pausing dummy.0
[2023/02/14 11:00:37] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/14 11:00:37] [ info] [input] pausing dummy.0
[2023/02/14 11:00:37] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/14 11:00:37] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```


<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
root@72be08b8372b:/fluent-bit/build# valgrind --leak-check=full ./bin/fluent-bit -c  ../dev-files/confs/ra_test.conf
==252308== Memcheck, a memory error detector
==252308== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==252308== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==252308== Command: ./bin/fluent-bit -c ../dev-files/confs/ra_test.conf
==252308==
Fluent Bit v2.0.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/14 10:59:39] [ info] [fluent bit] version=2.0.9, commit=7bcb502ebd, pid=252308
[2023/02/14 10:59:39] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/14 10:59:39] [ info] [output:stdout:stdout.0] worker #0 started
[2023/02/14 10:59:39] [ info] [cmetrics] version=0.5.8
[2023/02/14 10:59:39] [ info] [ctraces ] version=0.2.7
[2023/02/14 10:59:39] [ info] [input:dummy:dummy.0] initializing
[2023/02/14 10:59:39] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/02/14 10:59:39] [ info] [sp] stream processor started
[0] dummy.log: [1676372380.321719136, {"severity_text"=>"very severe text", "severity_number"=>"2", "resource"=>[{"resource-attr"=>"resource-val1"}], "body"=>{"testbody"=>"bod"}, "traceid"=>"2e9ab9abb4fca54cfda61ffea37e429d", "spanid"=>"804df3bd74eb09e2", "attributes"=>[{"testkey"=>"testval"}]}]
[2023/02/14 10:59:41] [ info] [output:opentelemetry:opentelemetry.1] 0.0.0.0:3434, HTTP status=200


^C[2023/02/14 10:59:42] [engine] caught signal (SIGINT)
[2023/02/14 10:59:42] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/14 10:59:42] [ info] [input] pausing dummy.0
[2023/02/14 10:59:43] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/14 10:59:43] [ info] [input] pausing dummy.0
[2023/02/14 10:59:43] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/14 10:59:43] [ info] [output:stdout:stdout.0] thread worker #0 stopped
clear array: 0x5479b80==252308==
==252308== HEAP SUMMARY:
==252308==     in use at exit: 0 bytes in 0 blocks
==252308==   total heap usage: 2,103 allocs, 2,103 frees, 1,466,157 bytes allocated
==252308==
==252308== All heap blocks were freed -- no leaks are possible
==252308==
==252308== For lists of detected and suppressed errors, rerun with: -s
==252308== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
