### PR TITLE
packaging: update workflows for new targets and branches

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -49,9 +49,9 @@ runs:
         matrix=$(echo '{ "distro" : '$(jq -cr '.linux_targets|map(.target)' packaging/build-config.json)'}'|jq -c .)
         echo "MATRIX=$matrix" >> $GITHUB_ENV
 
-        deb-matrix = =$(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="deb")|.target ]' packaging/build-config.json)'}'|jq -c .)
+        deb-matrix = $(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="deb")|.target ]' packaging/build-config.json)'}'|jq -c .)
         echo "DEB_MATRIX=$deb-matrix" >> $GITHUB_ENV
-        rpm-matrix = =$(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="rpm")|.target ]' packaging/build-config.json)'}'|jq -c .)
+        rpm-matrix = $(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="rpm")|.target ]' packaging/build-config.json)'}'|jq -c .)
         echo "RPM_MATRIX=$rpm-matrix" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -18,10 +18,10 @@ outputs:
     value: ${{ steps.set-matrix.outputs.matrix }}
   deb-build-matrix:
     description: The targets that provide DEB artefacts.
-    value: ${{ steps.set-matrix.outputs.deb-matrix }}
+    value: ${{ steps.set-matrix.outputs.debmatrix }}
   rpm-build-matrix:
     description: The targets that provide RPN artefacts.
-    value: ${{ steps.set-matrix.outputs.rpm-matrix }}
+    value: ${{ steps.set-matrix.outputs.rpmmatrix }}
 runs:
   using: "composite"
   steps:
@@ -49,10 +49,13 @@ runs:
         matrix=$(echo '{ "distro" : '$(jq -cr '.linux_targets|map(.target)' packaging/build-config.json)'}'|jq -c .)
         echo "MATRIX=$matrix" >> $GITHUB_ENV
 
-        deb-matrix = $(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="deb")|.target ]' packaging/build-config.json)'}'|jq -c .)
-        echo "DEB_MATRIX=$deb-matrix" >> $GITHUB_ENV
-        rpm-matrix = $(echo '{ "distro" : '$(jq -cr '[.linux_targets[] |select(.type=="rpm")|.target ]' packaging/build-config.json)'}'|jq -c .)
-        echo "RPM_MATRIX=$rpm-matrix" >> $GITHUB_ENV
+        debtargets=$(jq -cr '[.linux_targets[] |select(.type=="deb")|.target ]' packaging/build-config.json)
+        debmatrix=$(echo "{ \"distro\" : $debtargets }"|jq -c .)
+        echo "DEB_MATRIX=$debmatrix" >> $GITHUB_ENV
+
+        rpmtargets=$(jq -cr '[.linux_targets[] |select(.type=="rpm")|.target ]' packaging/build-config.json)
+        rpmmatrix=$(echo "{ \"distro\" : $rpmtargets}"|jq -c .)
+        echo "RPM_MATRIX=$rpmmatrix" >> $GITHUB_ENV
       shell: bash
 
     - name: 1.9 targets
@@ -69,7 +72,7 @@ runs:
           echo ']}'
         ) | jq -c .)
         echo "MATRIX=$matrix" >> $GITHUB_ENV
-        deb-matrix=$((
+        debmatrix=$((
           echo '{ "distro" : ['
           echo '"debian/buster", "debian/buster.arm64v8", "debian/bullseye", "debian/bullseye.arm64v8",'
           echo '"ubuntu/16.04", "ubuntu/18.04", "ubuntu/20.04", "ubuntu/22.04",'
@@ -77,14 +80,14 @@ runs:
           echo '"raspbian/buster", "raspbian/bullseye"'
           echo ']}'
         ) | jq -c .)
-        echo "DEB_MATRIX=$deb-matrix" >> $GITHUB_ENV
-        rpm-matrix=$((
+        echo "DEB_MATRIX=$debmatrix" >> $GITHUB_ENV
+        rpmmatrix=$((
           echo '{ "distro" : ['
           echo '"amazonlinux/2", "amazonlinux/2.arm64v8",'
           echo '"centos/7", "centos/7.arm64v8", "centos/8", "centos/8.arm64v8"'
           echo ']}'
         ) | jq -c .)
-        echo "RPM_MATRIX=$rpm-matrix" >> $GITHUB_ENV
+        echo "RPM_MATRIX=$rpmmatrix" >> $GITHUB_ENV
       shell: bash
 
     - name: Manual override of target
@@ -108,8 +111,8 @@ runs:
         echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
         echo $DEB_MATRIX
         echo $DEB_MATRIX| jq .
-        echo "deb-matrix=$DEB_MATRIX" >> $GITHUB_OUTPUT
+        echo "debmatrix=$DEB_MATRIX" >> $GITHUB_OUTPUT
         echo $RPM_MATRIX
         echo $RPM_MATRIX| jq .
-        echo "rpm-matrix=$RPM_MATRIX" >> $GITHUB_OUTPUT
+        echo "rpmmatrix=$RPM_MATRIX" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -125,13 +125,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - uses: frabert/replace-string-action@v2.4
+      - name: Replace all special characters with dashes
         id: formatted_distro
-        with:
-          pattern: '(.*)\/(.*)$'
-          string: "${{ matrix.distro }}"
-          replace-with: "$1-$2"
-          flags: "g"
+        run:
+          output=${INPUT//[\/]/-}
+          echo "$INPUT --> $output"
+          echo "replaced=$output" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env: 
+          INPUT: ${{ matrix.distro }}
 
       - name: fluent-bit - ${{ matrix.distro }} artifacts
         run: |
@@ -143,7 +145,7 @@ jobs:
           CMAKE_INSTALL_PREFIX: /opt/fluent-bit/
         working-directory: packaging
 
-      - name: Upload the ${{ matrix.distro }} artifacts
+      - name: Upload the ${{ steps.formatted_distro.outputs.replaced }} artifacts
         uses: actions/upload-artifact@v3
         with:
           name: packages-${{ inputs.version }}-${{ steps.formatted_distro.outputs.replaced }}

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install bison flex libyaml openssl || true
+          brew pkgconfig install bison flex libyaml openssl || true
 
       - name: Build Fluent Bit packages
         run: |

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew pkgconfig install bison flex libyaml openssl || true
+          brew install bison flex libyaml openssl pkgconfig || true
 
       - name: Build Fluent Bit packages
         run: |

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -36,9 +36,36 @@ on:
         required: false
 
 jobs:
+
+  call-build-windows-get-meta:
+    name: Determine build info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      armSupported: ${{ steps.armcheck.outputs.armSupported }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Determine if we are doing a build with ARM support
+        id: armcheck
+        # Check for new contents from https://github.com/fluent/fluent-bit/pull/6621
+        run: |
+          if grep -q "winarm64" CMakeLists.txt ; then
+            echo "armSupported=true" >> $GITHUB_OUTPUT
+          else
+            echo "armSupported=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
   call-build-windows-package:
     runs-on: windows-latest
     environment: ${{ inputs.environment }}
+    needs:
+      - call-build-windows-get-meta
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +88,12 @@ jobs:
             chocolatey_opt: ""
             cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
             vcpkg_triplet: arm64-windows-static
+        # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.
+        hasArmSupport:
+          - ${{ needs.call-build-windows-get-meta.outputs.armSupported }}
+        exclude:
+          - hasArmSupport: 'false'
+            name: "Windows 64bit (Arm64)"
     permissions:
       contents: read
     # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -129,14 +129,17 @@ jobs:
 
       - name: Build Fluent Bit packages
         # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.
+        # Trying to do via an exclude for the job triggers linting errors.
+        # This is only supposed to be a workaround for now so can be easily removed later.
         if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} -DOPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' ${{ matrix.config.cmake_additional_opt }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD='${{ inputs.unstable }}' -DOPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' ${{ matrix.config.cmake_additional_opt }} ../
           cmake --build .
           cpack
         working-directory: build
 
       - name: Upload build packages
+        # Skip upload if we skipped build.
         if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -92,8 +92,8 @@ jobs:
         hasArmSupport:
           - ${{ needs.call-build-windows-get-meta.outputs.armSupported }}
         exclude:
-          - hasArmSupport: 'false'
-            name: "Windows 64bit (Arm64)"
+          - hasArmSupport: false
+            arch: amd64_arm64
     permissions:
       contents: read
     # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -88,12 +88,6 @@ jobs:
             chocolatey_opt: ""
             cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
             vcpkg_triplet: arm64-windows-static
-        # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.
-        hasArmSupport:
-          - ${{ needs.call-build-windows-get-meta.outputs.armSupported }}
-        exclude:
-          - hasArmSupport: false
-            arch: amd64_arm64
     permissions:
       contents: read
     # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.
@@ -134,6 +128,8 @@ jobs:
         shell: cmd
 
       - name: Build Fluent Bit packages
+        # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.
+        if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
         run: |
           cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD=${{ inputs.unstable }} -DOPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' ${{ matrix.config.cmake_additional_opt }} ../
           cmake --build .
@@ -141,6 +137,7 @@ jobs:
         working-directory: build
 
       - name: Upload build packages
+        if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: windows-packages

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: 2.0 run
         if: github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'
         run: |
-          echo "cron_branch=1.9" >> $GITHUB_ENV
+          echo "cron_branch=2.0" >> $GITHUB_ENV
         shell: bash
 
       - name: Output the branch to use

--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -13,7 +13,7 @@ on:
   # Run nightly build at this time, bit of trial and error but this seems good.
   schedule:
     - cron: "0 6 * * *" # master build
-    - cron: "0 12 * * *" # 1.9 build
+    - cron: "0 12 * * *" # 2.0 build
 
 # We do not want a new unstable build to run whilst we are releasing the current unstable build.
 concurrency: unstable-build-release
@@ -51,7 +51,7 @@ jobs:
           echo "cron_branch=master" >> $GITHUB_ENV
         shell: bash
 
-      - name: 1.9 run
+      - name: 2.0 run
         if: github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'
         run: |
           echo "cron_branch=1.9" >> $GITHUB_ENV

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 2.0
       - 1.9
       - 1.8
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'examples/**'
     branches:
       - master
+      - 2.0
       - 1.9
       - 1.8
     types: [opened, reopened, synchronize]

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -61,39 +61,39 @@
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/16.04",
+          "target": "ubuntu/16.04",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/18.04",
+          "target": "ubuntu/18.04",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/18.04.arm64v8",
+          "target": "ubuntu/18.04.arm64v8",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/20.04",
+          "target": "ubuntu/20.04",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/20.04.arm64v8",
+          "target": "ubuntu/20.04.arm64v8",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/22.04",
+          "target": "ubuntu/22.04",
           "type": "deb"
         },
         {
-          "target": "debian/ubuntu/22.04.arm64v8",
+          "target": "ubuntu/22.04.arm64v8",
           "type": "deb"
         },
         {
-          "target": "debian/raspbian/buster",
+          "target": "raspbian/buster",
           "type": "deb"
         },
         {
-          "target": "debian/raspbian/bullseye",
+          "target": "raspbian/bullseye",
           "type": "deb"
         }
       ],

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -96,5 +96,10 @@
           "target": "debian/raspbian/bullseye",
           "type": "deb"
         }
+      ],
+      "windows_targets" : [
+        "x86",
+        "x64",
+        "amd64_arm64"
       ]
 }


### PR DESCRIPTION
Resolves typo in build matrix action causing issues like: https://github.com/fluent/fluent-bit/actions/runs/4229760590/jobs/7346422917

Removed nightly 1.9 build.

Resolves #6887  issues with new ARM target for Windows.

Ensure we run unit tests for 2.0 PRs and pushes.

Resolve macOS build issues as well.

Fix incorrect string replacement for uploaded package names.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

- `master`: https://github.com/fluent/fluent-bit/actions/runs/4260976499
  - Shows it builds all targets including Windows ARM
- `2.0`: https://github.com/fluent/fluent-bit/actions/runs/4261512866
  - Shows it builds all targets excluding Windows ARM
- `1.9`: https://github.com/fluent/fluent-bit/actions/runs/4261864100
  - Compilation failures but not related to this

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
