### PR TITLE
install: update to fix AmazonLinux versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ RELEASE_VERSION=${FLUENT_BIT_RELEASE_VERSION:-}
 INSTALL_CMD_PREFIX=${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}
 # Optionally set the name of th package to install, e.g. for legacy td-agent-bit.
 INSTALL_PACKAGE_NAME=${FLUENT_BIT_INSTALL_PACKAGE_NAME:-fluent-bit}
-# Optional Apt/Yum additional parameters (e.g. releasever for AL2022)
+# Optional Apt/Yum additional parameters (e.g. releasever for AL2022/AL2023)
 APT_PARAMETERS=${FLUENT_BIT_INSTALL_APT_PARAMETERS:-}
 YUM_PARAMETERS=${FLUENT_BIT_INSTALL_YUM_PARAMETERS:-}
 
@@ -57,26 +57,25 @@ fi
 # Will require sudo
 case ${OS} in
     amzn|amazonlinux)
-        # We need variable expansion and non-expansion on the URL line to pick up the base URL.
-        # Therefore we combine things with sed to handle it.
         $SUDO sh <<SCRIPT
 rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 [fluent-bit]
 name = Fluent Bit
 # Legacy server style
-baseurl = $RELEASE_URL/amazonlinux/VERSION_SUBSTR
+baseurl = $RELEASE_URL/amazonlinux/$VERSION
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY
 enabled=1
 EOF
-sed -i 's|VERSION_SUBSTR|\$releasever/|g' /etc/yum.repos.d/fluent-bit.repo
 cat /etc/yum.repos.d/fluent-bit.repo
 $INSTALL_CMD_PREFIX yum -y $YUM_PARAMETERS install $INSTALL_PACKAGE_NAME$YUM_VERSION
 SCRIPT
     ;;
     centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
+        # We need variable expansion and non-expansion on the URL line to pick up the base URL.
+        # Therefore we combine things with sed to handle it.
         $SUDO sh <<SCRIPT
 rpm --import $RELEASE_KEY
 cat << EOF > /etc/yum.repos.d/fluent-bit.repo

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -53,19 +53,13 @@ do
     echo "Testing $IMAGE"
     LOG_FILE=$(mktemp)
 
-    UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX=${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}
-    # For AL2023 we currently want a fixed 2023 version instead of build timestamps
-    if [[ "$IMAGE" == "amazonlinux:2023" ]]; then
-        UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX="sed -i 's|\$releasever/|2023/|g' /etc/yum.repos.d/fluent-bit.repo;${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}"
-    fi
-
     # We do want word splitting for EXTRA_MOUNTS
     # shellcheck disable=SC2086
     $CONTAINER_RUNTIME run --rm -t \
         -e FLUENT_BIT_PACKAGES_URL="${FLUENT_BIT_PACKAGES_URL:-https://packages.fluentbit.io}" \
         -e FLUENT_BIT_PACKAGES_KEY="${FLUENT_BIT_PACKAGES_KEY:-https://packages.fluentbit.io/fluentbit.key}" \
         -e FLUENT_BIT_RELEASE_VERSION="${FLUENT_BIT_RELEASE_VERSION:-}" \
-        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="$UPDATED_FLUENT_BIT_INSTALL_COMMAND_PREFIX" \
+        -e FLUENT_BIT_INSTALL_COMMAND_PREFIX="${FLUENT_BIT_INSTALL_COMMAND_PREFIX:-}" \
         -e FLUENT_BIT_INSTALL_PACKAGE_NAME="${FLUENT_BIT_INSTALL_PACKAGE_NAME:-fluent-bit}" \
         -e FLUENT_BIT_INSTALL_YUM_PARAMETERS="${FLUENT_BIT_INSTALL_YUM_PARAMETERS:-}" \
         $EXTRA_MOUNTS \


### PR DESCRIPTION
Resolves #7352 by ensuring we fix it to 2023 or 2 depending on the AL version.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Verified locally using containers:

```shell
$ docker run --rm -it -v $PWD/install.sh:/install.sh:ro amazonlinux:2023
bash-5.2# ./install.sh 
================================
 Fluent Bit Installation Script 
================================
This script requires superuser access to install packages.
You will be prompted for your password by sudo.
[fluent-bit]
name = Fluent Bit
# Legacy server style
baseurl = https://packages.fluentbit.io/amazonlinux/2023
...

$ docker run --rm -it -v $PWD/install.sh:/install.sh:ro amazonlinux:2
bash-4.2# /install.sh 
================================
 Fluent Bit Installation Script 
================================
This script requires superuser access to install packages.
You will be prompted for your password by sudo.
[fluent-bit]
name = Fluent Bit
# Legacy server style
baseurl = https://packages.fluentbit.io/amazonlinux/2
...
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
