### PR TITLE
filter_parser: fix timestamp and metadata to be properly copied

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -311,16 +311,18 @@ static int cb_parser_filter(const void *data, size_t bytes,
 
             encoder_result = flb_log_event_encoder_begin_record(&log_encoder);
 
-            if (out_buf != NULL) {
+            if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
                 encoder_result = flb_log_event_encoder_set_timestamp(
-                                    &log_encoder, &tm);
+                                     &log_encoder, &tm);
+            }
 
-                if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                    encoder_result = \
-                        flb_log_event_encoder_set_metadata_from_msgpack_object(
-                            &log_encoder, log_event.metadata);
-                }
+            if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
+                encoder_result = \
+                    flb_log_event_encoder_set_metadata_from_msgpack_object(
+                        &log_encoder, log_event.metadata);
+            }
 
+            if (out_buf != NULL) {
                 if (ctx->reserve_data) {
                     char *new_buf = NULL;
                     int  new_size;


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch fixes parser filters where they have dropped timestamp and metadata if the configured parser does not process a log (when `out_buf` is `NULL`) since #7133.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.