### PR TITLE
in_kafka: refactor to use flb_input_set_collector_time

### DIFF
--- a/examples/kafka_filter/Dockerfile
+++ b/examples/kafka_filter/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim as builder
 ENV DEBIAN_FRONTEND noninteractive
-ENV KAFKA_URL https://dlcdn.apache.org/kafka/3.0.0/kafka_2.13-3.0.0.tgz
-ENV KAFKA_SHA256 a82728166bbccf406009747a25e1fe52dbcb4d575e4a7a8616429b5818cd02d1
+ENV KAFKA_URL https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz
+ENV KAFKA_SHA256 67025feb03eb963a8852d4adc5b2810744f493a672c5992728955e38bed43da8
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -13,6 +13,7 @@ RUN apt-get update && \
     cmake \
     pkg-config \
     libsasl2-dev \
+    libssl-dev \
     flex \
     openjdk-11-jre-headless \
     bison \
@@ -32,8 +33,9 @@ COPY . /source
 RUN cmake -DFLB_DEV=On \
           -DFLB_IN_KAFKA=On \
           -DFLB_OUT_KAFKA=On \
+          -DFLB_CONFIG_YAML=Off \
           /source && \
-    make -j "$(getconf _NPROCESSORS_ONLN)"
+    cmake --build . --parallel
 
 FROM builder as runner
 COPY --from=builder /build/bin/fluent-bit /usr/local/bin/fluent-bit

--- a/examples/kafka_filter/Makefile
+++ b/examples/kafka_filter/Makefile
@@ -1,11 +1,11 @@
 build:
-	docker-compose build
+	docker compose build
 
 start:
-	docker-compose up -d
-	docker-compose logs -f fluent-bit kafka-consumer
+	docker compose up -d
+	docker compose logs -f fluent-bit kafka-consumer
 
 stop:
-	docker-compose down
+	docker compose down
 
 .PHONY: build start stop

--- a/examples/kafka_filter/kafka.conf
+++ b/examples/kafka_filter/kafka.conf
@@ -7,6 +7,7 @@
     Name kafka
     brokers kafka-broker:9092
     topics fb-source
+    poll_ms 100
 
 [FILTER]
     Name    lua

--- a/examples/kafka_filter/kafka.lua
+++ b/examples/kafka_filter/kafka.lua
@@ -2,6 +2,7 @@ local count = 0
 function modify_kafka_message(tag, timestamp, record)
     count = count + 1
     local payload = record.payload
+    payload.topic = record.topic
     payload.status = 'processed by fluent-bit, total records: '..tostring(count)
     return 1, timestamp, payload
 end

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -30,7 +30,6 @@
 struct flb_in_kafka_config {
     struct flb_kafka kafka;
     struct flb_input_instance *ins;
-    struct flb_input_thread it;
     struct flb_log_event_encoder *log_encoder;
 };
 

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -27,10 +27,14 @@
 #include <fluent-bit/flb_kafka.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
+
+#define FLB_IN_KAFKA_DEFAULT_POLL_MS  "500"
+
 struct flb_in_kafka_config {
     struct flb_kafka kafka;
     struct flb_input_instance *ins;
     struct flb_log_event_encoder *log_encoder;
+    int poll_ms;
 };
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

The flb_input_thread API was deprecated, so we are moving to a simpler implementation that uses `flb_input_set_collector_time` to periodically poll librdkafka for messages.

Also updated the example scripts, which were referencing kafka versions no longer available for download.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----

**Testing**

To see this working in action, go to `examples/kafka_filter` and execute `make && make start`. This will run the following containers in docker compose:

- kafka-broker is runing a kafka instance
- kafka-producer posts messages to the fb-source topic
- fluent-bit is running a lua filter that processes in the `fb-source` topic, and posting the results in the `fb-sink` topic
- kafka-consumer is reading messages posted on the `fb-sink` topic

After `make start`, you should see `kafka-consumer` messages on the terminal, showing the results of fluent-bit processing.
 (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
