### PR TITLE
in_otel: do not send content-length at 204(#7231)

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -95,7 +95,7 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
         flb_sds_printf(&out,
                        "HTTP/1.1 204 No Content\r\n"
                        "Server: Fluent Bit v%s\r\n"
-                       "Content-Length: 0\r\n\r\n",
+                       "\r\n",
                        FLB_VERSION_STR);
     }
     else if (http_status == 400) {


### PR DESCRIPTION
This patch is to follow RFC9110.
https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length
```
A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).
 A server MUST NOT send a Content-Length header field in any 2xx (Successful) response to a CONNECT request (Section 9.3.6).
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name opentelemetry
    successful_response_code 204

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

curl output:
```
$ curl -D - --header "Content-Type: application/json" --request POST --data '{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1660296023390371588","body":{"stringValue":"{\"message\":\"dummy\"}"},"traceId":"","spanId":""}]}]}]}'   http://0.0.0.0:4318/v1/logs
HTTP/1.1 204 No Content
Server: Fluent Bit v2.1.3


```

valgrind output:
```
$ valgrind --leak-check=full bin/fluent-bit -c issues/7231/a.conf 
==21675== Memcheck, a memory error detector
==21675== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==21675== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==21675== Command: bin/fluent-bit -c issues/7231/a.conf
==21675== 
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/04/30 09:19:20] [ info] [fluent bit] version=2.1.3, commit=ec32476dfc, pid=21675
[2023/04/30 09:19:20] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/04/30 09:19:20] [ info] [cmetrics] version=0.6.1
[2023/04/30 09:19:20] [ info] [ctraces ] version=0.3.0
[2023/04/30 09:19:20] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/04/30 09:19:20] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/04/30 09:19:20] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:4318
[2023/04/30 09:19:20] [ info] [output:stdout:stdout.0] worker #0 started
[2023/04/30 09:19:20] [ info] [sp] stream processor started
[0] v1_logs: [[1660296023.1698112429, {}], {"log"=>"{"message":"dummy"}"}]
^C[2023/04/30 09:19:24] [engine] caught signal (SIGINT)
[2023/04/30 09:19:24] [ warn] [engine] service will shutdown in max 5 seconds
[2023/04/30 09:19:24] [ info] [engine] service has stopped (0 pending tasks)
[2023/04/30 09:19:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/04/30 09:19:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==21675== 
==21675== HEAP SUMMARY:
==21675==     in use at exit: 0 bytes in 0 blocks
==21675==   total heap usage: 1,531 allocs, 1,531 frees, 1,239,360 bytes allocated
==21675== 
==21675== All heap blocks were freed -- no leaks are possible
==21675== 
==21675== For lists of detected and suppressed errors, rerun with: -s
==21675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
