### PR TITLE
opentelemetry: memory corruption fixes

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -270,9 +270,12 @@ static int otel_pack_array(msgpack_packer *mp_pck,
     int ret;
     int array_index;
 
+    ret = 0;
+
     for (array_index = 0; array_index < array->n_values && ret == 0; array_index++) {
         ret = otlp_pack_any_value(mp_pck, array->values[array_index]);
     }
+
     return ret;
 }
 


### PR DESCRIPTION
Most of these changes correct memory corruption issues in the opentelemetry output plugin, there is only one fix in the opentelemetry input plugin to correct a uninitialized variable usage that has not caused issues at the moment (but I know it will with the log event refactor because I have already fixed it in that branch as well).