### PR TITLE
tests: internal: log: make cache_basic_tmeout more stable

### DIFF
--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -83,6 +83,8 @@ static void cache_basic_timeout()
     TEST_CHECK(ret_1 == FLB_FALSE);
     TEST_CHECK(ret_2 == FLB_FALSE);
     sleep(1);
+    interval1++;
+    interval2++;
 
     for (i = 1; i < 10; i++) {
         ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
@@ -99,17 +101,13 @@ static void cache_basic_timeout()
 
         sleep(1);
     }
+    ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
     ret = update_and_check_interval(timeout, ret_1, &interval1);
     TEST_CHECK(ret == 0);
 
+    ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
     ret = update_and_check_interval(timeout, ret_2, &interval2);
     TEST_CHECK(ret == 0);
-
-    ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
-    TEST_CHECK(ret_1 == FLB_FALSE);
-
-    ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
-    TEST_CHECK(ret_2 == FLB_FALSE);
 
     flb_log_cache_destroy(cache);
 }


### PR DESCRIPTION
#6841 
This patch is to 
- Increment interval on first time
- update ret_1/ret_2 not to reuse last ret_1/ret_2

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-log 
==32624== Memcheck, a memory error detector
==32624== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32624== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==32624== Command: bin/flb-it-log
==32624== 
Test cache_basic_timeout...                     
------------------------
[ OK ]
==32625== Warning: invalid file descriptor -1 in syscall close()
==32625== 
==32625== HEAP SUMMARY:
==32625==     in use at exit: 32 bytes in 1 blocks
==32625==   total heap usage: 849 allocs, 848 frees, 93,693 bytes allocated
==32625== 
==32625== LEAK SUMMARY:
==32625==    definitely lost: 0 bytes in 0 blocks
==32625==    indirectly lost: 0 bytes in 0 blocks
==32625==      possibly lost: 0 bytes in 0 blocks
==32625==    still reachable: 32 bytes in 1 blocks
==32625==         suppressed: 0 bytes in 0 blocks
==32625== Reachable blocks (those to which a pointer was found) are not shown.
==32625== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==32625== 
==32625== For lists of detected and suppressed errors, rerun with: -s
==32625== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test cache_one_slot...                          
[ OK ]
==32632== Warning: invalid file descriptor -1 in syscall close()
==32632== 
==32632== HEAP SUMMARY:
==32632==     in use at exit: 32 bytes in 1 blocks
==32632==   total heap usage: 834 allocs, 833 frees, 86,158 bytes allocated
==32632== 
==32632== LEAK SUMMARY:
==32632==    definitely lost: 0 bytes in 0 blocks
==32632==    indirectly lost: 0 bytes in 0 blocks
==32632==      possibly lost: 0 bytes in 0 blocks
==32632==    still reachable: 32 bytes in 1 blocks
==32632==         suppressed: 0 bytes in 0 blocks
==32632== Reachable blocks (those to which a pointer was found) are not shown.
==32632== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==32632== 
==32632== For lists of detected and suppressed errors, rerun with: -s
==32632== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==32624== 
==32624== HEAP SUMMARY:
==32624==     in use at exit: 0 bytes in 0 blocks
==32624==   total heap usage: 3 allocs, 3 frees, 1,093 bytes allocated
==32624== 
==32624== All heap blocks were freed -- no leaks are possible
==32624== 
==32624== For lists of detected and suppressed errors, rerun with: -s
==32624== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
