### PR TITLE
out_vivo_exporter: add 'limit' query string property

### DIFF
--- a/plugins/out_vivo_exporter/vivo_stream.c
+++ b/plugins/out_vivo_exporter/vivo_stream.c
@@ -135,6 +135,7 @@ void vivo_stream_destroy(struct vivo_stream *vs)
 }
 
 flb_sds_t vivo_stream_get_content(struct vivo_stream *vs, int64_t from, int64_t to,
+                                  int64_t limit,
                                   int64_t *stream_start_id, int64_t *stream_end_id)
 {
     int64_t count = 0;
@@ -169,6 +170,10 @@ flb_sds_t vivo_stream_get_content(struct vivo_stream *vs, int64_t from, int64_t 
 
         *stream_end_id = e->id;
         count++;
+
+        if (limit > 0 && count >= limit) {
+            break;
+        }
     }
 
     if (ctx->empty_stream_on_read) {

--- a/plugins/out_vivo_exporter/vivo_stream.h
+++ b/plugins/out_vivo_exporter/vivo_stream.h
@@ -53,6 +53,7 @@ struct vivo_stream_entry *vivo_stream_entry_create(struct vivo_stream *vs,
 struct vivo_stream_entry *vivo_stream_append(struct vivo_stream *vs, void *data,
                                              size_t size);
 flb_sds_t vivo_stream_get_content(struct vivo_stream *vs, int64_t from, int64_t to,
+                                  int64_t limit,
                                   int64_t *stream_start_id, int64_t *stream_end_id);
 
 #endif


### PR DESCRIPTION
The new `limit` query string property allows to restrict the number of records to receive from the stream buffer, e.g:

```
curl  -s "http://127.0.0.1:2025/traces?limit=2&from=0" | jq 
{
  "resourceSpans": [
    {
      "resource": {
        "attributes": {},
        "dropped_attributes_count": 5
      },
      "schema_url": "https://ctraces/resource_span_schema_url",
      "scope_spans": [
        {
          "scope": {
            "name": "ctrace",
            "version": "a.b.c",
            "attributes": null,
            "dropped_attributes_count": 3
          },
          "spans": [
            {
              "trace_id": "7f746c2e4caecedd6faf008c52df1cf5",
              "span_id": "16b42256e4b64fef",
              "parent_span_id": null,
              "trace_state": null,
              "name": "main",
              "kind": 1,
              "start_time_unix_nano": 1679404204278695700,
              "end_time_unix_nano": 1679404204278695700,
              "attributes": {
                "agent": "Fluent Bit",
                "year": 2022,
                "open_source": true,
                "temperature": 25.5,
                "my_array": [
                  "first",
                  2,
                  false,
                  [
                    3.1,
                    5.2,
                    6.3
                  ]
                ],
                "my-list": {
                  "language": "c"
                }
              },
              "dropped_attributes_count": 0,
              "events": [
                {
                  "time_unix_nano": 1679404204278732000,
                  "name": "connect to remote server",
                  "attributes": {
                    "syscall 1": "open()",
                    "syscall 2": "connect()",
                    "syscall 3": "write()"
                  },
                  "dropped_attributes_count": 0
                }
              ],
              "links": [],
              "status": {
                "code": 0,
                "message": null
              }
            },
            {
              "trace_id": "7f746c2e4caecedd6faf008c52df1cf5",
              "span_id": "37af173f51dfa408",
              "parent_span_id": "16b42256e4b64fef",
              "trace_state": null,
              "name": "do-work",
              "kind": 3,
              "start_time_unix_nano": 1679404204278745000,
              "end_time_unix_nano": 1679404204278745000,
              "attributes": {},
              "dropped_attributes_count": 0,
              "events": [],
              "links": [
                {
                  "trace_id": "239f3806390c809c41036a251e488e35",
                  "span_id": "ceeabc247c84de46",
                  "trace_state": "aaabbbccc",
                  "attributes": null,
                  "dropped_attributes_count": 2
                }
              ],
              "status": {
                "code": 0,
                "message": null
              }
            }
          ],
          "schema_url": "https://ctraces/scope_span_schema_url"
        }
      ]
    }
  ]
}
{
  "resourceSpans": [
    {
      "resource": {
        "attributes": {},
        "dropped_attributes_count": 5
      },
      "schema_url": "https://ctraces/resource_span_schema_url",
      "scope_spans": [
        {
          "scope": {
            "name": "ctrace",
            "version": "a.b.c",
            "attributes": null,
            "dropped_attributes_count": 3
          },
          "spans": [
            {
              "trace_id": "556bc8581c459f602cab5a2825b3380b",
              "span_id": "c0321636aa4859e1",
              "parent_span_id": null,
              "trace_state": null,
              "name": "main",
              "kind": 1,
              "start_time_unix_nano": 1679404206276503000,
              "end_time_unix_nano": 1679404206276503000,
              "attributes": {
                "agent": "Fluent Bit",
                "year": 2022,
                "open_source": true,
                "temperature": 25.5,
                "my_array": [
                  "first",
                  2,
                  false,
                  [
                    3.1,
                    5.2,
                    6.3
                  ]
                ],
                "my-list": {
                  "language": "c"
                }
              },
              "dropped_attributes_count": 0,
              "events": [
                {
                  "time_unix_nano": 1679404206276515600,
                  "name": "connect to remote server",
                  "attributes": {
                    "syscall 1": "open()",
                    "syscall 2": "connect()",
                    "syscall 3": "write()"
                  },
                  "dropped_attributes_count": 0
                }
              ],
              "links": [],
              "status": {
                "code": 0,
                "message": null
              }
            },
            {
              "trace_id": "556bc8581c459f602cab5a2825b3380b",
              "span_id": "7818f8fc51ee8e17",
              "parent_span_id": "c0321636aa4859e1",
              "trace_state": null,
              "name": "do-work",
              "kind": 3,
              "start_time_unix_nano": 1679404206276520700,
              "end_time_unix_nano": 1679404206276520700,
              "attributes": {},
              "dropped_attributes_count": 0,
              "events": [],
              "links": [
                {
                  "trace_id": "2f9e8e7b17e924ff4c036ac0d3400cab",
                  "span_id": "b327217d9cfb1a55",
                  "trace_state": "aaabbbccc",
                  "attributes": null,
                  "dropped_attributes_count": 2
                }
              ],
              "status": {
                "code": 0,
                "message": null
              }
            }
          ],
          "schema_url": "https://ctraces/scope_span_schema_url"
        }
      ]
    }
  ]
}
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
