### PR TITLE
workflows: ensure we increment the version for the new PR

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -833,16 +833,24 @@ jobs:
         if: startsWith(inputs.version, '2.0')
         uses: actions/checkout@v3
         with:
-          repository: fluent/fluent-bit-docs
+          ref: 2.0
 
       - name: Release 2.1 and latest
         if: startsWith(inputs.version, '2.1')
         uses: actions/checkout@v3
 
+      # Get the new version to use
+      - name: 'Get next minor version'
+        id: semvers
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ inputs.version }}
+          strict: true
+
       - run: ./update-version.sh
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.version }}
+          NEW_VERSION: ${{ steps.semvers.outputs.patch }}
           # Ensure we use the PR action to do the work
           DISABLE_COMMIT: 'yes'
 


### PR DESCRIPTION
Ensures we pick the next patch version after release to auto-generate the PR with.
Also resolved an issue with using the wrong ref and repo for 2.0 releases.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
