### PR TITLE
input: use pthread_key to handle flb_libco_in_params

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -42,11 +42,11 @@
 #ifdef FLB_HAVE_METRICS
 #include <fluent-bit/flb_metrics.h>
 #endif
+#include <fluent-bit/flb_pthread.h>
 
 #include <cmetrics/cmetrics.h>
 #include <monkey/mk_core.h>
 #include <msgpack.h>
-
 #include <inttypes.h>
 
 #define FLB_COLLECT_TIME        1
@@ -461,6 +461,7 @@ struct flb_libco_in_params {
     struct flb_coro *coro;
 };
 
+extern pthread_key_t libco_in_param_key;
 extern struct flb_libco_in_params libco_in_param;
 void flb_input_coro_prepare_destroy(struct flb_input_coro *input_coro);
 
@@ -469,18 +470,44 @@ static FLB_INLINE void input_params_set(struct flb_coro *coro,
                              struct flb_config *config,
                              void *context)
 {
+    struct flb_libco_in_params *params;
+
+    params = pthread_getspecific(libco_in_param_key);
+    if (params == NULL) {
+        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
+        if (params == NULL) {
+            flb_errno();
+            return;
+        }
+        pthread_setspecific(libco_in_param_key, params);
+    }
+
     /* Set callback parameters */
-    libco_in_param.coll    = coll;
-    libco_in_param.config  = config;
-    libco_in_param.coro    = coro;
+    params->coll    = coll;
+    params->config  = config;
+    params->coro    = coro;
     co_switch(coro->callee);
 }
 
 static FLB_INLINE void input_pre_cb_collect(void)
 {
-    struct flb_input_collector *coll = libco_in_param.coll;
-    struct flb_config *config = libco_in_param.config;
-    struct flb_coro *coro     = libco_in_param.coro;
+    struct flb_input_collector *coll;
+    struct flb_config *config;
+    struct flb_coro *coro;
+    struct flb_libco_in_params *params;
+
+    params = pthread_getspecific(libco_in_param_key);
+    if (params == NULL) {
+        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
+        if (params == NULL) {
+            flb_errno();
+            return;
+        }
+        pthread_setspecific(libco_in_param_key, params);
+    }
+    coll = params->coll;
+    config = params->config;
+    coro = params->coro;
 
     co_switch(coro->caller);
     coll->cb_collect(coll->instance, config, coll->instance->context);
@@ -489,6 +516,13 @@ static FLB_INLINE void input_pre_cb_collect(void)
 static FLB_INLINE void flb_input_coro_resume(struct flb_input_coro *input_coro)
 {
     flb_coro_resume(input_coro->coro);
+}
+
+static void libco_in_param_key_destroy(void *data)
+{
+    struct flb_libco_inparams *params = (struct flb_libco_inparams*)data;
+
+    flb_free(params);
 }
 
 static FLB_INLINE
@@ -503,6 +537,8 @@ struct flb_input_coro *flb_input_coro_collect(struct flb_input_collector *coll,
     if (!input_coro) {
         return NULL;
     }
+
+    pthread_key_create(&libco_in_param_key, libco_in_param_key_destroy);
 
     coro = input_coro->coro;
     if (!coro) {

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -48,6 +48,7 @@
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
 struct flb_libco_in_params libco_in_param;
+pthread_key_t libco_in_param_key;
 
 #define protcmp(a, b)  strncasecmp(a, b, strlen(a))
 


### PR DESCRIPTION
#7061 
Note: Valgrind reports too many errors. We should check that this patch causes it.

I modified to use pthread_key to handle `flb_libco_in_params`.
Currently  `flb_libco_in_params` is a global variable, I suspect it causes race error.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Flush        0.5
    Daemon       Off
    Log_Level    info

[INPUT]
    name  event_type
    type  logs
    interval_sec 0
    interval_nsec 500

[INPUT]
    name  event_type
    type  metrics
    interval_sec 0
    interval_nsec 500

[OUTPUT]
    Name  vivo_exporter
    Match *
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
