### PR TITLE
sds: fix off by 1 bug in flb_sds_printf

### DIFF
--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -434,8 +434,8 @@ flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...)
     }
     va_end(ap);
 
-    if (size > flb_sds_avail(s)) {
-        tmp = flb_sds_increase(s, size);
+    if (size >= flb_sds_avail(s)) {
+        tmp = flb_sds_increase(s, size + 1);
         if (!tmp) {
             return NULL;
         }

--- a/src/flb_sds.c
+++ b/src/flb_sds.c
@@ -417,8 +417,8 @@ flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...)
     if (len < 64) len = 64;
 
     s = *sds;
-    if (flb_sds_avail(s)< len) {
-        tmp = flb_sds_increase(s, len);
+    if (flb_sds_avail(s) < len) {
+        tmp = flb_sds_increase(s, len - flb_sds_avail(s));
         if (!tmp) {
             return NULL;
         }
@@ -435,7 +435,7 @@ flb_sds_t flb_sds_printf(flb_sds_t *sds, const char *fmt, ...)
     va_end(ap);
 
     if (size >= flb_sds_avail(s)) {
-        tmp = flb_sds_increase(s, size + 1);
+        tmp = flb_sds_increase(s, size - flb_sds_avail(s) + 1);
         if (!tmp) {
             return NULL;
         }

--- a/tests/internal/sds.c
+++ b/tests/internal/sds.c
@@ -37,6 +37,36 @@ static void test_sds_printf()
     flb_sds_destroy(s);
 }
 
+/* https://github.com/fluent/fluent-bit/issues/7143 */
+static void test_sds_printf_7143_off_by_1()
+{
+    flb_sds_t tmp;
+    flb_sds_t test;
+    flb_sds_t test2;
+    int len;
+    
+    /* 66 char final string, not impacted by bug */
+    test = flb_sds_create_size(64);
+    TEST_CHECK(test != NULL);
+    tmp = flb_sds_printf(&test, "A0123456789 %s", "this-is-54-chars-1234567890-abcdefghijklmnopqrstuvwxyz");
+    TEST_CHECK(tmp != NULL);
+    len = flb_sds_len(test);
+    TEST_CHECK(len == 66);
+    TEST_CHECK(test[len -1] == 'z');
+    flb_sds_destroy(test);
+
+    /* 65 char final string, impacted by bug */
+    test2 = flb_sds_create_size(64);
+    TEST_CHECK(test2 != NULL);
+    tmp = flb_sds_printf(&test2, "0123456789 %s", "this-is-54-chars-1234567890-abcdefghijklmnopqrstuvwxyz");
+    TEST_CHECK(tmp != NULL);
+    len = flb_sds_len(test2);
+    TEST_CHECK(len == 65);
+    TEST_CHECK(test2[len -1] == 'z');
+    flb_sds_destroy(test2);
+
+}
+
 static void test_sds_cat_utf8()
 {
     flb_sds_t s;
@@ -53,5 +83,6 @@ TEST_LIST = {
     { "sds_usage" , test_sds_usage},
     { "sds_printf", test_sds_printf},
     { "sds_cat_utf8", test_sds_cat_utf8},
+    { "test_sds_printf_7143_off_by_1", test_sds_printf_7143_off_by_1},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#7143 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
