### PR TITLE
filter: aws ec2 tags include/exclude

### DIFF
--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -39,6 +39,7 @@
 #include <msgpack.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
 
 #include "aws.h"
 
@@ -251,6 +252,10 @@ void flb_filter_aws_tags_destroy(struct flb_filter_aws *ctx)
         flb_free(ctx->tag_values_len);
     }
     ctx->tag_values_len = NULL;
+    if (ctx->tag_is_enabled) {
+        flb_free(ctx->tag_is_enabled);
+    }
+    ctx->tag_is_enabled = NULL;
     ctx->tags_count = 0;
 }
 
@@ -349,9 +354,6 @@ static int get_ec2_tag_keys(struct flb_filter_aws *ctx)
             tag_key = tags_list + tag_start;
             memcpy(ctx->tag_keys[tag_index], tag_key, tag_key_len);
 
-            flb_plg_debug(ctx->ins, "tag found: %s (len=%zu)", ctx->tag_keys[tag_index],
-                          tag_key_len);
-
             tag_index++;
             tag_start = tag_end + 1;
         }
@@ -429,8 +431,135 @@ static int get_ec2_tag_values(struct flb_filter_aws *ctx)
     return 0;
 }
 
+static int tag_is_present_in_list(struct flb_filter_aws *ctx, flb_sds_t tag,
+        flb_sds_t *tags, int tags_n)
+{
+    int i;
+    for (i = 0; i < tags_n; i++) {
+        if (strcmp(tag, tags[i]) == 0) {
+            return FLB_TRUE;
+        }
+    }
+    return FLB_FALSE;
+}
+
+static int tags_split(char *tags, flb_sds_t **tags_list, int *tags_list_n) {
+    flb_sds_t token;
+    int i;
+    int n;
+    n = 1;
+    for (i = 0; i < strlen(tags); i++) {
+        if (tags[i] == ',') {
+            n++;
+        }
+    }
+
+    *tags_list = flb_calloc(sizeof(flb_sds_t), n);
+    if (*tags_list == NULL) {
+        return -2;
+    }
+
+    token = strtok(tags, ",");
+    i = 0;
+    while (token != NULL) {
+        (*tags_list)[i] = token;
+        i++;
+        token = strtok(NULL, ",");
+    }
+
+    *tags_list_n = n;
+
+    return 0;
+}
+
+static int get_ec2_tag_enabled(struct flb_filter_aws *ctx)
+{
+    const char *tags_include;
+    const char *tags_exclude;
+    char *tags_copy;
+    flb_sds_t *tags;
+    int tags_n;
+    int i;
+    int tag_present;
+    int result;
+
+    /* if there are no tags, there is no need to evaluate which tag is enabled */
+    if (ctx->tags_count == 0) {
+        return 0;
+    }
+
+
+    /* allocate memory for 'tag_is_enabled' for all tags */
+    ctx->tag_is_enabled = flb_calloc(ctx->tags_count, sizeof(int));
+    if (!ctx->tag_is_enabled) {
+        flb_plg_error(ctx->ins, "Failed to allocate memory for tag_is_enabled");
+        return -1;
+    }
+
+    /* if tags_include and tags_exclude are not defined, set all tags as enabled */
+    for (i = 0; i < ctx->tags_count; i++) {
+        ctx->tag_is_enabled[i] = FLB_TRUE;
+    }
+
+    /* apply tags_included configuration */
+    tags_include = flb_filter_get_property("tags_include", ctx->ins);
+    if (tags_include) {
+        /* copy const string in order to use strtok which modifes the string */
+        tags_copy = flb_strdup(tags_include);
+        if (!tags_copy) {
+            return -1;
+        }
+        result = tags_split(tags_copy, &tags, &tags_n);
+        if (result < 0) {
+            free(tags_copy);
+            return result;
+        }
+        for (i = 0; i < ctx->tags_count; i++) {
+            tag_present = tag_is_present_in_list(ctx, ctx->tag_keys[i], tags, tags_n);
+            /* tag is enabled if present in included list */
+            ctx->tag_is_enabled[i] = tag_present;
+        }
+        free(tags_copy);
+        free(tags);
+    }
+
+    /* apply tags_excluded configuration, only if tags_included is not defined */
+    tags_exclude = flb_filter_get_property("tags_exclude", ctx->ins);
+    if (tags_include && tags_exclude) {
+        flb_plg_warn(ctx->ins, "specyfing tags_include and tags_exclude at the same time"
+                " is invalid, ignoring tags_exclude");
+    }
+    if (!tags_include && tags_exclude) {
+        /* copy const string in order to use strtok which modifes the string */
+        tags_copy = flb_strdup(tags_exclude);
+        if (!tags_copy) {
+            return -1;
+        }
+        result = tags_split(tags_copy, &tags, &tags_n);
+        if (result < 0) {
+            free(tags_copy);
+            return result;
+        }
+        for (i = 0; i < ctx->tags_count; i++) {
+            tag_present = tag_is_present_in_list(ctx, ctx->tag_keys[i], tags, tags_n);
+            if (tag_present == FLB_TRUE) {
+                /* tag is excluded, so should be disabled */
+                ctx->tag_is_enabled[i] = FLB_FALSE;
+            } else {
+                /* tag is not excluded, therefore should be enabled */
+                ctx->tag_is_enabled[i] = FLB_TRUE;
+            }
+        }
+        free(tags_copy);
+        free(tags);
+    }
+
+    return 0;
+}
+
 static int get_ec2_tags(struct flb_filter_aws *ctx)
 {
+    int i;
     int ret;
 
     ctx->tags_fetched = FLB_FALSE;
@@ -457,6 +586,18 @@ static int get_ec2_tags(struct flb_filter_aws *ctx)
         return ret;
     }
 
+    ret = get_ec2_tag_enabled(ctx);
+    if (ret < 0) {
+        flb_filter_aws_tags_destroy(ctx);
+        return ret;
+    }
+
+    /* log tags debug information */
+    for (i = 0; i < ctx->tags_count; i++) {
+        flb_plg_debug(ctx->ins, "found tag %s which is included=%d",
+                ctx->tag_keys[i], ctx->tag_is_enabled[i]);
+    }
+
     ctx->tags_fetched = FLB_TRUE;
     return 0;
 }
@@ -468,6 +609,7 @@ static int get_ec2_tags(struct flb_filter_aws *ctx)
 static int get_ec2_metadata(struct flb_filter_aws *ctx)
 {
     int ret;
+    int i;
 
     if (ctx->instance_id_include && !ctx->instance_id) {
         ret = flb_aws_imds_request(ctx->client_imds, FLB_AWS_IMDS_INSTANCE_ID_PATH,
@@ -555,12 +697,16 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         ctx->new_keys++;
     }
 
-    if (ctx->tags_include && !ctx->tags_fetched) {
+    if (ctx->tags_enabled && !ctx->tags_fetched) {
         ret = get_ec2_tags(ctx);
         if (ret < 0) {
             return -1;
         }
-        ctx->new_keys += ctx->tags_count;
+        for (i = 0; i < ctx->tags_count; i++) {
+            if (ctx->tag_is_enabled[i] == FLB_TRUE) {
+                ctx->new_keys++;
+            }
+        }
     }
 
     ctx->metadata_retrieved = FLB_TRUE;
@@ -719,17 +865,19 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                                ctx->hostname_len));
         }
 
-        if (ctx->tags_include && ctx->tags_fetched) {
+        if (ctx->tags_enabled && ctx->tags_fetched) {
             for (i = 0;
                  i < ctx->tags_count &&
                  ret == FLB_EVENT_ENCODER_SUCCESS;
                  i++) {
-                ret = flb_log_event_encoder_append_body_values(
-                        &log_encoder,
-                        FLB_LOG_EVENT_STRING_VALUE(ctx->tag_keys[i],
-                                                   ctx->tag_keys_len[i]),
-                        FLB_LOG_EVENT_STRING_VALUE(ctx->tag_values[i],
-                                                   ctx->tag_values_len[i]));
+                if (ctx->tag_is_enabled[i] == FLB_TRUE) {
+                    ret = flb_log_event_encoder_append_body_values(
+                            &log_encoder,
+                            FLB_LOG_EVENT_STRING_VALUE(ctx->tag_keys[i],
+                                                       ctx->tag_keys_len[i]),
+                            FLB_LOG_EVENT_STRING_VALUE(ctx->tag_values[i],
+                                                       ctx->tag_values_len[i]));
+                }
             }
         }
 
@@ -877,8 +1025,25 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_BOOL, "tags_enabled", "false",
-     0, FLB_TRUE, offsetof(struct flb_filter_aws, tags_include),
-     "Enable EC2 instance tags"
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tags_enabled),
+     "Enable EC2 instance tags, "
+     "injects all tags if tags_include and tags_exclude are empty"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "tags_include", "",
+     0, FLB_FALSE, 0,
+     "Defines list of specific EC2 tag keys to inject into the logs; "
+     "tag keys must be separated by \",\" character; "
+     "tags which are not present in this list will be ignored; "
+     "e.g.: \"Name,tag1,tag2\""
+    },
+    {
+     FLB_CONFIG_MAP_STR, "tags_exclude", "",
+     0, FLB_FALSE, 0,
+     "Defines list of specific EC2 tag keys not to inject into the logs; "
+     "tag keys must be separated by \",\" character; "
+     "if both tags_include and tags_exclude are specified, configuration is invalid"
+     " and plugin fails"
     },
     {0}
 };

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -140,7 +140,6 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
     struct flb_aws_client_generator *generator;
     if (options && options->client_generator) {
         generator = options->client_generator;
-        flb_plg_info(ctx->ins, "options: %s", options->name);
     } else {
         generator = flb_aws_client_generator();
     }

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -90,8 +90,9 @@ struct flb_filter_aws {
     int hostname_include;
 
     /* tags_* fields are related to exposing EC2 tags in log labels
-     * tags_include defines if EC2 tags functionality is enabled */
-    int tags_include;
+     * tags_enabled defines if EC2 tags functionality is enabled */
+    int tags_enabled;
+
     /* tags_fetched defines if tag keys and values were fetched successfully
      * and might be used to inject into msgpack */
     int tags_fetched;
@@ -107,6 +108,9 @@ struct flb_filter_aws {
     flb_sds_t *tag_values;
     /* tag_values_len is an array of lengths related to tag_values items */
     size_t *tag_values_len;
+    /* tag_is_enabled is an array of bools which define if corresponding tag should be injected */
+    /* e.g.: if tag_is_enabled[0] = FALSE, then filter aws should not inject first tag */
+    int *tag_is_enabled;
 
     /* number of new keys added by this plugin */
     int new_keys;

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -126,7 +126,6 @@ struct flb_filter_aws {
 
 struct flb_filter_aws_init_options {
     struct flb_aws_client_generator *client_generator;
-    flb_sds_t name;
 };
 
 #endif

--- a/tests/runtime/filter_aws.c
+++ b/tests/runtime/filter_aws.c
@@ -53,7 +53,6 @@ void flb_test_aws_ec2_tags_present() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -166,7 +165,6 @@ void flb_test_aws_ec2_tags_present() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -183,7 +181,6 @@ void flb_test_aws_ec2_tags_404() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -205,7 +202,6 @@ void flb_test_aws_ec2_tags_404() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -270,7 +266,6 @@ void flb_test_aws_ec2_tags_404() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -287,7 +282,6 @@ void flb_test_aws_ec2_tags_list_500() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -314,7 +308,6 @@ void flb_test_aws_ec2_tags_list_500() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -371,7 +364,6 @@ void flb_test_aws_ec2_tags_list_500() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -388,7 +380,6 @@ void flb_test_aws_ec2_tags_value_404() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -429,7 +420,6 @@ void flb_test_aws_ec2_tags_value_404() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -486,7 +476,6 @@ void flb_test_aws_ec2_tags_value_404() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -503,7 +492,6 @@ void flb_test_aws_ec2_tags_value_500() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -544,7 +532,6 @@ void flb_test_aws_ec2_tags_value_500() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -601,7 +588,6 @@ void flb_test_aws_ec2_tags_value_500() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -618,7 +604,6 @@ void flb_test_aws_ec2_tags_include() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -656,7 +641,6 @@ void flb_test_aws_ec2_tags_include() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -724,7 +708,6 @@ void flb_test_aws_ec2_tags_include() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);
@@ -741,7 +724,6 @@ void flb_test_aws_ec2_tags_exclude() {
     struct flb_lib_out_cb cb_data;
     struct flb_aws_client_generator *client_generator;
     struct flb_filter_aws_init_options *ops;
-    flb_sds_t name;
     struct flb_aws_client_mock_request_chain *request_chain;
     char *output = NULL;
     char *result;
@@ -779,7 +761,6 @@ void flb_test_aws_ec2_tags_exclude() {
         return;
     }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -847,7 +828,6 @@ void flb_test_aws_ec2_tags_exclude() {
     flb_stop(ctx);
     flb_aws_client_mock_destroy_generator();
     flb_destroy(ctx);
-    flb_sds_destroy(name);
     flb_free(ops);
 
     set_output(NULL);

--- a/tests/runtime/filter_aws.c
+++ b/tests/runtime/filter_aws.c
@@ -689,9 +689,6 @@ void flb_test_aws_ec2_tags_include() {
     TEST_CHECK(ret == 0);
     ret = flb_filter_set(ctx, filter_ffd, "tags_include", "Namee,MyTag,Name", NULL);
     TEST_CHECK(ret == 0);
-    /* if tags_include and tags_exclude are defined, the tags_exclude has no effect */
-    ret = flb_filter_set(ctx, filter_ffd, "tags_exclude", "Name", NULL);
-    TEST_CHECK(ret == 0);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);

--- a/tests/runtime/filter_aws.c
+++ b/tests/runtime/filter_aws.c
@@ -36,7 +36,7 @@ char *get_output(void)
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_aws] received message: %s", data);
+        flb_debug("[test_filter_aws] received message: %s", (char*)data);
         set_output(data); /* success */
     }
     return 0;
@@ -92,10 +92,12 @@ void flb_test_aws_ec2_tags_present() {
 
     client_generator = flb_aws_client_get_mock_generator();
     ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
-    name = flb_sds_create_size(100);
-    name = flb_sds_printf(&name, "flb_test_aws_ec2_tags_present");
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
     ops->client_generator = client_generator;
-    ops->name = name;
 
     ctx = flb_create();
 
@@ -197,8 +199,11 @@ void flb_test_aws_ec2_tags_404() {
 
     client_generator = flb_aws_client_get_mock_generator();
     ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
-    name = flb_sds_create_size(100);
-    name = flb_sds_printf(&name, "flb_test_aws_ec2_tags_404");
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
     ops->client_generator = client_generator;
     ops->name = name;
 
@@ -303,8 +308,11 @@ void flb_test_aws_ec2_tags_list_500() {
 
     client_generator = flb_aws_client_get_mock_generator();
     ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
-    name = flb_sds_create_size(100);
-    name = flb_sds_printf(&name, "flb_test_aws_ec2_tags_list_500");
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
     ops->client_generator = client_generator;
     ops->name = name;
 
@@ -415,8 +423,11 @@ void flb_test_aws_ec2_tags_value_404() {
 
     client_generator = flb_aws_client_get_mock_generator();
     ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
-    name = flb_sds_create_size(100);
-    name = flb_sds_printf(&name, "flb_test_aws_ec2_tags_list_500");
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
     ops->client_generator = client_generator;
     ops->name = name;
 
@@ -527,8 +538,11 @@ void flb_test_aws_ec2_tags_value_500() {
 
     client_generator = flb_aws_client_get_mock_generator();
     ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
-    name = flb_sds_create_size(100);
-    name = flb_sds_printf(&name, "flb_test_aws_ec2_tags_list_500");
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
     ops->client_generator = client_generator;
     ops->name = name;
 
@@ -593,11 +607,263 @@ void flb_test_aws_ec2_tags_value_500() {
     set_output(NULL);
 }
 
+void flb_test_aws_ec2_tags_include() {
+    int ret;
+    int bytes;
+    char *p = "[0, {\"log\": \"hello, from my ec2 instance\"}]";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+    struct flb_aws_client_generator *client_generator;
+    struct flb_filter_aws_init_options *ops;
+    flb_sds_t name;
+    struct flb_aws_client_mock_request_chain *request_chain;
+    char *output = NULL;
+    char *result;
+
+    request_chain = FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/latest/meta-data/tags/instance"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "Name\nCUSTOMER_ID"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/tags/instance/Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "my_ec2_instance"),
+            set(PAYLOAD_SIZE, 15)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/tags/instance/CUSTOMER_ID"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "70ec5c04-3a6e-11ed-a261-0242ac120002"),
+            set(PAYLOAD_SIZE, 36)
+        )
+    );
+    flb_aws_client_mock_configure_generator(request_chain);
+
+    client_generator = flb_aws_client_get_mock_generator();
+    ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
+    ops->client_generator = client_generator;
+    ops->name = name;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "format", "json",
+                   NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "aws", ops);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "ec2_instance_id", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "az", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_enabled", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_include", "Namee,MyTag,Name", NULL);
+    TEST_CHECK(ret == 0);
+    /* if tags_include and tags_exclude are defined, the tags_exclude has no effect */
+    ret = flb_filter_set(ctx, filter_ffd, "tags_exclude", "Name", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    if (!TEST_CHECK(bytes > 0)) {
+        TEST_MSG("zero bytes were pushed\n");
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    output = get_output();
+    if (output) {
+        result = strstr(output, "\"Name\":\"my_ec2_instance\"");
+        if (!TEST_CHECK(result != NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+        result = strstr(output, "hello, from my ec2 instance");
+        if (!TEST_CHECK(result != NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+        /* CUSTOMER_ID is not included, so we don't expect it in the log */
+        result = strstr(output, "\"CUSTOMER_ID\":\"70ec5c04-3a6e-11ed-a261-0242ac120002\"");
+        if (!TEST_CHECK(result == NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+    }
+    else {
+        TEST_CHECK(false);
+        TEST_MSG("output is empty\n");
+    }
+
+    flb_stop(ctx);
+    flb_aws_client_mock_destroy_generator();
+    flb_destroy(ctx);
+    flb_sds_destroy(name);
+    flb_free(ops);
+
+    set_output(NULL);
+}
+
+void flb_test_aws_ec2_tags_exclude() {
+    int ret;
+    int bytes;
+    char *p = "[0, {\"log\": \"hello, from my ec2 instance\"}]";
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+    struct flb_aws_client_generator *client_generator;
+    struct flb_filter_aws_init_options *ops;
+    flb_sds_t name;
+    struct flb_aws_client_mock_request_chain *request_chain;
+    char *output = NULL;
+    char *result;
+
+    request_chain = FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/latest/meta-data/tags/instance"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "Name\nCUSTOMER_ID"),
+            set(PAYLOAD_SIZE, 16)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/tags/instance/Name"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "my_ec2_instance"),
+            set(PAYLOAD_SIZE, 15)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/tags/instance/CUSTOMER_ID"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "70ec5c04-3a6e-11ed-a261-0242ac120002"),
+            set(PAYLOAD_SIZE, 36)
+        )
+    );
+    flb_aws_client_mock_configure_generator(request_chain);
+
+    client_generator = flb_aws_client_get_mock_generator();
+    ops = flb_calloc(1, sizeof(struct flb_filter_aws_init_options));
+    if (ops == NULL) {
+        TEST_MSG("calloc for aws plugin options failed\n");
+        TEST_CHECK(false);
+        return;
+    }
+    ops->client_generator = client_generator;
+    ops->name = name;
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "format", "json",
+                   NULL);
+
+    filter_ffd = flb_filter(ctx, (char *) "aws", ops);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "ec2_instance_id", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "az", "false", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_enabled", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_filter_set(ctx, filter_ffd, "tags_exclude", "Name,Name2", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    if (!TEST_CHECK(bytes > 0)) {
+        TEST_MSG("zero bytes were pushed\n");
+    }
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    output = get_output();
+    if (output) {
+        /* Name is excluded, so we don't expect it in the log */
+        result = strstr(output, "\"Name\":\"my_ec2_instance\"");
+        if (!TEST_CHECK(result == NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+        result = strstr(output, "hello, from my ec2 instance");
+        if (!TEST_CHECK(result != NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+        result = strstr(output, "\"CUSTOMER_ID\":\"70ec5c04-3a6e-11ed-a261-0242ac120002\"");
+        if (!TEST_CHECK(result != NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+    }
+    else {
+        TEST_CHECK(false);
+        TEST_MSG("output is empty\n");
+    }
+
+    flb_stop(ctx);
+    flb_aws_client_mock_destroy_generator();
+    flb_destroy(ctx);
+    flb_sds_destroy(name);
+    flb_free(ops);
+
+    set_output(NULL);
+}
+
+
 TEST_LIST = {
     {"aws_ec2_tags_present", flb_test_aws_ec2_tags_present},
     {"aws_ec2_tags_404", flb_test_aws_ec2_tags_404},
     {"aws_ec2_tags_list_500", flb_test_aws_ec2_tags_list_500},
     {"aws_ec2_tags_value_404", flb_test_aws_ec2_tags_value_404},
     {"aws_ec2_tags_value_500", flb_test_aws_ec2_tags_value_500},
+    {"aws_ec2_tags_include", flb_test_aws_ec2_tags_include},
+    {"aws_ec2_tags_exclude", flb_test_aws_ec2_tags_exclude},
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

Add Filter AWS option for EC2 tags to include/exclude specified tags. Options are `tags_include` and `tags_exclude`.

Here is the usage (`tags_enabled` is already present in master, but left for context):
```
$ fluent-bit -F aws --help

tags_enabled       Enable EC2 instance tags, injects all tags if tags_include and
                   tags_exclude are empty
                   > default: false, type: boolean

tags_include       Defines list of specific EC2 tag keys to inject into the logs; tag keys
                   must be separated by "," character; tags which are not present in this
                   list will be ignored; e.g.: "Name,tag1,tag2"
                   > default: , type: string

tags_exclude       Defines list of specific EC2 tag keys not to inject into the logs; tag
                   keys must be separated by "," character; if both tags_include and
                   tags_exclude are specified, configuration is invalid and plugin fails
                   > default: , type: string
```

## Example

Let's assume that my EC2 has two tags:
```
Name: mwarzynski-fluentbit-dev
CUSTOMER_ID: 70ec5c04-3a6e-11ed-a261-0242ac120002
```

If we would configure the Filter AWS filter to include just the `Name`:
```
[FILTER]
    Name aws
    imds_version v1
    Match *
    tags_enabled true
    tags_include Name
```

then that's how the `{"log": "my message"}` would look like:

```
[0] stdin.0: [1676410937.168158063, {"log"=>"my message", "az"=>"us-east-1a", "ec2_instance_id"=>"i-0e66fc7f9809d7168", "Name"=>"mwarzynski-fluentbit-dev"}]
```

See? There is no `CUSTOMER_ID` tag.

We could achieve the same result by excluding the `CUSTOMER_ID`. Configuration:
```
[FILTER]
    Name aws
    imds_version v1
    Match *
    tags_enabled true
    tags_exclude CUSTOMER_ID
```

log:
```
[0] stdin.0: [1676411012.113442477, {"log"=>"my message", "az"=>"us-east-1a", "ec2_instance_id"=>"i-0e66fc7f9809d7168", "Name"=>"mwarzynski-fluentbit-dev"}]
```

### Metadata server mock

In order to test things quickly, without having to restart the EC2 instance to set up different tags, I have implemented a mock for the metadata server. It was used to present the previous example.

```python
#!/usr/bin/env python3

from http.server import BaseHTTPRequestHandler, HTTPServer


class HTTPHandler(BaseHTTPRequestHandler):
    def _send_response(
        self, status_code: int = 200, body: str = None, content_type: str = "text/plain"
    ):
        self.send_response(status_code)
        if body:
            self.send_header("Content-Type", content_type)
            self.send_header("Content-Length", len(body))
        self.end_headers()
        if body:
            self.wfile.write(body.encode("utf-8"))

    def do_GET(self):
        if self.path == "/":
            self._send_response()

        elif self.path == "/latest/meta-data/instance-id/":
            self._send_response(body="i-0e66fc7f9809d7168")

        elif self.path == "/latest/meta-data/instance-type/":
            self._send_response(body="t2.micro")

        elif self.path == "/latest/meta-data/local-ipv4/":
            self._send_response(body="10.158.112.84")

        elif self.path == "/latest/meta-data/mac/":
            self._send_response(body="00:00:5e:00:53:af")

        elif (
            self.path
            == "/latest/meta-data/network/interfaces/macs/00:00:5e:00:53:af/vpc-id/"
        ):
            self._send_response(body="vpc-2928ea42")

        elif self.path == "/latest/meta-data/ami-id/":
            self._send_response(body="ami-5fb8c835")

        elif self.path == "/latest/dynamic/instance-identity/document/":
            self._send_response(
                body="""{
    "devpayProductCodes" : null,
    "marketplaceProductCodes" : [ "1abc2defghijklm3nopqrs4tu" ],
    "availabilityZone" : "us-east-1a",
    "privateIp" : "10.158.112.84",
    "version" : "2017-09-30",
    "instanceId" : "i-1234567890abcdef0",
    "billingProducts" : null,
    "instanceType" : "t2.micro",
    "accountId" : "123456789012",
    "imageId" : "ami-5fb8c835",
    "pendingTime" : "2016-11-19T16:32:11Z",
    "architecture" : "x86_64",
    "kernelId" : null,
    "ramdiskId" : null,
    "region" : "us-east-1"
}""",
                content_type="application/json",
            )

        elif self.path == "/latest/meta-data/hostname/":
            self._send_response(body="ip-10-158-112-84.us-west-2.compute.internal")

        elif self.path == "/latest/meta-data/placement/availability-zone/":
            self._send_response(body="us-east-1a")

        elif self.path == "/latest/meta-data/tags/instance":
            # If there are 0 tags, AWS returns a 404.
            # self._send_response(status_code=404)
            self._send_response(body="Name\nCUSTOMER_ID")

        elif self.path == "/latest/meta-data/tags/instance/Name":
            self._send_response(body="mwarzynski-fluentbit-dev")

        elif self.path == "/latest/meta-data/tags/instance/CUSTOMER_ID":
            self._send_response(body="70ec5c04-3a6e-11ed-a261-0242ac120002")

        else:
            self._send_response(status_code=500)


def run():
    httpd = HTTPServer(("", 8000), HTTPHandler)
    try:
        httpd.serve_forever()
    except KeyboardInterrupt:
        pass
    httpd.server_close()


if __name__ == "__main__":
    run()
```

## Debug logs

One of the requirements for the PR is to include the debug logs. Here they are.
Config:
```
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug


[INPUT]
    name stdin

[FILTER]
    Name aws
    imds_version v1
    Match *
    tags_enabled true
    tags_include Name

[OUTPUT]
    name  stdout
    match *
```

```
mwarzynski@d39c219da365:/fluent-bit-dev/build$ ./bin/fluent-bit -c fluent-bit.conf
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/14 21:47:44] [ info] Configuration:
[2023/02/14 21:47:44] [ info]  flush time     | 1.000000 seconds
[2023/02/14 21:47:44] [ info]  grace          | 5 seconds
[2023/02/14 21:47:44] [ info]  daemon         | 0
[2023/02/14 21:47:44] [ info] ___________
[2023/02/14 21:47:44] [ info]  inputs:
[2023/02/14 21:47:44] [ info]      stdin
[2023/02/14 21:47:44] [ info] ___________
[2023/02/14 21:47:44] [ info]  filters:
[2023/02/14 21:47:44] [ info]      aws.0
[2023/02/14 21:47:44] [ info] ___________
[2023/02/14 21:47:44] [ info]  outputs:
[2023/02/14 21:47:44] [ info]      stdout.0
[2023/02/14 21:47:44] [ info] ___________
[2023/02/14 21:47:44] [ info]  collectors:
[2023/02/14 21:47:44] [ info] [fluent bit] version=2.1.0, commit=f0ab41a2ff, pid=9391
[2023/02/14 21:47:44] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/02/14 21:47:44] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/14 21:47:44] [ info] [cmetrics] version=0.5.8
[2023/02/14 21:47:44] [ info] [ctraces ] version=0.3.0
[2023/02/14 21:47:44] [ info] [input:stdin:stdin.0] initializing
[2023/02/14 21:47:44] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2023/02/14 21:47:44] [debug] [stdin:stdin.0] created event channels: read=21 write=22
[2023/02/14 21:47:44] [debug] [input:stdin:stdin.0] buf_size=16000
[2023/02/14 21:47:44] [debug] [imds] using IMDSv1
[2023/02/14 21:47:44] [debug] [http_client] not using http_proxy for header
[2023/02/14 21:47:44] [debug] [imds] using IMDSv1
[2023/02/14 21:47:44] [debug] [http_client] not using http_proxy for header
[2023/02/14 21:47:44] [debug] [imds] using IMDSv1
[2023/02/14 21:47:44] [debug] [http_client] not using http_proxy for header
[2023/02/14 21:47:44] [debug] [imds] using IMDSv1
[2023/02/14 21:47:44] [debug] [http_client] not using http_proxy for header
[2023/02/14 21:47:44] [debug] [imds] using IMDSv1
[2023/02/14 21:47:44] [debug] [http_client] not using http_proxy for header
[2023/02/14 21:47:44] [debug] [filter:aws:aws.0] found tag Name which is included=1
[2023/02/14 21:47:44] [debug] [filter:aws:aws.0] found tag CUSTOMER_ID which is included=0
[2023/02/14 21:47:44] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/02/14 21:47:44] [ info] [output:stdout:stdout.0] worker #0 started
[2023/02/14 21:47:44] [ info] [sp] stream processor started
{"log":"debug logs"}
[2023/02/14 21:47:54] [debug] [input chunk] update output instances with new chunk size diff=107
[2023/02/14 21:47:55] [debug] [task] created task=0x60b000005840 id=0 OK
[2023/02/14 21:47:55] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] stdin.0: [1676411274.927543256, {"log"=>"debug logs", "az"=>"us-east-1a", "ec2_instance_id"=>"i-0e66fc7f9809d7168", "Name"=>"mwarzynski-fluentbit-dev"}]
[2023/02/14 21:47:55] [debug] [out flush] cb_destroy coro_id=0
[2023/02/14 21:47:55] [debug] [task] destroy task=0x60b000005840 (task_id=0)
^C[2023/02/14 21:47:57] [engine] caught signal (SIGINT)
[2023/02/14 21:47:57] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/14 21:47:57] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/14 21:47:57] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/14 21:47:57] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### Valgrind

```
mwarzynski@3b7df7059468:/fluent-bit-dev/build$ valgrind ./bin/fluent-bit -c fluent-bit.conf
==11953== Memcheck, a memory error detector
==11953== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==11953== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==11953== Command: ./bin/fluent-bit -c fluent-bit.conf
==11953==
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/14 22:19:21] [ info] Configuration:
[2023/02/14 22:19:21] [ info]  flush time     | 1.000000 seconds
[2023/02/14 22:19:21] [ info]  grace          | 5 seconds
[2023/02/14 22:19:21] [ info]  daemon         | 0
[2023/02/14 22:19:21] [ info] ___________
[2023/02/14 22:19:21] [ info]  inputs:
[2023/02/14 22:19:21] [ info]      stdin
[2023/02/14 22:19:21] [ info] ___________
[2023/02/14 22:19:21] [ info]  filters:
[2023/02/14 22:19:21] [ info]      aws.0
[2023/02/14 22:19:21] [ info] ___________
[2023/02/14 22:19:21] [ info]  outputs:
[2023/02/14 22:19:21] [ info]      stdout.0
[2023/02/14 22:19:21] [ info] ___________
[2023/02/14 22:19:21] [ info]  collectors:
[2023/02/14 22:19:21] [ info] [fluent bit] version=2.1.0, commit=f0ab41a2ff, pid=11953
[2023/02/14 22:19:21] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/02/14 22:19:21] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/14 22:19:21] [ info] [cmetrics] version=0.5.8
[2023/02/14 22:19:21] [ info] [ctraces ] version=0.3.0
[2023/02/14 22:19:21] [ info] [input:stdin:stdin.0] initializing
[2023/02/14 22:19:21] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2023/02/14 22:19:21] [debug] [stdin:stdin.0] created event channels: read=21 write=22
[2023/02/14 22:19:21] [debug] [input:stdin:stdin.0] buf_size=16000
[2023/02/14 22:19:21] [debug] [imds] using IMDSv1
[2023/02/14 22:19:21] [debug] [http_client] not using http_proxy for header
[2023/02/14 22:19:21] [debug] [imds] using IMDSv1
[2023/02/14 22:19:21] [debug] [http_client] not using http_proxy for header
[2023/02/14 22:19:21] [debug] [imds] using IMDSv1
[2023/02/14 22:19:21] [debug] [http_client] not using http_proxy for header
[2023/02/14 22:19:21] [debug] [imds] using IMDSv1
[2023/02/14 22:19:21] [debug] [http_client] not using http_proxy for header
[2023/02/14 22:19:21] [debug] [imds] using IMDSv1
[2023/02/14 22:19:21] [debug] [http_client] not using http_proxy for header
[2023/02/14 22:19:21] [debug] [filter:aws:aws.0] found tag Name which is included=1
[2023/02/14 22:19:21] [debug] [filter:aws:aws.0] found tag CUSTOMER_ID which is included=0
[2023/02/14 22:19:21] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/02/14 22:19:21] [ info] [sp] stream processor started
[2023/02/14 22:19:21] [ info] [output:stdout:stdout.0] worker #0 started
{"test":1}
[2023/02/14 22:19:27] [debug] [input chunk] update output instances with new chunk size diff=98
[0] stdin.0: [1676413167.094411844, {"test"=>1, "az"=>"us-east-1a", "ec2_instance_id"=>"i-0e66fc7f9809d7168", "Name"=>"mwarzynski-fluentbit-dev"}]
[2023/02/14 22:19:27] [debug] [task] created task=0x5378a10 id=0 OK
[2023/02/14 22:19:27] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/02/14 22:19:27] [debug] [out flush] cb_destroy coro_id=0
[2023/02/14 22:19:27] [debug] [task] destroy task=0x5378a10 (task_id=0)
^C[2023/02/14 22:19:29] [engine] caught signal (SIGINT)
[2023/02/14 22:19:29] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/14 22:19:29] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/14 22:19:29] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/14 22:19:29] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==11953==
==11953== HEAP SUMMARY:
==11953==     in use at exit: 0 bytes in 0 blocks
==11953==   total heap usage: 1,873 allocs, 1,873 frees, 971,864 bytes allocated
==11953==
==11953== All heap blocks were freed -- no leaks are possible
==11953==
==11953== For lists of detected and suppressed errors, rerun with: -s
==11953== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)```
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature -> https://github.com/fluent/fluent-bit-docs/pull/897

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
