### PR TITLE
backport PR 7332

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -218,7 +218,7 @@ static int ra_parse_buffer(struct flb_record_accessor *ra, flb_sds_t buf)
     }
 
     /* Append remaining string */
-    if (i - 1 > end && pre < i) {
+    if ((i - 1 > end && pre < i) || i == 1 /*allow single character*/) {
         end = flb_sds_len(buf);
         rp_str = ra_parse_string(ra, buf, pre, end);
         if (rp_str) {

--- a/tests/internal/record_accessor.c
+++ b/tests/internal/record_accessor.c
@@ -1652,7 +1652,7 @@ void cb_issue_7330_single_char()
     msgpack_object map;
 
     json = "{\"tool\":\"fluent\"}";
-    ret = flb_pack_json(json, strlen(json), &out_buf, &out_size, &type, NULL);
+    ret = flb_pack_json(json, strlen(json), &out_buf, &out_size, &type);
     if (!TEST_CHECK(ret == 0)) {
         TEST_MSG("flb_pack_json failed");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #7335 


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
