### PR TITLE
output: backport of PR 6992

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1310,6 +1310,11 @@ int flb_output_upstream_set(struct flb_upstream *u, struct flb_output_instance *
         flags |= FLB_IO_IPV6;
     }
 
+    /* keepalive */
+    if (ins->net_setup.keepalive == FLB_TRUE) {
+        flags |= FLB_IO_TCP_KA;
+    }
+
     /* Set flags */
     flb_stream_enable_flags(&u->base, flags);
 


### PR DESCRIPTION
This PR fixes a bug in the base code that sets up an output plugins upstream which previously missed the keepalive flag.