### PR TITLE
parser: fix warning that pass size_t as a field precision specifier

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -1148,10 +1148,10 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
 
     if (p == NULL) {
         if (parser->time_strict) {
-            flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
+            flb_error("[parser] cannot parse '%.*s'", (int)tsize, time_str);
             return -1;
         }
-        flb_debug("[parser] non-exact match '%.*s'", tsize, time_str);
+        flb_debug("[parser] non-exact match '%.*s'", (int)tsize, time_str);
         return 0;
     }
 
@@ -1159,10 +1159,10 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
         ret = parse_subseconds(p, time_len - (p - time_ptr), ns);
         if (ret < 0) {
             if (parser->time_strict) {
-                flb_error("[parser] cannot parse %%L for '%.*s'", tsize, time_str);
+                flb_error("[parser] cannot parse %%L for '%.*s'", (int)tsize, time_str);
                 return -1;
             }
-            flb_debug("[parser] non-exact match on %%L '%.*s'", tsize, time_str);
+            flb_debug("[parser] non-exact match on %%L '%.*s'", (int)tsize, time_str);
             return 0;
         }
         p += ret;
@@ -1171,10 +1171,10 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
         p = flb_strptime(p, parser->time_frac_secs, tm);
         if (p == NULL) {
             if (parser->time_strict) {
-                flb_error("[parser] cannot parse '%.*s' after %%L", tsize, time_str);
+                flb_error("[parser] cannot parse '%.*s' after %%L", (int)tsize, time_str);
                 return -1;
             }
-            flb_debug("[parser] non-exact match after %%L '%.*s'", tsize, time_str);
+            flb_debug("[parser] non-exact match after %%L '%.*s'", (int)tsize, time_str);
             return 0;
         }
     }


### PR DESCRIPTION
This patch is to suppress following warnings.

```
[ 74%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_parser.c.o
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c: In function ‘flb_parser_time_lookup’:
/home/taka/git/fluent-bit/src/flb_parser.c:1151:23: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1151 |             flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                       |
      |                                                       size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:141:47: note: in definition of macro ‘flb_error’
  141 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1151:49: note: format string is defined here
 1151 |             flb_error("[parser] cannot parse '%.*s'", tsize, time_str);
      |                                               ~~^~
      |                                                 |
      |                                                 int
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c:1154:19: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1154 |         flb_debug("[parser] non-exact match '%.*s'", tsize, time_str);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                      |
      |                                                      size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1154:48: note: format string is defined here
 1154 |         flb_debug("[parser] non-exact match '%.*s'", tsize, time_str);
      |                                              ~~^~
      |                                                |
      |                                                int
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c:1162:27: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1162 |                 flb_error("[parser] cannot parse %%L for '%.*s'", tsize, time_str);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                                   |
      |                                                                   size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:141:47: note: in definition of macro ‘flb_error’
  141 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1162:61: note: format string is defined here
 1162 |                 flb_error("[parser] cannot parse %%L for '%.*s'", tsize, time_str);
      |                                                           ~~^~
      |                                                             |
      |                                                             int
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c:1165:23: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1165 |             flb_debug("[parser] non-exact match on %%L '%.*s'", tsize, time_str);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                                 |
      |                                                                 size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1165:59: note: format string is defined here
 1165 |             flb_debug("[parser] non-exact match on %%L '%.*s'", tsize, time_str);
      |                                                         ~~^~
      |                                                           |
      |                                                           int
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c:1174:27: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1174 |                 flb_error("[parser] cannot parse '%.*s' after %%L", tsize, time_str);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                                     |
      |                                                                     size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:141:47: note: in definition of macro ‘flb_error’
  141 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1174:53: note: format string is defined here
 1174 |                 flb_error("[parser] cannot parse '%.*s' after %%L", tsize, time_str);
      |                                                   ~~^~
      |                                                     |
      |                                                     int
In file included from /home/taka/git/fluent-bit/src/flb_parser.c:21:
/home/taka/git/fluent-bit/src/flb_parser.c:1177:23: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1177 |             flb_debug("[parser] non-exact match after %%L '%.*s'", tsize, time_str);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                                                    |
      |                                                                    size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/src/flb_parser.c:1177:62: note: format string is defined here
 1177 |             flb_debug("[parser] non-exact match after %%L '%.*s'", tsize, time_str);
      |                                                            ~~^~
      |                                                              |
      |                                                              int
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.



<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
