### PR TITLE
macos: in_http: in_elasticsearch: Remove needless evl operations on tests

### DIFF
--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -33,7 +33,6 @@ struct http_client_ctx {
     struct flb_upstream      *u;
     struct flb_connection    *u_conn;
     struct flb_config        *config;
-    struct mk_event_loop     *evl;
 };
 
 struct test_ctx {
@@ -101,7 +100,6 @@ static int cb_check_result_json(void *record, size_t size, void *data)
 struct http_client_ctx* http_client_ctx_create()
 {
     struct http_client_ctx *ret_ctx = NULL;
-    struct mk_event_loop *evl = NULL;
 
     ret_ctx = flb_calloc(1, sizeof(struct http_client_ctx));
     if (!TEST_CHECK(ret_ctx != NULL)) {
@@ -110,29 +108,20 @@ struct http_client_ctx* http_client_ctx_create()
         return NULL;
     }
 
-    evl = mk_event_loop_create(16);
-    if (!TEST_CHECK(evl != NULL)) {
-        TEST_MSG("mk_event_loop failed");
-        flb_free(ret_ctx);
-        return NULL;
-    }
-    ret_ctx->evl = evl;
-    flb_engine_evl_init();
-    flb_engine_evl_set(evl);
-
     ret_ctx->config = flb_config_init();
     if(!TEST_CHECK(ret_ctx->config != NULL)) {
         TEST_MSG("flb_config_init failed");
-        mk_event_loop_destroy(evl);
         flb_free(ret_ctx);
         return NULL;
     }
+
+    /* Event Loop needn't set up here because flb_start() already
+     * assigns its instance. */
 
     ret_ctx->u = flb_upstream_create(ret_ctx->config, "127.0.0.1", 9880, 0, NULL);
     if (!TEST_CHECK(ret_ctx->u != NULL)) {
         TEST_MSG("flb_upstream_create failed");
         flb_config_exit(ret_ctx->config);
-        mk_event_loop_destroy(evl);
         flb_free(ret_ctx);
         return NULL;
     }
@@ -188,9 +177,6 @@ int http_client_ctx_destroy(struct http_client_ctx* ctx)
     }
     if (ctx->config) {
         flb_config_exit(ctx->config);
-    }
-    if (ctx->evl) {
-        mk_event_loop_destroy(ctx->evl);
     }
 
     flb_free(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->
After merging https://github.com/fluent/fluent-bit/pull/6906, CI tasks for macOS are always failing due to reference glitches for event loops.

This PR should fix CI issues on macOS.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
