### PR TITLE
tests: runtime: core_log: suppress warning

### DIFF
--- a/tests/runtime/core_log.c
+++ b/tests/runtime/core_log.c
@@ -69,7 +69,7 @@ static int cb_resize(void *record, size_t size, void *data)
         TEST_MSG("log is not truncated.ret=%d", ret);
     }
 
-    ret = flb_error_is_truncated("%.*s", strlen(log) - ret, log);
+    ret = flb_error_is_truncated("%.*s", (int)(strlen(log) - ret), log);
     if (!TEST_CHECK(ret == 0)) {
         TEST_MSG("log is truncated.ret=%d", ret);
     }


### PR DESCRIPTION
This patch is to remove following warning.
```
[ 81%] Building C object tests/runtime/CMakeFiles/flb-rt-core_log.dir/core_log.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/core_log.c:3:
/home/taka/git/fluent-bit/tests/runtime/core_log.c: In function ‘cb_resize’:
/home/taka/git/fluent-bit/tests/runtime/core_log.c:72:34: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
   72 |     ret = flb_error_is_truncated("%.*s", strlen(log) - ret, log);
      |                                  ^~~~~~  ~~~~~~~~~~~~~~~~~
      |                                                      |
      |                                                      size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:145:56: note: in definition of macro ‘flb_error_is_truncated’
  145 |         ? flb_log_is_truncated(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__) \
      |                                                        ^~~
/home/taka/git/fluent-bit/tests/runtime/core_log.c:72:37: note: format string is defined here
   72 |     ret = flb_error_is_truncated("%.*s", strlen(log) - ret, log);
      |                                   ~~^~
      |                                     |
      |                                     int
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-core_log 
==18732== Memcheck, a memory error detector
==18732== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18732== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==18732== Command: bin/flb-rt-core_log
==18732== 
Test not_truncated_log...                       [2023/03/20 07:08:29] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=18732
[2023/03/20 07:08:29] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/20 07:08:29] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:08:29] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:08:29] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:08:29] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:08:29] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:08:29] [debug] [lib:lib.0] created event channels: read=21 write=22
[2023/03/20 07:08:29] [debug] [lib:lib.0] created event channels: read=25 write=26
[2023/03/20 07:08:29] [ info] [sp] stream processor started
[2023/03/20 07:08:29] [debug] [input chunk] update output instances with new chunk size diff=12
[2023/03/20 07:08:30] [debug] [task] created task=0x5480c30 id=0 OK
[2023/03/20 07:08:30] [debug] [out flush] cb_destroy coro_id=0
[2023/03/20 07:08:30] [debug] [task] destroy task=0x5480c30 (task_id=0)
[2023/03/20 07:08:30] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:08:31] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test truncated_log...                           [2023/03/20 07:08:31] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=18732
[2023/03/20 07:08:31] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/20 07:08:31] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:08:31] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:08:31] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:08:31] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:08:31] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:08:31] [debug] [lib:lib.0] created event channels: read=30 write=31
[2023/03/20 07:08:31] [debug] [lib:lib.0] created event channels: read=34 write=35
[2023/03/20 07:08:31] [ info] [sp] stream processor started
[2023/03/20 07:08:31] [debug] [input chunk] update output instances with new chunk size diff=12
[2023/03/20 07:08:31] [debug] [task] created task=0x55354d0 id=0 OK
[2023/03/20 07:08:31] [debug] [out flush] cb_destroy coro_id=0
[2023/03/20 07:08:31] [debug] [task] destroy task=0x55354d0 (task_id=0)
[2023/03/20 07:08:32] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:08:33] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test resize...                                  [ OK ]
Test log_level...                               [ OK ]
SUCCESS: All unit tests have passed.
==18732== 
==18732== HEAP SUMMARY:
==18732==     in use at exit: 0 bytes in 0 blocks
==18732==   total heap usage: 5,507 allocs, 5,507 frees, 2,562,721 bytes allocated
==18732== 
==18732== All heap blocks were freed -- no leaks are possible
==18732== 
==18732== For lists of detected and suppressed errors, rerun with: -s
==18732== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
