### PR TITLE
out_vivo_exporter: updated the code to use the log event decoder

### DIFF
--- a/plugins/out_vivo_exporter/vivo_http.c
+++ b/plugins/out_vivo_exporter/vivo_http.c
@@ -126,6 +126,7 @@ static void serve_content(mk_request_t *request, struct vivo_stream *vs)
     if (flb_sds_len(payload) == 0) {
         mk_http_status(request, 200);
         headers_set(request, vs);
+        flb_sds_destroy(payload);
         return;
     }
 


### PR DESCRIPTION
Additionally a small memory leak that happened when a client queried the endpoint while no data was available was fixed.