### PR TITLE
doc: MAINTAINERS: add Leonardo and Hiroshi as Fluent Bit maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,8 +5,10 @@ Fluent Bit is developed and supported by many individuals and companies.  The fo
 | Maintainer Name                                       | Components               | Company                                           |
 | :---------------------------------------------------- | ------------------------ | ------------------------------------------------- |
 | [Eduardo Silva](https://github.com/edsiper)           | All                      | [Calyptia](https://calyptia.com)                  |
+| [Leonardo Alminana](https://github.com/leonardo-albertovich) | All               | [Calyptia](https://calyptia.com)                  |
 | [Masoud Koleini](https://github.com/koleini)          | Stream Processor         | [Arm](https://www.arm.com/)                       |
-| [Fujimoto Seiji](https://github.com/fujimotos)        | Windows Platform         | [Clear Code](http://clear-code.com/)              |
+| [Hiroshi Hatake](https://github.com/cosmo0920)        | All                      | [Calyptia](https://calyptia.com)                  |
+| [Fujimoto Seiji](https://github.com/fujimotos)        | Windows Platform         | Individual                                        |
 | [Wesley Pettit](https://github.com/PettitWesley)      | Amazon Plugins (AWS)     | [Amazon Web Services](https://aws.amazon.com/)    |
 | [Cedric Lamoriniere](https://github.com/clamoriniere) | Datadog Output Plugin    | [Datadog](https://www.datadoghq.com/)             |
 | [Jonathan Gonzalez V.](https://github.com/sxd)        | PostgreSQL Output Plugin | [2ndQuadrant](https://www.2ndquadrant.com/en/)    |


### PR DESCRIPTION
I happy to announce that Leonardo and Hiroshi are becoming official Fluent Bit maintainers, part of their work:

- Leonardo has been contributed for more than 2 years around most of the subsystems like DNS, downstream, upstream, co-routines, event loop, log metadata, metrics/traces and many other plugins.

- Hiroshi has contributed extensively on making sure Fluent Bit works on macOS, Windows, metrics and log plugins, hot-reload, Wasm/Golang interface, automated testing, core fixes and many others.

Thanks for your valuable help!

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
