### PR TITLE
plugins: exec: exit fluent-bit after oneshot and propagate exit code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ include(ExternalProject)
 include(cmake/FindJournald.cmake)
 include(cmake/FindMonkey.cmake)
 include(cmake/macros.cmake)
+include(cmake/platform_feature_checks.cmake)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 

--- a/cmake/platform_feature_checks.cmake
+++ b/cmake/platform_feature_checks.cmake
@@ -1,0 +1,8 @@
+# Feature tests for various platform and compiler capabilities,
+# system headers, etc.
+
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE("sys/wait.h" FLB_HAVE_SYS_WAIT_H)
+if (FLB_HAVE_SYS_WAIT_H)
+    FLB_DEFINITION(FLB_HAVE_SYS_WAIT_H)
+endif()

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "in_exec.h"
 
@@ -37,6 +38,8 @@ static int in_exec_collect(struct flb_input_instance *ins,
                            struct flb_config *config, void *in_context)
 {
     int ret = -1;
+    int cmdret;
+    int flb_exit_code;
     uint64_t val;
     size_t str_len = 0;
     FILE *cmdp = NULL;
@@ -165,7 +168,72 @@ static int in_exec_collect(struct flb_input_instance *ins,
 
  collect_end:
     if(cmdp != NULL){
-        pclose(cmdp);
+        /*
+         * If we're propagating the child exit code to the fluent-bit exit code
+         * in one-shot mode, popen() will have invoked our child command via
+         * its own shell, so unless the shell itself exited on a signal the
+         * translation is already done for us.
+         * For references on exit code handling in wrappers see
+         * https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+         * and
+         * https://skarnet.org/software/execline/exitcodes.html
+         *
+         */
+        cmdret = pclose(cmdp);
+        if (cmdret == -1) {
+            flb_errno();
+            flb_plg_debug(ctx->ins,
+                    "unexpected error while waiting for exit of command %s ",
+                    ctx->cmd);
+            /*
+             * The exit code of the shell run by popen() could not be
+             * determined; exit with 128, which is not a code that could be
+             * returned through a shell by a real child command.
+             */
+            flb_exit_code = 128;
+        } else if (WIFEXITED(cmdret)) {
+            flb_plg_debug(ctx->ins, "command %s exited with code %d", ctx->cmd, WEXITSTATUS(cmdret));
+            /*
+             * Propagate shell exit code, which may encode a normal or signal
+             * exit for the real child process, directly to the caller. This
+             * could be greater than 127 if the shell encoded a signal exit
+             * status from the child process into its own return code.
+             */
+            flb_exit_code = WEXITSTATUS(cmdret);
+        } else if (WIFSIGNALED(cmdret)) {
+            flb_plg_debug(ctx->ins, "command %s exited with signal %d", ctx->cmd, WTERMSIG(cmdret));
+            /*
+             * Follow the shell convention of returning 128+signo for signal
+             * exits. The consumer of fluent-bit's exit code will be unable to
+             * differentiate between the shell exiting on a signal and the
+             * process called by the shell exiting on a signal.
+             */
+            flb_exit_code = 128 + WTERMSIG(cmdret);
+        } else {
+            flb_plg_debug(ctx->ins, "command %s exited with unknown status",
+                    ctx->cmd);
+            flb_exit_code = 128;
+        }
+
+        /*
+         * In one-shot mode, exit fluent-bit once the child process terminates.
+         */
+        if (ctx->exit_after_oneshot == FLB_TRUE) {
+            /*
+             * propagate the child process exit code as the fluent-bit exit
+             * code so fluent-bit with the exec plugin can be used as a
+             * command wrapper.
+             */
+            if (ctx->propagate_exit_code == FLB_TRUE) {
+                config->exit_status_code = flb_exit_code;
+            }
+            flb_plg_debug(ctx->ins,
+                    "one-shot command exited, terminating fluent-bit");
+            flb_engine_exit(config);
+        } else {
+            flb_plg_debug(ctx->ins,
+                    "one-shot command exited but exit_after_oneshot not set");
+        }
     }
 
     return ret;
@@ -210,6 +278,23 @@ static int in_exec_config_read(struct flb_exec *ctx,
         /* Illegal settings. Override them. */
         ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
         ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
+    }
+
+    /*
+     * propagate_exit_code is not being forced to imply exit_after_oneshot in
+     * case somebody in future wishes to make the exec plugin exit on nonzero
+     * exit codes for normal repeating commands.
+     */
+    if (ctx->propagate_exit_code && !ctx->exit_after_oneshot) {
+        flb_plg_error(in,
+                "propagate_exit_code=True option makes no sense without "
+                "exit_after_oneshot=True");
+        return -1;
+    }
+
+    if (ctx->exit_after_oneshot && !ctx->oneshot) {
+        flb_plg_debug(in, "exit_after_oneshot implies oneshot mode, enabling");
+        ctx->oneshot = FLB_TRUE;
     }
 
     if (ctx->oneshot) {
@@ -377,6 +462,17 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_BOOL, "oneshot", "false",
       0, FLB_TRUE, offsetof(struct flb_exec, oneshot),
       "execute the command only once"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "exit_after_oneshot", "false",
+      0, FLB_TRUE, offsetof(struct flb_exec, exit_after_oneshot),
+      "exit fluent-bit after the command terminates in one-shot mode"
+    },
+    {
+      FLB_CONFIG_MAP_BOOL, "propagate_exit_code", "false",
+      0, FLB_TRUE, offsetof(struct flb_exec, propagate_exit_code),
+      "propagate oneshot exit command fluent-bit exit code using "
+      "shell exit code translation conventions"
     },
     /* EOF */
     {0}

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -45,6 +45,8 @@ struct flb_exec {
     int interval_sec;
     int interval_nsec;
     struct flb_log_event_encoder log_encoder;
+    int exit_after_oneshot;
+    int propagate_exit_code;
 };
 
 #endif /* FLB_IN_EXEC_H */

--- a/plugins/in_exec/in_exec_win32_compat.h
+++ b/plugins/in_exec/in_exec_win32_compat.h
@@ -1,0 +1,94 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef FLB_IN_EXEC_WIN32_COMPAT_H
+#define FLB_IN_EXEC_WIN32_COMPAT_H
+
+#include <stdio.h>
+#include <fluent-bit/flb_info.h>
+
+/*
+ * Work around lack of sys/wait.h and POSIX exit status macros from waitpid()
+ * in win32's _popen() and _pclose() implementation, since fluent-bit uses
+ * these in the in_exec plugin.
+ *
+ * On POSIX-like OSes this'll just use the standard macros with a name alias.
+ *
+ * On windows, where the concept of a signal exit does not exist, it defines
+ * dummy macros to indicate that the process exited normally and extract the
+ * exit code.
+ *
+ * These macros are for use with flb_pclose() only. Do not use them with
+ * other APIs that may differ in return value semantics.
+ */
+#ifdef FLB_HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#define FLB_WIFEXITED(status) WIFEXITED((status))
+#define FLB_WEXITSTATUS(status) WEXITSTATUS((status))
+#define FLB_WIFSIGNALED(status) WIFSIGNALED((status))
+#define FLB_WTERMSIG(status) WTERMSIG((status))
+#else
+#define FLB_WIFEXITED(status) (1)
+#define FLB_WEXITSTATUS(status) ((status) & 0x00ff)
+#define FLB_WIFSIGNALED(status) (0)
+#define FLB_WTERMSIG(status) (-1)
+#endif
+
+/*
+ * Because Windows has to do everything differently, call _popen() and
+ * _pclose() instead of the POSIX popen() and pclose() functions.
+ *
+ * flb_pclose() has different return value semantics on Windows vs non-windows
+ * targets because it propagates the pclose() or _pclose() return value
+ * directly. You MUST use the FLB_WIFEXITED(), FLB_WEXITSTATUS(),
+ * FLB_WIFSIGNALED() and FLB_WTERMSIG() macros to consume the return value,
+ * rather than the underlying POSIX macros or manual bit-shifts.
+ */
+#if !defined(FLB_SYSTEM_WINDOWS)
+static inline FILE* flb_popen(const char *command, const char *type) {
+    return popen(command, type);
+}
+static inline int flb_pclose(FILE *stream) {
+    return pclose(stream);
+}
+#define FLB_PCLOSE pclose
+#else
+static inline FILE* flb_popen(const char *command, const char *type) {
+    return _popen(command, type);
+}
+/*
+ * flb_pclose() has the same return value on Windows as win32 _pclose(), rather
+ * than posix pclose(). The process exit code is not bit-shifted to the high
+ * byte.
+ *
+ * The MSVC docs for _pclose() at
+ * https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/pclose?view=msvc-170
+ * are misleading; they say that "The format of the return value is the same as
+ * for _cwait, except the low-order and high-order bytes are swapped." But
+ * _cwait isn't documented as having any meaningful return on success, the
+ * process exit code is meant to be in  its "termstat" out parameter per
+ * https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/cwait?view=msvc-170
+ * The return code of _pclose() actually appears to be the process exit code
+ * without the bit-shift that waitpid() applies.
+ */
+static inline int flb_pclose(FILE *stream) {
+    return _pclose(stream);
+}
+#endif
+
+#endif /* FLB_IN_EXEC_WIN32_COMPAT_H */


### PR DESCRIPTION
Enable use of `fluent-bit` as a log-processing command wrapper by enhancing the `exec` plugin with options to exit on child process exit and propagate exit code.

Adds new options to `in_exec` plugin:

    Exit_After_Oneshot [bool]
    Propagate_Exit_Code [bool]

`Exit_After_Oneshot` implies` Oneshot` and causes `fluent-bit` to terminate when the command run by the `exec` plugin terminates.

`Propagate_Exit_Code` causes `fluent-bit` to exit with the same exit code as the on-shot child process it invoked, following the shell convention for handling of signal exits.

```
$ ./bin/fluent-bit -q -o stdout -i exec -p propagate_exit_code=true -p exit_after_oneshot=true -p command='echo some command output; exit 2' 
[0] exec.0: [[1681771813.322498607, {}], {"exec"=>"some command output"}]
$ echo $?
2
```

Obviously practical uses will really be parsing and transforming the logs, shipping logs to external capture services, etc.

While exiting when the one-shot command exits would probably be a sensible default, that might surprise any existing users of the current one-shot option so it is not made the default. That way this change remains backwards compatible with existing `oneshot` uses.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

Docs PR: https://github.com/fluent/fluent-bit-docs/pull/1080

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
