### PR TITLE
slist: fix possible NULL derefence

### DIFF
--- a/src/flb_slist.c
+++ b/src/flb_slist.c
@@ -154,6 +154,10 @@ static flb_sds_t token_retrieve(char **str)
  exit:
     if (*p) {
         out = flb_sds_create_len(start, p - start);
+        if (!out) {
+            *str = NULL;
+            return NULL;
+        }
         if (quoted == FLB_TRUE) {
             len = token_unescape(out);
             flb_sds_len_set(out, len);


### PR DESCRIPTION
flb_sds_create_len can fail and return NULL. This adds a safeguard to ensure no NULL dereference happens if that's the case.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56223

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
