### PR TITLE
out_prometheus_remote_write: add aws sigv4 authentication

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.h
+++ b/plugins/out_prometheus_remote_write/remote_write.h
@@ -26,12 +26,27 @@
 #define FLB_PROMETHEUS_REMOTE_WRITE_MIME_PROTOBUF_LITERAL    "application/x-protobuf"
 #define FLB_PROMETHEUS_REMOTE_WRITE_VERSION_HEADER_NAME      "X-Prometheus-Remote-Write-Version"
 #define FLB_PROMETHEUS_REMOTE_WRITE_VERSION_LITERAL          "0.1.0"
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#define FLB_PROMETHEUS_REMOTE_WRITE_CREDENTIAL_PREFIX "aws_"
+#endif
+#endif
 
 /* Plugin context */
 struct prometheus_remote_write_context {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+
+    /* AWS Auth */
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    int has_aws_auth;
+    struct flb_aws_provider *aws_provider;
+    const char *aws_region;
+    const char *aws_service;
+#endif
+#endif
 
     /* Proxy */
     const char *proxy;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[SERVICE]
    flush           1
    log_level       debug

[INPUT]
    name            fluentbit_metrics
    tag             internal_metrics
    scrape_interval 2

[OUTPUT]
    Name            prometheus_remote_write
    Match           internal_metrics
    aws_region      us-east-1
    aws_auth        On
    Host            aps-workspaces.us-east-1.amazonaws.com
    Uri             /workspaces/ws-c0da0bb9-734c-496c-b9aa-7d14d688be8f/api/v1/remote_write
    Port            443
    Tls             On
    Tls.verify      On
```
- [x] Debug log output from testing the change
```
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/09 23:35:40] [ info] Configuration:
[2023/03/09 23:35:40] [ info]  flush time     | 1.000000 seconds
[2023/03/09 23:35:40] [ info]  grace          | 5 seconds
[2023/03/09 23:35:40] [ info]  daemon         | 0
[2023/03/09 23:35:40] [ info] ___________
[2023/03/09 23:35:40] [ info]  inputs:
[2023/03/09 23:35:40] [ info]      fluentbit_metrics
[2023/03/09 23:35:40] [ info] ___________
[2023/03/09 23:35:40] [ info]  filters:
[2023/03/09 23:35:40] [ info] ___________
[2023/03/09 23:35:40] [ info]  outputs:
[2023/03/09 23:35:40] [ info]      prometheus_remote_write.0
[2023/03/09 23:35:40] [ info] ___________
[2023/03/09 23:35:40] [ info]  collectors:
[2023/03/09 23:35:40] [ info] [fluent bit] version=2.1.0, commit=c5f187b15d, pid=26191
[2023/03/09 23:35:40] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/09 23:35:40] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/09 23:35:40] [ info] [cmetrics] version=0.5.8
[2023/03/09 23:35:40] [ info] [ctraces ] version=0.3.0
[2023/03/09 23:35:40] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2023/03/09 23:35:40] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2023/03/09 23:35:40] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2023/03/09 23:35:40] [debug] [prometheus_remote_write:prometheus_remote_write.0] created event channels: read=23 write=24
[2023/03/09 23:35:45] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2023/03/09 23:35:45] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2023/03/09 23:35:45] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2023/03/09 23:35:45] [debug] [aws_credentials] Not initializing ECS Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set
[2023/03/09 23:35:45] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2023/03/09 23:35:45] [debug] [aws_credentials] Sync called on the EC2 provider
[2023/03/09 23:35:45] [debug] [aws_credentials] Init called on the env provider
[2023/03/09 23:35:45] [debug] [aws_credentials] Init called on the profile provider
[2023/03/09 23:35:45] [debug] [aws_credentials] Reading shared config file.
[2023/03/09 23:35:45] [debug] [aws_credentials] Reading shared credentials file.
[2023/03/09 23:35:45] [debug] [aws_credentials] Async called on the EC2 provider
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==14384== Memcheck, a memory error detector
==14384== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==14384== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==14384== Command: ./build/bin/fluent-bit
==14384== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/10 02:51:00] [ info] [fluent bit] version=2.1.0, commit=52a12bf86c, pid=14384
[2023/03/10 02:51:00] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/10 02:51:00] [ info] [cmetrics] version=0.5.8
[2023/03/10 02:51:00] [ info] [ctraces ] version=0.3.0
[2023/03/10 02:51:00] [ info] [sp] stream processor started
[2023/03/10 02:52:03] [engine] caught signal (SIGTERM)
[2023/03/10 02:52:03] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/10 02:52:03] [ info] [engine] service has stopped (0 pending tasks)
==14384== 
==14384== HEAP SUMMARY:
==14384==     in use at exit: 99,944 bytes in 3,385 blocks
==14384==   total heap usage: 4,525 allocs, 1,140 frees, 891,411 bytes allocated
==14384== 
==14384== LEAK SUMMARY:
==14384==    definitely lost: 0 bytes in 0 blocks
==14384==    indirectly lost: 0 bytes in 0 blocks
==14384==      possibly lost: 0 bytes in 0 blocks
==14384==    still reachable: 99,944 bytes in 3,385 blocks
==14384==         suppressed: 0 bytes in 0 blocks
==14384== Rerun with --leak-check=full to see details of leaked memory
==14384== 
==14384== For lists of detected and suppressed errors, rerun with: -s
==14384== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1057
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
