### PR TITLE
utils: add plugins_file not found error case

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -110,6 +110,11 @@ void flb_utils_error(int err)
     case FLB_ERR_CORO_STACK_SIZE:
         msg = "invalid coroutine stack size";
         break;
+    case FLB_ERR_CFG_PLUGIN_FILE:
+        msg = "plugins_file not found";
+        break;
+    default:
+        flb_error("(error message is not defined. err=%d)", err);
     }
 
     if (!msg) {


### PR DESCRIPTION
Fixes #7009

Error message of `FLB_ERR_CFG_PLUGIN_FILE` is not defined and it causes #7009 
This patch is to define it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
[SERVICE]
    Plugins_File /home/fluentbit/plugins.conf

[INPUT]
    Name         cpu
    Tag          azure.cpu
    Interval_Sec 3600

[OUTPUT]
    Name         stdout
    Match        *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf -vv
==8544== Memcheck, a memory error detector
==8544== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8544== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==8544== Command: bin/fluent-bit -c a.conf -vv
==8544== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/15 20:04:14] [error] plugins_file not found, aborting.
[2023/03/15 20:04:14] [ info] Configuration:
[2023/03/15 20:04:14] [ info]  flush time     | 1.000000 seconds
[2023/03/15 20:04:14] [ info]  grace          | 5 seconds
[2023/03/15 20:04:14] [ info]  daemon         | 0
[2023/03/15 20:04:14] [ info] ___________
[2023/03/15 20:04:14] [ info]  inputs:
[2023/03/15 20:04:14] [ info]      cpu
[2023/03/15 20:04:14] [ info] ___________
[2023/03/15 20:04:14] [ info]  filters:
[2023/03/15 20:04:14] [ info] ___________
[2023/03/15 20:04:14] [ info]  outputs:
[2023/03/15 20:04:14] [ info]      stdout.0
[2023/03/15 20:04:14] [ info] ___________
[2023/03/15 20:04:14] [ info]  collectors:
[2023/03/15 20:04:14] [ info] [fluent bit] version=2.1.0, commit=21a2148171, pid=8544
[2023/03/15 20:04:14] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/15 20:04:14] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/15 20:04:14] [ info] [cmetrics] version=0.5.8
[2023/03/15 20:04:14] [ info] [ctraces ] version=0.3.0
[2023/03/15 20:04:14] [ info] [input:cpu:cpu.0] initializing
[2023/03/15 20:04:14] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/03/15 20:04:14] [debug] [cpu:cpu.0] created event channels: read=21 write=22
[2023/03/15 20:04:14] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2023/03/15 20:04:14] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/15 20:04:14] [ info] [sp] stream processor started
^C[2023/03/15 20:04:15] [engine] caught signal (SIGINT)
[2023/03/15 20:04:15] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/15 20:04:15] [ info] [input] pausing cpu.0
[2023/03/15 20:04:16] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/15 20:04:16] [ info] [input] pausing cpu.0
[2023/03/15 20:04:16] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/15 20:04:16] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==8544== 
==8544== HEAP SUMMARY:
==8544==     in use at exit: 0 bytes in 0 blocks
==8544==   total heap usage: 1,478 allocs, 1,478 frees, 286,552 bytes allocated
==8544== 
==8544== All heap blocks were freed -- no leaks are possible
==8544== 
==8544== For lists of detected and suppressed errors, rerun with: -s
==8544== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
