### PR TITLE
in_opentelemetry: fix record structure

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -270,7 +270,10 @@ static int otel_pack_array(msgpack_packer *mp_pck,
     int ret;
     int array_index;
 
-    ret = 0;
+    ret = msgpack_pack_array(mp_pck, array->n_values);
+    if (ret != 0) {
+        return ret;
+    }
 
     for (array_index = 0; array_index < array->n_values && ret == 0; array_index++) {
         ret = otlp_pack_any_value(mp_pck, array->values[array_index]);

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -423,6 +423,9 @@ static int binary_payload_to_msgpack(msgpack_packer *mp_pck,
             }
         }
     }
+
+    opentelemetry__proto__collector__logs__v1__export_logs_service_request__free_unpacked(input_logs, NULL);
+
     return 0;
 }
 

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -332,6 +332,32 @@ static int otlp_pack_any_value(msgpack_packer *mp_pck,
     return result;
 }
 
+static int otel_pack_body(msgpack_packer *mp_pck,
+                          Opentelemetry__Proto__Common__V1__AnyValue *body)
+{
+    int result;
+
+    if (body->value_case != OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_KVLIST_VALUE) {
+        result = msgpack_pack_map(mp_pck, 1);
+        if (result != 0) {
+            return result;
+        }
+
+        result = otel_pack_string(mp_pck, "message");
+        if (result != 0) {
+            return result;
+        }
+    }
+
+    result = otlp_pack_any_value(mp_pck, body);
+    if (result != 0) {
+        flb_error("[otel] Failed to convert log record body");
+        return -1;
+    }
+
+    return result;
+}
+
 static int binary_payload_to_msgpack(msgpack_packer *mp_pck,
                                      uint8_t *in_buf,
                                      size_t in_size)
@@ -385,12 +411,12 @@ static int binary_payload_to_msgpack(msgpack_packer *mp_pck,
 
                 log_record = log_records[log_record_index];
 
-                ret = otlp_pack_any_value(mp_pck, log_record->body);
-
+                ret = otel_pack_body(mp_pck, log_record->body);
                 if (ret != 0) {
-                    flb_error("[otel] Failed to convert log record body");
+                    flb_error("[otel] Failed to pack body field");
                     return -1;
                 }
+
             }
         }
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
in_opentelemetry: enforce log record structure as [ timestamp, { body } ], and start msgpack_array in otel_pack_array

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#7191 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[SERVICE]
    flush 1
    grace 1
    log_level info

[INPUT]
    name opentelemetry
    listen 127.0.0.1
    port 8101

[OUTPUT]
    name stdout
    match *
```

```
receivers:
  filelog:
    include: [./sample.json]
    start_at: beginning
    operators:
      - type: json_parser
        parse_from: body
        parse_to: body

exporters:
  logging:
    loglevel: debug

  otlphttp:
    endpoint: "http://127.0.0.1:8101"
    compression: none

service:
  telemetry:
    metrics:
      level: none

  pipelines:
    logs:
      receivers: [filelog]
      processors: []
      exporters: [otlphttp]
```
```
{"level":"error","error":"oops","foo":"bar","time":"2021-06-17T22:38:02+02:00","message":"something bad happened", "an array": [1,2,3,4]}
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
Fluent Bit v2.0.12
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/15 08:27:34] [ info] [fluent bit] version=2.0.12, commit=60cf5387fc, pid=5911
[2023/05/15 08:27:34] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/15 08:27:34] [ info] [cmetrics] version=0.6.1
[2023/05/15 08:27:34] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/15 08:27:34] [ info] [ctraces ] version=0.3.0
[2023/05/15 08:27:34] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/05/15 08:27:34] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/05/15 08:27:34] [ info] [input:opentelemetry:opentelemetry.0] listening on 127.0.0.1:8101
[2023/05/15 08:27:34] [ info] [sp] stream processor started
[0] v1_logs: [1684139261.490143338, {"message"=>"TEST LOG"}]
^C[2023/05/15 08:27:47] [engine] caught signal (SIGINT)
[2023/05/15 08:27:47] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/15 08:27:48] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/15 08:27:48] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/15 08:27:48] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==5911==
==5911== HEAP SUMMARY:
==5911==     in use at exit: 0 bytes in 0 blocks
==5911==   total heap usage: 1,574 allocs, 1,574 frees, 1,604,283 bytes allocated
==5911==
==5911== All heap blocks were freed -- no leaks are possible
==5911==
==5911== For lists of detected and suppressed errors, rerun with: -s
==5911== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
