### PR TITLE
pack: add flb_msgpack_get_char_from_obj

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -99,6 +99,8 @@ int flb_msgpack_to_json(char *json_str, size_t str_len,
                         const msgpack_object *obj);
 char* flb_msgpack_to_json_str(size_t size, const msgpack_object *obj);
 flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size);
+int flb_msgpack_get_char_from_obj(msgpack_object *obj,
+                                  const char **ret_char, size_t *ret_char_size);
 
 int flb_pack_time_now(msgpack_packer *pck);
 int flb_msgpack_expand_map(char *map_data, size_t map_size,

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -33,25 +33,6 @@
 
 #include "filter_parser.h"
 
-static int msgpackobj2char(msgpack_object *obj,
-                           const char **ret_char, int *ret_char_size)
-{
-    int ret = -1;
-
-    if (obj->type == MSGPACK_OBJECT_STR) {
-        *ret_char      = obj->via.str.ptr;
-        *ret_char_size = obj->via.str.size;
-        ret = 0;
-    }
-    else if (obj->type == MSGPACK_OBJECT_BIN) {
-        *ret_char      = obj->via.bin.ptr;
-        *ret_char_size = obj->via.bin.size;
-        ret = 0;
-    }
-
-    return ret;
-}
-
 static int add_parser(const char *parser, struct filter_parser_ctx *ctx,
                        struct flb_config *config)
 {
@@ -188,9 +169,9 @@ static int cb_parser_filter(const void *data, size_t bytes,
     int parse_ret = -1;
     int map_num;
     const char *key_str;
-    int key_len;
+    size_t key_len;
     const char *val_str;
-    int val_len;
+    size_t val_len;
     char *out_buf;
     size_t out_size;
     struct flb_time parsed_time;
@@ -240,13 +221,13 @@ static int cb_parser_filter(const void *data, size_t bytes,
                     append_arr[append_arr_i] = kv;
                     append_arr_i++;
                 }
-                if ( msgpackobj2char(&kv->key, &key_str, &key_len) < 0 ) {
+                if ( flb_msgpack_get_char_from_obj(&kv->key, &key_str, &key_len) < 0 ) {
                     /* key is not string */
                     continue;
                 }
                 if (key_len == ctx->key_name_len &&
                     !strncmp(key_str, ctx->key_name, key_len)) {
-                    if ( msgpackobj2char(&kv->val, &val_str, &val_len) < 0 ) {
+                    if ( flb_msgpack_get_char_from_obj(&kv->val, &val_str, &val_len) < 0 ) {
                         /* val is not string */
                         continue;
                     }

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -734,6 +734,30 @@ int flb_msgpack_to_json(char *json_str, size_t json_size,
     return ret ? off: ret;
 }
 
+/* This function updates a char pointer that points to a string in the msgpack object */
+int flb_msgpack_get_char_from_obj(msgpack_object *obj,
+                                  const char **ret_char, size_t *ret_char_size)
+{
+    int ret = -1;
+
+    if (obj == NULL || ret_char == NULL || ret_char_size == NULL) {
+        return ret;
+    }
+
+    if (obj->type == MSGPACK_OBJECT_STR) {
+        *ret_char      = obj->via.str.ptr;
+        *ret_char_size = obj->via.str.size;
+        ret = 0;
+    }
+    else if (obj->type == MSGPACK_OBJECT_BIN) {
+        *ret_char      = obj->via.bin.ptr;
+        *ret_char_size = obj->via.bin.size;
+        ret = 0;
+    }
+
+    return ret;
+}
+
 flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
 {
     int ret;


### PR DESCRIPTION
Bin type and Str type of msgpack represent string.
This function is to get a pointer of string in unified manner.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-pack 
==27047== Memcheck, a memory error detector
==27047== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27047== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==27047== Command: bin/flb-it-pack
==27047== 
Test json_pack...                               [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_iter...                          [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_mult...                          [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_mult_iter...                     [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_macros...                             [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_dup_keys...                           [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_bug342...                        [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_bug1278...                       
test 0 out => "one\u0007two"
test 1 out => "one\btwo"
test 2 out => "one\ttwo"
test 3 out => "one\ntwo"
test 4 out => "one\u000btwo"
test 5 out => "one\ftwo"
test 6 out => "one\rtwo"
test 7 out => "\\n"
[ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_nan...                           [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_pack_bug5336...                       [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_date_iso8601...                       [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_date_double...                        [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_date_java_sql...                      [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_date_epoch...                         [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test json_date_epoch_ms...                      [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test utf8_to_json...                            [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_get_char...                        [ OK ]
==27047== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==27047== 
==27047== HEAP SUMMARY:
==27047==     in use at exit: 0 bytes in 0 blocks
==27047==   total heap usage: 15,183 allocs, 15,183 frees, 6,184,825 bytes allocated
==27047== 
==27047== All heap blocks were freed -- no leaks are possible
==27047== 
==27047== For lists of detected and suppressed errors, rerun with: -s
==27047== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
