### PR TITLE
tests: runtime: filter_parser: make more stable 

### DIFF
--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -31,7 +31,7 @@ char *get_output(void)
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_parser] received message: %s", data);
+        flb_debug("[test_filter_parser] received message: %s", (char*)data);
         set_output(data); /* success */
     }
     return 0;

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -28,6 +28,13 @@ char *get_output(void)
     return val;
 }
 
+void clear_output()
+{
+    pthread_mutex_lock(&result_mutex);
+    output = NULL;
+    pthread_mutex_unlock(&result_mutex);
+}
+
 int callback_test(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
@@ -83,6 +90,8 @@ void flb_test_filter_parser_extract_fields()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -169,6 +178,8 @@ void flb_test_filter_parser_reserve_data_off()
     cb.cb   = callback_test;
     cb.data = NULL;
 
+    clear_output();
+
     ctx = flb_create();
 
     /* Configure service */
@@ -243,6 +254,8 @@ void flb_test_filter_parser_handle_time_key()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -319,6 +332,8 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     int out_ffd;
     int filter_ffd;
     struct flb_parser *parser;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -399,6 +414,8 @@ void flb_test_filter_parser_handle_time_key_with_time_zone()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -489,6 +506,8 @@ void flb_test_filter_parser_ignore_malformed_time()
     cb.cb   = callback_test;
     cb.data = NULL;
 
+    clear_output();
+
     ctx = flb_create();
 
     /* Configure service */
@@ -565,6 +584,8 @@ void flb_test_filter_parser_preserve_original_field()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -648,6 +669,8 @@ void flb_test_filter_parser_first_matched_when_mutilple_parser()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 
@@ -733,6 +756,8 @@ void flb_test_filter_parser_skip_empty_values_false()
     struct flb_lib_out_cb cb;
     cb.cb   = callback_test;
     cb.data = NULL;
+
+    clear_output();
 
     ctx = flb_create();
 


### PR DESCRIPTION
This patch is to 
- Fix warning
- Fix valgrind error



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_parser 
==36952== Memcheck, a memory error detector
==36952== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==36952== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==36952== Command: bin/flb-rt-filter_parser
==36952== 
Test filter_parser_extract_fields...            [2023/04/01 07:17:41] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:41] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:41] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:41] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:41] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:41] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:41] [ info] [sp] stream processor started
[2023/04/01 07:17:42] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/01 07:17:43] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_reserve_data_off...          [2023/04/01 07:17:43] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:43] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/01 07:17:43] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:43] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:43] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:43] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:43] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:43] [debug] [lib:lib.0] created event channels: read=30 write=31
[2023/04/01 07:17:43] [debug] [lib:lib.0] created event channels: read=34 write=35
[2023/04/01 07:17:43] [ info] [sp] stream processor started
[2023/04/01 07:17:43] [debug] [input chunk] update output instances with new chunk size diff=66
[2023/04/01 07:17:44] [debug] [task] created task=0x55519f0 id=0 OK
[2023/04/01 07:17:44] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example"}]
[2023/04/01 07:17:44] [debug] [out flush] cb_destroy coro_id=0
[2023/04/01 07:17:44] [debug] [task] destroy task=0x55519f0 (task_id=0)
[2023/04/01 07:17:44] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/01 07:17:45] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_handle_time_key...           [2023/04/01 07:17:45] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:45] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/01 07:17:45] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:45] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:45] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:45] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:45] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:45] [debug] [lib:lib.0] created event channels: read=39 write=40
[2023/04/01 07:17:45] [debug] [lib:lib.0] created event channels: read=43 write=44
[2023/04/01 07:17:45] [ info] [sp] stream processor started
[2023/04/01 07:17:45] [debug] [input chunk] update output instances with new chunk size diff=39
[2023/04/01 07:17:46] [debug] [task] created task=0x5615390 id=0 OK
[2023/04/01 07:17:46] [debug] [test_filter_parser] received message: [1509575121.648000,{"message":"This is an example"}]
[2023/04/01 07:17:46] [debug] [out flush] cb_destroy coro_id=0
[2023/04/01 07:17:46] [debug] [task] destroy task=0x5615390 (task_id=0)
[2023/04/01 07:17:46] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/01 07:17:47] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_handle_time_key_with_time_zone... [2023/04/01 07:17:47] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:47] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/01 07:17:47] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:47] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:47] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:47] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:47] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:47] [debug] [lib:lib.0] created event channels: read=48 write=49
[2023/04/01 07:17:47] [debug] [lib:lib.0] created event channels: read=52 write=53
[2023/04/01 07:17:47] [ info] [sp] stream processor started
[2023/04/01 07:17:47] [debug] [input chunk] update output instances with new chunk size diff=39
[2023/04/01 07:17:48] [debug] [task] created task=0x56d8ce0 id=0 OK
[2023/04/01 07:17:48] [debug] [test_filter_parser] received message: [1509589521.648000,{"message":"This is an example"}]
[2023/04/01 07:17:48] [debug] [out flush] cb_destroy coro_id=0
[2023/04/01 07:17:48] [debug] [task] destroy task=0x56d8ce0 (task_id=0)
[2023/04/01 07:17:48] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/01 07:17:49] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_ignore_malformed_time...     [2023/04/01 07:17:49] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:49] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/01 07:17:49] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:49] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:49] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:49] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:49] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:49] [debug] [lib:lib.0] created event channels: read=57 write=58
[2023/04/01 07:17:49] [debug] [lib:lib.0] created event channels: read=61 write=62
[2023/04/01 07:17:49] [ info] [sp] stream processor started
[2023/04/01 07:17:49] [error] [parser] cannot parse '2017_$!^-11-01T22:25:21.648'
[2023/04/01 07:17:49] [ warn] [parser:timestamp] invalid time format %Y-%m-%dT%H:%M:%S.%L for '2017_$!^-11-01T22:25:21.648'
[2023/04/01 07:17:49] [debug] [input chunk] update output instances with new chunk size diff=66
[2023/04/01 07:17:50] [debug] [task] created task=0x579c770 id=0 OK
[2023/04/01 07:17:50] [debug] [test_filter_parser] received message: [1448403340.000000,{"@timestamp":"2017_$!^-11-01T22:25:21.648","log":"An example"}]
[2023/04/01 07:17:50] [debug] [out flush] cb_destroy coro_id=0
[2023/04/01 07:17:50] [debug] [task] destroy task=0x579c770 (task_id=0)
[2023/04/01 07:17:50] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/01 07:17:51] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_preserve_original_field...   [2023/04/01 07:17:51] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:51] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/01 07:17:51] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:51] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:51] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:51] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:51] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:51] [debug] [lib:lib.0] created event channels: read=66 write=67
[2023/04/01 07:17:51] [debug] [lib:lib.0] created event channels: read=70 write=71
[2023/04/01 07:17:51] [ info] [sp] stream processor started
[2023/04/01 07:17:51] [debug] [input chunk] update output instances with new chunk size diff=118
[2023/04/01 07:17:52] [debug] [task] created task=0x6883380 id=0 OK
[2023/04/01 07:17:52] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example","data":"100 0.5 true This is an example","log":"An example"}]
[2023/04/01 07:17:52] [debug] [out flush] cb_destroy coro_id=0
[2023/04/01 07:17:52] [debug] [task] destroy task=0x6883380 (task_id=0)
[2023/04/01 07:17:52] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/01 07:17:53] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_first_matched_when_multiple_parser... [2023/04/01 07:17:53] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:53] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:53] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:53] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:53] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:53] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:53] [ info] [sp] stream processor started
[2023/04/01 07:17:54] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/01 07:17:55] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_skip_empty_values_false...   [2023/04/01 07:17:55] [ info] [fluent bit] version=2.1.0, commit=d847afc067, pid=36952
[2023/04/01 07:17:55] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/01 07:17:55] [ info] [cmetrics] version=0.5.9
[2023/04/01 07:17:55] [ info] [ctraces ] version=0.3.0
[2023/04/01 07:17:55] [ info] [input:lib:lib.0] initializing
[2023/04/01 07:17:55] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/01 07:17:55] [ info] [sp] stream processor started
[2023/04/01 07:17:56] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/01 07:17:57] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==36952== 
==36952== HEAP SUMMARY:
==36952==     in use at exit: 0 bytes in 0 blocks
==36952==   total heap usage: 12,206 allocs, 12,206 frees, 5,533,413 bytes allocated
==36952== 
==36952== All heap blocks were freed -- no leaks are possible
==36952== 
==36952== For lists of detected and suppressed errors, rerun with: -s
==36952== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
