### PR TITLE
node_exporter_metrics: textfile: Implement textfile metrics on node_exporter

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -10,6 +10,7 @@ set(src
   ne_time.c
   ne_loadavg.c
   ne_filefd_linux.c
+  ne_textfile.c
   ne_utils.c
   ne_config.c
   ne.c

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -39,6 +39,7 @@
 #include "ne_loadavg.h"
 #include "ne_vmstat_linux.h"
 #include "ne_netdev.h"
+#include "ne_textfile.h"
 
 static int ne_timer_cpu_metrics_cb(struct flb_input_instance *ins,
                                    struct flb_config *config, void *in_context)
@@ -156,6 +157,16 @@ static int ne_timer_filefd_metrics_cb(struct flb_input_instance *ins,
     struct flb_ne *ctx = in_context;
 
     ne_filefd_update(ctx);
+
+    return 0;
+}
+
+static int ne_timer_textfile_metrics_cb(struct flb_input_instance *ins,
+                                        struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    ne_textfile_update(ctx);
 
     return 0;
 }
@@ -294,6 +305,13 @@ static void ne_filefd_update_cb(char *name, void *p1, void *p2)
     ne_filefd_update(ctx);
 }
 
+static void ne_textfile_update_cb(char *name, void *p1, void *p2)
+{
+    struct flb_ne *ctx = p1;
+
+    ne_textfile_update(ctx);
+}
+
 static int ne_update_cb(struct flb_ne *ctx, char *name)
 {
     int ret;
@@ -319,6 +337,7 @@ struct flb_ne_callback ne_callbacks[] = {
     { "vmstat", ne_vmstat_update_cb },
     { "netdev", ne_netdev_update_cb },
     { "filefd", ne_filefd_update_cb },
+    { "textfile", ne_textfile_update_cb },
     { 0 }
 };
 
@@ -353,6 +372,7 @@ static int in_ne_init(struct flb_input_instance *in,
     ctx->coll_vmstat_fd = -1;
     ctx->coll_netdev_fd = -1;
     ctx->coll_filefd_fd = -1;
+    ctx->coll_textfile_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -622,6 +642,26 @@ static int in_ne_init(struct flb_input_instance *in,
                     }
                     ne_filefd_init(ctx);
                 }
+                else if (strncmp(entry->str, "textfile", 8) == 0) {
+                    if (ctx->textfile_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 12;
+                    }
+                    else if (ctx->textfile_scrape_interval > 0) {
+                        /* Create the filefd collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           ne_timer_textfile_metrics_cb,
+                                                           ctx->textfile_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set textfile collector for Node Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_textfile_fd = ret;
+                    }
+                    ne_textfile_init(ctx);
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                     metric_idx = -1;
@@ -701,6 +741,9 @@ static int in_ne_exit(void *data, struct flb_config *config)
                 else if (strncmp(entry->str, "filefd", 6) == 0) {
                     /* nop */
                 }
+                else if (strncmp(entry->str, "textfile", 8) == 0) {
+                    /* nop */
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                 }
@@ -776,6 +819,9 @@ static void in_ne_pause(void *data, struct flb_config *config)
     if (ctx->coll_filefd_fd != -1) {
         flb_input_collector_pause(ctx->coll_filefd_fd, ctx->ins);
     }
+    if (ctx->coll_textfile_fd != -1) {
+        flb_input_collector_pause(ctx->coll_textfile_fd, ctx->ins);
+    }
 }
 
 static void in_ne_resume(void *data, struct flb_config *config)
@@ -818,6 +864,9 @@ static void in_ne_resume(void *data, struct flb_config *config)
     }
     if (ctx->coll_filefd_fd != -1) {
         flb_input_collector_resume(ctx->coll_filefd_fd, ctx->ins);
+    }
+    if (ctx->coll_textfile_fd != -1) {
+        flb_input_collector_resume(ctx->coll_textfile_fd, ctx->ins);
     }
 }
 
@@ -902,10 +951,22 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_TIME, "collector.textfile.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_ne, textfile_scrape_interval),
+     "scrape interval to collect textfile metrics from the node."
+    },
+
+    {
      FLB_CONFIG_MAP_CLIST, "metrics",
      "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,filefd",
      0, FLB_TRUE, offsetof(struct flb_ne, metrics),
      "Comma separated list of keys to enable metrics."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "collector.textfile.path", NULL,
+     0, FLB_TRUE, offsetof(struct flb_ne, path_textfile),
+     "Specify path to collect textfile metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -966,7 +966,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "collector.textfile.path", NULL,
      0, FLB_TRUE, offsetof(struct flb_ne, path_textfile),
-     "Specify path to collect textfile metrics from the node."
+     "Specify file path or directory to collect textfile metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -34,6 +34,7 @@ struct flb_ne {
     /* configuration */
     flb_sds_t path_procfs;
     flb_sds_t path_sysfs;
+    flb_sds_t path_textfile;
     int scrape_interval;
 
     int coll_fd;                                      /* collector fd     */
@@ -55,6 +56,7 @@ struct flb_ne {
     int vmstat_scrape_interval;
     int netdev_scrape_interval;
     int filefd_scrape_interval;
+    int textfile_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_cpufreq_fd;                                /* collector fd (cpufreq)  */
@@ -68,6 +70,7 @@ struct flb_ne {
     int coll_vmstat_fd;                                 /* collector fd (vmstat)    */
     int coll_netdev_fd;                                 /* collector fd (netdev)    */
     int coll_filefd_fd;                                 /* collector fd (filefd)    */
+    int coll_textfile_fd;                               /* collector fd (textfile)  */
 
     /*
      * Metrics Contexts
@@ -141,6 +144,9 @@ struct flb_ne {
     struct flb_regex *fs_regex_read_only;
     struct flb_regex *fs_regex_skip_mount;
     struct flb_regex *fs_regex_skip_fs_types;
+
+    /* testfile */
+    struct cmt_counter *load_errors;
 };
 
 #endif

--- a/plugins/in_node_exporter_metrics/ne_textfile.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_textfile_linux.c"
+#endif

--- a/plugins/in_node_exporter_metrics/ne_textfile.h
+++ b/plugins/in_node_exporter_metrics/ne_textfile.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_TEXTFILE_H
+#define FLB_IN_NE_TEXTFILE_H
+
+#include "ne.h"
+
+int ne_textfile_init(struct flb_ne *ctx);
+int ne_textfile_update(struct flb_ne *ctx);
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_textfile_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile_linux.c
@@ -95,6 +95,7 @@ static int textfile_update(struct flb_ne *ctx)
 
     if (ctx->path_textfile == NULL) {
         flb_plg_warn(ctx->ins, "No valid path for textfile metric is registered");
+        return -1;
     }
 
     ext = strrchr(ctx->path_textfile, '.');

--- a/plugins/in_node_exporter_metrics/ne_textfile_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile_linux.c
@@ -1,0 +1,205 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_file.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+#include <unistd.h>
+#include <float.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <glob.h>
+
+/* Prometheus decoder */
+#include <cmetrics/cmt_decode_prometheus.h>
+#include "cmt_decode_prometheus_parser.h"
+
+static inline int do_glob(const char *pattern, int flags,
+                          void *not_used, glob_t *pglob)
+{
+    int ret;
+    (void) not_used;
+
+    /* invoke glob with parameters */
+    ret = glob(pattern, flags, NULL, pglob);
+
+    return ret;
+}
+
+static int textfile_update(struct flb_ne *ctx)
+{
+    int i;
+    int ret;
+    glob_t globbuf;
+    char errbuf[256];
+    struct stat st;
+    flb_sds_t contents;
+    struct cmt_decode_prometheus_parse_opts opts;
+    uint64_t timestamp;
+    char *error_reason;
+    struct cmt *cmt;
+    char *ext;
+
+    timestamp = cfl_time_now();
+
+    memset(&opts, 0, sizeof(opts));
+    opts.errbuf = errbuf;
+    opts.errbuf_size = sizeof(errbuf);
+    opts.default_timestamp = timestamp;
+
+    flb_plg_debug(ctx->ins, "scanning path %s", ctx->path_textfile);
+
+    /* Safe reset for globfree() */
+    globbuf.gl_pathv = NULL;
+
+    if (ctx->path_textfile == NULL) {
+        flb_plg_warn(ctx->ins, "No valid path for textfile metric is registered");
+    }
+
+    /* Scan the given path */
+    ret = do_glob(ctx->path_textfile, GLOB_TILDE | GLOB_ERR, NULL, &globbuf);
+    if (ret != 0) {
+        switch (ret) {
+        case GLOB_NOSPACE:
+            flb_plg_error(ctx->ins, "no memory space available");
+            return -1;
+        case GLOB_ABORTED:
+            flb_plg_error(ctx->ins, "read error, check permissions: %s", ctx->path_textfile);
+            return -1;
+        case GLOB_NOMATCH:
+            ret = stat(ctx->path_textfile, &st);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "cannot read info from: %s", ctx->path_textfile);
+            }
+            else {
+                ret = access(ctx->path_textfile, R_OK);
+                if (ret == -1 && errno == EACCES) {
+                    flb_plg_error(ctx->ins, "NO read access for path: %s", ctx->path_textfile);
+                }
+                else {
+                    flb_plg_debug(ctx->ins, "NO matches for path: %s", ctx->path_textfile);
+                }
+            }
+            return 0;
+        }
+    }
+
+    for (i = 0; i < globbuf.gl_pathc; i++) {
+        ret = stat(globbuf.gl_pathv[i], &st);
+        if (ret == 0 && S_ISREG(st.st_mode)) {
+            ext = strrchr(globbuf.gl_pathv[i], '.');
+            if (ext == NULL) {
+                flb_plg_warn(ctx->ins, "globbed file %s does not have extension part",
+                             globbuf.gl_pathv[i]);
+                continue;
+            }
+            if (strncmp(ext, ".prom", 5) != 0) {
+                flb_plg_warn(ctx->ins, "globbed file %s does not have \".prom\" extension",
+                             globbuf.gl_pathv[i]);
+                continue;
+            }
+            /* Update metrics from text file */
+            contents = flb_file_read(globbuf.gl_pathv[i]);
+            if (flb_sds_len(contents) == 0) {
+                flb_plg_debug(ctx->ins, "skip empty payload of prometheus: %s, inode %li",
+                              globbuf.gl_pathv[i], st.st_ino);
+                continue;
+            }
+
+            ret = cmt_decode_prometheus_create(&cmt, contents, 0, &opts);
+            if (ret == 0) {
+                flb_plg_debug(ctx->ins, "parse a payload of prometheus: %s, inode %li",
+                              globbuf.gl_pathv[i], st.st_ino);
+                cmt_cat(ctx->cmt, cmt);
+            }
+            else {
+                flb_plg_debug(ctx->ins, "parse a payload of prometheus: dismissed: %s, inode %li, error: %d",
+                              globbuf.gl_pathv[i], st.st_ino, ret);
+                switch(ret) {
+                case CMT_DECODE_PROMETHEUS_SYNTAX_ERROR:
+                    error_reason = "syntax error";
+                    break;
+                case CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR:
+                    error_reason = "allocation error";
+                    break;
+                case CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED:
+                    error_reason = "max label count exceeded";
+                    break;
+                case CMT_DECODE_PROMETHEUS_CMT_SET_ERROR:
+                    error_reason = "cmt set error";
+                    break;
+                case CMT_DECODE_PROMETHEUS_CMT_CREATE_ERROR:
+                    error_reason = "cmt create error";
+                    break;
+                case CMT_DECODE_PROMETHEUS_PARSE_VALUE_FAILED:
+                    error_reason = "parse value failed";
+                    break;
+                case CMT_DECODE_PROMETHEUS_PARSE_TIMESTAMP_FAILED:
+                    error_reason = "parse timestamp failed";
+                    break;
+                default:
+                    error_reason = "unknown reason";
+                }
+                cmt_counter_set(ctx->load_errors, timestamp, 1.0, 1,  (char*[]){error_reason});
+            }
+            flb_sds_destroy(contents);
+            cmt_decode_prometheus_destroy(cmt);
+        }
+        else {
+            flb_plg_debug(ctx->ins, "skip (invalid) entry=%s",
+                          globbuf.gl_pathv[i]);
+        }
+    }
+
+    globfree(&globbuf);
+    return 0;
+}
+
+int ne_textfile_init(struct flb_ne *ctx)
+{
+    ctx->load_errors = cmt_counter_create(ctx->cmt,
+                                          "node",
+                                          "textfile",
+                                          "node_textfile_scrape_error",
+                                          "Greater equal than 1 if there was an error opening, reading, or parsing a file, 0 otherwise.",
+                                          1, (char *[]) {"reason"});
+
+    if (ctx->load_errors == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ne_textfile_update(struct flb_ne *ctx)
+{
+    textfile_update(ctx);
+
+    return 0;
+}
+
+int ne_textfile_exit(struct flb_ne *ctx)
+{
+    return 0;
+}

--- a/plugins/in_node_exporter_metrics/ne_textfile_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile_linux.c
@@ -149,7 +149,7 @@ static int textfile_update(struct flb_ne *ctx)
             continue;
         }
 
-        ret = cmt_decode_prometheus_create(&cmt, contents, 0, &opts);
+        ret = cmt_decode_prometheus_create(&cmt, contents, flb_sds_len(contents), &opts);
         if (ret == 0) {
             flb_plg_debug(ctx->ins, "parse a payload of prometheus: %s",
                           entry->str);

--- a/plugins/in_node_exporter_metrics/ne_textfile_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile_linux.c
@@ -29,7 +29,6 @@
 #include <float.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <glob.h>
 
 /* Prometheus decoder */
 #include <cmetrics/cmt_decode_prometheus.h>


### PR DESCRIPTION
<!-- Provide summary of changes -->
Prometheus' node_exporter provides textfile metrics that handles text format of Prometheus payloads.

Note that the current implementation should work for Counter, Gauge, and Untyped metrics due to summary and histograms concatenations are not supported in cmetrics. 

See also: https://github.com/fluent/cmetrics/issues/178

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
    flush           1
    log_level       debug

[INPUT]
    name            node_exporter_metrics
    tag             fluentbit.metrics.${HOSTNAME}
    scrape_interval 2
    collector.textfile.path /path/to/prom_metrics/*/*.prom
    metrics textfile

[OUTPUT]
    name stdout
    Match *

```
- [x] Debug log output from testing the change

<details>

```log
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/27 11:13:04] [ info] Configuration:
[2023/03/27 11:13:04] [ info]  flush time     | 1.000000 seconds
[2023/03/27 11:13:04] [ info]  grace          | 5 seconds
[2023/03/27 11:13:04] [ info]  daemon         | 0
[2023/03/27 11:13:04] [ info] ___________
[2023/03/27 11:13:04] [ info]  inputs:
[2023/03/27 11:13:04] [ info]      node_exporter_metrics
[2023/03/27 11:13:04] [ info] ___________
[2023/03/27 11:13:04] [ info]  filters:
[2023/03/27 11:13:04] [ info] ___________
[2023/03/27 11:13:04] [ info]  outputs:
[2023/03/27 11:13:04] [ info]      stdout.0
[2023/03/27 11:13:04] [ info] ___________
[2023/03/27 11:13:04] [ info]  collectors:
[2023/03/27 11:13:04] [ info] [fluent bit] version=2.1.0, commit=fc8c14e804, pid=16043
[2023/03/27 11:13:04] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/27 11:13:04] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/03/27 11:13:04] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/27 11:13:04] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/03/27 11:13:04] [ info] [cmetrics] version=0.5.9
[2023/03/27 11:13:04] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics textfile
[2023/03/27 11:13:04] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/27 11:13:04] [ info] [ctraces ] version=0.3.0
[2023/03/27 11:13:04] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/03/27 11:13:04] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/03/27 11:13:04] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/03/27 11:13:04] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/03/27 11:13:04] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=30 write=31
[2023/03/27 11:13:04] [debug] [stdout:stdout.0] created event channels: read=34 write=35
[2023/03/27 11:13:04] [ info] [sp] stream processor started
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] scanning path /media/Data3/Gitrepo/prom_metrics/*/*.prom
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] specified path /media/Data3/Gitrepo/prom_metrics/*/*.prom has ".prom" extension
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] parse a payload of prometheus: /media/Data3/Gitrepo/prom_metrics/k8s/k8s_log.prom
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] parse a payload of prometheus: /media/Data3/Gitrepo/prom_metrics/logs/envoy_log.prom
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] parse a payload of prometheus: /media/Data3/Gitrepo/prom_metrics/logs/timestamp_logs.prom
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] parse a payload of prometheus: /media/Data3/Gitrepo/prom_metrics/prometheus/prom_engine_log.prom
[2023/03/27 11:13:05] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] parse a payload of prometheus: /media/Data3/Gitrepo/prom_metrics/various/various_logs.prom
[2023/03/27 11:13:05] [debug] [input chunk] update output instances with new chunk size diff=25957
1970-01-01T00:00:00.123000000Z hikaricp_connections_timeout_total{pool="mcadb"} = 0
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="0.05"} = 24054
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="0.1"} = 33444
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="0.2"} = 100392
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="0.5"} = 129389
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="1"} = 133988
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_bucket{le="+Inf"} = 144320
1970-01-01T00:00:00.000000000Z hikaricp_connections_timeout_total{pool="mcadb"} = 0
1970-01-01T00:00:00.000000000Z process_start_time_seconds = 1660594096.832
1970-01-01T00:00:00.000000000Z spring_kafka_listener_seconds_max{exception="ListenerExecutionFailedException",name="org.springframework.kafka.KafkaListenerEndpointContainer#0-0",result="failure"} = 0
1970-01-01T00:00:00.000000000Z spring_kafka_listener_seconds_max{exception="none",name="org.springframework.kafka.KafkaListenerEndpointContainer#0-0",result="success"} = 0
1970-01-01T00:00:00.000000000Z process_files_max_files = 1048576
1970-01-01T00:00:00.000000000Z hikaricp_connections_pending{pool="mcadb"} = 0
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="nonheap",id="CodeHeap 'profiled nmethods'"} = 16056320
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="heap",id="G1 Survivor Space"} = 20971520
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="heap",id="G1 Old Gen"} = 232783872
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="nonheap",id="Metaspace"} = 103374848
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="nonheap",id="CodeHeap 'non-nmethods'"} = 4390912
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="heap",id="G1 Eden Space"} = 373293056
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="nonheap",id="Compressed Class Space"} = 13500416
1970-01-01T00:00:00.000000000Z jvm_memory_committed_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'"} = 4521984
1970-01-01T00:00:00.000000000Z process_files_open_files = 290
1970-01-01T00:00:00.000000000Z kafka_consumer_sync_time_max_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z kafka_consumer_fetch_latency_avg_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z kafka_consumer_sync_rate_syncs{client_id="consumer-1"} = 0
1970-01-01T00:00:00.000000000Z jvm_classes_loaded_classes = 17220
1970-01-01T00:00:00.000000000Z kafka_consumer_fetch_throttle_time_avg_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z process_cpu_usage = 0.00070793903055696016
1970-01-01T00:00:00.000000000Z jvm_buffer_total_capacity_bytes{id="mapped"} = 0
1970-01-01T00:00:00.000000000Z jvm_buffer_total_capacity_bytes{id="direct"} = 81920
1970-01-01T00:00:00.000000000Z kafka_consumer_fetch_throttle_time_max_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z system_load_average_1m = 0.52000000000000002
1970-01-01T00:00:00.000000000Z kafka_consumer_join_time_avg_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z kafka_consumer_assigned_partitions{client_id="consumer-1"} = 0
1970-01-01T00:00:00.000000000Z kafka_consumer_heartbeat_response_time_max_seconds{client_id="consumer-1"} = nan
1970-01-01T00:00:00.000000000Z jvm_threads_daemon_threads = 20
1970-01-01T00:00:00.000000000Z system_cpu_count = 16
1970-01-01T00:00:00.000000000Z jvm_buffer_count_buffers{id="mapped"} = 0
1970-01-01T00:00:00.000000000Z jvm_buffer_count_buffers{id="direct"} = 10
1970-01-01T00:00:00.000000000Z kafka_consumer_io_wait_time_avg_seconds{client_id="consumer-1"} = 0.047184790159065626
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="nonheap",id="CodeHeap 'profiled nmethods'"} = 122028032
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="heap",id="G1 Survivor Space"} = -1
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="heap",id="G1 Old Gen"} = 8331984896
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="nonheap",id="Metaspace"} = -1
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="nonheap",id="CodeHeap 'non-nmethods'"} = 7598080
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="heap",id="G1 Eden Space"} = -1
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="nonheap",id="Compressed Class Space"} = 1073741824
1970-01-01T00:00:00.000000000Z jvm_memory_max_bytes{area="nonheap",id="CodeHeap 'non-profiled nmethods'"} = 122032128
1970-01-01T00:00:00.000000000Z jvm_gc_pause_seconds_max{action="end of minor GC",cause="Metadata GC Threshold"} = 0.02
1970-01-01T00:00:00.000000000Z jvm_gc_pause_seconds_max{action="end of minor GC",cause="G1 Evacuation Pause"} = 0
1970-01-01T00:00:00.000000000Z kafka_consumer_connection_count_connections{client_id="consumer-1"} = 0
2023-03-27T02:13:05.603374266Z prometheus_engine_query_duration_seconds = { quantiles = { 0.5=0.5, 0.9=0.9, 0.99=0.99 }, sum=0, count=3 }
1970-01-01T00:00:00.000000000Z spring_kafka_listener_seconds{exception="exception",name="name",result="result"} = { quantiles = { }, sum=0, count=0 }
2023-03-27T02:13:05.603374266Z spring_kafka_listener_seconds{exception="ListenerExecutionFailedException",name="org.springframework.kafka.KafkaListenerEndpointContainer#0-0",result="failure"} = { quantiles = { }, sum=0, count=0 }
2023-03-27T02:13:05.603374266Z spring_kafka_listener_seconds{exception="none",name="org.springframework.kafka.KafkaListenerEndpointContainer#0-0",result="success"} = { quantiles = { }, sum=0, count=0 }
1970-01-01T00:00:00.000000000Z hikaricp_connections_usage_seconds{pool="pool"} = { quantiles = { }, sum=0, count=0 }
2023-03-27T02:13:05.603374266Z hikaricp_connections_usage_seconds{pool="mcadb"} = { quantiles = { }, sum=0, count=0 }
1970-01-01T00:00:00.000000000Z jvm_gc_pause_seconds{action="action",cause="cause"} = { quantiles = { }, sum=0, count=0 }
2023-03-27T02:13:05.603374266Z jvm_gc_pause_seconds{action="end of minor GC",cause="Metadata GC Threshold"} = { quantiles = { }, sum=0.031, count=2 }
2023-03-27T02:13:05.603374266Z jvm_gc_pause_seconds{action="end of minor GC",cause="G1 Evacuation Pause"} = { quantiles = { }, sum=0.016, count=1 }
2023-03-27T02:13:05.603374266Z k8s_network_load = { buckets = { 0.05=1, 5=2, 10=3, +Inf=3 }, sum=15.05, count=3 }
1970-01-01T00:00:00.000000000Z k8s_network_load{my_label="my_label"} = { buckets = { 0.05=1, 5=2, 10=3, +Inf=3 }, sum=15.05, count=3 }
2023-03-27T02:13:05.603374266Z k8s_network_load{my_label="my_val"} = { buckets = { 0.05=0, 5=1, 10=2, +Inf=0 }, sum=1013, count=3 }
1970-01-01T00:00:00.000000000Z envoy_cluster_manager_cds_init_fetch_timeout = 0
1970-01-01T00:00:00.000000000Z envoy_cluster_manager_cds_update_attempt = 1
1970-01-01T00:00:00.000000000Z envoy_cluster_manager_cds_update_failure = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="0.5",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1.0",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="5.0",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="10.0",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="25.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="50.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="100.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="250.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="500.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="2500.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="5000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="10000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="30000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="60000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="300000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="600000.0",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1.8e+06",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="3.6e+06",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="+Inf",envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_sum{envoy_http_conn_manager_prefix="admin"} = 15.5
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_count{envoy_http_conn_manager_prefix="admin"} = 1
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="0.5",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="5.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="10.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="25.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="50.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="100.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="250.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="500.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="2500.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="5000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="10000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="30000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="60000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="300000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="600000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="1.8e+06",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="3.6e+06",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_bucket{le="+Inf",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_sum{envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_cx_length_ms_count{envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="0.5",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1.0",envoy_http_conn_manager_prefix="admin"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="5.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="10.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="25.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="50.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="100.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="250.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="500.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="2500.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="5000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="10000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="30000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="60000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="300000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="600000.0",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1.8e+06",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="3.6e+06",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="+Inf",envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_sum{envoy_http_conn_manager_prefix="admin"} = 25.5
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_count{envoy_http_conn_manager_prefix="admin"} = 10
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="0.5",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="5.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="10.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="25.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="50.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="100.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="250.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="500.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="2500.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="5000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="10000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="30000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="60000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="300000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="600000.0",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="1.8e+06",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="3.6e+06",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_bucket{le="+Inf",envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_sum{envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_http_downstream_rq_time_count{envoy_http_conn_manager_prefix="ingress_http"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="0.5"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="1.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="5.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="10.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="25.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="50.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="100.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="250.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="500.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="1000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="2500.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="5000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="10000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="30000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="60000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="300000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="600000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="1.8e+06"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="3.6e+06"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_bucket{le="+Inf"} = 1
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_sum = 15.5
1970-01-01T00:00:00.000000000Z envoy_listener_admin_downstream_cx_length_ms_count = 1
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="0.5",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="1.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="5.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="10.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="25.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="50.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="100.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="250.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="500.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="1000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="2500.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="5000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="10000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="30000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="60000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="300000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="600000.0",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="1.8e+06",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="3.6e+06",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_bucket{le="+Inf",envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_sum{envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_downstream_cx_length_ms_count{envoy_listener_address="0.0.0.0_10000"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="0.5"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="1.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="5.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="10.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="25.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="50.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="100.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="250.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="500.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="1000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="2500.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="5000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="10000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="30000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="60000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="300000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="600000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="1.8e+06"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="3.6e+06"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_bucket{le="+Inf"} = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_sum = 0
1970-01-01T00:00:00.000000000Z envoy_listener_manager_lds_update_duration_count = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="0.5"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="1.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="5.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="10.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="25.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="50.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="100.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="250.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="500.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="1000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="2500.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="5000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="10000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="30000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="60000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="300000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="600000.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="1.8e+06"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="3.6e+06"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_bucket{le="+Inf"} = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_sum = 0
1970-01-01T00:00:00.000000000Z envoy_sds_tls_sds_update_duration_count = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="0.5"} = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="1.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="5.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="10.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="25.0"} = 0
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="50.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="100.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="250.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="500.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="1000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="2500.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="5000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="10000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="30000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="60000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="300000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="600000.0"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="1.8e+06"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="3.6e+06"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_bucket{le="+Inf"} = 1
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_sum = 30.5
1970-01-01T00:00:00.000000000Z envoy_server_initialization_time_ms_count = 1
1970-01-01T00:00:00.123000000Z rabbitmq_consumed_total{name="rabbit"} = 0
1970-01-01T00:00:00.123000000Z rabbitmq_failed_to_publish_total{name="rabbit"} = 0
1970-01-01T00:00:00.123000000Z rabbitmq_acknowledged_published_total{name="rabbit"} = 0
1970-01-01T00:00:00.123000000Z tomcat_sessions_rejected_sessions_total = 0
1970-01-01T00:00:00.123000000Z http_request_duration_seconds_sum = 53423
1970-01-01T00:00:00.123000000[2023/03/27 11:13:06] [debug] [task] created task=0x54142c0 id=0 OK
Z http_request_duration_seconds_count = 144320
1970-01-01T00:00:00.000000000Z rabbitmq_consumed_total{name="rabbit"} = 0
1970-01-01T00:00:00.000000000Z rabbitmq_failed_to_publish_total{name="rabbit"} = 0
1970-01-01T00:00:00.000000000Z rabbitmq_acknowledged_published_total{name="rabbit"} = 0
[2023/03/27 11:13:06] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1970-01-01T00:00:00.000000000Z tomcat_sessions_rejected_sessions_total = 0
1970-01-01T00:00:00.000000000Z rabbitmq_channels{name="rabbit"} = 0
1970-01-01T00:00:00.000000000Z jdbc_connections_min{name="dataSource"} = 10
1970-01-01T00:00:00.000000000Z tomcat_sessions_active_max_sessions = 0
1970-01-01T00:00:00.000000000Z jdbc_connections_max{name="dataSource"} = 10
1970-01-01T00:00:00.000000000Z jdbc_connections_active{name="dataSource"} = 0
[2023/03/27 11:13:06] [debug] [out flush] cb_destroy coro_id=0
[2023/03/27 11:13:06] [debug] [task] destroy task=0x54142c0 (task_id=0)
^C[2023/03/27 11:13:07] [engine] caught signal (SIGINT)
[2023/03/27 11:13:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/27 11:13:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/03/27 11:13:07] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/27 11:13:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/03/27 11:13:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
[2023/03/27 11:13:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/27 11:13:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

</details>

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==16043== 
==16043== HEAP SUMMARY:
==16043==     in use at exit: 0 bytes in 0 blocks
==16043==   total heap usage: 14,807 allocs, 14,807 frees, 50,218,010 bytes allocated
==16043== 
==16043== All heap blocks were freed -- no leaks are possible
==16043== 
==16043== For lists of detected and suppressed errors, rerun with: -s
==16043== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
