### PR TITLE
filter_parser: refactoring. simplify msgpack loop.

### DIFF
--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -236,143 +236,141 @@ static int cb_parser_filter(const void *data, size_t bytes,
         flb_time_copy(&tm, &log_event.timestamp);
         obj = log_event.body;
 
-        if (obj->type == MSGPACK_OBJECT_MAP) {
-            map_num = obj->via.map.size;
-            if (ctx->reserve_data) {
-                append_arr_len = obj->via.map.size;
-                append_arr = flb_calloc(append_arr_len, sizeof(msgpack_object_kv *));
+        if (obj->type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
+        map_num = obj->via.map.size;
+        if (ctx->reserve_data) {
+            append_arr_len = obj->via.map.size;
+            append_arr = flb_calloc(append_arr_len, sizeof(msgpack_object_kv *));
 
-                if (append_arr == NULL) {
-                    flb_errno();
+            if (append_arr == NULL) {
+                flb_errno();
+
+                flb_log_event_decoder_destroy(&log_decoder);
+                flb_log_event_encoder_destroy(&log_encoder);
+
+                return FLB_FILTER_NOTOUCH;
+            }
+        }
+
+        continue_parsing = FLB_TRUE;
+        for (i = 0; i < map_num && continue_parsing; i++) {
+            kv = &obj->via.map.ptr[i];
+            if (ctx->reserve_data) {
+                append_arr[append_arr_i] = kv;
+                append_arr_i++;
+            }
+            if ( msgpackobj2char(&kv->key, &key_str, &key_len) < 0 ) {
+                /* key is not string */
+                continue;
+            }
+            if (key_len == ctx->key_name_len &&
+                !strncmp(key_str, ctx->key_name, key_len)) {
+                if ( msgpackobj2char(&kv->val, &val_str, &val_len) < 0 ) {
+                    /* val is not string */
+                    continue;
+                }
+
+                /* Lookup parser */
+                mk_list_foreach(head, &ctx->parsers) {
+                    fp = mk_list_entry(head, struct filter_parser, _head);
+
+                    /* Reset time */
+                    flb_time_zero(&parsed_time);
+
+                    parse_ret = flb_parser_do(fp->parser, val_str, val_len,
+                                              (void **) &out_buf, &out_size,
+                                              &parsed_time);
+                    if (parse_ret >= 0) {
+                        /*
+                         * If the parser succeeded we need to check the
+                         * status of the parsed time. If the time was
+                         * parsed successfully 'parsed_time' will be
+                         * different than zero, if so, override the time
+                         * holder with the new value, otherwise keep the
+                         * original.
+                         */
+                        if (flb_time_to_nanosec(&parsed_time) != 0L) {
+                            flb_time_copy(&tm, &parsed_time);
+                        }
+
+                        if (ctx->reserve_data) {
+                            if (!ctx->preserve_key) {
+                                append_arr_i--;
+                                append_arr_len--;
+                                append_arr[append_arr_i] = NULL;
+                            }
+                        }
+                        else {
+                            continue_parsing = FLB_FALSE;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        encoder_result = flb_log_event_encoder_begin_record(&log_encoder);
+
+        if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
+            encoder_result = flb_log_event_encoder_set_timestamp(
+                                     &log_encoder, &tm);
+        }
+
+        if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
+            encoder_result =                                            \
+                flb_log_event_encoder_set_metadata_from_msgpack_object(
+                        &log_encoder, log_event.metadata);
+        }
+
+        if (out_buf != NULL) {
+            if (ctx->reserve_data) {
+                char *new_buf = NULL;
+                int  new_size;
+                int ret;
+                ret = flb_msgpack_expand_map(out_buf, out_size,
+                                             append_arr, append_arr_len,
+                                             &new_buf, &new_size);
+                if (ret == -1) {
+                    flb_plg_error(ctx->ins, "cannot expand map");
 
                     flb_log_event_decoder_destroy(&log_decoder);
                     flb_log_event_encoder_destroy(&log_encoder);
+                    flb_free(append_arr);
 
                     return FLB_FILTER_NOTOUCH;
                 }
-            }
-
-            continue_parsing = FLB_TRUE;
-            for (i = 0; i < map_num && continue_parsing; i++) {
-                kv = &obj->via.map.ptr[i];
-                if (ctx->reserve_data) {
-                    append_arr[append_arr_i] = kv;
-                    append_arr_i++;
-                }
-                if ( msgpackobj2char(&kv->key, &key_str, &key_len) < 0 ) {
-                    /* key is not string */
-                    continue;
-                }
-                if (key_len == ctx->key_name_len &&
-                    !strncmp(key_str, ctx->key_name, key_len)) {
-                    if ( msgpackobj2char(&kv->val, &val_str, &val_len) < 0 ) {
-                        /* val is not string */
-                        continue;
-                    }
-
-                    /* Lookup parser */
-                    mk_list_foreach(head, &ctx->parsers) {
-                        fp = mk_list_entry(head, struct filter_parser, _head);
-
-                        /* Reset time */
-                        flb_time_zero(&parsed_time);
-
-                        parse_ret = flb_parser_do(fp->parser, val_str, val_len,
-                                                  (void **) &out_buf, &out_size,
-                                                  &parsed_time);
-                        if (parse_ret >= 0) {
-                            /*
-                             * If the parser succeeded we need to check the
-                             * status of the parsed time. If the time was
-                             * parsed successfully 'parsed_time' will be
-                             * different than zero, if so, override the time
-                             * holder with the new value, otherwise keep the
-                             * original.
-                             */
-                            if (flb_time_to_nanosec(&parsed_time) != 0L) {
-                                flb_time_copy(&tm, &parsed_time);
-                            }
-
-                            if (ctx->reserve_data) {
-                                if (!ctx->preserve_key) {
-                                    append_arr_i--;
-                                    append_arr_len--;
-                                    append_arr[append_arr_i] = NULL;
-                                }
-                            }
-                            else {
-                                continue_parsing = FLB_FALSE;
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
-
-            encoder_result = flb_log_event_encoder_begin_record(&log_encoder);
-
-            if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                encoder_result = flb_log_event_encoder_set_timestamp(
-                                     &log_encoder, &tm);
-            }
-
-            if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                encoder_result = \
-                    flb_log_event_encoder_set_metadata_from_msgpack_object(
-                        &log_encoder, log_event.metadata);
-            }
-
-            if (out_buf != NULL) {
-                if (ctx->reserve_data) {
-                    char *new_buf = NULL;
-                    int  new_size;
-                    int ret;
-                    ret = flb_msgpack_expand_map(out_buf, out_size,
-                                                 append_arr, append_arr_len,
-                                                 &new_buf, &new_size);
-                    if (ret == -1) {
-                        flb_plg_error(ctx->ins, "cannot expand map");
-
-                        flb_log_event_decoder_destroy(&log_decoder);
-                        flb_log_event_encoder_destroy(&log_encoder);
-                        flb_free(append_arr);
-
-                        return FLB_FILTER_NOTOUCH;
-                    }
-
-                    flb_free(out_buf);
-                    out_buf = new_buf;
-                    out_size = new_size;
-                }
-
-                if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                    encoder_result = \
-                        flb_log_event_encoder_set_body_from_raw_msgpack(
-                            &log_encoder, out_buf, out_size);
-                }
 
                 flb_free(out_buf);
-                ret = FLB_FILTER_MODIFIED;
-            }
-            else {
-                /* re-use original data*/
-                if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                    encoder_result = \
-                        flb_log_event_encoder_set_body_from_msgpack_object(
-                            &log_encoder, log_event.body);
-                }
+                out_buf = new_buf;
+                out_size = new_size;
             }
 
             if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
-                encoder_result = flb_log_event_encoder_commit_record(&log_encoder);
+                encoder_result =                                        \
+                    flb_log_event_encoder_set_body_from_raw_msgpack(
+                            &log_encoder, out_buf, out_size);
             }
 
-            flb_free(append_arr);
-            append_arr = NULL;
+            flb_free(out_buf);
+            ret = FLB_FILTER_MODIFIED;
         }
         else {
-            continue;
+            /* re-use original data*/
+            if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
+                encoder_result =                                        \
+                    flb_log_event_encoder_set_body_from_msgpack_object(
+                            &log_encoder, log_event.body);
+            }
         }
+
+        if (encoder_result == FLB_EVENT_ENCODER_SUCCESS) {
+            encoder_result = flb_log_event_encoder_commit_record(&log_encoder);
+        }
+
+        flb_free(append_arr);
+        append_arr = NULL;
     }
 
     if (log_encoder.output_length > 0) {


### PR DESCRIPTION
This patch is updated #6832 for v2.1.

From

```c
   if (obj->type == MSGPACK_OBJECT_MAP) {
       /* filtering */
   }
   else {
       continue;
   }

To
   if (obj->type != MSGPACK_OBJECT_MAP) {
       continue;
   }
   /* filtering */
```
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-filter_parser 
==12073== Memcheck, a memory error detector
==12073== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12073== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==12073== Command: bin/flb-rt-filter_parser
==12073== 
Test filter_parser_extract_fields...            [2023/05/14 08:40:36] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:36] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:36] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:36] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:36] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:36] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:36] [ info] [sp] stream processor started
[2023/05/14 08:40:37] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/14 08:40:38] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_reserve_data_off...          [2023/05/14 08:40:38] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:38] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/14 08:40:38] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:38] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:38] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:38] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:38] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:38] [debug] [lib:lib.0] created event channels: read=30 write=31
[2023/05/14 08:40:38] [debug] [lib:lib.0] created event channels: read=34 write=35
[2023/05/14 08:40:38] [ info] [sp] stream processor started
[2023/05/14 08:40:38] [debug] [input chunk] update output instances with new chunk size diff=76
[2023/05/14 08:40:39] [debug] [task] created task=0x5584810 id=0 OK
[2023/05/14 08:40:39] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example"}]
[2023/05/14 08:40:39] [debug] [out flush] cb_destroy coro_id=0
[2023/05/14 08:40:39] [debug] [task] destroy task=0x5584810 (task_id=0)
[2023/05/14 08:40:39] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/14 08:40:40] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_handle_time_key...           [2023/05/14 08:40:40] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:40] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/14 08:40:40] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:40] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:40] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:40] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:40] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:40] [debug] [lib:lib.0] created event channels: read=39 write=40
[2023/05/14 08:40:40] [debug] [lib:lib.0] created event channels: read=43 write=44
[2023/05/14 08:40:40] [ info] [sp] stream processor started
[2023/05/14 08:40:40] [debug] [input chunk] update output instances with new chunk size diff=49
[2023/05/14 08:40:41] [debug] [task] created task=0x56610c0 id=0 OK
[2023/05/14 08:40:41] [debug] [test_filter_parser] received message: [1509575121.648000,{"message":"This is an example"}]
[2023/05/14 08:40:41] [debug] [out flush] cb_destroy coro_id=0
[2023/05/14 08:40:41] [debug] [task] destroy task=0x56610c0 (task_id=0)
[2023/05/14 08:40:41] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/14 08:40:42] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_handle_time_key_with_time_zone... [2023/05/14 08:40:42] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:42] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/14 08:40:42] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:42] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:42] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:42] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:42] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:42] [debug] [lib:lib.0] created event channels: read=48 write=49
[2023/05/14 08:40:42] [debug] [lib:lib.0] created event channels: read=52 write=53
[2023/05/14 08:40:42] [ info] [sp] stream processor started
[2023/05/14 08:40:42] [debug] [input chunk] update output instances with new chunk size diff=49
[2023/05/14 08:40:43] [debug] [task] created task=0x573d930 id=0 OK
[2023/05/14 08:40:43] [debug] [test_filter_parser] received message: [1509589521.648000,{"message":"This is an example"}]
[2023/05/14 08:40:43] [debug] [out flush] cb_destroy coro_id=0
[2023/05/14 08:40:43] [debug] [task] destroy task=0x573d930 (task_id=0)
[2023/05/14 08:40:43] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/14 08:40:44] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_ignore_malformed_time...     [2023/05/14 08:40:44] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:44] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/14 08:40:44] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:44] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:44] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:44] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:44] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:44] [debug] [lib:lib.0] created event channels: read=57 write=58
[2023/05/14 08:40:44] [debug] [lib:lib.0] created event channels: read=61 write=62
[2023/05/14 08:40:44] [ info] [sp] stream processor started
[2023/05/14 08:40:44] [error] [parser] cannot parse '2017_$!^-11-01T22:25:21.648'
[2023/05/14 08:40:44] [ warn] [parser:timestamp] invalid time format %Y-%m-%dT%H:%M:%S.%L for '2017_$!^-11-01T22:25:21.648'
[2023/05/14 08:40:44] [debug] [input chunk] update output instances with new chunk size diff=76
[2023/05/14 08:40:45] [debug] [task] created task=0x57da2a0 id=0 OK
[2023/05/14 08:40:45] [debug] [test_filter_parser] received message: [1448403340.000000,{"@timestamp":"2017_$!^-11-01T22:25:21.648","log":"An example"}]
[2023/05/14 08:40:45] [debug] [out flush] cb_destroy coro_id=0
[2023/05/14 08:40:45] [debug] [task] destroy task=0x57da2a0 (task_id=0)
[2023/05/14 08:40:45] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/14 08:40:46] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_preserve_original_field...   [2023/05/14 08:40:46] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/14 08:40:46] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:46] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:46] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:46] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:46] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:46] [debug] [lib:lib.0] created event channels: read=66 write=67
[2023/05/14 08:40:46] [debug] [lib:lib.0] created event channels: read=70 write=71
[2023/05/14 08:40:46] [ info] [sp] stream processor started
[2023/05/14 08:40:46] [debug] [input chunk] update output instances with new chunk size diff=128
[2023/05/14 08:40:47] [debug] [task] created task=0x6919e20 id=0 OK
[2023/05/14 08:40:47] [debug] [test_filter_parser] received message: [1448403340.000000,{"INT":"100","FLOAT":"0.5","BOOL":"true","STRING":"This is an example","data":"100 0.5 true This is an example","log":"An example"}]
[2023/05/14 08:40:47] [debug] [out flush] cb_destroy coro_id=0
[2023/05/14 08:40:47] [debug] [task] destroy task=0x6919e20 (task_id=0)
[2023/05/14 08:40:47] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/14 08:40:48] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_first_matched_when_multiple_parser... [2023/05/14 08:40:48] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:48] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:48] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:48] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:48] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:48] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:48] [ info] [sp] stream processor started
[2023/05/14 08:40:49] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/14 08:40:50] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test filter_parser_skip_empty_values_false...   [2023/05/14 08:40:50] [ info] [fluent bit] version=2.1.3, commit=4398840ed5, pid=12073
[2023/05/14 08:40:50] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/14 08:40:50] [ info] [cmetrics] version=0.6.1
[2023/05/14 08:40:50] [ info] [ctraces ] version=0.3.0
[2023/05/14 08:40:50] [ info] [input:lib:lib.0] initializing
[2023/05/14 08:40:50] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/05/14 08:40:50] [ info] [sp] stream processor started
[2023/05/14 08:40:51] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/14 08:40:52] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==12073== 
==12073== HEAP SUMMARY:
==12073==     in use at exit: 0 bytes in 0 blocks
==12073==   total heap usage: 12,438 allocs, 12,438 frees, 6,334,462 bytes allocated
==12073== 
==12073== All heap blocks were freed -- no leaks are possible
==12073== 
==12073== For lists of detected and suppressed errors, rerun with: -s
==12073== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
