### PR TITLE
in_elasticsearch: release buffer on error case

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -121,6 +121,7 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
 
     if (flb_random_bytes(rand, 16)) {
         flb_plg_error(ctx->ins, "cannot generate cluster name");
+        in_elasticsearch_config_destroy(ctx);
         return -1;
     }
 
@@ -128,6 +129,7 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
 
     if (flb_random_bytes(rand, 12)) {
         flb_plg_error(ctx->ins, "cannot generate node name");
+        in_elasticsearch_config_destroy(ctx);
         return -1;
     }
 

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
@@ -64,6 +64,7 @@ static int in_elasticsearch_bulk_conn_event(void *data)
             tmp = flb_realloc(conn->buf_data, size);
             if (!tmp) {
                 flb_errno();
+                in_elasticsearch_bulk_conn_del(conn);
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %i",

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
@@ -120,6 +120,7 @@ static int send_dummy_sniffer_response(struct in_elasticsearch_bulk_conn *conn, 
 
     resp = flb_sds_create_size(384);
     if (!resp) {
+        flb_sds_destroy(out);
         return -1;
     }
 
@@ -725,6 +726,7 @@ int in_elasticsearch_bulk_prot_handle(struct flb_in_elasticsearch *ctx,
     /* HTTP/1.1 needs Host header */
     if (!request->host.data && request->protocol == MK_HTTP_PROTOCOL_11) {
         flb_sds_destroy(tag);
+        mk_mem_free(uri);
         return -1;
     }
 


### PR DESCRIPTION
This patch is to release buffer on error case.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_elasticsearch 
==5321== Memcheck, a memory error detector
==5321== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5321== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==5321== Command: bin/flb-rt-in_elasticsearch
==5321== 
Test version...                                 ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test index_op...                                ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test create_op...                               ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test update_op...                               ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test delete_op...                               ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test nonexistent_op...                          ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops...                               ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops_gzip...                          ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test node_info...                               ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key...                                 ==5321== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==5321== 
==5321== HEAP SUMMARY:
==5321==     in use at exit: 0 bytes in 0 blocks
==5321==   total heap usage: 23,112 allocs, 23,112 frees, 77,174,568 bytes allocated
==5321== 
==5321== All heap blocks were freed -- no leaks are possible
==5321== 
==5321== For lists of detected and suppressed errors, rerun with: -s
==5321== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
