### PR TITLE
output_upstream: set FLB_IO_TCP_KA flag when net.keepalive is true.

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1309,6 +1309,11 @@ int flb_output_upstream_set(struct flb_upstream *u, struct flb_output_instance *
     if (ins->host.ipv6 == FLB_TRUE) {
         flags |= FLB_IO_IPV6;
     }
+    
+    /* keepalive */
+    if (ins->net_setup.keepalive == FLB_TRUE) {
+        flags |= FLB_IO_TCP_KA;
+    }
 
     /* Set flags */
     flb_stream_enable_flags(&u->base, flags);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #6977 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change

**Test Case: net.keepalive on**
configuration:
```
[SERVICE]
    Flush         5
    Log_Level     debug
    Log_File      /usr/local/logs/fluent-bit.log
    Daemon        off
    HTTP_Server   On
    HTTP_Listen   0.0.0.0
    HTTP_Port     2020

[INPUT]
    Name              cpu
    Tag               demo

[OUTPUT]
    Name          forward
    Match_Regex   *
    Host          <fluentd host>
    Port          43000
    Retry_Limit   2
    net.keepalive on
```
Debug log output:
```
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [fluent bit] version=2.1.0, commit=6ee3b8a05d, pid=1191
[1m[[0m2023/03/10 12:58:38[1m][0m [[93mdebug[0m] [engine] coroutine stack size: 24576 bytes (24.0K)
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [cmetrics] version=0.5.8
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [ctraces ] version=0.3.0
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [input:cpu:cpu.0] initializing
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[1m[[0m2023/03/10 12:58:38[1m][0m [[93mdebug[0m] [cpu:cpu.0] created event channels: read=21 write=22
[1m[[0m2023/03/10 12:58:38[1m][0m [[93mdebug[0m] [forward:forward.0] created event channels: read=23 write=24
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [output:forward:forward.0] worker #1 started
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [output:forward:forward.0] worker #0 started
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [http_server] listen iface=0.0.0.0 tcp_port=2020
[1m[[0m2023/03/10 12:58:38[1m][0m [[92m info[0m] [sp] stream processor started
[1m[[0m2023/03/10 12:58:38[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:39[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:40[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:41[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [task] created task=0x7fc4f8035b40 id=0 OK
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 500 bytes to flush
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is connected
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is now available
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=0
[1m[[0m2023/03/10 12:58:42[1m][0m [[93mdebug[0m] [task] destroy task=0x7fc4f8035b40 (task_id=0)
[1m[[0m2023/03/10 12:58:43[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:44[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:45[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:46[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [task] created task=0x7fc4f8039210 id=0 OK
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #1
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [upstream] KA connection #62 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is connected
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [upstream] KA connection #62 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is now available
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=0
[1m[[0m2023/03/10 12:58:47[1m][0m [[93mdebug[0m] [task] destroy task=0x7fc4f8039210 (task_id=0)
[1m[[0m2023/03/10 12:58:48[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:49[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:50[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:51[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [task] created task=0x7fc4f8038ca0 id=0 OK
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 has been assigned (recycled)
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is now available
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=1
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:52[1m][0m [[93mdebug[0m] [task] destroy task=0x7fc4f8038ca0 (task_id=0)
[1m[[0m2023/03/10 12:58:53[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:54[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:55[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:56[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [task] created task=0x7fc4f8035b40 id=0 OK
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #1
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [upstream] KA connection #62 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 has been assigned (recycled)
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [upstream] KA connection #62 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is now available
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=1
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:57[1m][0m [[93mdebug[0m] [task] destroy task=0x7fc4f8035b40 (task_id=0)
[1m[[0m2023/03/10 12:58:58[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [task] created task=0x7fc4f8035b40 id=0 OK
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 250 bytes to flush
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 has been assigned (recycled)
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [upstream] KA connection #61 to ec2-35-86-108-178.us-west-2.compute.amazonaws.com:43000 is now available
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=2
[1m[[0m2023/03/10 12:58:59[1m][0m [[93m warn[0m] [engine] service will shutdown in max 5 seconds
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [input] pausing cpu.0
[1m[[0m2023/03/10 12:58:59[1m][0m [[93mdebug[0m] [task] destroy task=0x7fc4f8035b40 (task_id=0)
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [engine] service has stopped (0 pending tasks)
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [input] pausing cpu.0
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #0 stopping...
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #0 stopped
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #1 stopping...
[1m[[0m2023/03/10 12:58:59[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #1 stopped
```
network packages:
![keepalive-on](https://user-images.githubusercontent.com/6380723/224334734-3e85c611-fcd1-4bf6-a862-bf2738ed8f1a.png)

**Test Case: net.keepalive off**
configuration:
```
[SERVICE]
    Flush         5
    Log_Level     debug
    Log_File      /usr/local/logs/fluent-bit.log
    Daemon        off
    HTTP_Server   On
    HTTP_Listen   0.0.0.0
    HTTP_Port     2020

[INPUT]
    Name              cpu
    Tag               demo

[OUTPUT]
    Name          forward
    Match_Regex   *
    Host          <fluentd host>
    Port          43000
    Retry_Limit   2
    net.keepalive off
```
Debug log output:
```
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [fluent bit] version=2.1.0, commit=6ee3b8a05d, pid=1301
[1m[[0m2023/03/10 13:01:06[1m][0m [[93mdebug[0m] [engine] coroutine stack size: 24576 bytes (24.0K)
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [cmetrics] version=0.5.8
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [ctraces ] version=0.3.0
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [input:cpu:cpu.0] initializing
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[1m[[0m2023/03/10 13:01:06[1m][0m [[93mdebug[0m] [cpu:cpu.0] created event channels: read=21 write=22
[1m[[0m2023/03/10 13:01:06[1m][0m [[93mdebug[0m] [forward:forward.0] created event channels: read=23 write=24
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [output:forward:forward.0] worker #1 started
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [output:forward:forward.0] worker #0 started
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [http_server] listen iface=0.0.0.0 tcp_port=2020
[1m[[0m2023/03/10 13:01:06[1m][0m [[92m info[0m] [sp] stream processor started
[1m[[0m2023/03/10 13:01:07[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:08[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:09[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:10[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [task] created task=0x7f0d4c035b40 id=0 OK
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 500 bytes to flush
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=0
[1m[[0m2023/03/10 13:01:11[1m][0m [[93mdebug[0m] [task] destroy task=0x7f0d4c035b40 (task_id=0)
[1m[[0m2023/03/10 13:01:12[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:13[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:14[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:15[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [task] created task=0x7f0d4c039210 id=0 OK
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #1
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=0
[1m[[0m2023/03/10 13:01:16[1m][0m [[93mdebug[0m] [task] destroy task=0x7f0d4c039210 (task_id=0)
[1m[[0m2023/03/10 13:01:17[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:18[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:19[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:20[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [task] created task=0x7f0d4c038ca0 id=0 OK
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=1
[1m[[0m2023/03/10 13:01:21[1m][0m [[93mdebug[0m] [task] destroy task=0x7f0d4c038ca0 (task_id=0)
[1m[[0m2023/03/10 13:01:22[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:23[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:24[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:25[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [task] created task=0x7f0d4c035b40 id=0 OK
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #1
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 625 bytes to flush
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=1
[1m[[0m2023/03/10 13:01:26[1m][0m [[93mdebug[0m] [task] destroy task=0x7f0d4c035b40 (task_id=0)
[1m[[0m2023/03/10 13:01:27[1m][0m [[93mdebug[0m] [input chunk] update output instances with new chunk size diff=125
[1m[[0m2023/03/10 13:01:28[1m][0m [[93mdebug[0m] [task] created task=0x7f0d4c035b40 id=0 OK
[1m[[0m2023/03/10 13:01:28[1m][0m [[93mdebug[0m] [output:forward:forward.0] task_id=0 assigned to thread #0
[1m[[0m2023/03/10 13:01:28[1m][0m [[93mdebug[0m] [output:forward:forward.0] request 250 bytes to flush
[1m[[0m2023/03/10 13:01:28[1m][0m [[93m warn[0m] [engine] service will shutdown in max 5 seconds
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [input] pausing cpu.0
[1m[[0m2023/03/10 13:01:28[1m][0m [[93mdebug[0m] [out flush] cb_destroy coro_id=2
[1m[[0m2023/03/10 13:01:28[1m][0m [[93mdebug[0m] [task] destroy task=0x7f0d4c035b40 (task_id=0)
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [engine] service has stopped (0 pending tasks)
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [input] pausing cpu.0
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #0 stopping...
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #0 stopped
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #1 stopping...
[1m[[0m2023/03/10 13:01:28[1m][0m [[92m info[0m] [output:forward:forward.0] thread worker #1 stopped
```
![keepalive-off](https://user-images.githubusercontent.com/6380723/224335140-f2f53676-c723-4fd7-b373-18a06939bd1f.png)

As we can see from log output and network packages, after the modification, when keepalive is turned on, the tcp connections can be recycled normal, when keepalive is turned off, the tcp connections will be released after the data is flushed.

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind bin/fluent-bit -c fluent-bit.conf 
==1383== Memcheck, a memory error detector
==1383== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1383== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==1383== Command: bin/fluent-bit -c fluent-bit.conf
==1383== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

ret=-113. start=* end=
[2023/03/10 13:03:03] [ info] Configuration:
[2023/03/10 13:03:03] [ info]  flush time     | 5.000000 seconds
[2023/03/10 13:03:03] [ info]  grace          | 5 seconds
[2023/03/10 13:03:03] [ info]  daemon         | 0
[2023/03/10 13:03:03] [ info] ___________
[2023/03/10 13:03:03] [ info]  inputs:
[2023/03/10 13:03:03] [ info]      cpu
[2023/03/10 13:03:03] [ info] ___________
[2023/03/10 13:03:03] [ info]  filters:
[2023/03/10 13:03:03] [ info] ___________
[2023/03/10 13:03:03] [ info]  outputs:
[2023/03/10 13:03:03] [ info]      forward.0
[2023/03/10 13:03:03] [ info] ___________
[2023/03/10 13:03:03] [ info]  collectors:
==1383== Warning: client switching stacks?  SP change: 0x987d788 --> 0x7e56a10
==1383==          to suppress, use: --max-stackframe=27422072 or greater
==1383== Warning: client switching stacks?  SP change: 0x7e56988 --> 0x987d788
==1383==          to suppress, use: --max-stackframe=27422208 or greater
==1383== Warning: client switching stacks?  SP change: 0x987d788 --> 0x7e56988
==1383==          to suppress, use: --max-stackframe=27422208 or greater
==1383==          further instances of this message will not be shown.
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
