### PR TITLE
plugin: in_systemd: fix warning

### DIFF
--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -271,7 +271,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
     sd_journal_get_data_threshold(ctx->j, &size);
     flb_plg_debug(ctx->ins,
                   "sd_journal library may truncate values "
-                  "to sd_journal_get_data_threshold() bytes: %i", size);
+                  "to sd_journal_get_data_threshold() bytes: %zu", size);
 
     return ctx;
 }


### PR DESCRIPTION
This is to fix following warning.

```
[ 65%] Building C object plugins/in_systemd/CMakeFiles/flb-plugin-in_systemd.dir/systemd_config.c.o
In file included from /home/taka/git/fluent-bit/plugins/in_systemd/systemd_config.c:21:
/home/taka/git/fluent-bit/plugins/in_systemd/systemd_config.c: In function ‘flb_systemd_config_create’:
/home/taka/git/fluent-bit/include/fluent-bit/flb_input_plugin.h:45:47: warning: format ‘%i’ expects argument of type ‘int’, but argument 7 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
   45 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[input:%s:%s] " fmt,     \
      |                                               ^~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/plugins/in_systemd/systemd_config.c:272:5: note: in expansion of macro ‘flb_plg_debug’
  272 |     flb_plg_debug(ctx->ins,
      |     ^~~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
