### PR TITLE
in_gelf: New input plugin for ingest GELF messages #4156

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1270 +1,359 @@
-cmake_minimum_required(VERSION 3.12)
-project(fluent-bit C)
+set(flb_plugins "" CACHE INTERNAL "flb_plugins")
 
-# CMP0069 ensures that LTO is enabled for all compilers
-cmake_policy(SET CMP0069 NEW)
-set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+# REGISTER_CUSTOM_PLUGIN
+macro(REGISTER_CUSTOM_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL CUSTOM PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
 
-# Fluent Bit Version
-set(FLB_VERSION_MAJOR  2)
-set(FLB_VERSION_MINOR  1)
-set(FLB_VERSION_PATCH  0)
-set(FLB_VERSION_STR "${FLB_VERSION_MAJOR}.${FLB_VERSION_MINOR}.${FLB_VERSION_PATCH}")
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_IN_PLUGINS_DECL "${FLB_CUSTOM_PLUGINS_DECL}extern struct flb_custom_plugin ${p_name}_plugin;\n")
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    # C code
+    set(C_CODE          "    custom = flb_malloc(sizeof(struct flb_custom_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!custom) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(custom, &${p_name}_plugin, sizeof(struct flb_custom_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&custom->_head, &config->custom_plugins);\n\n")
 
-# Define macro to identify Windows system (without Cygwin)
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-  set(FLB_SYSTEM_WINDOWS On)
-  add_definitions(-DFLB_SYSTEM_WINDOWS)
+    set(FLB_IN_PLUGINS_ADD "${FLB_CUSTOM_PLUGINS_ADD}${C_CODE}")
+
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
+# REGISTER_IN_PLUGIN
+macro(REGISTER_IN_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL IN PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
+
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_IN_PLUGINS_DECL "${FLB_IN_PLUGINS_DECL}extern struct flb_input_plugin ${p_name}_plugin;\n")
+
+    # C code
+    set(C_CODE          "    in = flb_malloc(sizeof(struct flb_input_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!in) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(in, &${p_name}_plugin, sizeof(struct flb_input_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&in->_head, &config->in_plugins);\n\n")
+
+    set(FLB_IN_PLUGINS_ADD "${FLB_IN_PLUGINS_ADD}${C_CODE}")
+
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
+# REGISTER_OUT_PLUGIN
+macro(REGISTER_OUT_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL OUT PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
+
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_OUT_PLUGINS_DECL "${FLB_OUT_PLUGINS_DECL}extern struct flb_output_plugin ${p_name}_plugin;\n")
+
+    # C code
+    set(C_CODE          "    out = flb_malloc(sizeof(struct flb_output_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!out) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(out, &${p_name}_plugin, sizeof(struct flb_output_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&out->_head, &config->out_plugins);\n\n")
+
+    set(FLB_OUT_PLUGINS_ADD "${FLB_OUT_PLUGINS_ADD}${C_CODE}")
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
+# REGISTER_FILTER_PLUGIN
+macro(REGISTER_FILTER_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL FILTER PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
+
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_FILTER_PLUGINS_DECL "${FLB_FILTER_PLUGINS_DECL}extern struct flb_filter_plugin ${p_name}_plugin;\n")
+
+    # C code
+    set(C_CODE          "    filter = flb_malloc(sizeof(struct flb_filter_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!filter) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(filter, &${p_name}_plugin, sizeof(struct flb_filter_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&filter->_head, &config->filter_plugins);\n\n")
+
+    set(FLB_FILTER_PLUGINS_ADD "${FLB_FILTER_PLUGINS_ADD}${C_CODE}")
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
+# FLB_PLUGIN: used by plugins to perform registration and linking
+macro(FLB_PLUGIN name src deps)
+  add_library(flb-plugin-${name} STATIC ${src})
+  add_sanitizers(flb-plugin-${name})
+  target_link_libraries(flb-plugin-${name} fluent-bit-static msgpack-c-static ${deps})
+endmacro()
+
+
+# ======================
+#  Plugins Registration
+# ======================
+
+# Custom Plugins
+REGISTER_CUSTOM_PLUGIN("custom_calyptia")
+
+# These plugins works only on Linux
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  REGISTER_IN_PLUGIN("in_cpu")
+  REGISTER_IN_PLUGIN("in_mem")
+  REGISTER_IN_PLUGIN("in_thermal")
+  REGISTER_IN_PLUGIN("in_kmsg")
+  REGISTER_IN_PLUGIN("in_proc")
+  REGISTER_IN_PLUGIN("in_disk")
+  REGISTER_IN_PLUGIN("in_systemd")
+  REGISTER_IN_PLUGIN("in_netif")
+  REGISTER_IN_PLUGIN("in_docker")
+  REGISTER_IN_PLUGIN("in_docker_events")
+  REGISTER_IN_PLUGIN("in_node_exporter_metrics")
 endif()
 
-# Define macro to identify macOS system
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(FLB_SYSTEM_MACOS On)
-  add_definitions(-DFLB_SYSTEM_MACOS)
+REGISTER_IN_PLUGIN("in_kafka")
+REGISTER_IN_PLUGIN("in_fluentbit_metrics")
+REGISTER_IN_PLUGIN("in_prometheus_scrape")
+REGISTER_IN_PLUGIN("in_emitter")
+REGISTER_IN_PLUGIN("in_gelf")
+REGISTER_IN_PLUGIN("in_tail")
+REGISTER_IN_PLUGIN("in_dummy")
+REGISTER_IN_PLUGIN("in_head")
+REGISTER_IN_PLUGIN("in_health")
+REGISTER_IN_PLUGIN("in_http")
+REGISTER_IN_PLUGIN("in_collectd")
+REGISTER_IN_PLUGIN("in_statsd")
+REGISTER_IN_PLUGIN("in_opentelemetry")
+REGISTER_IN_PLUGIN("in_elasticsearch")
+
+# Test the event loop messaging when used in threaded mode
+REGISTER_IN_PLUGIN("in_event_test")
+
+# Send different event types: logs, metrics and traces
+REGISTER_IN_PLUGIN("in_event_type")
+
+
+if (FLB_IN_STORAGE_BACKLOG)
+  REGISTER_IN_PLUGIN("in_storage_backlog")
 endif()
 
-# Define macro to identify Linux system
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  set(FLB_SYSTEM_LINUX On)
-  add_definitions(-DFLB_SYSTEM_LINUX)
+REGISTER_IN_PLUGIN("in_nginx_exporter_metrics")
+
+if (FLB_STREAM_PROCESSOR)
+  REGISTER_IN_PLUGIN("in_stream_processor")
 endif()
 
-# Update CFLAGS
-if (MSVC)
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-  add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
-
-  # Use custom CFLAGS for MSVC
-  #
-  #   /Zi ...... Generate pdb files.
-  #   /MT ...... Static link C runtimes.
-  #   /wd4711 .. C4711 (function selected for inline expansion)
-  #   /wd4100 .. C4100 (unreferenced formal parameter)
-  #   /wd5045 .. C5045 (Spectre mitigation)
-  #
-  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
-  set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
-  set(CMAKE_BUILD_TYPE None)
-
-  # Use add_compile_options() to set /MT since Visual Studio
-  # Generator does not notice /MT in CMAKE_C_FLAGS.
-  add_compile_options(/MT)
+if (FLB_SYSTEM_WINDOWS)
+  REGISTER_IN_PLUGIN("in_winlog")
+  REGISTER_IN_PLUGIN("in_winstat")
+  REGISTER_IN_PLUGIN("in_winevtlog")
+  REGISTER_IN_PLUGIN("in_windows_exporter_metrics")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W2")
 else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-  # The following flags are to enhance security, but it may impact performance,
-  # we disable them by default.
-  if (FLB_WASM_STACK_PROTECT)
-    if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
-      set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftrapv -D_FORTIFY_SOURCE=2")
-    endif ()
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong --param ssp-buffer-size=4")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,noexecstack,-z,relro,-z,now")
-  endif()
+  REGISTER_IN_PLUGIN("in_serial")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FLB_FILENAME__=__FILE__")
-
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
-  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")
-  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-endif()
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(FLB_SYSTEM_FREEBSD On)
-  add_definitions(-DFLB_SYSTEM_FREEBSD)
-  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -lutil")
-  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -lutil")
-endif()
-
-# *BSD is not supported platform for wasm-micro-runtime. Now, we should be disabled for these platforms.
-if(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
-  message(STATUS "This platform is not supported for WASM feature so disabled.")
-  set(FLB_WASM OFF)
-endif()
-
-include(GNUInstallDirs)
-include(ExternalProject)
-include(cmake/FindJournald.cmake)
-include(cmake/FindMonkey.cmake)
-include(cmake/macros.cmake)
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
-find_package(Sanitizers)
-
-# Output paths
-set(FLB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/library")
-
-# Build Options
-option(FLB_ALL                 "Enable all features"                         No)
-option(FLB_DEBUG               "Build with debug mode (-g)"                 Yes)
-option(FLB_RELEASE             "Build with release mode (-O2 -g -DNDEBUG)"   No)
-set(FLB_IPO "ReleaseOnly" CACHE STRING "Build with interprocedural optimization")
-set_property(CACHE FLB_IPO PROPERTY STRINGS "On;Off;ReleaseOnly")
-option(FLB_SMALL               "Optimise for small size"       No)
-option(FLB_COVERAGE            "Build with code-coverage"      No)
-option(FLB_JEMALLOC            "Build with Jemalloc support"   No)
-option(FLB_REGEX               "Build with Regex support"     Yes)
-option(FLB_UTF8_ENCODER        "Build with UTF8 encoding support" Yes)
-option(FLB_PARSER              "Build with Parser support"    Yes)
-option(FLB_TLS                 "Build with SSL/TLS support"   Yes)
-option(FLB_BINARY              "Build executable binary"      Yes)
-option(FLB_EXAMPLES            "Build examples"               Yes)
-option(FLB_SHARED_LIB          "Build shared library"         Yes)
-option(FLB_VALGRIND            "Enable Valgrind support"       No)
-option(FLB_TRACE               "Enable trace mode"             No)
-option(FLB_CHUNK_TRACE         "Enable chunk traces"          Yes)
-option(FLB_TESTS_RUNTIME       "Enable runtime tests"          No)
-option(FLB_TESTS_INTERNAL      "Enable internal tests"         No)
-option(FLB_TESTS_INTERNAL_FUZZ "Enable internal fuzz tests"    No)
-option(FLB_TESTS_OSSFUZZ       "Enable OSS-Fuzz build"         No)
-option(FLB_MTRACE              "Enable mtrace support"         No)
-option(FLB_POSIX_TLS           "Force POSIX thread storage"    No)
-option(FLB_INOTIFY             "Enable inotify support"       Yes)
-option(FLB_SQLDB               "Enable SQL embedded DB"       Yes)
-option(FLB_HTTP_SERVER         "Enable HTTP Server"           Yes)
-option(FLB_BACKTRACE           "Enable stacktrace support"    Yes)
-option(FLB_LUAJIT              "Enable Lua Scripting support" Yes)
-option(FLB_RECORD_ACCESSOR     "Enable record accessor"       Yes)
-option(FLB_SIGNV4              "Enable AWS Signv4 support"    Yes)
-option(FLB_AWS                 "Enable AWS support"           Yes)
-option(FLB_STATIC_CONF         "Build binary using static configuration")
-option(FLB_STREAM_PROCESSOR    "Enable Stream Processor"                    Yes)
-option(FLB_CORO_STACK_SIZE     "Set coroutine stack size")
-option(FLB_AVRO_ENCODER        "Build with Avro encoding support"            No)
-option(FLB_AWS_ERROR_REPORTER  "Build with aws error reporting support"      No)
-option(FLB_ARROW               "Build with Apache Arrow support"             No)
-option(FLB_WINDOWS_DEFAULTS    "Build with predefined Windows settings"     Yes)
-option(FLB_WASM                "Build with WASM runtime support"            Yes)
-option(FLB_WAMRC               "Build with WASM AOT compiler executable"    No)
-option(FLB_WASM_STACK_PROTECT  "Build with WASM runtime with strong stack protector flags" No)
-
-# Native Metrics Support (cmetrics)
-option(FLB_METRICS             "Enable metrics support"       Yes)
-
-# Proxy Plugins
-option(FLB_PROXY_GO            "Enable Go plugins support"    Yes)
-
-# Built-in Custom Plugins
-option(FLB_CUSTOM_CALYPTIA     "Enable Calyptia Support"      Yes)
-
-# Config formats
-option(FLB_CONFIG_YAML         "Enable YAML config format"    Yes)
-
-# Built-in Plugins
-option(FLB_IN_CPU                      "Enable CPU input plugin"                      Yes)
-option(FLB_IN_THERMAL                  "Enable Thermal plugin"                        Yes)
-option(FLB_IN_DISK                     "Enable Disk input plugin"                     Yes)
-option(FLB_IN_DOCKER                   "Enable Docker input plugin"                   Yes)
-option(FLB_IN_DOCKER_EVENTS            "Enable Docker events input plugin"            Yes)
-option(FLB_IN_EXEC                     "Enable Exec input plugin"                     Yes)
-option(FLB_IN_EXEC_WASI                "Enable Exec WASI input plugin"                Yes)
-option(FLB_IN_EVENT_TEST               "Enable Events test plugin"                    Yes)
-option(FLB_IN_EVENT_TYPE               "Enable event type plugin"                     Yes)
-option(FLB_IN_FLUENTBIT_METRICS        "Enable Fluent Bit metrics  plugin"            Yes)
-option(FLB_IN_FORWARD                  "Enable Forward input plugin"                  Yes)
-option(FLB_IN_HEALTH                   "Enable Health input plugin"                   Yes)
-option(FLB_IN_HTTP                     "Enable HTTP input plugin"                     Yes)
-option(FLB_IN_MEM                      "Enable Memory input plugin"                   Yes)
-option(FLB_IN_KAFKA                    "Enable Kafka input plugin"                     No)
-option(FLB_IN_KMSG                     "Enable Kernel log input plugin"               Yes)
-option(FLB_IN_LIB                      "Enable library mode input plugin"             Yes)
-option(FLB_IN_RANDOM                   "Enable random input plugin"                   Yes)
-option(FLB_IN_SERIAL                   "Enable Serial input plugin"                   Yes)
-option(FLB_IN_STDIN                    "Enable Standard input plugin"                 Yes)
-option(FLB_IN_SYSLOG                   "Enable Syslog input plugin"                   Yes)
-option(FLB_IN_TAIL                     "Enable Tail input plugin"                     Yes)
-option(FLB_IN_UDP                      "Enable UDP input plugin"                      Yes)
-option(FLB_IN_TCP                      "Enable TCP input plugin"                      Yes)
-option(FLB_IN_UNIX_SOCKET              "Enable Unix socket input plugin"               No)
-option(FLB_IN_MQTT                     "Enable MQTT Broker input plugin"              Yes)
-option(FLB_IN_HEAD                     "Enable Head input plugin"                     Yes)
-option(FLB_IN_PROC                     "Enable Process input plugin"                  Yes)
-option(FLB_IN_SYSTEMD                  "Enable Systemd input plugin"                  Yes)
-option(FLB_IN_DUMMY                    "Enable Dummy input plugin"                    Yes)
-option(FLB_IN_NGINX_EXPORTER_METRICS   "Enable Nginx Metrics input plugin"            Yes)
-option(FLB_IN_NETIF                    "Enable NetworkIF input plugin"                Yes)
-option(FLB_IN_WINLOG                   "Enable Windows Log input plugin"               No)
-option(FLB_IN_WINSTAT                  "Enable Windows Stat input plugin"              No)
-option(FLB_IN_WINEVTLOG                "Enable Windows EvtLog input plugin"            No)
-option(FLB_IN_COLLECTD                 "Enable Collectd input plugin"                 Yes)
-option(FLB_IN_PROMETHEUS_SCRAPE        "Enable Promeheus Scrape input plugin"         Yes)
-option(FLB_IN_STATSD                   "Enable StatsD input plugin"                   Yes)
-option(FLB_IN_EVENT_TEST               "Enable event test plugin"                      No)
-option(FLB_IN_STORAGE_BACKLOG          "Enable storage backlog input plugin"          Yes)
-option(FLB_IN_EMITTER                  "Enable emitter input plugin"                  Yes)
-option(FLB_IN_NODE_EXPORTER_METRICS    "Enable node exporter metrics input plugin"    Yes)
-option(FLB_IN_WINDOWS_EXPORTER_METRICS "Enable windows exporter metrics input plugin" Yes)
-option(FLB_IN_OPENTELEMETRY            "Enable OpenTelemetry input plugin"            Yes)
-option(FLB_IN_ELASTICSEARCH            "Enable Elasticsearch (Bulk API) input plugin" Yes)
-option(FLB_IN_GELF                     "Enable GELF input plugin"                     Yes)
-option(FLB_OUT_AZURE                   "Enable Azure output plugin"                   Yes)
-option(FLB_OUT_AZURE_BLOB              "Enable Azure output plugin"                   Yes)
-option(FLB_OUT_AZURE_KUSTO             "Enable Azure Kusto output plugin"             Yes)
-option(FLB_OUT_BIGQUERY                "Enable BigQuery output plugin"                Yes)
-option(FLB_OUT_CALYPTIA                "Enable Calyptia monitoring plugin"            Yes)
-option(FLB_OUT_COUNTER                 "Enable Counter output plugin"                 Yes)
-option(FLB_OUT_DATADOG                 "Enable DataDog output plugin"                 Yes)
-option(FLB_OUT_ES                      "Enable Elasticsearch output plugin"           Yes)
-option(FLB_OUT_EXIT                    "Enable Exit output plugin"                    Yes)
-option(FLB_OUT_FORWARD                 "Enable Forward output plugin"                 Yes)
-option(FLB_OUT_GELF                    "Enable GELF output plugin"                    Yes)
-option(FLB_OUT_HTTP                    "Enable HTTP output plugin"                    Yes)
-option(FLB_OUT_INFLUXDB                "Enable InfluxDB output plugin"                Yes)
-option(FLB_OUT_NATS                    "Enable NATS output plugin"                    Yes)
-option(FLB_OUT_NRLOGS                  "Enable New Relic output plugin"               Yes)
-option(FLB_OUT_OPENSEARCH              "Enable OpenSearch output plugin"              Yes)
-option(FLB_OUT_TCP                     "Enable TCP output plugin"                     Yes)
-option(FLB_OUT_UDP                     "Enable UDP output plugin"                     Yes)
-option(FLB_OUT_PLOT                    "Enable Plot output plugin"                    Yes)
-option(FLB_OUT_FILE                    "Enable file output plugin"                    Yes)
-option(FLB_OUT_TD                      "Enable Treasure Data output plugin"           Yes)
-option(FLB_OUT_RETRY                   "Enable Retry test output plugin"               No)
-option(FLB_OUT_PGSQL                   "Enable PostgreSQL output plugin"               No)
-option(FLB_OUT_SKYWALKING              "Enable Apache SkyWalking output plugin"       Yes)
-option(FLB_OUT_SLACK                   "Enable Slack output plugin"                   Yes)
-option(FLB_OUT_SPLUNK                  "Enable Splunk output plugin"                  Yes)
-option(FLB_OUT_STACKDRIVER             "Enable Stackdriver output plugin"             Yes)
-option(FLB_OUT_STDOUT                  "Enable STDOUT output plugin"                  Yes)
-option(FLB_OUT_SYSLOG                  "Enable Syslog output plugin"                  Yes)
-option(FLB_OUT_LIB                     "Enable library mode output plugin"            Yes)
-option(FLB_OUT_NULL                    "Enable dev null output plugin"                Yes)
-option(FLB_OUT_FLOWCOUNTER             "Enable flowcount output plugin"               Yes)
-option(FLB_OUT_LOGDNA                  "Enable LogDNA output plugin"                  Yes)
-option(FLB_OUT_LOKI                    "Enable Loki output plugin"                    Yes)
-option(FLB_OUT_KAFKA                   "Enable Kafka output plugin"                    No)
-option(FLB_OUT_KAFKA_REST              "Enable Kafka Rest output plugin"              Yes)
-option(FLB_OUT_CLOUDWATCH_LOGS         "Enable AWS CloudWatch output plugin"          Yes)
-option(FLB_OUT_KINESIS_FIREHOSE        "Enable AWS Firehose output plugin"            Yes)
-option(FLB_OUT_KINESIS_STREAMS         "Enable AWS Kinesis output plugin"             Yes)
-option(FLB_OUT_OPENTELEMETRY           "Enable OpenTelemetry plugin"                  Yes)
-option(FLB_OUT_PROMETHEUS_EXPORTER     "Enable Prometheus exporter plugin"            Yes)
-option(FLB_OUT_PROMETHEUS_REMOTE_WRITE "Enable Prometheus remote write plugin"        Yes)
-option(FLB_OUT_S3                      "Enable AWS S3 output plugin"                  Yes)
-option(FLB_OUT_VIVO_EXPORTER           "Enabel Vivo exporter output plugin"           Yes)
-option(FLB_OUT_WEBSOCKET               "Enable Websocket output plugin"               Yes)
-option(FLB_FILTER_ALTER_SIZE           "Enable alter_size filter"                     Yes)
-option(FLB_FILTER_AWS                  "Enable aws filter"                            Yes)
-option(FLB_FILTER_ECS                  "Enable AWS ECS filter"                        Yes)
-option(FLB_FILTER_CHECKLIST            "Enable checklist filter"                      Yes)
-option(FLB_FILTER_EXPECT               "Enable expect filter"                         Yes)
-option(FLB_FILTER_GREP                 "Enable grep filter"                           Yes)
-option(FLB_FILTER_MODIFY               "Enable modify filter"                         Yes)
-option(FLB_FILTER_STDOUT               "Enable stdout filter"                         Yes)
-option(FLB_FILTER_PARSER               "Enable parser filter"                         Yes)
-option(FLB_FILTER_KUBERNETES           "Enable kubernetes filter"                     Yes)
-option(FLB_FILTER_REWRITE_TAG          "Enable tag rewrite filter"                    Yes)
-option(FLB_FILTER_THROTTLE             "Enable throttle filter"                       Yes)
-option(FLB_FILTER_THROTTLE_SIZE        "Enable throttle size filter"                   No)
-option(FLB_FILTER_TYPE_CONVERTER       "Enable type converter filter"                 Yes)
-option(FLB_FILTER_MULTILINE            "Enable multiline filter"                      Yes)
-option(FLB_FILTER_NEST                 "Enable nest filter"                           Yes)
-option(FLB_FILTER_LOG_TO_METRICS       "Enable log-derived metrics filter"            Yes)
-option(FLB_FILTER_LUA                  "Enable Lua scripting filter"                  Yes)
-option(FLB_FILTER_LUA_USE_MPACK        "Enable mpack on the lua filter"               Yes)
-option(FLB_FILTER_RECORD_MODIFIER      "Enable record_modifier filter"                Yes)
-option(FLB_FILTER_TENSORFLOW           "Enable tensorflow filter"                      No)
-option(FLB_FILTER_GEOIP2               "Enable geoip2 filter"                         Yes)
-option(FLB_FILTER_NIGHTFALL            "Enable Nightfall filter"                      Yes)
-option(FLB_FILTER_WASM                 "Enable WASM filter"                           Yes)
-
-
-if(DEFINED FLB_NIGHTLY_BUILD AND NOT "${FLB_NIGHTLY_BUILD}" STREQUAL "")
-  FLB_DEFINITION_VAL(FLB_NIGHTLY_BUILD ${FLB_NIGHTLY_BUILD})
-endif()
-
-if(FLB_IN_STORAGE_BACKLOG)
-  FLB_DEFINITION(FLB_HAVE_IN_STORAGE_BACKLOG)
-endif()
-
-# Debug callbacks
-option(FLB_HTTP_CLIENT_DEBUG  "Enable HTTP Client debug callbacks"   No)
-
-# Run ldconfig on package post-install
-option(FLB_RUN_LDCONFIG "Enable execution of ldconfig after installation" No)
-
-# Enable all features
-if(FLB_ALL)
-  # Global
-  set(FLB_DEBUG           1)
-  set(FLB_TLS             1)
-
-  # Input plugins
-  set(FLB_IN_CPU          1)
-  set(FLB_IN_MEM          1)
-  set(FLB_IN_KMSG         1)
-  set(FLB_IN_MQTT         1)
-  set(FLB_IN_SERIAL       1)
-  set(FLB_IN_STDIN        1)
-  set(FLB_IN_HEAD         1)
-  set(FLB_IN_PROC         1)
-  set(FLB_IN_DISK         1)
-  set(FLB_IN_DUMMY        1)
-  set(FLB_IN_DUMMY_THREAD 1)
-  set(FLB_IN_NETIF        1)
-  set(FLB_IN_NGINX_STATUS 1)
-  set(FLB_IN_EXEC         1)
-  set(FLB_IN_UNIX_SOCKET  1)
-
-  # Output plugins
-  set(FLB_OUT_ES          1)
-  set(FLB_OUT_FORWARD     1)
-  set(FLB_OUT_GELF        1)
-  set(FLB_OUT_HTTP        1)
-  set(FLB_OUT_NATS        1)
-  set(FLB_OUT_NULL        1)
-  set(FLB_OUT_PLOT        1)
-  set(FLB_OUT_FILE        1)
-  set(FLB_OUT_RETRY       1)
-  set(FLB_OUT_TD          1)
-  set(FLB_OUT_STDOUT      1)
-  set(FLB_OUT_S3          1)
-  set(FLB_OUT_SYSLOG      1)
-  set(FLB_OUT_LIB         1)
-  set(FLB_OUT_FLOWCOUNTER 1)
-  set(FLB_OUT_WEBSOCKET   1)
-endif()
-
-if(FLB_DEV)
-  set(FLB_DEBUG             On)
-  set(FLB_TRACE             On)
-  set(FLB_CHUNK_TRACE       On)
-  set(FLB_METRICS           On)
-  set(FLB_IN_EVENT_TEST     On)
-  set(FLB_HTTP_SERVER       On)
-  set(FLB_HTTP_CLIENT_DEBUG On)
-  set(FLB_TESTS_INTERNAL    On)
-endif()
-
-if(FLB_TRACE)
-  add_definitions(-DFLB_TRACE=1)
-endif()
-
-if(FLB_CHUNK_TRACE)
-  FLB_DEFINITION(FLB_HAVE_CHUNK_TRACE)
-endif()
-
-# SSL/TLS: add encryption support
-if(FLB_OUT_TD)
-  set(FLB_TLS ON)
-endif()
-
-if(FLB_HTTP_CLIENT_DEBUG)
-  FLB_DEFINITION(FLB_HAVE_HTTP_CLIENT_DEBUG)
-endif()
-
-if (FLB_TESTS_OSSFUZZ)
-  FLB_DEFINITION(FLB_HAVE_TESTS_OSSFUZZ)
-  # Disable for fuzz testing
-  set(FLB_CONFIG_YAML Off)
-endif()
-
-if (FLB_WASM)
-  # For Linking libedit adjustments on LLVM 15.
-  include(cmake/FindLibEdit.cmake)
-endif()
-
-# Set Fluent Bit dependency libraries path
-include(cmake/libraries.cmake)
-
-# Export headers provided by libraries/dependencies
-include(cmake/headers.cmake)
-
-# Tweak build targets for Windows
-if(FLB_SYSTEM_WINDOWS)
-  include(cmake/windows-setup.cmake)
-endif()
-
-# Tweak build targets for macOS
-if (FLB_SYSTEM_MACOS)
-  # build tweaks
-  include(cmake/macos-setup.cmake)
-endif()
-
-# Extract Git commit information for debug output.
-# Note that this is only set when cmake is run, the intent here is to use in CI for verification of releases so is acceptable.
-# For a better solution see https://jonathanhamberg.com/post/cmake-embedding-git-hash/ but this is simple and easy.
-find_package(Git)
-# If we do not have Git or this is not a Git repo or another error this just is ignored and we have no output at runtime.
-execute_process(COMMAND
-  "${GIT_EXECUTABLE}" log -1 --format=%H
-  WORKING_DIRECTORY "${FLB_ROOT}"
-  OUTPUT_VARIABLE FLB_GIT_HASH
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS "Git hash: ${FLB_GIT_HASH}")
-
-# Optional features like Stream Processor and Record Accessor needs Flex
-# and Bison to generate it parsers.
-find_package(FLEX 2)
-find_package(BISON 3)
-
-if(FLEX_FOUND AND BISON_FOUND)
-  set(FLB_FLEX_BISON  1)
-endif()
-
-if(FLB_SMALL)
-  if(CMAKE_COMPILER_IS_GNUCC)
-    set(strip_flag  " -s ")
-  else()
-    set(strip_flag  "")
-  endif()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -g0 ${strip_flag} -fno-stack-protector -fomit-frame-pointer -DNDEBUG -U_FORTIFY_SOURCE")
-endif()
-
-if(FLB_COVERAGE)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
-  set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-# Enable Debug symbols if specified
-if(MSVC)
-  set(CMAKE_BUILD_TYPE None)  # Avoid flag conflicts (See CMakeList.txt:L18)
-elseif(FLB_DEBUG)
-  set(CMAKE_BUILD_TYPE "Debug")
-elseif(FLB_RELEASE)
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
-endif()
-
-if(FLB_IPO STREQUAL "On" OR (FLB_IPO STREQUAL "ReleaseOnly" AND FLB_RELEASE))
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT ipo_supported)
-  # IPO in GCC versions smaller v8 is broken
-  if(ipo_supported AND NOT (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8))
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-  else()
-    message(Warning "IPO is not supported on this platform")
-  endif()
+if(FLB_REGEX)
+  REGISTER_IN_PLUGIN("in_stdin")
 endif()
 
 if(FLB_PARSER)
-  FLB_DEFINITION(FLB_HAVE_PARSER)
-  message(STATUS "Enabling FLB_REGEX since FLB_PARSER requires")
-  set(FLB_REGEX On)
+  REGISTER_IN_PLUGIN("in_syslog")
+  REGISTER_IN_PLUGIN("in_exec")
 endif()
 
-# Is sanitize_address defined ?
-if(SANITIZE_ADDRESS)
-  FLB_DEFINITION(FLB_HAVE_SANITIZE_ADDRESS)
-endif()
+REGISTER_IN_PLUGIN("in_udp")
 
-# Record Accessor
-if(FLB_RECORD_ACCESSOR)
-  if(NOT FLB_FLEX_BISON)
-    message(FATAL_ERROR
-      "Record Accessor feature requires Flex and Bison in your system.\n"
-      "This is a build time dependency, you can either install the "
-      "dependencies or disable the feature setting the CMake option "
-      "-DFLB_RECORD_ACCESSOR=Off ."
-      )
-  endif()
-  FLB_DEFINITION(FLB_HAVE_RECORD_ACCESSOR)
-endif()
-
-# Stream Processor
-if(FLB_STREAM_PROCESSOR)
-  if(NOT FLB_FLEX_BISON)
-    message(FATAL_ERROR
-      "Stream Processor feature requires Flex and Bison in your system.\n"
-      "This is a build time dependency, you can either install the "
-      "dependencies or disable the feature setting the CMake option "
-      "-DFLB_STREAM_PROCESSOR=Off ."
-      )
-  endif()
-
-  # Enable Stream Processor internal helper plugin
-  set(FLB_IN_STREAM_PROCESSOR On)
-  FLB_DEFINITION(FLB_HAVE_STREAM_PROCESSOR)
-endif()
-
-# mk_core is aware about jemalloc usage, we need to disable this as
-# fluent-bit do not use it.
-set(WITH_SYSTEM_MALLOC  1 CACHE BOOL "Use system memory allocator")
-
-# Headers: required headers by bundled libraries, this act as a helper for
-# CFL, Ctraces, CMetrics and fluent-otel-proto
-#
-# Note: any check_c_source_compiles() cmake function might require this to
-# work.
-#
-set(CMAKE_REQUIRED_INCLUDES
-  ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_CFL}/include
-  ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_FLUENT_OTEL}/include/
-  ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_FLUENT_OTEL}/proto_c/
-  )
-
-# CFL
-add_subdirectory(${FLB_PATH_LIB_CFL} EXCLUDE_FROM_ALL)
-
-# fluent-otel-proto
-FLB_OPTION(FLUENT_PROTO_METRICS ON)
-add_subdirectory(${FLB_PATH_LIB_FLUENT_OTEL} EXCLUDE_FROM_ALL)
-
-# MsgPack options
-option(MSGPACK_ENABLE_CXX             OFF)
-option(MSGPACK_ENABLE_SHARED          OFF)
-option(MSGPACK_BUILD_TESTS            OFF)
-option(MSGPACK_BUILD_EXAMPLES         OFF)
-add_subdirectory(${FLB_PATH_LIB_MSGPACK} EXCLUDE_FROM_ALL)
-
-# MPack
-add_definitions(-DMPACK_EXTENSIONS=1)
-add_subdirectory(${FLB_PATH_LIB_MPACK} EXCLUDE_FROM_ALL)
-
-# Miniz (zip)
-add_subdirectory(${FLB_PATH_LIB_MINIZ} EXCLUDE_FROM_ALL)
-
-# ring buffer library
-add_subdirectory(${FLB_PATH_LIB_RING_BUFFER} EXCLUDE_FROM_ALL)
-
-# Avro
-if(FLB_AVRO_ENCODER)
-  # jansson
-  option(JANSSON_BUILD_DOCS         OFF)
-  option(JANSSON_EXAMPLES           OFF)
-  option(JANSSON_WITHOUT_TESTS       ON)
-  option(JANSSON_BUILD_SHARED_LIBS  OFF)
-  add_subdirectory(${FLB_PATH_LIB_JANSSON})
-
-  #avro
-  add_subdirectory(${FLB_PATH_LIB_AVRO} EXCLUDE_FROM_ALL)
-endif()
-
-# tutf8e
-if(FLB_UTF8_ENCODER)
-  add_subdirectory(${FLB_PATH_LIB_TUTF8E} EXCLUDE_FROM_ALL)
-endif()
-
-# snappy
-add_subdirectory(${FLB_PATH_LIB_SNAPPY} EXCLUDE_FROM_ALL)
-
-# CMetrics
-add_subdirectory(${FLB_PATH_LIB_CMETRICS} EXCLUDE_FROM_ALL)
-
-# CTraces
-add_subdirectory(${FLB_PATH_LIB_CTRACES} EXCLUDE_FROM_ALL)
-
-# C-Ares (DNS library)
-FLB_OPTION(CARES_STATIC      ON)
-FLB_OPTION(CARES_SHARED      OFF)
-FLB_OPTION(CARES_INSTALL     OFF)
-FLB_OPTION(CARES_BUILD_TESTS OFF)
-FLB_OPTION(CARES_BUILD_TOOLS OFF)
-if (FLB_SYSTEM_MACOS)
-  # macOS SDK always has <arpa/nameser.h>.
-  FLB_DEFINITION(CARES_HAVE_ARPA_NAMESER_H)
-endif()
-add_subdirectory(${FLB_PATH_LIB_CARES})# EXCLUDE_FROM_ALL)
-
-# Chunk I/O
-FLB_OPTION(CIO_LIB_STATIC  ON)
-FLB_OPTION(CIO_LIB_SHARED  OFF)
-add_subdirectory(${FLB_PATH_LIB_CHUNKIO} EXCLUDE_FROM_ALL)
-
-# Lib: build the core libraries used by Fluent-Bit
-FLB_DEFINITION(JSMN_PARENT_LINKS)
-FLB_DEFINITION(JSMN_STRICT)
-add_subdirectory(${FLB_PATH_LIB_JSMN})
-# Runtime Tests (filter_kubernetes) requires HTTP Server
-if(FLB_TESTS_RUNTIME)
-  FLB_OPTION(FLB_HTTP_SERVER  ON)
-endif()
-
-# MK Core
-macro(MK_SET_OPTION option value)
-  set(${option} ${value} CACHE INTERNAL "" FORCE)
-endmacro()
-MK_SET_OPTION(MK_SYSTEM_MALLOC  ON)
-MK_SET_OPTION(MK_DEBUG          ON)
-
-# Build Monkey HTTP Server
-if(FLB_HTTP_SERVER)
-  add_subdirectory(${FLB_PATH_LIB_MONKEY} EXCLUDE_FROM_ALL)
-else()
-  add_subdirectory(${FLB_PATH_LIB_MONKEY}/mk_core EXCLUDE_FROM_ALL)
-endif()
-
-if(FLB_TLS)
-  FLB_DEFINITION(FLB_HAVE_TLS)
-
-  option(ENABLE_TESTING  OFF)
-  option(ENABLE_PROGRAMS OFF)
-  option(INSTALL_MBEDTLS_HEADERS OFF)
-
-  # Link OpenSSL statically on Windows.
-  if (FLB_SYSTEM_WINDOWS)
-    set(OPENSSL_USE_STATIC_LIBS ON)
-    set(OPENSSL_MSVC_STATIC_RT  ON)
-  endif()
-
-  # find OpenSSL (our preferred choice now)
-  find_package(OpenSSL)
-  if(OPENSSL_FOUND)
-    FLB_DEFINITION(FLB_HAVE_OPENSSL)
-  endif()
-endif()
-
-# Metrics
-if(FLB_METRICS)
-  FLB_DEFINITION(FLB_HAVE_METRICS)
-endif()
-
-# WASM
 if(FLB_WASM)
-  if (FLB_SYSTEM_LINUX)
-    check_c_source_compiles("
-       #include <stdatomic.h>
-       int main() {
-          _Atomic int a;
-          return 0;
-       }" FLB_HAVE_STDATOMIC_H)
-    check_include_files(stdatomic.h FLB_HAVE_STDATOMIC_H)
-    if (FLB_HAVE_STDATOMIC_H)
-      enable_language (ASM)
-      FLB_DEFINITION(FLB_HAVE_WASM)
-    else ()
-      message(STATUS "This platform does not provide stdatomic.h that is needed for the FLB_WASM feature so disabled.")
-      set(FLB_WASM OFF)
-    endif ()
-  else ()
-    enable_language (ASM)
-    FLB_DEFINITION(FLB_HAVE_WASM)
-  endif ()
+  REGISTER_IN_PLUGIN("in_exec_wasi")
 endif()
 
-# AWS
-if (FLB_AWS)
-  FLB_DEFINITION(FLB_HAVE_AWS)
+REGISTER_IN_PLUGIN("in_tcp")
+REGISTER_IN_PLUGIN("in_unix_socket")
+REGISTER_IN_PLUGIN("in_mqtt")
+REGISTER_IN_PLUGIN("in_lib")
+REGISTER_IN_PLUGIN("in_forward")
+REGISTER_IN_PLUGIN("in_random")
+REGISTER_OUT_PLUGIN("out_azure")
+REGISTER_OUT_PLUGIN("out_azure_blob")
+REGISTER_OUT_PLUGIN("out_azure_kusto")
+REGISTER_OUT_PLUGIN("out_bigquery")
+REGISTER_OUT_PLUGIN("out_calyptia")
+REGISTER_OUT_PLUGIN("out_counter")
+REGISTER_OUT_PLUGIN("out_datadog")
+REGISTER_OUT_PLUGIN("out_es")
+REGISTER_OUT_PLUGIN("out_exit")
+REGISTER_OUT_PLUGIN("out_file")
+REGISTER_OUT_PLUGIN("out_forward")
+REGISTER_OUT_PLUGIN("out_http")
+REGISTER_OUT_PLUGIN("out_influxdb")
+REGISTER_OUT_PLUGIN("out_logdna")
+REGISTER_OUT_PLUGIN("out_loki")
+REGISTER_OUT_PLUGIN("out_kafka")
+REGISTER_OUT_PLUGIN("out_kafka_rest")
+REGISTER_OUT_PLUGIN("out_nats")
+REGISTER_OUT_PLUGIN("out_nrlogs")
+REGISTER_OUT_PLUGIN("out_null")
+REGISTER_OUT_PLUGIN("out_opensearch")
 
-  # Support for credential_process in the AWS config file is currently Linux-only.
-  # The current implementation might work for other Unix systems, but would require
-  # further testing to confirm.
-  # Spawning a sub-process in Windows is very different and will require its own
-  # implementation.
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    FLB_OPTION(FLB_HAVE_AWS_CREDENTIAL_PROCESS ON)
-    FLB_DEFINITION(FLB_HAVE_AWS_CREDENTIAL_PROCESS)
-  else()
-    FLB_OPTION(FLB_HAVE_AWS_CREDENTIAL_PROCESS OFF)
-  endif()
+if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+  REGISTER_OUT_PLUGIN("out_plot")
 endif()
 
-if (FLB_AWS_ERROR_REPORTER)
-  FLB_DEFINITION(FLB_HAVE_AWS_ERROR_REPORTER)
-endif()
+REGISTER_OUT_PLUGIN("out_pgsql")
+REGISTER_OUT_PLUGIN("out_retry")
+REGISTER_OUT_PLUGIN("out_skywalking")
+REGISTER_OUT_PLUGIN("out_slack")
+REGISTER_OUT_PLUGIN("out_splunk")
+REGISTER_OUT_PLUGIN("out_stackdriver")
+REGISTER_OUT_PLUGIN("out_stdout")
+REGISTER_OUT_PLUGIN("out_syslog")
+REGISTER_OUT_PLUGIN("out_tcp")
+REGISTER_OUT_PLUGIN("out_udp")
+REGISTER_OUT_PLUGIN("out_td")
+REGISTER_OUT_PLUGIN("out_lib")
+REGISTER_OUT_PLUGIN("out_flowcounter")
+REGISTER_OUT_PLUGIN("out_gelf")
+REGISTER_OUT_PLUGIN("out_websocket")
+REGISTER_OUT_PLUGIN("out_cloudwatch_logs")
+REGISTER_OUT_PLUGIN("out_kinesis_firehose")
+REGISTER_OUT_PLUGIN("out_kinesis_streams")
+REGISTER_OUT_PLUGIN("out_opentelemetry")
+REGISTER_OUT_PLUGIN("out_prometheus_exporter")
+REGISTER_OUT_PLUGIN("out_prometheus_remote_write")
+REGISTER_OUT_PLUGIN("out_s3")
+REGISTER_OUT_PLUGIN("out_vivo_exporter")
 
-# Signv4
-if (FLB_SIGNV4)
-  FLB_DEFINITION(FLB_HAVE_SIGNV4)
-endif()
+# FILTERS
+# =======
+REGISTER_FILTER_PLUGIN("filter_alter_size")
+REGISTER_FILTER_PLUGIN("filter_aws")
+REGISTER_FILTER_PLUGIN("filter_checklist")
+REGISTER_FILTER_PLUGIN("filter_ecs")
+REGISTER_FILTER_PLUGIN("filter_record_modifier")
+REGISTER_FILTER_PLUGIN("filter_throttle")
+REGISTER_FILTER_PLUGIN("filter_throttle_size")
+REGISTER_FILTER_PLUGIN("filter_tensorflow")
+REGISTER_FILTER_PLUGIN("filter_type_converter")
 
-if(FLB_SQLDB)
-  FLB_DEFINITION(FLB_HAVE_SQLDB)
-  add_subdirectory(${FLB_PATH_LIB_SQLITE})
-endif()
-
-if(FLB_TRACE)
-  FLB_DEFINITION(FLB_HAVE_TRACE)
-endif()
-
-# Disable colors and any other control characters in the output
-if (FLB_LOG_NO_CONTROL_CHARS)
-  FLB_DEFINITION(FLB_LOG_NO_CONTROL_CHARS)
-endif()
-
-if(FLB_HTTP_SERVER)
-  FLB_OPTION(FLB_METRICS ON)
-  FLB_DEFINITION(FLB_HAVE_METRICS)
-  FLB_DEFINITION(FLB_HAVE_HTTP_SERVER)
-endif()
-
-if(NOT TARGET co)
-  add_subdirectory(${FLB_PATH_LIB_CO})
-endif()
-
-if(NOT TARGET rbtree)
-  add_subdirectory(${FLB_PATH_LIB_RBTREE})
-endif()
-
-# Systemd Journald support
-if(JOURNALD_FOUND)
-  FLB_DEFINITION(FLB_HAVE_SYSTEMD)
-else()
-  FLB_OPTION(FLB_IN_SYSTEMD OFF)
-endif()
-
-# Valgrind support
-check_c_source_compiles("
-  #include <valgrind/valgrind.h>
-  int main() {
-     return 0;
-  }" FLB_HAVE_VALGRIND)
-
-if(FLB_VALGRIND OR FLB_HAVE_VALGRIND)
-  FLB_DEFINITION(FLB_HAVE_VALGRIND)
-endif()
-
-# fork(2) support
-check_c_source_compiles("
-  #include <unistd.h>
-  int main() {
-     fork();
-     return 0;
-  }" FLB_HAVE_FORK)
-
-if(FLB_HAVE_FORK)
-  FLB_DEFINITION(FLB_HAVE_FORK)
-endif()
-
-# mtrace support
-if(FLB_MTRACE)
-  check_c_source_compiles("
-    #include <mcheck.h>
-    int main() {
-       return 0;
-    }" FLB_HAVE_MTRACE)
-
-  if(FLB_HAVE_MTRACE AND FLB_DEBUG)
-    FLB_DEFINITION(FLB_HAVE_MTRACE)
-  endif()
-endif()
-
-# timespec_get() support
-check_c_source_compiles("
-  #include <time.h>
-  int main() {
-     struct tm tm;
-     return timespec_get(&tm, TIME_UTC);
-  }" FLB_HAVE_TIMESPEC_GET)
-if(FLB_HAVE_TIMESPEC_GET)
-  FLB_DEFINITION(FLB_HAVE_TIMESPEC_GET)
-endif()
-
-# gmtoff support
-check_c_source_compiles("
-  #include <time.h>
-  int main() {
-     struct tm tm;
-     tm.tm_gmtoff = 0;
-     return 0;
-  }" FLB_HAVE_GMTOFF)
-if(FLB_HAVE_GMTOFF)
-  FLB_DEFINITION(FLB_HAVE_GMTOFF)
-endif()
-
-# clock_get_time() support for macOS.
-check_c_source_compiles("
-  #include <mach/clock.h>
-  #include <mach/mach.h>
-  int main() {
-      clock_serv_t cclock;
-      mach_timespec_t mts;
-      host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-      clock_get_time(cclock, &mts);
-      return mach_port_deallocate(mach_task_self(), cclock);
-  }" FLB_HAVE_CLOCK_GET_TIME)
-if(FLB_HAVE_CLOCK_GET_TIME)
-  FLB_DEFINITION(FLB_HAVE_CLOCK_GET_TIME)
-endif()
-
-# unix socket support
-check_c_source_compiles("
-  #include <unistd.h>
-  #include <sys/un.h>
-  #include <sys/types.h>
-  #include <sys/socket.h>
-  int main() {
-      int sock;
-      sock = socket(AF_UNIX, SOCK_STREAM, 0);
-      close(sock);
-      return 0;
-  }" FLB_HAVE_UNIX_SOCKET)
-if(FLB_HAVE_UNIX_SOCKET)
-  FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
-endif()
-
-# Configuration file YAML format support
-if(FLB_CONFIG_YAML)
-  find_package(PkgConfig)
-  # libyaml's corresponding pkg-config file is yaml-0.1.pc.
-  # We should search it first.
-  pkg_check_modules(LIBYAML QUIET yaml-0.1)
-
-  if (LIBYAML_FOUND)
-    # For if(FLB_HAVE_LIBYAML) clause on CMakeList.txt.
-    set(FLB_HAVE_LIBYAML 1)
-    FLB_DEFINITION(FLB_HAVE_LIBYAML)
-    # For non-standard libyaml installation paths such as homebrew bottled libyaml.
-    include_directories(${LIBYAML_INCLUDEDIR})
-    link_directories(${LIBYAML_LIBRARY_DIRS})
-  else()
-    # Requires libyaml support
-    check_c_source_compiles("
-      #include <yaml.h>
-      int main() {
-        yaml_parser_t parser;
-        return 0;
-      }" FLB_HAVE_LIBYAML)
-
-    if(NOT FLB_HAVE_LIBYAML)
-      message(FATAL_ERROR
-        "YAML development dependencies required for YAML configuration format handling.\n"
-        "This is a build time dependency, you can either install the "
-        "dependencies or disable the feature setting the CMake option "
-        "-DFLB_CONFIG_YAML=Off ."
-        )
-    endif()
-
-    FLB_DEFINITION(FLB_HAVE_LIBYAML)
-  endif()
-endif()
-
-# check attribute alloc_size
-check_c_source_compiles("
-#include <stdlib.h>
-__attribute__ ((alloc_size(1, 2))) static void* f(size_t a, size_t b) {
-    return calloc(a, b);
-}
-int main() {
-    f(1, 2);
-    return 0;
-}
-" FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
-if(FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
-  FLB_DEFINITION(FLB_HAVE_ATTRIBUTE_ALLOC_SIZE)
-endif()
-
-# parameters for flb_msgpack_raw_to_json_sds buffer strategy
-if (NOT DEFINED FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE)
-  FLB_DEFINITION_VAL(FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE 2.0)
-else()
-  FLB_DEFINITION_VAL(FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE ${FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE})
-endif()
-
-if (NOT DEFINED FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE)
-  FLB_DEFINITION_VAL(FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE 0.10)
-else()
-  FLB_DEFINITION_VAL(FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE ${FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE})
-endif()
-
-# Build tools/xxd-c
-add_subdirectory(tools/xxd-c)
-
-# Static configuration generator (using xxd-c)
-if(FLB_STATIC_CONF)
-  FLB_DEFINITION(FLB_HAVE_STATIC_CONF)
-  add_subdirectory(gen_static_conf)
-endif()
-
-# Special definition to set the coroutine stack size
-if(FLB_CORO_STACK_SIZE)
-  add_definitions(-DFLB_CORO_STACK_SIZE=${FLB_CORO_STACK_SIZE})
-  set(FLB_BUILD_FLAGS "${FLB_BUILD_FLAGS}#ifndef FLB_CORO_STACK_SIZE\n#define FLB_CORO_STACK_SIZE ${FLB_CORO_STACK_SIZE}\n#endif\n")
-else()
-
-endif()
-
-set(FLB_PROG_NAME "Fluent Bit")
-set(FLB_OUT_NAME "fluent-bit")
-
-if(FLB_PROXY_GO)
-  FLB_DEFINITION(FLB_HAVE_PROXY_GO)
-endif()
-
-if("${GNU_HOST}" STREQUAL "")
-    set(AUTOCONF_HOST_OPT "")
-else()
-    set(AUTOCONF_HOST_OPT "--host=${GNU_HOST}")
-endif()
-
-# Memory Allocator
-# ================
-if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  FLB_DEFINITION(FLB_HAVE_JEMALLOC)
-  FLB_DEFINITION(JEMALLOC_MANGLE)
-
-  # Add support for options like page size, if empty we default it
-  if(NOT DEFINED FLB_JEMALLOC_OPTIONS OR "${FLB_JEMALLOC_OPTIONS}" STREQUAL "")
-    set(FLB_JEMALLOC_OPTIONS "--with-lg-quantum=3")
-  endif()
-  # Split into a list so CMake handles it correctly when passing to configure command
-  separate_arguments(FLB_JEMALLOC_OPTIONS_LIST UNIX_COMMAND ${FLB_JEMALLOC_OPTIONS})
-  message(STATUS "jemalloc configure: ${FLB_JEMALLOC_OPTIONS_LIST}")
-
-  # Link to Jemalloc as an external dependency
-  ExternalProject_Add(jemalloc
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.3.0
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/jemalloc-5.3.0/configure ${AUTOCONF_HOST_OPT} "${FLB_JEMALLOC_OPTIONS_LIST}" --prefix=<INSTALL_DIR>
-    CFLAGS=-std=gnu99\ -Wall\ -pipe\ -g3\ -O3\ -funroll-loops
-    BUILD_COMMAND $(MAKE)
-    INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/
-    INSTALL_COMMAND $(MAKE) install_lib_static install_include)
-  add_library(libjemalloc STATIC IMPORTED GLOBAL)
-  set_target_properties(libjemalloc PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/lib/libjemalloc_pic.a")
-  add_dependencies(libjemalloc jemalloc)
-  include_directories("${CMAKE_BINARY_DIR}/include/")
-else()
-  FLB_OPTION(FLB_JEMALLOC OFF)
-endif()
-
-# LibBacktrace (friendly stacktrace support)
-# =========================================
-if(FLB_BACKTRACE)
-  FLB_DEFINITION(FLB_HAVE_LIBBACKTRACE)
-  if (CMAKE_OSX_SYSROOT)
-    # From macOS Mojave, /usr/include does not store C SDK headers.
-    # For libbacktrace building on macOS, we have to tell C headers where they are located.
-    set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} -isysroot ${CMAKE_OSX_SYSROOT}")
-  else()
-    set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
-  endif()
-  ExternalProject_Add(backtrace
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-8602fda/
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/libbacktrace-8602fda/configure ${AUTOCONF_HOST_OPT} --prefix=<INSTALL_DIR> --enable-shared=no --enable-static=yes
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) DESTDIR= install
-    )
-  add_library(libbacktrace STATIC IMPORTED GLOBAL)
-  set_target_properties(libbacktrace PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/backtrace-prefix/lib/libbacktrace.a")
-  add_dependencies(libbacktrace backtrace)
-  include_directories("${CMAKE_CURRENT_BINARY_DIR}/backtrace-prefix/include/")
-endif()
-
-if(FLB_IN_KAFKA OR FLB_OUT_KAFKA)
-    FLB_OPTION(RDKAFKA_BUILD_STATIC    On)
-    FLB_OPTION(RDKAFKA_BUILD_EXAMPLES Off)
-    FLB_OPTION(RDKAFKA_BUILD_TESTS    Off)
-    FLB_OPTION(ENABLE_LZ4_EXT         Off)
-
-    # disable Curl
-    if (FLB_SYSTEM_MACOS)
-      FLB_OPTION(WITH_CURL  Off)
-    endif()
-
-    add_subdirectory(${FLB_PATH_LIB_RDKAFKA} EXCLUDE_FROM_ALL)
-endif()
-
-# Onigmo (Regex Engine) options
-# =====================
 if(FLB_REGEX)
-  option(ONIGMO_SHARED_LIB    OFF)
-  option(ONIGMO_CTESTS        OFF)
-  option(ONIGMO_CTESTS_SAMPLE OFF)
-  option(ONIGMO_PYTHON_TESTS  OFF)
-  FLB_DEFINITION(FLB_HAVE_REGEX)
-
-  if (FLB_SYSTEM_WINDOWS)
-    # We need this line in order to link libonigmo.lib statically.
-    # Read onigmo/README for details.
-    FLB_DEFINITION_VAL(ONIG_EXTERN "extern")
-  endif()
-  add_subdirectory(${FLB_PATH_LIB_ONIGMO} EXCLUDE_FROM_ALL)
+  REGISTER_FILTER_PLUGIN("filter_kubernetes")
+  REGISTER_FILTER_PLUGIN("filter_modify")
+  REGISTER_FILTER_PLUGIN("filter_multiline")
+  REGISTER_FILTER_PLUGIN("filter_nest")
+  REGISTER_FILTER_PLUGIN("filter_parser")
 endif()
 
-# tutf8e (UTF8 Encoding)
-# =====================
-if(FLB_UTF8_ENCODER)
-  FLB_DEFINITION(FLB_HAVE_UTF8_ENCODER)
+if(FLB_RECORD_ACCESSOR)
+  REGISTER_FILTER_PLUGIN("filter_expect")
+  REGISTER_FILTER_PLUGIN("filter_grep")
+  REGISTER_FILTER_PLUGIN("filter_rewrite_tag")
 endif()
 
-# avro-c (Avro Encoding)
-# =====================
-if(FLB_AVRO_ENCODER)
-  FLB_DEFINITION(FLB_HAVE_AVRO_ENCODER)
+if(FLB_METRICS)
+  REGISTER_FILTER_PLUGIN("filter_log_to_metrics")
 endif()
 
-# LuaJIT (Scripting Support)
-# ==========================
 if(FLB_LUAJIT)
-  include(cmake/luajit.cmake)
-  FLB_DEFINITION(FLB_HAVE_LUAJIT)
+  REGISTER_FILTER_PLUGIN("filter_lua")
 endif()
 
-# PostgreSQL
-# ==========
-find_package(PostgreSQL)
-if(FLB_OUT_PGSQL AND (NOT PostgreSQL_FOUND))
-   FLB_OPTION(FLB_OUT_PGSQL OFF)
+REGISTER_FILTER_PLUGIN("filter_stdout")
+
+REGISTER_FILTER_PLUGIN("filter_geoip2")
+
+REGISTER_FILTER_PLUGIN("filter_nightfall")
+if (FLB_WASM)
+  REGISTER_FILTER_PLUGIN("filter_wasm")
+endif ()
+
+# Register external input and output plugins
+if(EXT_IN_PLUGINS)
+  string(REPLACE "," ";" plugins ${EXT_IN_PLUGINS})
+  foreach(entry ${plugins})
+    REGISTER_IN_PLUGIN(${entry})
+  endforeach()
 endif()
 
-# Arrow GLib
-# ==========
-find_package(PkgConfig)
-pkg_check_modules(ARROW_GLIB QUIET arrow-glib)
-if(FLB_ARROW AND ARROW_GLIB_FOUND)
-  FLB_DEFINITION(FLB_HAVE_ARROW)
-else()
-  set(FLB_ARROW OFF)
+if(EXT_OUT_PLUGINS)
+  string(REPLACE "," ";" plugins ${EXT_OUT_PLUGINS})
+  foreach(entry ${plugins})
+    REGISTER_OUT_PLUGIN(${entry})
+  endforeach()
 endif()
 
-# Pthread Local Storage
-# =====================
-# By default we expect the compiler already support thread local storage
-# through __thread type, otherwise Fluent Bit fallback to the old POSIX
-# pthread mode (pthread_key_t), or it can be forced setting FLB_POSIX_TLS
-# for testing/compatibility purposes.
-if(NOT FLB_POSIX_TLS)
-  check_c_source_compiles("
-   __thread int a;
-   int main() {
-       __tls_get_addr(0);
-       return 0;
-   }" FLB_HAVE_C_TLS)
-  if(FLB_HAVE_C_TLS)
-    FLB_DEFINITION(FLB_HAVE_C_TLS)
-  endif()
+if(EXT_FILTER_PLUGINS)
+  string(REPLACE "," ";" plugins ${EXT_FILTER_PLUGINS})
+  foreach(entry ${plugins})
+    REGISTER_FILTER_PLUGIN(${entry})
+  endforeach()
 endif()
 
-# accept(4)
-check_c_source_compiles("
-    #define _GNU_SOURCE
-    #include <stdio.h>
-    #include <sys/socket.h>
-    int main() {
-        accept4(0, NULL, NULL, 0);
-        return 0;
-    }" FLB_HAVE_ACCEPT4)
-if(FLB_HAVE_ACCEPT4)
-  FLB_DEFINITION(FLB_HAVE_ACCEPT4)
-endif()
-
-# inotify_init(2)
-if(FLB_INOTIFY)
-  check_c_source_compiles("
-    #include <sys/inotify.h>
-    int main() {
-        return inotify_init1(0);
-    }" FLB_HAVE_INOTIFY)
-  if(FLB_HAVE_INOTIFY)
-    FLB_DEFINITION(FLB_HAVE_INOTIFY)
-  endif()
-endif()
-
-include(CheckSymbolExists)
-
-# Check for getentropy(3)
-check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)
-if(HAVE_GETENTROPY)
-  FLB_DEFINITION(FLB_HAVE_GETENTROPY)
-endif()
-
-# getentropy(3) is in sys/random.h on mac
-check_symbol_exists(getentropy "sys/random.h" HAVE_GETENTROPY_SYS_RANDOM)
-if(HAVE_GETENTROPY_SYS_RANDOM)
-  FLB_DEFINITION(FLB_HAVE_GETENTROPY_SYS_RANDOM)
-endif()
-
+# Generate the header from the template
 configure_file(
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h.in"
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h"
+  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_plugins.h.in"
+  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_plugins.h"
   )
 
-configure_file(
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_version.h.in"
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_version.h"
-  )
-
-configure_file(
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/tls/flb_tls_info.h.in"
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/tls/flb_tls_info.h"
-  )
-
-# Installation Directories
-# ========================
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(FLB_INSTALL_BINDIR "bin")
-  set(FLB_INSTALL_LIBDIR "lib")
-  set(FLB_INSTALL_CONFDIR "conf")
-  set(FLB_INSTALL_INCLUDEDIR "include")
-else()
-  set(FLB_INSTALL_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
-  set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${FLB_OUT_NAME}")
-  set(FLB_INSTALL_CONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
-  set(FLB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
-endif()
-
-# Instruct CMake to build the Fluent Bit Core
-add_subdirectory(include)
-add_subdirectory(plugins)
-add_subdirectory(src)
-
-if(NOT FLB_SHARED_LIB)
-  set(FLB_EXAMPLES OFF)
-endif()
-
-if(FLB_EXAMPLES)
-  add_subdirectory(examples)
-endif()
-
-if(FLB_TESTS_RUNTIME)
-  enable_testing()
-  add_subdirectory(tests/runtime/)
-  add_subdirectory(tests/runtime_shell/)
-endif()
-
-if(FLB_TESTS_INTERNAL)
-  enable_testing()
-  add_subdirectory(tests/internal/)
-endif()
-
-# Installer Generation (Cpack)
-# ============================
-
-set(CPACK_PACKAGE_VERSION ${FLB_VERSION_STR})
-set(CPACK_PACKAGE_NAME "fluent-bit")
-
-set(CPACK_PACKAGE_RELEASE 1)
-set(CPACK_PACKAGE_CONTACT "Eduardo Silva <eduardo@calyptia.com>")
-set(CPACK_PACKAGE_VENDOR "Calyptia Inc.")
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
-set(CPACK_PACKAGING_INSTALL_PREFIX "/")
-
-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
-
-if(FLB_SYSTEM_WINDOWS)
-  set(CPACK_GENERATOR "NSIS" "ZIP" "WIX")
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|AARCH64)")
-    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-winarm64")
-  elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-win64")
-  else()
-    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-win32")
-  endif()
-endif()
-
-# Enable components
-set(CPACK_DEB_COMPONENT_INSTALL ON)
-set(CPACK_RPM_COMPONENT_INSTALL ON)
-set(CPACK_productbuild_COMPONENT_INSTALL ON)
-set(CPACK_COMPONENTS_ALL ${CPACK_COMPONENTS_ALL} binary library headers headers-extra)
-set(CPACK_COMPONENTS_GROUPING "ONE_PER_GROUP")
-
-set(CPACK_COMPONENT_BINARY_GROUP "RUNTIME")
-set(CPACK_COMPONENT_LIBRARY_GROUP "RUNTIME")
-
-# Debian package setup and name sanitizer
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-
-find_program(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
-if(DPKG_PROGRAM)
-  execute_process(
-    COMMAND ${DPKG_PROGRAM} --print-architecture
-    OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-  set(CPACK_DEBIAN_HEADERS_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}-headers.deb")
-  set(CPACK_DEBIAN_HEADERS_EXTRA_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}-headers-extra.deb")
-  set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "${CPACK_PACKAGE_NAME}")
-  set(CPACK_DEBIAN_RUNTIME_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
-  set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA
-    ${PROJECT_SOURCE_DIR}/cpack/debian/conffiles
-    )
-
-  if(FLB_RUN_LDCONFIG)
-    set(LDCONFIG_DIR ${FLB_INSTALL_LIBDIR})
-    file(WRITE ${PROJECT_BINARY_DIR}/scripts/postinst "
-mkdir -p /etc/ld.so.conf.d
-echo \"${LDCONFIG_DIR}\" > /etc/ld.so.conf.d/libfluent-bit.conf
-ldconfig
-    ")
-    file(WRITE ${PROJECT_BINARY_DIR}/scripts/prerm "
-rm -f -- /etc/ld.so.conf.d/libfluent-bit.conf
-ldconfig
-    ")
-    set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
-  endif(FLB_RUN_LDCONFIG)
-
-endif()
-
-# RPM Generation information
-set(CPACK_RPM_PACKAGE_GROUP "System Environment/Daemons")
-set(CPACK_RPM_PACKAGE_LICENSE "Apache v2.0")
-set(CPACK_RPM_PACKAGE_RELEASE ${CPACK_PACKAGE_RELEASE})
-set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/cpack/description")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast data collector for Linux")
-set(CPACK_RPM_SPEC_MORE_DEFINE "%define ignore \#")
-set(CPACK_RPM_RUNTIME_USER_FILELIST
-  "%config(noreplace) /etc/${FLB_OUT_NAME}/${FLB_OUT_NAME}.conf"
-  "%config(noreplace) /etc/${FLB_OUT_NAME}/parsers.conf"
-  "%config(noreplace) /etc/${FLB_OUT_NAME}/plugins.conf"
-  "%ignore /lib"
-  "%ignore /lib/systemd"
-  "%ignore /lib/systemd/system"
-  "%ignore /lib64"
-  "%ignore /lib64/pkgconfig"
-  "%ignore /usr/local"
-  "%ignore /usr/local/bin"
-  "%ignore /opt"
-  "%ignore /etc")
-
-set(CPACK_RPM_PACKAGE_AUTOREQ ON)
-set(CPACK_RPM_RUNTIME_PACKAGE_NAME "${CPACK_PACKAGE_NAME}")
-set(CPACK_RPM_HEADERS_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}-headers.rpm")
-set(CPACK_RPM_HEADERS_EXTRA_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}-headers-extra.rpm")
-set(CPACK_RPM_RUNTIME_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.rpm")
-
-# CPack: DEB
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-
-# CPack: Windows System
-if(CPACK_GENERATOR MATCHES "NSIS")
-  set(CPACK_MONOLITHIC_INSTALL 1)
-  set(CPACK_PACKAGE_INSTALL_DIRECTORY "fluent-bit")
-endif()
-
-# CPack: Windows System w/ WiX
-if(CPACK_GENERATOR MATCHES "WIX")
-  set(CPACK_WIX_UPGRADE_GUID cb6825fd-37e6-4596-a55d-6d490d4fe178)
-  configure_file(LICENSE "${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt")
-  configure_file(${CMAKE_SOURCE_DIR}/cpack/wix/WIX.template.in.cmakein
-    ${CMAKE_CURRENT_BINARY_DIR}/WIX.template.in)
-  # Specify LICENSE file that has .txt extension
-  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt")
-  set(CPACK_WIX_TEMPLATE ${CMAKE_CURRENT_BINARY_DIR}/WIX.template.in)
-  set(CPACK_WIX_LIGHT_EXTENSIONS "WixUtilExtension")
-endif()
-
-if(FLB_SYSTEM_MACOS)
-  # Determine the platform suffix
-  execute_process(
-    COMMAND uname -m
-    RESULT_VARIABLE UNAME_M_RESULT
-    OUTPUT_VARIABLE UNAME_ARCH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  if (UNAME_M_RESULT EQUAL 0 AND UNAME_ARCH STREQUAL "arm64")
-    set(FLUENT_BIT_PKG ${CMAKE_CURRENT_BINARY_DIR}/fluent-bit-${FLB_VERSION_STR}-apple)
-  elseif(UNAME_M_RESULT EQUAL 0 AND UNAME_ARCH STREQUAL "x86_64")
-    set(FLUENT_BIT_PKG ${CMAKE_CURRENT_BINARY_DIR}/fluent-bit-${FLB_VERSION_STR}-intel)
-  else()
-    set(FLUENT_BIT_PKG ${CMAKE_CURRENT_BINARY_DIR}/fluent-bit-${FLB_VERSION_STR}-${UNAME_ARCH})
-  endif()
-
-  if (CPACK_GENERATOR MATCHES "productbuild")
-    set(CPACK_SET_DESTDIR "ON")
-    configure_file(cpack/macos/welcome.txt.cmakein ${CMAKE_CURRENT_BINARY_DIR}/welcome.txt)
-    configure_file(cpack/macos/fluent-bit.plist.cmakein ${CMAKE_CURRENT_BINARY_DIR}/${FLB_OUT_NAME}.plist)
-    configure_file(LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt)
-    find_program(CONVERTER textutil)
-    if (NOT CONVERTER)
-      message(FATAL_ERROR "textutil not found.")
-    endif()
-    if (CONVERTER)
-      execute_process(COMMAND ${CONVERTER} -convert html "${CMAKE_SOURCE_DIR}/README.md" -output "${CMAKE_BINARY_DIR}/README.html")
-    endif()
-    set(CPACK_PACKAGE_FILE_NAME "${FLUENT_BIT_PKG}")
-    set(CPACK_RESOURCE_FILE_WELCOME ${CMAKE_CURRENT_BINARY_DIR}/welcome.txt)
-    set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt)
-    set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_BINARY_DIR}/README.html)
-    set(CPACK_PRODUCTBUILD_IDENTIFIER "io.fluentbit.${FLB_OUT_NAME}")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${FLB_OUT_NAME}.plist
-      COMPONENT binary
-      DESTINATION /Library/LaunchDaemons)
-  endif()
-endif()
-
-include(CPack)
+set(FLB_PLUGINS "${flb_plugins}" PARENT_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ option(FLB_IN_NODE_EXPORTER_METRICS    "Enable node exporter metrics input plugi
 option(FLB_IN_WINDOWS_EXPORTER_METRICS "Enable windows exporter metrics input plugin" Yes)
 option(FLB_IN_OPENTELEMETRY            "Enable OpenTelemetry input plugin"            Yes)
 option(FLB_IN_ELASTICSEARCH            "Enable Elasticsearch (Bulk API) input plugin" Yes)
+option(FLB_IN_GELF                     "Enable GELF input plugin"                     Yes)
 option(FLB_OUT_AZURE                   "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_BLOB              "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_KUSTO             "Enable Azure Kusto output plugin"             Yes)

--- a/flb_gzip.c
+++ b/flb_gzip.c
@@ -1,0 +1,427 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_gzip.h>
+#include <miniz/miniz.h>
+
+#define FLB_GZIP_HEADER_OFFSET 10
+
+typedef enum {
+    FTEXT    = 1,
+    FHCRC    = 2,
+    FEXTRA   = 4,
+    FNAME    = 8,
+    FCOMMENT = 16
+} flb_tinf_gzip_flag;
+
+static unsigned int read_le16(const unsigned char *p)
+{
+    return ((unsigned int) p[0]) | ((unsigned int) p[1] << 8);
+}
+
+static unsigned int read_le32(const unsigned char *p)
+{
+    return ((unsigned int) p[0])
+        | ((unsigned int) p[1] << 8)
+        | ((unsigned int) p[2] << 16)
+        | ((unsigned int) p[3] << 24);
+}
+
+static inline void gzip_header(void *buf)
+{
+    uint8_t *p;
+
+    /* GZip Magic bytes */
+    p = buf;
+    *p++ = 0x1F;
+    *p++ = 0x8B;
+    *p++ = 8;
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0xFF;
+}
+
+int flb_gzip_compress(void *in_data, size_t in_len,
+                      void **out_data, size_t *out_len)
+{
+    int flush;
+    int status;
+    int footer_start;
+    uint8_t *pb;
+    size_t out_size;
+    void *out_buf;
+    z_stream strm;
+    mz_ulong crc;
+
+    /*
+     * Calculating the upper bound for a gzip compression is
+     * non-trivial, so we rely on miniz's own calculation
+     * to guarantee memory safety.
+     */
+    out_size = compressBound(in_len);
+    out_buf = flb_malloc(out_size);
+
+    if (!out_buf) {
+        flb_errno();
+        flb_error("[gzip] could not allocate outgoing buffer");
+        return -1;
+    }
+
+    /* Initialize streaming buffer context */
+    memset(&strm, '\0', sizeof(strm));
+    strm.zalloc    = Z_NULL;
+    strm.zfree     = Z_NULL;
+    strm.opaque    = Z_NULL;
+    strm.next_in   = in_data;
+    strm.avail_in  = in_len;
+    strm.total_out = 0;
+
+    /* Deflate mode */
+    deflateInit2(&strm, Z_DEFAULT_COMPRESSION,
+                 Z_DEFLATED, -Z_DEFAULT_WINDOW_BITS, 9, Z_DEFAULT_STRATEGY);
+
+    /*
+     * Miniz don't support GZip format directly, instead we will:
+     *
+     * - append manual GZip magic bytes
+     * - deflate raw content
+     * - append manual CRC32 data
+     */
+    gzip_header(out_buf);
+
+    /* Header offset */
+    pb = (uint8_t *) out_buf + FLB_GZIP_HEADER_OFFSET;
+
+    flush = Z_NO_FLUSH;
+    while (1) {
+        strm.next_out  = pb + strm.total_out;
+        strm.avail_out = out_size - (pb - (uint8_t *) out_buf);
+
+        if (strm.avail_in == 0) {
+            flush = Z_FINISH;
+        }
+
+        status = deflate(&strm, flush);
+        if (status == Z_STREAM_END) {
+            break;
+        }
+        else if (status != Z_OK) {
+            deflateEnd(&strm);
+            return -1;
+        }
+    }
+
+    if (deflateEnd(&strm) != Z_OK) {
+        flb_free(out_buf);
+        return -1;
+    }
+    *out_len = strm.total_out;
+
+    /* Construct the gzip checksum (CRC32 footer) */
+    footer_start = FLB_GZIP_HEADER_OFFSET + *out_len;
+    pb = (uint8_t *) out_buf + footer_start;
+
+    crc = mz_crc32(MZ_CRC32_INIT, in_data, in_len);
+    *pb++ = crc & 0xFF;
+    *pb++ = (crc >> 8) & 0xFF;
+    *pb++ = (crc >> 16) & 0xFF;
+    *pb++ = (crc >> 24) & 0xFF;
+    *pb++ = in_len & 0xFF;
+    *pb++ = (in_len >> 8) & 0xFF;
+    *pb++ = (in_len >> 16) & 0xFF;
+    *pb++ = (in_len >> 24) & 0xFF;
+
+    /* Set the real buffer size for the caller */
+    *out_len += FLB_GZIP_HEADER_OFFSET + 8;
+    *out_data = out_buf;
+
+    return 0;
+}
+
+/* Uncompress (inflate) GZip data */
+int flb_gzip_uncompress(void *in_data, size_t in_len,
+                        void **out_data, size_t *out_len)
+{
+    int status;
+    uint8_t *p;
+    void *out_buf;
+    size_t out_size = 0;
+    size_t data_in_len, total_out;
+    void *zip_data;
+    size_t zip_len;
+    unsigned char flg;
+    unsigned int xlen, hcrc;
+    unsigned int dlen, crc;
+    mz_ulong crc_out;
+    mz_stream stream;
+    const unsigned char *start;
+
+    /* Minimal length: header + crc32 */
+    if (in_len < 18) {
+        flb_error("[gzip] unexpected content length");
+        return -1;
+    }
+
+    /* Magic bytes */
+    p = in_data;
+    if (p[0] != 0x1F || p[1] != 0x8B) {
+        flb_error("[gzip] invalid magic bytes");
+        return -1;
+    }
+
+    if (p[2] != 8) {
+        flb_error("[gzip] invalid method");
+        return -1;
+    }
+
+    /* Flag byte */
+    flg = p[3];
+
+    /* Reserved bits */
+    if (flg & 0xE0) {
+        flb_error("[gzip] invalid flag");
+        return -1;
+    }
+
+    /* Skip base header of 10 bytes */
+    start = p + FLB_GZIP_HEADER_OFFSET;
+
+    /* Skip extra data if present */
+    if (flg & FEXTRA) {
+        xlen = read_le16(start);
+        if (xlen > in_len - 12) {
+            flb_error("[gzip] invalid gzip data");
+            return -1;
+        }
+        start += xlen + 2;
+    }
+
+    /* Skip file name if present */
+    if (flg & FNAME) {
+        do {
+            if (start - p >= in_len) {
+                flb_error("[gzip] invalid gzip data (FNAME)");
+                return -1;
+            }
+        } while (*start++);
+    }
+
+    /* Skip file comment if present */
+    if (flg & FCOMMENT) {
+        do {
+            if (start - p >= in_len) {
+                flb_error("[gzip] invalid gzip data (FCOMMENT)");
+                return -1;
+            }
+        } while (*start++);
+    }
+
+    /* Check header crc if present */
+    if (flg & FHCRC) {
+        if (start - p > in_len - 2) {
+            flb_error("[gzip] invalid gzip data (FHRC)");
+            return -1;
+        }
+
+        hcrc = read_le16(start);
+        crc = mz_crc32(MZ_CRC32_INIT, p, start - p) & 0x0000FFFF;
+        if (hcrc != crc) {
+            flb_error("[gzip] invalid gzip header CRC");
+            return -1;
+        }
+        start += 2;
+    }
+
+    /* Ensure size is above 0 */
+    if (((p + in_len) - start - 8) <= 0) {
+        return -1;
+    }
+
+    /* Map zip content */
+    zip_data = (uint8_t *) start;
+    zip_len = (p + in_len) - start - 8;
+
+    /* Allocate outgoing buffer */
+    out_size = zip_len * 2;
+    out_buf = flb_malloc(out_size);
+    if (!out_buf) {
+        flb_errno();
+        return -1;
+    }
+
+    memset(&stream, 0, sizeof(stream));
+    stream.next_in = zip_data;
+    stream.avail_in = zip_len;
+    stream.next_out = out_buf;
+    stream.avail_out = out_size;
+
+    status = mz_inflateInit2(&stream, -Z_DEFAULT_WINDOW_BITS);
+    if (status != MZ_OK) {
+        flb_free(out_buf);
+        return -1;
+    }
+
+    while (1) {
+        status = mz_inflate(&stream, MZ_NO_FLUSH);
+        if (status == MZ_STREAM_END) {
+            break;
+        }
+        else if (status == MZ_OK) {
+            void *tmp;
+            size_t new_out_size = out_size * 2;
+            /* Limit decompressed length to 100MB */
+            if (new_out_size > 100000000) {
+                flb_error("[gzip] maximum decompression size is 100MB");
+                mz_inflateEnd(&stream);
+                flb_free(out_buf);
+                return -1;
+            }
+            tmp = flb_realloc(out_buf, new_out_size);
+            if (!tmp) {
+                flb_errno();
+                mz_inflateEnd(&stream);
+                flb_free(out_buf);
+                return -1;
+            }
+            out_buf = tmp;
+            stream.next_out = (unsigned char *)out_buf + stream.total_out;
+            stream.avail_out = new_out_size - out_size;
+            out_size = new_out_size;
+        }
+        else {
+            flb_error("[gzip] error: %s", mz_error(status));
+            mz_inflateEnd(&stream);
+            flb_free(out_buf);
+            return -1;
+        }
+    }
+
+    total_out = stream.total_out;
+    data_in_len = start - p + stream.total_in + 8;
+
+    /* terminate the stream, it's not longer required */
+    mz_inflateEnd(&stream);
+
+    if (data_in_len > in_len) {
+        flb_error("[gzip] invalid number of procesed bytes");
+        flb_free(out_buf);
+        return -1;
+    }
+
+    /* Get decompressed length */
+    dlen = read_le32(&p[data_in_len - 4]);
+    if (dlen != total_out) {
+        flb_error("[gzip] invalid decompress size");
+        flb_free(out_buf);
+        return -1;
+    }
+
+    /* Get CRC32 checksum of original data */
+    crc = read_le32(&p[data_in_len - 8]);
+    /* Validate message CRC vs inflated data CRC */
+    crc_out = mz_crc32(MZ_CRC32_INIT, out_buf, total_out);
+    if (crc_out != crc) {
+        flb_error("[gzip] invalid GZip checksum (CRC32)");
+        flb_free(out_buf);
+        return -2;
+    }
+
+    /* set the uncompressed data */
+    *out_len = total_out;
+    *out_data = out_buf;
+
+    return 0;
+}
+
+int flb_zlib_uncompress(void *in_data, size_t in_len,
+                        void **out_data, size_t *out_len)
+{
+    int status;
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    mz_stream stream;
+
+    /* Allocate outgoing buffer */
+    out_size = in_len * 2;
+    out_buf = flb_malloc(out_size);
+    if (!out_buf) {
+        flb_errno();
+        return -1;
+    }
+
+    memset(&stream, 0, sizeof(stream));
+    stream.next_in = in_data,
+    stream.avail_in = in_len,
+    stream.next_out = out_buf;
+    stream.avail_out = out_size;
+
+    status = mz_inflateInit2(&stream, Z_DEFAULT_WINDOW_BITS);
+    if (status != MZ_OK) {
+        flb_free(out_buf);
+        return -1;
+    }
+
+    while (1) {
+        status = mz_inflate(&stream, MZ_NO_FLUSH);
+        if (status == MZ_STREAM_END) {
+            break;
+        }
+        else if (status == MZ_OK) {
+            void *tmp;
+            size_t new_out_size = out_size * 2;
+            /* Limit decompressed length to 100MB */
+            if (new_out_size > 100000000) {
+                flb_error("[zlib] maximum decompression size is 100MB");
+                mz_inflateEnd(&stream);
+                flb_free(out_buf);
+                return -1;
+            }
+            tmp = flb_realloc(out_buf, new_out_size);
+            if (!tmp) {
+                flb_errno();
+                mz_inflateEnd(&stream);
+                flb_free(out_buf);
+                return -1;
+            }
+            out_buf = tmp;
+            stream.next_out = (unsigned char *)out_buf + stream.total_out;
+            stream.avail_out = new_out_size - out_size;
+            out_size = new_out_size;
+        }
+        else {
+            flb_error("[zlib] error: %s", mz_error(status));
+            mz_inflateEnd(&stream);
+            flb_free(out_buf);
+            return -1;
+        }
+    }
+
+    *out_len = stream.total_out;
+    *out_data = out_buf;
+    mz_inflateEnd(&stream);
+
+    return 0;
+}

--- a/flb_gzip.h
+++ b/flb_gzip.h
@@ -1,0 +1,34 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_GZIP_H
+#define FLB_GZIP_H
+
+#include <fluent-bit/flb_info.h>
+#include <stdio.h>
+
+int flb_gzip_compress(void *in_data, size_t in_len,
+                      void **out_data, size_t *out_len);
+int flb_gzip_uncompress(void *in_data, size_t in_len,
+                        void **out_data, size_t *out_size);
+
+int flb_zlib_uncompress(void *in_data, size_t in_len,
+                        void **out_data, size_t *out_len);
+
+#endif

--- a/flb_pack.c
+++ b/flb_pack.c
@@ -1,0 +1,1270 @@
+/*-*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_unescape.h>
+
+/* cmetrics */
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_decode_msgpack.h>
+#include <cmetrics/cmt_encode_text.h>
+
+#include <msgpack.h>
+#include <math.h>
+#include <jsmn/jsmn.h>
+
+#define try_to_write_str  flb_utils_write_str
+
+static int convert_nan_to_null = FLB_FALSE;
+
+static int flb_pack_set_null_as_nan(int b) {
+    if (b == FLB_TRUE || b == FLB_FALSE) {
+        convert_nan_to_null = b;
+    }
+    return convert_nan_to_null;
+}
+
+int flb_json_tokenise(const char *js, size_t len,
+                      struct flb_pack_state *state)
+{
+    int ret;
+    int new_tokens = 256;
+    size_t old_size;
+    size_t new_size;
+    void *tmp;
+
+    ret = jsmn_parse(&state->parser, js, len,
+                     state->tokens, state->tokens_size);
+    while (ret == JSMN_ERROR_NOMEM) {
+        /* Get current size of the array in bytes */
+        old_size = state->tokens_size * sizeof(jsmntok_t);
+
+        /* New size: add capacity for new 256 entries */
+        new_size = old_size + (sizeof(jsmntok_t) * new_tokens);
+
+        tmp = flb_realloc(state->tokens, new_size);
+        if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+        state->tokens = tmp;
+        state->tokens_size += new_tokens;
+
+        ret = jsmn_parse(&state->parser, js, len,
+                         state->tokens, state->tokens_size);
+    }
+
+    if (ret == JSMN_ERROR_INVAL) {
+        return FLB_ERR_JSON_INVAL;
+    }
+
+    if (ret == JSMN_ERROR_PART) {
+        /* This is a partial JSON message, just stop */
+        flb_trace("[json tokenise] incomplete");
+        return FLB_ERR_JSON_PART;
+    }
+
+    state->tokens_count += ret;
+    return 0;
+}
+
+static inline int is_float(const char *buf, int len)
+{
+    const char *end = buf + len;
+    const char *p = buf;
+
+    while (p <= end) {
+        if (*p == 'e' && p < end && *(p + 1) == '-') {
+            return 1;
+        }
+        else if (*p == '.') {
+            return 1;
+        }
+        p++;
+    }
+
+    return 0;
+}
+
+/* Sanitize incoming JSON string */
+static inline int pack_string_token(struct flb_pack_state *state,
+                                    const char *str, int len,
+                                    msgpack_packer *pck)
+{
+    int s;
+    int out_len;
+    char *tmp;
+    char *out_buf;
+
+    if (state->buf_size < len + 1) {
+        s = len + 1;
+        tmp = flb_realloc(state->buf_data, s);
+        if (!tmp) {
+            flb_errno();
+            return -1;
+        }
+        else {
+            state->buf_data = tmp;
+            state->buf_size = s;
+        }
+    }
+    out_buf = state->buf_data;
+
+    /* Always decode any UTF-8 or special characters */
+    out_len = flb_unescape_string_utf8(str, len, out_buf);
+
+    /* Pack decoded text */
+    msgpack_pack_str(pck, out_len);
+    msgpack_pack_str_body(pck, out_buf, out_len);
+
+    return out_len;
+}
+
+/* Receive a tokenized JSON message and convert it to MsgPack */
+static char *tokens_to_msgpack(struct flb_pack_state *state,
+                               const char *js,
+                               int *out_size, int *last_byte,
+                               int *out_records)
+{
+    int i;
+    int flen;
+    int arr_size;
+    int records = 0;
+    const char *p;
+    char *buf;
+    const jsmntok_t *t;
+    msgpack_packer pck;
+    msgpack_sbuffer sbuf;
+    jsmntok_t *tokens;
+
+    tokens = state->tokens;
+    arr_size = state->tokens_count;
+
+    if (arr_size == 0) {
+        return NULL;
+    }
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+
+    for (i = 0; i < arr_size ; i++) {
+        t = &tokens[i];
+
+        if (t->start == -1 || t->end == -1 || (t->start == 0 && t->end == 0)) {
+            break;
+        }
+
+        if (t->parent == -1) {
+            *last_byte = t->end;
+            records++;
+        }
+
+        flen = (t->end - t->start);
+        switch (t->type) {
+        case JSMN_OBJECT:
+            msgpack_pack_map(&pck, t->size);
+            break;
+        case JSMN_ARRAY:
+            msgpack_pack_array(&pck, t->size);
+            break;
+        case JSMN_STRING:
+            pack_string_token(state, js + t->start, flen, &pck);
+            break;
+        case JSMN_PRIMITIVE:
+            p = js + t->start;
+            if (*p == 'f') {
+                msgpack_pack_false(&pck);
+            }
+            else if (*p == 't') {
+                msgpack_pack_true(&pck);
+            }
+            else if (*p == 'n') {
+                msgpack_pack_nil(&pck);
+            }
+            else {
+                if (is_float(p, flen)) {
+                    msgpack_pack_double(&pck, atof(p));
+                }
+                else {
+                    msgpack_pack_int64(&pck, atoll(p));
+                }
+            }
+            break;
+        case JSMN_UNDEFINED:
+            msgpack_sbuffer_destroy(&sbuf);
+            return NULL;
+        }
+    }
+
+    *out_size = sbuf.size;
+    *out_records = records;
+    buf = sbuf.data;
+
+    return buf;
+}
+
+/*
+ * It parse a JSON string and convert it to MessagePack format, this packer is
+ * useful when a complete JSON message exists, otherwise it will fail until
+ * the message is complete.
+ *
+ * This routine do not keep a state in the parser, do not use it for big
+ * JSON messages.
+ */
+static int pack_json_to_msgpack(const char *js, size_t len, char **buffer,
+                                size_t *size, int *root_type, int *records,
+                                size_t *consumed)
+{
+    int ret = -1;
+    int n_records;
+    int out;
+    int last;
+    char *buf = NULL;
+    struct flb_pack_state state;
+
+    ret = flb_pack_state_init(&state);
+    if (ret != 0) {
+        return -1;
+    }
+    ret = flb_json_tokenise(js, len, &state);
+    if (ret != 0) {
+        ret = -1;
+        goto flb_pack_json_end;
+    }
+
+    if (state.tokens_count == 0) {
+        ret = -1;
+        goto flb_pack_json_end;
+    }
+
+    buf = tokens_to_msgpack(&state, js, &out, &last, &n_records);
+    if (!buf) {
+        ret = -1;
+        goto flb_pack_json_end;
+    }
+
+    *root_type = state.tokens[0].type;
+    *size = out;
+    *buffer = buf;
+    *records = n_records;
+
+    if (consumed != NULL) {
+        *consumed = last;
+    }
+
+    ret = 0;
+
+ flb_pack_json_end:
+    flb_pack_state_reset(&state);
+    return ret;
+}
+
+/* Pack unlimited serialized JSON messages into msgpack */
+int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size,
+                  int *root_type, size_t *consumed)
+{
+    int records;
+
+    return pack_json_to_msgpack(js, len, buffer, size, root_type, &records, consumed);
+}
+
+/*
+ * Pack unlimited serialized JSON messages into msgpack, finally it writes on
+ * 'out_records' the number of messages.
+ */
+int flb_pack_json_recs(const char *js, size_t len, char **buffer, size_t *size,
+                       int *root_type, int *out_records, size_t *consumed)
+{
+    return pack_json_to_msgpack(js, len, buffer, size, root_type, out_records, consumed);
+}
+
+/* Initialize a JSON packer state */
+int flb_pack_state_init(struct flb_pack_state *s)
+{
+    int tokens = 256;
+    size_t size = 256;
+
+    jsmn_init(&s->parser);
+
+    size = sizeof(jsmntok_t) * tokens;
+    s->tokens = flb_malloc(size);
+    if (!s->tokens) {
+        flb_errno();
+        return -1;
+    }
+    s->tokens_size   = tokens;
+    s->tokens_count  = 0;
+    s->last_byte     = 0;
+    s->multiple      = FLB_FALSE;
+
+    s->buf_data = flb_malloc(size);
+    if (!s->buf_data) {
+        flb_errno();
+        flb_free(s->tokens);
+        s->tokens = NULL;
+        return -1;
+    }
+    s->buf_size = size;
+    s->buf_len = 0;
+
+    return 0;
+}
+
+void flb_pack_state_reset(struct flb_pack_state *s)
+{
+    flb_free(s->tokens);
+    s->tokens = NULL;
+    s->tokens_size  = 0;
+    s->tokens_count = 0;
+    s->last_byte    = 0;
+    s->buf_size     = 0;
+    flb_free(s->buf_data);
+    s->buf_data = NULL;
+}
+
+
+/*
+ * It parse a JSON string and convert it to MessagePack format. The main
+ * difference of this function and the previous flb_pack_json() is that it
+ * keeps a parser and tokens state, allowing to process big messages and
+ * resume the parsing process instead of start from zero.
+ */
+int flb_pack_json_state(const char *js, size_t len,
+                        char **buffer, int *size,
+                        struct flb_pack_state *state)
+{
+    int ret;
+    int out;
+    int delim = 0;
+    int last =  0;
+    int records;
+    char *buf;
+    jsmntok_t *t;
+
+    ret = flb_json_tokenise(js, len, state);
+    state->multiple = FLB_TRUE;
+    if (ret == FLB_ERR_JSON_PART && state->multiple == FLB_TRUE) {
+        /*
+         * If the caller enabled 'multiple' flag, it means that the incoming
+         * JSON message may have multiple messages concatenated and likely
+         * the last one is only incomplete.
+         *
+         * The following routine aims to determinate how many JSON messages
+         * are OK in the array of tokens, if any, process them and adjust
+         * the JSMN context/buffers.
+         */
+
+        /*
+         * jsmn_parse updates jsmn_parser members. (state->parser)
+         * A member 'toknext' points next incomplete object token.
+         * We use toknext - 1 as an index of last member of complete JSON.
+         */
+        int i;
+        int found = 0;
+
+        if (state->parser.toknext == 0) {
+            return ret;
+        }
+
+        for (i = (int)state->parser.toknext - 1; i >= 1; i--) {
+            t = &state->tokens[i];
+
+            if (t->parent == -1 && (t->end != 0)) {
+                found++;
+                delim = i;
+                break;
+            }
+        }
+
+        if (found == 0) {
+            return ret; /* FLB_ERR_JSON_PART */
+        }
+        state->tokens_count += delim;
+    }
+    else if (ret != 0) {
+        return ret;
+    }
+
+    if (state->tokens_count == 0 || state->tokens == NULL) {
+        state->last_byte = last;
+        return FLB_ERR_JSON_INVAL;
+    }
+
+    buf = tokens_to_msgpack(state, js, &out, &last, &records);
+    if (!buf) {
+        return -1;
+    }
+
+    *size = out;
+    *buffer = buf;
+    state->last_byte = last;
+
+    return 0;
+}
+
+int flb_metadata_pop_from_msgpack(msgpack_object **metadata, msgpack_unpacked *upk,
+                                  msgpack_object **map)
+{
+    if (metadata == NULL || upk == NULL) {
+        return -1;
+    }
+
+    if (upk->data.type != MSGPACK_OBJECT_ARRAY) {
+        return -1;
+    }
+
+    *metadata = &upk->data.via.array.ptr[0].via.array.ptr[1];
+    *map = &upk->data.via.array.ptr[1];
+
+    return 0;
+}
+
+static int pack_print_fluent_record(size_t cnt, msgpack_unpacked result)
+{
+    msgpack_object  *metadata;
+    msgpack_object   root;
+    msgpack_object  *obj;
+    struct flb_time  tms;
+    msgpack_object   o;
+
+    root = result.data;
+    if (root.type != MSGPACK_OBJECT_ARRAY) {
+        return -1;
+    }
+
+    o = root.via.array.ptr[0];
+    if (o.type != MSGPACK_OBJECT_ARRAY) {
+        return -1;
+    }
+
+    /* decode expected timestamp only (integer, float or ext) */
+    o = o.via.array.ptr[0];
+    if (o.type != MSGPACK_OBJECT_POSITIVE_INTEGER &&
+        o.type != MSGPACK_OBJECT_FLOAT &&
+        o.type != MSGPACK_OBJECT_EXT) {
+        return -1;
+    }
+
+    /* This is a Fluent Bit record, just do the proper unpacking/printing */
+    flb_time_pop_from_msgpack(&tms, &result, &obj);
+    flb_metadata_pop_from_msgpack(&metadata, &result, &obj);
+
+    fprintf(stdout, "[%zd] [%"PRIu32".%09lu, ", cnt,
+            (uint32_t) tms.tm.tv_sec, tms.tm.tv_nsec);
+
+    msgpack_object_print(stdout, *metadata);
+
+    fprintf(stdout, ", ");
+
+    msgpack_object_print(stdout, *obj);
+
+    fprintf(stdout, "]\n");
+
+    return 0;
+}
+
+void flb_pack_print(const char *data, size_t bytes)
+{
+    int ret;
+    msgpack_unpacked result;
+    size_t off = 0, cnt = 0;
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+        /* Check if we are processing an internal Fluent Bit record */
+        ret = pack_print_fluent_record(cnt, result);
+        if (ret == 0) {
+            continue;
+        }
+
+        printf("[%zd] ", cnt++);
+        msgpack_object_print(stdout, result.data);
+        printf("\n");
+    }
+    msgpack_unpacked_destroy(&result);
+}
+
+void flb_pack_print_metrics(const char *data, size_t bytes)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+
+    printf("%s", text);
+    fflush(stdout);
+
+    cmt_encode_text_destroy(text);
+}
+
+static inline int try_to_write(char *buf, int *off, size_t left,
+                               const char *str, size_t str_len)
+{
+    if (str_len <= 0){
+        str_len = strlen(str);
+    }
+    if (left <= *off+str_len) {
+        return FLB_FALSE;
+    }
+    memcpy(buf+*off, str, str_len);
+    *off += str_len;
+    return FLB_TRUE;
+}
+
+
+/*
+ * Check if a key exists in the map using the 'offset' as an index to define
+ * which element needs to start looking from
+ */
+static inline int key_exists_in_map(msgpack_object key, msgpack_object map, int offset)
+{
+    int i;
+    msgpack_object p;
+
+    if (key.type != MSGPACK_OBJECT_STR) {
+        return FLB_FALSE;
+    }
+
+    for (i = offset; i < map.via.map.size; i++) {
+        p = map.via.map.ptr[i].key;
+        if (p.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (key.via.str.size != p.via.str.size) {
+            continue;
+        }
+
+        if (memcmp(key.via.str.ptr, p.via.str.ptr, p.via.str.size) == 0) {
+            return FLB_TRUE;
+        }
+    }
+
+    return FLB_FALSE;
+}
+
+static int msgpack2json(char *buf, int *off, size_t left,
+                        const msgpack_object *o)
+{
+    int i;
+    int dup;
+    int ret = FLB_FALSE;
+    int loop;
+    int packed;
+
+    switch(o->type) {
+    case MSGPACK_OBJECT_NIL:
+        ret = try_to_write(buf, off, left, "null", 4);
+        break;
+
+    case MSGPACK_OBJECT_BOOLEAN:
+        ret = try_to_write(buf, off, left,
+                           (o->via.boolean ? "true":"false"),0);
+
+        break;
+
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            char temp[32] = {0};
+            i = snprintf(temp, sizeof(temp)-1, "%"PRIu64, o->via.u64);
+            ret = try_to_write(buf, off, left, temp, i);
+        }
+        break;
+
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            char temp[32] = {0};
+            i = snprintf(temp, sizeof(temp)-1, "%"PRId64, o->via.i64);
+            ret = try_to_write(buf, off, left, temp, i);
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            char temp[512] = {0};
+            if (o->via.f64 == (double)(long long int)o->via.f64) {
+                i = snprintf(temp, sizeof(temp)-1, "%.1f", o->via.f64);
+            }
+            else if (convert_nan_to_null && isnan(o->via.f64) ) {
+                i = snprintf(temp, sizeof(temp)-1, "null");
+            }
+            else {
+                i = snprintf(temp, sizeof(temp)-1, "%.16g", o->via.f64);
+            }
+            ret = try_to_write(buf, off, left, temp, i);
+        }
+        break;
+
+    case MSGPACK_OBJECT_STR:
+        if (try_to_write(buf, off, left, "\"", 1) &&
+            (o->via.str.size > 0 ?
+             try_to_write_str(buf, off, left, o->via.str.ptr, o->via.str.size)
+             : 1/* nothing to do */) &&
+            try_to_write(buf, off, left, "\"", 1)) {
+            ret = FLB_TRUE;
+        }
+        break;
+
+    case MSGPACK_OBJECT_BIN:
+        if (try_to_write(buf, off, left, "\"", 1) &&
+            (o->via.bin.size > 0 ?
+             try_to_write_str(buf, off, left, o->via.bin.ptr, o->via.bin.size)
+              : 1 /* nothing to do */) &&
+            try_to_write(buf, off, left, "\"", 1)) {
+            ret = FLB_TRUE;
+        }
+        break;
+
+    case MSGPACK_OBJECT_EXT:
+        if (!try_to_write(buf, off, left, "\"", 1)) {
+            goto msg2json_end;
+        }
+        /* ext body. fortmat is similar to printf(1) */
+        {
+            char temp[32] = {0};
+            int  len;
+            loop = o->via.ext.size;
+            for(i=0; i<loop; i++) {
+                len = snprintf(temp, sizeof(temp)-1, "\\x%02x", (char)o->via.ext.ptr[i]);
+                if (!try_to_write(buf, off, left, temp, len)) {
+                    goto msg2json_end;
+                }
+            }
+        }
+        if (!try_to_write(buf, off, left, "\"", 1)) {
+            goto msg2json_end;
+        }
+        ret = FLB_TRUE;
+        break;
+
+    case MSGPACK_OBJECT_ARRAY:
+        loop = o->via.array.size;
+
+        if (!try_to_write(buf, off, left, "[", 1)) {
+            goto msg2json_end;
+        }
+        if (loop != 0) {
+            msgpack_object* p = o->via.array.ptr;
+            if (!msgpack2json(buf, off, left, p)) {
+                goto msg2json_end;
+            }
+            for (i=1; i<loop; i++) {
+                if (!try_to_write(buf, off, left, ",", 1) ||
+                    !msgpack2json(buf, off, left, p+i)) {
+                    goto msg2json_end;
+                }
+            }
+        }
+
+        ret = try_to_write(buf, off, left, "]", 1);
+        break;
+
+    case MSGPACK_OBJECT_MAP:
+        loop = o->via.map.size;
+        if (!try_to_write(buf, off, left, "{", 1)) {
+            goto msg2json_end;
+        }
+        if (loop != 0) {
+            msgpack_object k;
+            msgpack_object_kv *p = o->via.map.ptr;
+
+            packed = 0;
+            dup = FLB_FALSE;
+
+            k = o->via.map.ptr[0].key;
+            for (i = 0; i < loop; i++) {
+                k = o->via.map.ptr[i].key;
+                dup = key_exists_in_map(k, *o, i + 1);
+                if (dup == FLB_TRUE) {
+                    continue;
+                }
+
+                if (packed > 0) {
+                    if (!try_to_write(buf, off, left, ",", 1)) {
+                        goto msg2json_end;
+                    }
+                }
+
+                if (
+                    !msgpack2json(buf, off, left, &(p+i)->key) ||
+                    !try_to_write(buf, off, left, ":", 1)  ||
+                    !msgpack2json(buf, off, left, &(p+i)->val) ) {
+                    goto msg2json_end;
+                }
+                packed++;
+            }
+        }
+
+        ret = try_to_write(buf, off, left, "}", 1);
+        break;
+
+    default:
+        flb_warn("[%s] unknown msgpack type %i", __FUNCTION__, o->type);
+    }
+
+ msg2json_end:
+    return ret;
+}
+
+/**
+ *  convert msgpack to JSON string.
+ *  This API is similar to snprintf.
+ *
+ *  @param  json_str  The buffer to fill JSON string.
+ *  @param  json_size The size of json_str.
+ *  @param  data      The msgpack_unpacked data.
+ *  @return success   ? a number characters filled : negative value
+ */
+int flb_msgpack_to_json(char *json_str, size_t json_size,
+                        const msgpack_object *obj)
+{
+    int ret = -1;
+    int off = 0;
+
+    if (json_str == NULL || obj == NULL) {
+        return -1;
+    }
+
+    ret = msgpack2json(json_str, &off, json_size - 1, obj);
+    json_str[off] = '\0';
+    return ret ? off: ret;
+}
+
+flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
+{
+    int ret;
+    size_t off = 0;
+    size_t out_size;
+    size_t realloc_size;
+
+    msgpack_unpacked result;
+    msgpack_object *root;
+    flb_sds_t out_buf;
+    flb_sds_t tmp_buf;
+
+    /* buffer size strategy */
+    out_size = in_size * FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE;
+    realloc_size = in_size * FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE;
+    if (realloc_size < 256) {
+        realloc_size = 256;
+    }
+
+    out_buf = flb_sds_create_size(out_size);
+    if (!out_buf) {
+        flb_errno();
+        return NULL;
+    }
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, in_buf, in_size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        flb_sds_destroy(out_buf);
+        msgpack_unpacked_destroy(&result);
+        return NULL;
+    }
+
+    root = &result.data;
+    while (1) {
+        ret = flb_msgpack_to_json(out_buf, out_size, root);
+        if (ret <= 0) {
+            tmp_buf = flb_sds_increase(out_buf, realloc_size);
+            if (tmp_buf) {
+                out_buf = tmp_buf;
+                out_size += realloc_size;
+            }
+            else {
+                flb_errno();
+                flb_sds_destroy(out_buf);
+                msgpack_unpacked_destroy(&result);
+                return NULL;
+            }
+        }
+        else {
+            break;
+        }
+    }
+
+    msgpack_unpacked_destroy(&result);
+    flb_sds_len_set(out_buf, ret);
+
+    return out_buf;
+}
+
+/*
+ * Given a 'format' string type, return it integer representation. This
+ * is used by output plugins that uses pack functions to convert
+ * msgpack records to JSON.
+ */
+int flb_pack_to_json_format_type(const char *str)
+{
+    if (strcasecmp(str, "msgpack") == 0) {
+        return FLB_PACK_JSON_FORMAT_NONE;
+    }
+    else if (strcasecmp(str, "json") == 0) {
+        return FLB_PACK_JSON_FORMAT_JSON;
+    }
+    else if (strcasecmp(str, "json_stream") == 0) {
+        return FLB_PACK_JSON_FORMAT_STREAM;
+    }
+    else if (strcasecmp(str, "json_lines") == 0) {
+        return FLB_PACK_JSON_FORMAT_LINES;
+    }
+
+    return -1;
+}
+
+/* Given a 'date string type', return it integer representation */
+int flb_pack_to_json_date_type(const char *str)
+{
+    if (strcasecmp(str, "double") == 0) {
+        return FLB_PACK_JSON_DATE_DOUBLE;
+    }
+    else if (strcasecmp(str, "java_sql_timestamp") == 0) {
+        return FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP;
+    }
+    else if (strcasecmp(str, "iso8601") == 0) {
+        return FLB_PACK_JSON_DATE_ISO8601;
+    }
+    else if (strcasecmp(str, "epoch") == 0) {
+        return FLB_PACK_JSON_DATE_EPOCH;
+    }
+    else if (strcasecmp(str, "epoch_ms") == 0 ||
+             strcasecmp(str, "epoch_millis") == 0 ||
+             strcasecmp(str, "epoch_milliseconds") == 0) {
+        return FLB_PACK_JSON_DATE_EPOCH_MS;
+    }
+
+    return -1;
+}
+
+
+static int msgpack_pack_formatted_datetime(flb_sds_t out_buf, char time_formatted[], int max_len,
+                                           msgpack_packer* tmp_pck, struct flb_time* tms,
+                                           const char *date_format,
+                                           const char *time_format)
+{
+    int len;
+    size_t s;
+    struct tm tm;
+
+    gmtime_r(&tms->tm.tv_sec, &tm);
+
+    s = strftime(time_formatted, max_len,
+                 date_format, &tm);
+    if (!s) {
+        flb_debug("strftime failed in flb_pack_msgpack_to_json_format");
+        return 1;
+    }
+
+    /* Format the time, use microsecond precision not nanoseconds */
+    max_len -= s;
+    len = snprintf(&time_formatted[s],
+                    max_len,
+                    time_format,
+                    (uint64_t) tms->tm.tv_nsec / 1000);
+    if (len >= max_len) {
+        flb_debug("snprintf: %d >= %d in flb_pack_msgpack_to_json_format", len, max_len);
+        return 2;
+    }
+    s += len;
+    msgpack_pack_str(tmp_pck, s);
+    msgpack_pack_str_body(tmp_pck, time_formatted, s);
+    return 0;
+}
+
+flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
+                                          int json_format, int date_format,
+                                          flb_sds_t date_key)
+{
+    int i;
+    int ok = MSGPACK_UNPACK_SUCCESS;
+    int records = 0;
+    int map_size;
+    size_t off = 0;
+    char time_formatted[38];
+    flb_sds_t out_tmp;
+    flb_sds_t out_js;
+    flb_sds_t out_buf = NULL;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object map;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    msgpack_object *obj;
+    msgpack_object *k;
+    msgpack_object *v;
+    struct flb_time tms;
+
+    /* For json lines and streams mode we need a pre-allocated buffer */
+    if (json_format == FLB_PACK_JSON_FORMAT_LINES ||
+        json_format == FLB_PACK_JSON_FORMAT_STREAM) {
+        out_buf = flb_sds_create_size(bytes + bytes / 4);
+        if (!out_buf) {
+            flb_errno();
+            return NULL;
+        }
+    }
+
+    /* Create temporary msgpack buffer */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+    /*
+     * If the format is the original msgpack style of one big array,
+     * registrate the array, otherwise is not necessary. FYI, original format:
+     *
+     * [
+     *   [timestamp, map],
+     *   [timestamp, map],
+     *   [T, M]...
+     * ]
+     */
+    if (json_format == FLB_PACK_JSON_FORMAT_JSON) {
+        records = flb_mp_count(data, bytes);
+        if (records <= 0) {
+            msgpack_sbuffer_destroy(&tmp_sbuf);
+            return NULL;
+        }
+        msgpack_pack_array(&tmp_pck, records);
+    }
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == ok) {
+        /* Each array must have two entries: time and record */
+        root = result.data;
+        if (root.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+        if (root.via.array.size != 2) {
+            continue;
+        }
+
+        /* Unpack time */
+        flb_time_pop_from_msgpack(&tms, &result, &obj);
+
+        /* Get the record/map */
+        map = root.via.array.ptr[1];
+        if (map.type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
+        map_size = map.via.map.size;
+
+        if (date_key != NULL) {
+            msgpack_pack_map(&tmp_pck, map_size + 1);
+        }
+        else {
+            msgpack_pack_map(&tmp_pck, map_size);
+        }
+
+        if (date_key != NULL) {
+            /* Append date key */
+            msgpack_pack_str(&tmp_pck, flb_sds_len(date_key));
+            msgpack_pack_str_body(&tmp_pck, date_key, flb_sds_len(date_key));
+
+            /* Append date value */
+            switch (date_format) {
+            case FLB_PACK_JSON_DATE_DOUBLE:
+                msgpack_pack_double(&tmp_pck, flb_time_to_double(&tms));
+                break;
+            case FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP:
+                if (msgpack_pack_formatted_datetime(out_buf, time_formatted, sizeof(time_formatted), &tmp_pck, &tms,
+                                                    FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT, ".%06" PRIu64)) {
+                    flb_sds_destroy(out_buf);
+                    msgpack_sbuffer_destroy(&tmp_sbuf);
+                    msgpack_unpacked_destroy(&result);
+                    return NULL;
+                }
+                break;
+            case FLB_PACK_JSON_DATE_ISO8601:
+                if (msgpack_pack_formatted_datetime(out_buf, time_formatted, sizeof(time_formatted), &tmp_pck, &tms,
+                                                    FLB_PACK_JSON_DATE_ISO8601_FMT, ".%06" PRIu64 "Z")) {
+                    flb_sds_destroy(out_buf);
+                    msgpack_sbuffer_destroy(&tmp_sbuf);
+                    msgpack_unpacked_destroy(&result);
+                    return NULL;
+                }
+                break;
+            case FLB_PACK_JSON_DATE_EPOCH:
+                msgpack_pack_uint64(&tmp_pck, (long long unsigned)(tms.tm.tv_sec));
+                break;
+            case FLB_PACK_JSON_DATE_EPOCH_MS:
+                msgpack_pack_uint64(&tmp_pck, flb_time_to_millisec(&tms));
+                break;
+            }
+        }
+
+        /* Append remaining keys/values */
+        for (i = 0; i < map_size; i++) {
+            k = &map.via.map.ptr[i].key;
+            v = &map.via.map.ptr[i].val;
+            msgpack_pack_object(&tmp_pck, *k);
+            msgpack_pack_object(&tmp_pck, *v);
+        }
+
+        /*
+         * If the format is the original msgpack style, just continue since
+         * we don't care about separator or JSON convertion at this point.
+         */
+        if (json_format == FLB_PACK_JSON_FORMAT_JSON) {
+            continue;
+        }
+
+        /*
+         * Here we handle two types of records concatenation:
+         *
+         * FLB_PACK_JSON_FORMAT_LINES: add  breakline (\n) after each record
+         *
+         *
+         *     {'ts':abc,'k1':1}
+         *     {'ts':abc,'k1':2}
+         *     {N}
+         *
+         * FLB_PACK_JSON_FORMAT_STREAM: no separators, e.g:
+         *
+         *     {'ts':abc,'k1':1}{'ts':abc,'k1':2}{N}
+         */
+        if (json_format == FLB_PACK_JSON_FORMAT_LINES ||
+            json_format == FLB_PACK_JSON_FORMAT_STREAM) {
+
+            /* Encode current record into JSON in a temporary variable */
+            out_js = flb_msgpack_raw_to_json_sds(tmp_sbuf.data, tmp_sbuf.size);
+            if (!out_js) {
+                flb_sds_destroy(out_buf);
+                msgpack_sbuffer_destroy(&tmp_sbuf);
+                msgpack_unpacked_destroy(&result);
+                return NULL;
+            }
+
+            /*
+             * One map record has been converted, now append it to the
+             * outgoing out_buf sds variable.
+             */
+            out_tmp = flb_sds_cat(out_buf, out_js, flb_sds_len(out_js));
+            if (!out_tmp) {
+                flb_sds_destroy(out_js);
+                flb_sds_destroy(out_buf);
+                msgpack_sbuffer_destroy(&tmp_sbuf);
+                msgpack_unpacked_destroy(&result);
+                return NULL;
+            }
+
+            /* Release temporary json sds buffer */
+            flb_sds_destroy(out_js);
+
+            /* If a realloc happened, check the returned address */
+            if (out_tmp != out_buf) {
+                out_buf = out_tmp;
+            }
+
+            /* Append the breakline only for json lines mode */
+            if (json_format == FLB_PACK_JSON_FORMAT_LINES) {
+                out_tmp = flb_sds_cat(out_buf, "\n", 1);
+                if (!out_tmp) {
+                    flb_sds_destroy(out_buf);
+                    msgpack_sbuffer_destroy(&tmp_sbuf);
+                    msgpack_unpacked_destroy(&result);
+                    return NULL;
+                }
+                if (out_tmp != out_buf) {
+                    out_buf = out_tmp;
+                }
+            }
+            msgpack_sbuffer_clear(&tmp_sbuf);
+        }
+    }
+
+    /* Release the unpacker */
+    msgpack_unpacked_destroy(&result);
+
+    /* Format to JSON */
+    if (json_format == FLB_PACK_JSON_FORMAT_JSON) {
+        out_buf = flb_msgpack_raw_to_json_sds(tmp_sbuf.data, tmp_sbuf.size);
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+
+        if (!out_buf) {
+            return NULL;
+        }
+    }
+    else {
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+    }
+
+    if (out_buf && flb_sds_len(out_buf) == 0) {
+        flb_sds_destroy(out_buf);
+        return NULL;
+    }
+
+    return out_buf;
+}
+
+/**
+ *  convert msgpack to JSON string.
+ *  This API is similar to snprintf.
+ *  @param  size     Estimated length of json str.
+ *  @param  data     The msgpack_unpacked data.
+ *  @return success  ? allocated json str ptr : NULL
+ */
+char *flb_msgpack_to_json_str(size_t size, const msgpack_object *obj)
+{
+    int ret;
+    char *buf = NULL;
+    char *tmp;
+
+    if (obj == NULL) {
+        return NULL;
+    }
+
+    if (size <= 0) {
+        size = 128;
+    }
+
+    buf = flb_malloc(size);
+    if (!buf) {
+        flb_errno();
+        return NULL;
+    }
+
+    while (1) {
+        ret = flb_msgpack_to_json(buf, size, obj);
+        if (ret <= 0) {
+            /* buffer is small. retry.*/
+            size += 128;
+            tmp = flb_realloc(buf, size);
+            if (tmp) {
+                buf = tmp;
+            }
+            else {
+                flb_free(buf);
+                flb_errno();
+                return NULL;
+            }
+        }
+        else {
+            break;
+        }
+    }
+
+    return buf;
+}
+
+int flb_pack_time_now(msgpack_packer *pck)
+{
+    int ret;
+    struct flb_time t;
+
+    flb_time_get(&t);
+    ret = flb_time_append_to_msgpack(&t, pck, 0);
+
+    return ret;
+}
+
+int flb_msgpack_expand_map(char *map_data, size_t map_size,
+                           msgpack_object_kv **kv_arr, int kv_arr_len,
+                           char** out_buf, int* out_size)
+{
+    msgpack_sbuffer sbuf;
+    msgpack_packer  pck;
+    msgpack_unpacked result;
+    size_t off = 0;
+    char *ret_buf;
+    int map_num;
+    int i;
+    int len;
+
+    if (map_data == NULL){
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    if ((i=msgpack_unpack_next(&result, map_data, map_size, &off)) !=
+        MSGPACK_UNPACK_SUCCESS ) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    if (result.data.type != MSGPACK_OBJECT_MAP) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    len = result.data.via.map.size;
+    map_num = kv_arr_len + len;
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&pck, map_num);
+
+    for (i=0; i<len; i++) {
+        msgpack_pack_object(&pck, result.data.via.map.ptr[i].key);
+        msgpack_pack_object(&pck, result.data.via.map.ptr[i].val);
+    }
+    for (i=0; i<kv_arr_len; i++){
+        msgpack_pack_object(&pck, kv_arr[i]->key);
+        msgpack_pack_object(&pck, kv_arr[i]->val);
+    }
+    msgpack_unpacked_destroy(&result);
+
+    *out_size = sbuf.size;
+    ret_buf  = flb_malloc(sbuf.size);
+    *out_buf = ret_buf;
+    if (*out_buf == NULL) {
+        flb_errno();
+        msgpack_sbuffer_destroy(&sbuf);
+        return -1;
+    }
+    memcpy(*out_buf, sbuf.data, sbuf.size);
+    msgpack_sbuffer_destroy(&sbuf);
+
+    return 0;
+}
+
+int flb_pack_init(struct flb_config *config)
+{
+    int ret;
+
+    if (config == NULL) {
+        return -1;
+    }
+    ret = flb_pack_set_null_as_nan(config->convert_nan_to_null);
+
+    return ret;
+}

--- a/flb_pack.h
+++ b/flb_pack.h
@@ -1,0 +1,128 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PACK_H
+#define FLB_PACK_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_config.h>
+
+#include <msgpack.h>
+
+/* JSON types */
+#define FLB_PACK_JSON_UNDEFINED     JSMN_UNDEFINED
+#define FLB_PACK_JSON_OBJECT        JSMN_OBJECT
+#define FLB_PACK_JSON_ARRAY         JSMN_ARRAY
+#define FLB_PACK_JSON_STRING        JSMN_STRING
+#define FLB_PACK_JSON_PRIMITIVE     JSMN_PRIMITIVE
+
+/* Date formats */
+#define FLB_PACK_JSON_DATE_DOUBLE                0
+#define FLB_PACK_JSON_DATE_ISO8601               1
+#define FLB_PACK_JSON_DATE_EPOCH                 2
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP    3
+#define FLB_PACK_JSON_DATE_EPOCH_MS              4
+
+/* Specific ISO8601 format */
+#define FLB_PACK_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
+/* Specific Java SQL Timestamp format */
+#define FLB_PACK_JSON_DATE_JAVA_SQL_TIMESTAMP_FMT "%Y-%m-%d %H:%M:%S"
+
+#define FBL_PACK_JSON_DATE_FORMAT_DESCRIPTION   "Specify the format of the date, " \
+    "supported formats: double, " \
+     "iso8601 (e.g: 2018-05-30T09:39:52.000681Z), " \
+     "java_sql_timestamp (e.g: 2018-05-30 09:39:52.000681, useful for AWS Athena), "\
+     "and epoch."
+
+/* JSON formats (modes) */
+#define FLB_PACK_JSON_FORMAT_NONE        0
+#define FLB_PACK_JSON_FORMAT_JSON        1
+#define FLB_PACK_JSON_FORMAT_STREAM      2
+#define FLB_PACK_JSON_FORMAT_LINES       3
+
+struct flb_pack_state {
+    int multiple;         /* support multiple jsons? */
+    int tokens_count;     /* number of parsed tokens */
+    int tokens_size;      /* total tokens in the array */
+    int last_byte;        /* last byte of a full msg   */
+    jsmntok_t *tokens;    /* tokens array              */
+    jsmn_parser parser;   /* parser state              */
+    char *buf_data;       /* temporary buffer           */
+    size_t buf_size;      /* temporary buffer size      */
+    size_t buf_len;       /* temporary buffer length    */
+};
+
+int flb_pack_init(struct flb_config *config);
+int flb_json_tokenise(const char *js, size_t len, struct flb_pack_state *state);
+
+
+int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size,
+                  int *root_type, size_t *consumed);
+int flb_pack_json_recs(const char *js, size_t len, char **buffer, size_t *size,
+                       int *root_type, int *out_records, size_t *consumed);
+
+int flb_pack_state_init(struct flb_pack_state *s);
+void flb_pack_state_reset(struct flb_pack_state *s);
+
+int flb_pack_json_state(const char *js, size_t len,
+                        char **buffer, int *size,
+                        struct flb_pack_state *state);
+int flb_pack_json_valid(const char *json, size_t len);
+
+flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
+                                          int json_format, int date_format,
+                                          flb_sds_t date_key);
+int flb_pack_to_json_format_type(const char *str);
+int flb_pack_to_json_date_type(const char *str);
+
+void flb_pack_print(const char *data, size_t bytes);
+int flb_msgpack_to_json(char *json_str, size_t str_len,
+                        const msgpack_object *obj);
+char* flb_msgpack_to_json_str(size_t size, const msgpack_object *obj);
+flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size);
+
+int flb_pack_time_now(msgpack_packer *pck);
+int flb_msgpack_expand_map(char *map_data, size_t map_size,
+                           msgpack_object_kv **obj_arr, int obj_arr_len,
+                           char** out_buf, int* out_size);
+
+struct flb_gelf_fields {
+    flb_sds_t timestamp_key;
+    flb_sds_t host_key;
+    flb_sds_t short_message_key;
+    flb_sds_t full_message_key;
+    flb_sds_t level_key;
+};
+
+flb_sds_t flb_msgpack_to_gelf(flb_sds_t *s, msgpack_object *o,
+                              struct flb_time *tm,
+                              struct flb_gelf_fields *fields);
+
+flb_sds_t flb_msgpack_raw_to_gelf(char *buf, size_t buf_size,
+                                  struct flb_time *tm,
+                                  struct flb_gelf_fields *fields);
+
+int flb_gelf_to_msgpack(const char *js, size_t len, struct flb_time *tm,
+                        char **buffer, size_t *size, bool strict);
+
+#endif

--- a/gelf.c
+++ b/gelf.c
@@ -1,0 +1,918 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_macros.h>
+#include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "gelf.h"
+
+static struct gelf_chunk_entry *gelf_chunk_tbl_add(struct gelf_chunk_tbl *tbl,
+                                                   uint64_t msg_id,
+                                                   struct gelf_chunk *chunk);
+
+static int gelf_udp_message(struct flb_gelf *ctx, char *buffer_data,
+                            size_t buffer_len, bool chunked);
+
+static int gelf_chunk_tbl_resize(struct gelf_chunk_tbl *tbl, size_t new_size)
+{
+    int i;
+    struct gelf_chunk_entry *new_entries;
+    struct gelf_chunk_tbl new_tbl;
+
+    if (new_size <= tbl->used) {
+       return -1;
+    }
+
+    new_entries = flb_calloc(1, sizeof(struct gelf_chunk_entry) * new_size);
+    if (!new_entries) {
+       flb_errno();
+       return -1;
+    }
+
+    new_tbl.size = new_size;
+    new_tbl.used = 0;
+    new_tbl.entries = new_entries;
+
+    for (i=0; i < tbl->size; i++) {
+        if (tbl->entries[i].msg_id != 0) {
+            gelf_chunk_tbl_add(&new_tbl,
+                               tbl->entries[i].msg_id,
+                               tbl->entries[i].chunk);
+        }
+    }
+    flb_free(tbl->entries);
+
+    tbl->size = new_tbl.size;
+    tbl->used = new_tbl.used;
+    tbl->entries = new_entries;
+
+    return 0;
+}
+
+static struct gelf_chunk_entry *gelf_chunk_tbl_add(struct gelf_chunk_tbl *tbl,
+                                                   uint64_t msg_id,
+                                                   struct gelf_chunk *chunk)
+{
+    uint64_t dib, pos;
+
+    pos = msg_id % tbl->size;
+    dib = 0;
+    while(1) {
+        if (tbl->entries[pos].msg_id == 0) {
+            tbl->entries[pos].dib = dib;
+            tbl->entries[pos].msg_id = msg_id;
+            tbl->entries[pos].chunk = chunk;
+            tbl->used++;
+            return &(tbl->entries[pos]);
+        }
+        if (tbl->entries[pos].msg_id == msg_id) {
+            return &(tbl->entries[pos]);
+        }
+        if (tbl->entries[pos].dib < dib) {
+            uint64_t mv_msg_id = tbl->entries[pos].msg_id;
+            struct gelf_chunk *mv_chunk = tbl->entries[pos].chunk;
+
+            tbl->entries[pos].dib = dib;
+            tbl->entries[pos].msg_id = msg_id;
+            tbl->entries[pos].chunk = chunk;
+
+            gelf_chunk_tbl_add(tbl, mv_msg_id, mv_chunk);
+            return &(tbl->entries[pos]);
+        }
+        dib++;
+        pos = (pos + 1) % tbl->size;
+    }
+
+    return NULL;
+}
+
+static struct gelf_chunk_entry *gelf_chunk_tbl_get(struct gelf_chunk_tbl *tbl,
+                                                   uint64_t msg_id,
+                                                   uint8_t seq_cnt)
+{
+    struct gelf_chunk_entry *entry;
+    struct gelf_chunk *chunk;
+
+    if ((tbl->used * 3) > (tbl->size * 2)) {
+        if (gelf_chunk_tbl_resize(tbl, tbl->size * 2) < 0) {
+            return NULL;
+        }
+    }
+
+    entry = gelf_chunk_tbl_add(tbl, msg_id, NULL);
+    if (!entry) {
+        return NULL;
+    }
+
+    if (!entry->chunk) {
+        entry->msg_id = msg_id;
+        chunk = flb_calloc(1, sizeof(struct gelf_chunk) +
+                              sizeof(struct gelf_chunk_sgmt)*seq_cnt);
+        if (!chunk) {
+            flb_errno();
+            return NULL;
+        }
+        chunk->start = time(NULL);
+        chunk->sgmt_cnt = seq_cnt;
+        entry->chunk = chunk;
+
+        return entry;
+    }
+
+    return entry;
+}
+
+static void gelf_chunk_tbl_entry_free(struct gelf_chunk_tbl *tbl,
+                                      struct gelf_chunk_entry *entry)
+{
+    int i;
+
+    if (!entry) {
+       return;
+    }
+
+    if (entry->chunk) {
+        for (i = 0; i < entry->chunk->sgmt_cnt; i++) {
+            if (entry->chunk->sgmt[i].base) {
+                flb_free(entry->chunk->sgmt[i].base);
+            }
+        }
+        flb_free(entry->chunk);
+        entry->chunk = NULL;
+    }
+
+    entry->dib = 0;
+    entry->msg_id = 0;
+    tbl->used--;
+}
+
+static int gelf_chunk_tbl_alloc(struct gelf_chunk_tbl *tbl)
+{
+    if (tbl->entries == NULL) {
+        tbl->size = FLB_GELF_TBL_SIZE;
+        tbl->used = 0;
+        tbl->entries = flb_calloc(1,
+                                  sizeof(struct gelf_chunk_entry) * tbl->size);
+        if (!tbl->entries) {
+            flb_errno();
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void gelf_chunk_tbl_free(struct gelf_chunk_tbl *tbl)
+{
+    int i;
+
+    if (!tbl->entries) {
+       return;
+    }
+
+    for (i=0; i < tbl->size; i++) {
+        if (tbl->entries[i].msg_id) {
+            gelf_chunk_tbl_entry_free(tbl, &tbl->entries[i]);
+        }
+    }
+
+    flb_free(tbl->entries);
+    tbl->entries = NULL;
+    tbl->used = 0;
+}
+
+static int in_gelf_purge_udp(struct flb_input_instance *ins,
+                             struct flb_config *config, void *in_context)
+{
+    struct flb_gelf *ctx = in_context;
+    struct gelf_chunk_tbl *tbl;
+    int i;
+    time_t now;
+    (void) ins;
+
+    tbl = &ctx->chunks;
+    if (!tbl->entries) {
+        return 0;
+    }
+
+    now = time(NULL);
+    for (i=0; i < tbl->size; i++) {
+        if (!tbl->entries[i].msg_id) {
+            continue;
+        }
+        if (tbl->entries[i].chunk) {
+            if ((now - tbl->entries[i].chunk->start) > FLB_GELF_CHUNK_TMOUT) {
+                gelf_chunk_tbl_entry_free(tbl, &tbl->entries[i]);
+            }
+        }
+        else {
+            gelf_chunk_tbl_entry_free(tbl, &tbl->entries[i]);
+        }
+    }
+
+    if (tbl->size <= FLB_GELF_TBL_SIZE) {
+        return 0;
+    }
+
+    if ((tbl->used * 5) < tbl->size) {
+        tbl->resize_hits++;
+        if (tbl->resize_hits < 60) {
+            return 0;
+        }
+        int new_size = tbl->used * 3;
+        if (new_size < FLB_GELF_TBL_SIZE) {
+            new_size = FLB_GELF_TBL_SIZE;
+        }
+        gelf_chunk_tbl_resize(tbl, new_size);
+    } else {
+        tbl->resize_hits = 0;
+    }
+
+    return 0;
+}
+
+static int gelf_chunk_append (struct flb_gelf *ctx,
+                              uint8_t *buffer, size_t buffer_size)
+{
+    int i;
+    size_t len;
+    uint64_t msg_id;
+    uint8_t seq_num;
+    uint8_t seq_cnt;
+    size_t data_size;
+    void *data;
+    char *msg;
+    struct gelf_chunk_entry *entry;
+    struct gelf_chunk *chunk;
+
+    if (buffer_size <= FLB_GELF_HEADER_SIZE) {
+        flb_plg_error(ctx->ins, "chunked message is too short");
+        return -1;
+    }
+
+    seq_num = *(buffer + FLB_GELF_HEADER_SEQNUM);
+    seq_cnt = *(buffer + FLB_GELF_HEADER_SEQCNT);
+    msg_id = *(uint64_t *)(buffer + FLB_GELF_HEADER_ID);
+
+    if (msg_id == 0) {
+        flb_plg_error(ctx->ins, "chunked message with zero message id");
+        return -1;
+    }
+
+    if ((seq_num > 127) || (seq_cnt > 128)) {
+        flb_plg_error(ctx->ins, "chunked message with more than 128 segments");
+        return -1;
+    }
+
+    if (seq_num >= seq_cnt) {
+        flb_plg_error(ctx->ins, "chunked message with sequence number "
+                  "greater than total segments");
+        return -1;
+    }
+
+    data = buffer + FLB_GELF_HEADER_SIZE;
+    data_size = buffer_size - FLB_GELF_HEADER_SIZE;
+
+    entry = gelf_chunk_tbl_get(&ctx->chunks, msg_id, seq_cnt);
+    if (entry == NULL) {
+        flb_plg_error(ctx->ins, "cannot get a slot for the chunked message");
+        return -1;
+    }
+    chunk = entry->chunk;
+
+    if (chunk->sgmt_cnt != seq_cnt) {
+        flb_plg_error(ctx->ins, "chunked message with "
+                                "different number of segments");
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+
+    if (chunk->sgmt[seq_num].base) {
+        flb_plg_error(ctx->ins, "chunked message already recived");
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+
+    chunk->sgmt[seq_num].base = flb_malloc(data_size);
+    if (!chunk->sgmt[seq_num].base) {
+        flb_errno();
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+    chunk->sgmt[seq_num].len = data_size;
+    memcpy(chunk->sgmt[seq_num].base, data, data_size);
+
+    chunk->sgmt_found++;
+
+    if (chunk->sgmt_found != chunk->sgmt_cnt) {
+        /* we need more segments */
+        return 0;
+    }
+
+    len = 0;
+    for (i = 0; i < seq_cnt; i++) {
+        if (chunk->sgmt[i].len == 0) {
+             break;
+        }
+        len += chunk->sgmt[i].len;
+    }
+
+    if (i != seq_cnt) {
+        flb_plg_error(ctx->ins, "chunked message with missing segments");
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+
+    if (len == 0) {
+        flb_plg_error(ctx->ins, "chunked message with 0 total bytes");
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+
+    msg = flb_malloc(len);
+    if (!msg) {
+        flb_errno();
+        gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+        return -1;
+    }
+
+    len = 0;
+    for (i = 0; i < seq_cnt; i++) {
+        memcpy(msg + len, chunk->sgmt[i].base, chunk->sgmt[i].len);
+        len += chunk->sgmt[i].len;
+    }
+    gelf_chunk_tbl_entry_free(&ctx->chunks, entry);
+
+    gelf_udp_message(ctx, msg, len, true);
+
+    flb_free(msg);
+    return 0;
+}
+
+static int gelf_pack_message(struct flb_gelf *ctx,
+                             char *data, size_t data_size)
+{
+    int ret;
+    int records;
+    struct flb_time tm;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    char *packed_data = NULL;
+    size_t packed_size = 0;
+
+    flb_time_zero(&tm);
+    ret = flb_gelf_to_msgpack(data, data_size, &tm,
+                              &packed_data, &packed_size, ctx->strict);
+    if (ret < 0) {
+        flb_plg_error(ctx->ins, "failed to convert gelf message to msgpack");
+        return -1;
+    }
+
+    if ((tm.tm.tv_sec == 0) && (tm.tm.tv_nsec == 0)) {
+        flb_time_get(&tm);
+    }
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    flb_time_append_to_msgpack(&tm, &mp_pck, 0);
+    msgpack_sbuffer_write(&mp_sbuf, packed_data, packed_size);
+    records = flb_mp_count(mp_sbuf.data, sizeof(mp_sbuf.data));
+    flb_input_chunk_append_raw(ctx->ins, FLB_INPUT_LOGS, records, NULL, 0, mp_sbuf.data, mp_sbuf.size);                           
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    flb_free(packed_data);
+    return 0;
+}
+
+static int gelf_message_type(uint8_t *buffer, size_t buffer_size)
+{
+    if (buffer_size < 2) {
+        return FLB_GELF_TYPE_UNSUPPORTED;
+    }
+
+    if (buffer[0] == 0x78) {
+        uint16_t flg, cmf;
+        cmf = buffer[0];
+        flg = buffer[1];
+        if ((256 * cmf + flg) % 31 == 0) {
+            return FLB_GELF_TYPE_ZLIB;
+        }
+        else {
+            return FLB_GELF_TYPE_UNSUPPORTED;
+        }
+    }
+    else if (buffer[0] == 0x1f) {
+        if (buffer[1] == 0x8b) {
+            return FLB_GELF_TYPE_GZIP;
+        }
+        else {
+            return FLB_GELF_TYPE_UNSUPPORTED;
+        }
+    }
+    else if (buffer[0] == 0x1e) {
+        if (buffer[1] == 0x0f) {
+            return FLB_GELF_TYPE_CHUNKED;
+        }
+        else {
+            return FLB_GELF_TYPE_UNSUPPORTED;
+        }
+    }
+
+    return FLB_GELF_TYPE_UNCOMPRESSED;
+}
+
+static int gelf_udp_message(struct flb_gelf *ctx, char *buffer_data,
+                            size_t buffer_len, bool chunked)
+{
+    int ret = -1;
+    int type;
+    void *out_msg = NULL;
+    size_t out_msg_size = 0;
+
+    type = gelf_message_type((uint8_t *)buffer_data, buffer_len);
+
+    if (type == FLB_GELF_TYPE_GZIP) {
+        ret = flb_gzip_uncompress((void *)buffer_data, buffer_len,
+                                  &out_msg, &out_msg_size);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "failed to uncompress gzip message");
+            return -1;
+        }
+        if (out_msg != NULL) {
+            gelf_pack_message(ctx, out_msg, out_msg_size);
+            flb_free(out_msg);
+        }
+    }
+    else if (type == FLB_GELF_TYPE_CHUNKED) {
+        if (chunked) {
+            flb_plg_error(ctx->ins, "nested chunked message");
+            return -1;
+        }
+        gelf_chunk_append (ctx, (uint8_t *)buffer_data, buffer_len);
+    }
+    else if (type == FLB_GELF_TYPE_ZLIB) {
+        ret = flb_zlib_uncompress((void *)buffer_data, buffer_len,
+                                  &out_msg, &out_msg_size);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "failed to uncompress lzib message");
+            return -1;
+        }
+        if (out_msg != NULL) {
+            gelf_pack_message(ctx, out_msg, out_msg_size);
+            flb_free(out_msg);
+        }
+    }
+    else if (type == FLB_GELF_TYPE_UNCOMPRESSED) {
+        gelf_pack_message(ctx, buffer_data, buffer_len);
+    }
+    else {
+        flb_plg_error(ctx->ins, "unsupported message type");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int gelf_tcp_message(struct gelf_tcp_conn *conn)
+{
+    size_t len;
+    char *zero;
+    struct flb_gelf *ctx = conn->ctx;
+
+    while (1) {
+        zero = memchr(conn->buf_data, 0, conn->buf_len);
+        if (!zero) {
+           break;
+        }
+        len = zero - conn->buf_data + 1;
+
+        gelf_pack_message(ctx, conn->buf_data, len -1);
+
+        memmove(conn->buf_data, conn->buf_data + len, conn->buf_len - len);
+        conn->buf_len -= len;
+        if (!conn->buf_len) {
+            break;
+        }
+    }
+    return 0;
+}
+
+static int gelf_tcp_conn_del(struct gelf_tcp_conn *conn)
+{
+    /* Unregister the file descriptior from the event-loop */
+    mk_event_del(conn->ctx->evl, &conn->event);
+
+    /* Release resources */
+    mk_list_del(&conn->_head);
+    close(conn->fd);
+    flb_free(conn->buf_data);
+    flb_free(conn);
+
+    return 0;
+}
+
+static int gelf_tcp_conn_event(void *data)
+{
+    int ret;
+    int bytes;
+    int available;
+    size_t size;
+    char *tmp;
+    struct mk_event *event;
+    struct gelf_tcp_conn *conn = data;
+    struct flb_gelf *ctx = conn->ctx;
+
+    event = &conn->event;
+    if (event->mask & MK_EVENT_READ) {
+        available = (conn->buf_size - conn->buf_len) - 1;
+        if (available < 1) {
+            if (conn->buf_size + ctx->buffer_chunk_size >
+                ctx->buffer_max_size) {
+                flb_plg_debug(ctx->ins,
+                              "fd=%i incoming data exceed limit (%zd bytes)",
+                              event->fd, (ctx->buffer_max_size));
+                gelf_tcp_conn_del(conn);
+                return -1;
+            }
+
+            size = conn->buf_size + ctx->buffer_chunk_size;
+            tmp = flb_realloc(conn->buf_data, size);
+            if (!tmp) {
+                gelf_tcp_conn_del(conn);
+                flb_errno();
+                return -1;
+            }
+            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %zd -> %zd",
+                          event->fd, conn->buf_size, size);
+
+            conn->buf_data = tmp;
+            conn->buf_size = size;
+            available = (conn->buf_size - conn->buf_len) - 1;
+        }
+
+        bytes = read(conn->fd, conn->buf_data + conn->buf_len, available);
+        if (bytes > 0) {
+            flb_plg_trace(ctx->ins, "read()=%i pre_len=%zu now_len=%zu",
+                          bytes, conn->buf_len, conn->buf_len + bytes);
+            conn->buf_len += bytes;
+            ret = gelf_tcp_message(conn);
+            if (ret == -1) {
+                return -1;
+            }
+            return bytes;
+        }
+        else {
+            flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
+            gelf_tcp_conn_del(conn);
+            return -1;
+        }
+    }
+
+    if (event->mask & MK_EVENT_CLOSE) {
+        flb_plg_trace(ctx->ins, "fd=%i hangup", event->fd);
+        gelf_tcp_conn_del(conn);
+        return -1;
+    }
+    return 0;
+}
+
+static struct gelf_tcp_conn *gelf_tcp_conn_add(int fd, struct flb_gelf *ctx)
+{
+    int ret;
+    struct gelf_tcp_conn *conn;
+    struct mk_event *event;
+
+    conn = flb_calloc(1, sizeof(struct gelf_tcp_conn));
+    if (!conn) {
+        return NULL;
+    }
+
+    /* Set data for the event-loop */
+    event = &conn->event;
+    MK_EVENT_NEW(event);
+    event->fd      = fd;
+    event->type    = FLB_ENGINE_EV_CUSTOM;
+    event->handler = gelf_tcp_conn_event;
+
+    /* Connection info */
+    conn->fd         = fd;
+    conn->ctx        = ctx;
+    conn->ins        = ctx->ins;
+    conn->buf_len    = 0;
+    conn->buf_parsed = 0;
+
+    /* Allocate read buffer */
+    conn->buf_data = flb_calloc(1, ctx->buffer_chunk_size);
+    if (!conn->buf_data) {
+        flb_errno();
+        close(fd);
+        flb_free(conn);
+        return NULL;
+    }
+    conn->buf_size = ctx->buffer_chunk_size;
+
+    /* Register instance into the event loop */
+    ret = mk_event_add(ctx->evl, fd, FLB_ENGINE_EV_CUSTOM, MK_EVENT_READ, conn);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not register new connection");
+        close(fd);
+        flb_free(conn->buf_data);
+        flb_free(conn);
+        return NULL;
+    }
+
+    mk_list_add(&conn->_head, &ctx->connections);
+
+    return conn;
+}
+
+static int gelf_tcp_conn_exit(struct flb_gelf *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct gelf_tcp_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct gelf_tcp_conn, _head);
+        gelf_tcp_conn_del(conn);
+    }
+
+    return 0;
+}
+
+static int gelf_server_create(struct flb_gelf *ctx)
+{
+    if (ctx->mode == FLB_GELF_UDP) {
+        ctx->buffer_data = flb_calloc(1, ctx->buffer_chunk_size);
+        if (!ctx->buffer_data) {
+            flb_errno();
+            return -1;
+        }
+        ctx->buffer_size = ctx->buffer_chunk_size;
+        flb_info("[in_gelf] UDP buffer size set to %lu bytes",
+                 ctx->buffer_size);
+    }
+
+    if (ctx->mode == FLB_GELF_TCP) {
+        ctx->server_fd = flb_net_server(ctx->port, ctx->listen);
+    }
+    else {
+        ctx->server_fd = flb_net_server_udp(ctx->port, ctx->listen);
+    }
+
+    if (ctx->server_fd > 0) {
+        flb_info("[in_gelf] %s server binding %s:%s",
+                 ((ctx->mode == FLB_GELF_TCP) ? "TCP" : "UDP"),
+                 ctx->listen, ctx->port);
+    }
+    else {
+        flb_plg_error(ctx->ins, "could not bind address %s:%s. Aborting",
+                  ctx->listen, ctx->port);
+        return -1;
+    }
+
+    flb_net_socket_nonblocking(ctx->server_fd);
+
+    return 0;
+}
+
+struct flb_gelf *gelf_conf_create(struct flb_input_instance *ins,
+                                  struct flb_config *config)
+{
+    const char *tmp;
+    struct flb_gelf *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct flb_gelf));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->evl = config->evl;
+    ctx->ins = ins;
+    ctx->buffer_data = NULL;
+    mk_list_init(&ctx->connections);
+
+    tmp = flb_input_get_property("mode", ins);
+    if (tmp) {
+        if (strcasecmp(tmp, "tcp") == 0) {
+            ctx->mode = FLB_GELF_TCP;
+        }
+        else if (strcasecmp(tmp, "udp") == 0) {
+            ctx->mode = FLB_GELF_UDP;
+        }
+        else {
+            flb_plg_error(ctx->ins, "Unknown gelf mode %s", tmp);
+            flb_free(ctx);
+            return NULL;
+        }
+    }
+    else {
+        ctx->mode = FLB_GELF_UDP;
+    }
+
+    /* Listen interface (if not set, defaults to 0.0.0.0:12201) */
+    flb_input_net_default_listener("0.0.0.0", 12201, ins);
+    ctx->listen = ins->host.listen;
+    snprintf(ctx->port, sizeof(ctx->port) - 1, "%d", ins->host.port);
+    ctx->port[sizeof(ctx->port)-1] = '\0';
+
+    /* Buffer Chunk Size */
+    tmp = flb_input_get_property("buffer_chunk_size", ins);
+    if (!tmp) {
+        ctx->buffer_chunk_size = FLB_GELF_CHUNK;
+    }
+    else {
+        ctx->buffer_chunk_size = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* Buffer Max Size */
+    tmp = flb_input_get_property("buffer_max_size", ins);
+    if (!tmp) {
+        ctx->buffer_max_size = ctx->buffer_chunk_size;
+    }
+    else {
+        ctx->buffer_max_size  = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* Strict parser */
+    tmp = flb_input_get_property("strict_parser", ins);
+    if (tmp) {
+        ctx->strict = flb_utils_bool(tmp);
+    }
+    else {
+        ctx->strict = FLB_TRUE;
+    }
+
+    return ctx;
+}
+
+int gelf_conf_destroy(struct flb_gelf *ctx)
+{
+    if (ctx->buffer_data) {
+        flb_free(ctx->buffer_data);
+        ctx->buffer_data = NULL;
+    }
+
+    close(ctx->server_fd);
+
+    flb_free(ctx);
+
+    return 0;
+}
+
+static int in_gelf_collect_tcp(struct flb_input_instance *i_ins,
+                               struct flb_config *config,
+                               void *in_context)
+{
+    int fd;
+    struct flb_gelf *ctx = in_context;
+    struct gelf_tcp_conn *conn;
+    (void) i_ins;
+
+    fd = flb_net_accept(ctx->server_fd);
+    if (fd == -1) {
+        flb_plg_error(ctx->ins, "could not accept new connection");
+        return -1;
+    }
+
+    flb_plg_debug(ctx->ins, "new connection arrived FD=%i", fd);
+    conn = gelf_tcp_conn_add(fd, ctx);
+    if (!conn) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int in_gelf_collect_udp(struct flb_input_instance *i_ins,
+                               struct flb_config *config,
+                               void *in_context)
+{
+    int bytes;
+    struct flb_gelf *ctx = in_context;
+    (void) i_ins;
+
+    bytes = recvfrom(ctx->server_fd,
+                     ctx->buffer_data, ctx->buffer_size, 0,
+                     NULL, NULL);
+    if (bytes > 0) {
+        ctx->buffer_len = bytes;
+        gelf_udp_message(ctx, ctx->buffer_data, ctx->buffer_len, false);
+    }
+    else {
+        flb_errno();
+    }
+    ctx->buffer_len = 0;
+
+    return 0;
+}
+
+static int in_gelf_init(struct flb_input_instance *in,
+                        struct flb_config *config, void *data)
+{
+    int ret = 0;
+    struct flb_gelf *ctx;
+
+    ctx = gelf_conf_create(in, config);
+    if (!ctx) {
+        flb_plg_error(in, "could not initialize plugin");
+        return -1;
+    }
+
+    ret = gelf_server_create(ctx);
+    if (ret == -1) {
+        gelf_conf_destroy(ctx);
+        return -1;
+    }
+
+    flb_input_set_context(in, ctx);
+
+    if (ctx->mode == FLB_GELF_TCP) {
+        ret = flb_input_set_collector_socket(in,
+                                             in_gelf_collect_tcp,
+                                             ctx->server_fd,
+                                             config);
+    }
+    else {
+        ret = flb_input_set_collector_socket(in,
+                                             in_gelf_collect_udp,
+                                             ctx->server_fd,
+                                             config);
+        if (ret != -1) {
+            ret = flb_input_set_collector_time(in,
+                                               in_gelf_purge_udp,
+                                               1, 0,
+                                               config);
+        }
+        if (ret != -1) {
+            ret = gelf_chunk_tbl_alloc(&ctx->chunks);
+        }
+    }
+
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "Could not set collector");
+        gelf_conf_destroy(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int in_gelf_exit(void *data, struct flb_config *config)
+{
+    struct flb_gelf *ctx = data;
+    (void) config;
+
+    if (ctx->mode == FLB_GELF_TCP) {
+        gelf_tcp_conn_exit(ctx);
+    }
+    else {
+        gelf_chunk_tbl_free(&ctx->chunks);
+    }
+
+    gelf_conf_destroy(ctx);
+
+    return 0;
+}
+
+struct flb_input_plugin in_gelf_plugin = {
+    .name         = "gelf",
+    .description  = "gelf",
+    .cb_init      = in_gelf_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = NULL,
+    .cb_flush_buf = NULL,
+    .cb_exit      = in_gelf_exit,
+    .flags        = FLB_INPUT_NET
+};

--- a/gelf.h
+++ b/gelf.h
@@ -1,0 +1,118 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_GELF_CONN_H
+#define FLB_IN_GELF_CONN_H
+
+#define FLB_GELF_TCP   1
+#define FLB_GELF_UDP   2
+
+#define FLB_GELF_CHUNK        65536
+#define FLB_GELF_MAX_CHUNKS   128
+#define FLB_GELF_TBL_SIZE     64
+
+#define FLB_GELF_CHUNK_TMOUT  5
+
+#define FLB_GELF_TYPE_UNSUPPORTED    0
+#define FLB_GELF_TYPE_ZLIB           1
+#define FLB_GELF_TYPE_GZIP           2
+#define FLB_GELF_TYPE_CHUNKED        3
+#define FLB_GELF_TYPE_UNCOMPRESSED   4
+
+#define FLB_GELF_HEADER_ID     2
+#define FLB_GELF_HEADER_SEQNUM 10
+#define FLB_GELF_HEADER_SEQCNT 11
+#define FLB_GELF_HEADER_SIZE   12
+
+struct gelf_chunk_sgmt {
+    void  *base;
+    size_t len;
+};
+
+struct gelf_chunk {
+    time_t start;
+    size_t sgmt_found;
+    size_t sgmt_cnt;
+    struct gelf_chunk_sgmt sgmt[];
+};
+
+struct gelf_chunk_entry {
+    uint64_t hash;
+    uint64_t dib;
+    uint64_t msg_id;
+    struct gelf_chunk *chunk;
+};
+
+struct gelf_chunk_tbl {
+    size_t size;
+    size_t used;
+    size_t resize_hits;
+    struct gelf_chunk_entry *entries;
+};
+
+/* Context / Config*/
+struct flb_gelf {
+    /* Listening mode: tcp or udp */
+    int mode;
+
+    /* Network mode */
+    char *listen;
+    char port[24];
+
+    /* strict parsing messages */
+    bool strict;
+
+    /* UDP/TCP */
+    int server_fd;
+    
+    /* UDP buffer, data length and buffer size */
+    char *buffer_data;
+    size_t buffer_len;
+    size_t buffer_size;
+
+    struct gelf_chunk_tbl chunks;
+
+    /* Buffers setup */
+    size_t buffer_max_size;
+    size_t buffer_chunk_size;
+
+    /* List for connections and event loop */
+    struct mk_list connections;
+    struct mk_event_loop *evl;
+    struct flb_input_instance *ins;
+};
+
+struct gelf_tcp_conn {
+    struct mk_event event;           /* Built-in event data for mk_events */
+    int fd;                          /* Socket file descriptor            */
+    int status;                      /* Connection status                 */
+
+    /* Buffer */
+    char *buf_data;                  /* Buffer data                       */
+    size_t buf_size;                 /* Buffer size                       */
+    size_t buf_len;                  /* Buffer length                     */
+    size_t buf_parsed;               /* Parsed buffer (offset)            */
+    struct flb_input_instance *ins;  /* Parent plugin instance            */
+    struct flb_gelf *ctx;            /* Plugin configuration context      */
+
+    struct mk_list _head;
+};
+
+#endif


### PR DESCRIPTION
This is a rebased version of [PR-4156](https://github.com/fluent/fluent-bit/pull/4156) with a fixed compile issue.
> New input plugin for ingest GELF messages from TCP and UDP. In UDP support for gzip and zlib compressed messages, and chunked messages.
> 
> Enter `[N/A]` in the box, if an item is not applicable to your change.
> 
> **Testing** Before we can approve your change; please submit the following in a comment:
> 
> * [x]  Example configuration file for the change
> * [N/A] Debug log output from testing the change
> 
> * [x]  Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
> 
> **Documentation**
> 
> * [x]  Documentation required for this feature
> 
> Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

