### PR TITLE
out_prometheus_remote_write: added missing header inclusion

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -19,6 +19,7 @@
 
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_snappy.h>
+#include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_kv.h>
 


### PR DESCRIPTION
This PR fixes a missing header issue introduced by the previous prometheus remote write improvement PR.