### PR TITLE
workflows: add GKE auth plugin

### DIFF
--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -283,6 +283,8 @@ jobs:
 
       - if: matrix.cloud == 'gke'
         uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Setup BATS
         uses: mig4/setup-bats@v1

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -216,10 +216,16 @@ jobs:
           ref: ${{ inputs.ref }}
           repository: fluent/fluent-bit-ci
 
+      - name: Configure system for Opensearch
+        run: |
+          sudo sysctl -w vm.max_map_count=262144
+          sysctl -p
+        shell: bash
+
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.7.0
+          bats-version: 1.9.0
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.5.0
@@ -236,6 +242,7 @@ jobs:
         uses: azure/setup-kubectl@v3.2
 
       - name: Run tests
+        timeout-minutes: 60
         run:  |
           kind load docker-image ${{ inputs.image_name }}:${{ inputs.image_tag }}
           ./run-tests.sh
@@ -278,7 +285,7 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1
         with:
-          bats-version: 1.7.0
+          bats-version: 1.9.0
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5
@@ -291,6 +298,7 @@ jobs:
       - name: Get the GKE Kubeconfig
         if: matrix.cloud == 'gke'
         run: |
+          gcloud components install gke-gcloud-auth-plugin || sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
           gcloud info
           gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --zone "$GKE_ZONE"
         shell: bash
@@ -321,8 +329,7 @@ jobs:
         shell: bash
 
       - name: Run tests
-        # https://github.com/fluent/fluent-bit-ci/issues/80
-        continue-on-error: ${{ matrix.cloud == 'gke' }}
+        timeout-minutes: 60
         run:  |
           ./run-tests.sh
         shell: bash

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -269,7 +269,7 @@ jobs:
           - aks
           - gke
     env:
-      USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
+      USE_GKE_GCLOUD_AUTH_PLUGIN: true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -268,6 +268,8 @@ jobs:
         cloud:
           - aks
           - gke
+    env:
+      USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -337,4 +339,5 @@ jobs:
           HOSTED_OPENSEARCH_HOST: ${{ needs.call-run-terraform-setup.outputs.aws-opensearch-endpoint }}
           HOSTED_OPENSEARCH_PORT: 443
           HOSTED_OPENSEARCH_USERNAME: admin
+          USE_GKE_GCLOUD_AUTH_PLUGIN: true
           HOSTED_OPENSEARCH_PASSWORD: ${{ secrets.opensearch_admin_password }}

--- a/.github/workflows/call-run-integration-test.yaml
+++ b/.github/workflows/call-run-integration-test.yaml
@@ -297,14 +297,10 @@ jobs:
 
       - name: Get the GKE Kubeconfig
         if: matrix.cloud == 'gke'
-        run: |
-          gcloud components install gke-gcloud-auth-plugin || sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
-          gcloud info
-          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --zone "$GKE_ZONE"
-        shell: bash
-        env:
-          GKE_CLUSTER_NAME: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-name }}
-          GKE_ZONE: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-zone }}
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-name }}
+          location: ${{ needs.call-run-terraform-setup.outputs.gke-cluster-zone }}
 
       - name: Get the AKS Kubeconfig
         if: matrix.cloud == 'aks'


### PR DESCRIPTION
Resolves some integration test failures: https://github.com/fluent/fluent-bit-ci/pull/99

Due to changes on GKE 1.26, it's required to install gke-gcloud-auth-plugin and also we changed GKE auth method from gcloud cli to google-github-actions/get-gke-credentials actions.

Same changes are all green on fluent-bit-ci repo -> https://github.com/fluent/fluent-bit-ci/actions/runs/4639117016/jobs/8209803655

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

https://github.com/fluent/fluent-bit/actions/runs/4315962903

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
