### PR TITLE
node_exporter_metrics: Support individual on/off and intervals for metrics [2.0 backport]

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -40,6 +40,127 @@
 #include "ne_vmstat_linux.h"
 #include "ne_netdev.h"
 
+static int ne_timer_cpu_metrics_cb(struct flb_input_instance *ins,
+                                   struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_cpu_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_cpufreq_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_cpufreq_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_meminfo_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_meminfo_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_diskstats_metrics_cb(struct flb_input_instance *ins,
+                                         struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_diskstats_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_filesystem_metrics_cb(struct flb_input_instance *ins,
+                                          struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_filesystem_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_uname_metrics_cb(struct flb_input_instance *ins,
+                                     struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_uname_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_stat_metrics_cb(struct flb_input_instance *ins,
+                                    struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_stat_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_time_metrics_cb(struct flb_input_instance *ins,
+                                    struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_time_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_loadavg_metrics_cb(struct flb_input_instance *ins,
+                                       struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_loadavg_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_vmstat_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_vmstat_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_netdev_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_netdev_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_filefd_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_filefd_update(ctx);
+
+    return 0;
+}
+
+
 struct flb_ne_callback {
     char *name;
     void (*func)(char *, void *, void *);
@@ -62,7 +183,7 @@ static void update_metrics(struct flb_input_instance *ins, struct flb_ne *ctx)
                 ne_update_cb(ctx, entry->str);
             }
             else {
-                flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
+                flb_plg_debug(ctx->ins, "Callback for metrics '%s' is not registered", entry->str);
             }
         }
     }
@@ -205,7 +326,7 @@ static int in_ne_init(struct flb_input_instance *in,
                       struct flb_config *config, void *data)
 {
     int ret;
-    int metric_idx = 0;
+    int metric_idx = -1;
     struct flb_ne *ctx;
     struct mk_list *head;
     struct flb_slist_entry *entry;
@@ -217,6 +338,21 @@ static int in_ne_init(struct flb_input_instance *in,
         flb_errno();
         return -1;
     }
+
+    /* Initialize fds */
+    ctx->coll_fd = -1;
+    ctx->coll_cpu_fd = -1;
+    ctx->coll_cpufreq_fd = -1;
+    ctx->coll_meminfo_fd = -1;
+    ctx->coll_diskstats_fd = -1;
+    ctx->coll_filesystem_fd = -1;
+    ctx->coll_uname_fd = -1;
+    ctx->coll_stat_fd = -1;
+    ctx->coll_time_fd = -1;
+    ctx->coll_loadavg_fd = -1;
+    ctx->coll_vmstat_fd = -1;
+    ctx->coll_netdev_fd = -1;
+    ctx->coll_filefd_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -239,22 +375,7 @@ static int in_ne_init(struct flb_input_instance *in,
     }
     ctx->coll_fd = ret;
 
-    /* Initialize node metric collectors */
-    ne_cpu_init(ctx);
-    ne_cpufreq_init(ctx);
-    ne_meminfo_init(ctx);
-    ne_diskstats_init(ctx);
-    ne_filesystem_init(ctx);
-    ne_uname_init(ctx);
-    ne_stat_init(ctx);
-    ne_time_init(ctx);
-    ne_loadavg_init(ctx);
-    ne_vmstat_init(ctx);
-    ne_netdev_init(ctx);
-    ne_filefd_init(ctx);
-
-    /* Check enabled metrics */
-        /* Update our metrics */
+    /* Check and initialize enabled metrics */
     if (ctx->metrics) {
         mk_list_foreach(head, ctx->metrics) {
             entry = mk_list_entry(head, struct flb_slist_entry, _head);
@@ -262,52 +383,244 @@ static int in_ne_init(struct flb_input_instance *in,
 
             if (ret == FLB_FALSE) {
                 if (strncmp(entry->str, "cpufreq", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 0;
+                    if (ctx->cpu_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 0;
+                    }
+                    else if (ctx->cpufreq_scrape_interval > 0) {
+                        /* Create the cpufreq collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_cpufreq_metrics_cb,
+                                                           ctx->cpufreq_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set cpufreq collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_cpufreq_fd = ret;
+                    }
+                    ne_cpufreq_init(ctx);
                 }
                 else if (strncmp(entry->str, "cpu", 3) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 1;
+                    if (ctx->cpufreq_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 1;
+                    }
+                    else if (ctx->cpu_scrape_interval > 0) {
+                        /* Create the cpu collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_cpu_metrics_cb,
+                                                           ctx->cpu_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set cpu collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_cpu_fd = ret;
+                    }
+                    ne_cpu_init(ctx);
                 }
                 else if (strncmp(entry->str, "meminfo", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 2;
+                    if (ctx->meminfo_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 2;
+                    }
+                    else if (ctx->meminfo_scrape_interval > 0) {
+                        /* Create the meminfo collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_meminfo_metrics_cb,
+                                                           ctx->meminfo_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set meminfo collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_meminfo_fd = ret;
+                    }
+                    ne_meminfo_init(ctx);
                 }
                 else if (strncmp(entry->str, "diskstats", 9) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 3;
+                    if (ctx->diskstats_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 3;
+                    }
+                    else if (ctx->diskstats_scrape_interval > 0) {
+                        /* Create the diskstats collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_diskstats_metrics_cb,
+                                                           ctx->diskstats_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set diskstats collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_diskstats_fd = ret;
+                    }
+                    ne_diskstats_init(ctx);
                 }
                 else if (strncmp(entry->str, "filesystem", 10) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 4;
+                    if (ctx->diskstats_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 4;
+                    }
+                    else if (ctx->filesystem_scrape_interval > 0) {
+                        /* Create the diskstats collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_filesystem_metrics_cb,
+                                                           ctx->filesystem_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set filesystem collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_filesystem_fd = ret;
+                    }
+                    ne_filesystem_init(ctx);
                 }
                 else if (strncmp(entry->str, "uname", 5) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 5;
+                    if (ctx->uname_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 5;
+                    }
+                    else if (ctx->uname_scrape_interval > 0) {
+                        /* Create the uname collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_uname_metrics_cb,
+                                                           ctx->uname_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set uname collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_uname_fd = ret;
+                    }
+                    ne_uname_init(ctx);
                 }
                 else if (strncmp(entry->str, "stat", 4) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 6;
+                    if (ctx->stat_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 6;
+                    }
+                    else if (ctx->stat_scrape_interval > 0) {
+                        /* Create the meminfo collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_stat_metrics_cb,
+                                                           ctx->stat_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set meminfo collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_stat_fd = ret;
+                    }
+                    ne_stat_init(ctx);
                 }
                 else if (strncmp(entry->str, "time", 4) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 7;
+                    if (ctx->time_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 7;
+                    }
+                    else if (ctx->time_scrape_interval > 0) {
+                        /* Create the time collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_time_metrics_cb,
+                                                           ctx->time_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set time collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_time_fd = ret;
+                    }
+                    ne_time_init(ctx);
                 }
                 else if (strncmp(entry->str, "loadavg", 7) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 8;
+                    if (ctx->loadavg_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 8;
+                    }
+                    else if (ctx->loadavg_scrape_interval > 0) {
+                        /* Create the loadavg collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_loadavg_metrics_cb,
+                                                           ctx->loadavg_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set loadavg collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_loadavg_fd = ret;
+                    }
+                    ne_loadavg_init(ctx);
                 }
                 else if (strncmp(entry->str, "vmstat", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 9;
+                    if (ctx->vmstat_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 9;
+                    }
+                    else if (ctx->vmstat_scrape_interval > 0) {
+                        /* Create the vmstat collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_vmstat_metrics_cb,
+                                                           ctx->vmstat_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set vmstat collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_vmstat_fd = ret;
+                    }
+                    ne_vmstat_init(ctx);
                 }
                 else if (strncmp(entry->str, "netdev", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 10;
+                    if (ctx->netdev_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 10;
+                    }
+                    else if (ctx->netdev_scrape_interval > 0) {
+                        /* Create the netdev collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_netdev_metrics_cb,
+                                                           ctx->netdev_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set netdev collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_netdev_fd = ret;
+                    }
+                    ne_netdev_init(ctx);
                 }
                 else if (strncmp(entry->str, "filefd", 6) == 0) {
-                    flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
-                    metric_idx = 11;
+                    if (ctx->filefd_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 11;
+                    }
+                    else if (ctx->filefd_scrape_interval > 0) {
+                        /* Create the filefd collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_filefd_metrics_cb,
+                                                           ctx->filefd_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set filefd collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_filefd_fd = ret;
+                    }
+                    ne_filefd_init(ctx);
                 }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
@@ -336,17 +649,81 @@ static int in_ne_init(struct flb_input_instance *in,
 
 static int in_ne_exit(void *data, struct flb_config *config)
 {
+    int ret;
     struct flb_ne *ctx = data;
+    struct mk_list *head;
+    struct flb_slist_entry *entry;
 
     if (!ctx) {
         return 0;
     }
 
-    ne_diskstats_exit(ctx);
-    ne_filesystem_exit(ctx);
-    ne_meminfo_exit(ctx);
-    ne_vmstat_exit(ctx);
-    ne_netdev_exit(ctx);
+    /* Teardown for callback tied up resources */
+    if (ctx->metrics) {
+        mk_list_foreach(head, ctx->metrics) {
+            entry = mk_list_entry(head, struct flb_slist_entry, _head);
+            ret = flb_callback_exists(ctx->callback, entry->str);
+
+            if (ret == FLB_TRUE) {
+                if (strncmp(entry->str, "cpufreq", 7) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "cpu", 3) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "meminfo", 7) == 0) {
+                    ne_meminfo_exit(ctx);
+                }
+                else if (strncmp(entry->str, "diskstats", 9) == 0) {
+                    ne_diskstats_exit(ctx);
+                }
+                else if (strncmp(entry->str, "filesystem", 10) == 0) {
+                    ne_filesystem_exit(ctx);
+                }
+                else if (strncmp(entry->str, "uname", 5) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "stat", 4) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "time", 4) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "loadavg", 7) == 0) {
+                    /* nop */
+                }
+                else if (strncmp(entry->str, "vmstat", 6) == 0) {
+                    ne_vmstat_exit(ctx);
+                }
+                else if (strncmp(entry->str, "netdev", 6) == 0) {
+                    ne_netdev_exit(ctx);
+                }
+                else if (strncmp(entry->str, "filefd", 6) == 0) {
+                    /* nop */
+                }
+                else {
+                    flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
+                }
+            }
+        }
+    }
+
+    /* Teardown for timer tied up resources */
+    if (ctx->coll_meminfo_fd != -1) {
+        ne_meminfo_exit(ctx);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        ne_diskstats_exit(ctx);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        ne_filesystem_exit(ctx);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        ne_vmstat_exit(ctx);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        ne_netdev_exit(ctx);
+    }
 
     flb_ne_config_destroy(ctx);
     /* destroy callback context */
@@ -362,6 +739,42 @@ static void in_ne_pause(void *data, struct flb_config *config)
     struct flb_ne *ctx = data;
 
     flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+    if (ctx->coll_cpu_fd != -1) {
+        flb_input_collector_pause(ctx->coll_cpu_fd, ctx->ins);
+    }
+    if (ctx->coll_cpufreq_fd != -1) {
+        flb_input_collector_pause(ctx->coll_cpufreq_fd, ctx->ins);
+    }
+    if (ctx->coll_meminfo_fd != -1) {
+        flb_input_collector_pause(ctx->coll_meminfo_fd, ctx->ins);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        flb_input_collector_pause(ctx->coll_diskstats_fd, ctx->ins);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        flb_input_collector_pause(ctx->coll_filesystem_fd, ctx->ins);
+    }
+    if (ctx->coll_uname_fd != -1) {
+        flb_input_collector_pause(ctx->coll_uname_fd, ctx->ins);
+    }
+    if (ctx->coll_stat_fd != -1) {
+        flb_input_collector_pause(ctx->coll_stat_fd, ctx->ins);
+    }
+    if (ctx->coll_time_fd != -1) {
+        flb_input_collector_pause(ctx->coll_time_fd, ctx->ins);
+    }
+    if (ctx->coll_loadavg_fd != -1) {
+        flb_input_collector_pause(ctx->coll_loadavg_fd, ctx->ins);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        flb_input_collector_pause(ctx->coll_vmstat_fd, ctx->ins);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        flb_input_collector_pause(ctx->coll_netdev_fd, ctx->ins);
+    }
+    if (ctx->coll_filefd_fd != -1) {
+        flb_input_collector_pause(ctx->coll_filefd_fd, ctx->ins);
+    }
 }
 
 static void in_ne_resume(void *data, struct flb_config *config)
@@ -369,6 +782,42 @@ static void in_ne_resume(void *data, struct flb_config *config)
     struct flb_ne *ctx = data;
 
     flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+    if (ctx->coll_cpu_fd != -1) {
+        flb_input_collector_resume(ctx->coll_cpu_fd, ctx->ins);
+    }
+    if (ctx->coll_cpufreq_fd != -1) {
+        flb_input_collector_resume(ctx->coll_cpufreq_fd, ctx->ins);
+    }
+    if (ctx->coll_meminfo_fd != -1) {
+        flb_input_collector_resume(ctx->coll_meminfo_fd, ctx->ins);
+    }
+    if (ctx->coll_diskstats_fd != -1) {
+        flb_input_collector_resume(ctx->coll_diskstats_fd, ctx->ins);
+    }
+    if (ctx->coll_filesystem_fd != -1) {
+        flb_input_collector_resume(ctx->coll_filesystem_fd, ctx->ins);
+    }
+    if (ctx->coll_uname_fd != -1) {
+        flb_input_collector_resume(ctx->coll_uname_fd, ctx->ins);
+    }
+    if (ctx->coll_stat_fd != -1) {
+        flb_input_collector_resume(ctx->coll_stat_fd, ctx->ins);
+    }
+    if (ctx->coll_time_fd != -1) {
+        flb_input_collector_resume(ctx->coll_time_fd, ctx->ins);
+    }
+    if (ctx->coll_loadavg_fd != -1) {
+        flb_input_collector_resume(ctx->coll_loadavg_fd, ctx->ins);
+    }
+    if (ctx->coll_vmstat_fd != -1) {
+        flb_input_collector_resume(ctx->coll_vmstat_fd, ctx->ins);
+    }
+    if (ctx->coll_netdev_fd != -1) {
+        flb_input_collector_resume(ctx->coll_netdev_fd, ctx->ins);
+    }
+    if (ctx->coll_filefd_fd != -1) {
+        flb_input_collector_resume(ctx->coll_filefd_fd, ctx->ins);
+    }
 }
 
 /* Configuration properties map */
@@ -377,6 +826,78 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "scrape_interval", "5",
      0, FLB_TRUE, offsetof(struct flb_ne, scrape_interval),
      "scrape interval to collect metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.cpu.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, cpu_scrape_interval),
+     "scrape interval to collect cpu metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.cpufreq.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, cpufreq_scrape_interval),
+     "scrape interval to collect cpufreq metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.meminfo.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, meminfo_scrape_interval),
+     "scrape interval to collect meminfo metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.diskstats.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, diskstats_scrape_interval),
+     "scrape interval to collect diskstats metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.filesystem.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, filesystem_scrape_interval),
+     "scrape interval to collect filesystem metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.uname.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, uname_scrape_interval),
+     "scrape interval to collect uname metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.stat.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, stat_scrape_interval),
+     "scrape interval to collect stat metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.time.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, time_scrape_interval),
+     "scrape interval to collect time metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.loadavg.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, loadavg_scrape_interval),
+     "scrape interval to collect loadavg metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.vmstat.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, vmstat_scrape_interval),
+     "scrape interval to collect vmstat metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.netdev.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, netdev_scrape_interval),
+     "scrape interval to collect netdev metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.filefd.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, filefd_scrape_interval),
+     "scrape interval to collect filefd metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -708,6 +708,11 @@ static int in_ne_exit(void *data, struct flb_config *config)
         }
     }
 
+    /* destroy callback context */
+    if (ctx->callback) {
+        flb_callback_destroy(ctx->callback);
+    }
+
     /* Teardown for timer tied up resources */
     if (ctx->coll_meminfo_fd != -1) {
         ne_meminfo_exit(ctx);
@@ -726,10 +731,6 @@ static int in_ne_exit(void *data, struct flb_config *config)
     }
 
     flb_ne_config_destroy(ctx);
-    /* destroy callback context */
-    if (ctx->callback) {
-        flb_callback_destroy(ctx->callback);
-    }
 
     return 0;
 }

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -39,6 +39,8 @@ struct flb_ne {
     int coll_fd;                                      /* collector fd     */
     struct cmt *cmt;                                  /* cmetrics context */
     struct flb_input_instance *ins;                   /* input instance   */
+    struct flb_callback *callback;                    /* metric callback */
+    struct mk_list *metrics;                          /* enabled metrics */
 
     /*
      * Metrics Contexts

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -42,6 +42,33 @@ struct flb_ne {
     struct flb_callback *callback;                    /* metric callback */
     struct mk_list *metrics;                          /* enabled metrics */
 
+    /* Individual intervals for metrics */
+    int cpu_scrape_interval;
+    int cpufreq_scrape_interval;
+    int meminfo_scrape_interval;
+    int diskstats_scrape_interval;
+    int filesystem_scrape_interval;
+    int uname_scrape_interval;
+    int stat_scrape_interval;
+    int time_scrape_interval;
+    int loadavg_scrape_interval;
+    int vmstat_scrape_interval;
+    int netdev_scrape_interval;
+    int filefd_scrape_interval;
+
+    int coll_cpu_fd;                                    /* collector fd (cpu)    */
+    int coll_cpufreq_fd;                                /* collector fd (cpufreq)  */
+    int coll_meminfo_fd;                                /* collector fd (meminfo)  */
+    int coll_diskstats_fd;                              /* collector fd (diskstat) */
+    int coll_filesystem_fd;                             /* collector fd (filesystem) */
+    int coll_uname_fd;                                  /* collector fd (uname)    */
+    int coll_stat_fd;                                   /* collector fd (stat)    */
+    int coll_time_fd;                                   /* collector fd (time)    */
+    int coll_loadavg_fd;                                /* collector fd (loadavg)    */
+    int coll_vmstat_fd;                                 /* collector fd (vmstat)    */
+    int coll_netdev_fd;                                 /* collector fd (netdev)    */
+    int coll_filefd_fd;                                 /* collector fd (filefd)    */
+
     /*
      * Metrics Contexts
      * ----------------


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is backporting PR that is corresponds to https://github.com/fluent/fluent-bit/pull/6737 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
