### PR TITLE
in_kafka: use log encoder

### DIFF
--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -36,7 +36,8 @@
 #include "in_kafka.h"
 #include "rdkafka.h"
 
-static int try_json(mpack_writer_t *writer, rd_kafka_message_t *rkm)
+static int try_json(struct flb_log_event_encoder *log_encoder,
+                    rd_kafka_message_t *rkm)
 {
     int root_type;
     char *buf = NULL;
@@ -50,111 +51,145 @@ static int try_json(mpack_writer_t *writer, rd_kafka_message_t *rkm)
         }
         return ret;
     }
-    mpack_write_object_bytes(writer, buf, bufsize);
+    flb_log_event_encoder_append_body_binary_body(log_encoder, buf, bufsize);
     flb_free(buf);
     return 0;
 }
 
-static void process_message(mpack_writer_t *writer,
-                            rd_kafka_message_t *rkm)
+static int process_message(struct flb_log_event_encoder *log_encoder,
+                           rd_kafka_message_t *rkm)
 {
-    struct flb_time t;
+    int ret;
 
-    mpack_write_tag(writer, mpack_tag_array(2));
+    ret = flb_log_event_encoder_begin_record(log_encoder);
 
-    flb_time_get(&t);
-    flb_time_append_to_mpack(writer, &t, 0);
-
-    mpack_write_tag(writer, mpack_tag_map(6));
-
-    mpack_write_cstr(writer, "topic");
-    if (rkm->rkt) {
-        mpack_write_cstr(writer, rd_kafka_topic_name(rkm->rkt));
-    }
-    else {
-        mpack_write_nil(writer);
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_set_current_timestamp(log_encoder);
     }
 
-    mpack_write_cstr(writer, "partition");
-    mpack_write_i32(writer, rkm->partition);
-
-    mpack_write_cstr(writer, "offset");
-    mpack_write_i64(writer, rkm->offset);
-
-    mpack_write_cstr(writer, "error");
-    if (rkm->err) {
-        mpack_write_cstr(writer, rd_kafka_message_errstr(rkm));
-    }
-    else {
-        mpack_write_nil(writer);
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "topic");
     }
 
-    mpack_write_cstr(writer, "key");
-    if (rkm->key) {
-        mpack_write_str(writer, rkm->key, rkm->key_len);
-    }
-    else {
-        mpack_write_nil(writer);
-    }
-
-    mpack_write_cstr(writer, "payload");
-    if (rkm->payload) {
-        if (try_json(writer, rkm)) {
-            mpack_write_str(writer, rkm->payload, rkm->len);
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        if (rkm->rkt) {
+            ret = flb_log_event_encoder_append_body_cstring(log_encoder,
+                                                            rd_kafka_topic_name(rkm->rkt));
+        }
+        else {
+            ret = flb_log_event_encoder_append_body_null(log_encoder);
         }
     }
-    else {
-        mpack_write_nil(writer);
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_values(log_encoder,
+                                                       FLB_LOG_EVENT_CSTRING_VALUE("partition"),
+                                                       FLB_LOG_EVENT_INT32_VALUE(rkm->partition));
     }
 
-    mpack_writer_flush_message(writer);
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_values(log_encoder,
+                                                       FLB_LOG_EVENT_CSTRING_VALUE("offset"),
+                                                       FLB_LOG_EVENT_INT64_VALUE(rkm->offset));
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "error");
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        if (rkm->err) {
+            ret = flb_log_event_encoder_append_body_cstring(log_encoder,
+                                                            rd_kafka_message_errstr(rkm));
+        }
+        else {
+            ret = flb_log_event_encoder_append_body_null(log_encoder);
+        }
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "key");
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        if (rkm->key) {
+            ret = flb_log_event_encoder_append_body_string(log_encoder,
+                                                           rkm->key,
+                                                           rkm->key_len);
+        }
+        else {
+            ret = flb_log_event_encoder_append_body_null(log_encoder);
+        }
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "payload");
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        if (rkm->payload) {
+            if (try_json(log_encoder, rkm)) {
+                ret = flb_log_event_encoder_append_body_string(log_encoder,
+                                                               rkm->payload,
+                                                               rkm->len);
+            }
+        }
+        else {
+            ret = flb_log_event_encoder_append_body_null(log_encoder);
+        }
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_commit_record(log_encoder);
+    }
+
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+    }
+
+    return ret;
 }
 
 static int in_kafka_collect(struct flb_input_instance *ins,
                             struct flb_config *config, void *in_context)
 {
-    mpack_writer_t writer;
-    char *buf;
-    size_t bufsize;
-    size_t written = 0;
+    int ret;
     struct flb_in_kafka_config *ctx = in_context;
+    rd_kafka_message_t *rkm;
 
-    mpack_writer_init_growable(&writer, &buf, &bufsize);
+    ret = FLB_EVENT_ENCODER_SUCCESS;
 
-    if (writer.error == mpack_error_memory) {
-        flb_plg_error(ins, "Failed to allocate buffer.");
-        return -1;
-    }
-
-    while (true) {
-        rd_kafka_message_t *rkm = rd_kafka_consumer_poll(ctx->kafka.rk, 1);
+    while (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        rkm = rd_kafka_consumer_poll(ctx->kafka.rk, 1);
 
         if (!rkm) {
             break;
         }
 
         flb_plg_debug(ins, "kafka message received");
-        process_message(&writer, rkm);
+
+        ret = process_message(ctx->log_encoder, rkm);
+
         rd_kafka_message_destroy(rkm);
+
+        /* TO-DO: commit the record based on `ret` */
         rd_kafka_commit(ctx->kafka.rk, NULL, 0);
-
-        if (writer.error == mpack_error_memory) {
-            flb_plg_error(ins, "Failed to allocate buffer.");
-            return -1;
-        }
     }
 
-    written = writer.position - writer.buffer;
-
-    if (written == 0) {
-        mpack_writer_destroy(&writer);
-        return -1;
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        flb_input_log_append(ins, NULL, 0,
+                             ctx->log_encoder->output_buffer,
+                             ctx->log_encoder->output_length);
+        ret = 0;
+    }
+    else {
+        flb_plg_error(ins, "Error encoding record : %d", ret);
+        ret = -1;
     }
 
-    flb_input_log_append(ins, NULL, 0, writer.buffer, written);
-    mpack_writer_destroy(&writer);
+    flb_log_event_encoder_reset(ctx->log_encoder);
 
-    return 0;
+    return ret;
 }
 
 /* Initialize plugin */
@@ -234,6 +269,13 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
+    ctx->log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+
+    if (ctx->log_encoder == NULL) {
+        flb_plg_error(ins, "could not initialize log encoder");
+        goto init_error;
+    }
+
     return 0;
 
 init_error:
@@ -244,7 +286,7 @@ init_error:
         rd_kafka_destroy(ctx->kafka.rk);
     }
     else if (kafka_conf) {
-        // conf is already destroyed when rd_kafka is initialized
+        /* conf is already destroyed when rd_kafka is initialized */
         rd_kafka_conf_destroy(kafka_conf);
     }
     flb_free(ctx);
@@ -264,6 +306,11 @@ static int in_kafka_exit(void *in_context, struct flb_config *config)
     ctx = in_context;
     rd_kafka_destroy(ctx->kafka.rk);
     flb_free(ctx->kafka.brokers);
+
+    if (ctx->log_encoder){
+        flb_log_event_encoder_destroy(ctx->log_encoder);
+    }
+
     flb_free(ctx);
 
     return 0;
@@ -297,7 +344,7 @@ static struct flb_config_map config_map[] = {
    },
    {
     FLB_CONFIG_MAP_STR_PREFIX, "rdkafka.", NULL,
-    //FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_in_kafka_config, rdkafka_opts),
+    /* FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_in_kafka_config, rdkafka_opts), */
     0,  FLB_FALSE, 0,
     "Set the librdkafka options"
    },

--- a/src/flb_log_event_encoder_primitives.c
+++ b/src/flb_log_event_encoder_primitives.c
@@ -66,6 +66,9 @@ int flb_log_event_encoder_append_value(
                 result = msgpack_pack_ext(&field->packer, value_length,
                                           *((int8_t *) value_buffer));
             }
+            else if (value_type == FLB_LOG_EVENT_NULL_VALUE_TYPE) {
+                result = msgpack_pack_nil(&field->packer);
+            }
             else {
                 if (value_buffer == NULL) {
                     return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
@@ -85,9 +88,6 @@ int flb_log_event_encoder_append_value(
                     result = msgpack_pack_ext_body(&field->packer,
                                                    value_buffer,
                                                    value_length);
-                }
-                else if (value_type == FLB_LOG_EVENT_NULL_VALUE_TYPE) {
-                    result = msgpack_pack_nil(&field->packer);
                 }
                 else if (value_type == FLB_LOG_EVENT_CHAR_VALUE_TYPE) {
                     result = msgpack_pack_char(&field->packer,


### PR DESCRIPTION
<!-- Provide summary of changes -->

Use log_encoder instead of mpack in in_kafka

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

#7301 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[INPUT]
	Name kafka
	topics quickstart-events
	brokers 0.0.0.0:9092

[OUTPUT]
	Name stdout
	Match *
```

- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io/

[2023/05/11 08:43:35] [ info] [fluent bit] version=2.1.3, commit=1e62c1b861, pid=45090
[2023/05/11 08:43:35] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/11 08:43:35] [ info] [cmetrics] version=0.6.1
[2023/05/11 08:43:35] [ info] [ctraces ] version=0.3.0
[2023/05/11 08:43:35] [ info] [input:kafka:kafka.0] initializing
[2023/05/11 08:43:35] [ info] [input:kafka:kafka.0] storage_strategy='memory' (memory only)
[2023/05/11 08:43:35] [ info] [sp] stream processor started
[2023/05/11 08:43:35] [ info] [output:stdout:stdout.0] worker #0 started
[0] kafka.0: [[1683794628.892560263, {}], {"topic"=>"quickstart-events", "partition"=>88494920, "offset"=>88494960, "error"=>nil, "key"=>nil, "payload"=>"test1"}]
[0] kafka.0: [[1683794630.378107708, {}], {"topic"=>"quickstart-events", "partition"=>89114664, "offset"=>89114704, "error"=>nil, "key"=>nil, "payload"=>"test2"}]
[2023/05/11 08:43:56] [engine] caught signal (SIGTERM)
[2023/05/11 08:43:57] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/11 08:43:57] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/11 08:43:58] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/11 08:43:58] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==45090==
==45090== HEAP SUMMARY:
==45090==     in use at exit: 8,033 bytes in 19 blocks
==45090==   total heap usage: 2,600 allocs, 2,581 frees, 2,207,704 bytes allocated
==45090==
==45090== LEAK SUMMARY:
==45090==    definitely lost: 0 bytes in 0 blocks
==45090==    indirectly lost: 0 bytes in 0 blocks
==45090==      possibly lost: 0 bytes in 0 blocks
==45090==    still reachable: 8,033 bytes in 19 blocks
==45090==         suppressed: 0 bytes in 0 blocks
==45090== Reachable blocks (those to which a pointer was found) are not shown.
==45090== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==45090==
==45090== For lists of detected and suppressed errors, rerun with: -s
==45090== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
