### PR TITLE
go: fix segfault on shutdown by separating exit and unregister

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -71,6 +71,8 @@ int flb_plugin_proxy_init(struct flb_plugin_proxy *proxy,
 int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
                               struct flb_config *config);
 
+void flb_plugin_proxy_unregister(struct flb_output_plugin *out);
+
 struct flb_plugin_proxy *flb_plugin_proxy_create(const char *dso_path, int type,
                                                  struct flb_config *config);
 int flb_plugin_proxy_load_all(struct flb_config *config);

--- a/include/fluent-bit/flb_plugins.h.in
+++ b/include/fluent-bit/flb_plugins.h.in
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_plugin_proxy.h>
 #include <fluent-bit/flb_log.h>
 
 @FLB_IN_PLUGINS_DECL@
@@ -70,6 +71,9 @@ void flb_plugins_unregister(struct flb_config *config)
 
     mk_list_foreach_safe(head, tmp, &config->out_plugins) {
         out = mk_list_entry(head, struct flb_output_plugin, _head);
+        if (out->proxy) {
+            flb_plugin_proxy_unregister(out);
+        }
         mk_list_del(&out->_head);
         flb_free(out);
     }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -940,6 +940,9 @@ int flb_engine_shutdown(struct flb_config *config)
     }
 #endif
 
+    /* free/destroy plugins */
+    flb_plugins_unregister(config);
+
     return 0;
 }
 

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -75,10 +75,19 @@ static int flb_proxy_cb_exit(void *data, struct flb_config *config)
     struct flb_plugin_proxy *proxy = (instance->proxy);
 
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
+        proxy_go_exit(proxy->data);
+    }
+    return 0;
+}
+
+void flb_plugin_proxy_unregister(struct flb_output_plugin *out)
+{
+    struct flb_plugin_proxy *proxy = (out->proxy);
+
+    if (proxy->def->proxy == FLB_PROXY_GOLANG) {
         proxy_go_destroy(proxy->data);
     }
     flb_plugin_proxy_destroy(proxy);
-    return 0;
 }
 
 static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -145,7 +145,7 @@ int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
     return ret;
 }
 
-int proxy_go_destroy(void *data)
+int proxy_go_exit(void *data)
 {
     int ret = 0;
     struct flbgo_output_plugin *plugin;
@@ -159,6 +159,16 @@ int proxy_go_destroy(void *data)
     else if (plugin->cb_exit) {
         ret = plugin->cb_exit();
     }
+
+    return ret;
+}
+
+void proxy_go_destroy(void *data)
+{
+    int ret = 0;
+    struct flbgo_output_plugin *plugin;
+
+    plugin = (struct flbgo_output_plugin *) data;
     flb_free(plugin->name);
     flb_free(plugin);
     return ret;

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -44,5 +44,6 @@ int proxy_go_init(struct flb_plugin_proxy *proxy);
 int proxy_go_flush(struct flb_plugin_proxy_context *ctx,
                    const void *data, size_t size,
                    const char *tag, int tag_len);
-int proxy_go_destroy(void *data);
+void proxy_go_destroy(void *data);
+int proxy_go_exit(void *data);
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

Previously the go plugin code attempted to free and unregister the plugin
    in the same code as the call to cb_exit on the plugin instance. This
    causes a segfault when there are multiple instances of the same go
    plugin configured.

https://github.com/aws/aws-for-fluent-bit/issues/613

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
