### PR TITLE
in_windows_exporter_metrics: Fill the empty string when l2/l3 cache is not defined case

### DIFF
--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -240,6 +240,8 @@ static inline int wmi_update_metrics(struct flb_we *ctx, struct wmi_query_spec *
             free(strlabel);
             break;
         default:
+            metric_label_set[label_index] = strdup("");
+            metric_label_count++;
             break;
         }
         VariantClear(&prop);

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -162,7 +162,9 @@ static char *convert_prop_to_str(VARIANT *prop, int handle_null)
         }
     }
     else {
-        VariantChangeType(prop, prop, 0, VT_BSTR);
+        if (VariantChangeType(prop, prop, 0, VT_BSTR) != S_OK) {
+            return NULL;
+        }
         strlabel = we_convert_wstr(prop->bstrVal, CP_UTF8);
         if (strlabel == NULL) {
             return NULL;

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -169,6 +169,7 @@ static char *convert_prop_to_str(VARIANT *prop, int handle_null)
         }
         newstr = strdup(strlabel);
         if (newstr == NULL) {
+            free(strlabel);
             return NULL;
         }
         free(strlabel);

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -187,6 +187,9 @@ static double wmi_get_value(struct flb_we *ctx, struct wmi_query_spec *spec, IWb
     VariantInit(&prop);
     wproperty = we_convert_str(spec->wmi_property);
     hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
+    if (FAILED(hr)) {
+        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+    }
     strprop = convert_prop_to_str(&prop, FLB_FALSE);
     if (strprop == NULL) {
         return 0;
@@ -210,6 +213,9 @@ static double wmi_get_property_value(struct flb_we *ctx, char *raw_property_key,
     VariantInit(&prop);
     wproperty = we_convert_str(raw_property_key);
     hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
+    if (FAILED(hr)) {
+        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+    }
     strprop = convert_prop_to_str(&prop, FLB_FALSE);
     if (strprop == NULL) {
         return 0;
@@ -241,6 +247,9 @@ static inline int wmi_update_metrics(struct flb_we *ctx, struct wmi_query_spec *
     for (label_index = 0; label_index < spec->label_property_count; label_index++) {
         wlabel = we_convert_str(spec->label_property_keys[label_index]);
         hr = class_obj->lpVtbl->Get(class_obj, wlabel, 0, &prop, 0, 0);
+        if (FAILED(hr)) {
+            flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+        }
         newstr = convert_prop_to_str(&prop, FLB_TRUE);
         if (newstr == NULL) {
             continue;


### PR DESCRIPTION
This could be occurred on Windows VM environment.

In on premise case, this situation does not occur.
However, fluent-bit is running on Windows VM, L2/L2 cache is not provided from WMI information:

```powershell
PS>  Get-WmiObject Win32_Processor | Format-List *
<snip>
CpuStatus                               : 0
CreationClassName                       : Win32_Processor
CurrentClockSpeed                       : 3200
CurrentVoltage                          :
DataWidth                               : 64
Description                             : ARMv8 (64-bit) Family 8 Model 0 Revision   0
DeviceID                                : CPU1
ErrorCleared                            :
ErrorDescription                        :
ExtClock                                :
Family                                  : 2
InstallDate                             :
L2CacheSize                             :
L2CacheSpeed                            :
L3CacheSize                             : 0
L3CacheSpeed                            : 0
LastErrorCode                           :
Level                                   : 0
LoadPercentage                          : 1
Manufacturer                            :
MaxClockSpeed                           : 3200
Name                                    : Apple Silicon
NumberOfCores                           : 1
NumberOfEnabledCore                     :
NumberOfLogicalProcessors               : 1
OtherFamilyDescription                  :
PartNumber                              :
```  

If the error occurred or type glitch during retrieving a metrics from WMI, we need to plug with the empty string to adjust the count of labels.
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```console
PS> bin/fluent-bit -i windows_exporter_metrics -i stdout
```
- [ ] Debug log output from testing the change
After applying this change, we can see the cpu_info information on stdout:
```
PS C:\Users\cosmo\Documents\GitHub\fluent-bit\build> bin/fluent-bit -i windows_exporter_metrics -o stdout
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/16 16:07:34] [ info] [fluent bit] version=2.1.3, commit=e35b58f7dd, pid=8000
[2023/05/16 16:07:34] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/16 16:07:34] [ info] [cmetrics] version=0.6.1
[2023/05/16 16:07:34] [ info] [ctraces ] version=0.3.0
[2023/05/16 16:07:34] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2023/05/16 16:07:34] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/05/16 16:07:34] [ info] [sp] stream processor started
[2023/05/16 16:07:34] [ info] [output:stdout:stdout.0] worker #0 started
<snip>
2023-05-16T07:07:54.030095200Z windows_cpu_info{architecture="12",device_id="CPU0",description="ARMv8 (64-bit) Family 8 Model 0 Revision   0",family="257",l2_cache_size="",l3_cache_size="0",name="Apple Silicon"} = 1
2023-05-16T07:07:54.030095200Z windows_cpu_info{architecture="12",device_id="CPU1",description="ARMv8 (64-bit) Family 8 Model 0 Revision   0",family="2",l2_cache_size="",l3_cache_size="0",name="Apple Silicon"} = 1
2023-05-16T07:07:54.030095200Z windows_cpu_info{architecture="12",device_id="CPU2",description="ARMv8 (64-bit) Family 8 Model 0 Revision   0",family="2",l2_cache_size="",l3_cache_size="0",name="Apple Silicon"} = 1
2023-05-16T07:07:54.030095200Z windows_cpu_info{architecture="12",device_id="CPU3",description="ARMv8 (64-bit) Family 8 Model 0 Revision   0",family="2",l2_cache_size="",l3_cache_size="0",name="Apple Silicon"} = 1
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
