### PR TITLE
in_systemd: init last_tag to fix valgrind warning

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -94,7 +94,7 @@ static int in_systemd_collect(struct flb_input_instance *ins,
 #endif
     char *tag = NULL;
     char new_tag[PATH_MAX];
-    char last_tag[PATH_MAX];
+    char last_tag[PATH_MAX] = {0};
     size_t tag_len;
     size_t last_tag_len = 0;
     const void *data;


### PR DESCRIPTION
This patch is to fix following warning what I found while investigating #7234 

```
==66582== Thread 2 flb-pipeline:
==66582== Conditional jump or move depends on uninitialised value(s)
==66582==    at 0x22E588: flb_router_match (flb_router.c:111)
==66582==    by 0x2456C0: flb_routes_mask_set_by_tag (flb_routes_mask.c:51)
==66582==    by 0x1CC70E: flb_input_chunk_create (flb_input_chunk.c:1018)
==66582==    by 0x1CD03F: input_chunk_get (flb_input_chunk.c:1268)
==66582==    by 0x1CDB18: input_chunk_append_raw (flb_input_chunk.c:1639)
==66582==    by 0x1CE688: flb_input_chunk_append_raw (flb_input_chunk.c:1989)
==66582==    by 0x2C4B41: input_log_append (flb_input_log.c:65)
==66582==    by 0x2C4BDC: flb_input_log_append (flb_input_log.c:84)
==66582==    by 0x343212: in_systemd_collect (systemd.c:185)
==66582==    by 0x343A3E: in_systemd_collect_archive (systemd.c:363)
==66582==    by 0x1C688D: flb_input_collector_fd (flb_input.c:1915)
==66582==    by 0x209EF6: flb_engine_handle_event (flb_engine.c:503)
==66582==    by 0x209EF6: flb_engine_start (flb_engine.c:866)
==66582== 
```

The tag of warning case is a `last_tag` of in_systemd.
```c
int flb_router_match(const char *tag, int tag_len, const char *match,
                     void *match_regex)
{
    int ret;
    flb_sds_t t;

    if (tag[tag_len] != '\0') {
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[Input]
    Name   systemd
    Tag    systemd.*

[OUTPUT]
    Name   null
    Match  systemd.*
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c c.conf 
==63726== Memcheck, a memory error detector
==63726== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==63726== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==63726== Command: bin/fluent-bit -c c.conf
==63726== 
Fluent Bit v2.1.1
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/23 10:57:30] [ info] [fluent bit] version=2.1.1, commit=840d52649b, pid=63726
[2023/04/23 10:57:30] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/23 10:57:30] [ info] [cmetrics] version=0.6.1
[2023/04/23 10:57:30] [ info] [ctraces ] version=0.3.0
[2023/04/23 10:57:30] [ info] [input:systemd:systemd.0] initializing
[2023/04/23 10:57:30] [ info] [input:systemd:systemd.0] storage_strategy='memory' (memory only)
[2023/04/23 10:57:30] [ info] [output:null:null.0] worker #0 started
[2023/04/23 10:57:30] [ info] [sp] stream processor started
^C[2023/04/23 10:59:54] [engine] caught signal (SIGINT)
[2023/04/23 11:00:00] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/23 11:00:00] [ info] [input] pausing systemd.0
[2023/04/23 11:00:01] [ info] [task] systemd/systemd.0 has 180 pending task(s):

(snip)

[2023/04/23 11:00:01] [ info] [input] pausing systemd.0
[2023/04/23 11:00:02] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/23 11:00:02] [ info] [input] pausing systemd.0
[2023/04/23 11:00:02] [ info] [output:null:null.0] thread worker #0 stopping...
[2023/04/23 11:00:02] [ info] [output:null:null.0] thread worker #0 stopped
==63726== 
==63726== HEAP SUMMARY:
==63726==     in use at exit: 0 bytes in 0 blocks
==63726==   total heap usage: 1,175,402 allocs, 1,175,402 frees, 2,410,603,118 bytes allocated
==63726== 
==63726== All heap blocks were freed -- no leaks are possible
==63726== 
==63726== For lists of detected and suppressed errors, rerun with: -s
==63726== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
