### PR TITLE
chunk_trace: remove unused function log_cb

### DIFF
--- a/src/flb_chunk_trace.c
+++ b/src/flb_chunk_trace.c
@@ -98,23 +98,6 @@ static struct flb_output_instance *find_calyptia_output_instance(struct flb_conf
     return NULL;
 }
 
-static void log_cb(void *ctx, int level, const char *file, int line,
-                   const char *str)
-{
-    if (level == CIO_LOG_ERROR) {
-        flb_error("[trace] %s", str);
-    }
-    else if (level == CIO_LOG_WARN) {
-        flb_warn("[trace] %s", str);
-    }
-    else if (level == CIO_LOG_INFO) {
-        flb_info("[trace] %s", str);
-    }
-    else if (level == CIO_LOG_DEBUG) {
-        flb_debug("[trace] %s", str);
-    }
-}
-
 static void trace_chunk_context_destroy(struct flb_chunk_trace_context *ctxt)
 {
     int i;


### PR DESCRIPTION
This patch is to fix following warning.

```
[ 75%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_chunk_trace.c.o
/home/taka/git/fluent-bit/src/flb_chunk_trace.c:101:13: warning: ‘log_cb’ defined but not used [-Wunused-function]
  101 | static void log_cb(void *ctx, int level, const char *file, int line,
      |             ^~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
