### PR TITLE
tests: runtime: filter_kubernetes: fix warnings

### DIFF
--- a/tests/runtime/filter_kubernetes.c
+++ b/tests/runtime/filter_kubernetes.c
@@ -936,13 +936,13 @@ static void flb_test_systemd_logs()
         sd_journal *journal;
         r = sd_journal_open(&journal, 0);
         if (r < 0) {
-            flb_error("Skip test: journal error: ", strerror(-r));
+            flb_error("Skip test: journal error: %s", strerror(-r));
             return;
         }
 
         r = sd_journal_get_fd(journal);
         if (r < 0) {
-            flb_error("Skip test: journal fd error: ", strerror(-r));
+            flb_error("Skip test: journal fd error: %s", strerror(-r));
             sd_journal_close(journal);
             return;
         }
@@ -955,28 +955,28 @@ static void flb_test_systemd_logs()
          */
         if (flb_test_systemd_send() < 0) {
 
-            flb_error("Skip test: journal send error: ", strerror(-r));
+            flb_error("Skip test: journal send error: %s", strerror(-r));
             sd_journal_close(journal);
             return;
         }
 
         r = sd_journal_previous(journal);
         if (r < 0) {
-            flb_error("Skip test: journal previous error: ", strerror(-r));
+            flb_error("Skip test: journal previous error: %s", strerror(-r));
             sd_journal_close(journal);
             return;
         }
 
         r = sd_journal_next(journal);
         if (r < 0) {
-            flb_error("Skip test: journal next error: ", strerror(-r));
+            flb_error("Skip test: journal next error: %s", strerror(-r));
             sd_journal_close(journal);
             return;
         }
 
         r = sd_journal_wait(journal, 2000);
         if (r < 0) {
-            flb_error("Skip test: journal wait error: ", strerror(-r));
+            flb_error("Skip test: journal wait error: %s", strerror(-r));
             sd_journal_close(journal);
             return;
         }


### PR DESCRIPTION
This patch is to fix following warnings.

```
Consolidate compiler generated dependencies of target flb-rt-filter_kubernetes
[ 81%] Building C object tests/runtime/CMakeFiles/flb-rt-filter_kubernetes.dir/filter_kubernetes.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_config.h:27,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_utils.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit.h:37,
                 from /home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:4:
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c: In function ‘flb_test_systemd_logs’:
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:939:23: warning: too many arguments for format [-Wformat-extra-args]
  939 |             flb_error("Skip test: journal error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:945:23: warning: too many arguments for format [-Wformat-extra-args]
  945 |             flb_error("Skip test: journal fd error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:958:23: warning: too many arguments for format [-Wformat-extra-args]
  958 |             flb_error("Skip test: journal send error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:965:23: warning: too many arguments for format [-Wformat-extra-args]
  965 |             flb_error("Skip test: journal previous error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:972:23: warning: too many arguments for format [-Wformat-extra-args]
  972 |             flb_error("Skip test: journal next error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/tests/runtime/filter_kubernetes.c:979:23: warning: too many arguments for format [-Wformat-extra-args]
  979 |             flb_error("Skip test: journal wait error: ", strerror(-r));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
[ 81%] Linking C executable ../../bin/flb-rt-filter_kubernetes
[ 81%] Built target flb-rt-filter_kubernetes
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_kubernetes 
==12918== Memcheck, a memory error detector
==12918== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12918== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==12918== Command: bin/flb-rt-filter_kubernetes
==12918== 
Test kube_core_base...                          [ OK ]

(snip)

Test kube_systemd_logs...                       [ OK ]
SUCCESS: All unit tests have passed.
==12918== 
==12918== HEAP SUMMARY:
==12918==     in use at exit: 0 bytes in 0 blocks
==12918==   total heap usage: 275,453 allocs, 275,453 frees, 102,853,131 bytes allocated
==12918== 
==12918== All heap blocks were freed -- no leaks are possible
==12918== 
==12918== For lists of detected and suppressed errors, rerun with: -s
==12918== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
