### PR TITLE
filter: aws fix ec2 long tags

### DIFF
--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -390,7 +390,7 @@ static int get_ec2_tag_values(struct flb_filter_aws *ctx)
         /* fetch tag value using path: /latest/meta-data/tags/instance/{tag_name} */
         tag_value_path_len = ctx->tag_keys_len[i] + 1 +
                              strlen(FLB_AWS_IMDS_INSTANCE_TAG);
-        tag_value_path = flb_sds_create_size(tag_value_path_len);
+        tag_value_path = flb_sds_create_size(tag_value_path_len + 1);
         if (!tag_value_path) {
             flb_errno();
             return -1;

--- a/tests/runtime/filter_aws.c
+++ b/tests/runtime/filter_aws.c
@@ -63,8 +63,8 @@ void flb_test_aws_ec2_tags_present() {
             expect(URI, "/latest/meta-data/tags/instance"),
             expect(METHOD, FLB_HTTP_GET),
             set(STATUS, 200),
-            set(PAYLOAD, "Name\nCUSTOMER_ID"),
-            set(PAYLOAD_SIZE, 16)
+            set(PAYLOAD, "Name\nCUSTOMER_ID\nthis-would-be-my-very-long-tag-name-does-it-work"),
+            set(PAYLOAD_SIZE, 65)
         ),
         response(
             expect(URI, "/latest/meta-data/tags/instance/Name"),
@@ -79,6 +79,13 @@ void flb_test_aws_ec2_tags_present() {
             set(STATUS, 200),
             set(PAYLOAD, "70ec5c04-3a6e-11ed-a261-0242ac120002"),
             set(PAYLOAD_SIZE, 36)
+        ),
+        response(
+            expect(URI, "/latest/meta-data/tags/instance/this-would-be-my-very-long-tag-name-does-it-work"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "yes-it-does"),
+            set(PAYLOAD_SIZE, 11)
         )
     );
     flb_aws_client_mock_configure_generator(request_chain);
@@ -137,6 +144,10 @@ void flb_test_aws_ec2_tags_present() {
             TEST_MSG("output:%s\n", output);
         }
         result = strstr(output, "\"CUSTOMER_ID\":\"70ec5c04-3a6e-11ed-a261-0242ac120002\"");
+        if (!TEST_CHECK(result != NULL)) {
+            TEST_MSG("output:%s\n", output);
+        }
+        result = strstr(output, "\"this-would-be-my-very-long-tag-name-does-it-work\":\"yes-it-does\"");
         if (!TEST_CHECK(result != NULL)) {
             TEST_MSG("output:%s\n", output);
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes parsing EC2 tags when tag names are quite long.

Example configuration:
```
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug


[INPUT]
    name stdin

[FILTER]
    Name aws
    imds_version v1
    Match *
    tags_enabled true

[OUTPUT]
    name  stdout
    match *
```

Valgrind output with debug logs:
```
mwarzynski@e5c714a8ed5d:/fluent-bit-dev/build$ valgrind ./bin/fluent-bit -c fluent-bit.conf
==28096== Memcheck, a memory error detector
==28096== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28096== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==28096== Command: ./bin/fluent-bit -c fluent-bit.conf
==28096==
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/06 10:53:38] [ info] Configuration:
[2023/04/06 10:53:38] [ info]  flush time     | 1.000000 seconds
[2023/04/06 10:53:38] [ info]  grace          | 5 seconds
[2023/04/06 10:53:38] [ info]  daemon         | 0
[2023/04/06 10:53:38] [ info] ___________
[2023/04/06 10:53:38] [ info]  inputs:
[2023/04/06 10:53:38] [ info]      stdin
[2023/04/06 10:53:38] [ info] ___________
[2023/04/06 10:53:38] [ info]  filters:
[2023/04/06 10:53:38] [ info]      aws.0
[2023/04/06 10:53:38] [ info] ___________
[2023/04/06 10:53:38] [ info]  outputs:
[2023/04/06 10:53:38] [ info]      stdout.0
[2023/04/06 10:53:38] [ info] ___________
[2023/04/06 10:53:38] [ info]  collectors:
[2023/04/06 10:53:39] [ info] [fluent bit] version=2.1.0, commit=1f04c0b399, pid=28096
[2023/04/06 10:53:39] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/06 10:53:39] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/06 10:53:39] [ info] [cmetrics] version=0.6.0
[2023/04/06 10:53:39] [ info] [ctraces ] version=0.3.0
[2023/04/06 10:53:39] [ info] [input:stdin:stdin.0] initializing
[2023/04/06 10:53:39] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2023/04/06 10:53:39] [debug] [stdin:stdin.0] created event channels: read=21 write=22
[2023/04/06 10:53:39] [debug] [input:stdin:stdin.0] buf_size=16000
[2023/04/06 10:53:39] [debug] [imds] using IMDSv1
[2023/04/06 10:53:39] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:53:39] [debug] [imds] using IMDSv1
[2023/04/06 10:53:39] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:53:39] [debug] [imds] using IMDSv1
[2023/04/06 10:53:39] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:53:39] [debug] [filter:aws:aws.0] tag found: Name (len=4)
[2023/04/06 10:53:39] [debug] [filter:aws:aws.0] tag found: this-would-be-my-very-long-tag-name-does-it-work (len=48)
[2023/04/06 10:53:39] [debug] [imds] using IMDSv1
[2023/04/06 10:53:39] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:53:39] [debug] [imds] using IMDSv1
[2023/04/06 10:53:39] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:53:39] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/04/06 10:53:39] [ info] [sp] stream processor started
[2023/04/06 10:53:39] [ info] [output:stdout:stdout.0] worker #0 started
{"test":1}
[2023/04/06 10:53:46] [debug] [input chunk] update output instances with new chunk size diff=159
[2023/04/06 10:53:47] [debug] [task] created task=0x5388750 id=0 OK
[0] stdin.0: [1680778426.559410640, {"test"=>1, "az"=>"us-east-1a", "ec2_instance_id"=>"i-0e66fc7f9809d7168", "Name"=>"fluent-bit-docs-example", "this-would-be-my-very-long-tag-name-does-it-work"=>"yes-it-does"}]
[2023/04/06 10:53:47] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/04/06 10:53:47] [debug] [task] destroy task=0x5388750 (task_id=0)
[2023/04/06 10:53:47] [debug] [out flush] cb_destroy coro_id=0
^C[2023/04/06 10:53:48] [engine] caught signal (SIGINT)
[2023/04/06 10:53:48] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/06 10:53:49] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/06 10:53:49] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/04/06 10:53:49] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==28096==
==28096== HEAP SUMMARY:
==28096==     in use at exit: 0 bytes in 0 blocks
==28096==   total heap usage: 1,867 allocs, 1,867 frees, 1,045,419 bytes allocated
==28096==
==28096== All heap blocks were freed -- no leaks are possible
==28096==
==28096== For lists of detected and suppressed errors, rerun with: -s
==28096== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0
```

---

## Logs from the `master` build:

```
mwarzynski@e5c714a8ed5d:/fluent-bit-dev/build$ ./bin/fluent-bit -c fluent-bit.conf
Fluent Bit v2.1.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/06 10:56:20] [ info] Configuration:
[2023/04/06 10:56:20] [ info]  flush time     | 1.000000 seconds
[2023/04/06 10:56:20] [ info]  grace          | 5 seconds
[2023/04/06 10:56:20] [ info]  daemon         | 0
[2023/04/06 10:56:20] [ info] ___________
[2023/04/06 10:56:20] [ info]  inputs:
[2023/04/06 10:56:20] [ info]      stdin
[2023/04/06 10:56:20] [ info] ___________
[2023/04/06 10:56:20] [ info]  filters:
[2023/04/06 10:56:20] [ info]      aws.0
[2023/04/06 10:56:20] [ info] ___________
[2023/04/06 10:56:20] [ info]  outputs:
[2023/04/06 10:56:20] [ info]      stdout.0
[2023/04/06 10:56:20] [ info] ___________
[2023/04/06 10:56:20] [ info]  collectors:
[2023/04/06 10:56:20] [ info] [fluent bit] version=2.1.0, commit=1f04c0b399, pid=31197
[2023/04/06 10:56:20] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/04/06 10:56:20] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/06 10:56:20] [ info] [cmetrics] version=0.6.0
[2023/04/06 10:56:20] [ info] [ctraces ] version=0.3.0
[2023/04/06 10:56:20] [ info] [input:stdin:stdin.0] initializing
[2023/04/06 10:56:20] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2023/04/06 10:56:20] [debug] [stdin:stdin.0] created event channels: read=21 write=22
[2023/04/06 10:56:20] [debug] [input:stdin:stdin.0] buf_size=16000
[2023/04/06 10:56:20] [debug] [imds] using IMDSv1
[2023/04/06 10:56:20] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:56:20] [debug] [imds] using IMDSv1
[2023/04/06 10:56:20] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:56:20] [debug] [imds] using IMDSv1
[2023/04/06 10:56:20] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:56:20] [debug] [filter:aws:aws.0] tag found: Name (len=4)
[2023/04/06 10:56:20] [debug] [filter:aws:aws.0] tag found: this-would-be-my-very-long-tag-name-does-it-work (len=48)
[2023/04/06 10:56:20] [debug] [imds] using IMDSv1
[2023/04/06 10:56:20] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:56:20] [debug] [imds] using IMDSv1
[2023/04/06 10:56:20] [debug] [http_client] not using http_proxy for header
[2023/04/06 10:56:20] [debug] [aws_client] (null): http_do=0, HTTP Status: 404
[2023/04/06 10:56:20] [error] [filter:aws:aws.0] no value for tag this-would-be-my-very-long-tag-name-does-it-work
[2023/04/06 10:56:20] [error] [filter:aws:aws.0] Could not retrieve ec2 metadata from IMDS on initialization
[2023/04/06 10:56:20] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/04/06 10:56:20] [ info] [sp] stream processor started
[2023/04/06 10:56:20] [ info] [output:stdout:stdout.0] worker #0 started
^C[2023/04/06 10:56:22] [engine] caught signal (SIGINT)
[2023/04/06 10:56:22] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/06 10:56:23] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/06 10:56:23] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/04/06 10:56:23] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

It constructed the wrong URL path:
```
127.0.0.1 - - [06/Apr/2023 10:56:20] "GET /latest/meta-data/tags/instance/this-would-be-my-very-long-tag-name-does-it-wor HTTP/1.1" 404 -
```
There is no missing `k` at the end. That's why adding `+1` to length of allocated memory for the path helps.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
