### PR TITLE
config_map: fix possible NULL-deref

### DIFF
--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -284,6 +284,11 @@ struct mk_list *flb_config_map_create(struct flb_config *config,
 
         new->type = m->type;
         new->name = flb_sds_create(m->name);
+        if (new->name == NULL) {
+            flb_free(new);
+            flb_config_map_destroy(list);
+            return NULL;
+        }
 
         /* Translate default value */
         if (m->def_value) {


### PR DESCRIPTION
flb_sds_create can return NULL and this need to be guarded, as otherwise NULL-dereferences can happen later in the execution. This was found by the fuzzer locally from https://github.com/fluent/fluent-bit/pull/6858

Signed-off-by: David Korczynski <david@adalogics.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
