### PR TITLE
out_stackdriver: process spanId special field

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1417,6 +1417,7 @@ static int pack_json_payload(int insert_id_extracted,
         ctx->labels_key,
         ctx->severity_key,
         ctx->trace_key,
+        ctx->span_id_key,
         ctx->log_name_key,
         stream
         /* more special fields are required to be added, but, if this grows with more
@@ -1593,6 +1594,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     flb_sds_t trace;
     char stackdriver_trace[PATH_MAX];
     const char *new_trace;
+
+    /* Parameters for span id */
+    int span_id_extracted = FLB_FALSE;
+    flb_sds_t span_id;
 
     /* Parameters for log name */
     int log_name_extracted = FLB_FALSE;
@@ -2034,6 +2039,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
          *  "logName": "...",
          *  "jsonPayload": {...},
          *  "timestamp": "...",
+         *  "spanId": "...",
          *  "trace": "..."
          * }
          */
@@ -2052,6 +2058,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         if (ctx->trace_key
             && get_string(&trace, obj, ctx->trace_key) == 0) {
             trace_extracted = FLB_TRUE;
+            entry_size += 1;
+        }
+
+        /* Extract span id */
+        span_id_extracted = FLB_FALSE;
+        if (ctx->span_id_key
+            && get_string(&span_id, obj, ctx->span_id_key) == 0) {
+            span_id_extracted = FLB_TRUE;
             entry_size += 1;
         }
 
@@ -2168,6 +2182,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             msgpack_pack_str(&mp_pck, len);
             msgpack_pack_str_body(&mp_pck, new_trace, len);
             flb_sds_destroy(trace);
+        }
+
+        /* Add spanId field into the log entry */
+        if (span_id_extracted == FLB_TRUE) {
+            msgpack_pack_str_with_body(&mp_pck, "spanId", 6);
+            len = flb_sds_len(span_id);
+            msgpack_pack_str_with_body(&mp_pck, span_id, len);
+            flb_sds_destroy(span_id);
         }
 
         /* Add insertId field into the log entry */
@@ -2555,12 +2577,17 @@ static struct flb_config_map config_map[] = {
     {
       FLB_CONFIG_MAP_BOOL, "autoformat_stackdriver_trace", "false",
       0, FLB_TRUE, offsetof(struct flb_stackdriver, autoformat_stackdriver_trace),
-      "Autoformat the stacrdriver trace"
+      "Autoformat the stackdriver trace"
     },
     {
       FLB_CONFIG_MAP_STR, "trace_key", DEFAULT_TRACE_KEY,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, trace_key),
       "Set the trace key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "span_id_key", DEFAULT_SPAN_ID_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, span_id_key),
+      "Set the span id key"
     },
     {
       FLB_CONFIG_MAP_STR, "log_name_key", DEFAULT_LOG_NAME_KEY,

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -51,6 +51,7 @@
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_SEVERITY_KEY "logging.googleapis.com/severity"
 #define DEFAULT_TRACE_KEY "logging.googleapis.com/trace"
+#define DEFAULT_SPAN_ID_KEY "logging.googleapis.com/spanId"
 #define DEFAULT_LOG_NAME_KEY "logging.googleapis.com/logName"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
@@ -163,6 +164,7 @@ struct flb_stackdriver {
     flb_sds_t resource;
     flb_sds_t severity_key;
     flb_sds_t trace_key;
+    flb_sds_t span_id_key;
     flb_sds_t log_name_key;
     flb_sds_t http_request_key;
     int http_request_key_size;

--- a/tests/runtime/data/stackdriver/stackdriver_test_span_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_span_id.h
@@ -1,0 +1,6 @@
+#define SPAN_ID_COMMON_CASE	"[" \
+	"1591111124," \
+	"{"	\
+      "\"logging.googleapis.com/spanId\": \"000000000000004a\"" \
+	"}]"
+	

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -35,6 +35,7 @@
 #include "data/stackdriver/stackdriver_test_k8s_resource.h"
 #include "data/stackdriver/stackdriver_test_labels.h"
 #include "data/stackdriver/stackdriver_test_trace.h"
+#include "data/stackdriver/stackdriver_test_span_id.h"
 #include "data/stackdriver/stackdriver_test_log_name.h"
 #include "data/stackdriver/stackdriver_test_resource_labels.h"
 #include "data/stackdriver/stackdriver_test_insert_id.h"
@@ -748,6 +749,24 @@ static void cb_check_trace_stackdriver_autoformat(void *ctx, int ffd,
 
     /* trace has been removed from jsonPayload */
     ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['trace']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_span_id(void *ctx, int ffd,
+                                         int res_ret, void *res_data, size_t res_size,
+                                         void *data)
+{
+    int ret;
+
+    /* span id in the entries */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['spanId']", "000000000000004a");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* span id has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/spanId']");
     TEST_CHECK(ret == FLB_FALSE);
 
     flb_sds_destroy(res_data);
@@ -2433,6 +2452,47 @@ void flb_test_trace_stackdriver_autoformat()
 
     /* Ingest data sample */
     flb_lib_push(ctx, in_ffd, (char *) TRACE_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
+void flb_test_span_id()
+{
+    int ret;
+    int size = sizeof(SPAN_ID_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_span_id,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SPAN_ID_COMMON_CASE, size);
 
     sleep(2);
     flb_stop(ctx);
@@ -5963,6 +6023,9 @@ TEST_LIST = {
     /* test trace */
     {"trace_no_autoformat", flb_test_trace_no_autoformat},
     {"trace_stackdriver_autoformat", flb_test_trace_stackdriver_autoformat},
+
+    /* test span id */
+    {"span_id", flb_test_span_id},
 
     /* test metadata server */
     {"set_metadata_server", flb_test_set_metadata_server},


### PR DESCRIPTION
This adds support for processing the logging.googleapis.com/spanId special field from the jsonPayload

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
This is backporting: https://github.com/fluent/fluent-bit/pull/7345

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
