### PR TITLE
in_winevtlog: fix missing break

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -384,6 +384,7 @@ static void pack_string_inserts(msgpack_packer *mp_pck, PEVT_VARIANT values, DWO
             if (pack_binary(mp_pck, values[i].BinaryVal, values[i].Count)) {
                 pack_nullstr(mp_pck);
             }
+            break;
         default:
             msgpack_pack_str(mp_pck, 1);
             msgpack_pack_str_body(mp_pck, "?", 1);


### PR DESCRIPTION
The missing break was causing an extra `?` string to be packed after packing a binary `StringInsert`; the extra string causes all kinds of problems downstream.

Fixes #7017.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
