### PR TITLE
bin: config: reload: Enable hot reloading via config file

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -335,6 +335,8 @@ enum conf_type {
 #define FLB_CONF_STR_ENABLE_CHUNK_TRACE      "Enable_Chunk_Trace"
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
+#define FLB_CONF_STR_ENABLE_HOT_RELOAD "Enable_Hot_Reload"
+
 /* DNS */
 #define FLB_CONF_DNS_MODE              "dns.mode"
 #define FLB_CONF_DNS_RESOLVER          "dns.resolver"

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -335,7 +335,7 @@ enum conf_type {
 #define FLB_CONF_STR_ENABLE_CHUNK_TRACE      "Enable_Chunk_Trace"
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
-#define FLB_CONF_STR_ENABLE_HOT_RELOAD "Enable_Hot_Reload"
+#define FLB_CONF_STR_HOT_RELOAD        "Hot_Reload"
 
 /* DNS */
 #define FLB_CONF_DNS_MODE              "dns.mode"

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -173,6 +173,10 @@ struct flb_service_config service_configs[] = {
      offsetof(struct flb_config, enable_chunk_trace)},
 #endif
 
+    {FLB_CONF_STR_ENABLE_HOT_RELOAD,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, enable_hot_reload)},
+
     {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
 };
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -173,7 +173,7 @@ struct flb_service_config service_configs[] = {
      offsetof(struct flb_config, enable_chunk_trace)},
 #endif
 
-    {FLB_CONF_STR_ENABLE_HOT_RELOAD,
+    {FLB_CONF_STR_HOT_RELOAD,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, enable_hot_reload)},
 

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -422,8 +422,6 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     /* Inherit verbose from the old ctx instance */
     verbose = ctx->config->verbose;
     new_config->verbose = verbose;
-    enable_reloading = ctx->config->enable_hot_reload;
-    new_config->enable_hot_reload = enable_reloading;
 
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     /* Inherit stream processor definitions from command line */

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -971,7 +971,7 @@ int flb_main(int argc, char **argv)
             config->support_mode = FLB_TRUE;
             break;
         case 'Y':
-            flb_cf_section_property_add(cf_opts, service->properties, FLB_CONF_STR_ENABLE_HOT_RELOAD, 0, "on", 0);
+            flb_cf_section_property_add(cf_opts, service->properties, FLB_CONF_STR_HOT_RELOAD, 0, "on", 0);
             break;
 #ifdef FLB_HAVE_CHUNK_TRACE
         case 'Z':

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -971,7 +971,7 @@ int flb_main(int argc, char **argv)
             config->support_mode = FLB_TRUE;
             break;
         case 'Y':
-            config->enable_hot_reload = FLB_TRUE;
+            flb_cf_section_property_add(cf_opts, service->properties, FLB_CONF_STR_ENABLE_HOT_RELOAD, 0, "on", 0);
             break;
 #ifdef FLB_HAVE_CHUNK_TRACE
         case 'Z':


### PR DESCRIPTION
<!-- Provide summary of changes -->
The previous hot reload PR does not handle for enabling hot reloading feature with configuration file. 
This PR should fix this specification mistake.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
This service configuration option should be used as:

```conf
[SERVICE]
    Enable_Hot_Reload On
    # .. other stuffs
```
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==547697== 
==547697== HEAP SUMMARY:
==547697==     in use at exit: 0 bytes in 0 blocks
==547697==   total heap usage: 52,235 allocs, 52,235 frees, 15,953,425 bytes allocated
==547697== 
==547697== All heap blocks were freed -- no leaks are possible
==547697== 
==547697== For lists of detected and suppressed errors, rerun with: -s
==547697== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
