### PR TITLE
input_thread: remove unused function worker

### DIFF
--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -49,14 +49,6 @@ static void cb_thread_sched_timer(struct flb_config *ctx, void *data)
     flb_downstream_conn_timeouts(&ins->downstreams);
 }
 
-static void *worker(void *arg)
-{
-    struct flb_input_thread *it = arg;
-    it->callback(it->write, it->data);
-    fclose(it->write_file);
-    return NULL;
-}
-
 static inline int handle_input_event(flb_pipefd_t fd, struct flb_input_instance *ins)
 {
     int bytes;


### PR DESCRIPTION
This patch is to fix following warning.

```
[ 70%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_input_thread.c.o
/home/taka/git/fluent-bit/src/flb_input_thread.c:52:14: warning: ‘worker’ defined but not used [-Wunused-function]
   52 | static void *worker(void *arg)
      |              ^~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
