### PR TITLE
tests: internal: fuzzers: add aws utils fuzzer

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -812,8 +812,12 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
             flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
         }
 
+        if (buf != tmp) {
+            flb_sds_destroy(buf);
+        }
         flb_sds_destroy(tmp);
         tmp = NULL;
+        buf = NULL;
         flb_sds_destroy(s3_key);
         s3_key = tmp_key;
         tmp_key = NULL;
@@ -935,7 +939,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
         if (s3_key){
             flb_sds_destroy(s3_key);
         }
-        if (buf){
+        if (buf && buf != tmp){
             flb_sds_destroy(buf);
         }
         if (tmp){

--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(UNIT_TESTS_FILES
+  aws_util_fuzzer.c
   base64_fuzzer.c
   engine_fuzzer.c
   config_fuzzer.c

--- a/tests/internal/fuzzers/aws_util_fuzzer.c
+++ b/tests/internal/fuzzers/aws_util_fuzzer.c
@@ -1,0 +1,89 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdint.h>
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_mem.h>
+#include "flb_fuzz_header.h"
+
+int initialization_crutch()
+{
+    struct flb_config *config;
+    config = flb_config_init();
+    if (config == NULL) {
+        return -1;
+    }
+    flb_config_exit(config);
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *format = NULL;
+    char *tag = NULL;
+    char *tag_delimiter = NULL;
+
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
+    if (size < 4) {
+        return 0;
+    }
+    flb_malloc_p = 0;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
+
+    if (size < 300) {
+        return 0;
+    }
+
+    format = get_null_terminated(50, &data, &size);
+    tag = get_null_terminated(100, &data, &size);
+    tag_delimiter = get_null_terminated(100, &data, &size);
+
+    struct tm day = { 0, 0, 0, 15, 7, 120};
+    time_t t;
+    memset(&t, 0, sizeof(time_t));
+
+    if (format && tag && tag_delimiter) {
+        if (!initialization_crutch()) {
+            flb_sds_t s3_key_format = NULL;
+            s3_key_format = flb_get_s3_key(format, t, tag, tag_delimiter, 0);
+            if (s3_key_format) {
+                flb_sds_destroy(s3_key_format);
+            }
+        }
+    }
+    if (format) {
+        flb_free(format);
+    }
+    if (tag) {
+        flb_free(tag);
+    }
+    if (tag_delimiter) {
+        flb_free(tag_delimiter);
+    }
+    return 0;
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds a fuzzer for aws_util and also fixes a possible double free on `buf` and `tmp`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
