### PR TITLE
downstream: add mutex for busy_queue

### DIFF
--- a/include/fluent-bit/flb_downstream.h
+++ b/include/fluent-bit/flb_downstream.h
@@ -28,6 +28,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_io.h>
 #include <fluent-bit/flb_stream.h>
+#include <fluent-bit/flb_pthread.h>
 
 struct flb_connection;
 
@@ -40,6 +41,7 @@ struct flb_downstream {
     flb_sockfd_t           server_fd;
     struct flb_connection *dgram_connection;
 
+    pthread_mutex_t        busy_queue_mutex;
     struct mk_list         busy_queue;
     struct mk_list         destroy_queue;
 };

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -127,7 +127,9 @@ static int in_fw_collect(struct flb_input_instance *ins,
 
     ctx = in_context;
 
+    pthread_mutex_lock(&ctx->connections_mutex);
     connection = flb_downstream_conn_get(ctx->downstream);
+    pthread_mutex_unlock(&ctx->connections_mutex);
 
     if (connection == NULL) {
         flb_plg_error(ctx->ins, "could not accept new connection");
@@ -136,7 +138,9 @@ static int in_fw_collect(struct flb_input_instance *ins,
     }
 
     if (!config->is_ingestion_active) {
+        pthread_mutex_lock(&ctx->connections_mutex);
         flb_downstream_conn_release(connection);
+        pthread_mutex_unlock(&ctx->connections_mutex);
 
         return -1;
     }

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -22,6 +22,7 @@
 
 #include <msgpack.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_pthread.h>
 
 struct flb_in_fw_config {
     size_t buffer_max_size;         /* Max Buffer size             */
@@ -41,6 +42,7 @@ struct flb_in_fw_config {
     int coll_fd;
     struct flb_downstream *downstream; /* Client manager          */
     struct mk_list connections;     /* List of active connections */
+    pthread_mutex_t connections_mutex;
     struct mk_event_loop *evl;      /* Event loop file descriptor */
     struct flb_input_instance *ins; /* Input plugin instace       */
 };

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -65,6 +65,7 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         flb_debug("[in_fw] Listen='%s' TCP_Port=%s",
                   config->listen, config->tcp_port);
     }
+    pthread_mutex_init(&config->connections_mutex, NULL);
     return config;
 }
 

--- a/plugins/in_forward/fw_conn.h
+++ b/plugins/in_forward/fw_conn.h
@@ -51,7 +51,7 @@ struct fw_conn {
 };
 
 struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_config *ctx);
-int fw_conn_del(struct fw_conn *conn);
+int fw_conn_del(struct flb_in_fw_config *ctx, struct fw_conn *conn);
 int fw_conn_del_all(struct flb_in_fw_config *ctx);
 
 #endif


### PR DESCRIPTION
Fixes #6865 

This patch is to fix two data races.

1. busy_queue of downstream
2. connections of in_foward

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name forward
    Threaded on

[OUTPUT]
    Name stdout
```

If you use thread sanitizer, it is better to use following configuration.
```
[INPUT]
    Name forward
    Threaded on

[OUTPUT]
    Name null
```

```
cmake .. -DSANITIZE_THREAD=on && make
bin/fluent-bit -c a.conf &
bin/fluent-bit -i dummy -p rate=100000 -o forward
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c issues/6865/a.conf 
==41111== Memcheck, a memory error detector
==41111== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==41111== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==41111== Command: bin/fluent-bit -c issues/6865/a.conf
==41111== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/02/19 09:07:12] [ info] [fluent bit] version=2.1.0, commit=268a7dbb3e, pid=41111
[2023/02/19 09:07:12] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/02/19 09:07:12] [ info] [cmetrics] version=0.5.8
[2023/02/19 09:07:12] [ info] [ctraces ] version=0.3.0
[2023/02/19 09:07:12] [ info] [input:forward:forward.0] initializing
[2023/02/19 09:07:12] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2023/02/19 09:07:12] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2023/02/19 09:07:12] [ info] [input:forward:forward.0] thread instance initialized
[2023/02/19 09:07:12] [ info] [output:stdout:stdout.0] worker #0 started
[2023/02/19 09:07:12] [ info] [sp] stream processor started
[0] dummy.0: [1676765232.944973010, {"message"=>"dummy"}]
[0] dummy.0: [1676765233.944555601, {"message"=>"dummy"}]
[1] dummy.0: [1676765234.944781819, {"message"=>"dummy"}]
^C[2023/02/19 09:07:17] [engine] caught signal (SIGINT)
[2023/02/19 09:07:17] [ warn] [engine] service will shutdown in max 5 seconds
[2023/02/19 09:07:17] [ info] [engine] service has stopped (0 pending tasks)
[2023/02/19 09:07:18] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/02/19 09:07:18] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==41111== 
==41111== HEAP SUMMARY:
==41111==     in use at exit: 0 bytes in 0 blocks
==41111==   total heap usage: 1,596 allocs, 1,596 frees, 4,163,670 bytes allocated
==41111== 
==41111== All heap blocks were freed -- no leaks are possible
==41111== 
==41111== For lists of detected and suppressed errors, rerun with: -s
==41111== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
