### PR TITLE
dockerfiles: revert update ldap dependencies from 7309

### DIFF
--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -16,6 +16,9 @@ jobs:
       name: PR - Buildkit docker build test
       runs-on: ubuntu-latest
       environment: pr
+      permissions:
+        contents: read
+        packages: write
       steps:
         - name: Checkout code
           uses: actions/checkout@v3
@@ -23,7 +26,16 @@ jobs:
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v2
 
+        - name: Extract metadata from Github
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ github.repository }}/pr-${{ github.event.pull_request.number }}
+            tags: |
+              type=sha
+
         - name: Build the multi-arch images
+          id: build
           uses: docker/build-push-action@v4
           with:
             file: ./dockerfiles/Dockerfile
@@ -31,8 +43,15 @@ jobs:
             platforms: linux/amd64
             target: production
             push: false
-            load: false
+            load: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
 
+        - name: Sanity check it runs
+          run: |
+            docker run --rm -t ${{ steps.meta.outputs.tags }} --help
+          shell: bash
+        
         - name: Build the debug multi-arch images
           uses: docker/build-push-action@v4
           with:

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -15,10 +15,9 @@ jobs:
     pr-image-tests-build-images:
       name: PR - Buildkit docker build test
       runs-on: ubuntu-latest
-      environment: pr
       permissions:
         contents: read
-        packages: write
+        # We do not push and this allows simpler workflow running for forks too
       steps:
         - name: Checkout code
           uses: actions/checkout@v3
@@ -33,7 +32,7 @@ jobs:
             images: ${{ github.repository }}/pr-${{ github.event.pull_request.number }}
             tags: |
               type=sha
-
+    
         - name: Build the multi-arch images
           id: build
           uses: docker/build-push-action@v4
@@ -48,6 +47,7 @@ jobs:
             labels: ${{ steps.meta.outputs.labels }}
 
         - name: Sanity check it runs
+          # We do this for a simple check of dependencies
           run: |
             docker run --rm -t ${{ steps.meta.outputs.tags }} --help
           shell: bash
@@ -65,7 +65,8 @@ jobs:
     pr-image-tests-classic-docker-build:
       name: PR - Classic docker build test
       runs-on: ubuntu-latest
-      environment: pr
+      permissions:
+        contents: read
       steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -120,7 +120,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/
     libzstd1 \
     liblz4-1 \
     libgssapi-krb5-2 \
-    libldap-2.5-0/bullseye-backports \
+    libldap-2.4-2 \
     libgpg-error0 \
     libkrb5-3 \
     libk5crypto3 \


### PR DESCRIPTION
Resolves #7383  by reverting #7309 as there are a few conflicts and it triggers an issue at runtime as the library is missing.

Primarily the issue is that even some of the bullseye-backports components we use still have this dependency, e.g. installing `curl/bullseye-backports` triggers it: https://packages.debian.org/bullseye-backports/libcurl4

Realistically I think it needs more work to remove or update this dependency - this is primarily a fix to the image to ensure it works. cc @Garfield96 

Also added a sanity test to the PR image tests workflow.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

CI verifies it with the new test case.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
