### PR TITLE
out_s3: major refactor to only upload in the timer callback

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1114,7 +1114,6 @@ put_object:
         flb_free(payload_buf);
     }
     if (ret < 0) {
-        /* re-add chunk to list */
         if (chunk) {
             chunk->failures += 1;
             if (chunk->failures > ctx->ins->retry_limit){
@@ -1173,7 +1172,6 @@ multipart:
             flb_free(payload_buf);
         }
 
-        /* re-add chunk to list */
         if (chunk) {
             chunk->failures += 1;
             if (chunk->failures > ctx->ins->retry_limit) {

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -140,7 +140,7 @@ static void s3_retry_warn(struct flb_s3 *ctx, const char *tag,
             flb_plg_warn(ctx->ins,
                         "chunk tag=%s, create_time=%s cannot be retried",
                         tag, create_time_str);
-        }
+        }   
     }
     else {
         if (less_than_limit == FLB_TRUE) {
@@ -1118,12 +1118,12 @@ put_object:
         if (chunk) {
             chunk->failures += 1;
             if (chunk->failures > ctx->ins->retry_limit){
-                s3_retry_warn(ctx, tag, chunk->input_name, create_time, FLB_FALSE);
+                s3_retry_warn(ctx, tag, chunk->input_name, file_first_log_time, FLB_FALSE);
                 s3_store_file_delete(ctx, chunk);
                 return -2;
             }
             else {
-                s3_retry_warn(ctx, tag, chunk->input_name, create_time, FLB_TRUE);
+                s3_retry_warn(ctx, tag, chunk->input_name, file_first_log_time, FLB_TRUE);
                 s3_store_file_unlock(chunk);
                 return -1;
             }

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -2213,14 +2213,6 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                         m_upload_file, file_first_log_time);
     }
 
-    /* Discard upload_file if it has failed to upload ctx->ins->retry_limit times */
-    if (upload_file != NULL && upload_file->failures > ctx->ins->retry_limit) {
-        s3_retry_warn(ctx, event_chunk->tag, out_flush->task->i_ins->name,
-                      upload_file->create_time, FLB_FALSE);
-        s3_store_file_delete(ctx, upload_file);
-        upload_file = NULL;
-    }
-
     /* If upload_timeout has elapsed, upload file */
     if (upload_file != NULL && time(NULL) >
         (upload_file->create_time + ctx->upload_timeout)) {

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1699,7 +1699,7 @@ static void cb_s3_upload(struct flb_config *config, void *data)
         if (m_upload->complete_errors > ctx->ins->retry_limit) {
             flb_plg_error(ctx->ins,
                           "Multipart Upload for %s has failed "
-                          "s3: CompleteMultipartUpload more than configured retry_limit, "
+                          "s3:CompleteMultipartUpload more than configured retry_limit, "
                           "output will give up ", m_upload->s3_key);
             mk_list_del(&m_upload->_head);
             multipart_upload_destroy(m_upload);
@@ -2048,13 +2048,6 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
 
     m_upload_file = get_upload(ctx,
                                event_chunk->tag, flb_sds_len(event_chunk->tag));
-
-    if (m_upload_file != NULL && time(NULL) >
-        (m_upload_file->init_time + ctx->upload_timeout)) {
-        upload_timeout_check = FLB_TRUE;
-        flb_plg_info(ctx->ins, "upload_timeout reached for %s", event_chunk->tag);
-        m_upload_file->input_name = out_flush->task->i_ins->name;
-    }
 
     /* If total_file_size has been reached, upload file */
     if ((upload_file && upload_file->size + chunk_size > ctx->upload_chunk_size) ||

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -129,6 +129,9 @@ struct flb_s3 {
 
     struct mk_list uploads;
 
+    /* list of locked chunks that are ready to send */
+    struct mk_list upload_queue;
+
     int preserve_data_ordering;
 
     size_t file_size;

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -47,17 +47,6 @@
 
 #define DEFAULT_UPLOAD_TIMEOUT 3600
 
-struct upload_queue {
-    struct s3_file *upload_file;
-    struct multipart_upload *m_upload_file;
-    char *tag;
-    int tag_len;
-
-    time_t upload_time;
-
-    struct mk_list _head;
-};
-
 struct multipart_upload {
     flb_sds_t s3_key;
     flb_sds_t tag;
@@ -141,8 +130,6 @@ struct flb_s3 {
     struct mk_list uploads;
 
     int preserve_data_ordering;
-    int upload_queue_success;
-    struct mk_list upload_queue;
 
     size_t file_size;
     size_t upload_chunk_size;

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -126,7 +126,8 @@ struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
                         char *data, size_t bytes,
-                        time_t file_first_log_time)
+                        time_t file_first_log_time,
+                        char* input_name)
 {
     int ret;
     flb_sds_t name;
@@ -178,6 +179,7 @@ int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
         s3_file->fsf = fsf;
         s3_file->first_log_time = file_first_log_time;
         s3_file->create_time = time(NULL);
+        s3_file->input_name = input_name;
 
         /* Use fstore opaque 'data' reference to keep our context */
         fsf->data = s3_file;

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -37,7 +37,8 @@ struct s3_file {
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,
                         const char *tag, int tag_len,
                         char *data, size_t bytes,
-                        time_t file_first_log_time);
+                        time_t file_first_log_time,
+                        char *input_name);
 
 int s3_store_init(struct flb_s3 *ctx);
 int s3_store_exit(struct flb_s3 *ctx);

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -32,6 +32,7 @@ struct s3_file {
     time_t first_log_time;           /* first log time */
     flb_sds_t file_path;             /* file path */
     struct flb_fstore_file *fsf;     /* reference to parent flb_fstore_file */
+    struct mk_list _head;
 };
 
 int s3_store_buffer_put(struct flb_s3 *ctx, struct s3_file *s3_file,

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -24,7 +24,7 @@
 #include <fluent-bit/flb_fstore.h>
 
 struct s3_file {
-    int locked;                      /* locked chunk is busy, cannot write to it */
+    int locked;                      /* locked = no appends to this chunk */
     int failures;                    /* delivery failures */
     char *input_name;                /* for s3_retry_warn output message gets input name */
     size_t size;                     /* file size */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
