### PR TITLE
out_forward: added missing code to drop metadata by default

### DIFF
--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -282,10 +282,10 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
 }
 #endif
 
-static int flb_forward_format_transcode(
-            struct flb_forward *ctx, int format,
-            char *input_buffer, size_t input_length,
-            char **output_buffer, size_t *output_length)
+int flb_forward_format_transcode(
+        struct flb_forward *ctx, int format,
+        char *input_buffer, size_t input_length,
+        char **output_buffer, size_t *output_length)
 {
     struct flb_log_event_encoder log_encoder;
     struct flb_log_event_decoder log_decoder;
@@ -403,7 +403,7 @@ static int flb_forward_format_forward_mode(struct flb_forward *ctx,
             entries = 0;
         }
 
-        if (fc->fwd_retain_metadata && event_type == FLB_EVENT_TYPE_LOGS) {
+        if (!fc->fwd_retain_metadata && event_type == FLB_EVENT_TYPE_LOGS) {
             result = flb_forward_format_transcode(ctx, FLB_LOG_EVENT_FORMAT_FORWARD,
                                                   (char *) data, bytes,
                                                   &transcoded_buffer,

--- a/plugins/out_forward/forward_format.h
+++ b/plugins/out_forward/forward_format.h
@@ -40,4 +40,9 @@ int flb_forward_format(struct flb_config *config,
                        const void *data, size_t bytes,
                        void **out_buf, size_t *out_size);
 
+int flb_forward_format_transcode(
+        struct flb_forward *ctx, int format,
+        char *input_buffer, size_t input_length,
+        char **output_buffer, size_t *output_length);
+
 #endif


### PR DESCRIPTION
This PR fixes the wrong default behavior that caused issue #7240 when interacting with fluent-bit 1.9