### PR TITLE
out_s3: fix tag corruption with preserve_data_ordering

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -105,7 +105,7 @@ static char *mock_error_response(char *error_env_var)
 
     err_val = getenv(error_env_var);
     if (err_val != NULL && strlen(err_val) > 0) {
-        error = flb_malloc(strlen(err_val) + sizeof(char));
+        error = flb_calloc(strlen(err_val) + 1, sizeof(char));
         if (error == NULL) {
             flb_errno();
             return NULL;
@@ -158,7 +158,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         return 0;
     }
 
-    s3_headers = flb_malloc(sizeof(struct flb_aws_header) * headers_len);
+    s3_headers = flb_calloc(headers_len, sizeof(struct flb_aws_header));
     if (s3_headers == NULL) {
         flb_errno();
         return -1;
@@ -243,7 +243,7 @@ struct flb_http_client *mock_s3_call(char *error_env_var, char *api)
                               "Server: AmazonS3";
             /* since etag is in the headers, this code uses resp.data */
             len = strlen(resp);
-            c->resp.data = flb_malloc(len + 1);
+            c->resp.data = flb_calloc(len + 1, sizeof(char));
             if (!c->resp.data) {
                 flb_errno();
                 return NULL;
@@ -1568,7 +1568,7 @@ static int add_to_queue(struct flb_s3 *ctx, struct s3_file *upload_file,
     char *tag_cpy;
 
     /* Create upload contents object and add to upload queue */
-    upload_contents = flb_malloc(sizeof(struct upload_queue));
+    upload_contents = flb_calloc(1, sizeof(struct upload_queue));
     if (upload_contents == NULL) {
         flb_plg_error(ctx->ins, "Error allocating memory for upload_queue entry");
         flb_errno();
@@ -1882,7 +1882,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
     }
 
     /* Allocate buffer to store log_key contents */
-    val_buf = flb_malloc(msgpack_size);
+    val_buf = flb_calloc(1, msgpack_size);
     if (val_buf == NULL) {
         flb_plg_error(ctx->ins, "Could not allocate enough "
                       "memory to read record");

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -61,7 +61,7 @@
 struct upload_queue {
     struct s3_file *upload_file;
     struct multipart_upload *m_upload_file;
-    char *tag;
+    flb_sds_t tag;
     int tag_len;
 
     int retry_counter;

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -700,7 +700,7 @@ static char* replace_uri_tokens(const char* original_string, const char* current
     i = 0;
     while (*original_string) {
         if (strstr(original_string, current_word) == original_string) {
-            strcpy(&result[i], new_word);
+            strncpy(&result[i], new_word, new_word_len);
             i += new_word_len;
             original_string += old_word_len;
         }

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -94,7 +94,7 @@ char *flb_aws_endpoint(char* service, char* region)
     len += strlen(region);
     len++; /* null byte */
 
-    endpoint = flb_malloc(len);
+    endpoint = flb_calloc(len, sizeof(char));
     if (!endpoint) {
         flb_errno();
         return NULL;
@@ -136,7 +136,7 @@ int flb_read_file(const char *path, char **out_buf, size_t *out_size)
         return -1;
     }
 
-    buf = flb_malloc(st.st_size + sizeof(char));
+    buf = flb_calloc(st.st_size + 1, sizeof(char));
     if (!buf) {
         flb_errno();
         close(fd);
@@ -855,7 +855,7 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
     /* Find all occurences of $INDEX and replace with the appropriate index. */
     if (strstr((char *) format, INDEX_STRING)) {
         seq_index_len = snprintf(NULL, 0, "%"PRIu64, seq_index);
-        seq_index_str = flb_malloc(seq_index_len + 1);
+        seq_index_str = flb_calloc(seq_index_len + 1, sizeof(char));
         if (seq_index_str == NULL) {
             goto error;
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #6933

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
