### PR TITLE
events: minimal fix - zero events via calloc

### DIFF
--- a/src/flb_metrics_exporter.c
+++ b/src/flb_metrics_exporter.c
@@ -218,7 +218,7 @@ struct flb_me *flb_me_create(struct flb_config *ctx)
     struct flb_me *me;
 
     /* Context */
-    me = flb_malloc(sizeof(struct flb_me));
+    me = flb_calloc(1, sizeof(struct flb_me));
     if (!me) {
         flb_errno();
         return NULL;

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -174,7 +174,7 @@ void test_non_blocking_and_blocking_timeout()
 {   
     struct test_evl_context *ctx;
 
-    struct mk_event event;
+    struct mk_event event = {0};
 
     struct flb_time start_time;
     struct flb_time end_time;
@@ -281,7 +281,7 @@ void test_infinite_wait()
 {   
     struct test_evl_context *ctx;
 
-    struct mk_event event;
+    struct mk_event event = {0};
 
     struct flb_time start_time;
     struct flb_time end_time;
@@ -364,7 +364,7 @@ void event_loop_stress_priority_add_delete()
     struct test_evl_context *ctx;
 
     const int n_timers = EVENT_LOOP_MAX_EVENTS;
-    struct mk_event events[EVENT_LOOP_MAX_EVENTS];
+    struct mk_event events[EVENT_LOOP_MAX_EVENTS] = {0};
     struct mk_event *event_cronology[EVENT_LOOP_TEST_PRIORITIES] = {0}; /* event loop priority fifo */
     int priority_cronology = 0;
 
@@ -395,6 +395,7 @@ void event_loop_stress_priority_add_delete()
     for (i = 0; i < n_timers / 2; ++i) {
         priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
         target = 0;
+        memset(&events[i], 0, sizeof(struct mk_event));
         test_timeout_create(ctx->evl, 0, 0, &events[i]);
         events[i].priority = priority;
         ++immediate_timers[priority];
@@ -467,6 +468,7 @@ void event_loop_stress_priority_add_delete()
     for (i = 0; i < n_timers / 2; ++i) {
         priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
         target = 0;
+        memset(&events[i], 0, sizeof(struct mk_event));
         test_timeout_create(ctx->evl, target, 0, &events[i]);
         events[i].priority = priority;
         ++immediate_timers[priority];
@@ -478,6 +480,7 @@ void event_loop_stress_priority_add_delete()
     for (i = n_timers / 2; i < n_timers; ++i) {
         priority = rand() % EVENT_LOOP_TEST_PRIORITIES;
         target = 2; /* 2 second delay */
+        memset(&events[i], 0, sizeof(struct mk_event));
         test_timeout_create(ctx->evl, target, 0, &events[i]);
         events[i].priority = priority;
         ++delayed_timers[priority];

--- a/tests/internal/fuzzers/signv4_fuzzer.c
+++ b/tests/internal/fuzzers/signv4_fuzzer.c
@@ -68,7 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     http_u = flb_upstream_create(http_config, "127.0.0.1", 8001, 0, NULL);
     if (http_u != NULL) {
-        http_u_conn = flb_malloc(sizeof(struct flb_connection));
+        http_u_conn = flb_calloc(1, sizeof(struct flb_connection));
         if (http_u_conn != NULL) {
             http_u_conn->upstream = http_u;
 

--- a/tests/internal/http_client.c
+++ b/tests/internal/http_client.c
@@ -42,7 +42,7 @@ struct test_ctx* test_ctx_create()
         return NULL;
     }
 
-    ret_ctx->u_conn = flb_malloc(sizeof(struct flb_connection));
+    ret_ctx->u_conn = flb_calloc(1, sizeof(struct flb_connection));
     if(!TEST_CHECK(ret_ctx->u_conn != NULL)) {
         flb_errno();
         TEST_MSG("flb_malloc(flb_connection) failed");

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -47,8 +47,8 @@ static void test_client_server(int is_ipv6)
     flb_sockfd_t fd_client;
     flb_sockfd_t fd_server;
     flb_sockfd_t fd_remote = -1;
-    struct mk_event e_client;
-    struct mk_event e_server;
+    struct mk_event e_client = {0};
+    struct mk_event e_server = {0};
     struct mk_event *e_item;
     struct mk_event_loop *evl;
 


### PR DESCRIPTION
## Event Loop Corruption Fix
Note: This is a minimized version of this PR, following the decisions made in a sync up with Leonardo 2 weeks ago: https://github.com/fluent/fluent-bit/pull/7001

>   Fluent Bit seems to support multiple adds of the same events to the event loop.
>     
>   However there's an issue where if you add the same event multiple times, the internal linked list that tracks ready events could be corrupted.
>   
>   This is solved by checking if the event is in the event loop's ready list and if so, removing it. See this monkey pr on the fix: https://github.com/monkey/monkey/pull/389
>   
>   However the solution requires that events are initialized, so that we can track if the event has or has not been added to the ready list. Uninitialized memory can't be trusted.

Leonardo agrees that this change is important but due to the brittle nature of the event system wants a minimal change that will most likely not break Fluent Bit.

### Here's the Plan

**Fluent Bit**
Ensure CALLOC initializes the event on creation for each of these calls

- MK_EVENT_NEW
- MK_EVENT_INIT
- MK_EVENT_ZERO

**Monkey**
Remove event from the Priority Loop on Add
In progress: https://github.com/monkey/monkey/pull/389

@leonardo-albertovich