### PR TITLE
tests: internal: input_chunk: fix warnings

### DIFF
--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -474,7 +474,7 @@ void flb_test_input_chunk_fs_chunks_size_real()
      */
     mk_list_foreach_safe(head, tmp, &ic->in->config->outputs) {
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
-        flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
+        flb_info("[input chunk test] chunk_size=%zu fs_chunk_size=%zu", chunk_size,
                  o_ins->fs_chunks_size);
         has_checked_size = FLB_TRUE;
         TEST_CHECK_(chunk_size == o_ins->fs_chunks_size, "fs_chunks_size must match total real size");


### PR DESCRIPTION
This patch is to fix following warnings.

```
[ 92%] Building C object tests/internal/CMakeFiles/flb-it-input_chunk.dir/input_chunk.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/internal/input_chunk.c:3:
/home/taka/git/fluent-bit/tests/internal/input_chunk.c: In function ‘flb_test_input_chunk_fs_chunks_size_real’:
/home/taka/git/fluent-bit/tests/internal/input_chunk.c:477:18: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  477 |         flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                                       |
      |                                                                       size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:159:46: note: in definition of macro ‘flb_info’
  159 |         flb_log_print(FLB_LOG_INFO, NULL, 0, fmt, ##__VA_ARGS__)
      |                                              ^~~
/home/taka/git/fluent-bit/tests/internal/input_chunk.c:477:50: note: format string is defined here
  477 |         flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
      |                                                 ~^
      |                                                  |
      |                                                  int
      |                                                 %ld
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/internal/input_chunk.c:3:
/home/taka/git/fluent-bit/tests/internal/input_chunk.c:477:18: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  477 |         flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  478 |                  o_ins->fs_chunks_size);
      |                  ~~~~~~~~~~~~~~~~~~~~~
      |                       |
      |                       size_t {aka long unsigned int}
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:159:46: note: in definition of macro ‘flb_info’
  159 |         flb_log_print(FLB_LOG_INFO, NULL, 0, fmt, ##__VA_ARGS__)
      |                                              ^~~
/home/taka/git/fluent-bit/tests/internal/input_chunk.c:477:67: note: format string is defined here
  477 |         flb_info("[input chunk test] chunk_size=%d fs_chunk_size=%d", chunk_size,
      |                                                                  ~^
      |                                                                   |
      |                                                                   int
      |                                                                  %ld
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-input_chunk 
==19788== Memcheck, a memory error detector
==19788== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==19788== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==19788== Command: bin/flb-it-input_chunk
==19788== 
Test input_chunk_exceed_limit...                [ OK ]
==19788== Warning: invalid file descriptor -1 in syscall close()
Test input_chunk_buffer_valid...                [ OK ]
==19788== Warning: invalid file descriptor -1 in syscall close()
Test input_chunk_dropping_chunks...             [2023/03/21 07:48:07] [error] [input chunk] chunk 19788-1679352486.687501752.flb would exceed total limit size in plugin http.0
[2023/03/21 07:48:07] [error] [input chunk] no available chunk
[2023/03/21 07:48:09] [error] [input chunk] chunk 19788-1679352488.663612194.flb would exceed total limit size in plugin http.0
[2023/03/21 07:48:09] [error] [input chunk] no available chunk
[2023/03/21 07:48:11] [error] [input chunk] chunk 19788-1679352490.664263742.flb would exceed total limit size in plugin http.0
[2023/03/21 07:48:11] [error] [input chunk] no available chunk
[2023/03/21 07:48:13] [error] [input chunk] chunk 19788-1679352492.664585908.flb would exceed total limit size in plugin http.0
[2023/03/21 07:48:13] [error] [input chunk] no available chunk
[2023/03/21 07:48:15] [error] [input chunk] chunk 19788-1679352494.665882449.flb would exceed total limit size in plugin http.0
[2023/03/21 07:48:15] [error] [input chunk] no available chunk
[ OK ]
==19788== Warning: invalid file descriptor -1 in syscall close()
Test input_chunk_fs_chunk_size_real...          [2023/03/21 07:48:19] [debug] [fstore] [cio stream] new stream registered: dummy.0
[2023/03/21 07:48:19] [ info] [input:dummy:dummy.0] initializing
[2023/03/21 07:48:19] [ info] [input:dummy:dummy.0] storage_strategy='filesystem' (memory + filesystem)
[2023/03/21 07:48:19] [debug] [dummy:dummy.0] created event channels: read=26 write=32
[2023/03/21 07:48:19] [debug] [fstore] dummy.0:19788-1679352499.901862006.flb adjusting size OK
[2023/03/21 07:48:19] [debug] [fstore] dummy.0:19788-1679352499.901862006.flb mapped OK
[2023/03/21 07:48:19] [debug] [input chunk] chunk 19788-1679352499.901862006.flb required 262144 bytes and 1000000 bytes left in plugin http.0
[2023/03/21 07:48:19] [debug] [fstore] [cio file] alloc_size from 4096 to 266240
[2023/03/21 07:48:19] [debug] [input chunk] update output instances with new chunk size diff=266240
[2023/03/21 07:48:19] [debug] [input chunk] chunk 19788-1679352499.901862006.flb update plugin http.0 fs_chunks_size by 266240 bytes, the current fs_chunks_size is 266240 bytes
[2023/03/21 07:48:19] [debug] [input chunk] chunk 19788-1679352499.901862006.flb required 256 bytes and 733760 bytes left in plugin http.0
[2023/03/21 07:48:19] [ info] [input chunk test] chunk_size=266240 fs_chunk_size=266240
[2023/03/21 07:48:19] [debug] [input chunk] remove chunk 19788-1679352499.901862006.flb with 266240 bytes from plugin http.0, the updated fs_chunks_size is 0 bytes
[2023/03/21 07:48:19] [debug] [fstore] [cio file] synced at: dummy.0/19788-1679352499.901862006.flb
==19788== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==19788== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==19788== 
==19788== HEAP SUMMARY:
==19788==     in use at exit: 0 bytes in 0 blocks
==19788==   total heap usage: 10,106 allocs, 10,106 frees, 2,982,298 bytes allocated
==19788== 
==19788== All heap blocks were freed -- no leaks are possible
==19788== 
==19788== For lists of detected and suppressed errors, rerun with: -s
==19788== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
