### PR TITLE
ci: 2.1 Windows release not synced

### DIFF
--- a/packaging/update-source-packages.sh
+++ b/packaging/update-source-packages.sh
@@ -21,9 +21,12 @@ if [[ ! -d "$SOURCE_DIR" ]]; then
     exit 1
 fi
 
-if [ ! -d "$TARGET_DIR/$MAJOR_VERSION" ]; then
-    mkdir -p "$TARGET_DIR/$MAJOR_VERSION"
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Missing target directory: $TARGET_DIR"
+    exit 1
 fi
+# create MAJOR_VERSION dir if not exist
+mkdir -p "$TARGET_DIR/$MAJOR_VERSION"
 
 # Handle the JSON schema by copying in the new versions (if they exist).
 echo "Updating JSON schema"

--- a/packaging/update-source-packages.sh
+++ b/packaging/update-source-packages.sh
@@ -21,9 +21,8 @@ if [[ ! -d "$SOURCE_DIR" ]]; then
     exit 1
 fi
 
-if [[ ! -d "$TARGET_DIR" ]]; then
-    echo "Missing target directory: $TARGET_DIR"
-    exit 1
+if [ ! -d "$TARGET_DIR/$MAJOR_VERSION" ]; then
+    mkdir -p "$TARGET_DIR/$MAJOR_VERSION"
 fi
 
 # Handle the JSON schema by copying in the new versions (if they exist).


### PR DESCRIPTION
<!-- Provide summary of changes -->
Creates target directory if not exist
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #7222 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
