### PR TITLE
out_forward: Plug undefined timestamp on message mode

### DIFF
--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -242,7 +242,9 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
 
         /* Pack timestamp */
         if (fc->time_as_integer == FLB_TRUE) {
-            msgpack_pack_uint64(&mp_pck, tm.tm.tv_sec);
+            flb_time_append_to_msgpack(&log_event.timestamp,
+                                       &mp_pck,
+                                       FLB_TIME_ETFMT_INT);
         }
         else {
             flb_time_append_to_msgpack(&log_event.timestamp,

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -505,6 +505,8 @@ static int flb_forward_format_forward_compat_mode(struct flb_forward *ctx,
                        (char *) data, bytes, NULL, chunk);
     }
 
+    flb_log_event_decoder_destroy(&log_decoder);
+
     *out_buf  = mp_sbuf.data;
     *out_size = mp_sbuf.size;
 

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -196,7 +196,6 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
     size_t record_size;
     char *chunk;
     char chunk_buf[33];
-    msgpack_object   ts;
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
     struct flb_time tm;
@@ -246,7 +245,9 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
             msgpack_pack_uint64(&mp_pck, tm.tm.tv_sec);
         }
         else {
-            msgpack_pack_object(&mp_pck, ts);
+            flb_time_append_to_msgpack(&log_event.timestamp,
+                                       &mp_pck,
+                                       FLB_TIME_ETFMT_V1_FIXEXT);
         }
 
         /* Pack records */

--- a/tests/runtime/out_forward.c
+++ b/tests/runtime/out_forward.c
@@ -45,7 +45,7 @@ static void cb_check_message_mode(void *ctx, int ffd,
 
     TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
     TEST_CHECK(root.type == MSGPACK_OBJECT_ARRAY);
-    TEST_CHECK(root.via.array.size == 3);
+    TEST_CHECK(root.via.array.size == 4);
 
     /* Tag */
     tag = root.via.array.ptr[0];
@@ -89,7 +89,7 @@ static void cb_check_message_compat_mode(void *ctx, int ffd,
 
     TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
     TEST_CHECK(root.type == MSGPACK_OBJECT_ARRAY);
-    TEST_CHECK(root.via.array.size == 3);
+    TEST_CHECK(root.via.array.size == 4);
 
     /* Tag */
     tag = root.via.array.ptr[0];


### PR DESCRIPTION
<!-- Provide summary of changes -->

After merging on #7133, out_forward test case is failing.
I plugged a memory leak and undefined timestamp on message mode.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change


```
% bin/flb-rt-out_forward -v
Test message_mode:
  out_forward.c:222: Check ret == 0... ok
[2023/04/10 14:19:24] [ info] [fluent bit] version=2.1.0, commit=0d4006faad, pid=618266
[2023/04/10 14:19:24] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/10 14:19:24] [ info] [output:forward:forward.0] worker #0 started
[2023/04/10 14:19:24] [ info] [output:forward:forward.0] worker #1 started
[2023/04/10 14:19:24] [ info] [cmetrics] version=0.6.1
[2023/04/10 14:19:24] [ info] [ctraces ] version=0.3.0
[2023/04/10 14:19:24] [ info] [input:dummy:dummy.0] initializing
[2023/04/10 14:19:24] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/04/10 14:19:24] [ info] [sp] stream processor started
  out_forward.c:46: Check ret == MSGPACK_UNPACK_SUCCESS... ok
  out_forward.c:47: Check root.type == MSGPACK_OBJECT_ARRAY... ok
  out_forward.c:48: Check root.via.array.size == 4... ok
  out_forward.c:52: Check tag.type == MSGPACK_OBJECT_STR... ok
  out_forward.c:54: Check ret == 0... ok
  out_forward.c:58: Check ts.type == MSGPACK_OBJECT_EXT... ok
  out_forward.c:61: Check ret == 0... ok
  out_forward.c:62: Check time.tm.tv_nsec != 0... ok
  out_forward.c:66: Check record.type == MSGPACK_OBJECT_MAP... ok
  out_forward.c:67: Check record.via.map.size == 2... ok
[2023/04/10 14:19:25] [ info] [task] cleanup test task
[2023/04/10 14:19:26] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/10 14:19:26] [ info] [input] pausing dummy.0
[2023/04/10 14:19:26] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/10 14:19:26] [ info] [input] pausing dummy.0
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] thread worker #0 stopped
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] thread worker #1 stopped
  SUCCESS: All conditions have passed.

Test message_compat_mode:
[2023/04/10 14:19:26] [ info] [fluent bit] version=2.1.0, commit=0d4006faad, pid=618266
[2023/04/10 14:19:26] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/10 14:19:26] [ info] [cmetrics] version=0.6.1
[2023/04/10 14:19:26] [ info] [ctraces ] version=0.3.0
[2023/04/10 14:19:26] [ info] [input:dummy:dummy.0] initializing
  out_forward.c:264: Check ret == 0... ok
[2023/04/10 14:19:26] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] worker #0 started
[2023/04/10 14:19:26] [ info] [sp] stream processor started
[2023/04/10 14:19:26] [ info] [output:forward:forward.0] worker #1 started
  out_forward.c:90: Check ret == MSGPACK_UNPACK_SUCCESS... ok
  out_forward.c:91: Check root.type == MSGPACK_OBJECT_ARRAY... ok
  out_forward.c:92: Check root.via.array.size == 4... ok
  out_forward.c:96: Check tag.type == MSGPACK_OBJECT_STR... ok
  out_forward.c:98: Check ret == 0... ok
  out_forward.c:102: Check ts.type == MSGPACK_OBJECT_POSITIVE_INTEGER... ok
  out_forward.c:105: Check ret == 0... ok
  out_forward.c:106: Check time.tm.tv_nsec == 0... ok
  out_forward.c:110: Check record.type == MSGPACK_OBJECT_MAP... ok
  out_forward.c:111: Check record.via.map.size == 2... ok
[2023/04/10 14:19:28] [ info] [task] cleanup test task
[2023/04/10 14:19:28] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/10 14:19:28] [ info] [input] pausing dummy.0
[2023/04/10 14:19:29] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/10 14:19:29] [ info] [input] pausing dummy.0
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] thread worker #0 stopped
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] thread worker #1 stopped
  SUCCESS: All conditions have passed.

Test forward_mode:
[2023/04/10 14:19:29] [ info] [fluent bit] version=2.1.0, commit=0d4006faad, pid=618266
[2023/04/10 14:19:29] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
  out_forward.c:306: Check ret == 0... ok
[2023/04/10 14:19:29] [ info] [cmetrics] version=0.6.1
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] worker #0 started
[2023/04/10 14:19:29] [ info] [ctraces ] version=0.3.0
[2023/04/10 14:19:29] [ info] [input:dummy:dummy.0] initializing
[2023/04/10 14:19:29] [ info] [output:forward:forward.0] worker #1 started
[2023/04/10 14:19:29] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/04/10 14:19:29] [ info] [sp] stream processor started
  out_forward.c:133: Check res_ret == MODE_FORWARD... ok
  out_forward.c:139: Check ret == MSGPACK_UNPACK_SUCCESS... ok
  out_forward.c:140: Check root.type == MSGPACK_OBJECT_MAP... ok
  out_forward.c:143: Check root.via.map.size == 2... ok
  out_forward.c:150: Check ret == 0... ok
  out_forward.c:151: Check val.type == MSGPACK_OBJECT_POSITIVE_INTEGER... ok
  out_forward.c:152: Check val.via.u64 == 0... ok
[2023/04/10 14:19:31] [ info] [task] cleanup test task
[2023/04/10 14:19:31] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/10 14:19:31] [ info] [input] pausing dummy.0
[2023/04/10 14:19:32] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/10 14:19:32] [ info] [input] pausing dummy.0
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] thread worker #0 stopped
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] thread worker #1 stopped
  SUCCESS: All conditions have passed.

Test forward_compat_mode:
[2023/04/10 14:19:32] [ info] [fluent bit] version=2.1.0, commit=0d4006faad, pid=618266
  out_forward.c:348: Check ret == 0... ok
[2023/04/10 14:19:32] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] worker #0 started
[2023/04/10 14:19:32] [ info] [output:forward:forward.0] worker #1 started
[2023/04/10 14:19:32] [ info] [cmetrics] version=0.6.1
[2023/04/10 14:19:32] [ info] [ctraces ] version=0.3.0
[2023/04/10 14:19:32] [ info] [input:dummy:dummy.0] initializing
[2023/04/10 14:19:32] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/04/10 14:19:32] [ info] [sp] stream processor started
  out_forward.c:169: Check res_ret == MODE_FORWARD_COMPAT... ok
  out_forward.c:176: Check ret == MSGPACK_UNPACK_SUCCESS... ok
  out_forward.c:177: Check root.type == MSGPACK_OBJECT_ARRAY... ok
  out_forward.c:181: Check entry.type == MSGPACK_OBJECT_ARRAY... ok
  out_forward.c:182: Check entry.via.array.ptr[0].type == MSGPACK_OBJECT_POSITIVE_INTEGER... ok
[2023/04/10 14:19:34] [ info] [task] cleanup test task
[2023/04/10 14:19:34] [ warn] [engine] service will shutdown in max 1 seconds
[2023/04/10 14:19:34] [ info] [input] pausing dummy.0
[2023/04/10 14:19:35] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/10 14:19:35] [ info] [input] pausing dummy.0
[2023/04/10 14:19:35] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2023/04/10 14:19:35] [ info] [output:forward:forward.0] thread worker #0 stopped
[2023/04/10 14:19:35] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2023/04/10 14:19:35] [ info] [output:forward:forward.0] thread worker #1 stopped
  SUCCESS: All conditions have passed.

Summary:
  Count of all unit tests:        4
  Count of run unit tests:        4
  Count of failed unit tests:     0
  Count of skipped unit tests:    0
SUCCESS: All unit tests have passed.


```

<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==618266== 
==618266== HEAP SUMMARY:
==618266==     in use at exit: 0 bytes in 0 blocks
==618266==   total heap usage: 6,281 allocs, 6,281 frees, 2,793,138 bytes allocated
==618266== 
==618266== All heap blocks were freed -- no leaks are possible
==618266== 
==618266== For lists of detected and suppressed errors, rerun with: -s
==618266== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
