### PR TITLE
config_map: fix possible NULL-deref

### DIFF
--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -285,6 +285,12 @@ struct mk_list *flb_config_map_create(struct flb_config *config,
         new->type = m->type;
         new->name = flb_sds_create(m->name);
 
+        if (new->name == NULL) {
+            flb_free(new);
+            flb_config_map_destroy(list);
+            return NULL;
+        }
+
         /* Translate default value */
         if (m->def_value) {
             /*


### PR DESCRIPTION
This is a backport of PR #6859 which fixes a potential NULL dereference that could be triggered by flb_sds_create returning NULL in flb_config_map_create.