### PR TITLE
out_opentelemetry: fix some warnings

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -820,7 +820,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
         log_object = msgpack_object_to_otlp_any_value(obj);
 
         if (log_object == NULL) {
-            flb_plg_error(ins, "log event conversion failure");
+            flb_plg_error(ctx->ins, "log event conversion failure");
             res = FLB_ERROR;
             continue;
         }

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -71,7 +71,7 @@ static void check_proxy(struct flb_output_instance *ins,
                         char *host, char *port,
                         char *protocol, char *uri){
 
-    char *tmp = NULL;
+    const char *tmp = NULL;
     int ret;
     tmp = flb_output_get_property("proxy", ins);
     if (tmp) {
@@ -132,7 +132,7 @@ struct opentelemetry_context *flb_opentelemetry_context_create(
     char *logs_uri = NULL;
     struct flb_upstream *upstream;
     struct opentelemetry_context *ctx = NULL;
-    char *tmp = NULL;
+    const char *tmp = NULL;
 
     /* Allocate plugin context */
     ctx = flb_calloc(1, sizeof(struct opentelemetry_context));


### PR DESCRIPTION
This patch is to suppress some warnings.

opentelemetry.c: 
```
[ 46%] Building C object plugins/out_opentelemetry/CMakeFiles/flb-plugin-out_opentelemetry.dir/opentelemetry.c.o
In file included from /home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry.c:20:
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry.c: In function ‘process_logs’:
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry.c:823:27: warning: passing argument 1 of ‘flb_output_plugin_log_suppress_check’ from incompatible pointer type [-Wincompatible-pointer-types]
  823 |             flb_plg_error(ins, "log event conversion failure");
      |                           ^~~
      |                           |
      |                           struct flb_input_instance *
/home/taka/git/fluent-bit/include/fluent-bit/flb_output_plugin.h:63:50: note: in definition of macro ‘flb_plg_error’
   63 |         if (flb_output_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
      |                                                  ^~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_output_plugin.h:32:84: note: expected ‘struct flb_output_instance *’ but argument is of type ‘struct flb_input_instance *’
   32 | static inline int flb_output_plugin_log_suppress_check(struct flb_output_instance *ins, const char *fmt, ...)
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry.c:823:27: warning: passing argument 1 of ‘flb_output_name’ from incompatible pointer type [-Wincompatible-pointer-types]
  823 |             flb_plg_error(ins, "log event conversion failure");
      |                           ^~~
      |                           |
      |                           struct flb_input_instance *
/home/taka/git/fluent-bit/include/fluent-bit/flb_output_plugin.h:65:57: note: in definition of macro ‘flb_plg_error’
   65 |                           ctx->p->name, flb_output_name(ctx), ##__VA_ARGS__)
      |                                                         ^~~
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_output_plugin.h:24,
                 from /home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry.c:20:
/home/taka/git/fluent-bit/include/fluent-bit/flb_output.h:744:57: note: expected ‘struct flb_output_instance *’ but argument is of type ‘struct flb_input_instance *’
  744 | const char *flb_output_name(struct flb_output_instance *in);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

opentelemetry_conf.c:
```
[ 46%] Building C object plugins/out_opentelemetry/CMakeFiles/flb-plugin-out_opentelemetry.dir/opentelemetry_conf.c.o
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry_conf.c: In function ‘check_proxy’:
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry_conf.c:76:9: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   76 |     tmp = flb_output_get_property("proxy", ins);
      |         ^
```

```
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry_conf.c: In function ‘flb_opentelemetry_context_create’:
/home/taka/git/fluent-bit/plugins/out_opentelemetry/opentelemetry_conf.c:236:9: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  236 |     tmp = flb_output_get_property("compress", ins);
      |         ^
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
