### PR TITLE
time: fixed printf format string in flb_time_pop_from_mpack

### DIFF
--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -346,7 +346,7 @@ int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader)
             time->tm.tv_nsec = (uint32_t) ntohl(tmp);
             break;
         default:
-            flb_warn("unknown time format %s", tag.type);
+            flb_warn("unknown time format %d", tag.type);
             return -1;
     }
 


### PR DESCRIPTION
This is a backport of commit e77d32b42133294bca3f01cb5d4171a12dbb0989 by Benoît Garnier.