### PR TITLE
example: wasm: Fix typos in Filter declaration

### DIFF
--- a/examples/filter_rust/README.md
+++ b/examples/filter_rust/README.md
@@ -44,11 +44,11 @@ Create fluent-bit configuration file as follows:
 
 [INPUT]
     Name dummy
-    Tag dummy.local
+    Tag  dummy.local
 
 [FILTER]
-    Name wasm
-    Tag  dummy.*
+    Name   wasm
+    match  dummy.*
     WASM_Path /path/to/filter_rust.wasm
     Function_Name rust_filter
     accessible_paths .,/path/to/fluent-bit

--- a/examples/filter_rust/src/lib.rs
+++ b/examples/filter_rust/src/lib.rs
@@ -10,8 +10,8 @@ use std::io::Write;
 
 #[no_mangle]
 pub extern "C" fn rust_filter(tag: *const c_char, tag_len: u32, time_sec: u32, time_nsec: u32, record: *const c_char, record_len: u32) -> *const u8 {
-  let slice_tag: &[u8] = unsafe { slice::from_raw_parts(tag as *mut u8, tag_len as usize) };
-  let slice_record: &[u8] = unsafe { slice::from_raw_parts(record as *mut u8, record_len as usize) };
+  let slice_tag: &[u8] = unsafe { slice::from_raw_parts(tag as *const u8, tag_len as usize) };
+  let slice_record: &[u8] = unsafe { slice::from_raw_parts(record as *const u8, record_len as usize) };
   let mut vt: Vec<u8> = Vec::new();
   vt.write(slice_tag).expect("Unable to write");
   let vtag = str::from_utf8(&vt).unwrap();

--- a/examples/filter_rust_clib/README.md
+++ b/examples/filter_rust_clib/README.md
@@ -62,11 +62,11 @@ Create fluent-bit configuration file as follows:
 
 [INPUT]
     Name dummy
-    Tag dummy.local
+    Tag  dummy.local
 
 [FILTER]
-    Name wasm
-    Tag  dummy.*
+    Name   wasm
+    match  dummy.*
     WASM_Path /path/to/rust_clib_filter.wasm
     Function_Name rust_clib_filter
     accessible_paths .,/path/to/fluent-bit

--- a/examples/filter_rust_clib/src/lib.rs
+++ b/examples/filter_rust_clib/src/lib.rs
@@ -10,8 +10,8 @@ use std::io::Write;
 
 #[no_mangle]
 pub extern "C" fn rust_filter(tag: *const c_char, tag_len: u32, time_sec: u32, time_nsec: u32, record: *const c_char, record_len: u32) -> *const u8 {
-  let slice_tag: &[u8] = unsafe { slice::from_raw_parts(tag as *mut u8, tag_len as usize) };
-  let slice_record: &[u8] = unsafe { slice::from_raw_parts(record as *mut u8, record_len as usize) };
+  let slice_tag: &[u8] = unsafe { slice::from_raw_parts(tag as *const u8, tag_len as usize) };
+  let slice_record: &[u8] = unsafe { slice::from_raw_parts(record as *const u8, record_len as usize) };
   let mut vt: Vec<u8> = Vec::new();
   vt.write(slice_tag).expect("Unable to write");
   let vtag = str::from_utf8(&vt).unwrap();


### PR DESCRIPTION
`WASM` filter declaration should have `match` field. Examples should be in sync with the [docs](https://docs.fluentbit.io/manual/pipeline/filters/wasm#config_example).

Signed-off-by: Eugene Tolbakov [ev.tolbakov@gmail.com](mailto:ev.tolbakov@gmail.com)

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature. The issue in the documentation itself.

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
