### PR TITLE
build: use the system provided LuaJIT if found

### DIFF
--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -30,3 +30,46 @@ jobs:
         push: false
         load: false
         provenance: false
+
+  # Sanity check for compilation using system libraries
+  pr-compile-system-libs:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        flb_option:
+          - "-DFLB_PREFER_SYSTEM_LIBS=On"
+        compiler:
+          - gcc
+          - clang
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-7 g++-7 clang-6.0 libsystemd-dev gcovr libyaml-dev libluajit-5.1-dev
+          sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
+
+      - name: Checkout Fluent Bit code
+        uses: actions/checkout@v4
+
+      - name: ${{ matrix.compiler }} - ${{ matrix.flb_option }}
+        run: |
+          export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
+          echo "CC = $CC, CXX = $CXX, FLB_OPT = $FLB_OPT"
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
+          cmake $GLOBAL_OPTS $FLB_OPT  ../
+          make -j $nparallel
+        working-directory: build
+        env:
+          CC: ${{ matrix.compiler }}
+          CXX: ${{ matrix.compiler }}
+          FLB_OPT: ${{ matrix.flb_option }}
+          GLOBAL_OPTS: "-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
+
+      - name: Display dependencies w/ ldd
+        run: |
+          ldd ./bin/fluent-bit
+        working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,10 @@ option(FLB_HTTP_CLIENT_DEBUG  "Enable HTTP Client debug callbacks"   No)
 # Run ldconfig on package post-install
 option(FLB_RUN_LDCONFIG "Enable execution of ldconfig after installation" No)
 
+# Prefer system libraries if available
+option(FLB_PREFER_SYSTEM_LIBS             "Prefer system libraries"                   No)
+option(FLB_PREFER_SYSTEM_LIB_LUAJIT       "Prefer the libluajit system library"       ${FLB_PREFER_SYSTEM_LIBS})
+
 # Enable all features
 if(FLB_ALL)
   # Global
@@ -923,7 +927,16 @@ endif()
 # LuaJIT (Scripting Support)
 # ==========================
 if(FLB_LUAJIT)
-  include(cmake/luajit.cmake)
+  if(FLB_PREFER_SYSTEM_LIB_LUAJIT)
+    find_package(PkgConfig)
+    pkg_check_modules(LUAJIT luajit>=2.1.0)
+  endif()
+  if(LUAJIT_FOUND)
+    include_directories(${LUAJIT_INCLUDE_DIRS})
+    link_directories(${LUAJIT_LIBRARY_DIRS})
+  else()
+    include(cmake/luajit.cmake)
+  endif()
   FLB_DEFINITION(FLB_HAVE_LUAJIT)
 endif()
 

--- a/cmake/headers.cmake
+++ b/cmake/headers.cmake
@@ -22,10 +22,6 @@ include_directories(
   ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_CHUNKIO}/include
   ${CMAKE_CURRENT_BINARY_DIR}/lib/chunkio/include
 
-  # LuaJIT
-  ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_LUAJIT}/src
-  ${CMAKE_CURRENT_BINARY_DIR}/lib/luajit-cmake
-
   ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_MONKEY}/include
   ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_MONKEY}/include/monkey
   ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_MBEDTLS}/include

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -2,4 +2,9 @@
 option(LUAJIT_DIR "Path of LuaJIT 2.1 source dir" ON)
 option(LUAJIT_SETUP_INCLUDE_DIR "Setup include dir if parent is present" OFF)
 set(LUAJIT_DIR ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_LUAJIT})
+include_directories(
+  ${LUAJIT_DIR}/src
+  ${CMAKE_CURRENT_BINARY_DIR}/lib/luajit-cmake
+)
 add_subdirectory("lib/luajit-cmake")
+set(LUAJIT_LIBRARIES "libluajit")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,7 +223,7 @@ endif()
 if(FLB_LUAJIT)
   set(extra_libs
     ${extra_libs}
-    "libluajit")
+    ${LUAJIT_LIBRARIES})
 endif()
 
 if(FLB_SQLDB)


### PR DESCRIPTION
e.g. buildroot has logic to build luajit,
so if pkg_check_modules can find a suitable version, then use that one

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
