### PR TITLE
filter_grep: remove unused val

### DIFF
--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -295,8 +295,6 @@ static int cb_grep_filter(const void *data, size_t bytes,
     int old_size = 0;
     int new_size = 0;
     msgpack_object map;
-    size_t record_begining = 0;
-    size_t record_end = 0;
     struct flb_log_event_encoder log_encoder;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
@@ -332,7 +330,6 @@ static int cb_grep_filter(const void *data, size_t bytes,
     while ((ret = flb_log_event_decoder_next(
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        record_end = log_decoder.offset;
         old_size++;
 
         /* get time and map */
@@ -356,8 +353,6 @@ static int cb_grep_filter(const void *data, size_t bytes,
         else if (ret == GREP_RET_EXCLUDE) {
             /* Do nothing */
         }
-
-        record_begining = record_end;
     }
 
     if (ret == FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA &&


### PR DESCRIPTION
This patch is to fix following warning.

```
[ 41%] Building C object plugins/filter_grep/CMakeFiles/flb-plugin-filter_grep.dir/grep.c.o
/home/taka/git/fluent-bit/plugins/filter_grep/grep.c: In function ‘cb_grep_filter’:
/home/taka/git/fluent-bit/plugins/filter_grep/grep.c:298:12: warning: variable ‘record_begining’ set but not used [-Wunused-but-set-variable]
  298 |     size_t record_begining = 0;
      |            ^~~~~~~~~~~~~~~
```

```
[ 41%] Building C object plugins/filter_grep/CMakeFiles/flb-plugin-filter_grep.dir/grep.c.o
/home/taka/git/fluent-bit/plugins/filter_grep/grep.c: In function ‘cb_grep_filter’:
/home/taka/git/fluent-bit/plugins/filter_grep/grep.c:298:12: warning: variable ‘record_end’ set but not used [-Wunused-but-set-variable]
  298 |     size_t record_end = 0;
      |            ^~~~~~~~~~
[ 41%] Linking C static library ../../library/libflb-plugin-filter_grep.a
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_grep
==36662== Memcheck, a memory error detector
==36662== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==36662== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==36662== Command: bin/flb-rt-filter_grep
==36662== 
Test regex...                                   [2023/04/08 09:22:03] [ info] [fluent bit] version=2.1.0, commit=c5fc1b9b94, pid=36662
[2023/04/08 09:22:03] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/08 09:22:03] [ info] [cmetrics] version=0.6.1
[2023/04/08 09:22:03] [ info] [ctraces ] version=0.3.0
[2023/04/08 09:22:03] [ info] [input:lib:lib.0] initializing

(snip)

[ OK ]
SUCCESS: All unit tests have passed.
==36662== 
==36662== HEAP SUMMARY:
==36662==     in use at exit: 0 bytes in 0 blocks
==36662==   total heap usage: 63,490 allocs, 63,490 frees, 116,636,255 bytes allocated
==36662== 
==36662== All heap blocks were freed -- no leaks are possible
==36662== 
==36662== For lists of detected and suppressed errors, rerun with: -s
==36662== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
