### PR TITLE
processor: new input and output processors

### DIFF
--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -62,20 +62,20 @@ enum section_type {
 };
 
 struct flb_cf_group {
-    flb_sds_t name;               /* group name */
-    struct cfl_kvlist *properties;    /* key value properties */
-    struct mk_list _head;         /* link to struct flb_cf_section->groups */
+    flb_sds_t name;                /* group name */
+    struct cfl_kvlist *properties; /* key value properties */
+    struct mk_list _head;          /* link to struct flb_cf_section->groups */
 };
 
 struct flb_cf_section {
     int type;
-    flb_sds_t name;               /* name (used for FLB_CF_OTHER type) */
-    struct cfl_kvlist *properties;    /* key value properties              */
+    flb_sds_t name;                /* name (used for FLB_CF_OTHER type) */
+    struct cfl_kvlist *properties; /* key value properties              */
 
-    struct mk_list groups;        /* list of groups */
+    struct mk_list groups;         /* list of groups */
 
-    struct mk_list _head;         /* link to struct flb_cf->sections */
-    struct mk_list _head_section; /* link to section type, e.g: inputs, filters.. */
+    struct mk_list _head;          /* link to struct flb_cf->sections */
+    struct mk_list _head_section;  /* link to section type, e.g: inputs, filters.. */
 };
 
 struct flb_cf {
@@ -138,6 +138,9 @@ void flb_cf_meta_destroy_all(struct flb_cf *cf);
 /* groups */
 struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_section *s,
                                          char *name, int len);
+struct flb_cf_group *flb_cf_group_get(struct flb_cf *cf, struct flb_cf_section *s, char *name);
+void flb_cf_group_print(struct flb_cf_group *g);
+
 void flb_cf_group_destroy(struct flb_cf_group *g);
 
 /* sections */

--- a/include/fluent-bit/flb_event.h
+++ b/include/fluent-bit/flb_event.h
@@ -39,7 +39,7 @@
 struct flb_event_chunk {
     int type;               /* event type */
     flb_sds_t tag;          /* tag associated */
-    const void *data;       /* event content */
+    void *data;             /* event content */
     size_t size;            /* size of event */
     size_t total_events;    /* total number of serialized events */
 };

--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -41,10 +41,21 @@
 #define FLB_FILTER_MODIFIED 1
 #define FLB_FILTER_NOTOUCH  2
 
+/*
+ * Types are defined by creating a mask using numbers. However, it's important
+ * to note that the masks used in this process are different from the ones used
+ * in flb_event.h. The original chunk values are not actually masks, but rather set
+ * numbers starting from 0; this is for compatibility reasons.
+ */
+#define FLB_FILTER_LOGS        1
+#define FLB_FILTER_METRICS     2
+#define FLB_FILTER_TRACES      4
+
 struct flb_input_instance;
 struct flb_filter_instance;
 
 struct flb_filter_plugin {
+    int event_type;        /* Event type: logs, metrics, traces */
     int flags;             /* Flags (not available at the moment */
     char *name;            /* Filter short name            */
     char *description;     /* Description                  */
@@ -66,6 +77,7 @@ struct flb_filter_plugin {
 };
 
 struct flb_filter_instance {
+    int event_type;                /* Event type: logs, metrics, traces */
     int id;                        /* instance id              */
     int log_level;                 /* instance log level       */
     char name[32];                 /* numbered name            */
@@ -113,12 +125,17 @@ const char *flb_filter_get_property(const char *key,
 
 struct flb_filter_instance *flb_filter_new(struct flb_config *config,
                                            const char *filter, void *data);
+void flb_filter_instance_exit(struct flb_filter_instance *ins,
+                              struct flb_config *config);
+
 void flb_filter_exit(struct flb_config *config);
 void flb_filter_do(struct flb_input_chunk *ic,
                    const void *data, size_t bytes,
                    const char *tag, int tag_len,
                    struct flb_config *config);
 const char *flb_filter_name(struct flb_filter_instance *ins);
+
+int flb_filter_init(struct flb_config *config, struct flb_filter_instance *ins);
 int flb_filter_init_all(struct flb_config *config);
 void flb_filter_set_context(struct flb_filter_instance *ins, void *context);
 void flb_filter_instance_destroy(struct flb_filter_instance *ins);

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -38,6 +38,8 @@
 #include <fluent-bit/flb_input_log.h>
 #include <fluent-bit/flb_input_metric.h>
 #include <fluent-bit/flb_input_trace.h>
+#include <fluent-bit/flb_config_format.h>
+#include <fluent-bit/flb_processor.h>
 
 #ifdef FLB_HAVE_METRICS
 #include <fluent-bit/flb_metrics.h>
@@ -152,10 +154,7 @@ struct flb_input_plugin {
 struct flb_input_instance {
     struct mk_event event;           /* events handler */
 
-
-    /* DEPRECATED: no logic should be build on top of this flag
-     * int event_type;                   FLB_INPUT_LOGS, FLB_INPUT_METRICS
-     */
+    struct flb_processor *processor;
 
     /*
      * The instance flags are derived from the fixed plugin flags. This
@@ -690,5 +689,8 @@ struct mk_event_loop *flb_input_event_loop_get(struct flb_input_instance *ins);
 int flb_input_upstream_set(struct flb_upstream *u, struct flb_input_instance *ins);
 int flb_input_downstream_set(struct flb_downstream *stream,
                              struct flb_input_instance *ins);
+
+/* processors */
+int flb_input_instance_processors_load(struct flb_input_instance *ins, struct flb_cf_group *processors);
 
 #endif

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -64,7 +64,14 @@
 #define FLB_OUTPUT_SYNCHRONOUS  2048  /* run one task at a time, no flush cycle limit */
 
 
-/* Event type handlers */
+/*
+ * Event type handlers
+ *
+ * These types are defined by creating a mask using numbers. However, it's important
+ * to note that the masks used in this process are different from the ones used
+ * in flb_event.h. The original chunk values are not actually masks, but rather set
+ * numbers starting from 0; this is for compatibility reasons.
+ */
 #define FLB_OUTPUT_LOGS        1
 #define FLB_OUTPUT_METRICS     2
 #define FLB_OUTPUT_TRACES      4

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -47,6 +47,7 @@
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_upstream_ha.h>
 #include <fluent-bit/flb_event.h>
+#include <fluent-bit/flb_processor.h>
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
@@ -238,6 +239,8 @@ struct flb_output_plugin {
  */
 struct flb_output_instance {
     struct mk_event event;               /* events handler               */
+
+    struct flb_processor *processor;
 
     /*
      * a 'mask' to define what kind of data the plugin can manage:
@@ -438,6 +441,14 @@ struct flb_output_flush {
     struct flb_config *config;         /* FLB context        */
     struct flb_output_instance *o_ins; /* output instance    */
     struct flb_coro *coro;             /* parent coro addr   */
+
+    /*
+     * if the original event_chunk has been processed, a new
+     * temporary event_chunk is created, so the flush callback
+     * receives new data.
+     */
+    struct flb_event_chunk *processed_event_chunk;
+
     struct mk_list _head;              /* Link to flb_task->threads */
 };
 
@@ -494,7 +505,12 @@ static FLB_INLINE void output_params_set(struct flb_output_flush *out_flush,
     }
 
     /* Callback parameters in order */
-    params->event_chunk = task->event_chunk;
+    if (out_flush->processed_event_chunk) {
+        params->event_chunk = out_flush->processed_event_chunk;
+    }
+    else {
+        params->event_chunk = task->event_chunk;
+    }
     params->out_flush   = out_flush;
     params->i_ins       = task->i_ins;
     params->out_context = out_context;
@@ -532,6 +548,7 @@ static FLB_INLINE void output_pre_cb_flush(void)
 
     /* Continue, we will resume later */
     out_p = persisted_params.out_plugin;
+
     out_p->cb_flush(persisted_params.event_chunk,
                     persisted_params.out_flush,
                     persisted_params.i_ins,
@@ -548,10 +565,16 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
                                                  struct flb_output_instance *o_ins,
                                                  struct flb_config *config)
 {
+    int ret;
+    size_t records;
+    void *p_buf;
+    size_t p_size;
     size_t stack_size;
     struct flb_coro *coro;
     struct flb_output_flush *out_flush;
     struct flb_out_thread_instance *th_ins;
+    struct flb_event_chunk *evc;
+    struct flb_event_chunk *tmp;
 
     /* Custom output coroutine info */
     out_flush = (struct flb_output_flush *) flb_calloc(1, sizeof(struct flb_output_flush));
@@ -577,6 +600,40 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
     out_flush->buffer = task->event_chunk->data;
     out_flush->config = config;
     out_flush->coro   = coro;
+    out_flush->processed_event_chunk = NULL;
+
+    /* Logs processor */
+    evc = task->event_chunk;
+    if (evc->type == FLB_EVENT_TYPE_LOGS && flb_processor_is_active(o_ins->processor)) {
+
+        /* run the processor */
+        ret = flb_processor_run(o_ins->processor, FLB_PROCESSOR_LOGS,
+                                evc->tag, flb_sds_len(evc->tag),
+                                evc->data, evc->size,
+                                &p_buf, &p_size);
+        if (ret == -1 || p_size == 0) {
+            flb_coro_destroy(coro);
+            flb_free(out_flush);
+            return NULL;
+        }
+
+        records = flb_mp_count(p_buf, p_size);
+        if (records == 0) {
+            flb_coro_destroy(coro);
+            flb_free(out_flush);
+            flb_free(p_buf);
+            return NULL;
+        }
+
+        tmp = flb_event_chunk_create(evc->type, records, evc->tag, flb_sds_len(evc->tag), p_buf, p_size);
+        if (!tmp) {
+            flb_coro_destroy(coro);
+            flb_free(out_flush);
+            flb_free(p_buf);
+            return NULL;
+        }
+        out_flush->processed_event_chunk = tmp;
+    }
 
     coro->caller = co_active();
     coro->callee = co_create(config->coro_stack_size,
@@ -584,6 +641,10 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
 
     if (coro->callee == NULL) {
         flb_coro_destroy(coro);
+        if (out_flush->processed_event_chunk) {
+            flb_free(out_flush->processed_event_chunk->data);
+            flb_event_chunk_destroy(out_flush->processed_event_chunk);
+        }
         flb_free(out_flush);
         return NULL;
     }
@@ -630,6 +691,12 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
     out_flush = (struct flb_output_flush *) co->data;
     o_ins = out_flush->o_ins;
     task = out_flush->task;
+
+    if (out_flush->processed_event_chunk) {
+        flb_free(out_flush->processed_event_chunk->data);
+        flb_event_chunk_destroy(out_flush->processed_event_chunk);
+        out_flush->processed_event_chunk = NULL;
+    }
 
     /*
      * To compose the signal event the relevant info is:

--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -1,0 +1,106 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PROCESSOR_H
+#define FLB_PROCESSOR_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_format.h>
+
+#define FLB_PROCESSOR_LOGS      1
+#define FLB_PROCESSOR_METRICS   2
+#define FLB_PROCESSOR_TRACES    4
+
+/* Type of processor unit: 'pipeline filter' or 'native unit' */
+#define FLB_PROCESSOR_UNIT_NATIVE    0
+#define FLB_PROCESSOR_UNIT_FILTER    1
+
+struct flb_processor_unit {
+    int event_type;
+    int unit_type;
+    flb_sds_t name;
+
+    /*
+     * Opaque data type for custom reference (for pipeline filters this
+     * contains the filter instance context.
+     */
+    void *ctx;
+
+    /*
+     * pipeline filters needs to be linked somewhere since the destroy
+     * function will do the mk_list_del(). To avoid corruptions we link
+     * normal filters here, this list is never iterated or used besides
+     * for this purpose.
+     */
+    struct mk_list unused_list;
+
+    /* link to struct flb_processor->(logs, metrics, traces) list */
+    struct mk_list _head;
+
+    /* link to parent processor */
+    void *parent;
+};
+
+struct flb_processor {
+    int is_active;
+
+    /* user-defined processor name */
+    flb_sds_t name;
+
+    /* lists for different types */
+    struct mk_list logs;
+    struct mk_list metrics;
+    struct mk_list traces;
+
+    /*
+     * opaque data type to reference anything specific from the caller, for input
+     * plugins this will contain the input instance context.
+     */
+    void *data;
+
+    /* Fluent Bit context */
+    struct flb_config *config;
+};
+
+
+struct flb_processor *flb_processor_create(struct flb_config *config, char *name, void *data);
+
+int flb_processor_is_active(struct flb_processor *proc);
+
+int flb_processor_init(struct flb_processor *proc);
+void flb_processor_destroy(struct flb_processor *proc);
+
+int flb_processor_run(struct flb_processor *proc,
+                      int type,
+                      const char *tag, size_t tag_len,
+                      void *data, size_t data_size,
+                      void **out_buf, size_t *out_size);
+
+
+struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
+                                                     int event_type,
+                                                     char *unit_name);
+void flb_processor_unit_destroy(struct flb_processor_unit *pu);
+int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k, const char *v);
+
+int flb_processors_load_from_config_format_group(struct flb_processor *proc, struct flb_cf_group *g);
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(src
   flb_log_event_encoder.c
   flb_log_event_encoder_primitives.c
   flb_log_event_encoder_dynamic_field.c
+  flb_processor.c
   )
 
 # Config format

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1064,6 +1064,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->val = NULL;
             break;
         case YAML_SEQUENCE_START_EVENT: /* start a new group */
+            if (strcmp(s->key, "processors") == 0) {
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+            }
             s->state = STATE_GROUP_KEY;
             s->cf_group = flb_cf_group_create(cf, s->cf_section,
                                               s->key, flb_sds_len(s->key));

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -45,6 +45,8 @@
 #define PATH_MAX MAX_PATH
 #endif
 
+#include <stdio.h>
+
 enum section {
     SECTION_ENV,
     SECTION_INCLUDE,
@@ -90,6 +92,16 @@ enum state {
     STATE_GROUP_KEY,
     STATE_GROUP_VAL,
 
+    STATE_INPUT_PROCESSOR,
+    STATE_INPUT_PROCESSOR_LOGS_KEY,
+    STATE_INPUT_PROCESSOR_LOGS_VAL,
+
+    STATE_INPUT_PROCESSOR_METRICS_KEY,
+    STATE_INPUT_PROCESSOR_METRICS_VAL,
+
+    STATE_INPUT_PROCESSOR_TRACES_KEY,
+    STATE_INPUT_PROCESSOR_TRACES_VAL,
+
     /* environment variables */
     STATE_ENV,
 
@@ -114,6 +126,11 @@ struct parser_state {
 
     /* active group */
     struct flb_cf_group *cf_group;
+
+    /* active processor group: logs, metrics or traces */
+    struct cfl_kvlist *cf_processor_kv;
+    struct cfl_array *cf_processor_type_array;
+    struct cfl_kvlist *cf_processor_type_list;
 
     /* file */
     flb_sds_t file;                /* file name */
@@ -160,6 +177,37 @@ static int add_section_type(struct flb_cf *cf, struct parser_state *s)
     return 0;
 }
 
+static char *event_type_str(yaml_event_t *event)
+{
+    switch (event->type) {
+    case YAML_NO_EVENT:
+        return "no-event";
+    case YAML_STREAM_START_EVENT:
+        return "stream-start-event";
+    case YAML_STREAM_END_EVENT:
+        return "stream-end-event";
+    case YAML_DOCUMENT_START_EVENT:
+        return "document-start-event";
+    case YAML_DOCUMENT_END_EVENT:
+        return "document-end-event";
+    case YAML_ALIAS_EVENT:
+        return "alias-event";
+    case YAML_SCALAR_EVENT:
+        return "scalar-event";
+    case YAML_SEQUENCE_START_EVENT:
+        return "sequence-start-event";
+        break;
+    case YAML_SEQUENCE_END_EVENT:
+        return "sequence-end-event";
+    case YAML_MAPPING_START_EVENT:
+        return "mapping-start-event";
+    case YAML_MAPPING_END_EVENT:
+        return "mapping-end-event";
+    default:
+        return "unknown";
+    }
+}
+
 static char *get_last_included_file(struct local_ctx *ctx)
 {
     struct flb_slist_entry *e;
@@ -176,9 +224,9 @@ static void yaml_error_event(struct local_ctx *ctx, struct parser_state *s,
     e = mk_list_entry_last(&ctx->includes, struct flb_slist_entry, _head);
 
     flb_error("[config] YAML error found in file \"%s\", line %zu, column %zu: "
-              "unexpected event %d in state %d.",
+              "unexpected event '%s' (%d) in state %d.",
               e->str, event->start_mark.line + 1, event->start_mark.column,
-              event->type, s->state);
+              event_type_str(event), event->type, s->state);
 }
 
 static void yaml_error_definition(struct local_ctx *ctx, struct parser_state *s,
@@ -788,6 +836,210 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
         }
         break;
 
+    case STATE_INPUT_PROCESSOR:
+        switch(event->type) {
+            case YAML_MAPPING_START_EVENT:
+                break;
+            case YAML_MAPPING_END_EVENT:
+                s->state = STATE_PLUGIN_KEY;
+                break;
+            case YAML_SCALAR_EVENT:
+                /* remove 'processors' key, not longer needed */
+                if (s->key) {
+                    flb_sds_destroy(s->key);
+                    s->key = NULL;
+                }
+                /* Check if we are entering a 'logs', 'metrics' or 'traces' section */
+                value = (char *) event->data.scalar.value;
+                if (strcasecmp(value, "logs") == 0) {
+                    /* logs state */
+                    s->state = STATE_INPUT_PROCESSOR_LOGS_KEY;
+
+                    /* create the array for definitions found under 'log' */
+                    s->cf_processor_type_array = cfl_array_create(1);
+                    cfl_array_resizable(s->cf_processor_type_array, CFL_TRUE);
+
+                    cfl_kvlist_insert_array(s->cf_group->properties, "logs", s->cf_processor_type_array);
+                }
+                else if (strcasecmp(value, "metrics") == 0) {
+                    /* metrics state */
+                    s->state = STATE_INPUT_PROCESSOR_METRICS_KEY;
+
+                    /* create the array for definitions found under 'log' */
+                    s->cf_processor_type_array = cfl_array_create(1);
+                    cfl_array_resizable(s->cf_processor_type_array, CFL_TRUE);
+
+                    cfl_kvlist_insert_array(s->cf_group->properties, "metrics", s->cf_processor_type_array);
+                }
+                else if (strcasecmp(value, "traces") == 0) {
+                    /* metrics state */
+                    s->state = STATE_INPUT_PROCESSOR_TRACES_KEY;
+
+                    /* create the array for definitions found under 'log' */
+                    s->cf_processor_type_array = cfl_array_create(1);
+                    cfl_array_resizable(s->cf_processor_type_array, CFL_TRUE);
+
+                    cfl_kvlist_insert_array(s->cf_group->properties, "traces", s->cf_processor_type_array);
+                }
+                else {
+                    printf("processor unknown\n");
+                }
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+    case STATE_INPUT_PROCESSOR_LOGS_KEY:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                s->state = STATE_INPUT_PROCESSOR;
+                break;
+            case YAML_MAPPING_START_EVENT:
+                s->cf_processor_type_list = cfl_kvlist_create();
+                cfl_array_append_kvlist(s->cf_processor_type_array, s->cf_processor_type_list);
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                /* Check if we are entering a 'logs', 'metrics' or 'traces' section */
+                value = (char *) event->data.scalar.value;
+                s->key = flb_sds_create(value);
+                s->state = STATE_INPUT_PROCESSOR_LOGS_VAL;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+
+    case STATE_INPUT_PROCESSOR_LOGS_VAL:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                s->state = STATE_INPUT_PROCESSOR_LOGS_KEY;
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                break;
+            case YAML_MAPPING_START_EVENT:
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                value = (char *) event->data.scalar.value;
+                if (!s->cf_processor_type_list || !s->key || !value) {
+                    s->state = STATE_INPUT_PROCESSOR;
+                    break;
+                }
+                cfl_kvlist_insert_string(s->cf_processor_type_list, s->key, value);
+                flb_sds_destroy(s->key);
+                s->key = NULL;
+                s->state = STATE_INPUT_PROCESSOR_LOGS_KEY;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+
+    case STATE_INPUT_PROCESSOR_METRICS_KEY:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                s->state = STATE_INPUT_PROCESSOR;
+                break;
+            case YAML_MAPPING_START_EVENT:
+                s->cf_processor_type_list = cfl_kvlist_create();
+                cfl_array_append_kvlist(s->cf_processor_type_array, s->cf_processor_type_list);
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                value = (char *) event->data.scalar.value;
+                s->key = flb_sds_create(value);
+                s->state = STATE_INPUT_PROCESSOR_METRICS_VAL;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+
+    case STATE_INPUT_PROCESSOR_METRICS_VAL:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                s->state = STATE_INPUT_PROCESSOR_METRICS_KEY;
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                break;
+            case YAML_MAPPING_START_EVENT:
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                value = (char *) event->data.scalar.value;
+                cfl_kvlist_insert_string(s->cf_processor_type_list, s->key, value);
+                flb_sds_destroy(s->key);
+                s->key = NULL;
+                s->val = NULL;
+                s->state = STATE_INPUT_PROCESSOR_METRICS_KEY;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+
+    case STATE_INPUT_PROCESSOR_TRACES_KEY:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                s->state = STATE_INPUT_PROCESSOR;
+                break;
+            case YAML_MAPPING_START_EVENT:
+                s->cf_processor_type_list = cfl_kvlist_create();
+                cfl_array_append_kvlist(s->cf_processor_type_array, s->cf_processor_type_list);
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                value = (char *) event->data.scalar.value;
+                s->key = flb_sds_create(value);
+                s->state = STATE_INPUT_PROCESSOR_TRACES_VAL;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
+
+    case STATE_INPUT_PROCESSOR_TRACES_VAL:
+        switch(event->type) {
+            case YAML_SEQUENCE_START_EVENT:
+                s->state = STATE_INPUT_PROCESSOR_TRACES_KEY;
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                break;
+            case YAML_MAPPING_START_EVENT:
+                break;
+            case YAML_MAPPING_END_EVENT:
+                break;
+            case YAML_SCALAR_EVENT:
+                value = (char *) event->data.scalar.value;
+                cfl_kvlist_insert_string(s->cf_processor_type_list, s->key, value);
+                flb_sds_destroy(s->key);
+                s->key = NULL;
+                s->val = NULL;
+                s->state = STATE_INPUT_PROCESSOR_TRACES_KEY;
+                break;
+            default:
+                yaml_error_event(ctx, s, event);
+                return YAML_FAILURE;
+        };
+        break;
     case STATE_PLUGIN_VAL:
         switch(event->type) {
         case YAML_SCALAR_EVENT:
@@ -806,8 +1058,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             }
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
+            s->key = NULL;
+            s->val = NULL;
             break;
-        case YAML_MAPPING_START_EVENT: /* start a new group */
+        case YAML_SEQUENCE_START_EVENT: /* start a new group */
             s->state = STATE_GROUP_KEY;
             s->cf_group = flb_cf_group_create(cf, s->cf_section,
                                               s->key, flb_sds_len(s->key));
@@ -816,7 +1070,20 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
             }
             break;
-        case YAML_SEQUENCE_START_EVENT:
+        case YAML_SEQUENCE_END_EVENT:   /* end of group */
+            s->state = STATE_PLUGIN_KEY;
+            s->cf_group = NULL;
+            break;
+        case YAML_MAPPING_START_EVENT:
+            /* Special handling for input processor */
+            if (strcmp(s->key, "processors") == 0) {
+                s->state = STATE_INPUT_PROCESSOR;
+
+                /* set active group: processors.logs */
+                s->cf_group = flb_cf_group_create(cf, s->cf_section, "processors", 10);
+                break;
+            }
+
             s->state = STATE_PLUGIN_VAL_LIST;
             s->values = flb_cf_section_property_add_list(cf,
                                                          s->cf_section->properties,
@@ -825,7 +1092,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
             }
             flb_sds_destroy(s->key);
-        break;
+            break;
+        case YAML_MAPPING_END_EVENT:
+            s->state = STATE_PLUGIN_KEY;
+            break;
         default:
             yaml_error_event(ctx, s, event);
             return YAML_FAILURE;
@@ -838,11 +1108,16 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             if (s->values == NULL) {
                 return YAML_FAILURE;
             }
-            cfl_array_append_string(s->values, (char *)event->data.scalar.value);
+            cfl_array_append_string(s->values, (char *) event->data.scalar.value);
             break;
         case YAML_SEQUENCE_END_EVENT:
             s->values = NULL;
             s->state = STATE_PLUGIN_KEY;
+            break;
+        case YAML_MAPPING_START_EVENT: /* opening a group (STATE_GROUP_KEY) */
+            s->values = NULL;
+            s->state = STATE_GROUP_KEY;
+            printf("opening a group\n");
             break;
         default:
             yaml_error_event(ctx, s, event);
@@ -850,16 +1125,29 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
         }
         break;
 
+    /* groups: a group is a sub-section and here we handle the key/value pairs */
     case STATE_GROUP_KEY:
         switch(event->type) {
         case YAML_SCALAR_EVENT:
+            /* next state */
             s->state = STATE_GROUP_VAL;
+
+            /* grab current value (key) */
             value = (char *) event->data.scalar.value;
             s->key = flb_sds_create(value);
+            printf("  scalar event > KEY -> %s\n", value);
+            break;
+        case YAML_MAPPING_START_EVENT:
+            printf("mapping start event > \n");
             break;
         case YAML_MAPPING_END_EVENT:
-            s->cf_group = NULL;
+            printf("mapping end event, going to state group key\n");
+            s->state = STATE_GROUP_KEY;
+            break;
+        case YAML_SEQUENCE_END_EVENT:
+            printf("sequence end ?\n");
             s->state = STATE_PLUGIN_KEY;
+            s->cf_group = NULL;
             break;
         default:
             yaml_error_event(ctx, s, event);
@@ -874,12 +1162,17 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             value = (char *) event->data.scalar.value;
             s->val = flb_sds_create(value);
 
-            /* register key/value pair as a property */
+            printf("  scalar event > VAL -> %s\n", value);
+
+            /* add the kv pair to the active group properties */
             flb_cf_section_property_add(cf, s->cf_group->properties,
                                         s->key, flb_sds_len(s->key),
                                         s->val, flb_sds_len(s->val));
             flb_sds_destroy(s->key);
             flb_sds_destroy(s->val);
+            s->key = NULL;
+            s->val = NULL;
+
             break;
         default:
             yaml_error_event(ctx, s, event);

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -465,6 +465,26 @@ struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_sectio
     return g;
 }
 
+struct flb_cf_group *flb_cf_group_get(struct flb_cf *cf, struct flb_cf_section *s, char *name)
+{
+    struct mk_list *head;
+    struct flb_cf_group *g;
+
+    mk_list_foreach(head, &s->groups) {
+        g = mk_list_entry(head, struct flb_cf_group, _head);
+        if (strcasecmp(g->name, name) == 0){
+            return g;
+        }
+    }
+
+    return NULL;
+}
+
+void flb_cf_group_print(struct flb_cf_group *g)
+{
+    cfl_kvlist_print(stdout, g->properties);
+}
+
 void flb_cf_group_destroy(struct flb_cf_group *g)
 {
     if (g->name) {

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -373,6 +373,17 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
     }
     instance->config = config;
 
+    /*
+     * Initialize event type, if not set, default to FLB_FILTER_LOGS. Note that a
+     * zero value means it's undefined.
+     */
+    if (plugin->event_type == 0) {
+        instance->event_type = FLB_FILTER_LOGS;
+    }
+    else {
+        instance->event_type = plugin->event_type;
+    }
+
     /* Get an ID */
     id =  instance_id(config);
 
@@ -406,140 +417,148 @@ const char *flb_filter_name(struct flb_filter_instance *ins)
     return ins->name;
 }
 
-/* Initialize all filter plugins */
-int flb_filter_init_all(struct flb_config *config)
+int flb_filter_init(struct flb_config *config, struct flb_filter_instance *ins)
 {
     int ret;
     uint64_t ts;
     char *name;
-    struct mk_list *tmp;
-    struct mk_list *head;
     struct mk_list *config_map;
     struct flb_filter_plugin *p;
+
+    if (!ins->match
+#ifdef FLB_HAVE_REGEX
+        && !ins->match_regex
+#endif
+        ) {
+        flb_warn("[filter] NO match rule for %s filter instance, unloading.",
+                 ins->name);
+        return -1;
+    }
+
+    if (ins->log_level == -1 && config->log) {
+        ins->log_level = config->log->level;
+    }
+
+    p = ins->p;
+
+    /* Get name or alias for the instance */
+    name = (char *) flb_filter_name(ins);
+    ts = cfl_time_now();
+
+    /* CMetrics */
+    ins->cmt = cmt_create();
+    if (!ins->cmt) {
+        flb_error("[filter] could not create cmetrics context: %s",
+                  flb_filter_name(ins));
+        return -1;
+    }
+
+    /* Register generic filter plugin metrics */
+    ins->cmt_records = cmt_counter_create(ins->cmt,
+                                              "fluentbit", "filter",
+                                              "records_total",
+                                              "Total number of new records processed.",
+                                              1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_records, ts, 0, 1, (char *[]) {name});
+
+    /* Register generic filter plugin metrics */
+    ins->cmt_bytes = cmt_counter_create(ins->cmt,
+                                              "fluentbit", "filter",
+                                              "bytes_total",
+                                              "Total number of new bytes processed.",
+                                              1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_bytes, ts, 0, 1, (char *[]) {name});
+
+    /* Register generic filter plugin metrics */
+    ins->cmt_add_records = cmt_counter_create(ins->cmt,
+                                              "fluentbit", "filter",
+                                              "add_records_total",
+                                              "Total number of new added records.",
+                                              1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_add_records, ts, 0, 1, (char *[]) {name});
+
+    /* Register generic filter plugin metrics */
+    ins->cmt_drop_records = cmt_counter_create(ins->cmt,
+                                              "fluentbit", "filter",
+                                              "drop_records_total",
+                                              "Total number of dropped records.",
+                                              1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_drop_records, ts, 0, 1, (char *[]) {name});
+
+    /* OLD Metrics API */
+#ifdef FLB_HAVE_METRICS
+
+    /* Create the metrics context */
+    ins->metrics = flb_metrics_create(name);
+    if (!ins->metrics) {
+        flb_warn("[filter] cannot initialize metrics for %s filter, "
+                 "unloading.", name);
+        return -1;
+    }
+
+    /* Register filter metrics */
+    flb_metrics_add(FLB_METRIC_N_DROPPED, "drop_records", ins->metrics);
+    flb_metrics_add(FLB_METRIC_N_ADDED, "add_records", ins->metrics);
+    flb_metrics_add(FLB_METRIC_N_RECORDS, "records", ins->metrics);
+    flb_metrics_add(FLB_METRIC_N_BYTES, "bytes", ins->metrics);
+#endif
+
+    /*
+     * Before to call the initialization callback, make sure that the received
+     * configuration parameters are valid if the plugin is registering a config map.
+     */
+    if (p->config_map) {
+        /*
+         * Create a dynamic version of the configmap that will be used by the specific
+         * instance in question.
+         */
+        config_map = flb_config_map_create(config, p->config_map);
+        if (!config_map) {
+            flb_error("[filter] error loading config map for '%s' plugin",
+                      p->name);
+            return -1;
+        }
+        ins->config_map = config_map;
+
+        /* Validate incoming properties against config map */
+        ret = flb_config_map_properties_check(ins->p->name,
+                                              &ins->properties, ins->config_map);
+        if (ret == -1) {
+            if (config->program_name) {
+                flb_helper("try the command: %s -F %s -h\n",
+                           config->program_name, ins->p->name);
+            }
+            return -1;
+        }
+    }
+
+    /* Initialize the input */
+    if (p->cb_init) {
+        ret = p->cb_init(ins, config, ins->data);
+        if (ret != 0) {
+            flb_error("Failed initialize filter %s", ins->name);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/* Initialize all filter plugins */
+int flb_filter_init_all(struct flb_config *config)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
     struct flb_filter_instance *ins;
 
     /* Iterate all active filter instance plugins */
     mk_list_foreach_safe(head, tmp, &config->filters) {
         ins = mk_list_entry(head, struct flb_filter_instance, _head);
-
-        if (!ins->match
-#ifdef FLB_HAVE_REGEX
-            && !ins->match_regex
-#endif
-            ) {
-            flb_warn("[filter] NO match rule for %s filter instance, unloading.",
-                     ins->name);
+        ret = flb_filter_init(config, ins);
+        if (ret == -1) {
             flb_filter_instance_destroy(ins);
-            continue;
-        }
-        if (ins->log_level == -1) {
-            ins->log_level = config->log->level;
-        }
-
-        p = ins->p;
-
-        /* Get name or alias for the instance */
-        name = (char *) flb_filter_name(ins);
-        ts = cfl_time_now();
-
-        /* CMetrics */
-        ins->cmt = cmt_create();
-        if (!ins->cmt) {
-            flb_error("[filter] could not create cmetrics context: %s",
-                      flb_filter_name(ins));
             return -1;
-        }
-
-        /* Register generic filter plugin metrics */
-        ins->cmt_records = cmt_counter_create(ins->cmt,
-                                                  "fluentbit", "filter",
-                                                  "records_total",
-                                                  "Total number of new records processed.",
-                                                  1, (char *[]) {"name"});
-        cmt_counter_set(ins->cmt_records, ts, 0, 1, (char *[]) {name});
-
-        /* Register generic filter plugin metrics */
-        ins->cmt_bytes = cmt_counter_create(ins->cmt,
-                                                  "fluentbit", "filter",
-                                                  "bytes_total",
-                                                  "Total number of new bytes processed.",
-                                                  1, (char *[]) {"name"});
-        cmt_counter_set(ins->cmt_bytes, ts, 0, 1, (char *[]) {name});
-
-        /* Register generic filter plugin metrics */
-        ins->cmt_add_records = cmt_counter_create(ins->cmt,
-                                                  "fluentbit", "filter",
-                                                  "add_records_total",
-                                                  "Total number of new added records.",
-                                                  1, (char *[]) {"name"});
-        cmt_counter_set(ins->cmt_add_records, ts, 0, 1, (char *[]) {name});
-
-        /* Register generic filter plugin metrics */
-        ins->cmt_drop_records = cmt_counter_create(ins->cmt,
-                                                  "fluentbit", "filter",
-                                                  "drop_records_total",
-                                                  "Total number of dropped records.",
-                                                  1, (char *[]) {"name"});
-        cmt_counter_set(ins->cmt_drop_records, ts, 0, 1, (char *[]) {name});
-
-        /* OLD Metrics API */
-#ifdef FLB_HAVE_METRICS
-
-        /* Create the metrics context */
-        ins->metrics = flb_metrics_create(name);
-        if (!ins->metrics) {
-            flb_warn("[filter] cannot initialize metrics for %s filter, "
-                     "unloading.", name);
-            mk_list_del(&ins->_head);
-            flb_free(ins);
-            continue;
-        }
-
-        /* Register filter metrics */
-        flb_metrics_add(FLB_METRIC_N_DROPPED, "drop_records", ins->metrics);
-        flb_metrics_add(FLB_METRIC_N_ADDED, "add_records", ins->metrics);
-        flb_metrics_add(FLB_METRIC_N_RECORDS, "records", ins->metrics);
-        flb_metrics_add(FLB_METRIC_N_BYTES, "bytes", ins->metrics);
-#endif
-
-        /*
-         * Before to call the initialization callback, make sure that the received
-         * configuration parameters are valid if the plugin is registering a config map.
-         */
-        if (p->config_map) {
-            /*
-             * Create a dynamic version of the configmap that will be used by the specific
-             * instance in question.
-             */
-            config_map = flb_config_map_create(config, p->config_map);
-            if (!config_map) {
-                flb_error("[filter] error loading config map for '%s' plugin",
-                          p->name);
-                return -1;
-            }
-            ins->config_map = config_map;
-
-            /* Validate incoming properties against config map */
-            ret = flb_config_map_properties_check(ins->p->name,
-                                                  &ins->properties, ins->config_map);
-            if (ret == -1) {
-                if (config->program_name) {
-                    flb_helper("try the command: %s -F %s -h\n",
-                               config->program_name, ins->p->name);
-                }
-                flb_filter_instance_destroy(ins);
-                return -1;
-            }
-        }
-
-        /* Initialize the input */
-        if (p->cb_init) {
-            ret = p->cb_init(ins, config, ins->data);
-            if (ret != 0) {
-                flb_error("Failed initialize filter %s", ins->name);
-                flb_filter_instance_destroy(ins);
-                return -1;
-            }
         }
     }
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -39,6 +39,7 @@
 #include <fluent-bit/flb_hash_table.h>
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_ring_buffer.h>
+#include <fluent-bit/flb_processor.h>
 
 /* input plugin macro helpers */
 #include <fluent-bit/flb_input_plugin.h>
@@ -336,6 +337,9 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->mem_chunks_size = 0;
         instance->storage_buf_status = FLB_INPUT_RUNNING;
         mk_list_add(&instance->_head, &config->inputs);
+
+        /* processor instance */
+        instance->processor = flb_processor_create(config, instance->name, instance);
     }
 
     return instance;
@@ -781,8 +785,14 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
 
     mk_list_del(&ins->_head);
 
+    /* ring buffer */
     if (ins->rb) {
         flb_ring_buffer_destroy(ins->rb);
+    }
+
+    /* processor */
+    if (ins->processor) {
+        flb_processor_destroy(ins->processor);
     }
     flb_free(ins);
 }

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -423,6 +423,12 @@ int flb_output_instance_destroy(struct flb_output_instance *ins)
     }
 
     mk_list_del(&ins->_head);
+
+    /* processor */
+    if (ins->processor) {
+        flb_processor_destroy(ins->processor);
+    }
+
     flb_free(ins);
 
     return 0;
@@ -693,8 +699,12 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
 
     mk_list_add(&instance->_head, &config->outputs);
 
+    /* processor instance */
+    instance->processor = flb_processor_create(config, instance->name, instance);
+
     /* Tests */
     instance->test_formatter.callback = plugin->test_formatter.callback;
+
 
     return instance;
 }
@@ -1309,8 +1319,7 @@ int flb_output_upstream_set(struct flb_upstream *u, struct flb_output_instance *
     if (ins->host.ipv6 == FLB_TRUE) {
         flags |= FLB_IO_IPV6;
     }
-    
-    /* keepalive */
+        /* keepalive */
     if (ins->net_setup.keepalive == FLB_TRUE) {
         flags |= FLB_IO_TCP_KA;
     }

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -35,13 +35,14 @@ struct flb_processor *flb_processor_create(struct flb_config *config, char *name
 {
     struct flb_processor *proc;
 
-    proc = flb_malloc(sizeof(struct flb_processor));
+    proc = flb_calloc(1, sizeof(struct flb_processor));
     if (!proc) {
         flb_errno();
         return NULL;
     }
     proc->config = config;
     proc->data = data;
+    proc->is_active = FLB_FALSE;
 
     /* lists for types */
     mk_list_init(&proc->logs);

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -1,0 +1,498 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_event.h>
+#include <fluent-bit/flb_processor.h>
+#include <fluent-bit/flb_filter.h>
+
+/*
+ * A processor creates a chain of processing units for different telemetry data
+ * types such as logs, metrics and traces.
+ *
+ * From a design perspective, a Processor can be run independently from inputs, outputs
+ * or unit tests directly.
+ */
+struct flb_processor *flb_processor_create(struct flb_config *config, char *name, void *data)
+{
+    struct flb_processor *proc;
+
+    proc = flb_malloc(sizeof(struct flb_processor));
+    if (!proc) {
+        flb_errno();
+        return NULL;
+    }
+    proc->config = config;
+    proc->data = data;
+
+    /* lists for types */
+    mk_list_init(&proc->logs);
+    mk_list_init(&proc->metrics);
+    mk_list_init(&proc->traces);
+
+    return proc;
+}
+
+struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
+                                                     int event_type,
+                                                     char *unit_name)
+{
+    struct mk_list *head;
+    struct flb_filter_plugin *f = NULL;
+    struct flb_filter_instance *f_ins;
+    struct flb_config *config = proc->config;
+    struct flb_processor_unit *pu = NULL;
+
+    /*
+     * Looking the processor unit by using it's name and type, the first list we
+     * will iterate are the common pipeline filters.
+     */
+    mk_list_foreach(head, &config->filter_plugins) {
+        f = mk_list_entry(head, struct flb_filter_plugin, _head);
+
+        /* skip filters which don't handle the required type */
+        if (!(event_type & f->event_type)) {
+            continue;
+        }
+
+        if (strcmp(f->name, unit_name) == 0) {
+            break;
+        }
+
+        f = NULL;
+    }
+
+    /* allocate and initialize processor unit context */
+    pu = flb_calloc(1, sizeof(struct flb_processor_unit));
+    if (!pu) {
+        flb_errno();
+        return NULL;
+    }
+    pu->parent = proc;
+    pu->event_type = event_type;
+    pu->name = flb_sds_create(unit_name);
+    if (!pu->name) {
+        flb_free(pu);
+        return NULL;
+    }
+    mk_list_init(&pu->unused_list);
+
+    /* If we matched a pipeline filter, create the speacial processing unit for it */
+    if (f) {
+        /* create an instance of the filter */
+        f_ins = flb_filter_new(config, unit_name, NULL);
+        if (!f_ins) {
+            flb_free(pu);
+            return NULL;
+        }
+        /* matching rule: just set to workaround the pipeline initializer */
+        f_ins->match = flb_sds_create("*");
+
+        /* unit type and context */
+        pu->unit_type = FLB_PROCESSOR_UNIT_FILTER;
+        pu->ctx = f_ins;
+
+
+        /*
+         * The filter was added to the linked list config->filters, since this filter
+         * won't run as part of the normal pipeline, we just unlink the node.
+         */
+        mk_list_del(&f_ins->_head);
+
+        /* link the filter to the unused list */
+        mk_list_add(&f_ins->_head, &pu->unused_list);
+    }
+    else {
+        pu->unit_type = FLB_PROCESSOR_UNIT_NATIVE;
+
+        /* FIXME */
+    }
+
+    /* Link the processor unit to the proper list */
+    if (event_type == FLB_PROCESSOR_LOGS) {
+        mk_list_add(&pu->_head, &proc->logs);
+    }
+    else if (event_type == FLB_PROCESSOR_METRICS) {
+        mk_list_add(&pu->_head, &proc->metrics);
+    }
+    else if (event_type == FLB_PROCESSOR_TRACES) {
+        mk_list_add(&pu->_head, &proc->traces);
+    }
+    return pu;
+}
+
+int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k, const char *v)
+{
+    if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
+        return flb_filter_set_property(pu->ctx, k, v);
+    }
+    else {
+        /* FIXME */
+    }
+    return -1;
+}
+
+void flb_processor_unit_destroy(struct flb_processor_unit *pu)
+{
+    struct flb_processor *proc = pu->parent;
+    struct flb_config *config = proc->config;
+
+    if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
+        flb_filter_instance_exit(pu->ctx, config);
+        flb_filter_instance_destroy(pu->ctx);
+    }
+    else {
+        /* FIXME */
+    }
+    flb_sds_destroy(pu->name);
+    flb_free(pu);
+}
+
+/* Initialize a specific unit */
+int flb_processor_unit_init(struct flb_processor_unit *pu)
+{
+    int ret = -1;
+    struct flb_config;
+    struct flb_processor *proc = pu->parent;
+
+    if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
+        ret = flb_filter_init(proc->config, pu->ctx);
+        if (ret == -1) {
+            flb_error("[processor] error initializing unit filter %s", pu->name);
+            return -1;
+        }
+    }
+    else {
+        /* FIXME */
+    }
+
+    return ret;
+}
+
+/* Initialize the processor and all the units */
+int flb_processor_init(struct flb_processor *proc)
+{
+    int ret;
+    int count = 0;
+    struct mk_list *head;
+    struct flb_processor_unit *pu;
+
+    /* Go through every unit and initialize it */
+    mk_list_foreach(head, &proc->logs) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        ret = flb_processor_unit_init(pu);
+        if (ret == -1) {
+            return -1;
+        }
+        count++;
+    }
+
+    mk_list_foreach(head, &proc->metrics) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        ret = flb_processor_unit_init(pu);
+        if (ret == -1) {
+            return -1;
+        }
+        count++;
+    }
+
+    mk_list_foreach(head, &proc->traces) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        ret = flb_processor_unit_init(pu);
+        if (ret == -1) {
+            return -1;
+        }
+        count++;
+    }
+
+    if (count > 0) {
+        proc->is_active = FLB_TRUE;
+    }
+    return 0;
+}
+
+int flb_processor_is_active(struct flb_processor *proc)
+{
+    if (proc->is_active) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+/*
+ * This function will run all the processor units for the given tag and data, note
+ * that depending of the 'type', 'data' can reference a msgpack for logs, a CMetrics
+ * context for metrics or a 'CTraces' context for traces.
+ */
+int flb_processor_run(struct flb_processor *proc,
+                      int type,
+                      const char *tag, size_t tag_len,
+                      void *data, size_t data_size,
+                      void **out_buf, size_t *out_size)
+{
+    int ret;
+    void *cur_buf;
+    size_t cur_size;
+    void *tmp_buf;
+    size_t tmp_size;
+    struct mk_list *head;
+    struct mk_list *list = NULL;
+    struct flb_processor_unit *pu;
+    struct flb_filter_instance *f_ins;
+
+    if (type == FLB_PROCESSOR_LOGS) {
+        list = &proc->logs;
+    }
+    else if (type == FLB_PROCESSOR_METRICS) {
+        list = &proc->metrics;
+    }
+    else if (type == FLB_PROCESSOR_TRACES) {
+        list = &proc->traces;
+    }
+
+    /* set current data buffer */
+    cur_buf = data;
+    cur_size = data_size;
+
+    /* iterate list units */
+    mk_list_foreach(head, list) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+
+        /* run the unit */
+        if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
+            /* get the filter context */
+            f_ins = pu->ctx;
+
+            /* run the filtering callback */
+            ret = f_ins->p->cb_filter(cur_buf, cur_size,    /* msgpack buffer */
+                                      tag, tag_len,         /* tag */
+                                      &tmp_buf, &tmp_size,  /* output buffer */
+                                      f_ins,                /* filter instance */
+                                      proc->data,           /* (input/output) instance context */
+                                      f_ins->context,       /* filter context */
+                                      proc->config);
+
+            /*
+             * The cb_filter() function return status tells us if something changed
+             * during it process. The possible values are:
+             *
+             * - FLB_FILTER_MODIFIED: the record was modified and the output buffer
+             *                        contains the new record.
+             *
+             * - FLB_FILTER_NOTOUCH: the record was not modified.
+             *
+             */
+            if (ret == FLB_FILTER_MODIFIED) {
+                /*
+                 * if the content has been modified and the returned size is zero, it means
+                 * the whole content has been dropped, on this case we just return since
+                 * no more data exists to be processed.
+                 */
+                if (out_size == 0) {
+                    *out_buf = NULL;
+                    *out_size = 0;
+                    return 0;
+                }
+
+                /* release intermediate buffer */
+                if (cur_buf != data) {
+                    flb_free(cur_buf);
+
+                }
+
+                /* set new buffer */
+                cur_buf = tmp_buf;
+                cur_size = tmp_size;
+            }
+            else if (ret == FLB_FILTER_NOTOUCH) {
+                /* keep original data, do nothing */
+            }
+        }
+        else {
+            /* FIXME */
+        }
+    }
+
+    /* set output buffer */
+    *out_buf = cur_buf;
+    *out_size = cur_size;
+
+    return 0;
+}
+
+void flb_processor_destroy(struct flb_processor *proc)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_processor_unit *pu;
+
+    mk_list_foreach_safe(head, tmp, &proc->logs) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        mk_list_del(&pu->_head);
+        flb_processor_unit_destroy(pu);
+    }
+
+    mk_list_foreach_safe(head, tmp, &proc->metrics) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        mk_list_del(&pu->_head);
+        flb_processor_unit_destroy(pu);
+    }
+
+    mk_list_foreach_safe(head, tmp, &proc->traces) {
+        pu = mk_list_entry(head, struct flb_processor_unit, _head);
+        mk_list_del(&pu->_head);
+        flb_processor_unit_destroy(pu);
+    }
+    flb_free(proc);
+}
+
+
+static int load_from_config_format_group(struct flb_processor *proc, int type, struct cfl_variant *val)
+{
+    int i;
+    int ret;
+    char *name;
+    struct cfl_variant *tmp;
+    struct cfl_array *array;
+    struct cfl_kvlist *kvlist;
+    struct cfl_kvpair *pair = NULL;
+    struct cfl_list *head;
+    struct flb_processor_unit *pu;
+
+    if (val->type != CFL_VARIANT_ARRAY) {
+        return -1;
+    }
+
+    array = val->data.as_array;
+    for (i = 0; i < array->entry_count; i++) {
+        /* every entry in the array must be a map */
+        tmp = array->entries[i];
+        if (tmp->type != CFL_VARIANT_KVLIST) {
+            return -1;
+        }
+
+        kvlist = tmp->data.as_kvlist;
+
+        /* get the processor name, this is a mandatory config field */
+        tmp = cfl_kvlist_fetch(kvlist, "name");
+        if (!tmp) {
+            flb_error("processor configuration don't have a 'name' defined");
+            return -1;
+        }
+
+        /* create the processor unit and load all the properties */
+        name = tmp->data.as_string;
+        pu = flb_processor_unit_create(proc, type, name);
+        if (!pu) {
+            flb_error("cannot create '%s' processor unit", name);
+            return -1;
+        }
+
+        /* iterate list of properties and set each one (skip name) */
+        cfl_list_foreach(head, &kvlist->list) {
+            pair = cfl_list_entry(head, struct cfl_kvpair, _head);
+            if (strcmp(pair->key, "name") == 0) {
+                continue;
+            }
+
+            if (pair->val->type != CFL_VARIANT_STRING) {
+                continue;
+            }
+
+            ret = flb_processor_unit_set_property(pu, pair->key, pair->val->data.as_string);
+            if (ret == -1) {
+                flb_error("cannot set property '%s' for processor '%s'", pair->key, name);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+
+}
+
+/* Load processors into an input instance */
+int flb_processors_load_from_config_format_group(struct flb_processor *proc, struct flb_cf_group *g)
+{
+    int ret;
+    struct cfl_variant *val;
+
+    /* logs */
+    val = cfl_kvlist_fetch(g->properties, "logs");
+    if (val) {
+        ret = load_from_config_format_group(proc, FLB_PROCESSOR_LOGS, val);
+        if (ret == -1) {
+            flb_error("failed to load 'logs' processors");
+            return -1;
+        }
+    }
+
+    /* metrics */
+    val = cfl_kvlist_fetch(g->properties, "metrics");
+    if (val) {
+        ret = load_from_config_format_group(proc, FLB_PROCESSOR_METRICS, val);
+        if (ret == -1) {
+            flb_error("failed to load 'metrics' processors");
+            return -1;
+        }
+    }
+
+    /* traces */
+    val = cfl_kvlist_fetch(g->properties, "traces");
+    if (val) {
+        ret = load_from_config_format_group(proc, FLB_PROCESSOR_TRACES, val);
+        if (ret == -1) {
+            flb_error("failed to load 'traces' processors");
+            return -1;
+        }
+    }
+
+    /* initialize processors */
+    ret = flb_processor_init(proc);
+    if (ret == -1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -794,11 +794,13 @@ static int service_configure_plugin(struct flb_config *config,
                 flb_processors_load_from_config_format_group(((struct flb_input_instance *) ins)->processor, processors);
             }
             else if (type == FLB_CF_OUTPUT) {
-                /* FIXME */
+                flb_processors_load_from_config_format_group(((struct flb_output_instance *) ins)->processor, processors);
+            }
+            else {
+                flb_error("[config] section '%s' does not support processors", s_type);
             }
         }
     }
-
     return 0;
 }
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -38,6 +38,7 @@ set(UNIT_TESTS_FILES
   parser_logfmt.c
   env.c
   log.c
+  processor.c
   )
 
 # Config format

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_lib.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_processor.h>
@@ -68,6 +69,8 @@ static void processor()
     size_t out_size;
 
     printf("\n\n");
+
+    flb_init_env();
 
     config = flb_config_init();
     TEST_CHECK(config != NULL);

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -45,7 +45,7 @@ static int create_msgpack_records(char **out_buf, size_t *out_size)
     msgpack_pack_array(&mp_pck, 2);
     flb_pack_time_now(&mp_pck);
 
-    ret = flb_pack_json(json, strlen(json), &mp_tmp, &mp_size, &root_type);
+    ret = flb_pack_json(json, strlen(json), &mp_tmp, &mp_size, &root_type, NULL);
     TEST_CHECK(ret == 0);
 
     msgpack_sbuffer_write(&mp_sbuf, mp_tmp, mp_size);

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -1,0 +1,112 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_processor.h>
+//#include <msgpack.h>
+
+#include "flb_tests_internal.h"
+
+#define APACHE_10K    FLB_TESTS_DATA_PATH "/data/mp/apache_10k.mp"
+
+static int create_msgpack_records(char **out_buf, size_t *out_size)
+{
+    int ret;
+    int root_type;
+    char *json = "{\"key1\": 12345, \"key2\": \"fluent bit\"}";
+    char *mp_tmp;
+    size_t mp_size;
+
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    flb_pack_time_now(&mp_pck);
+
+    ret = flb_pack_json(json, strlen(json), &mp_tmp, &mp_size, &root_type);
+    TEST_CHECK(ret == 0);
+
+    msgpack_sbuffer_write(&mp_sbuf, mp_tmp, mp_size);
+    flb_free(mp_tmp);
+
+    *out_buf = mp_sbuf.data;
+    *out_size = mp_sbuf.size;
+
+    return 0;
+}
+
+static void processor()
+{
+    int ret;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_config *config;
+    char *mp_buf;
+    size_t mp_size;
+    void *out_buf = NULL;
+    size_t out_size;
+
+    printf("\n\n");
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    proc = flb_processor_create(config, "unit_test", NULL);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_LOGS, "stdout");
+    TEST_CHECK(pu != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_LOGS, "modify");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "add", "hostname monox");
+    TEST_CHECK(ret == 0);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_LOGS, "stdout");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_init(proc);
+    TEST_CHECK(ret == 0);
+
+    /* generate records (simulate an input plugin */
+    ret = create_msgpack_records(&mp_buf, &mp_size);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_run(proc, FLB_PROCESSOR_LOGS, "TEST", 4, mp_buf, mp_size, &out_buf, &out_size);
+
+    if (out_buf != mp_buf) {
+        flb_free(out_buf);
+    }
+    flb_free(mp_buf);
+
+    flb_processor_destroy(proc);
+    flb_config_exit(config);
+
+}
+
+TEST_LIST = {
+    { "processor", processor },
+    { 0 }
+};


### PR DESCRIPTION
(note: fixed branch of #7121)

Fluent Bit is able to filter, drop or enrich data before the data hits the final destination, but has been always limited to logs data type and depended on tag/matching routing mechanism, in long configurations this becomes problematic.

In recent versions of Fluent Bit, the input plugins can run in a separate thread, so doing data processing in a separate thread helps to desaturate the main event loop. All of this is an optional feature with no breaking changes.

To take advantage of processors, the user must use Yaml configuration format, this functionality is not exposed in classic mode due to the restriction of nested levels of configuration. Here you can find an example of Yaml that implements processing rules for logs in a random input:

```yaml
service:
    log_level: info
    http_server: on
    http_listen: 0.0.0.0
    http_port: 2021


  pipeline:
    inputs:
      - name: random
        tag: test-tag
        interval_sec: 1

        processors:
          logs:
            - name: modify
              add: hostname monox

            - name: lua
              call: append_tag
              code: |
                  function append_tag(tag, timestamp, record)
                     new_record = record
                     new_record["tag"] = tag
                     return 1, timestamp, new_record
                  end

    outputs:
      - name: stdout
        match: '*'

        processors:
          logs:
            - name: lua
              call: add_field
              code: |
                  function add_field(tag, timestamp, record)
                     new_record = record
                     new_record["output"] = "new data"
                     return 1, timestamp, new_record
                  end
```

In the example above, no routing is needed and the output of processors is what gets enqueued into the engine for processing. Also you can notice that we will have processors for logs, metrics and traces (the latest two will be available in the upcoming days).

This same functionality will be available for output plugins too for more granular data modification.

------------
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.