### PR TITLE
in_elasticsearch: Refer the plugin provided tag [2.0 backport]

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -185,6 +185,7 @@ struct flb_input_instance {
     /* Plugin properties */
     char *tag;                           /* Input tag for routing        */
     int tag_len;
+    int tag_default;                     /* is it using the default tag? */
 
     /* By default all input instances are 'routable' */
     int routable;

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
@@ -691,26 +691,33 @@ int in_elasticsearch_bulk_prot_handle(struct flb_in_elasticsearch *ctx,
         uri[diff] = '\0';
     }
 
-    /* Compose the query string using the URI */
-    len = strlen(uri);
-
-    if (len == 1) {
-        tag = NULL; /* use default tag */
-    }
-    else {
-        tag = flb_sds_create_size(len);
-        if (!tag) {
-            mk_mem_free(uri);
+    /* Refer the tag at first*/
+    if (ctx->ins->tag && !ctx->ins->tag_default) {
+        tag = flb_sds_create(ctx->ins->tag);
+        if (tag == NULL) {
             return -1;
         }
+    }
+    else {
+        /* Compose the query string using the URI */
+        len = strlen(uri);
 
-        /* New tag skipping the URI '/' */
-        flb_sds_cat(tag, uri + 1, len - 1);
+        if (len == 1) {
+            tag = NULL; /* use default tag */
+        }
+        else {
+            /* New tag skipping the URI '/' */
+            tag = flb_sds_create_len(&uri[1], len - 1);
+            if (!tag) {
+                mk_mem_free(uri);
+                return -1;
+            }
 
-        /* Sanitize, only allow alphanum chars */
-        for (i = 0; i < flb_sds_len(tag); i++) {
-            if (!isalnum(tag[i]) && tag[i] != '_' && tag[i] != '.') {
-                tag[i] = '_';
+            /* Sanitize, only allow alphanum chars */
+            for (i = 0; i < flb_sds_len(tag); i++) {
+                if (!isalnum(tag[i]) && tag[i] != '_' && tag[i] != '.') {
+                    tag[i] = '_';
+                }
             }
         }
     }

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -242,6 +242,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->p        = plugin;
         instance->tag      = NULL;
         instance->tag_len  = 0;
+        instance->tag_default = FLB_FALSE;
         instance->routable = FLB_TRUE;
         instance->data     = data;
         instance->storage  = NULL;
@@ -471,6 +472,7 @@ int flb_input_set_property(struct flb_input_instance *ins,
     if (prop_key_check("tag", k, len) == 0 && tmp) {
         ins->tag     = tmp;
         ins->tag_len = flb_sds_len(tmp);
+        ins->tag_default = FLB_FALSE;
     }
     else if (prop_key_check("log_level", k, len) == 0 && tmp) {
         ret = flb_log_get_level_str(tmp);
@@ -1120,6 +1122,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
         /* Sanity check: all non-dynamic tag input plugins must have a tag */
         if (!ins->tag) {
             flb_input_set_property(ins, "tag", ins->name);
+            ins->tag_default = FLB_TRUE;
         }
 
         if (flb_input_is_threaded(ins)) {

--- a/tests/runtime/in_elasticsearch.c
+++ b/tests/runtime/in_elasticsearch.c
@@ -282,7 +282,7 @@ void flb_test_in_elasticsearch_version()
     test_ctx_destroy(ctx);
 }
 
-void flb_test_in_elasticsearch(char *write_op, int port)
+void flb_test_in_elasticsearch(char *write_op, int port, char *tag)
 {
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
@@ -314,12 +314,27 @@ void flb_test_in_elasticsearch(char *write_op, int port)
                         "port", sport,
                         NULL);
     TEST_CHECK(ret == 0);
+    if (tag != NULL) {
+        ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                            "tag", tag,
+                            NULL);
+        TEST_CHECK(ret == 0);
+    }
 
-    ret = flb_output_set(ctx->flb, ctx->o_ffd,
-                         "match", "*",
-                         "format", "json",
-                         NULL);
-    TEST_CHECK(ret == 0);
+    if (tag != NULL) {
+        ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                             "match", tag,
+                             "format", "json",
+                             NULL);
+        TEST_CHECK(ret == 0);
+    }
+    else {
+        ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                             "match", "*",
+                             "format", "json",
+                             NULL);
+        TEST_CHECK(ret == 0);
+    }
 
     /* Start the engine */
     ret = flb_start(ctx->flb);
@@ -363,12 +378,12 @@ void flb_test_in_elasticsearch(char *write_op, int port)
 
 void flb_test_in_elasticsearch_index_op()
 {
-    flb_test_in_elasticsearch("index", 9202);
+    flb_test_in_elasticsearch("index", 9202, NULL);
 }
 
 void flb_test_in_elasticsearch_create_op()
 {
-    flb_test_in_elasticsearch("create", 9203);
+    flb_test_in_elasticsearch("create", 9203, NULL);
 }
 
 void flb_test_in_elasticsearch_invalid(char *write_op, int status, char *expected_op, int port)
@@ -793,6 +808,11 @@ void flb_test_in_elasticsearch_tag_key()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_in_elasticsearch_index_op_with_plugin_tag()
+{
+    flb_test_in_elasticsearch("index", 9210, "es.index");
+}
+
 TEST_LIST = {
     {"version", flb_test_in_elasticsearch_version},
     {"index_op", flb_test_in_elasticsearch_index_op},
@@ -802,6 +822,7 @@ TEST_LIST = {
     {"nonexistent_op", flb_test_in_elasticsearch_nonexistent_op},
     {"multi_ops", flb_test_in_elasticsearch_multi_ops},
     {"multi_ops_gzip", flb_test_in_elasticsearch_multi_ops_gzip},
+    {"index_op_with_plugin_tag", flb_test_in_elasticsearch_index_op_with_plugin_tag},
     {"node_info", flb_test_in_elasticsearch_node_info},
     {"tag_key", flb_test_in_elasticsearch_tag_key},
     {NULL, NULL}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is backporting PR that is corresponds to https://github.com/fluent/fluent-bit/pull/7360
Closes https://github.com/fluent/fluent-bit/issues/7365

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
