### PR TITLE
out_opensearch: remove unused variables

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -284,8 +284,6 @@ static int opensearch_format(struct flb_config *config,
     int write_op_upsert = FLB_FALSE;
     flb_sds_t ra_index = NULL;
     size_t s = 0;
-    size_t off = 0;
-    char *p;
     char *index = NULL;
     char logstash_index[256];
     char time_formatted[256];


### PR DESCRIPTION
This patch is to address following warnings.

```
[ 49%] Building C object plugins/out_opensearch/CMakeFiles/flb-plugin-out_opensearch.dir/opensearch.c.o
/home/taka/git/fluent-bit/plugins/out_opensearch/opensearch.c: In function ‘opensearch_format’:
/home/taka/git/fluent-bit/plugins/out_opensearch/opensearch.c:288:11: warning: unused variable ‘p’ [-Wunused-variable]
  288 |     char *p;
      |           ^
/home/taka/git/fluent-bit/plugins/out_opensearch/opensearch.c:287:12: warning: unused variable ‘off’ [-Wunused-variable]
  287 |     size_t off = 0;
      |            ^~~
[ 49%] Building C object plugins/out_opensearch/CMakeFiles/flb-plugin-out_opensearch.dir/__/__/lib/lwrb/lwrb/src/lwrb/lwrb.c.o
[ 49%] Linking C static library ../../library/libflb-plugin-out_opensearch.a
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
