### PR TITLE
out_prometheus_remote_write: add aws sigv4 authentication

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.h
+++ b/plugins/out_prometheus_remote_write/remote_write.h
@@ -26,12 +26,27 @@
 #define FLB_PROMETHEUS_REMOTE_WRITE_MIME_PROTOBUF_LITERAL    "application/x-protobuf"
 #define FLB_PROMETHEUS_REMOTE_WRITE_VERSION_HEADER_NAME      "X-Prometheus-Remote-Write-Version"
 #define FLB_PROMETHEUS_REMOTE_WRITE_VERSION_LITERAL          "0.1.0"
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#define FLB_PROMETHEUS_REMOTE_WRITE_CREDENTIAL_PREFIX "aws_"
+#endif
+#endif
 
 /* Plugin context */
 struct prometheus_remote_write_context {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+
+    /* AWS Auth */
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    int has_aws_auth;
+    struct flb_aws_provider *aws_provider;
+    const char *aws_region;
+    const char *aws_service;
+#endif
+#endif
 
     /* Proxy */
     const char *proxy;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[SERVICE]
    flush           1
    log_level       debug

[INPUT]
    name            fluentbit_metrics
    tag             internal_metrics
    scrape_interval 2

[OUTPUT]
    Name            prometheus_remote_write
    Match           internal_metrics
    aws_region      us-east-1
    aws_auth        On
    Host            aps-workspaces.us-east-1.amazonaws.com
    Uri             /workspaces/ws-c0da0bb9-734c-496c-b9aa-7d14d688be8f/api/v1/remote_write
    Port            443
    Tls             On
    Tls.verify      On
```
- [x] Debug log output from testing the change
```

Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/09 23:59:38] [ info] Configuration:
[2023/03/09 23:59:38] [ info]  flush time     | 1.000000 seconds
[2023/03/09 23:59:38] [ info]  grace          | 5 seconds
[2023/03/09 23:59:38] [ info]  daemon         | 0
[2023/03/09 23:59:38] [ info] ___________
[2023/03/09 23:59:38] [ info]  inputs:
[2023/03/09 23:59:38] [ info]      fluentbit_metrics
[2023/03/09 23:59:38] [ info] ___________
[2023/03/09 23:59:38] [ info]  filters:
[2023/03/09 23:59:38] [ info] ___________
[2023/03/09 23:59:38] [ info]  outputs:
[2023/03/09 23:59:38] [ info]      prometheus_remote_write.0
[2023/03/09 23:59:38] [ info] ___________
[2023/03/09 23:59:38] [ info]  collectors:
[2023/03/09 23:59:38] [ info] [fluent bit] version=1.9.10, commit=e47bbd824c, pid=16069
[2023/03/09 23:59:38] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/09 23:59:38] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2023/03/09 23:59:38] [ info] [cmetrics] version=0.3.7
[2023/03/09 23:59:38] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2023/03/09 23:59:38] [debug] [prometheus_remote_write:prometheus_remote_write.0] created event channels: read=23 write=24
[2023/03/09 23:59:42] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2023/03/09 23:59:42] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2023/03/09 23:59:42] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2023/03/09 23:59:42] [debug] [aws_credentials] Not initializing ECS Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set
[2023/03/09 23:59:42] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2023/03/09 23:59:42] [debug] [aws_credentials] Sync called on the EC2 provider
[2023/03/09 23:59:42] [debug] [aws_credentials] Init called on the env provider
[2023/03/09 23:59:42] [debug] [aws_credentials] Init called on the profile provider
[2023/03/09 23:59:42] [debug] [aws_credentials] Reading shared config file.
[2023/03/09 23:59:42] [debug] [aws_credentials] Reading shared credentials file.
[2023/03/09 23:59:42] [debug] [aws_credentials] Async called on the EC2 provider
[2023/03/09 23:59:42] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #0 started
[2023/03/09 23:59:42] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #1 started
[2023/03/09 23:59:42] [debug] [router] match rule fluentbit_metrics.0:prometheus_remote_write.0
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/10 03:17:36] [ info] Configuration:
[2023/03/10 03:17:36] [ info]  flush time     | 1.000000 seconds
[2023/03/10 03:17:36] [ info]  grace          | 5 seconds
[2023/03/10 03:17:36] [ info]  daemon         | 0
[2023/03/10 03:17:36] [ info] ___________
[2023/03/10 03:17:36] [ info]  inputs:
[2023/03/10 03:17:36] [ info]      fluentbit_metrics
[2023/03/10 03:17:36] [ info] ___________
[2023/03/10 03:17:36] [ info]  filters:
[2023/03/10 03:17:36] [ info] ___________
[2023/03/10 03:17:36] [ info]  outputs:
[2023/03/10 03:17:36] [ info]      prometheus_remote_write.0
[2023/03/10 03:17:36] [ info] ___________
[2023/03/10 03:17:36] [ info]  collectors:
[2023/03/10 03:17:36] [ info] [fluent bit] version=1.9.10, commit=8eb9212b7f, pid=3119
[2023/03/10 03:17:36] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/10 03:17:36] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2023/03/10 03:17:36] [ info] [cmetrics] version=0.3.7
[2023/03/10 03:17:36] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2023/03/10 03:17:36] [debug] [prometheus_remote_write:prometheus_remote_write.0] created event channels: read=23 write=24
[ec2-user@ip-172-31-72-14 fluent-bit]$ valgrind ./build/bin/fluent-bit
==3714== Memcheck, a memory error detector
==3714== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==3714== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==3714== Command: ./build/bin/fluent-bit
==3714== 
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/10 03:18:59] [ info] [fluent bit] version=1.9.10, commit=8eb9212b7f, pid=3714
[2023/03/10 03:18:59] [ info] [storage] version=1.3.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2023/03/10 03:18:59] [ info] [cmetrics] version=0.3.7
[2023/03/10 03:18:59] [ info] [sp] stream processor started
[2023/03/10 03:22:28] [engine] caught signal (SIGTERM)
[2023/03/10 03:22:28] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/10 03:22:28] [ info] [engine] service has stopped (0 pending tasks)
==3714== 
==3714== HEAP SUMMARY:
==3714==     in use at exit: 99,944 bytes in 3,385 blocks
==3714==   total heap usage: 4,442 allocs, 1,057 frees, 1,961,527 bytes allocated
==3714== 
==3714== LEAK SUMMARY:
==3714==    definitely lost: 0 bytes in 0 blocks
==3714==    indirectly lost: 0 bytes in 0 blocks
==3714==      possibly lost: 0 bytes in 0 blocks
==3714==    still reachable: 99,944 bytes in 3,385 blocks
==3714==         suppressed: 0 bytes in 0 blocks
==3714== Rerun with --leak-check=full to see details of leaked memory
==3714== 
==3714== For lists of detected and suppressed errors, rerun with: -s
==3714== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1057
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
