### PR TITLE
out_opensearch: Add gzip compression

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -909,7 +909,7 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     final_payload_buf = pack;
     final_payload_size = pack_size;
     /* Should we compress the payload ? */
-    if (ctx->compress_gzip == FLB_TRUE) {
+    if (ctx->compression == FLB_OS_COMPRESSION_GZIP) {
         ret = flb_gzip_compress((void *) pack, pack_size,
                                 &out_buf, &out_size);
         if (ret == -1) {
@@ -951,9 +951,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     }
 #endif
 
-    /* Content Encoding: gzip */
+    /* Set Content-Encoding of compressed payload */
     if (compressed == FLB_TRUE) {
-        flb_http_set_content_encoding_gzip(c);
+        if (ctx->compression == FLB_OS_COMPRESSION_GZIP) {
+            flb_http_set_content_encoding_gzip(c);
+        }
     }
 
     /* Map debug callbacks */
@@ -1258,7 +1260,7 @@ static struct flb_config_map config_map[] = {
     /* HTTP Compression */
     {
      FLB_CONFIG_MAP_STR, "compress", NULL,
-     0, FLB_FALSE, 0,
+     0, FLB_TRUE, offsetof(struct flb_opensearch, compression_str),
      "Set payload compression mechanism. Option available is 'gzip'"
     },
 

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_signv4.h>
 #include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_ra_key.h>
 #include <fluent-bit/flb_log_event_decoder.h>
@@ -868,6 +869,9 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     struct flb_connection *u_conn;
     struct flb_http_client *c;
     flb_sds_t signature = NULL;
+    int compressed = FLB_FALSE;
+    void *final_payload_buf = NULL;
+    size_t final_payload_size = 0;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -902,9 +906,26 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     pack = (char *) out_buf;
     pack_size = out_size;
 
+    /* Should we compress the payload ? */
+    if (ctx->compress_gzip == FLB_TRUE) {
+        ret = flb_gzip_compress((void *) pack, pack_size,
+                                &final_payload_buf, &final_payload_size);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins,
+                          "cannot gzip payload, disabling compression");
+        }
+        else {
+            compressed = FLB_TRUE;
+        }
+    }
+    else {
+        final_payload_buf = pack;
+        final_payload_size = pack_size;
+    }
+
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
-                        pack, pack_size, NULL, 0, NULL, 0);
+                        final_payload_buf, final_payload_size, NULL, 0, NULL, 0);
 
     flb_http_buffer_size(c, ctx->buffer_size);
 
@@ -929,6 +950,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
         flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
     }
 #endif
+
+    /* Content Encoding: gzip */
+    if (compressed == FLB_TRUE) {
+        flb_http_set_content_encoding_gzip(c);
+    }
 
     /* Map debug callbacks */
     flb_http_client_debug(c, ctx->ins->callback);
@@ -965,7 +991,7 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
                     /*
                      * If trace_error is set, trace the actual
                      * response from Elasticsearch explaining the problem.
-                     * Trace_Output can be used to see the request. 
+                     * Trace_Output can be used to see the request.
                      */
                     if (pack_size < 4000) {
                         flb_plg_debug(ctx->ins, "error caused by: Input\n%.*s\n",
@@ -998,6 +1024,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     /* Cleanup */
     flb_http_client_destroy(c);
     flb_sds_destroy(pack);
+
+    if (final_payload_buf != pack) {
+        flb_free(final_payload_buf);
+    }
+
     flb_upstream_conn_release(u_conn);
     if (signature) {
         flb_sds_destroy(signature);
@@ -1008,6 +1039,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
  retry:
     flb_http_client_destroy(c);
     flb_sds_destroy(pack);
+
+    if (final_payload_buf != pack) {
+        flb_free(final_payload_buf);
+    }
+
     flb_upstream_conn_release(u_conn);
     FLB_OUTPUT_RETURN(FLB_RETRY);
 }
@@ -1217,6 +1253,13 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_opensearch, trace_error),
      "When enabled print the OpenSearch exception to stderr (for diag only)"
+    },
+
+    /* HTTP Compression */
+    {
+     FLB_CONFIG_MAP_STR, "compress", NULL,
+     0, FLB_FALSE, 0,
+     "Set payload compression mechanism. Option available is 'gzip'"
     },
 
     /* EOF */

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -906,21 +906,21 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     pack = (char *) out_buf;
     pack_size = out_size;
 
+    final_payload_buf = pack;
+    final_payload_size = pack_size;
     /* Should we compress the payload ? */
     if (ctx->compress_gzip == FLB_TRUE) {
         ret = flb_gzip_compress((void *) pack, pack_size,
-                                &final_payload_buf, &final_payload_size);
+                                &out_buf, &out_size);
         if (ret == -1) {
             flb_plg_error(ctx->ins,
                           "cannot gzip payload, disabling compression");
         }
         else {
             compressed = FLB_TRUE;
+            final_payload_buf = out_buf;
+            final_payload_size = out_size;
         }
-    }
-    else {
-        final_payload_buf = pack;
-        final_payload_size = pack_size;
     }
 
     /* Compose HTTP Client request */

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -51,6 +51,10 @@
 #define OS_BULK_UPDATE_OP_BODY       "{\"doc\":"
 #define OS_BULK_UPSERT_OP_BODY       "{\"doc_as_upsert\":true,\"doc\":"
 
+/* Supported compression algorithms */
+#define FLB_OS_COMPRESSION_NONE 0
+#define FLB_OS_COMPRESSION_GZIP 1
+
 struct flb_opensearch {
     /* OpenSearch index (database) and type (table) */
     flb_sds_t index;
@@ -143,8 +147,9 @@ struct flb_opensearch {
     /* Plugin output instance reference */
     struct flb_output_instance *ins;
 
-    /* Compression mode (gzip) */
-    int compress_gzip;
+    /* Compression algorithm */
+    int compression;
+    flb_sds_t compression_str;
 };
 
 #endif

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -127,7 +127,7 @@ struct flb_opensearch {
     /* id_key */
     flb_sds_t id_key;
     struct flb_record_accessor *ra_id_key;
-    
+
     /* include_tag_key */
     int include_tag_key;
     flb_sds_t tag_key;
@@ -142,6 +142,9 @@ struct flb_opensearch {
 
     /* Plugin output instance reference */
     struct flb_output_instance *ins;
+
+    /* Compression mode (gzip) */
+    int compress_gzip;
 };
 
 #endif

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -214,6 +214,15 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* Compress (gzip) */
+    tmp = flb_output_get_property("compress", ins);
+    ctx->compress_gzip = FLB_FALSE;
+    if (tmp) {
+        if (strcasecmp(tmp, "gzip") == 0) {
+            ctx->compress_gzip = FLB_TRUE;
+        }
+    }
+
 #ifdef FLB_HAVE_AWS
     /* AWS Auth Unsigned Headers */
     ctx->aws_unsigned_headers = flb_malloc(sizeof(struct mk_list));

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -214,13 +214,16 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
         }
     }
 
-    /* Compress (gzip) */
-    tmp = flb_output_get_property("compress", ins);
-    ctx->compress_gzip = FLB_FALSE;
-    if (tmp) {
-        if (strcasecmp(tmp, "gzip") == 0) {
-            ctx->compress_gzip = FLB_TRUE;
+    if (ctx->compression_str) {
+        if (strcasecmp(ctx->compression_str, "gzip") == 0) {
+            ctx->compression = FLB_OS_COMPRESSION_GZIP;
         }
+        else {
+            ctx->compression = FLB_OS_COMPRESSION_NONE;
+        }
+    }
+    else {
+        ctx->compression = FLB_OS_COMPRESSION_NONE;
     }
 
 #ifdef FLB_HAVE_AWS


### PR DESCRIPTION
This change adds support for compressing the payload sent to an OpenSearch server using gzip.

Compression is off by default, similar to other outputs that support compression.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1104

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
