### PR TITLE
in_tail: use orig_name for path_key.

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -159,8 +159,8 @@ static int record_append_custom_keys(struct flb_tail_file *file,
             msgpack_pack_str_body(&mp_pck, file->config->path_key, len);
 
             /* val */
-            msgpack_pack_str(&mp_pck, file->name_len);
-            msgpack_pack_str_body(&mp_pck, file->name, file->name_len);
+            msgpack_pack_str(&mp_pck, file->orig_name_len);
+            msgpack_pack_str_body(&mp_pck, file->orig_name, file->orig_name_len);
         }
 
         /* offset_key */
@@ -958,6 +958,16 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         goto error;
     }
 
+    /* We keep a copy of the initial filename in orig_name. This is required
+     * for path_key to continue working after rotation. */
+    file->orig_name = flb_strdup(file->name);
+    if (!file->orig_name) {
+        flb_free(file->name);
+        flb_errno();
+        goto error;
+    }
+    file->orig_name_len = file->name_len;
+
     /* multiline msgpack buffers */
     file->mult_records = 0;
     msgpack_sbuffer_init(&file->mult_sbuf);
@@ -1155,6 +1165,7 @@ void flb_tail_file_remove(struct flb_tail_file *file)
 
     flb_free(file->buf_data);
     flb_free(file->name);
+    flb_free(file->orig_name);
     flb_free(file->real_name);
     flb_sds_destroy(file->hash_key);
 

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -283,7 +283,7 @@ int flb_tail_pack_line_map(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         append_record_to_map(data, data_size,
                              file->config->path_key,
                              flb_sds_len(file->config->path_key),
-                             file->name, file->name_len, 0);
+                             file->orig_name, file->orig_name_len, 0);
     }
     if (file->config->offset_key != NULL) {
         append_record_to_map(data, data_size,
@@ -321,8 +321,8 @@ int flb_tail_file_pack_line(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         msgpack_pack_str(mp_pck, flb_sds_len(file->config->path_key));
         msgpack_pack_str_body(mp_pck, file->config->path_key,
                               flb_sds_len(file->config->path_key));
-        msgpack_pack_str(mp_pck, file->name_len);
-        msgpack_pack_str_body(mp_pck, file->name, file->name_len);
+        msgpack_pack_str(mp_pck, file->orig_name_len);
+        msgpack_pack_str_body(mp_pck, file->orig_name, file->orig_name_len);
     }
     if (file->config->offset_key != NULL) {
         /* append offset_key */

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -46,7 +46,9 @@ struct flb_tail_file {
     int   is_link;
     char *name;                 /* target file name given by scan routine */
     char *real_name;            /* real file name in the file system */
+    char *orig_name;            /* original file name (before rotation) */
     size_t name_len;
+    size_t orig_name_len;
     time_t rotated;
     int64_t pending_bytes;
 


### PR DESCRIPTION
# Summary

Use `orig_name` consistently for `path_key`. This solves some weird edge cases where the rotated log path name gets used instead.

This is a back port of #6996, #6997, #7057.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [*] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [*] Backport to latest stable release.

This is the pull request for the 2.0 backport: https://github.com/fluent/fluent-bit/pull/6997

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.