### PR TITLE
in_calyptia_fleet: fixes found when connecting to production.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -200,6 +200,9 @@ static int is_new_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
     int ret = FLB_FALSE;
 
 
+    if (cfg->conf_path_file == NULL) {
+        return FLB_FALSE;
+    }
     cfgnewname = new_fleet_config_filename(ctx);
     if (strcmp(cfgnewname, cfg->conf_path_file) == 0) {
         ret = FLB_TRUE;
@@ -216,6 +219,9 @@ static int is_cur_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
     int ret = FLB_FALSE;
 
 
+    if (cfg->conf_path_file == NULL) {
+        return FLB_FALSE;
+    }
     cfgcurname = cur_fleet_config_filename(ctx);
     if (strcmp(cfgcurname, cfg->conf_path_file) == 0) {
         ret = FLB_TRUE;
@@ -228,6 +234,9 @@ static int is_cur_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
 
 static int is_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
 {
+    if (cfg->conf_path_file == NULL) {
+        return FLB_FALSE;
+    }
     return is_new_fleet_config(ctx, cfg) || is_cur_fleet_config(ctx, cfg);
 }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -428,12 +428,14 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
                        "    fleet_id      %s\n"
                        "    Host          %s\n"
                        "    Port          %d\n"
-                       "    TLS           %d\n",
+                       "    Config_Dir    %s\n"
+                       "    TLS           %s\n",
                        ctx->api_key,
                        ctx->fleet_id,
                        ctx->ins->host.name,
                        ctx->ins->host.port,
-                       ctx->ins->tls_verify
+                       ctx->config_dir,
+                       (ctx->ins->tls_verify ? "On" : "Off")
         );
         fwrite(header, strlen(header), 1, cfgfp);
         flb_sds_destroy(header);

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -363,19 +363,25 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
 
     u_conn = flb_upstream_conn_get(ctx->u);
     if (!u_conn) {
+        flb_plg_error(ctx->ins, "could not get an upstream connection to %s:%u",
+                      ctx->ins->host.name, ctx->ins->host.port);
         goto conn_error;
     }
 
     client = flb_http_client(u_conn, FLB_HTTP_GET, ctx->fleet_url,
-                             NULL, 0, ctx->ins->host.name, ctx->ins->host.port, NULL, 0);
+                             NULL, 0, 
+                             ctx->ins->host.name, ctx->ins->host.port, NULL, 0);
     if (!client) {
         flb_plg_error(ins, "unable to create http client");
         goto client_error;
     }
 
+    flb_http_buffer_size(client, 8192);
+
     flb_http_add_header(client,
                         CALYPTIA_H_PROJECT, sizeof(CALYPTIA_H_PROJECT) - 1,
                         ctx->api_key, flb_sds_len(ctx->api_key));
+
     ret = flb_http_do(client, &b_sent);
     if (ret != 0) {
         flb_plg_error(ins, "http do error");


### PR DESCRIPTION
# Summary

Fix a few minor issues for Calyptia fleet management:

- Implement configuration rollback:
  - Check the syntax of the configuration file before loading it.
  - Use cur.ini upon load, rename old.ini back to cur.ini when new.ini
    fails to validate.
- Make the `Last-Modified` header lookup case insensitive.
- Fix Fleet configuration section generated in the new configuration file:
  - Use valid values for `TLS`.
  - Add Missing `Config_Dir` setting.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
