### PR TITLE
windows_exporter_metrics: Support individual on/off and intervals for metrics [2.0 backport]

### DIFF
--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -193,6 +193,27 @@ struct flb_we {
     struct flb_callback *callback;                    /* metric callback */
     struct mk_list *metrics;                          /* enabled metrics */
 
+    /* Individual intervals for metrics */
+    int cpu_scrape_interval;
+    int net_scrape_interval;
+    int logical_disk_scrape_interval;
+    int cs_scrape_interval;
+    int os_scrape_interval;
+    int wmi_thermalzone_scrape_interval;
+    int wmi_cpu_info_scrape_interval;
+    int wmi_logon_scrape_interval;
+    int wmi_system_scrape_interval;
+
+    int coll_cpu_fd;                                    /* collector fd (cpu)    */
+    int coll_net_fd;                                    /* collector fd (net)  */
+    int coll_logical_disk_fd;                           /* collector fd (logical_disk) */
+    int coll_cs_fd;                                     /* collector fd (cs) */
+    int coll_os_fd;                                     /* collector fd (os)    */
+    int coll_wmi_thermalzone_fd;                        /* collector fd (wmi_thermalzone) */
+    int coll_wmi_cpu_info_fd;                           /* collector fd (wmi_cpu_info) */
+    int coll_wmi_logon_fd;                              /* collector fd (wmi_logon)    */
+    int coll_wmi_system_fd;                             /* collector fd (wmi_system)    */
+
     /*
      * Metrics Contexts
      * ----------------

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -190,6 +190,9 @@ struct flb_we {
 
     float windows_version;
 
+    struct flb_callback *callback;                    /* metric callback */
+    struct mk_list *metrics;                          /* enabled metrics */
+
     /*
      * Metrics Contexts
      * ----------------


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is backporting PR that is corresponds to https://github.com/fluent/fluent-bit/pull/6766

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
