### PR TITLE
in_http: added support for custom headers upon successful ingestion

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -167,6 +167,12 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_SLIST_1, "success_header", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_http, success_headers),
+     "Add an HTTP header key/value pair on success. Multiple headers can be set"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_http, tag_key),
      ""

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -38,6 +38,10 @@ struct flb_http {
 
     int collector_id;
 
+    /* Success HTTP headers */
+    struct mk_list *success_headers;
+    flb_sds_t success_headers_str;
+
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */
 

--- a/plugins/in_http/http_config.c
+++ b/plugins/in_http/http_config.c
@@ -20,13 +20,18 @@
 #include <fluent-bit/flb_input_plugin.h>
 
 #include "http.h"
+#include "http_config.h"
 #include "http_conn.h"
 
 struct flb_http *http_config_create(struct flb_input_instance *ins)
 {
-    int ret;
-    char port[8];
-    struct flb_http *ctx;
+    struct mk_list            *header_iterator;
+    struct flb_slist_entry    *header_value;
+    struct flb_slist_entry    *header_name;
+    struct flb_config_map_val *header_pair;
+    char                       port[8];
+    int                        ret;
+    struct flb_http           *ctx;
 
     ctx = flb_calloc(1, sizeof(struct flb_http));
     if (!ctx) {
@@ -58,6 +63,52 @@ struct flb_http *http_config_create(struct flb_input_instance *ins)
      * moment so we want to make sure that it stays that way!
      */
 
+    ctx->success_headers_str = flb_sds_create_size(1);
+
+    if (ctx->success_headers_str == NULL) {
+        http_config_destroy(ctx);
+
+        return NULL;
+    }
+
+    flb_config_map_foreach(header_iterator, header_pair, ctx->success_headers) {
+        header_name = mk_list_entry_first(header_pair->val.list,
+                                          struct flb_slist_entry,
+                                          _head);
+
+        header_value = mk_list_entry_last(header_pair->val.list,
+                                          struct flb_slist_entry,
+                                          _head);
+
+        ret = flb_sds_cat_safe(&ctx->success_headers_str,
+                               header_name->str,
+                               flb_sds_len(header_name->str));
+
+        if (ret == 0) {
+            ret = flb_sds_cat_safe(&ctx->success_headers_str,
+                                   ": ",
+                                   2);
+        }
+
+        if (ret == 0) {
+            ret = flb_sds_cat_safe(&ctx->success_headers_str,
+                                   header_value->str,
+                                   flb_sds_len(header_value->str));
+        }
+
+        if (ret == 0) {
+            ret = flb_sds_cat_safe(&ctx->success_headers_str,
+                                   "\r\n",
+                                   2);
+        }
+
+        if (ret != 0) {
+            http_config_destroy(ctx);
+
+            return NULL;
+        }
+    }
+
     return ctx;
 }
 
@@ -79,6 +130,12 @@ int http_config_destroy(struct flb_http *ctx)
     if (ctx->server) {
         flb_free(ctx->server);
     }
+
+    if (ctx->success_headers_str != NULL) {
+        flb_sds_destroy(ctx->success_headers_str);
+    }
+
+
     flb_free(ctx->listen);
     flb_free(ctx->tcp_port);
     flb_free(ctx);

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -32,9 +32,12 @@
 
 static int send_response(struct http_conn *conn, int http_status, char *message)
 {
-    size_t    sent;
-    int       len;
-    flb_sds_t out;
+    struct flb_http *context;
+    size_t           sent;
+    int              len;
+    flb_sds_t        out;
+
+    context = (struct flb_http *) conn->ctx;
 
     out = flb_sds_create_size(256);
     if (!out) {
@@ -52,22 +55,28 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
         flb_sds_printf(&out,
                        "HTTP/1.1 201 Created \r\n"
                        "Server: Fluent Bit v%s\r\n"
+                       "%s"
                        "Content-Length: 0\r\n\r\n",
-                       FLB_VERSION_STR);
+                       FLB_VERSION_STR,
+                       context->success_headers_str);
     }
     else if (http_status == 200) {
         flb_sds_printf(&out,
                        "HTTP/1.1 200 OK\r\n"
                        "Server: Fluent Bit v%s\r\n"
+                       "%s"
                        "Content-Length: 0\r\n\r\n",
-                       FLB_VERSION_STR);
+                       FLB_VERSION_STR,
+                       context->success_headers_str);
     }
     else if (http_status == 204) {
         flb_sds_printf(&out,
                        "HTTP/1.1 204 No Content\r\n"
                        "Server: Fluent Bit v%s\r\n"
+                       "%s"
                        "Content-Length: 0\r\n\r\n",
-                       FLB_VERSION_STR);
+                       FLB_VERSION_STR,
+                       context->success_headers_str);
     }
     else if (http_status == 400) {
         flb_sds_printf(&out,


### PR DESCRIPTION
This PR adds a new option to in_http that allows the plugin to append a number of custom headers to the response when ingestion succeeds.