### PR TITLE
fluent-bit: fix printf-like format and arguments

### DIFF
--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -347,7 +347,7 @@ static int get_ec2_tag_keys(struct flb_filter_aws *ctx)
             tag_key = tags_list + tag_start;
             memcpy(ctx->tag_keys[tag_index], tag_key, tag_key_len);
 
-            flb_plg_debug(ctx->ins, "tag found: %s (len=%d)", ctx->tag_keys[tag_index],
+            flb_plg_debug(ctx->ins, "tag found: %s (len=%zu)", ctx->tag_keys[tag_index],
                           tag_key_len);
 
             tag_index++;

--- a/plugins/filter_checklist/checklist.c
+++ b/plugins/filter_checklist/checklist.c
@@ -231,8 +231,8 @@ static int init_config(struct checklist *ctx)
     /* record accessor pattern / key name */
     ctx->ra_lookup_key = flb_ra_create(ctx->lookup_key, FLB_TRUE);
     if (!ctx->ra_lookup_key) {
-        flb_plg_error(ctx->ins, "invalid ra_lookup_key pattern: %s",
-                      ctx->ra_lookup_key);
+        flb_plg_error(ctx->ins, "invalid lookup_key pattern: %s",
+                      ctx->lookup_key);
         return -1;
     }
 

--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -1352,8 +1352,8 @@ static void clean_old_metadata_buffers(struct flb_filter_ecs *ctx)
     mk_list_foreach_safe(head, tmp, &ctx->metadata_buffers) {
         buf = mk_list_entry(head, struct flb_ecs_metadata_buffer, _head);
         if (now > (buf->last_used_time + ctx->ecs_meta_cache_ttl)) {
-            flb_plg_debug(ctx->ins, "cleaning buffer: now=%ld, ttl=%ld, last_used_time=%ld",
-                          now, ctx->ecs_meta_cache_ttl, buf->last_used_time);
+            flb_plg_debug(ctx->ins, "cleaning buffer: now=%ld, ttl=%d, last_used_time=%ld",
+                          (long)now, ctx->ecs_meta_cache_ttl, (long)buf->last_used_time);
             mk_list_del(&buf->_head);
             flb_hash_table_del(ctx->container_hash_table, buf->id);
             flb_ecs_metadata_buffer_destroy(buf);

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -166,7 +166,7 @@ static int get_http_auth_header(struct flb_kube *ctx)
         if (ret == -1) {
             flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
         }
-        flb_plg_info(ctx->ins, " token updated", FLB_KUBE_TOKEN);
+        flb_plg_info(ctx->ins, " token updated");
     }
     ctx->kube_token_create = time(NULL);
 

--- a/plugins/filter_nightfall/nightfall_api.c
+++ b/plugins/filter_nightfall/nightfall_api.c
@@ -175,7 +175,7 @@ static flb_sds_t build_request_body(struct flb_filter_nightfall *ctx,
                 key_val_str = flb_sds_create_size(pl->key_to_scan_with->via.str.size + 
                                                   num_str_len + 2);
                 num_str_len = flb_sds_snprintf(&num_str, flb_sds_alloc(num_str), 
-                                               "%lld", pl->obj->via.i64);
+                                               "%"PRIi64, pl->obj->via.i64);
                 key_val_str_len = flb_sds_snprintf(&key_val_str, 
                                                    flb_sds_alloc(key_val_str), 
                                                    "%s %s", key_str, num_str);
@@ -185,7 +185,7 @@ static flb_sds_t build_request_body(struct flb_filter_nightfall *ctx,
             }
             else {
                 num_str_len = flb_sds_snprintf(&num_str, flb_sds_alloc(num_str), 
-                                               "%lld", pl->obj->via.i64);
+                                               "%"PRIi64, pl->obj->via.i64);
                 msgpack_pack_str_with_body(&req_pk, num_str, num_str_len);
             }
         }

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
@@ -66,7 +66,7 @@ static int in_elasticsearch_bulk_conn_event(void *data)
                 flb_errno();
                 return -1;
             }
-            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %i",
+            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
             conn->buf_data = tmp;
@@ -85,7 +85,7 @@ static int in_elasticsearch_bulk_conn_event(void *data)
             return -1;
         }
 
-        flb_plg_trace(ctx->ins, "read()=%i pre_len=%i now_len=%i",
+        flb_plg_trace(ctx->ins, "read()=%zi pre_len=%i now_len=%zi",
                       bytes, conn->buf_len, conn->buf_len + bytes);
         conn->buf_len += bytes;
         conn->buf_data[conn->buf_len] = '\0';

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -183,7 +183,7 @@ static int in_exec_config_read(struct flb_exec *ctx,
         ctx->interval_nsec = -1;
     }
 
-    flb_plg_debug(in, "interval_sec=%d interval_nsec=%d oneshot=%i buf_size=%d",
+    flb_plg_debug(in, "interval_sec=%d interval_nsec=%d oneshot=%i buf_size=%zu",
               ctx->interval_sec, ctx->interval_nsec, ctx->oneshot, ctx->buf_size);
 
     return 0;

--- a/plugins/in_exec_wasi/in_exec_wasi.c
+++ b/plugins/in_exec_wasi/in_exec_wasi.c
@@ -203,7 +203,7 @@ static int in_exec_wasi_config_read(struct flb_exec_wasi *ctx,
         ctx->interval_nsec = -1;
     }
 
-    flb_plg_debug(in, "interval_sec=%d interval_nsec=%d oneshot=%i buf_size=%d",
+    flb_plg_debug(in, "interval_sec=%d interval_nsec=%d oneshot=%i buf_size=%zu",
               ctx->interval_sec, ctx->interval_nsec, ctx->oneshot, ctx->buf_size);
 
     return 0;

--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -66,7 +66,7 @@ static int http_conn_event(void *data)
                 flb_errno();
                 return -1;
             }
-            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %i",
+            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
             conn->buf_data = tmp;
@@ -85,7 +85,7 @@ static int http_conn_event(void *data)
             return -1;
         }
 
-        flb_plg_trace(ctx->ins, "read()=%i pre_len=%i now_len=%i",
+        flb_plg_trace(ctx->ins, "read()=%zi pre_len=%i now_len=%zi",
                       bytes, conn->buf_len, conn->buf_len + bytes);
         conn->buf_len += bytes;
         conn->buf_data[conn->buf_len] = '\0';

--- a/plugins/in_opentelemetry/http_conn.c
+++ b/plugins/in_opentelemetry/http_conn.c
@@ -67,7 +67,7 @@ static int opentelemetry_conn_event(void *data)
                 flb_errno();
                 return -1;
             }
-            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %i",
+            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
             conn->buf_data = tmp;
@@ -86,7 +86,7 @@ static int opentelemetry_conn_event(void *data)
             return -1;
         }
 
-        flb_plg_trace(ctx->ins, "read()=%i pre_len=%i now_len=%i",
+        flb_plg_trace(ctx->ins, "read()=%zi pre_len=%i now_len=%zi",
                       bytes, conn->buf_len, conn->buf_len + bytes);
         conn->buf_len += bytes;
         conn->buf_data[conn->buf_len] = '\0';

--- a/plugins/in_stdin/in_stdin.c
+++ b/plugins/in_stdin/in_stdin.c
@@ -242,7 +242,7 @@ static int in_stdin_config_init(struct flb_in_stdin_config *ctx,
         return -1;
     }
     else if (ctx->buf_size < DEFAULT_BUF_SIZE) {
-        flb_plg_error(ctx->ins, "buffer_size '%d' must be at least %i bytes",
+        flb_plg_error(ctx->ins, "buffer_size '%zu' must be at least %i bytes",
                       ctx->buf_size, DEFAULT_BUF_SIZE);
         return -1;
     }

--- a/plugins/out_azure_blob/azure_blob_http.c
+++ b/plugins/out_azure_blob/azure_blob_http.c
@@ -202,7 +202,7 @@ flb_sds_t azb_http_canonical_request(struct flb_azure_blob *ctx,
 
     if (content_length >= 0) {
         flb_sds_printf(&can_req,
-                       "%i\n"     /* Content-Length */,
+                       "%zi\n"     /* Content-Length */,
                        content_length);
     }
     else {

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -541,7 +541,7 @@ static int post_all_requests(struct flb_out_http *ctx,
         }
 
         if (body_found && headers_found) {
-            flb_plg_trace(ctx->ins, "posting record %d", record_count++);
+            flb_plg_trace(ctx->ins, "posting record %zu", record_count++);
             ret = http_post(ctx, body, body_size, event_chunk->tag,
                     flb_sds_len(event_chunk->tag), headers);
         }

--- a/plugins/out_kinesis_firehose/firehose_api.c
+++ b/plugins/out_kinesis_firehose/firehose_api.c
@@ -318,7 +318,7 @@ static int process_event(struct flb_firehose *ctx, struct flush *buf,
                                                        &size); /* evaluate size */
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Unable to compress record, discarding, "
-                                    "%s", written + 1, ctx->delivery_stream);
+                                    "%s", ctx->delivery_stream);
             return 2;
         }
         flb_free(buf->event_buf);

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -478,7 +478,7 @@ static int create_label_map_entry(struct flb_loki *ctx,
 
         break;
     default:
-        flb_plg_error(ctx->ins, "[%s] value type is not str or map. type=%d", val->type);
+        flb_plg_error(ctx->ins, "[%s] value type is not str or map. type=%d", __FUNCTION__, val->type);
         return -1;
     }
     return 0;

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -400,7 +400,7 @@ static int init_seq_index(void *context) {
             return -1;
         }
         flb_plg_info(ctx->ins, "Successfully recovered index. "
-                     "Continuing at index=%d", ctx->seq_index);
+                     "Continuing at index=%"PRIu64, ctx->seq_index);
     }
     return 0;
 }
@@ -1038,7 +1038,7 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
         }
         else {
             if (ctx->use_put_object == FLB_FALSE && ctx->compression == FLB_AWS_COMPRESS_GZIP) {
-                flb_plg_info(ctx->ins, "Pre-compression upload_chunk_size= %d, After compression, chunk is only %d bytes, "
+                flb_plg_info(ctx->ins, "Pre-compression upload_chunk_size= %zu, After compression, chunk is only %zu bytes, "
                                        "the chunk was too small, using PutObject to upload", preCompress_size, body_size);
             }
             goto put_object;
@@ -1231,7 +1231,7 @@ static int put_all_chunks(struct flb_s3 *ctx)
                 if (ret == -1) {
                     flb_plg_error(ctx->ins, "Failed to compress data, uploading uncompressed data instead to prevent data loss");
                 } else {
-                    flb_plg_info(ctx->ins, "Pre-compression chunk size is %d, After compression, chunk is %d bytes", buffer_size, payload_size);
+                    flb_plg_info(ctx->ins, "Pre-compression chunk size is %zu, After compression, chunk is %zu bytes", buffer_size, payload_size);
                     buffer = (void *) payload_buf;
                     buffer_size = payload_size;
                 }

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -57,7 +57,7 @@ static int event_fields_create(struct flb_splunk *ctx)
             flb_plg_error(ctx->ins,
                           "could not process event_field number #%i with "
                           "pattern '%s'",
-                          i, pattern);
+                          i, pattern->str);
             flb_sds_destroy(f->key_name);
             flb_free(f);
             return -1;

--- a/plugins/out_stackdriver/stackdriver_resource_types.c
+++ b/plugins/out_stackdriver/stackdriver_resource_types.c
@@ -108,8 +108,8 @@ int resource_api_has_required_labels(struct flb_stackdriver *ctx)
 
     required_labels = get_required_labels(ctx->resource_type);
     if (required_labels == NULL) {
-        flb_plg_warn(ctx->ins, "no validation applied to resource_labels ",
-            "for set resource type");
+        flb_plg_warn(ctx->ins, "no validation applied to resource_labels "
+                               "for set resource type");
         return FLB_FALSE;
     }
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -175,7 +175,7 @@ static void yaml_error_event(struct local_ctx *ctx, struct parser_state *s,
 
     e = mk_list_entry_last(&ctx->includes, struct flb_slist_entry, _head);
 
-    flb_error("[config] YAML error found in file \"%s\", line %i, column %i: "
+    flb_error("[config] YAML error found in file \"%s\", line %zu, column %zu: "
               "unexpected event %d in state %d.",
               e->str, event->start_mark.line + 1, event->start_mark.column,
               event->type, s->state);
@@ -184,7 +184,7 @@ static void yaml_error_event(struct local_ctx *ctx, struct parser_state *s,
 static void yaml_error_definition(struct local_ctx *ctx, struct parser_state *s,
                                   yaml_event_t *event, char *value)
 {
-    flb_error("[config] YAML error found in file \"%s\", line %i, column %i: "
+    flb_error("[config] YAML error found in file \"%s\", line %zu, column %zu: "
               "duplicated definition of '%s'",
               s->file, event->start_mark.line + 1, event->start_mark.column,
               value);
@@ -193,7 +193,7 @@ static void yaml_error_definition(struct local_ctx *ctx, struct parser_state *s,
 static void yaml_error_plugin_category(struct local_ctx *ctx, struct parser_state *s,
                                        yaml_event_t *event, char *value)
 {
-    flb_error("[config] YAML error found in file \"%s\", line %i, column %i: "
+    flb_error("[config] YAML error found in file \"%s\", line %zu, column %zu: "
               "the pipeline component '%s' is not valid. Try one of these values: "
               "customs, inputs, filters or outputs.",
               s->file, event->start_mark.line + 1, event->start_mark.column,
@@ -542,7 +542,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 ret = read_config(cf, ctx, s->file, value);
             }
             if (ret == -1) {
-                flb_error("[config]  including file '%s' at %s:%i",
+                flb_error("[config]  including file '%s' at %s:%zu",
                           value,
                           last_included, event->start_mark.line + 1);
                 return YAML_FAILURE;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1214,7 +1214,7 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
 
     if (tag_len > FLB_INPUT_CHUNK_TAG_MAX) {
         flb_plg_warn(in,
-                     "Tag set exceeds limit, truncating from %lu to %lu bytes",
+                     "Tag set exceeds limit, truncating from %i to %i bytes",
                      tag_len, FLB_INPUT_CHUNK_TAG_MAX);
         tag_len = FLB_INPUT_CHUNK_TAG_MAX;
     }
@@ -1376,7 +1376,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
         in->storage_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
             in->p->cb_resume(in->context, in->config);
-            flb_info("[input] %s resume (storage buf overlimit %d/%d)",
+            flb_info("[input] %s resume (storage buf overlimit %zu/%zu)",
                       in->name,
                       ((struct flb_storage_input *)in->storage)->cio->total_chunks_up,
                       ((struct flb_storage_input *)in->storage)->cio->max_chunks_up);
@@ -1395,7 +1395,7 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i)
     struct flb_storage_input *storage = i->storage;
 
     if (flb_input_chunk_is_storage_overlimit(i) == FLB_TRUE) {
-        flb_warn("[input] %s paused (storage buf overlimit %d/%d)",
+        flb_warn("[input] %s paused (storage buf overlimit %zu/%zu)",
                  i->name,
                  storage->cio->total_chunks_up,
                  storage->cio->max_chunks_up);
@@ -1808,7 +1808,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     real_size = flb_input_chunk_get_real_size(ic);
     real_diff = real_size - pre_real_size;
     if (real_diff != 0) {
-        flb_debug("[input chunk] update output instances with new chunk size diff=%d",
+        flb_debug("[input chunk] update output instances with new chunk size diff=%zu",
                   real_diff);
         flb_input_chunk_update_output_instances(ic, real_diff);
     }

--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -762,8 +762,8 @@ flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
         *s = tmp;
 
         /* gelf supports milliseconds */
-        tmp = flb_sds_printf(s, "%" PRIu32".%03lu",
-                             tm->tm.tv_sec, tm->tm.tv_nsec / 1000000);
+        tmp = flb_sds_printf(s, "%li.%03lu",
+                             (long)tm->tm.tv_sec, tm->tm.tv_nsec / 1000000);
         if (tmp == NULL) {
             return NULL;
         }

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -351,7 +351,7 @@ int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader)
             time->tm.tv_nsec = (uint32_t) ntohl(tmp);
             break;
         default:
-            flb_warn("unknown time format %s", tag.type);
+            flb_warn("unknown time format %d", tag.type);
             return -1;
     }
 

--- a/src/flb_typecast.c
+++ b/src/flb_typecast.c
@@ -366,14 +366,14 @@ struct flb_typecast_rule *flb_typecast_rule_create(char *from_type, int from_len
 
     rule->from_type = flb_typecast_str_to_type_t(from_type, from_len);
     if (rule->from_type == FLB_TYPECAST_TYPE_ERROR) {
-        flb_error("%s: unknown from str %s", from_type);
+        flb_error("%s: unknown from str %s", __FUNCTION__, from_type);
         flb_typecast_rule_destroy(rule);
         return NULL;
     }
 
     rule->to_type = flb_typecast_str_to_type_t(to_type, to_len);
     if (rule->to_type   == FLB_TYPECAST_TYPE_ERROR) {
-        flb_error("%s: unknown to str %s", to_type);
+        flb_error("%s: unknown to str %s", __FUNCTION__, to_type);
         flb_typecast_rule_destroy(rule);
         return NULL;
     }

--- a/src/http_server/api/v1/trace.c
+++ b/src/http_server/api/v1/trace.c
@@ -257,7 +257,7 @@ static int http_enable_trace(mk_request_t *request, void *data, const char *inpu
     rc = msgpack_unpack_next(&result, buf, buf_size, &off);
     if (rc != MSGPACK_UNPACK_SUCCESS) {
         ret = 503;
-        flb_error("unable to unpack msgpack parameters", input_name);
+        flb_error("unable to unpack msgpack parameters for %s", input_name);
         goto unpack_error;
     }
 

--- a/src/multiline/flb_ml_parser.c
+++ b/src/multiline/flb_ml_parser.c
@@ -226,7 +226,7 @@ struct flb_ml_parser_ins *flb_ml_parser_instance_create(struct flb_ml *ml,
     ret = flb_ml_group_add_parser(ml, ins);
     if (ret != 0) {
         flb_error("[multiline] could not register parser '%s' on "
-                  "multiline '%s 'group", ml->name);
+                  "multiline '%s 'group", name, ml->name);
         flb_free(ins);
         return NULL;
     }

--- a/src/multiline/flb_ml_stream.c
+++ b/src/multiline/flb_ml_stream.c
@@ -253,7 +253,7 @@ int flb_ml_stream_create(struct flb_ml *ml,
             if (!mst) {
                 flb_error("[multiline] could not create stream_id=%" PRIu64
                           "for stream '%s' on parser '%s'",
-                          stream_id, name, parser->ml_parser->name);
+                          *stream_id, name, parser->ml_parser->name);
                 return -1;
             }
         }


### PR DESCRIPTION
Fixed format and arguments for:
- flb_log_print(), and associated macros like flb_error() and flb_plg_error()
- flb_sds_printf()

These formatting issues were revealed by #6921 and #6925.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
