### PR TITLE
packaging: fix missing source packages

### DIFF
--- a/packaging/update-source-packages.sh
+++ b/packaging/update-source-packages.sh
@@ -60,8 +60,12 @@ else
 fi
 
 # Source - we do want word splitting and ensure some files exist
-if compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
+if compgen -G "$SOURCE_DIR/source-$VERSION*" > /dev/null; then
     echo "Copying source artefacts"
+    # shellcheck disable=SC2086
+    cp -vf "$SOURCE_DIR"/source-$VERSION* "$TARGET_DIR/$MAJOR_VERSION/"
+elif compgen -G "$SOURCE_DIR/source/*$VERSION*" > /dev/null; then
+    echo "Copying (legacy) source artefacts"
     # shellcheck disable=SC2086
     cp -vf "$SOURCE_DIR"/source/*$VERSION* "$TARGET_DIR/$MAJOR_VERSION/"
 else


### PR DESCRIPTION
Resolves #7048.

We refactored things for 2.0.9 to split up various jobs and unfortunately that slightly changed the path for the source to copy over.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
