### PR TITLE
filter_modify: fix clean up function for cond/rule(#7368)

### DIFF
--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -58,10 +58,10 @@ static void condition_free(struct modify_condition *condition)
         flb_free(condition->raw_v);
     }
 
-    if (condition->a_is_regex) {
+    if (condition->a_regex) {
         flb_regex_destroy(condition->a_regex);
     }
-    if (condition->b_is_regex) {
+    if (condition->b_regex) {
         flb_regex_destroy(condition->b_regex);
     }
     if (condition->ra_a) {
@@ -308,6 +308,7 @@ static int setup(struct filter_modify_ctx *ctx,
                     flb_plg_error(ctx->ins, "Unable to create regex for "
                                   "condition %s %s",
                                   condition->raw_k, condition->raw_v);
+                    teardown(ctx);
                     condition_free(condition);
                     flb_utils_split_free(split);
                     return -1;
@@ -327,6 +328,7 @@ static int setup(struct filter_modify_ctx *ctx,
                     flb_plg_error(ctx->ins, "Unable to create regex "
                                   "for condition %s %s",
                                   condition->raw_k, condition->raw_v);
+                    teardown(ctx);
                     condition_free(condition);
                     flb_utils_split_free(split);
                     return -1;

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -41,10 +41,22 @@
 
 static void condition_free(struct modify_condition *condition)
 {
-    flb_sds_destroy(condition->a);
-    flb_free(condition->b);
-    flb_free(condition->raw_k);
-    flb_free(condition->raw_v);
+    if (condition == NULL) {
+        return;
+    }
+
+    if (condition->a) {
+        flb_sds_destroy(condition->a);
+    }
+    if (condition->b) {
+        flb_free(condition->b);
+    }
+    if (condition->raw_k) {
+        flb_free(condition->raw_k);
+    }
+    if (condition->raw_v) {
+        flb_free(condition->raw_v);
+    }
 
     if (condition->a_is_regex) {
         flb_regex_destroy(condition->a_regex);
@@ -59,6 +71,36 @@ static void condition_free(struct modify_condition *condition)
     flb_free(condition);
 }
 
+static void rule_free(struct modify_rule *rule)
+{
+    if (rule == NULL) {
+        return;
+    }
+
+    if (rule->key) {
+        flb_free(rule->key);
+    }
+    if (rule->val) {
+        flb_free(rule->val);
+    }
+    if (rule->raw_k) {
+        flb_free(rule->raw_k);
+    }
+    if (rule->raw_v) {
+        flb_free(rule->raw_v);
+    }
+    if (rule->key_regex) {
+        flb_regex_destroy(rule->key_regex);
+    }
+    if (rule->val_regex) {
+        flb_regex_destroy(rule->val_regex);
+    }
+    if (!mk_list_entry_is_orphan(&rule->_head)) {
+        mk_list_del(&rule->_head);
+    }
+    flb_free(rule);
+}
+
 static void teardown(struct filter_modify_ctx *ctx)
 {
     struct mk_list *tmp;
@@ -69,20 +111,15 @@ static void teardown(struct filter_modify_ctx *ctx)
 
     mk_list_foreach_safe(head, tmp, &ctx->conditions) {
         condition = mk_list_entry(head, struct modify_condition, _head);
-        mk_list_del(&condition->_head);
+        if (!mk_list_entry_is_orphan(&condition->_head)) {
+            mk_list_del(&condition->_head);
+        }
         condition_free(condition);
     }
 
     mk_list_foreach_safe(head, tmp, &ctx->rules) {
         rule = mk_list_entry(head, struct modify_rule, _head);
-        flb_free(rule->key);
-        flb_free(rule->val);
-        flb_free(rule->raw_k);
-        flb_free(rule->raw_v);
-        flb_regex_destroy(rule->key_regex);
-        flb_regex_destroy(rule->val_regex);
-        mk_list_del(&rule->_head);
-        flb_free(rule);
+        rule_free(rule);
     }
 }
 
@@ -314,7 +351,7 @@ static int setup(struct filter_modify_ctx *ctx,
             // Build a rule
             //
 
-            rule = flb_malloc(sizeof(struct modify_rule));
+            rule = flb_calloc(1, sizeof(struct modify_rule));
             if (!rule) {
                 flb_plg_error(ctx->ins, "Unable to allocate memory for rule");
                 teardown(ctx);
@@ -329,7 +366,7 @@ static int setup(struct filter_modify_ctx *ctx,
                 flb_errno();
                 flb_plg_error(ctx->ins, "Unable to allocate memory for rule->raw_k");
                 teardown(ctx);
-                flb_free(rule);
+                rule_free(rule);
                 flb_utils_split_free(split);
                 return -1;
             }
@@ -338,8 +375,7 @@ static int setup(struct filter_modify_ctx *ctx,
                 flb_errno();
                 flb_plg_error(ctx->ins, "Unable to allocate memory for rule->raw_v");
                 teardown(ctx);
-                flb_free(rule->raw_k);
-                flb_free(rule);
+                rule_free(rule);
                 flb_utils_split_free(split);
                 return -1;
             }
@@ -351,9 +387,7 @@ static int setup(struct filter_modify_ctx *ctx,
                 flb_errno();
                 flb_plg_error(ctx->ins, "Unable to allocate memory for rule->key");
                 teardown(ctx);
-                flb_free(rule->raw_v);
-                flb_free(rule->raw_k);
-                flb_free(rule);
+                rule_free(rule);
                 flb_utils_split_free(split);
                 return -1;
             }
@@ -365,10 +399,7 @@ static int setup(struct filter_modify_ctx *ctx,
                 flb_errno();
                 flb_plg_error(ctx->ins, "Unable to allocate memory for rule->val");
                 teardown(ctx);
-                flb_free(rule->key);
-                flb_free(rule->raw_v);
-                flb_free(rule->raw_k);
-                flb_free(rule);
+                rule_free(rule);
                 flb_utils_split_free(split);
                 return -1;
             }
@@ -397,7 +428,7 @@ static int setup(struct filter_modify_ctx *ctx,
                     flb_plg_error(ctx->ins, "Invalid operation %s : %s in "
                                   "configuration", kv->key, kv->val);
                     teardown(ctx);
-                    flb_free(rule);
+                    rule_free(rule);
                     return -1;
                 }
             }
@@ -430,7 +461,7 @@ static int setup(struct filter_modify_ctx *ctx,
                     flb_plg_error(ctx->ins, "Invalid operation %s : %s in "
                                   "configuration", kv->key, kv->val);
                     teardown(ctx);
-                    flb_free(rule);
+                    rule_free(rule);
                     return -1;
                 }
             }
@@ -439,22 +470,38 @@ static int setup(struct filter_modify_ctx *ctx,
                 flb_plg_error(ctx->ins, "Unable to create regex for rule %s %s",
                               rule->raw_k, rule->raw_v);
                 teardown(ctx);
-                flb_free(rule);
+                rule_free(rule);
                 return -1;
             }
             else {
                 rule->key_regex =
                     flb_regex_create(rule->key);
+                if (rule->key_regex == NULL) {
+                    flb_plg_error(ctx->ins, "Unable to create regex(key) from %s",
+                                  rule->key);
+                    teardown(ctx);
+                    rule_free(rule);
+                    return -1;
+                }
             }
 
             if (rule->val_is_regex && rule->val_len == 0) {
                 flb_plg_error(ctx->ins, "Unable to create regex for rule %s %s",
                               rule->raw_k, rule->raw_v);
+                teardown(ctx);
+                rule_free(rule);
                 return -1;
             }
             else {
                 rule->val_regex =
                     flb_regex_create(rule->val);
+                if (rule->val_regex == NULL) {
+                    flb_plg_error(ctx->ins, "Unable to create regex(val) from %s",
+                                  rule->val);
+                    teardown(ctx);
+                    rule_free(rule);
+                    return -1;
+                }
             }
 
             mk_list_add(&rule->_head, &ctx->rules);

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -68,6 +68,9 @@ static void condition_free(struct modify_condition *condition)
         flb_ra_destroy(condition->ra_a);
         condition->ra_a = NULL;
     }
+    if (!mk_list_entry_is_orphan(&condition->_head)) {
+        mk_list_del(&condition->_head);
+    }
     flb_free(condition);
 }
 
@@ -111,9 +114,6 @@ static void teardown(struct filter_modify_ctx *ctx)
 
     mk_list_foreach_safe(head, tmp, &ctx->conditions) {
         condition = mk_list_entry(head, struct modify_condition, _head);
-        if (!mk_list_entry_is_orphan(&condition->_head)) {
-            mk_list_del(&condition->_head);
-        }
         condition_free(condition);
     }
 

--- a/src/flb_regex.c
+++ b/src/flb_regex.c
@@ -140,7 +140,6 @@ static int str_to_regex(const char *pattern, OnigRegex *reg)
                    ONIG_ENCODING_UTF8, ONIG_SYNTAX_RUBY, &einfo);
 
     if (ret != ONIG_NORMAL) {
-        printf("ret=%d. start=%s end=%c\n", ret, start, *end);
         return -1;
     }
     return 0;

--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1594,6 +1594,38 @@ static void flb_test_issue_7075()
     filter_test_destroy(ctx);
 }
 
+static void flb_test_issue_7368()
+{
+    int len;
+    int ret;
+    int bytes;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure filter */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "remove_wildcard", "*s3",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = "\"r1\":\"someval\"";
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret != 0);
+
+    filter_test_destroy(ctx);
+}
+
 TEST_LIST = {
     /* Operations / Commands */
     {"op_set_append"            , flb_test_op_set_append },
@@ -1639,6 +1671,7 @@ TEST_LIST = {
     {"cond_key_value_does_not_matches and key does not exist", flb_test_issue_4319_2 },
     {"Key_value_matches and value is bool type", flb_test_issue_7075},
     {"operation_with_whitespace", flb_test_issue_1225 },
+    {"invalid_wildcard", flb_test_issue_7368 },
 
     {NULL, NULL}
 };

--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1596,10 +1596,7 @@ static void flb_test_issue_7075()
 
 static void flb_test_issue_7368()
 {
-    int len;
     int ret;
-    int bytes;
-    char *p;
     struct flb_lib_out_cb cb_data;
     struct filter_test *ctx;
 


### PR DESCRIPTION
Fixes #7368 

This patch is to 
- Add `rule_free` to release `struct modify_rule`
- Check if valid pointer before releasing
- Use `flb_calloc` to initialize members of struct
- Add test code for #7368 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Flush      1
    Grace      2
    Log_Level  info

[INPUT]
    Name       dummy
    Dummy      {"r1":"someval"}
    Samples    1

[FILTER]
    Name                 modify
    Match                *
    Log_Level            debug
    Remove_wildcard      *s3

[OUTPUT]
    Name  stdout
    Match *

[OUTPUT]
    Name exit
    Match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_modify 
==34097== Memcheck, a memory error detector
==34097== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==34097== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==34097== Command: bin/flb-rt-filter_modify
==34097== 
Test op_set_append...                           [2023/05/13 08:13:56] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=34097
[2023/05/13 08:13:57] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/13 08:13:57] [ info] [cmetrics] version=0.6.1

(snip)

Test invalid_wildcard...                        [2023/05/13 08:15:10] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=34097
[2023/05/13 08:15:10] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/13 08:15:10] [ info] [cmetrics] version=0.6.1
[2023/05/13 08:15:10] [ info] [ctraces ] version=0.3.0
[2023/05/13 08:15:10] [ info] [input:lib:lib.0] initializing
[2023/05/13 08:15:10] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/13 08:15:10] [error] [filter:modify:modify.0] Unable to create regex(key) from *s3
[2023/05/13 08:15:10] [error] Failed initialize filter modify.0
[2023/05/13 08:15:10] [error] [engine] filter initialization failed
[2023/05/13 08:15:10] [error] [lib] backend failed
[ OK ]
SUCCESS: All unit tests have passed.
==34097== 
==34097== HEAP SUMMARY:
==34097==     in use at exit: 0 bytes in 0 blocks
==34097==   total heap usage: 56,139 allocs, 56,139 frees, 28,221,757 bytes allocated
==34097== 
==34097== All heap blocks were freed -- no leaks are possible
==34097== 
==34097== For lists of detected and suppressed errors, rerun with: -s
==34097== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
