### PR TITLE
pipeline: outputs: azure_kuto: fix upstream node creation

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -40,6 +40,8 @@ static struct flb_upstream_node *flb_upstream_node_create_url(struct flb_azure_k
     char *host = NULL;
     char *port = NULL;
     char *uri = NULL;
+    flb_sds_t sds_host = NULL;
+    flb_sds_t sds_port = NULL;
     char *tmp;
     struct flb_hash_table *kv = NULL;
     struct flb_upstream_node *node = NULL;
@@ -71,8 +73,12 @@ static struct flb_upstream_node *flb_upstream_node_create_url(struct flb_azure_k
                                    sas_length);
 
                 if (ret != -1) {
+                    /* if any/all of these creations would fail the node creation will fail and cleanup */
+                    sds_host = flb_sds_create(host);
+                    sds_port = flb_sds_create(port);
+
                     node = flb_upstream_node_create(
-                        NULL, host, port, FLB_TRUE, ctx->ins->tls->verify,
+                        NULL, sds_host, sds_port, FLB_TRUE, ctx->ins->tls->verify,
                         ctx->ins->tls->debug, ctx->ins->tls->vhost, NULL, NULL, NULL,
                         NULL, NULL, kv, config);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

https://github.com/fluent/fluent-bit/pull/6729 changed the signature of `flb_upstream_node_create` to use `flb_sds_t` instead of `char*`, this caused the azure_kusto output plugin, which was passing `char*` to create broken upstream nodes that would eventually fail the plugin, this fix merely creates sds strings and passes those along the upstream node creation.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
