### PR TITLE
input: filter: support log_suppress_interval

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -68,6 +68,7 @@ struct flb_filter_plugin {
 struct flb_filter_instance {
     int id;                        /* instance id              */
     int log_level;                 /* instance log level       */
+    int log_suppress_interval;     /* log suppression interval     */
     char name[32];                 /* numbered name            */
     char *alias;                   /* alias name               */
     char *match;                   /* match rule based on Tags */

--- a/include/fluent-bit/flb_filter_plugin.h
+++ b/include/fluent-bit/flb_filter_plugin.h
@@ -24,30 +24,38 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_log.h>
 
+#define flb_filter_plugin_log_suppress_check(ins, fmt, ...) \
+    flb_log_suppress_check(ins->log_suppress_interval, fmt, ##__VA_ARGS__)
+
 #define flb_plg_error(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_ERROR))             \
-        flb_log_print(FLB_LOG_ERROR, NULL, 0, "[filter:%s:%s] " fmt,    \
-                      ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
+        if (flb_filter_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_ERROR, NULL, 0, "[filter:%s:%s] " fmt, \
+                          ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_warn(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_WARN))              \
-        flb_log_print(FLB_LOG_WARN, NULL, 0, "[filter:%s:%s] " fmt,     \
-                      ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
+        if (flb_filter_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_WARN, NULL, 0, "[filter:%s:%s] " fmt, \
+                          ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_info(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_INFO))              \
-        flb_log_print(FLB_LOG_INFO, NULL, 0, "[filter:%s:%s] " fmt,     \
-                      ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
+        if (flb_filter_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_INFO, NULL, 0, "[filter:%s:%s] " fmt, \
+                          ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_debug(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_DEBUG))             \
-        flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[filter:%s:%s] " fmt,    \
-                      ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
+        if (flb_filter_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[filter:%s:%s] " fmt, \
+                          ctx->p->name, flb_filter_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_trace(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
-        flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
-                      "[filter:%s:%s at %s:%i] " fmt,                   \
-                      ctx->p->name, flb_filter_name(ctx), __FLB_FILENAME__, \
-                      __LINE__, ##__VA_ARGS__)
+        if (flb_filter_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_TRACE, NULL, 0,                       \
+                          "[filter:%s:%s at %s:%i] " fmt,               \
+                          ctx->p->name, flb_filter_name(ctx), __FLB_FILENAME__, \
+                          __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -174,6 +174,7 @@ struct flb_input_instance {
     pthread_mutex_t chunk_trace_lock;
 #endif /* FLB_HAVE_CHUNK_TRACE */
     int log_level;                       /* log level for this plugin    */
+    int log_suppress_interval;           /* log suppression interval     */
     flb_pipefd_t channel[2];             /* pipe(2) channel              */
     int runs_in_coroutine;               /* instance runs in coroutine ? */
     char name[32];                       /* numbered name (cpu -> cpu.0) */

--- a/include/fluent-bit/flb_input_plugin.h
+++ b/include/fluent-bit/flb_input_plugin.h
@@ -25,30 +25,39 @@
 #include <fluent-bit/flb_input_metric.h>
 #include <fluent-bit/flb_log.h>
 
+#define flb_input_plugin_log_suppress_check(ins, fmt, ...) \
+    flb_log_suppress_check(ins->log_suppress_interval, fmt, ##__VA_ARGS__)
+
+
 #define flb_plg_error(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_ERROR))             \
-        flb_log_print(FLB_LOG_ERROR, NULL, 0, "[input:%s:%s] " fmt,     \
-                      ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
+        if (flb_input_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_ERROR, NULL, 0, "[input:%s:%s] " fmt, \
+                          ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_warn(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_WARN))              \
-        flb_log_print(FLB_LOG_WARN, NULL, 0, "[input:%s:%s] " fmt,      \
-                      ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
+        if (flb_input_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_WARN, NULL, 0, "[input:%s:%s] " fmt,  \
+                          ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_info(ctx, fmt, ...)                                     \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_INFO))                             \
-        flb_log_print(FLB_LOG_INFO, NULL, 0, "[input:%s:%s] " fmt,      \
-                      ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
+        if (flb_input_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_INFO, NULL, 0, "[input:%s:%s] " fmt,  \
+                          ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_debug(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_DEBUG))             \
-        flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[input:%s:%s] " fmt,     \
-                      ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
+        if (flb_input_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[input:%s:%s] " fmt, \
+                          ctx->p->name, flb_input_name(ctx), ##__VA_ARGS__)
 
 #define flb_plg_trace(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_TRACE))             \
-        flb_log_print(FLB_LOG_TRACE, NULL, 0,                           \
-                      "[input:%s:%s at %s:%i] " fmt,                    \
-                      ctx->p->name, flb_input_name(ctx), __FLB_FILENAME__,  \
-                      __LINE__, ##__VA_ARGS__)
+        if (flb_input_plugin_log_suppress_check(ctx, fmt, ##__VA_ARGS__) == FLB_FALSE) \
+            flb_log_print(FLB_LOG_TRACE, NULL, 0,                       \
+                          "[input:%s:%s at %s:%i] " fmt,                \
+                          ctx->p->name, flb_input_name(ctx), __FLB_FILENAME__, \
+                          __LINE__, ##__VA_ARGS__)
 #endif

--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <stdarg.h>
 
 /* FIXME: this extern should be auto-populated from flb_thread_storage.h */
 extern FLB_TLS_DEFINE(struct flb_log, flb_log_ctx)
@@ -130,6 +131,35 @@ struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache
 
 int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, size_t msg_size);
 
+
+static inline int flb_log_suppress_check(int log_suppress_interval, const char *fmt, ...)
+{
+    int ret;
+    size_t size;
+    va_list args;
+    char buf[4096];
+    struct flb_worker *w;
+
+    if (log_suppress_interval <= 0) {
+        return FLB_FALSE;
+    }
+
+    va_start(args, fmt);
+    size = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
+    va_end(args);
+
+    if (size == -1) {
+        return FLB_FALSE;
+    }
+
+    w = flb_worker_get();
+    if (!w) {
+        return FLB_FALSE;
+    }
+
+    ret = flb_log_cache_check_suppress(w->log_cache, buf, size);
+    return ret;
+}
 
 
 /* Logging macros */

--- a/include/fluent-bit/flb_output_plugin.h
+++ b/include/fluent-bit/flb_output_plugin.h
@@ -27,36 +27,8 @@
 #include <cmetrics/cmt_encode_text.h>
 #include <cmetrics/cmt_encode_prometheus.h>
 
-#include <stdarg.h>
-
-static inline int flb_output_plugin_log_suppress_check(struct flb_output_instance *ins, const char *fmt, ...)
-{
-    int ret;
-    size_t size;
-    va_list args;
-    char buf[4096];
-    struct flb_worker *w;
-
-    if (ins->log_suppress_interval <= 0) {
-        return FLB_FALSE;
-    }
-
-    va_start(args, fmt);
-    size = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
-    va_end(args);
-
-    if (size == -1) {
-        return FLB_FALSE;
-    }
-
-    w = flb_worker_get();
-    if (!w) {
-        return FLB_FALSE;
-    }
-
-    ret = flb_log_cache_check_suppress(w->log_cache, buf, size);
-    return ret;
-}
+#define flb_output_plugin_log_suppress_check(ins, fmt, ...) \
+    flb_log_suppress_check(ins->log_suppress_interval, fmt, ##__VA_ARGS__)
 
 #define flb_plg_error(ctx, fmt, ...)                                    \
     if (flb_log_check_level(ctx->log_level, FLB_LOG_ERROR))             \

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -288,6 +288,14 @@ int flb_filter_set_property(struct flb_filter_instance *ins,
         }
         ins->log_level = ret;
     }
+    else if (prop_key_check("log_suppress_interval", k, len) == 0 && tmp) {
+        ret = flb_utils_time_to_seconds(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
+        }
+        ins->log_suppress_interval = ret;
+    }
     else {
         /*
          * Create the property, we don't pass the value since we will
@@ -389,6 +397,7 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
     instance->match_regex = NULL;
 #endif
     instance->log_level = -1;
+    instance->log_suppress_interval = -1;
 
     mk_list_init(&instance->properties);
     mk_list_add(&instance->_head, &config->filters);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -247,6 +247,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->storage  = NULL;
         instance->storage_type = -1;
         instance->log_level = -1;
+        instance->log_suppress_interval = -1;
         instance->runs_in_coroutine = FLB_FALSE;
 
         /* net */
@@ -479,6 +480,14 @@ int flb_input_set_property(struct flb_input_instance *ins,
             return -1;
         }
         ins->log_level = ret;
+    }
+    else if (prop_key_check("log_suppress_interval", k, len) == 0 && tmp) {
+        ret = flb_utils_time_to_seconds(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
+        }
+        ins->log_suppress_interval = ret;
     }
     else if (prop_key_check("routable", k, len) == 0 && tmp) {
         ins->routable = flb_utils_bool(tmp);


### PR DESCRIPTION
This patch is to support `log_suppress_interval` for input/filter plugins.
See also #6435 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgri nd ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Input configuration and log

```
[INPUT]
    Name      node_exporter_metrics
    Log_Level debug
    Log_Suppress_Interval 60s

[OUTPUT]
    Name         null
    Match        *
```

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==28827== Memcheck, a memory error detector
==28827== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28827== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==28827== Command: bin/fluent-bit -c a.conf
==28827== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/18 08:49:01] [ info] [fluent bit] version=2.1.0, commit=21a2148171, pid=28827
[2023/03/18 08:49:01] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/18 08:49:01] [ info] [cmetrics] version=0.5.8
[2023/03/18 08:49:01] [ info] [ctraces ] version=0.3.0
[2023/03/18 08:49:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/03/18 08:49:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/03/18 08:49:02] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/03/18 08:49:02] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/03/18 08:49:02] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics cpu
[2023/03/18 08:49:02] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/03/18 08:49:02] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/03/18 08:49:02] [ info] [output:null:null.0] worker #0 started
[2023/03/18 08:49:02] [ info] [sp] stream processor started
[2023/03/18 08:49:06] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] skip device: loop0
[2023/03/18 08:49:16] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] skip device: loop0
^C[2023/03/18 08:49:17] [engine] caught signal (SIGINT)
[2023/03/18 08:49:17] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/18 08:49:17] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/03/18 08:49:17] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/18 08:49:17] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
[2023/03/18 08:49:17] [ info] [output:null:null.0] thread worker #0 stopping...
[2023/03/18 08:49:17] [ info] [output:null:null.0] thread worker #0 stopped
==28827== 
==28827== HEAP SUMMARY:
==28827==     in use at exit: 0 bytes in 0 blocks
==28827==   total heap usage: 18,876 allocs, 18,876 frees, 2,919,203 bytes allocated
==28827== 
==28827== All heap blocks were freed -- no leaks are possible
==28827== 
==28827== For lists of detected and suppressed errors, rerun with: -s
==28827== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Filter configuration and log

```
[INPUT]
    Name      dummy

[FILTER]
    Name      modify
    Match *
    Log_Level debug
    Log_Suppress_Interval 60s
    Condition key_exists dummy
    Add a b

[OUTPUT]
    Name         null
    Match        *
```

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==28862== Memcheck, a memory error detector
==28862== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28862== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==28862== Command: bin/fluent-bit -c a.conf
==28862== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/03/18 08:54:15] [ info] [fluent bit] version=2.1.0, commit=21a2148171, pid=28862
[2023/03/18 08:54:15] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/18 08:54:15] [ info] [cmetrics] version=0.5.8
[2023/03/18 08:54:15] [ info] [ctraces ] version=0.3.0
[2023/03/18 08:54:15] [ info] [input:dummy:dummy.0] initializing
[2023/03/18 08:54:15] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/03/18 08:54:15] [debug] [filter:modify:modify.0] Initialized modify filter with 1 conditions and 1 rules
[2023/03/18 08:54:15] [ info] [output:null:null.0] worker #0 started
[2023/03/18 08:54:15] [ info] [sp] stream processor started
[2023/03/18 08:54:16] [debug] [filter:modify:modify.0] Condition not met : key_exists dummy
[2023/03/18 08:54:16] [debug] [filter:modify:modify.0] Conditions not met, not touching record
[2023/03/18 08:54:26] [debug] [filter:modify:modify.0] Condition not met : key_exists dummy
[2023/03/18 08:54:26] [debug] [filter:modify:modify.0] Conditions not met, not touching record
^C[2023/03/18 08:54:27] [engine] caught signal (SIGINT)
[2023/03/18 08:54:27] [ warn] [engine] service will shutdown in max 5 seconds
[2023/03/18 08:54:27] [ info] [input] pausing dummy.0
[2023/03/18 08:54:27] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/18 08:54:27] [ info] [input] pausing dummy.0
[2023/03/18 08:54:27] [ info] [output:null:null.0] thread worker #0 stopping...
[2023/03/18 08:54:27] [ info] [output:null:null.0] thread worker #0 stopped
==28862== 
==28862== HEAP SUMMARY:
==28862==     in use at exit: 0 bytes in 0 blocks
==28862==   total heap usage: 1,933 allocs, 1,933 frees, 4,192,559 bytes allocated
==28862== 
==28862== All heap blocks were freed -- no leaks are possible
==28862== 
==28862== For lists of detected and suppressed errors, rerun with: -s
==28862== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
