### PR TITLE
in_winevtlog: properly pass the log encoder arg

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -280,6 +280,9 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid)
 static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT values, DWORD count)
 {
     int i;
+    int ret;
+
+    ret = flb_log_event_encoder_body_begin_array(ctx->log_encoder);
 
     for (i = 0; i < count; i++) {
         if (values[i].Type & EVT_VARIANT_TYPE_ARRAY) {
@@ -381,6 +384,11 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             msgpack_pack_str_body(ctx, "?", 1);
         }
     }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_body_commit_array(ctx->log_encoder);
+    }
+
 }
 
 void winevtlog_pack_xml_event(WCHAR *system_xml, WCHAR *message,

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -301,37 +301,37 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             }
             break;
         case EvtVarTypeSByte:
-            flb_log_event_encoder_append_body_int8(ctx, values[i].SByteVal);
+            flb_log_event_encoder_append_body_int8(ctx->log_encoder, values[i].SByteVal);
             break;
         case EvtVarTypeByte:
-            flb_log_event_encoder_append_body_uint8(ctx, values[i].ByteVal);
+            flb_log_event_encoder_append_body_uint8(ctx->log_encoder, values[i].ByteVal);
             break;
         case EvtVarTypeInt16:
-            flb_log_event_encoder_append_body_int16(ctx, values[i].Int16Val);
+            flb_log_event_encoder_append_body_int16(ctx->log_encoder, values[i].Int16Val);
             break;
         case EvtVarTypeUInt16:
-            flb_log_event_encoder_append_body_uint16(ctx, values[i].UInt16Val);
+            flb_log_event_encoder_append_body_uint16(ctx->log_encoder, values[i].UInt16Val);
             break;
         case EvtVarTypeInt32:
-            flb_log_event_encoder_append_body_int32(ctx, values[i].Int32Val);
+            flb_log_event_encoder_append_body_int32(ctx->log_encoder, values[i].Int32Val);
             break;
         case EvtVarTypeUInt32:
-            flb_log_event_encoder_append_body_uint32(ctx, values[i].UInt32Val);
+            flb_log_event_encoder_append_body_uint32(ctx->log_encoder, values[i].UInt32Val);
             break;
         case EvtVarTypeInt64:
-            flb_log_event_encoder_append_body_int64(ctx, values[i].Int64Val);
+            flb_log_event_encoder_append_body_int64(ctx->log_encoder, values[i].Int64Val);
             break;
         case EvtVarTypeUInt64:
-            flb_log_event_encoder_append_body_uint64(ctx, values[i].UInt64Val);
+            flb_log_event_encoder_append_body_uint64(ctx->log_encoder, values[i].UInt64Val);
             break;
         case EvtVarTypeSingle:
-            flb_log_event_encoder_append_body_double(ctx, values[i].SingleVal);
+            flb_log_event_encoder_append_body_double(ctx->log_encoder, values[i].SingleVal);
             break;
         case EvtVarTypeDouble:
-            flb_log_event_encoder_append_body_double(ctx, values[i].DoubleVal);
+            flb_log_event_encoder_append_body_double(ctx->log_encoder, values[i].DoubleVal);
             break;
         case EvtVarTypeBoolean:
-            flb_log_event_encoder_append_body_boolean(ctx, (int) values[i].BooleanVal);
+            flb_log_event_encoder_append_body_boolean(ctx->log_encoder, (int) values[i].BooleanVal);
             break;
         case EvtVarTypeGuid:
             if (pack_guid(ctx, values[i].GuidVal)) {
@@ -339,7 +339,7 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             }
             break;
         case EvtVarTypeSizeT:
-            flb_log_event_encoder_append_body_uint64(ctx, values[i].SizeTVal);
+            flb_log_event_encoder_append_body_uint64(ctx->log_encoder, values[i].SizeTVal);
             break;
         case EvtVarTypeFileTime:
             if (pack_filetime(ctx, values[i].FileTimeVal)) {

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -380,8 +380,7 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             }
             break;
         default:
-            msgpack_pack_str(ctx, 1);
-            msgpack_pack_str_body(ctx, "?", 1);
+            flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "?");
         }
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this particular function, we were accidentally passing in the actual `winevtlog_config` instead of the log_encoder field of the config. This caused Fluent Bit to crash with an access violation error, since it gets a completely unexpected shape of data.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #7270

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

No need to backport because this is a bug introduced in 2.1.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
