### PR TITLE
in_calyptia_fleet: initial implementation of calyptia fleet management.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ option(FLB_IN_NODE_EXPORTER_METRICS    "Enable node exporter metrics input plugi
 option(FLB_IN_WINDOWS_EXPORTER_METRICS "Enable windows exporter metrics input plugin" Yes)
 option(FLB_IN_OPENTELEMETRY            "Enable OpenTelemetry input plugin"            Yes)
 option(FLB_IN_ELASTICSEARCH            "Enable Elasticsearch (Bulk API) input plugin" Yes)
+option(FLB_IN_CALYPTIA_FLEET           "Enable Calyptia Fleet input plugin"           Yes)
 option(FLB_OUT_AZURE                   "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_BLOB              "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_KUSTO             "Enable Azure Kusto output plugin"             Yes)

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -56,6 +56,8 @@ if(FLB_WINDOWS_DEFAULTS)
   set(FLB_IN_STORAGE_BACKLOG    Yes)
   set(FLB_IN_EMITTER            Yes)
   set(FLB_IN_ELASTICSEARCH      Yes)
+  # disable calyptia fleet management for now
+  set(FLB_IN_CALYPTIA_FLEET     No)
 
   # OUTPUT plugins
   # ==============

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -185,6 +185,7 @@ REGISTER_IN_PLUGIN("in_collectd")
 REGISTER_IN_PLUGIN("in_statsd")
 REGISTER_IN_PLUGIN("in_opentelemetry")
 REGISTER_IN_PLUGIN("in_elasticsearch")
+REGISTER_IN_PLUGIN("in_calyptia_fleet")
 
 # Test the event loop messaging when used in threaded mode
 REGISTER_IN_PLUGIN("in_event_test")

--- a/plugins/in_calyptia_fleet/CMakeLists.txt
+++ b/plugins/in_calyptia_fleet/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  in_calyptia_fleet.c)
+
+FLB_PLUGIN(in_calyptia_fleet "${src}" "")

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2,7 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1,0 +1,558 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <signal.h>
+#include <sys/stat.h>
+
+#include <msgpack.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_strptime.h>
+#include <fluent-bit/flb_reload.h>
+#include <fluent-bit/flb_lib.h>
+#include <fluent-bit/config_format/flb_cf_fluentbit.h>
+
+
+#define CALYPTIA_H_PROJECT       "X-Project-Token"
+#define CALYPTIA_H_CTYPE         "Content-Type"
+#define CALYPTIA_H_CTYPE_JSON    "application/json"
+
+#define DEFAULT_INTERVAL_SEC  "3"
+#define DEFAULT_INTERVAL_NSEC "0"
+
+#define CALYPTIA_HOST "cloud-api.calyptia.com"
+#define CALYPTIA_PORT "443"
+
+struct flb_in_calyptia_fleet_config {
+    /* Time interval check */
+    int interval_sec;
+    int interval_nsec;
+
+    flb_sds_t api_key;
+    flb_sds_t fleet_id;
+    flb_sds_t cloud_host;
+    flb_sds_t cloud_port;
+
+    flb_sds_t fleet_url;
+
+    struct flb_input_instance *ins;       /* plugin instance */
+    struct flb_config *config;            /* Fluent Bit context */
+
+    /* Networking */
+    struct flb_upstream *u;
+
+    int event_fd;
+
+    int collect_fd;
+};
+
+/* Try to find a header value in the buffer. Copied from flb_http_client.c. */
+static int header_lookup(struct flb_http_client *c,
+                         const char *header, int header_len,
+                         const char **out_val, int *out_len)
+{
+    char *p;
+    char *crlf;
+    char *end;
+
+    if (!c->resp.data) {
+        return -1;
+    }
+
+    /* Lookup the beginning of the header */
+    p = strstr(c->resp.data, header);
+    end = strstr(c->resp.data, "\r\n\r\n");
+    if (!p) {
+        if (end) {
+            /* The headers are complete but the header is not there */
+            return -1;
+        }
+
+        /* We need more data */
+        return -1;
+    }
+
+    /* Exclude matches in the body */
+    if (end && p > end) {
+        return -1;
+    }
+
+    /* Lookup CRLF (end of line \r\n) */
+    crlf = strstr(p, "\r\n");
+    if (!crlf) {
+        return -1;
+    }
+
+    p += header_len;
+
+    *out_val = p;
+    *out_len = (crlf - p);
+
+    return 0;
+}
+
+struct reload_ctx {
+    flb_ctx_t *flb;
+    flb_sds_t cfg_path;
+};
+
+static flb_sds_t fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx, char *fname)
+{
+    flb_sds_t cfgname;
+
+    cfgname = flb_sds_create_size(4096);
+    flb_sds_printf(&cfgname, "/tmp/calyptia-fleet/%s/%s.ini", ctx->fleet_id, fname);
+
+    return cfgname;
+}
+
+static flb_sds_t new_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return fleet_config_filename(ctx, "new");
+}
+
+static flb_sds_t cur_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return fleet_config_filename(ctx, "cur");
+}
+
+static flb_sds_t old_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return fleet_config_filename(ctx, "old");
+}
+
+static flb_sds_t time_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx, time_t t)
+{
+    char s_last_modified[32];
+
+    snprintf(s_last_modified, sizeof(s_last_modified)-1, "%d", (int)t);
+    return fleet_config_filename(ctx, s_last_modified);
+}
+
+static int is_new_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
+{
+    flb_sds_t cfgnewname;
+    int ret = FLB_FALSE;
+
+
+    cfgnewname = new_fleet_config_filename(ctx);
+    if (strcmp(cfgnewname, cfg->conf_path_file) == 0) {
+        ret = FLB_TRUE;
+    }
+
+    flb_sds_destroy(cfgnewname);
+
+    return ret;
+}
+
+static int is_cur_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
+{
+    flb_sds_t cfgcurname;
+    int ret = FLB_FALSE;
+
+
+    cfgcurname = cur_fleet_config_filename(ctx);
+    if (strcmp(cfgcurname, cfg->conf_path_file) == 0) {
+        ret = FLB_TRUE;
+    }
+
+    flb_sds_destroy(cfgcurname);
+
+    return ret;
+}
+
+static int is_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
+{
+    return is_new_fleet_config(ctx, cfg) || is_cur_fleet_config(ctx, cfg);
+}
+
+static int exists_new_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
+{
+    flb_sds_t cfgnewname;
+    int ret = FLB_FALSE;
+
+
+    cfgnewname = new_fleet_config_filename(ctx);
+    ret = access(cfgnewname, F_OK) == 0 ? FLB_TRUE : FLB_FALSE;
+
+    flb_sds_destroy(cfgnewname);
+    return ret;
+}
+
+static int exists_cur_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
+{
+    flb_sds_t cfgcurname;
+    int ret = FLB_FALSE;
+
+
+    cfgcurname = cur_fleet_config_filename(ctx);
+    ret = access(cfgcurname, F_OK) == 0 ? FLB_TRUE : FLB_FALSE;
+
+    flb_sds_destroy(cfgcurname);
+    return ret;
+}
+
+static void *do_reload(void *data)
+{
+    struct reload_ctx *reload = (struct reload_ctx *)data;
+    // avoid reloading the current configuration... just use our new one!
+    reload->flb->config->enable_hot_reload = FLB_TRUE;
+    reload->flb->config->conf_path_file = reload->cfg_path;
+    sleep(5);
+    kill(getpid(), SIGHUP);
+
+    return NULL;
+}
+
+static void execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cfgpath)
+{
+    struct reload_ctx *reload;
+    pthread_t pth;
+    pthread_attr_t ptha;
+    flb_ctx_t *flb = flb_context_get();
+
+
+    // fix execution in valgrind...
+    // otherwise flb_reload errors out with:
+    //    [error] [reload] given flb context is NULL
+    flb_plg_info(ctx->ins, "loading configuration from %s.", cfgpath);
+
+    reload = flb_calloc(1, sizeof(struct reload_ctx));
+    reload->flb = flb;
+    reload->cfg_path = cfgpath;
+
+    pthread_attr_init(&ptha);
+    pthread_attr_setdetachstate(&ptha, 1);
+    pthread_create(&pth, &ptha, do_reload, reload);
+}
+
+/* cb_collect callback */
+static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
+                            struct flb_config *config, void *in_context)
+{
+    struct flb_in_calyptia_fleet_config *ctx = in_context;
+    struct flb_connection *u_conn;
+    struct flb_http_client *client;
+    flb_sds_t cfgname;
+    flb_sds_t cfgnewname;
+    flb_sds_t cfgoldname;
+    flb_sds_t header;
+    FILE *cfgfp;
+    const char *fbit_last_modified;
+    int fbit_last_modified_len;
+    struct flb_tm tm_last_modified;
+    time_t time_last_modified;
+    char *data;
+    size_t b_sent;
+    int ret = -1;
+
+    u_conn = flb_upstream_conn_get(ctx->u);
+    if (!u_conn) {
+        goto conn_error;
+    }
+
+    client = flb_http_client(u_conn, FLB_HTTP_GET, ctx->fleet_url,
+                             NULL, 0, ctx->ins->host.name, ctx->ins->host.port, NULL, 0);
+    if (!client) {
+        flb_plg_error(ins, "unable to create http client");
+        goto client_error;
+    }
+
+    flb_http_add_header(client,
+                        CALYPTIA_H_PROJECT, sizeof(CALYPTIA_H_PROJECT) - 1,
+                        ctx->api_key, flb_sds_len(ctx->api_key));
+    ret = flb_http_do(client, &b_sent);
+    if (ret != 0) {
+        flb_plg_error(ins, "http do error");
+        goto http_error;
+    }
+
+    if (client->resp.status != 200) {
+        flb_plg_error(ins, "http status code error: %d", client->resp.status);
+        goto http_error;
+    }
+
+    if (client->resp.payload_size <= 0) {
+        flb_plg_error(ins, "empty response");
+        goto http_error;
+    }
+
+    /* copy and NULL terminate the payload */
+    data = flb_sds_create_size(client->resp.payload_size + 1);
+    if (!data) {
+        goto http_error;
+    }
+    memcpy(data, client->resp.payload, client->resp.payload_size);
+    data[client->resp.payload_size] = '\0';
+
+    ret = header_lookup(client, "Last-Modified: ", strlen("Last-Modified: "), 
+                        &fbit_last_modified, &fbit_last_modified_len);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "unable to get last-modified header");
+        goto http_error;
+    }
+
+    // Wed, 21 Oct 2015 07:28:00 GMT
+    flb_strptime(fbit_last_modified, "%a, %d %B %Y %H:%M:%S GMT", &tm_last_modified);
+    time_last_modified = mktime(&tm_last_modified.tm);
+
+    cfgname = time_fleet_config_filename(ctx, time_last_modified);
+    if (access(cfgname, F_OK) == -1 && errno == ENOENT) {
+        cfgfp = fopen(cfgname, "w+");
+        header = flb_sds_create_size(4096);
+        flb_sds_printf(&header, 
+                       "[INPUT]\n"
+                       "    Name          calyptia_fleet\n"
+                       "    Api_Key       %s\n"
+                       "    fleet_id      %s\n"
+                       "    Host          %s\n"
+                       "    Port          %d\n"
+                       "    TLS           %d\n",
+                       ctx->api_key,
+                       ctx->fleet_id,
+                       ctx->ins->host.name,
+                       ctx->ins->host.port,
+                       ctx->ins->tls_verify
+        );
+        fwrite(header, strlen(header), 1, cfgfp);
+        flb_sds_destroy(header);
+        fwrite(data, client->resp.payload_size, 1, cfgfp);
+        fclose(cfgfp);
+
+        cfgnewname = new_fleet_config_filename(ctx);
+        if (exists_new_fleet_config(ctx) == FLB_TRUE) {
+            cfgoldname = old_fleet_config_filename(ctx);
+            rename(cfgnewname, cfgoldname);
+            unlink(cfgnewname);
+            flb_sds_destroy(cfgoldname);
+        }
+        link(cfgname, cfgnewname);
+
+        // FORCE THE RELOAD!!!
+        flb_plg_info(ctx->ins, "force the reloading of the configuration file=%d.", ctx->event_fd);
+        flb_sds_destroy(cfgname);
+        flb_sds_destroy(data);
+
+        execute_reload(ctx, cfgnewname);
+        FLB_INPUT_RETURN(0);
+    }
+
+    flb_sds_destroy(cfgname);
+    flb_sds_destroy(data);
+    ret = 0;
+
+http_error:
+    flb_http_client_destroy(client);
+client_error:
+    flb_upstream_conn_release(u_conn);
+conn_error:
+    FLB_INPUT_RETURN(ret);
+}
+
+static void create_fleet_directory(struct flb_in_calyptia_fleet_config *ctx)
+{
+    flb_sds_t myfleetdir;
+
+    if (access("/tmp/calyptia-fleet", F_OK)) {
+        mkdir("/tmp/calyptia-fleet", 0700);
+    }
+
+    myfleetdir = flb_sds_create_size(256);
+    flb_sds_printf(&myfleetdir, "/tmp/calyptia-fleet/%s", ctx->fleet_id);
+
+    if (access(myfleetdir, F_OK)) {
+        mkdir(myfleetdir, 0700);
+    }
+}
+
+static void load_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
+{
+    flb_ctx_t *flb_ctx = flb_context_get();
+
+
+    create_fleet_directory(ctx);
+
+    // check if we are already using the fleet configuration file.
+    if (is_fleet_config(ctx, flb_ctx->config) == FLB_FALSE) {
+        // check which one and load it
+        if (exists_new_fleet_config(ctx) == FLB_TRUE) {
+            execute_reload(ctx, new_fleet_config_filename(ctx));
+        } else if (exists_cur_fleet_config(ctx) == FLB_TRUE) {
+            execute_reload(ctx, cur_fleet_config_filename(ctx));
+        }
+    } else if (is_new_fleet_config(ctx, flb_ctx->config) == FLB_TRUE) {
+        // WE HAVE SUCCESSFULLY LOADED THE NEW CONFIGURATION?
+        flb_plg_info(ctx->ins, "successfully loaded new configuration file.");
+    }
+}
+
+static int in_calyptia_fleet_init(struct flb_input_instance *in,
+                          struct flb_config *config, void *data)
+{
+    int ret;
+    int upstream_flags;
+    struct flb_in_calyptia_fleet_config *ctx;
+    (void) data;
+
+    flb_plg_info(in, "initializing calyptia fleet input.");
+    if (in->host.name == NULL) {
+        flb_plg_error(in, "no input 'Host' provided");
+        return -1;
+    }
+
+    /* Allocate space for the configuration */
+    ctx = flb_calloc(1, sizeof(struct flb_in_calyptia_fleet_config));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+    ctx->ins      = in;
+
+
+    /* Load the config map */
+    ret = flb_input_config_map_set(in, (void *)ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        flb_plg_error(in, "unable to load configuration");
+        return -1;
+    }
+
+    upstream_flags = FLB_IO_TCP;
+
+    if (in->use_tls) {
+        flb_plg_error(in, "using TLS");
+        upstream_flags |= FLB_IO_TLS;
+    }
+
+    ctx->u = flb_upstream_create(config, in->host.name, in->host.port,
+                                 upstream_flags, in->tls);
+
+    if (!ctx->u) {
+        flb_plg_error(ctx->ins, "could not initialize upstream");
+        flb_free(ctx);
+        return -1;
+    }
+
+    if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
+        /* Illegal settings. Override them. */
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
+    }
+
+    ctx->fleet_url = flb_sds_create_size(4096);
+    flb_sds_printf(&ctx->fleet_url, "/v1/fleets/%s/config?format=ini", ctx->fleet_id);
+
+    /* Set the context */
+    flb_input_set_context(in, ctx);
+
+    /* Set our collector based on time */
+    ret = flb_input_set_collector_time(in,
+                                       in_calyptia_fleet_collect,
+                                       ctx->interval_sec,
+                                       ctx->interval_nsec,
+                                       config);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not set collector for Health input plugin");
+        flb_free(ctx);
+        return -1;
+    }
+
+    ctx->collect_fd = ret;
+
+    load_fleet_config(ctx);
+
+    return 0;
+}
+
+static void cb_in_calyptia_fleet_pause(void *data, struct flb_config *config)
+{
+    struct flb_in_calyptia_fleet_config *ctx = data;
+    flb_input_collector_pause(ctx->collect_fd, ctx->ins);
+}
+
+static void cb_in_calyptia_fleet_resume(void *data, struct flb_config *config)
+{
+    struct flb_in_calyptia_fleet_config *ctx = data;
+    flb_input_collector_resume(ctx->collect_fd, ctx->ins);
+}
+
+static int in_calyptia_fleet_exit(void *data, struct flb_config *config)
+{
+    (void) *config;
+    struct flb_in_calyptia_fleet_config *ctx = data;
+
+    flb_input_collector_delete(ctx->collect_fd, ctx->ins);
+    flb_upstream_destroy(ctx->u);
+    flb_free(ctx);
+
+    return 0;
+}
+
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "api_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, api_key),
+     "Calyptia Cloud API Key."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "fleet_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, fleet_id),
+     "Calyptia Fleet ID."
+    },
+    {
+      FLB_CONFIG_MAP_INT, "event_fd", "-1",
+      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, event_fd),
+      "Used internally to set the event fd."
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, interval_nsec),
+      "Set the collector interval (nanoseconds)"
+    },
+    /* EOF */
+    {0}
+};
+
+/* Plugin reference */
+struct flb_input_plugin in_calyptia_fleet_plugin = {
+    .name         = "calyptia_fleet",
+    .description  = "Calyptia Fleet Input",
+    .cb_init      = in_calyptia_fleet_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = in_calyptia_fleet_collect,
+    .cb_resume    = cb_in_calyptia_fleet_resume,
+    .cb_pause     = cb_in_calyptia_fleet_pause,
+    .cb_flush_buf = NULL,
+    .cb_exit      = in_calyptia_fleet_exit,
+    .config_map   = config_map,
+    .flags        = FLB_INPUT_NET|FLB_INPUT_CORO|FLB_IO_OPT_TLS
+};

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -246,7 +246,7 @@ static void execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t c
     reload->cfg_path = cfgpath;
 
     pthread_attr_init(&ptha);
-    pthread_attr_setdetachstate(&ptha, 1);
+    pthread_attr_setdetachstate(&ptha, PTHREAD_CREATE_DETACHED);
     pthread_create(&pth, &ptha, do_reload, reload);
 }
 

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -633,6 +633,7 @@ static void flb_lib_worker(void *data)
     struct flb_config *config;
 
     config = ctx->config;
+    flb_context_set(ctx);
     mk_utils_worker_rename("flb-pipeline");
     ret = flb_engine_start(config);
     if (ret == -1) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
# Summary

This pull request adds support for the forthcoming Calyptia cloud fleet management feature.

The configuration is downloaded from the calyptia API and then saved to a /tmp directory with the fleet_id in it. Each configuration is saved with a timestamp based on its last-modified date and then hard linked to new.ini. The old configuration is then hard linked to old.ini. The intent is to later use this to rollback in case of errors.

There are no known memory leaks at the moment. There is a single known bug where sometimes flb_reload will simply not work on initialization when running via valgrind. This must be some kind of race condition.

I still have the following improvements to make:

- [ ] automatic rollback
- [ ] configuration of the base path (hardcoded to /tmp/calyptia-fleet ATM)

Here is a simple example configuration:

```ini
[INPUT]
    Name          calyptia_fleet
    Api_Key       eyJUb..........
    fleet_id      28ae74d4-d53f-4fa7-90eb-6c6ef2fcaab1
    Host          calyptia-cloud.default.k8s
    Port          5000
    TLS           0
```

The default configuration should work against the production cloud but I have not tested it yet.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
