### PR TITLE
filter_geoip2: Guard for insifficient data error for fully decoded case

### DIFF
--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -448,6 +448,11 @@ static int cb_geoip2_filter(const void *data, size_t bytes,
         }
     }
 
+    if (ret == FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA &&
+        log_decoder.offset == bytes) {
+        ret = FLB_EVENT_ENCODER_SUCCESS;
+    }
+
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
         *out_buf  = log_encoder.output_buffer;
         *out_size = log_encoder.output_length;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/7351.
For other filters, there is a guard for decoder error when decoding done but FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA.
In this code path, we should handle this error as success.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
