### PR TITLE
out_forward: fix warning

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -725,7 +725,7 @@ static int forward_read_ack(struct flb_forward *ctx,
         goto error;
     }
 
-    flb_plg_debug(ctx->ins, "protocol: received ACK %.*s", ack_len, ack);
+    flb_plg_debug(ctx->ins, "protocol: received ACK %.*s", (int)ack_len, ack);
     msgpack_unpacked_destroy(&result);
     return 0;
 


### PR DESCRIPTION
This patch is to fix following warning.

```
[ 53%] Building C object plugins/out_forward/CMakeFiles/flb-plugin-out_forward.dir/forward.c.o
In file included from /home/taka/git/fluent-bit/plugins/out_forward/forward.c:20:
/home/taka/git/fluent-bit/plugins/out_forward/forward.c: In function ‘forward_read_ack’:
/home/taka/git/fluent-bit/include/fluent-bit/flb_output_plugin.h:82:51: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 7 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
   82 |             flb_log_print(FLB_LOG_DEBUG, NULL, 0, "[output:%s:%s] " fmt,    \
      |                                                   ^~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/plugins/out_forward/forward.c:728:5: note: in expansion of macro ‘flb_plg_debug’
  728 |     flb_plg_debug(ctx->ins, "protocol: received ACK %.*s", ack_len, ack);
      |     ^~~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
