### PR TITLE
tests: intenral: fuzzers: make config_map fuzz able to fail malloc

### DIFF
--- a/tests/internal/fuzzers/config_map_fuzzer.c
+++ b/tests/internal/fuzzers/config_map_fuzzer.c
@@ -155,43 +155,58 @@ struct flb_config_map *configs[] = {config_map_mult, config_map};
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    /* Set fuzzer-malloc chance of failure */
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
+    if (size < 4) {
+        return 0;
+    }
     flb_malloc_p = 0;
-    flb_malloc_mod = 25000;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
+
     if (size < 40) {
         return 0;
     }
 
+    struct mk_list *map = NULL;
+    struct flb_config *config = NULL;
     struct context ctx;
-    struct mk_list *map;
+    bzero(&ctx, sizeof(struct context));
     struct mk_list prop;
-    struct flb_config *config;
+    bzero(&prop, sizeof(struct mk_list));
 
-    char *null_terminated1 = get_null_terminated(15, &data, &size);
-    char *null_terminated2 = get_null_terminated(15, &data, &size);
-    char *null_terminated3 = get_null_terminated(size, &data, &size);
+    char *fuzz_str1 = get_null_terminated(15, &data, &size);
+    char *fuzz_str2 = get_null_terminated(15, &data, &size);
+    char *fuzz_str3 = get_null_terminated(size, &data, &size);
 
     for (int i = 0; i < 2; i++) {
         config = flb_config_init();
-        if (!config) {
-            return 0;
+        if (config) {
+            memset(&ctx, '\0', sizeof(struct context));
+
+            flb_kv_init(&prop);
+            if (flb_kv_item_create(&prop, fuzz_str1, fuzz_str2) != NULL) {
+                /* Assign one of the config maps */
+                map = flb_config_map_create(config, configs[i]);
+                if (map) {
+                    if (flb_config_map_set(&prop, map, &ctx) != -1) {
+                        flb_config_map_properties_check(fuzz_str3, &prop, map);
+                    }
+                    flb_config_map_destroy(map);
+                }
+            }
+            flb_kv_release(&prop);
+            flb_config_exit(config);
         }
-        memset(&ctx, '\0', sizeof(struct context));
-
-        flb_kv_init(&prop);
-        flb_kv_item_create(&prop, null_terminated1, null_terminated2);
-
-        /* Assign one of the config maps */
-        map = flb_config_map_create(config, configs[i]);
-        flb_config_map_set(&prop, map,&ctx);
-        flb_config_map_properties_check(null_terminated3, &prop, map);
-        flb_config_map_destroy(map);
-        flb_kv_release(&prop);
-        flb_config_exit(config);
     }
 
-    flb_free(null_terminated1);
-    flb_free(null_terminated2);
-    flb_free(null_terminated3);
+    flb_free(fuzz_str1);
+    flb_free(fuzz_str2);
+    flb_free(fuzz_str3);
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
