### PR TITLE
build: macOS: Don't override OPENSSL_ROOT_DIR cmake option if specified

### DIFF
--- a/cmake/homebrew.cmake
+++ b/cmake/homebrew.cmake
@@ -21,14 +21,18 @@ if (HOMEBREW_FLEX EQUAL 0 AND EXISTS "${HOMEBREW_FLEX_PREFIX}")
   set(FLEX_EXECUTABLE "${HOMEBREW_FLEX_PREFIX}/bin/flex")
 endif()
 
-# Also, searching homebrewed OpenSSL automatically.
-execute_process(
-  COMMAND brew --prefix openssl
-  RESULT_VARIABLE HOMEBREW_OPENSSL
-  OUTPUT_VARIABLE HOMEBREW_OPENSSL_PREFIX
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-if (HOMEBREW_OPENSSL EQUAL 0 AND EXISTS "${HOMEBREW_OPENSSL_PREFIX}")
-  message(STATUS "Using openssl keg installed by Homebrew at ${HOMEBREW_OPENSSL_PREFIX}")
-  set(OPENSSL_ROOT_DIR "${HOMEBREW_OPENSSL_PREFIX}")
+if (OPENSSL_ROOT_DIR)
+  message(STATUS "Using openssl specified by cmake option: ${OPENSSL_ROOT_DIR}")
+else()
+  # Also, searching homebrewed OpenSSL automatically.
+  execute_process(
+    COMMAND brew --prefix openssl
+    RESULT_VARIABLE HOMEBREW_OPENSSL
+    OUTPUT_VARIABLE HOMEBREW_OPENSSL_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if (HOMEBREW_OPENSSL EQUAL 0 AND EXISTS "${HOMEBREW_OPENSSL_PREFIX}")
+    message(STATUS "Using openssl keg installed by Homebrew at ${HOMEBREW_OPENSSL_PREFIX}")
+    set(OPENSSL_ROOT_DIR "${HOMEBREW_OPENSSL_PREFIX}")
+  endif()
 endif()


### PR DESCRIPTION
Sometimes, homebrew's OpenSSL formula is not working as expected. There is a motivation to handle specified versioned OpenSSL reference. Homebrew has two version lines for OpenSSL which are 3.x and 1.1. 3.0 is sometimes breaking changes and 1.1 line is quite stable for production or debugging with lldb.

For specific OpenSSL 3.x version, I've been suffering some of issues not to run with lldb:

```
Process 14498 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=1, subcode=0x4a03000)
    frame #0: 0x0000000100e83328 libcrypto.3.dylib`_armv8_sve_probe
libcrypto.3.dylib`:
->  0x100e83328 <+0>: eor    z0.d, z0.d, z0.d
    0x100e8332c <+4>: ret    

libcrypto.3.dylib`:
    0x100e83330 <+0>: xar    z0.d, z0.d, z0.d, #0x20
    0x100e83334 <+4>: ret    
Target 0: (flb-rt-out_exit) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=1, subcode=0x4a03000)
  * frame #0: 0x0000000100e83328 libcrypto.3.dylib`_armv8_sve_probe
    frame #1: 0x0000000100e83830 libcrypto.3.dylib`OPENSSL_cpuid_setup + 600
    frame #2: 0x000000019c3837c4 dyld`invocation function for block in dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 156
    frame #3: 0x000000019c3c8214 dyld`invocation function for block in dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 340
    frame #4: 0x000000019c3bb524 dyld`invocation function for block in dyld3::MachOFile::forEachSection(void (dyld3::MachOFile::SectionInfo const&, bool, bool&) block_pointer) const + 524
    frame #5: 0x000000019c3682d8 dyld`dyld3::MachOFile::forEachLoadCommand(Diagnostics&, void (load_command const*, bool&) block_pointer) const + 296
    frame #6: 0x000000019c3ba548 dyld`dyld3::MachOFile::forEachSection(void (dyld3::MachOFile::SectionInfo const&, bool, bool&) block_pointer) const + 192
    frame #7: 0x000000019c3c7bf4 dyld`dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 516
    frame #8: 0x000000019c38369c dyld`dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 176
    frame #9: 0x000000019c383950 dyld`dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState&, dyld3::Array<dyld4::Loader const*>&) const + 216
    frame #10: 0x000000019c38392c dyld`dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState&, dyld3::Array<dyld4::Loader const*>&) const + 180
    frame #11: 0x000000019c38392c dyld`dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState&, dyld3::Array<dyld4::Loader const*>&) const + 180
    frame #12: 0x000000019c383ae8 dyld`dyld4::Loader::runInitializersBottomUpPlusUpwardLinks(dyld4::RuntimeState&) const + 328
    frame #13: 0x000000019c3a64b8 dyld`dyld4::APIs::runAllInitializersForMain() + 480
    frame #14: 0x000000019c36cdd8 dyld`dyld4::prepare(dyld4::APIs&, dyld3::MachOAnalyzer const*) + 3500
    frame #15: 0x000000019c36bdc4 dyld`start + 2404
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
