### PR TITLE
aws: Profile support for AWS output plugins

### DIFF
--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -161,7 +161,8 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
                                                             char *proxy,
                                                             struct
                                                             flb_aws_client_generator
-                                                            *generator);
+                                                            *generator,
+                                                            char *profile);
 
 /* Provide base configuration options for managed chain */
 #define FLB_AWS_CREDENTIAL_BASE_CONFIG_MAP(prefix)                                    \
@@ -185,8 +186,13 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
      0, FLB_FALSE, 0,                                                                 \
      "Specify an external ID for the STS API, can be used with the `" prefix          \
      "role_arn` parameter if your role requires an external ID."                      \
+    },                                                                                \
+    {                                                                                 \
+     FLB_CONFIG_MAP_STR, prefix "profile", NULL,                                      \
+     0, FLB_FALSE, 0,                                                                 \
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually"  \
+     "stored in $HOME/.aws/ directory."                                               \
     }
-    
 /*
  * Managed chain provider; Creates and manages removal of dependancies for an instance
  */
@@ -277,7 +283,7 @@ struct flb_aws_provider *flb_ec2_provider_create(struct flb_config *config,
 /*
  * New AWS Profile provider, reads from the shared credentials file
  */
-struct flb_aws_provider *flb_profile_provider_create();
+struct flb_aws_provider *flb_profile_provider_create(char* profile);
 
 /*
  * Helper functions

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -711,7 +711,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                                                NULL,
                                                                NULL,
                                                                NULL,
-                                                               flb_aws_client_generator());
+                                                               flb_aws_client_generator(),
+                                                               NULL);
 
         if (!ctx->aws_provider) {
             flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -256,7 +256,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                                            (char *) ctx->region,
                                                            (char *) ctx->sts_endpoint,
                                                            NULL,
-                                                           flb_aws_client_generator());
+                                                           flb_aws_client_generator(),
+                                                           ctx->profile);
     if (!ctx->aws_provider) {
         flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");
         goto error;
@@ -652,6 +653,13 @@ static struct flb_config_map config_map[] = {
      "dimensions, put the values as a comma seperated string. If you want to put "
      "list of lists, use the list as semicolon seperated strings. If your value "
      "is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]]."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "profile", NULL,
+     0, FLB_TRUE, offsetof(struct flb_cloudwatch, profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
     },
 
     /* EOF */

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -114,6 +114,7 @@ struct flb_cloudwatch {
     const char *log_key;
     const char *extra_user_agent;
     const char *external_id;
+    const char *profile;
     int custom_endpoint;
     /* Should the plugin create the log group */
     int create_group;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -1016,6 +1016,12 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_service_name),
      "AWS Service Name"
     },
+    {
+     FLB_CONFIG_MAP_STR, "aws_profile", NULL,
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
+    },
 #endif
 
     /* Logstash compatibility */

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -54,6 +54,7 @@ struct flb_elasticsearch {
     int has_aws_auth;
     char *aws_region;
     char *aws_sts_endpoint;
+    char *aws_profile;
     struct flb_aws_provider *aws_provider;
     struct flb_aws_provider *base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -347,7 +347,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                                                    ctx->aws_region,
                                                                    ctx->aws_sts_endpoint,
                                                                    NULL,
-                                                                   flb_aws_client_generator());
+                                                                   flb_aws_client_generator(),
+                                                                   ctx->aws_profile);
             if (!ctx->aws_provider) {
                 flb_error("[out_es] Failed to create AWS Credential Provider");
                 flb_es_conf_destroy(ctx);

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -181,7 +181,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                                            (char *) ctx->region,
                                                            ctx->sts_endpoint,
                                                            NULL,
-                                                           flb_aws_client_generator());
+                                                           flb_aws_client_generator(),
+                                                           ctx->profile);
     if (!ctx->aws_provider) {
         flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");
         goto error;
@@ -474,6 +475,12 @@ static struct flb_config_map config_map[] = {
      "networking issues."
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "profile", NULL,
+     0, FLB_TRUE, offsetof(struct flb_firehose, profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
+    },
     /* EOF */
     {0}
 };

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -87,6 +87,7 @@ struct flb_firehose {
     const char *log_key;
     const char *external_id;
     char *sts_endpoint;
+    char *profile;
     int custom_endpoint;
     int retry_requests;
     int compression;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -170,7 +170,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                                            (char *) ctx->region,
                                                            ctx->sts_endpoint,
                                                            NULL,
-                                                           flb_aws_client_generator());
+                                                           flb_aws_client_generator(),
+                                                           ctx->profile);
     if (!ctx->aws_provider) {
         flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");
         goto error;
@@ -467,6 +468,13 @@ static struct flb_config_map config_map[] = {
      "Instead, it enables an immediate retry with no delay for networking "
      "errors, which may help improve throughput when there are transient/random "
      "networking issues."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "profile", NULL,
+     0, FLB_TRUE, offsetof(struct flb_kinesis, profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
     },
 
     /* EOF */

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -92,6 +92,7 @@ struct flb_kinesis {
     int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;
+    char *profile;
 
     /* in this plugin the 'random' partition key is a uuid + fluent tag + timestamp */
     char *uuid;

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -1002,6 +1002,12 @@ static struct flb_config_map config_map[] = {
      "AWS Region of your Amazon OpenSearch Service cluster"
     },
     {
+     FLB_CONFIG_MAP_STR, "aws_profile", "default",
+     0, FLB_TRUE, offsetof(struct flb_opensearch, aws_profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
+    },
+    {
      FLB_CONFIG_MAP_STR, "aws_sts_endpoint", NULL,
      0, FLB_TRUE, offsetof(struct flb_opensearch, aws_sts_endpoint),
      "Custom endpoint for the AWS STS API, used with the AWS_Role_ARN option"

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -66,6 +66,7 @@ struct flb_opensearch {
     int has_aws_auth;
     char *aws_region;
     char *aws_sts_endpoint;
+    char *aws_profile;
     struct flb_aws_provider *aws_provider;
     struct flb_aws_provider *base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -255,7 +255,8 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
                                                                    ctx->aws_region,
                                                                    ctx->aws_sts_endpoint,
                                                                    NULL,
-                                                                   flb_aws_client_generator());
+                                                                   flb_aws_client_generator(),
+                                                                   ctx->aws_profile);
             if (!ctx->aws_provider) {
                 flb_error("[out_es] Failed to create AWS Credential Provider");
                 flb_os_conf_destroy(ctx);

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -851,7 +851,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                                        ctx->region,
                                                        ctx->sts_endpoint,
                                                        NULL,
-                                                       flb_aws_client_generator());
+                                                       flb_aws_client_generator(),
+                                                       ctx->profile);
 
     if (!ctx->provider) {
         flb_plg_error(ctx->ins, "Failed to create AWS Credential Provider");
@@ -2528,6 +2529,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Specify the storage class for S3 objects. If this option is not specified, objects "
      "will be stored with the default 'STANDARD' storage class."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "profile", NULL,
+     0, FLB_TRUE, offsetof(struct flb_s3, profile),
+     "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
+     "$HOME/.aws/ directory."
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -96,6 +96,7 @@ struct flb_s3 {
     char *storage_class;
     char *log_key;
     char *external_id;
+    char *profile;
     int free_endpoint;
     int retry_requests;
     int use_put_object;

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -48,7 +48,8 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
                                                       struct
                                                       flb_aws_client_generator
                                                       *generator,
-                                                      int eks_irsa);
+                                                      int eks_irsa,
+                                                      char *profile);
 
 
 /*
@@ -273,7 +274,8 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
                                                             char *proxy,
                                                             struct
                                                             flb_aws_client_generator
-                                                            *generator)
+                                                            *generator,
+                                                            char *profile)
 {
     struct flb_aws_provider *provider;
     struct flb_aws_provider *tmp_provider;
@@ -289,7 +291,7 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
          */
         flb_debug("[aws_credentials] Using EKS_POD_EXECUTION_ROLE=%s", eks_pod_role);
         tmp_provider = standard_chain_create(config, tls, region, sts_endpoint,
-                                             proxy, generator, FLB_FALSE);
+                                             proxy, generator, FLB_FALSE, profile);
 
         if (!tmp_provider) {
             return NULL;
@@ -320,7 +322,7 @@ struct flb_aws_provider *flb_standard_chain_provider_create(struct flb_config
 
     /* standard case- not in EKS Fargate */
     provider = standard_chain_create(config, tls, region, sts_endpoint,
-                                     proxy, generator, FLB_TRUE);
+                                     proxy, generator, FLB_TRUE, profile);
     return provider;
 }
 
@@ -338,10 +340,12 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     flb_sds_t config_key_sts_endpoint;
     flb_sds_t config_key_role_arn;
     flb_sds_t config_key_external_id;
+    flb_sds_t config_key_profile;
     const char *region = NULL;
     const char *sts_endpoint = NULL;
     const char *role_arn = NULL;
     const char *external_id = NULL;
+    const char *profile = NULL;
     char *session_name = NULL;
     int key_prefix_len;
     int key_max_len;
@@ -367,6 +371,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     strcpy(config_key_role_arn + key_prefix_len, "role_arn");
     config_key_external_id = flb_sds_create_len(config_key_prefix, key_max_len);
     strcpy(config_key_external_id + key_prefix_len, "external_id");
+    config_key_profile = flb_sds_create_len(config_key_prefix, key_max_len);
+    strcpy(config_key_profile + key_prefix_len, "profile");
 
     /* AWS provider needs a separate TLS instance */
     cred_tls = flb_tls_create(FLB_TRUE,
@@ -391,13 +397,15 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
 
     /* Use null sts_endpoint if none provided */
     sts_endpoint = flb_output_get_property(config_key_sts_endpoint, ins);
-
+    /* Get the profile from configuration */
+    profile = flb_output_get_property(config_key_profile, ins);
     aws_provider = flb_standard_chain_provider_create(config,
                                                       cred_tls,
                                                       (char *) region,
                                                       (char *) sts_endpoint,
                                                       NULL,
-                                                      flb_aws_client_generator());
+                                                      flb_aws_client_generator(),
+                                                      profile);
     if (!aws_provider) {
         flb_plg_error(ins, "Failed to create AWS Credential Provider");
         goto error;
@@ -513,7 +521,8 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
                                                       struct
                                                       flb_aws_client_generator
                                                       *generator,
-                                                      int eks_irsa)
+                                                      int eks_irsa,
+                                                      char *profile)
 {
     struct flb_aws_provider *sub_provider;
     struct flb_aws_provider *provider;
@@ -550,7 +559,8 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
 
     mk_list_add(&sub_provider->_head, &implementation->sub_providers);
 
-    sub_provider = flb_profile_provider_create();
+    flb_debug("[aws_credentials] creating profile %s provider", profile);
+    sub_provider = flb_profile_provider_create(profile);
     if (sub_provider) {
         /* Profile provider can fail if HOME env var is not set */;
         mk_list_add(&sub_provider->_head, &implementation->sub_providers);

--- a/src/aws/flb_aws_credentials_profile.c
+++ b/src/aws/flb_aws_credentials_profile.c
@@ -221,12 +221,11 @@ static struct flb_aws_provider_vtable profile_provider_vtable = {
     .upstream_set = upstream_set_fn_profile,
 };
 
-struct flb_aws_provider *flb_profile_provider_create()
+struct flb_aws_provider *flb_profile_provider_create(char* profile)
 {
     struct flb_aws_provider *provider = NULL;
     struct flb_aws_provider_profile *implementation = NULL;
     int result = -1;
-    char *profile = NULL;
 
     provider = flb_calloc(1, sizeof(struct flb_aws_provider));
 
@@ -266,8 +265,10 @@ struct flb_aws_provider *flb_profile_provider_create()
         goto error;
     }
 
-    /* AWS profile name */
-    profile = getenv(AWS_PROFILE);
+    /* AWS profile name. */
+    if (profile == NULL) {
+        profile = getenv(AWS_PROFILE);
+    }
     if (profile && strlen(profile) > 0) {
         goto set_profile;
     }

--- a/tests/internal/aws_credentials.c
+++ b/tests/internal/aws_credentials.c
@@ -278,7 +278,8 @@ static void test_standard_chain_provider()
     provider = flb_standard_chain_provider_create(config, NULL, "us-west-2",
                                                   "https://sts.us-west-2.amazonaws.com",
                                                   NULL,
-                                                  flb_aws_client_generator());
+                                                  flb_aws_client_generator(),
+                                                  NULL);
     if (!provider) {
         flb_errno();
         return;

--- a/tests/internal/aws_credentials_process.c
+++ b/tests/internal/aws_credentials_process.c
@@ -64,7 +64,7 @@ static void test_credential_process_default(void)
     MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
     MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
 
-    provider = flb_profile_provider_create();
+    provider = flb_profile_provider_create(NULL);
     TEST_ASSERT(provider != NULL);
 
     /* These environment variables are used by the test credential_process. */
@@ -139,7 +139,7 @@ static void test_credential_process_no_expiration(void)
     MUST_SETENV("AWS_PROFILE", "nondefault");
     MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
 
-    provider = flb_profile_provider_create();
+    provider = flb_profile_provider_create(NULL);
     TEST_ASSERT(provider != NULL);
 
     /* These environment variables are used by the test credential_process. */
@@ -229,7 +229,7 @@ static void test_credential_process_expired_helper(char* expiration)
     MUST_SETENV("AWS_PROFILE", "nondefault");
     MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
 
-    provider = flb_profile_provider_create();
+    provider = flb_profile_provider_create(NULL);
     TEST_ASSERT(provider != NULL);
 
     /* These environment variable are used by the test credential_process. */
@@ -303,7 +303,7 @@ static void test_credential_process_failure(void)
     MUST_SETENV("AWS_CONFIG_FILE", AWS_TEST_DATA_PATH("shared_config.ini"));
     MUST_SETENV("PATH", AWS_TEST_DATA_PATH("credential_process"));
 
-    provider = flb_profile_provider_create();
+    provider = flb_profile_provider_create(NULL);
     TEST_ASSERT(provider != NULL);
 
     /* These environment variables are used by the test credential_process. */

--- a/tests/internal/data/aws_credentials/shared_credentials_file.ini
+++ b/tests/internal/data/aws_credentials/shared_credentials_file.ini
@@ -7,6 +7,10 @@ aws_session_token = IQoJb3JpZ2luX2VjEOD//////////wEaCNVzLWVhc3QtMSJHMEUCIKCn7v/E
 aws_access_key_id = akid
 aws_secret_access_key =	skid
 
+[custom]
+aws_access_key_id=custom_access_key_id
+aws_secret_access_key=custom_secret_access_key
+
 #some comment line
 sadfjasdlkfajskldfjasd some garbage = not_actually_valid_but=parser_should_handle_it
 


### PR DESCRIPTION
**Description**

This PR introduces a new feature that enables users to specify the profile attribute in their AWS output plugins such as S3, Cloudwatch, Firehose, ES, Kinesis, and OpenSearch. With this feature, customers can now configure multiple profiles, offering greater flexibility in setting up multiple destinations. By specifying the profile attribute, users can easily select the appropriate AWS credentials to access different accounts in different regions making cross-account access simpler.


**Testing**

Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
```
[SERVICE]
    log_level debug
    flush 10
[INPUT]
    Name dummy
    Tag mylog
[OUTPUT]
    Name s3
    Match *
    region us-east-1
    bucket testfluentbitbucket
    static_file_path On
    profile custom_profile
    upload_timeout 1m
    s3_key_format /application/$TAG[0].txt
```
- [ ] Debug log output from testing the change

````
[debug] [aws_credentials] Initialized Env Provider in standard chain
[2023/03/28 11:04:44] [debug] [aws_credentials] creating profile custom_profile provider
[2023/03/28 11:04:44] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
````
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
HEAP SUMMARY:
==16286==     in use at exit: 102,576 bytes in 3,418 blocks
==16286==   total heap usage: 94,882 allocs, 91,464 frees, 41,745,104 bytes allocated
==16286== 
==16286== LEAK SUMMARY:
==16286==    definitely lost: 0 bytes in 0 blocks
==16286==    indirectly lost: 0 bytes in 0 blocks
==16286==      possibly lost: 0 bytes in 0 blocks
==16286==    still reachable: 102,576 bytes in 3,418 blocks
==16286==         suppressed: 0 bytes in 0 blocks
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ NA] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [NA ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1068

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
