### PR TITLE
out_calyptia: fixes to get calyptia cloud traces working.

### DIFF
--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -929,7 +929,8 @@ static void cb_calyptia_flush(struct flb_event_chunk *event_chunk,
     }
     
 #ifdef FLB_HAVE_CHUNK_TRACE
-    if (event_chunk->type == (FLB_EVENT_TYPE_LOGS | FLB_EVENT_TYPE_HAS_TRACE)) {
+    // in_emitter no longer allows us to sent the event type so use the tag instead.
+    if (strcmp(event_chunk->tag, "trace") == 0) {
         json = flb_pack_msgpack_to_json_format(event_chunk->data,
                                                event_chunk->size,
                                                FLB_PACK_JSON_FORMAT_STREAM,

--- a/plugins/out_calyptia/calyptia.h
+++ b/plugins/out_calyptia/calyptia.h
@@ -39,7 +39,7 @@
 #define CALYPTIA_ENDPOINT_CREATE  "/v1/agents"
 #define CALYPTIA_ENDPOINT_PATCH   "/v1/agents/%s"
 #define CALYPTIA_ENDPOINT_METRICS "/v1/agents/%s/metrics"
-#define CALYPTIA_ENDPOINT_TRACE   "/v1/traces/%s"
+#define CALYPTIA_ENDPOINT_TRACE   "/v1/pipelines/%s/trace_session/records"
 
 /* Storage */
 #define CALYPTIA_SESSION_FILE     "session.CALYPTIA"

--- a/src/flb_chunk_trace.c
+++ b/src/flb_chunk_trace.c
@@ -211,7 +211,7 @@ struct flb_chunk_trace_context *flb_chunk_trace_context_new(void *trace_input,
         goto error_input;
     }
 
-    output = flb_output_new(ctx->flb->config, output_name, data, 1);
+    output = flb_output_new(ctx->flb->config, output_name, data, 0);
     if (output == NULL) {
         flb_error("could not create trace output");
         goto error_input;


### PR DESCRIPTION
Fixes traces for calyptia cloud

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
