### PR TITLE
gzip: config: make configurable for the upper limit of gzip decompression

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -37,6 +37,7 @@
 #define HC_RETRY_FAILURE_COUNTS_DEFAULT 5
 #define HEALTH_CHECK_PERIOD 60
 #define FLB_CONFIG_DEFAULT_TAG  "fluent_bit"
+#define FLB_CONFIG_DEFAULT_GZIP_DECOMPRESS_UPPER_LIMIT "100MB"
 
 /* Main struct to hold the configuration of the runtime service */
 struct flb_config {
@@ -257,6 +258,7 @@ struct flb_config {
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
     int enable_hot_reload;
+    char *gzip_decompress_limit;
 
     /* Co-routines */
     unsigned int coro_stack_size;
@@ -359,5 +361,8 @@ enum conf_type {
 /* Scheduler */
 #define FLB_CONF_STR_SCHED_CAP        "scheduler.cap"
 #define FLB_CONF_STR_SCHED_BASE       "scheduler.base"
+
+/* Gzip */
+#define FLB_CONF_STR_GZIP_DECOMPRESS_LIMIT  "Gzip_Decompress_Limit"
 
 #endif

--- a/include/fluent-bit/flb_gzip.h
+++ b/include/fluent-bit/flb_gzip.h
@@ -26,6 +26,7 @@
 int flb_gzip_compress(void *in_data, size_t in_len,
                       void **out_data, size_t *out_len);
 int flb_gzip_uncompress(void *in_data, size_t in_len,
-                        void **out_data, size_t *out_size);
+                        void **out_data, size_t *out_size,
+                        int64_t gzip_decompress_limit);
 
 #endif

--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -99,7 +99,7 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
     (void) data;
 
     /* Create context and basic conf */
-    ctx = in_elasticsearch_config_create(ins);
+    ctx = in_elasticsearch_config_create(ins, config);
     if (!ctx) {
         return -1;
     }

--- a/plugins/in_elasticsearch/in_elasticsearch.h
+++ b/plugins/in_elasticsearch/in_elasticsearch.h
@@ -44,6 +44,7 @@ struct flb_in_elasticsearch {
 
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */
+    int64_t gzip_decompress_limit;
 
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* linked list of connections */

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
@@ -624,7 +624,8 @@ static int process_payload(struct flb_in_elasticsearch *ctx, struct in_elasticse
     if (type == HTTP_CONTENT_NDJSON || type == HTTP_CONTENT_JSON) {
         if (gzip_compressed == FLB_TRUE) {
             ret = flb_gzip_uncompress((void *) request->data.data, request->data.len,
-                                      &gz_data, &gz_size);
+                                      &gz_data, &gz_size,
+                                      ctx->gzip_decompress_limit);
             if (ret == -1) {
                 flb_error("[elasticsearch_bulk_prot] gzip uncompress is failed");
                 return -1;

--- a/plugins/in_elasticsearch/in_elasticsearch_config.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_config.c
@@ -17,13 +17,14 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_input_plugin.h>
 
 #include "in_elasticsearch.h"
 #include "in_elasticsearch_config.h"
 #include "in_elasticsearch_bulk_conn.h"
 
-struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_instance *ins)
+struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_instance *ins, struct flb_config *config)
 {
     int ret;
     char port[8];
@@ -54,6 +55,8 @@ struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_ins
     /* HTTP Server specifics */
     ctx->server = flb_calloc(1, sizeof(struct mk_server));
     ctx->server->keep_alive = MK_TRUE;
+
+    ctx->gzip_decompress_limit = flb_utils_size_to_bytes(config->gzip_decompress_limit);
 
     /* monkey detects server->workers == 0 as the server not being initialized at the
      * moment so we want to make sure that it stays that way!

--- a/plugins/in_elasticsearch/in_elasticsearch_config.h
+++ b/plugins/in_elasticsearch/in_elasticsearch_config.h
@@ -23,7 +23,7 @@
 #include <fluent-bit/flb_input_plugin.h>
 #include "in_elasticsearch.h"
 
-struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_instance *ins);
+struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_instance *ins, struct flb_config *config);
 int in_elasticsearch_config_destroy(struct flb_in_elasticsearch *ctx);
 
 #endif

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -479,6 +479,7 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
     struct flb_in_fw_config *ctx = conn->ctx;
     struct cmt *cmt;
     struct ctrace *ctr;
+    int64_t gzip_decompress_limit = 100000000; /* 100MB */
 
     /*
      * [tag, time, record]
@@ -746,7 +747,8 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
 
                     if (ret == FLB_TRUE) {
                         ret = flb_gzip_uncompress((void *) data, len,
-                                                  &gz_data, &gz_size);
+                                                  &gz_data, &gz_size,
+                                                  gzip_decompress_limit);
                         if (ret == -1) {
                             flb_plg_error(ctx->ins, "gzip uncompress failure");
                             msgpack_unpacked_destroy(&result);

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -1438,11 +1438,13 @@ int uncompress_gzip(char **output_buffer,
                     size_t input_size)
 {
     int ret;
+    int64_t gzip_decompress_limit = 100000000; /* 100MB */
 
     ret = flb_gzip_uncompress(input_buffer,
                               input_size,
                               (void *) output_buffer,
-                              output_size);
+                              output_size,
+                              gzip_decompress_limit);
 
     if (ret == -1) {
         flb_error("[opentelemetry] gzip decompression failed");

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -478,13 +478,16 @@ static void debug_request_response(struct flb_splunk *ctx,
     unsigned char *ptr;
     flb_sds_t req_headers = NULL;
     flb_sds_t req_body = NULL;
+    int64_t gzip_decompress_limit = 100000000; /* 100MB */
 
     if (c->body_len > 3) {
         ptr = (unsigned char *) c->body_buf;
         if (ptr[0] == 0x1F && ptr[1] == 0x8B && ptr[2] == 0x08) {
             /* uncompress payload */
             ret = flb_gzip_uncompress((void *) c->body_buf, c->body_len,
-                                      &tmp_buf, &tmp_size);
+                                      &tmp_buf, &tmp_size,
+                                      gzip_decompress_limit);
+
             if (ret == -1) {
                 fprintf(stdout, "[out_splunk] could not uncompress data\n");
             }

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -177,6 +177,11 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, enable_hot_reload)},
 
+    {FLB_CONF_STR_GZIP_DECOMPRESS_LIMIT,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, gzip_decompress_limit)},
+
+
     {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
 };
 
@@ -289,6 +294,9 @@ struct flb_config *flb_config_init()
                  config->coro_stack_size, getpagesize());
         config->coro_stack_size = (unsigned int)getpagesize();
     }
+
+    /* Set the default gzip decompression size */
+    config->gzip_decompress_limit = flb_strdup(FLB_CONFIG_DEFAULT_GZIP_DECOMPRESS_UPPER_LIMIT);
 
     /* collectors */
     pthread_mutex_init(&config->collectors_mutex, NULL);
@@ -500,6 +508,10 @@ void flb_config_exit(struct flb_config *config)
 
     flb_slist_destroy(&config->stream_processor_tasks);
 #endif
+
+    if (config->gzip_decompress_limit) {
+        flb_free(config->gzip_decompress_limit);
+    }
 
     flb_slist_destroy(&config->external_plugins);
 

--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -163,7 +163,8 @@ int flb_gzip_compress(void *in_data, size_t in_len,
 
 /* Uncompress (inflate) GZip data */
 int flb_gzip_uncompress(void *in_data, size_t in_len,
-                        void **out_data, size_t *out_len)
+                        void **out_data, size_t *out_len,
+                        int64_t gzip_decompress_limit)
 {
     int status;
     uint8_t *p;
@@ -257,9 +258,9 @@ int flb_gzip_uncompress(void *in_data, size_t in_len,
     /* Get decompressed length */
     dlen = read_le32(&p[in_len - 4]);
 
-    /* Limit decompressed length to 100MB */
-    if (dlen > 100000000) {
-        flb_error("[gzip] maximum decompression size is 100MB");
+    /* Limit decompressed length to be the configured limit */
+    if (dlen > gzip_decompress_limit) {
+        flb_error("[gzip] maximum decompression size is %ld", gzip_decompress_limit);
         return -1;
     }
 

--- a/tests/internal/gzip.c
+++ b/tests/internal/gzip.c
@@ -20,6 +20,7 @@ void test_compress()
     size_t in_len;
     void *str;
     size_t len;
+    int64_t gzip_decompress_limit = 100000000; /* 100MB */
 
     sample_len = strlen(morpheus);
     in_len = sample_len;
@@ -29,7 +30,7 @@ void test_compress()
     in_data = str;
     in_len = len;
 
-    ret = flb_gzip_uncompress(in_data, in_len, &str, &len);
+    ret = flb_gzip_uncompress(in_data, in_len, &str, &len, gzip_decompress_limit);
     TEST_CHECK(ret == 0);
 
     TEST_CHECK(sample_len == len);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, gzip decompression is capped for the upper limit of 100MB.
This limitation is worth for eating up for heap memory.
The motivation is: increasing the upper limit of gzip decompression should increase the throughput for in_elasticsearch ingestion with gzip compressed payloads.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
