### PR TITLE
tests: runtime: filter_log_to_metrics: fix warning

### DIFF
--- a/tests/runtime/filter_log_to_metrics.c
+++ b/tests/runtime/filter_log_to_metrics.c
@@ -135,7 +135,7 @@ int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
         new_data = true;
-        flb_debug("[test_filter_log_to_metrics] received message: %s", data);
+        flb_debug("[test_filter_log_to_metrics] received message: %s", (char*)data);
         pthread_mutex_lock(&result_mutex);
             strncat(output, data, size);
             data_size = size; 


### PR DESCRIPTION
This patch is to suppress following warning.

```
Consolidate compiler generated dependencies of target flb-rt-filter_log_to_metrics
[ 82%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_log_to_metrics.dir/filter_log_to_metrics.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/filter_log_to_metrics.c:21:
/home/taka/git/fluent-bit/tests/runtime/filter_log_to_metrics.c: In function ‘callback_test’:
/home/taka/git/fluent-bit/tests/runtime/filter_log_to_metrics.c:138:19: warning: format ‘%s’ expects argument of type ‘char *’, but argument 5 has type ‘void *’ [-Wformat=]
  138 |         flb_debug("[test_filter_log_to_metrics] received message: %s", data);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                                                        |
      |                                                                        void *
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_log_to_metrics.c:138:68: note: format string is defined here
  138 |         flb_debug("[test_filter_log_to_metrics] received message: %s", data);
      |                                                                   ~^
      |                                                                    |
      |                                                                    char *
      |                                                                   %p
[ 82%] Linking C executable ../../bin/flb-rt-filter_log_to_metrics
[ 82%] Built target flb-rt-filter_log_to_metrics
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_log_to_metrics 
==84211== Memcheck, a memory error detector
==84211== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==84211== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==84211== Command: bin/flb-rt-filter_log_to_metrics
==84211== 
Test counter_k8s...                             [ OK ]
Test counter...                                 [ OK ]
Test counter_k8s_two_tuples...                  [ OK ]
Test gauge...                                   [ OK ]
Test histogram...                               [ OK ]
Test counter_regex...                           [ OK ]
Test regex_empty_label_keys...                  [ OK ]
SUCCESS: All unit tests have passed.
==84211== 
==84211== HEAP SUMMARY:
==84211==     in use at exit: 0 bytes in 0 blocks
==84211==   total heap usage: 16,473 allocs, 16,473 frees, 9,227,437 bytes allocated
==84211== 
==84211== All heap blocks were freed -- no leaks are possible
==84211== 
==84211== For lists of detected and suppressed errors, rerun with: -s
==84211== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
