### PR TITLE
tail: always use file->orig_name for the path_key even when file is rotated.

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -283,7 +283,7 @@ int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         append_record_to_map(data, data_size,
                              file->config->path_key,
                              flb_sds_len(file->config->path_key),
-                             file->name, file->name_len, 0);
+                             file->orig_name, file->orig_name_len, 0);
     }
     if (file->config->offset_key != NULL) {
         append_record_to_map(data, data_size,
@@ -321,8 +321,8 @@ int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         msgpack_pack_str(mp_pck, flb_sds_len(file->config->path_key));
         msgpack_pack_str_body(mp_pck, file->config->path_key,
                               flb_sds_len(file->config->path_key));
-        msgpack_pack_str(mp_pck, file->name_len);
-        msgpack_pack_str_body(mp_pck, file->name, file->name_len);
+        msgpack_pack_str(mp_pck, file->orig_name_len);
+        msgpack_pack_str_body(mp_pck, file->orig_name, file->orig_name_len);
     }
     if (file->config->offset_key != NULL) {
         /* append offset_key */


### PR DESCRIPTION
This is the tiger-1.8.15 backport for https://github.com/fluent/fluent-bit/pull/6996.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
