### PR TITLE
filter_wasm: skip log on NULL or empty WASM return

### DIFF
--- a/plugins/filter_wasm/filter_wasm.c
+++ b/plugins/filter_wasm/filter_wasm.c
@@ -123,6 +123,13 @@ static int cb_wasm_filter(const void *data, size_t bytes,
             continue;
         }
 
+        
+        if (strlen(ret_val) == 0) { /* Skip record */
+            flb_plg_debug(ctx->ins, "WASM function returned empty string. Skip.");
+            flb_free(ret_val);
+            continue;
+        }
+
         ret = flb_log_event_encoder_begin_record(&log_encoder);
 
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {

--- a/src/wasm/flb_wasm.c
+++ b/src/wasm/flb_wasm.c
@@ -245,6 +245,10 @@ char *flb_wasm_call_function_format_json(struct flb_wasm *fw, const char *functi
     }
     func_result = wasm_runtime_addr_app_to_native(fw->module_inst, func_args[0]);
 
+    if (func_result == NULL) {
+        return NULL;
+    }
+
     return (char *)flb_strdup(func_result);
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR adds two fixes, first, the WASM can return NULL and then it's still converted to a string via `flb_strdup`. Second it adds that it correctly skips the log entry on returning NULL, it also adds that in some languages the return value is still an empty string. I consider that a good tradeoff, as a fully empty result will likely not be useful at all for follow up filters/outputs.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change

```bash
filter_rust-test-1  | filter found: abcd
filter_rust-test-1  | skip log
filter_rust-test-1  | [2023/03/15 06:37:36] [error] [filter:wasm:wasm.0] invalid JSON format. ret: -1, buf: 
filter_rust-test-1  | container_name: test
filter_rust-test-1  | namespace_name: test
```

```bash
filter_rust-test-1  | podName: test
filter_rust-test-1  | filter found: abcd
filter_rust-test-1  | skip log
filter_rust-test-1  | container_name: test
filter_rust-test-1  | namespace_name: test
```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
