### PR TITLE
macos: test: out_exit: Plug invalid evl context case

### DIFF
--- a/tests/runtime/out_exit.c
+++ b/tests/runtime/out_exit.c
@@ -59,7 +59,9 @@ void flb_test_exit_json_invalid(void)
 
     sleep(WAIT_STOP); /* waiting stop automatically */
 
-    /* call flb_stop() from out_exit plugin */
+    /* On invalid case, flb_stop() is not called from out_exit plugin.
+     * To shutdown normally and cleanly, it needs to call flb_stop() here. */
+    flb_stop(ctx);
     flb_destroy(ctx);
 }
 


### PR DESCRIPTION
This is because not calling flb_stop on json_invalid case, event loop is still continuing during shutdown.
That causes invalid evl context and causes SEGV on teardown.

On invalid case, the following `flb_engine_exit` is not called and also cb_exit_flush is not called due to no ingested logs.
https://github.com/fluent/fluent-bit/blob/1fa0e94a09e4155f8a6d8a0efe36a5668cdc074e/plugins/out_exit/exit.c#L71-L74

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
