### PR TITLE
in_opentelemetry: fix warning

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -1339,7 +1339,7 @@ static int process_payload_logs(struct flb_opentelemetry *ctx, struct http_conn 
         ret = binary_payload_to_msgpack(encoder, (uint8_t *) request->data.data, request->data.len);
     }
     else {
-        flb_error("[otel] Unsupported content type %.*s", request->content_type.len, request->content_type.data);
+        flb_error("[otel] Unsupported content type %.*s", (int)request->content_type.len, request->content_type.data);
 
         ret = -1;
     }


### PR DESCRIPTION
Fix following warning.

```
[ 56%] Built target flb-plugin-in_elasticsearch
Consolidate compiler generated dependencies of target flb-plugin-in_opentelemetry
[ 56%] Building C object plugins/in_opentelemetry/CMakeFiles/flb-plugin-in_opentelemetry.dir/opentelemetry_prot.c.o
In file included from /home/taka/git/fluent-bit/include/fluent-bit/flb_coro.h:34,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_input.h:25,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_input_plugin.h:24,
                 from /home/taka/git/fluent-bit/plugins/in_opentelemetry/opentelemetry_prot.c:20:
/home/taka/git/fluent-bit/plugins/in_opentelemetry/opentelemetry_prot.c: In function ‘process_payload_logs’:
/home/taka/git/fluent-bit/plugins/in_opentelemetry/opentelemetry_prot.c:1342:19: warning: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘long unsigned int’ [-Wformat=]
 1342 |         flb_error("[otel] Unsupported content type %.*s", request->content_type.len, request->content_type.data);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                |
      |                                                                                long unsigned int
/home/taka/git/fluent-bit/include/fluent-bit/flb_log.h:171:47: note: in definition of macro ‘flb_error’
  171 |         flb_log_print(FLB_LOG_ERROR, NULL, 0, fmt, ##__VA_ARGS__)
      |                                               ^~~
/home/taka/git/fluent-bit/plugins/in_opentelemetry/opentelemetry_prot.c:1342:54: note: format string is defined here
 1342 |         flb_error("[otel] Unsupported content type %.*s", request->content_type.len, request->content_type.data);
      |                                                    ~~^~
      |                                                      |
      |                                                      int
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
