### PR TITLE
tests: runtime: filter_wasm: make more stable

### DIFF
--- a/tests/runtime/filter_wasm.c
+++ b/tests/runtime/filter_wasm.c
@@ -96,7 +96,7 @@ static int cb_count_msgpack_events(void *record, size_t size, void *data)
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_lua] received message: %s", data);
+        flb_debug("[test_filter_wasm] received message: %s", (char*)data);
         set_output(data); /* success */
     }
     return 0;

--- a/tests/runtime/filter_wasm.c
+++ b/tests/runtime/filter_wasm.c
@@ -54,6 +54,13 @@ char *get_output(void)
     return val;
 }
 
+static void clear_output()
+{
+    pthread_mutex_lock(&result_mutex);
+    output = NULL;
+    pthread_mutex_unlock(&result_mutex);
+}
+
 static void clear_output_num()
 {
     pthread_mutex_lock(&result_mutex);
@@ -145,6 +152,9 @@ void flb_test_append_tag(void)
     char *input = "[0, {\"key\":\"val\"}]";
     char *result;
     struct flb_lib_out_cb cb_data;
+
+    /* clear previous output */
+    clear_output();
 
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
@@ -242,6 +252,9 @@ void flb_test_numerics_records(void)
     char *result;
     struct flb_lib_out_cb cb_data;
 
+    /* clear previous output */
+    clear_output();
+
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
     flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
@@ -332,6 +345,9 @@ void flb_test_array_contains_null(void)
     char *input = "[0, {\"hello\": [1, null, \"world\"]}]";
     char *result;
     struct flb_lib_out_cb cb_data;
+
+    /* clear previous output */
+    clear_output();
 
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();

--- a/tests/runtime/filter_wasm.c
+++ b/tests/runtime/filter_wasm.c
@@ -453,9 +453,6 @@ void flb_test_drop_all_records(void)
         TEST_MSG("error. got %d expect 0", ret);
     }
 
-    /* clean up */
-    flb_lib_free(output);
-
     flb_stop(ctx);
     flb_destroy(ctx);
 }


### PR DESCRIPTION
This patch is to 
- remove warning
- fix valgrind errors



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_wasm 
==27680== Memcheck, a memory error detector
==27680== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27680== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==27680== Command: bin/flb-rt-filter_wasm
==27680== 
Test hello_world...                             [2023/03/20 07:43:36] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=27680
[2023/03/20 07:43:36] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:43:36] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:43:36] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:43:36] [ info] [input:dummy:dummy.0] initializing
[2023/03/20 07:43:36] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/03/20 07:43:36] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/20 07:43:36] [ info] [sp] stream processor started
[2023/03/20 07:43:36] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:43:36] [ info] [input] pausing dummy.0
[2023/03/20 07:43:37] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/20 07:43:37] [ info] [input] pausing dummy.0
[2023/03/20 07:43:37] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/20 07:43:37] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2023/03/20 07:43:37] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=27680
[2023/03/20 07:43:37] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:43:37] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:43:37] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:43:37] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:43:37] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:43:37] [ info] [sp] stream processor started
==27680== Warning: client switching stacks?  SP change: 0x5fdd960 --> 0x67d9f20
==27680==          to suppress, use: --max-stackframe=8373696 or greater
==27680== Warning: set address range perms: large range [0x59c87000, 0x259e87000) (noaccess)
==27680== Warning: set address range perms: large range [0x59e00000, 0x259e00000) (noaccess)
[2023/03/20 07:43:39] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:43:40] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test numeric_records...                         ==27680== Warning: client switching stacks?  SP change: 0x57dc960 --> 0x5fd8f20
==27680==          to suppress, use: --max-stackframe=8373696 or greater
[2023/03/20 07:43:40] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=27680
[2023/03/20 07:43:40] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:43:40] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:43:40] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:43:40] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:43:40] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:43:40] [ info] [sp] stream processor started
==27680== Warning: set address range perms: large range [0x59c87000, 0x259e87000) (noaccess)
==27680== Warning: set address range perms: large range [0x59e00000, 0x259e00000) (noaccess)
[2023/03/20 07:43:41] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:43:42] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     ==27680== Warning: client switching stacks?  SP change: 0x5fdd960 --> 0x67d9f20
==27680==          to suppress, use: --max-stackframe=8373696 or greater
==27680==          further instances of this message will not be shown.
[2023/03/20 07:43:42] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=27680
[2023/03/20 07:43:42] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:43:42] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:43:42] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:43:42] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:43:42] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:43:42] [ info] [sp] stream processor started
==27680== Warning: set address range perms: large range [0x59c87000, 0x259e87000) (noaccess)
==27680== Warning: set address range perms: large range [0x59e00000, 0x259e00000) (noaccess)
[2023/03/20 07:43:43] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:43:44] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2023/03/20 07:43:44] [ info] [fluent bit] version=2.1.0, commit=177a8ca583, pid=27680
[2023/03/20 07:43:44] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/20 07:43:44] [ info] [cmetrics] version=0.5.8
[2023/03/20 07:43:44] [ info] [ctraces ] version=0.3.0
[2023/03/20 07:43:44] [ info] [input:lib:lib.0] initializing
[2023/03/20 07:43:44] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/20 07:43:44] [ info] [sp] stream processor started
==27680== Warning: set address range perms: large range [0x59c87000, 0x259e87000) (noaccess)
[2023/03/20 07:43:44] [error] [filter:wasm:wasm.0] invalid JSON format. ret: -1, buf: 
==27680== Warning: set address range perms: large range [0x59e00000, 0x259e00000) (noaccess)
[2023/03/20 07:43:44] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/20 07:43:45] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==27680== 
==27680== HEAP SUMMARY:
==27680==     in use at exit: 0 bytes in 0 blocks
==27680==   total heap usage: 90,756 allocs, 90,756 frees, 15,350,160 bytes allocated
==27680== 
==27680== All heap blocks were freed -- no leaks are possible
==27680== 
==27680== For lists of detected and suppressed errors, rerun with: -s
==27680== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
