### PR TITLE
in_http: do not send content-length at 204(#7231)

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -74,7 +74,7 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
                        "HTTP/1.1 204 No Content\r\n"
                        "Server: Fluent Bit v%s\r\n"
                        "%s"
-                       "Content-Length: 0\r\n\r\n",
+                       "\r\n\r\n",
                        FLB_VERSION_STR,
                        context->success_headers_str);
     }


### PR DESCRIPTION
This patch is to follow RFC9110.
https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length
```
A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).
 A server MUST NOT send a Content-Length header field in any 2xx (Successful) response to a CONNECT request (Section 9.3.6).
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name http
    successful_response_code 204

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

Curl output:
```
$ curl -D -  --data '{"data":"sample"}' -XPOST -H "content-type: application/json" http://localhost:9880/app.log
HTTP/1.1 204 No Content
Server: Fluent Bit v2.1.3


```

valgrind output:
```
$ valgrind --leak-check=full bin/fluent-bit -c issues/7231/a.conf 
==18728== Memcheck, a memory error detector
==18728== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18728== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==18728== Command: bin/fluent-bit -c issues/7231/a.conf
==18728== 
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/30 08:58:40] [ info] [fluent bit] version=2.1.3, commit=ec32476dfc, pid=18728
[2023/04/30 08:58:40] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/30 08:58:40] [ info] [cmetrics] version=0.6.1
[2023/04/30 08:58:40] [ info] [ctraces ] version=0.3.0
[2023/04/30 08:58:40] [ info] [input:http:http.0] initializing
[2023/04/30 08:58:40] [ info] [input:http:http.0] storage_strategy='memory' (memory only)
[2023/04/30 08:58:40] [ info] [output:stdout:stdout.0] worker #0 started
[2023/04/30 08:58:40] [ info] [sp] stream processor started
[0] app.log: [[1682812722.280236062, {}], {"data"=>"sample"}]
^C[2023/04/30 08:58:45] [engine] caught signal (SIGINT)
[2023/04/30 08:58:45] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/30 08:58:45] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/30 08:58:45] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/04/30 08:58:45] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==18728== 
==18728== HEAP SUMMARY:
==18728==     in use at exit: 0 bytes in 0 blocks
==18728==   total heap usage: 1,538 allocs, 1,538 frees, 1,296,521 bytes allocated
==18728== 
==18728== All heap blocks were freed -- no leaks are possible
==18728== 
==18728== For lists of detected and suppressed errors, rerun with: -s
==18728== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
