### PR TITLE
tests: runtime: filter_nest: fix warning

### DIFF
--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -50,7 +50,7 @@ int get_output_num()
 int callback_count(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_nest] received message: %s", data);
+        flb_debug("[test_filter_nest] received message: %s", (char*)data);
         add_output_num(); /* success */
     }
     return 0;
@@ -77,7 +77,7 @@ char *get_output(void)
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_nest] received message: %s", data);
+        flb_debug("[test_filter_nest] received message: %s", (char*)data);
         set_output(data); /* success */
     }
     return 0;

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -52,6 +52,7 @@ int callback_count(void* data, size_t size, void* cb_data)
     if (size > 0) {
         flb_debug("[test_filter_nest] received message: %s", (char*)data);
         add_output_num(); /* success */
+        flb_free(data);
     }
     return 0;
 }


### PR DESCRIPTION
This patch is to 
- Fix warning.
- Release unused data on callback.

```
[ 81%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_nest.dir/filter_nest.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/filter_nest.c:3:
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c: In function ‘callback_count’:
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c:53:19: warning: format ‘%s’ expects argument of type ‘char *’, but argument 5 has type ‘void *’ [-Wformat=]
   53 |         flb_debug("[test_filter_nest] received message: %s", data);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                                              |
      |                                                              void *
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c:53:58: note: format string is defined here
   53 |         flb_debug("[test_filter_nest] received message: %s", data);
      |                                                         ~^
      |                                                          |
      |                                                          char *
      |                                                         %p
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/filter_nest.c:3:
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c: In function ‘callback_test’:
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c:80:19: warning: format ‘%s’ expects argument of type ‘char *’, but argument 5 has type ‘void *’ [-Wformat=]
   80 |         flb_debug("[test_filter_nest] received message: %s", data);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                                              |
      |                                                              void *
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_nest.c:80:58: note: format string is defined here
   80 |         flb_debug("[test_filter_nest] received message: %s", data);
      |                                                         ~^
      |                                                          |
      |                                                          char *
      |                                                         %p
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_nest
==86148== Memcheck, a memory error detector
==86148== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==86148== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==86148== Command: bin/flb-rt-filter_nest
==86148== 
Test single...                                  [2023/03/26 19:59:16] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=86148
[2023/03/26 19:59:16] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/26 19:59:16] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 19:59:16] [ info] [cmetrics] version=0.5.8
[2023/03/26 19:59:16] [ info] [ctraces ] version=0.3.0
[2023/03/26 19:59:16] [ info] [input:lib:lib.0] initializing
[2023/03/26 19:59:16] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 19:59:16] [debug] [lib:lib.0] created event channels: read=21 write=22
[2023/03/26 19:59:16] [debug] [lib:lib.0] created event channels: read=25 write=26
[2023/03/26 19:59:16] [ info] [sp] stream processor started
[2023/03/26 19:59:16] [debug] [input chunk] update output instances with new chunk size diff=73
[2023/03/26 19:59:17] [debug] [task] created task=0x5487f20 id=0 OK
[2023/03/26 19:59:17] [debug] [test_filter_nest] received message: [1448403340.000000,{"extra":"Some more data","nested_key":{"to_nest":"This is the data to nest"}}]
[2023/03/26 19:59:17] [debug] [out flush] cb_destroy coro_id=0
[2023/03/26 19:59:17] [debug] [task] destroy task=0x5487f20 (task_id=0)
[2023/03/26 19:59:18] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 19:59:18] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test multiple events are not dropped(nest)...   [2023/03/26 19:59:18] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=86148
[2023/03/26 19:59:18] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/26 19:59:18] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 19:59:18] [ info] [cmetrics] version=0.5.8
[2023/03/26 19:59:18] [ info] [ctraces ] version=0.3.0
[2023/03/26 19:59:18] [ info] [input:lib:lib.0] initializing
[2023/03/26 19:59:18] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 19:59:18] [debug] [lib:lib.0] created event channels: read=30 write=31
[2023/03/26 19:59:18] [debug] [lib:lib.0] created event channels: read=34 write=35
[2023/03/26 19:59:18] [ info] [sp] stream processor started
[2023/03/26 19:59:18] [debug] [filter:nest:nest.0] no match found for (null)
[2023/03/26 19:59:18] [debug] [input chunk] update output instances with new chunk size diff=122
[2023/03/26 19:59:19] [debug] [task] created task=0x5547d40 id=0 OK
[2023/03/26 19:59:19] [debug] [test_filter_nest] received message: [1448403340.000000,{"extra":"Some more data","nested_key":{"to_nest":"This is the data to nest"}}]
[2023/03/26 19:59:19] [debug] [test_filter_nest] received message: [1448403341.000000,{"not_nest":"dummy data","extra":"dummy more data"}]
[2023/03/26 19:59:19] [debug] [out flush] cb_destroy coro_id=0
[2023/03/26 19:59:19] [debug] [task] destroy task=0x5547d40 (task_id=0)
[2023/03/26 19:59:20] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 19:59:20] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test multiple events are not dropped(lift)...   [2023/03/26 19:59:20] [ info] [fluent bit] version=2.1.0, commit=f550076325, pid=86148
[2023/03/26 19:59:20] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/03/26 19:59:20] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/03/26 19:59:20] [ info] [cmetrics] version=0.5.8
[2023/03/26 19:59:20] [ info] [ctraces ] version=0.3.0
[2023/03/26 19:59:20] [ info] [input:lib:lib.0] initializing
[2023/03/26 19:59:20] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/03/26 19:59:20] [debug] [lib:lib.0] created event channels: read=39 write=40
[2023/03/26 19:59:20] [debug] [lib:lib.0] created event channels: read=43 write=44
[2023/03/26 19:59:20] [ info] [sp] stream processor started
[2023/03/26 19:59:20] [debug] [filter:nest:nest.0] Lift : Outer map size is 2, will be 2, lifting 1 record(s)
[2023/03/26 19:59:20] [debug] [filter:nest:nest.0] Lift : No match found for nested
[2023/03/26 19:59:20] [debug] [input chunk] update output instances with new chunk size diff=100
[2023/03/26 19:59:21] [debug] [task] created task=0x5608a00 id=0 OK
[2023/03/26 19:59:21] [debug] [test_filter_nest] received message: [1448403340.000000,{"not_nestd":"not nested data","child":"nested data"}]
[2023/03/26 19:59:21] [debug] [test_filter_nest] received message: [1448403341.000000,{"not_nest":"dummy data","extra":"dummy more data"}]
[2023/03/26 19:59:21] [debug] [out flush] cb_destroy coro_id=0
[2023/03/26 19:59:21] [debug] [task] destroy task=0x5608a00 (task_id=0)
[2023/03/26 19:59:22] [ warn] [engine] service will shutdown in max 1 seconds
[2023/03/26 19:59:22] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==86148== 
==86148== HEAP SUMMARY:
==86148==     in use at exit: 0 bytes in 0 blocks
==86148==   total heap usage: 4,472 allocs, 4,472 frees, 2,048,836 bytes allocated
==86148== 
==86148== All heap blocks were freed -- no leaks are possible
==86148== 
==86148== For lists of detected and suppressed errors, rerun with: -s
==86148== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
