### PR TITLE
tests: runtime: filter_lua: remove warning

### DIFF
--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -39,6 +39,13 @@ void set_output(char *val)
     pthread_mutex_unlock(&result_mutex);
 }
 
+void clear_output()
+{
+    pthread_mutex_lock(&result_mutex);
+    output = NULL;
+    pthread_mutex_unlock(&result_mutex);
+}
+
 char *get_output(void)
 {
     char *val;
@@ -182,6 +189,8 @@ void flb_test_type_int_key(void)
       "    return 1, timestamp, new_record\n"
       "end\n";
 
+    clear_output();
+
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
     flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
@@ -256,6 +265,8 @@ void flb_test_type_int_key_multi(void)
       "    new_record[\"lua_int_2\"] = 100.2\n"
       "    return 1, timestamp, new_record\n"
       "end\n";
+
+    clear_output();
 
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
@@ -463,6 +474,8 @@ void flb_test_type_array_key(void)
       "    return 1, timestamp, new_record\n"
       "end\n";
 
+    clear_output();
+
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
     flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
@@ -537,6 +550,8 @@ void flb_test_array_contains_null(void)
       "    new_record[\"modify\"] = \"yes\"\n"
       "    return 1, timestamp, new_record\n"
       "end\n";
+
+    clear_output();
 
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
@@ -684,6 +699,8 @@ void flb_test_split_record(void)
       "function lua_main(tag, timestamp, record)\n"
       "    return 1, 5, record.x\n"
       "end\n";
+
+    clear_output();
 
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -92,7 +92,7 @@ static int cb_count_msgpack_events(void *record, size_t size, void *data)
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_lua] received message: %s", data);
+        flb_debug("[test_filter_lua] received message: %s", (char*)data);
         set_output(data); /* success */
     }
     return 0;
@@ -102,7 +102,7 @@ int callback_cat(void* data, size_t size, void* cb_data)
 {
     flb_sds_t *outbuf = cb_data;
     if (size > 0) {
-        flb_debug("[test_filter_lua] received message: %s", data);
+        flb_debug("[test_filter_lua] received message: %s", (char*)data);
         pthread_mutex_lock(&result_mutex);
         flb_sds_cat_safe(outbuf, data, size);
         pthread_mutex_unlock(&result_mutex);

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -112,6 +112,7 @@ int callback_cat(void* data, size_t size, void* cb_data)
         flb_debug("[test_filter_lua] received message: %s", (char*)data);
         pthread_mutex_lock(&result_mutex);
         flb_sds_cat_safe(outbuf, data, size);
+        flb_free(data);
         pthread_mutex_unlock(&result_mutex);
     }
     return 0;


### PR DESCRIPTION
This patch is to 
- Remove warning
- Fix valgrind errors



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_lua 
==80978== Memcheck, a memory error detector
==80978== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==80978== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==80978== Command: bin/flb-rt-filter_lua
==80978== 
Test hello_world...                             [2023/03/26 09:32:46] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:47] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:47] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:47] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:47] [ info] [input:dummy:dummy.0] initializing
[2023/03/26 09:32:47] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:47] [ info] [output:stdout:stdout.0] worker #0 started
[2023/03/26 09:32:47] [ info] [sp] stream processor started
[2023/03/26 09:32:47] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:47] [ info] [input] pausing dummy.0
[2023/03/26 09:32:47] [ info] [engine] service has stopped (0 pending tasks)
[2023/03/26 09:32:47] [ info] [input] pausing dummy.0
[2023/03/26 09:32:47] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/03/26 09:32:47] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2023/03/26 09:32:47] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:47] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:47] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:47] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:47] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:47] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:47] [ info] [sp] stream processor started
[2023/03/26 09:32:48] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:49] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key...                            [2023/03/26 09:32:49] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:49] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:49] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:49] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:49] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:49] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:49] [ info] [sp] stream processor started
[2023/03/26 09:32:50] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:51] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key_multi...                      [2023/03/26 09:32:51] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:51] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:51] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:51] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:51] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:51] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:51] [ info] [sp] stream processor started
[2023/03/26 09:32:52] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:53] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_array_key...                          [2023/03/26 09:32:53] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:53] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:53] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:53] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:53] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:53] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:53] [ info] [sp] stream processor started
[2023/03/26 09:32:54] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:55] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2023/03/26 09:32:55] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:55] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:55] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:55] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:55] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:55] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:55] [ info] [sp] stream processor started
[2023/03/26 09:32:56] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:57] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2023/03/26 09:32:57] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:57] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:57] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:57] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:57] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:57] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:57] [ info] [sp] stream processor started
[2023/03/26 09:32:59] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:32:59] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test split_record...                            [2023/03/26 09:32:59] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=80978
[2023/03/26 09:32:59] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 09:32:59] [ info] [cmetrics] version=0.5.8
[2023/03/26 09:32:59] [ info] [ctraces ] version=0.3.0
[2023/03/26 09:32:59] [ info] [input:lib:lib.0] initializing
[2023/03/26 09:32:59] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 09:32:59] [ info] [sp] stream processor started
[2023/03/26 09:33:01] [ warn] [timeout] elapsed_time: 2004
[2023/03/26 09:33:01] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 09:33:02] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==80978== 
==80978== HEAP SUMMARY:
==80978==     in use at exit: 0 bytes in 0 blocks
==80978==   total heap usage: 11,971 allocs, 11,971 frees, 5,004,046 bytes allocated
==80978== 
==80978== All heap blocks were freed -- no leaks are possible
==80978== 
==80978== For lists of detected and suppressed errors, rerun with: -s
==80978== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
