### PR TITLE
record_accessor: allow single char for flb_ra_translate(#7330)

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -218,7 +218,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
     }
 
     /* Append remaining string */
-    if (i - 1 > end && pre < i) {
+    if ((i - 1 > end && pre < i) || i == 1 /*allow single character*/) {
         end = flb_sds_len(buf);
         rp_str = ra_parse_string(ra, buf, pre, end);
         if (rp_str) {


### PR DESCRIPTION
This patch is to allow a single character for `flb_ra_translate`.

Currently, `flb_ra_translate` doesn't allow a single character and it causes a issue like #7330.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Flush     1

[INPUT]
    NAME   dummy
    Dummy  {"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}
    Tag    a

[FILTER]
    Name          rewrite_tag
    Match         a
    Rule          $tool ^(fluent)$ b false
    Emitter_Name  re_emitted

[OUTPUT]
    Name stdout
    Match a

[OUTPUT]
    Name stdout
    Match b
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full ~/git/fluent-bit/build/bin/fluent-bit -c a.conf 
==59827== Memcheck, a memory error detector
==59827== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==59827== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==59827== Command: /home/taka/git/fluent-bit/build/bin/fluent-bit -c a.conf
==59827== 
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/06 09:55:43] [ info] [fluent bit] version=2.1.3, commit=7c2feae84d, pid=59827
[2023/05/06 09:55:43] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/06 09:55:43] [ info] [cmetrics] version=0.6.1
[2023/05/06 09:55:43] [ info] [ctraces ] version=0.3.0
[2023/05/06 09:55:43] [ info] [input:dummy:dummy.0] initializing
[2023/05/06 09:55:43] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/05/06 09:55:43] [ info] [input:emitter:re_emitted] initializing
[2023/05/06 09:55:43] [ info] [input:emitter:re_emitted] storage_strategy='memory' (memory only)
[2023/05/06 09:55:43] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/06 09:55:43] [ info] [output:stdout:stdout.1] worker #0 started
[2023/05/06 09:55:43] [ info] [sp] stream processor started
[0] b: [[1683334544.612985850, {}], {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[0] b: [[1683334545.612677235, {}], {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
^C[2023/05/06 09:55:47] [engine] caught signal (SIGINT)
[2023/05/06 09:55:47] [ warn] [engine] service will shutdown in max 5 seconds
[0] b: [[1683334546.585829956, {}], {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
[2023/05/06 09:55:47] [ info] [input] pausing dummy.0
[2023/05/06 09:55:47] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/06 09:55:47] [ info] [input] pausing dummy.0
[2023/05/06 09:55:47] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/06 09:55:47] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/05/06 09:55:47] [ info] [output:stdout:stdout.1] thread worker #0 stopping...
[2023/05/06 09:55:47] [ info] [output:stdout:stdout.1] thread worker #0 stopped
==59827== 
==59827== HEAP SUMMARY:
==59827==     in use at exit: 0 bytes in 0 blocks
==59827==   total heap usage: 2,307 allocs, 2,307 frees, 2,425,964 bytes allocated
==59827== 
==59827== All heap blocks were freed -- no leaks are possible
==59827== 
==59827== For lists of detected and suppressed errors, rerun with: -s
==59827== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
