### PR TITLE
sp: release name and exec after using

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -59,8 +59,8 @@ static int sp_config_file(struct flb_config *config, struct flb_sp *sp,
                           const char *file)
 {
     int ret;
-    char *name;
-    char *exec;
+    flb_sds_t name;
+    flb_sds_t exec;
     char *cfg = NULL;
     char tmp[PATH_MAX + 1];
     struct stat st;
@@ -125,12 +125,22 @@ static int sp_config_file(struct flb_config *config, struct flb_sp *sp,
         if (!task) {
             goto fconf_error;
         }
+        flb_sds_destroy(name);
+        flb_sds_destroy(exec);
+        name = NULL;
+        exec = NULL;
     }
 
     flb_cf_destroy(cf);
     return 0;
 
 fconf_error:
+    if (name) {
+        flb_sds_destroy(name);
+    }
+    if (exec) {
+        flb_sds_destroy(exec);
+    }
     flb_cf_destroy(cf);
     return -1;
 }


### PR DESCRIPTION
This patch is to fix following stream processor leak.
It detected `name` and `exec` were lost.

`flb_cf_section_property_get_string` allocates and returns flb_sds_t and it is passed to `flb_sp_task_create`.
`flb_sp_task_create` also creates flb_sds_t from `name` and `exec`.
So we should release `name` and `exec` after passing.

```
==40140== 
==40140== HEAP SUMMARY:
==40140==     in use at exit: 172 bytes in 2 blocks
==40140==   total heap usage: 4,596 allocs, 4,594 frees, 576,266 bytes allocated
==40140== 
==40140== 23 bytes in 1 blocks are definitely lost in loss record 1 of 2
==40140==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==40140==    by 0x1B9657: flb_malloc (flb_mem.h:80)
==40140==    by 0x1B983A: sds_alloc (flb_sds.c:41)
==40140==    by 0x1B98C1: flb_sds_create_len (flb_sds.c:62)
==40140==    by 0x1B9967: flb_sds_create (flb_sds.c:88)
==40140==    by 0x242C90: flb_cf_section_property_get_string (flb_config_format.c:301)
==40140==    by 0xA5C5E3: sp_config_file (flb_sp.c:110)
==40140==    by 0xA5DAEB: flb_sp_create (flb_sp.c:703)
==40140==    by 0x2028C8: flb_engine_start (flb_engine.c:802)
==40140==    by 0x1A1B1F: flb_lib_worker (flb_lib.c:629)
==40140==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==40140==    by 0x5068BB3: clone (clone.S:100)
==40140== 
==40140== 149 bytes in 1 blocks are definitely lost in loss record 2 of 2
==40140==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==40140==    by 0x1B9657: flb_malloc (flb_mem.h:80)
==40140==    by 0x1B983A: sds_alloc (flb_sds.c:41)
==40140==    by 0x1B98C1: flb_sds_create_len (flb_sds.c:62)
==40140==    by 0x1B9967: flb_sds_create (flb_sds.c:88)
==40140==    by 0x242C90: flb_cf_section_property_get_string (flb_config_format.c:301)
==40140==    by 0xA5C658: sp_config_file (flb_sp.c:117)
==40140==    by 0xA5DAEB: flb_sp_create (flb_sp.c:703)
==40140==    by 0x2028C8: flb_engine_start (flb_engine.c:802)
==40140==    by 0x1A1B1F: flb_lib_worker (flb_lib.c:629)
==40140==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==40140==    by 0x5068BB3: clone (clone.S:100)
==40140== 
==40140== LEAK SUMMARY:
==40140==    definitely lost: 172 bytes in 2 blocks
==40140==    indirectly lost: 0 bytes in 0 blocks
==40140==      possibly lost: 0 bytes in 0 blocks
==40140==    still reachable: 0 bytes in 0 blocks
==40140==         suppressed: 0 bytes in 0 blocks
==40140== 
==40140== For lists of detected and suppressed errors, rerun with: -s
==40140== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

Log file is [here](https://raw.githubusercontent.com/fluent/fluent-bit-docs/37b477786d6e28eb223e08611c26ec93671a34ac/stream-processing/samples/sp-samples-1k.log)

a.conf:
```
[SERVICE]
    Streams_File stream.conf
    Parsers_File parsers.conf

[INPUT]
    Name tail
    Path sp-samples-1k.log
    Parser json
    Read_From_Head true

[OUTPUT]
    Name stdout
    Match test
```

stream.conf:
```
[STREAM_TASK]
    Name sample
    Exec CREATE STREAM test WITH (tag='test') AS SELECT word, num, COUNT(*) FROM STREAM:tail.0 WINDOW TUMBLING (1 MINUTE) GROUP BY word, num;
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/git/WORKTREE/fix_5629/build/a.conf 
==37619== Memcheck, a memory error detector
==37619== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==37619== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==37619== Command: bin/fluent-bit -c /home/taka/git/WORKTREE/fix_5629/build/a.conf
==37619== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/12 09:00:33] [ info] [fluent bit] version=2.1.0, commit=21a2148171, pid=37619
[2023/03/12 09:00:33] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/12 09:00:33] [ info] [cmetrics] version=0.5.8
[2023/03/12 09:00:33] [ info] [ctraces ] version=0.3.0
[2023/03/12 09:00:33] [ info] [input:tail:tail.0] initializing
[2023/03/12 09:00:33] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/03/12 09:00:33] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/12 09:00:33] [ info] [input:stream_processor:test] initializing
[2023/03/12 09:00:33] [ info] [input:stream_processor:test] storage_strategy=(null)
[2023/03/12 09:00:33] [ info] [sp] stream processor started
[2023/03/12 09:00:33] [ info] [sp] registered task: sample
^C[2023/03/12 09:00:34] [engine] caught signal (SIGINT)
[2023/03/12 09:00:34] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/12 09:00:34] [ info] [input] pausing tail.0
[2023/03/12 09:00:34] [ info] [input] pausing test
[2023/03/12 09:00:34] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/12 09:00:34] [ info] [input] pausing tail.0
[2023/03/12 09:00:34] [ info] [input] pausing test
[2023/03/12 09:00:34] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/12 09:00:34] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==37619== 
==37619== HEAP SUMMARY:
==37619==     in use at exit: 0 bytes in 0 blocks
==37619==   total heap usage: 4,596 allocs, 4,596 frees, 576,266 bytes allocated
==37619== 
==37619== All heap blocks were freed -- no leaks are possible
==37619== 
==37619== For lists of detected and suppressed errors, rerun with: -s
==37619== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
