### PR TITLE
in_http: add support for form/url_encoded payloads.

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -61,6 +61,8 @@ static int sds_uri_decode(flb_sds_t s)
             }
             *optr++ = hex2nibble(*(iptr+1)) << 4 | hex2nibble(*(iptr+2));
             iptr+=2;
+        } else if (*iptr == '+') {
+            *optr++ = ' ';
         } else {
             *optr++ = *iptr;
         }

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -312,39 +312,39 @@ static ssize_t parse_payload_urlencoded(struct flb_http *ctx, flb_sds_t tag,
 
     kvs = flb_utils_split(payload, '&', -1 );
     if (kvs == NULL) {
-    	goto split_error;
+        goto split_error;
     }
 
     keys = flb_calloc(mk_list_size(kvs), sizeof(char *));
     if (keys == NULL) {
-    	goto keys_calloc_error;
+        goto keys_calloc_error;
     }
 
     vals = flb_calloc(mk_list_size(kvs), sizeof(char *));
     if (vals == NULL) {
-    	goto vals_calloc_error;
+        goto vals_calloc_error;
     }
 
     mk_list_foreach(head, kvs) {
-    	cur = mk_list_entry(head, struct flb_split_entry, _head);
-    	if (cur->value[0] == '\n') {
-    	    start = &cur->value[1];
-    	} else {
-    	    start = cur->value;
-	}
-	sep = strchr(start, '=');
-	if (sep == NULL) {
-	    vals[idx] = NULL;
-	    continue;
-	}
-	*sep++ = '\0';
-        
-        keys[idx] = flb_sds_create_len(start, strlen(start));
-	vals[idx] = flb_sds_create_len(sep, strlen(sep));
+        cur = mk_list_entry(head, struct flb_split_entry, _head);
+        if (cur->value[0] == '\n') {
+            start = &cur->value[1];
+        } else {
+            start = cur->value;
+        }
+        sep = strchr(start, '=');
+        if (sep == NULL) {
+            vals[idx] = NULL;
+            continue;
+        }
+        *sep++ = '\0';
 
-	flb_sds_trim(keys[idx]);
-	flb_sds_trim(vals[idx]);
-	idx++;
+        keys[idx] = flb_sds_create_len(start, strlen(start));
+        vals[idx] = flb_sds_create_len(sep, strlen(sep));
+
+        flb_sds_trim(keys[idx]);
+        flb_sds_trim(vals[idx]);
+        idx++;
     }
 
     msgpack_pack_map(&pck, mk_list_size(kvs));


### PR DESCRIPTION
Add support for `Content-Type:application/x-www-form-urlencoded` to the `in_http` plugin.

This PR addresses #5385.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
