### PR TITLE
in_elasticseach: minor fixes

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -159,7 +159,7 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
                                          ctx->downstream->server_fd,
                                          config);
     if (ret == -1) {
-        flb_plg_error(ctx->ins, "Could not set collector for IN_TCP input plugin");
+        flb_plg_error(ctx->ins, "Could not set collector for IN_ELASTICSEARCH input plugin");
         in_elasticsearch_config_destroy(ctx);
 
         return -1;

--- a/plugins/in_elasticsearch/in_elasticsearch_config.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_config.c
@@ -46,9 +46,9 @@ struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_ins
     /* Listen interface (if not set, defaults to 0.0.0.0:9200) */
     flb_input_net_default_listener("0.0.0.0", 9200, ins);
 
-    ctx->listen = flb_strdup(ins->host.listen);
+    ctx->listen = flb_sds_create(ins->host.listen);
     snprintf(port, sizeof(port) - 1, "%d", ins->host.port);
-    ctx->tcp_port = flb_strdup(port);
+    ctx->tcp_port = flb_sds_create(port);
 
     /* HTTP Server specifics */
     ctx->server = flb_calloc(1, sizeof(struct mk_server));
@@ -79,8 +79,8 @@ int in_elasticsearch_config_destroy(struct flb_in_elasticsearch *ctx)
     if (ctx->server) {
         flb_free(ctx->server);
     }
-    flb_free(ctx->listen);
-    flb_free(ctx->tcp_port);
+    flb_sds_destroy(ctx->listen);
+    flb_sds_destroy(ctx->tcp_port);
     flb_free(ctx);
     return 0;
 }


### PR DESCRIPTION
This patch is minor fixes.

- Use flb_sds APIs since `ctx->listen` and `ctx->tcp_port` are `flb_sds_t`
- Fix typo `IN TCP` -> `IN_ELASTICSEARCH`
- Add missing releasing functions
- Allocates `bulk_statuses` and `bulk_response`. I think they are allocated only in POST case.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind toutpu

```
$ valgrind --leak-check=full bin/flb-rt-in_elasticsearch 
==87444== Memcheck, a memory error detector
==87444== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==87444== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==87444== Command: bin/flb-rt-in_elasticsearch
==87444== 
Test version...                                 ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test index_op...                                ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test create_op...                               ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test update_op...                               ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test delete_op...                               ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test nonexistent_op...                          ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops...                               ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops_gzip...                          ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test node_info...                               ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key...                                 ==87444== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==87444== 
==87444== HEAP SUMMARY:
==87444==     in use at exit: 0 bytes in 0 blocks
==87444==   total heap usage: 23,112 allocs, 23,112 frees, 77,174,653 bytes allocated
==87444== 
==87444== All heap blocks were freed -- no leaks are possible
==87444== 
==87444== For lists of detected and suppressed errors, rerun with: -s
==87444== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
