### PR TITLE
tests: runtime: filter_modify: fix warning

### DIFF
--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1337,8 +1337,9 @@ static int get_output_num()
 static int callback_count(void* data, size_t size, void* cb_data)
 {
     if (size > 0) {
-        flb_debug("[test_filter_modify] received message: %s", data);
+        flb_debug("[test_filter_modify] received message: %s", (char*)data);
         add_output_num(); /* success */
+        flb_free(data);
     }
     return 0;
 }


### PR DESCRIPTION
This patch is to fix following warning and valgrind error.

```
[ 85%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_modify.dir/filter_modify.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/filter_modify.c:3:
/home/taka/git/fluent-bit/tests/runtime/filter_modify.c: In function ‘callback_count’:
/home/taka/git/fluent-bit/tests/runtime/filter_modify.c:1340:19: warning: format ‘%s’ expects argument of type ‘char *’, but argument 5 has type ‘void *’ [-Wformat=]
 1340 |         flb_debug("[test_filter_modify] received message: %s", data);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~
      |                                                                |
      |                                                                void *
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:168:47: note: in definition of macro ‘flb_debug’
  168 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_modify.c:1340:60: note: format string is defined here
 1340 |         flb_debug("[test_filter_modify] received message: %s", data);
      |                                                           ~^
      |                                                            |
      |                                                            char *
      |                                                           %p
[ 85%] Linking C executable ../../bin/flb-rt-filter_modify
```

Valrgind error
```
SUCCESS: All unit tests have passed.
==13754== 
==13754== HEAP SUMMARY:
==13754==     in use at exit: 185 bytes in 3 blocks
==13754==   total heap usage: 53,132 allocs, 53,129 frees, 27,103,480 bytes allocated
==13754== 
==13754== 185 bytes in 3 blocks are definitely lost in loss record 1 of 1
==13754==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==13754==    by 0x5BC128: flb_malloc (flb_mem.h:80)
==13754==    by 0x5C04A0: out_lib_flush (out_lib.c:177)
==13754==    by 0x170818: output_pre_cb_flush (flb_output.h:528)
==13754==    by 0xB019CA: co_init (amd64.c:117)
==13754== 
==13754== LEAK SUMMARY:
==13754==    definitely lost: 185 bytes in 3 blocks
==13754==    indirectly lost: 0 bytes in 0 blocks
==13754==      possibly lost: 0 bytes in 0 blocks
==13754==    still reachable: 0 bytes in 0 blocks
==13754==         suppressed: 0 bytes in 0 blocks
==13754== 
==13754== For lists of detected and suppressed errors, rerun with: -s
==13754== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_modify 
==15486== Memcheck, a memory error detector
==15486== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15486== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==15486== Command: bin/flb-rt-filter_modify
==15486== 
Test op_set_append...                           [2023/04/08 08:46:58] [ info] [fluent bit] version=2.1.0, commit=c5fc1b9b94, pid=15486
[2023/04/08 08:46:58] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/08 08:46:58] [ info] [cmetrics] version=0.6.1
[2023/04/08 08:46:58] [ info] [ctraces ] version=0.3.0
[2023/04/08 08:46:58] [ info] [input:lib:lib.0] initializing
[2023/04/08 08:46:58] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/08 08:46:58] [ info] [sp] stream processor started
[2023/04/08 08:46:59] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/08 08:47:00] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]


(snip)

Test Key_value_matches and value is bool type... [2023/04/08 08:48:07] [ info] [fluent bit] version=2.1.0, commit=c5fc1b9b94, pid=15486
[2023/04/08 08:48:07] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/08 08:48:07] [ info] [cmetrics] version=0.6.1
[2023/04/08 08:48:07] [ info] [ctraces ] version=0.3.0
[2023/04/08 08:48:07] [ info] [input:lib:lib.0] initializing
[2023/04/08 08:48:07] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/04/08 08:48:07] [ info] [sp] stream processor started
[2023/04/08 08:48:09] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/08 08:48:10] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==15486== 
==15486== HEAP SUMMARY:
==15486==     in use at exit: 0 bytes in 0 blocks
==15486==   total heap usage: 53,132 allocs, 53,132 frees, 27,103,479 bytes allocated
==15486== 
==15486== All heap blocks were freed -- no leaks are possible
==15486== 
==15486== For lists of detected and suppressed errors, rerun with: -s
==15486== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
