### PR TITLE
filter_modify: support boolean as VALUE

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -483,6 +483,16 @@ static inline bool helper_msgpack_object_matches_regex(msgpack_object * obj,
         key = obj->via.str.ptr;
         len = obj->via.str.size;
     }
+    else if (obj->type == MSGPACK_OBJECT_BOOLEAN) {
+        if (obj->via.boolean) {
+            key = "true";
+            len = 4;
+        }
+        else {
+            key = "false";
+            len = 5;
+        }
+    }
     else {
         return false;
     }

--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1503,6 +1503,55 @@ static void flb_test_issue_4319_2()
     filter_test_destroy(ctx);
 }
 
+/*
+ * to check issue https://github.com/fluent/fluent-bit/issues/7075
+*/
+static void flb_test_issue_7075()
+{
+    char *p;
+    int len;
+    int ret;
+    int bytes;
+    int count;
+
+    struct filter_test *ctx;
+    struct flb_lib_out_cb cb_data;
+
+    clear_output_num();
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"matched\":true";
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         /* set key which doesn't exist */
+                         "condition", "key_value_matches ok true",
+                         "rename", "ok matched",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+        /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest event */
+    p = "[0, {\"ok\":true}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    sleep(1); /* waiting flush */
+
+    filter_test_destroy(ctx);
+}
+
 TEST_LIST = {
     /* Operations / Commands */
     {"op_set_append"            , flb_test_op_set_append },
@@ -1546,6 +1595,7 @@ TEST_LIST = {
     {"multiple events are not dropped", flb_test_not_drop_multi_event },
     {"cond_key_value_does_not_equal and key does not exist", flb_test_issue_4319 },
     {"cond_key_value_does_not_matches and key does not exist", flb_test_issue_4319_2 },
+    {"Key_value_matches and value is bool type", flb_test_issue_7075},
 
     {NULL, NULL}
 };


### PR DESCRIPTION
This patch is to support boolean type as a VALUE of condition.

#7075 


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Cofiguration

This configuration is to add `TAG:Log` if the condition is matched.
```
[INPUT]
    Name dummy
    Dummy {"isAudit":{"true":true}}

[FILTER]
    Name modify
    Match *
    Condition Key_value_matches $isAudit['true'] true
    Add TAG Log

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

Filtered output is `[0] dummy.0: [1680396959.502707583, {"isAudit"=>{"true"=>true}, "TAG"=>"Log"}]`
```
$ valgrind --leak-check=full bin/fluent-bit -c issues/7075/a.conf 
==66367== Memcheck, a memory error detector
==66367== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==66367== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==66367== Command: bin/fluent-bit -c issues/7075/a.conf
==66367== 
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/02 09:55:56] [ info] [fluent bit] version=2.1.0, commit=1d9691490f, pid=66367
[2023/04/02 09:55:57] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/02 09:55:57] [ info] [cmetrics] version=0.6.0
[2023/04/02 09:55:57] [ info] [ctraces ] version=0.3.0
[2023/04/02 09:55:57] [ info] [input:dummy:dummy.0] initializing
[2023/04/02 09:55:57] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/04/02 09:55:57] [ info] [output:stdout:stdout.0] worker #0 started
[2023/04/02 09:55:57] [ info] [sp] stream processor started
[0] dummy.0: [1680396957.531957062, {"isAudit"=>{"true"=>true}, "TAG"=>"Log"}]
[0] dummy.0: [1680396958.528912909, {"isAudit"=>{"true"=>true}, "TAG"=>"Log"}]
^C[2023/04/02 09:55:59] [engine] caught signal (SIGINT)
[2023/04/02 09:55:59] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [1680396959.502707583, {"isAudit"=>{"true"=>true}, "TAG"=>"Log"}]
[2023/04/02 09:55:59] [ info] [input] pausing dummy.0
[2023/04/02 09:56:00] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/02 09:56:00] [ info] [input] pausing dummy.0
[2023/04/02 09:56:00] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/04/02 09:56:00] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==66367== 
==66367== HEAP SUMMARY:
==66367==     in use at exit: 0 bytes in 0 blocks
==66367==   total heap usage: 1,768 allocs, 1,768 frees, 1,455,261 bytes allocated
==66367== 
==66367== All heap blocks were freed -- no leaks are possible
==66367== 
==66367== For lists of detected and suppressed errors, rerun with: -s
==66367== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
