### PR TITLE
filter_rewrite_tag: skip if incoming data is not array

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -409,6 +409,9 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
         root = result.data;
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
         map = root.via.array.ptr[1];
         is_matched = FLB_FALSE;
         /*


### PR DESCRIPTION
This patch is to mitigate issue #6991.

#6991 is caused by invalid incoming data.
Filter plugins and output plugins expect incoming data is array.
If no array types are passed , it can cause SIGSEGV.
Some plugins skip if incoming data is not array.

https://github.com/fluent/fluent-bit/blob/v2.0.9/plugins/filter_record_modifier/filter_modifier.c#L342

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output 

```
$ valgrind --leak-check=full bin/flb-rt-filter_rewrite_tag 
==16798== Memcheck, a memory error detector
==16798== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16798== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==16798== Command: bin/flb-rt-filter_rewrite_tag
==16798== 
Test matched...                                 [ OK ]
Test not_matched...                             [ OK ]
Test keep_true...                               [ OK ]
Test heavy_input_pause_emitter...               [ OK ]
Test issue_4518...                              [ OK ]
Test issue_4793...                              [ OK ]
Test sigsegv_issue_5846...                      [ OK ]
SUCCESS: All unit tests have passed.
==16798== 
==16798== HEAP SUMMARY:
==16798==     in use at exit: 0 bytes in 0 blocks
==16798==   total heap usage: 921,763 allocs, 921,763 frees, 2,051,228,684 bytes allocated
==16798== 
==16798== All heap blocks were freed -- no leaks are possible
==16798== 
==16798== For lists of detected and suppressed errors, rerun with: -s
==16798== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
