### PR TITLE
out_vivo_exporter: add new option 'http_cors_allow_origin' for CORS handling

### DIFF
--- a/plugins/out_vivo_exporter/vivo.c
+++ b/plugins/out_vivo_exporter/vivo.c
@@ -145,12 +145,7 @@ static int logs_event_chunk_append(struct vivo_exporter *ctx,
     flb_sds_t json;
     struct vivo_stream_entry *entry;
 
-    /* Convert msgpack to readable JSON format
-    json = flb_pack_msgpack_to_json_format(event_chunk->data,
-                                           event_chunk->size,
-                                           FLB_PACK_JSON_FORMAT_LINES,
-                                           FLB_PACK_JSON_DATE_FLUENT, NULL);
-    */
+
     json = format_logs(event_chunk);
     if (!json) {
         flb_plg_error(ctx->ins, "cannot convert logs chunk to JSON");
@@ -185,6 +180,8 @@ static int metrics_traces_event_chunk_append(struct vivo_exporter *ctx,
         flb_plg_error(ctx->ins, "cannot convert metrics chunk to JSON");
         return -1;
     }
+
+    flb_sds_cat_safe(&json, "\n", 1);
 
     /* append content to the stream */
     len = flb_sds_len(json);

--- a/plugins/out_vivo_exporter/vivo.c
+++ b/plugins/out_vivo_exporter/vivo.c
@@ -328,6 +328,12 @@ static struct flb_config_map config_map[] = {
      "and traces can hold up to 'stream_queue_size' bytes."
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "http_cors_allow_origin", NULL,
+     0, FLB_TRUE, offsetof(struct vivo_exporter, http_cors_allow_origin),
+     "Specify the value for the HTTP Access-Control-Allow-Origin header (CORS)"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/out_vivo_exporter/vivo.h
+++ b/plugins/out_vivo_exporter/vivo.h
@@ -36,6 +36,7 @@ struct vivo_exporter {
     /* options */
     int empty_stream_on_read;
     size_t stream_queue_size;
+    flb_sds_t http_cors_allow_origin;
 
     /* instance context */
     struct flb_output_instance *ins;


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
