### PR TITLE
dockerfiles: remove openssl shell and binaries

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -175,7 +175,7 @@ COPY --from=deb-extractor /dpkg /
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 # Mitigate https://www.form3.tech/engineering/content/exploiting-distroless-images by removing the binaries for OpenSSL CLI
-RUN rm -f /usr/bin/openssl /usr/bin/c_rehash
+RUN rm -fv /usr/bin/openssl && rm -fv /usr/bin/c_rehash
 
 # Finally the binaries as most likely to change
 COPY --from=builder /fluent-bit /fluent-bit

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -174,6 +174,9 @@ COPY --from=deb-extractor /dpkg /
 # Copy certificates
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Mitigate https://www.form3.tech/engineering/content/exploiting-distroless-images by removing the binaries for OpenSSL CLI
+RUN rm -f /usr/bin/openssl /usr/bin/c_rehash
+
 # Finally the binaries as most likely to change
 COPY --from=builder /fluent-bit /fluent-bit
 


### PR DESCRIPTION
Resolves a possible exploit to get a shell in the distroless images: https://www.form3.tech/engineering/content/exploiting-distroless-images

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
