### PR TITLE
filter_wasm: skip log on NULL or empty WASM return [2.0 backport]

### DIFF
--- a/plugins/filter_wasm/filter_wasm.c
+++ b/plugins/filter_wasm/filter_wasm.c
@@ -116,6 +116,12 @@ static int cb_wasm_filter(const void *data, size_t bytes,
             continue;
         }
 
+        if (strlen(ret_val) == 0) { /* Skip record */
+            flb_plg_debug(ctx->ins, "WASM function returned empty string. Skip.");
+            flb_free(ret_val);
+            continue;
+        }
+
         /* main array */
         msgpack_pack_array(&tmp_pck, 2);
 

--- a/src/wasm/flb_wasm.c
+++ b/src/wasm/flb_wasm.c
@@ -243,6 +243,10 @@ char *flb_wasm_call_function_format_json(struct flb_wasm *fw, const char *functi
     }
     func_result = wasm_runtime_addr_app_to_native(fw->module_inst, func_args[0]);
 
+    if (func_result == NULL) {
+        return NULL;
+    }
+
     return (char *)flb_strdup(func_result);
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is backporting PR that is corresponds to https://github.com/fluent/fluent-bit/pull/7020.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
