### PR TITLE
tests: internal: sds: check buffer resizing by flb_sds_printf()

### DIFF
--- a/tests/internal/sds.c
+++ b/tests/internal/sds.c
@@ -37,6 +37,45 @@ static void test_sds_printf()
     flb_sds_destroy(s);
 }
 
+static void test_sds_printf_larger()
+{
+    flb_sds_t buf;
+    int len = 69;
+    char *str = "This is a text string that is exactly 69 (sixty-nine) characters long";
+
+    /* Test 1: buffer larger than copied string */
+    buf = flb_sds_create_size(len + 2);
+    buf = flb_sds_printf(&buf, "%s", str);
+    TEST_CHECK(buf[len - 1] == 'g');
+    flb_sds_destroy(buf);
+}
+
+static void test_sds_printf_smaller()
+{
+    flb_sds_t buf;
+    int len = 69;
+    char *str = "This is a text string that is exactly 69 (sixty-nine) characters long";
+
+    /* Test 2: buffer smaller than copied string */
+    buf = flb_sds_create_size(len - 2);
+    buf = flb_sds_printf(&buf, "%s", str);
+    TEST_CHECK(buf[len - 1] == 'g');
+    flb_sds_destroy(buf);
+}
+
+static void test_sds_printf_exact()
+{
+    flb_sds_t buf;
+    int len = 69;
+    char *str = "This is a text string that is exactly 69 (sixty-nine) characters long";
+
+    /* Test 3: buffer same size as copied string */
+    buf = flb_sds_create_size(len);
+    buf = flb_sds_printf(&buf, "%s", str);
+    TEST_CHECK(buf[len - 1] == 'g');
+    flb_sds_destroy(buf);
+}
+
 static void test_sds_cat_utf8()
 {
     flb_sds_t s;
@@ -50,8 +89,11 @@ static void test_sds_cat_utf8()
 }
 
 TEST_LIST = {
-    { "sds_usage" , test_sds_usage},
-    { "sds_printf", test_sds_printf},
-    { "sds_cat_utf8", test_sds_cat_utf8},
+    { "sds_usage" , test_sds_usage },
+    { "sds_printf", test_sds_printf },
+    { "sds_printf_larger", test_sds_printf_larger },
+    { "sds_printf_smaller", test_sds_printf_smaller },
+    { "sds_printf_exact", test_sds_printf_exact },
+    { "sds_cat_utf8", test_sds_cat_utf8 },
     { 0 }
 };


### PR DESCRIPTION
We should ensure that function `flb_sds_printf()` increases the target buffer size if it doesn't fit the copied string.

* Added tests to validate that the whole string is copied to the target buffer.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #7042

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
