### PR TITLE
filter_lua: fix buffer size calculation(#7304)

### DIFF
--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -606,8 +606,8 @@ static int cb_lua_filter(const void *data, size_t bytes,
 
             ret = flb_log_event_encoder_emit_raw_record(
                     &log_encoder,
-                    &((char *) data)[record_begining],
-                    record_end);
+                    log_decoder.record_base,
+                    log_decoder.record_length);
 
             if (ret != FLB_EVENT_ENCODER_SUCCESS) {
                 flb_plg_error(ctx->ins,


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/blob/v2.1.2/plugins/filter_lua/lua.c#L610
filter_lua passes ` record_end` as a buffer size.
However it is an offset, it means `record_end` increases per loop.
https://github.com/fluent/fluent-bit/blob/v2.1.2/plugins/filter_lua/lua.c#L493

It will cause SIGSEGV, when `record_end` becomes huge value.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

[Log file](https://github.com/rhysm/flb-sigsegv-repro/blob/main/logs/test.json)

```
[SERVICE]
    parsers_file parsers.conf

[INPUT]
    name             tail
    parser           docker
    path             test.json
    tag              logs.docker-container
    Read_from_Head   True

[FILTER]
    Name lua
    Match logs.docker-container
    Script a.lua
    Call first
    alias lua.first

[FILTER]
    Name lua
    Match logs.docker-container
    Script a.lua
    Call second
    alias lua.second

[OUTPUT]
    Name stdout
    Match *
```

parsers.conf:
```
[PARSER]
    Name         docker
    Format       json
    Time_Key     time
    Time_Format  %Y-%m-%dT%H:%M:%S.%L
    Time_Keep    On
```

## Debug/Valgrind output

```
e$ valgrind --leak-check=full ~/git/fluent-bit/build/bin/fluent-bit -c a.conf 
==120874== Memcheck, a memory error detector
==120874== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==120874== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==120874== Command: /home/taka/git/fluent-bit/build/bin/fluent-bit -c a.conf
==120874== 
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/03 11:10:08] [ info] [fluent bit] version=2.1.3, commit=2d71ea9ab0, pid=120874
[2023/05/03 11:10:08] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/03 11:10:08] [ info] [cmetrics] version=0.6.1
[2023/05/03 11:10:08] [ info] [ctraces ] version=0.3.0
[2023/05/03 11:10:08] [ info] [input:tail:tail.0] initializing
[2023/05/03 11:10:08] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/05/03 11:10:08] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/03 11:10:08] [ info] [sp] stream processor started
[2023/05/03 11:10:09] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3977771 watch_fd=1 name=test.json
(snip)
^C[2023/05/03 11:10:10] [engine] caught signal (SIGINT)
[2023/05/03 11:10:10] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/03 11:10:10] [ info] [input] pausing tail.0
[2023/05/03 11:10:11] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/03 11:10:11] [ info] [input] pausing tail.0
[2023/05/03 11:10:11] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=3977771 watch_fd=1
[2023/05/03 11:10:11] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/03 11:10:11] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==120874== 
==120874== HEAP SUMMARY:
==120874==     in use at exit: 0 bytes in 0 blocks
==120874==   total heap usage: 7,334 allocs, 7,334 frees, 20,028,263 bytes allocated
==120874== 
==120874== All heap blocks were freed -- no leaks are possible
==120874== 
==120874== For lists of detected and suppressed errors, rerun with: -s
==120874== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
