### PR TITLE
out_prometheus_remote_write: added configurable compression method

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.h
+++ b/plugins/out_prometheus_remote_write/remote_write.h
@@ -58,6 +58,8 @@ struct prometheus_remote_write_context {
     char *host;
     int port;
 
+    const char *compression;
+
     /* Log the response paylod */
     int log_response_payload;
 


### PR DESCRIPTION
This PR adds a new setting named `compression` which accept a string value the user should set to the desired compression algorithm.

The default value is `snappy` to retain the current behavior but it can also be set to `gzip` or `none`.