### PR TITLE
filter_rewrite_tag: emit using decoder parameters

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -456,8 +456,8 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
         if (keep == FLB_TRUE || is_matched != FLB_TRUE) {
             ret = flb_log_event_encoder_emit_raw_record(
                     &log_encoder,
-                    &((char *) data)[pre],
-                    off - pre);
+                    log_decoder.record_base,
+                    log_decoder.record_length);
         }
 
         /* Adjust previous offset */


### PR DESCRIPTION
This patch is to emit record using decoder parameters.
See also https://github.com/fluent/fluent-bit/pull/7305#pullrequestreview-1410313237

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
[INPUT]
    name dummy

[FILTER]
    name rewrite_tag
    match dummy*
    Rule aa bb new_tag false

[OUTPUT]
    name stdout
    match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==25114== Memcheck, a memory error detector
==25114== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25114== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==25114== Command: bin/fluent-bit -c a.conf
==25114== 
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/04 09:03:24] [ info] [fluent bit] version=2.1.3, commit=c7c6aebf69, pid=25114
[2023/05/04 09:03:24] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/04 09:03:24] [ info] [cmetrics] version=0.6.1
[2023/05/04 09:03:24] [ info] [ctraces ] version=0.3.0
[2023/05/04 09:03:24] [ info] [input:dummy:dummy.0] initializing
[2023/05/04 09:03:24] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/05/04 09:03:25] [ info] [input:emitter:emitter_for_rewrite_tag.0] initializing
[2023/05/04 09:03:25] [ info] [input:emitter:emitter_for_rewrite_tag.0] storage_strategy='memory' (memory only)
[2023/05/04 09:03:25] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/04 09:03:25] [ info] [sp] stream processor started
[0] dummy.0: [[1683158606.065207974, {}], {"message"=>"dummy"}]
[0] dummy.0: [[1683158607.065530256, {}], {"message"=>"dummy"}]
^C[2023/05/04 09:03:28] [engine] caught signal (SIGINT)
[2023/05/04 09:03:28] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [[1683158608.033553902, {}], {"message"=>"dummy"}]
[2023/05/04 09:03:28] [ info] [input] pausing dummy.0
[2023/05/04 09:03:29] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/04 09:03:29] [ info] [input] pausing dummy.0
[2023/05/04 09:03:29] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/04 09:03:29] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==25114== 
==25114== HEAP SUMMARY:
==25114==     in use at exit: 0 bytes in 0 blocks
==25114==   total heap usage: 1,971 allocs, 1,971 frees, 1,581,267 bytes allocated
==25114== 
==25114== All heap blocks were freed -- no leaks are possible
==25114== 
==25114== For lists of detected and suppressed errors, rerun with: -s
==25114== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
