### PR TITLE
in_forward: allow to override events tag with 'tag' property

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -185,6 +185,7 @@ struct flb_input_instance {
     /* Plugin properties */
     char *tag;                           /* Input tag for routing        */
     int tag_len;
+    int tag_default;                     /* is it using the default tag? */
 
     /* By default all input instances are 'routable' */
     int routable;

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -168,6 +168,7 @@ static int in_fw_init(struct flb_input_instance *ins,
     if (!ctx) {
         return -1;
     }
+
     ctx->coll_fd = -1;
     ctx->ins = ins;
     mk_list_init(&ctx->connections);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -245,6 +245,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->p        = plugin;
         instance->tag      = NULL;
         instance->tag_len  = 0;
+        instance->tag_default = FLB_FALSE;
         instance->routable = FLB_TRUE;
         instance->data     = data;
         instance->storage  = NULL;
@@ -478,6 +479,7 @@ int flb_input_set_property(struct flb_input_instance *ins,
     if (prop_key_check("tag", k, len) == 0 && tmp) {
         ins->tag     = tmp;
         ins->tag_len = flb_sds_len(tmp);
+        ins->tag_default = FLB_FALSE;
     }
     else if (prop_key_check("log_level", k, len) == 0 && tmp) {
         ret = flb_log_get_level_str(tmp);
@@ -1157,6 +1159,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
         /* Sanity check: all non-dynamic tag input plugins must have a tag */
         if (!ins->tag) {
             flb_input_set_property(ins, "tag", ins->name);
+            ins->tag_default = FLB_TRUE;
         }
 
         if (flb_input_is_threaded(ins)) {


### PR DESCRIPTION
Forward input plugin always respected the Tag set by the client on every record, for usability reasons it also supports `tag_prefix` option to prefix events so  routing can be more customizable, but there are other cases where fully replace the tag is desired.

This patch makes the plugin to override the events Tag if it was manually set in the configuration.