### PR TITLE
config: fix possible null-dereference

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -309,6 +309,11 @@ struct flb_config *flb_config_init()
 
     /* Environment */
     config->env = flb_env_create();
+    if (!config->env) {
+        flb_error("[config] environment creation failed");
+        flb_config_exit(config);
+        return NULL;
+    }
 
     /* Multiline core */
     mk_list_init(&config->multiline_parsers);

--- a/src/multiline/flb_ml_parser.c
+++ b/src/multiline/flb_ml_parser.c
@@ -340,6 +340,11 @@ void flb_ml_parser_destroy_all(struct mk_list *list)
     struct mk_list *head;
     struct flb_ml_parser *parser;
 
+    /* Ensure list is initialized */
+    if (list->next == NULL) {
+        return;
+    }
+
     mk_list_foreach_safe(head, tmp, list) {
         parser = mk_list_entry(head, struct flb_ml_parser, _head);
         flb_ml_parser_destroy(parser);


### PR DESCRIPTION
flb_env_create can fail which causes config->env to be NULL, and this can cause NULL-dereferences further in the process. Bail if environment creation failed. Consequently, we need to add a safeguard for cleaning up multiline parsers as these have not been initialized yet.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56031

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
