### PR TITLE
sp: prevent converting from string to num if config is set

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -235,6 +235,7 @@ struct flb_config {
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     char *stream_processor_file;            /* SP configuration file */
     void *stream_processor_ctx;             /* SP context */
+    int  stream_processor_str_conv;         /* SP enable converting from string to number */
 
     /*
      * Temporal list to hold tasks defined before the SP context is created
@@ -307,6 +308,7 @@ enum conf_type {
 #define FLB_CONF_STR_PARSERS_FILE "Parsers_File"
 #define FLB_CONF_STR_PLUGINS_FILE "Plugins_File"
 #define FLB_CONF_STR_STREAMS_FILE "Streams_File"
+#define FLB_CONF_STR_STREAMS_STR_CONV "sp.convert_from_str_to_num"
 #define FLB_CONF_STR_CONV_NAN     "json.convert_nan_to_null"
 
 /* FLB_HAVE_HTTP_SERVER */

--- a/include/fluent-bit/stream_processor/flb_sp.h
+++ b/include/fluent-bit/stream_processor/flb_sp.h
@@ -171,7 +171,7 @@ int sp_process_data(const char *tag, int tag_len,
 int sp_process_data_aggr(const char *buf_data, size_t buf_size,
                          const char *tag, int tag_len,
                          struct flb_sp_task *task,
-                         struct flb_sp *sp);
+                         struct flb_sp *sp, int convert_str_to_num);
 void package_results(const char *tag, int tag_len,
                      char **out_buf, size_t *out_size,
                      struct flb_sp_task *task);

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -164,6 +164,9 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STR_STREAMS_FILE,
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, stream_processor_file)},
+    {FLB_CONF_STR_STREAMS_STR_CONV,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, stream_processor_str_conv)},
 #endif
 
 #ifdef FLB_HAVE_CHUNK_TRACE
@@ -273,6 +276,7 @@ struct flb_config *flb_config_init()
 
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     flb_slist_create(&config->stream_processor_tasks);
+    config->stream_processor_str_conv = FLB_TRUE;
 #endif
 
     /* Set default coroutines stack size */

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -339,7 +339,8 @@ static int string_to_number(const char *str, int len, int64_t *i, double *d)
  *
  * This function aims to take care of strings representing a value too.
  */
-static int object_to_number(msgpack_object obj, int64_t *i, double *d)
+static int object_to_number(msgpack_object obj, int64_t *i, double *d,
+                            int convert_str_to_num)
 {
     int ret;
     int64_t i_out;
@@ -356,7 +357,7 @@ static int object_to_number(msgpack_object obj, int64_t *i, double *d)
         *d = obj.via.f64;
         return FLB_STR_FLOAT;
     }
-    else if (obj.type == MSGPACK_OBJECT_STR) {
+    else if (obj.type == MSGPACK_OBJECT_STR && convert_str_to_num == FLB_TRUE) {
         /* A numeric representation of a string should not exceed 19 chars */
         if (obj.via.str.size > 19) {
             return -1;
@@ -1220,7 +1221,8 @@ next:
 }
 
 static struct aggregate_node * sp_process_aggregate_data(struct flb_sp_task *task,
-                                                         msgpack_object map)
+                                                         msgpack_object map,
+                                                         int convert_str_to_num)
 {
     int i;
     int ret;
@@ -1279,7 +1281,7 @@ static struct aggregate_node * sp_process_aggregate_data(struct flb_sp_task *tas
                 values_found++;
 
                 /* Convert string to number if that is possible */
-                ret = object_to_number(sval->o, &ival, &dval);
+                ret = object_to_number(sval->o, &ival, &dval, convert_str_to_num);
                 if (ret == -1) {
                     if (sval->o.type == MSGPACK_OBJECT_STR) {
                         gb_nums[key_id].type = FLB_SP_STRING;
@@ -1376,7 +1378,8 @@ static struct aggregate_node * sp_process_aggregate_data(struct flb_sp_task *tas
 int sp_process_data_aggr(const char *buf_data, size_t buf_size,
                          const char *tag, int tag_len,
                          struct flb_sp_task *task,
-                         struct flb_sp *sp)
+                         struct flb_sp *sp,
+                         int convert_str_to_num)
 {
     int i;
     int ok;
@@ -1435,7 +1438,7 @@ int sp_process_data_aggr(const char *buf_data, size_t buf_size,
             }
         }
 
-        aggr_node = sp_process_aggregate_data(task, map);
+        aggr_node = sp_process_aggregate_data(task, map, convert_str_to_num);
         if (!aggr_node)
         {
             continue;
@@ -1491,7 +1494,7 @@ int sp_process_data_aggr(const char *buf_data, size_t buf_size,
                 ival = 0;
                 dval = 0.0;
                 if (ckey->aggr_func != FLB_SP_NOP) {
-                    ret = object_to_number(sval->o, &ival, &dval);
+                    ret = object_to_number(sval->o, &ival, &dval, convert_str_to_num);
                     if (ret == -1) {
                         /* Value cannot be represented as a number */
                         key_id++;
@@ -1981,7 +1984,7 @@ int flb_sp_do(struct flb_sp *sp, struct flb_input_instance *in,
         if (task->aggregate_keys == FLB_TRUE) {
             ret = sp_process_data_aggr(buf_data, buf_size,
                                        tag, tag_len,
-                                       task, sp);
+                                       task, sp, in->config->stream_processor_str_conv);
 
             if (ret == -1) {
                 flb_error("[sp] error processing records for '%s'",

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -23,10 +23,12 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_router.h>
+#include <fluent-bit/flb_storage.h>
 #include <fluent-bit/stream_processor/flb_sp.h>
 #include <fluent-bit/stream_processor/flb_sp_parser.h>
 #include <fluent-bit/stream_processor/flb_sp_stream.h>
 #include <fluent-bit/stream_processor/flb_sp_window.h>
+#include <msgpack.h>
 
 #include "flb_tests_internal.h"
 #include "include/sp_invalid_queries.h"
@@ -107,7 +109,7 @@ int flb_sp_do_test(struct flb_sp *sp, struct flb_sp_task *task,
     if (task->aggregate_keys == FLB_TRUE) {
         ret = sp_process_data_aggr(data_buf->buffer, data_buf->size,
                                    tag, tag_len,
-                                   task, sp);
+                                   task, sp, FLB_TRUE);
         if (ret == -1) {
             flb_error("[sp] error error processing records for '%s'",
                       task->name);
@@ -119,8 +121,7 @@ int flb_sp_do_test(struct flb_sp *sp, struct flb_sp_task *task,
                       task->name);
             return -1;
         }
-
-        if (task->window.type == FLB_SP_WINDOW_DEFAULT) {
+        if (task->window.type == FLB_SP_WINDOW_DEFAULT || task->window.type == FLB_SP_WINDOW_TUMBLING) {
             package_results(tag, tag_len, &out_buf->buffer, &out_buf->size, task);
         }
 
@@ -744,11 +745,143 @@ static void test_snapshot()
 #endif
 }
 
+static void test_conv_from_str_to_num()
+{
+    struct flb_config *config = NULL;
+    struct flb_sp *sp = NULL;
+    struct flb_sp_task *task = NULL;
+    struct sp_buffer out_buf;
+    struct sp_buffer data_buf;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pck;
+    msgpack_unpacked result;
+    size_t off = 0;
+    char json[4096] = {0};
+    int ret;
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+
+    WSAStartup(0x0201, &wsa_data);
+#endif
+    out_buf.buffer = NULL;
+
+    config = flb_config_init();
+    config->evl = mk_event_loop_create(256);
+
+    ret = flb_storage_create(config);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_storage_create failed");
+        flb_config_exit(config);
+        return;
+    }
+
+    sp = flb_sp_create(config);
+    if (!TEST_CHECK(sp != NULL)) {
+        TEST_MSG("[sp test] cannot create stream processor context");
+        goto test_conv_from_str_to_num_end;
+    }
+
+    task = flb_sp_task_create(sp, "tail.0", "CREATE STREAM test WITH (tag=\'test\') AS SELECT word, num, COUNT(*) FROM STREAM:tail.0 WINDOW TUMBLING (1 SECOND) GROUP BY word, num;");
+    if (!TEST_CHECK(task != NULL)) {
+        TEST_MSG("[sp test] wrong check 'conv', fix it!");
+        goto test_conv_from_str_to_num_end;
+    }
+
+    /* Create input data */
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&pck, 2);
+    flb_pack_time_now(&pck);
+    msgpack_pack_map(&pck, 2);
+    
+    msgpack_pack_str(&pck, 4);
+    msgpack_pack_str_body(&pck, "word", 4);
+    msgpack_pack_str(&pck, 4);
+    msgpack_pack_str_body(&pck, "hoge", 4);
+
+    msgpack_pack_str(&pck, 3);
+    msgpack_pack_str_body(&pck, "num", 3);
+    msgpack_pack_str(&pck, 6);
+    msgpack_pack_str_body(&pck, "123456", 6);
+
+    data_buf.buffer = sbuf.data;
+    data_buf.size = sbuf.size;
+
+    out_buf.buffer = NULL;
+    out_buf.size = 0;
+
+    /* Exec stream processor */
+    ret = flb_sp_do_test(sp, task, "tail.0", strlen("tail.0"), &data_buf, &out_buf);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_sp_do_test failed");
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+
+    if (!TEST_CHECK(out_buf.size > 0)) {
+        TEST_MSG("out_buf size is 0");
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+
+
+    /* Check output buffer. It should contain a number 123456 not a string "123456" */
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, out_buf.buffer, out_buf.size, &off);
+    if (!TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("failed to unpack ret=%d", ret);
+        msgpack_unpacked_destroy(&result);
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+
+    ret = flb_msgpack_to_json(&json[0], sizeof(json), &result.data);
+    if (!TEST_CHECK(ret > 0)) {
+        TEST_MSG("flb_msgpack_to_json failed");
+        msgpack_unpacked_destroy(&result);
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+
+    if (!TEST_CHECK(strstr(json,"123456") != NULL)) {
+        TEST_MSG("number not found");
+        msgpack_unpacked_destroy(&result);
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+    if (!TEST_CHECK(strstr(json,"\"123456\"") == NULL)) {
+        TEST_MSG("output should be number type");
+        msgpack_unpacked_destroy(&result);
+        msgpack_sbuffer_destroy(&sbuf);
+        goto test_conv_from_str_to_num_end;
+    }
+
+    msgpack_unpacked_destroy(&result);
+    msgpack_sbuffer_destroy(&sbuf);
+
+ test_conv_from_str_to_num_end:
+    if (out_buf.buffer != NULL) {
+        flb_free(out_buf.buffer);
+    }
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
+    if (sp != NULL) {
+        flb_sp_destroy(sp);
+    }
+    flb_storage_destroy(config);
+    flb_config_exit(config);
+}
+
 TEST_LIST = {
     { "invalid_queries", invalid_queries},
     { "select_keys",     test_select_keys},
     { "select_subkeys",  test_select_subkeys},
     { "window",          test_window},
     { "snapshot",        test_snapshot},
+    { "conv_from_str_to_num", test_conv_from_str_to_num},
     { NULL }
 };


### PR DESCRIPTION
This patch is to fix #2498 #5629
TODO: add test code.

This patch is to support following configuration.

|Key|Description|Default|
|--|--|--|
|sp.convert_from_str_to_num|If enabled, Stream processor converts from number string to number type.|true|


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

a.conf:
```
[SERVICE]
    Streams_File stream.conf
    Parsers_File parsers.conf
    sp.convert_from_str_to_num false

[INPUT]
    Name tail
    Path b.log
    Parser json
    Read_From_Head true

[OUTPUT]
    Name stdout
    Match test
```

stream.conf:
```
[STREAM_TASK]
    Name sample
    Exec CREATE STREAM test WITH (tag='test') AS SELECT word, num, COUNT(*) FROM STREAM:tail.0 WINDOW TUMBLING (1 SECOND) GROUP BY word, num;
```

b.log:
```
{"date": "22/abr/2019:12:43:51 -0600", "ip": "73.113.230.135", "word": "balsamine", "country": "Japan", "flag": false, "num": 96}
{"date": "22/abr/2019:12:43:52 -0600", "ip": "242.212.128.227", "word": "23456", "country": "Chile", "flag": false, "num": 15}
{"date": "22/abr/2019:12:43:52 -0600", "ip": "85.61.182.212", "word": "elicits", "country": "Argentina", "flag": true, "num": 73}
```

## Debug/Valgrind output
Following error will be fixed by #7004

```
$ valgrind --leak-check=full bin/fluent-bit -c ~/git/WORKTREE/fix_5629/build/a.conf 
==47513== Memcheck, a memory error detector
==47513== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==47513== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==47513== Command: bin/fluent-bit -c /home/taka/git/WORKTREE/fix_5629/build/a.conf
==47513== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/12 14:18:40] [ info] [fluent bit] version=2.1.0, commit=e209745f5e, pid=47513
[2023/03/12 14:18:40] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/12 14:18:40] [ info] [cmetrics] version=0.5.8
[2023/03/12 14:18:40] [ info] [ctraces ] version=0.3.0
[2023/03/12 14:18:40] [ info] [input:tail:tail.0] initializing
[2023/03/12 14:18:40] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/03/12 14:18:40] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/12 14:18:40] [ info] [input:stream_processor:test] initializing
[2023/03/12 14:18:40] [ info] [input:stream_processor:test] storage_strategy=(null)
[2023/03/12 14:18:40] [ info] [sp] stream processor started
[2023/03/12 14:18:40] [ info] [sp] registered task: sample
[2023/03/12 14:18:40] [ info] [input:tail:tail.0] inotify_fs_add(): inode=4209349 watch_fd=1 name=b.log
[0] test: [1678598379.944006594, {""=>"balsamine", ""=>96, "COUNT(*)"=>1}]
[1] test: [1678598379.956341834, {""=>"23456", ""=>15, "COUNT(*)"=>1}]
[2] test: [1678598379.956385237, {""=>"elicits", ""=>73, "COUNT(*)"=>1}]
^C[2023/03/12 14:19:42] [engine] caught signal (SIGINT)
[2023/03/12 14:19:42] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/12 14:19:42] [ info] [input] pausing tail.0
[2023/03/12 14:19:42] [ info] [input] pausing test
[2023/03/12 14:19:42] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/12 14:19:42] [ info] [input] pausing tail.0
[2023/03/12 14:19:42] [ info] [input] pausing test
[2023/03/12 14:19:42] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=4209349 watch_fd=1
[2023/03/12 14:19:43] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/12 14:19:43] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==47513== 
==47513== HEAP SUMMARY:
==47513==     in use at exit: 172 bytes in 2 blocks
==47513==   total heap usage: 4,981 allocs, 4,979 frees, 3,419,150 bytes allocated
==47513== 
==47513== 23 bytes in 1 blocks are definitely lost in loss record 1 of 2
==47513==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47513==    by 0x1B9657: flb_malloc (flb_mem.h:80)
==47513==    by 0x1B983A: sds_alloc (flb_sds.c:41)
==47513==    by 0x1B98C1: flb_sds_create_len (flb_sds.c:62)
==47513==    by 0x1B9967: flb_sds_create (flb_sds.c:88)
==47513==    by 0x242C87: flb_cf_section_property_get_string (flb_config_format.c:301)
==47513==    by 0xA5C272: sp_config_file (flb_sp.c:110)
==47513==    by 0xA5D787: flb_sp_create (flb_sp.c:704)
==47513==    by 0x2028C2: flb_engine_start (flb_engine.c:802)
==47513==    by 0x1A1B1F: flb_lib_worker (flb_lib.c:629)
==47513==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==47513==    by 0x5068BB3: clone (clone.S:100)
==47513== 
==47513== 149 bytes in 1 blocks are definitely lost in loss record 2 of 2
==47513==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47513==    by 0x1B9657: flb_malloc (flb_mem.h:80)
==47513==    by 0x1B983A: sds_alloc (flb_sds.c:41)
==47513==    by 0x1B98C1: flb_sds_create_len (flb_sds.c:62)
==47513==    by 0x1B9967: flb_sds_create (flb_sds.c:88)
==47513==    by 0x242C87: flb_cf_section_property_get_string (flb_config_format.c:301)
==47513==    by 0xA5C2E7: sp_config_file (flb_sp.c:117)
==47513==    by 0xA5D787: flb_sp_create (flb_sp.c:704)
==47513==    by 0x2028C2: flb_engine_start (flb_engine.c:802)
==47513==    by 0x1A1B1F: flb_lib_worker (flb_lib.c:629)
==47513==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==47513==    by 0x5068BB3: clone (clone.S:100)
==47513== 
==47513== LEAK SUMMARY:
==47513==    definitely lost: 172 bytes in 2 blocks
==47513==    indirectly lost: 0 bytes in 0 blocks
==47513==      possibly lost: 0 bytes in 0 blocks
==47513==    still reachable: 0 bytes in 0 blocks
==47513==         suppressed: 0 bytes in 0 blocks
==47513== 
==47513== For lists of detected and suppressed errors, rerun with: -s
==47513== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
