### PR TITLE
processor: input: output: organize initialization sequence for processor

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1255,6 +1255,12 @@ int flb_input_init_all(struct flb_config *config)
             flb_input_instance_destroy(ins);
             return -1;
         }
+
+        /* initialize processors */
+        ret = flb_processor_init(ins->processor);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1206,6 +1206,12 @@ int flb_input_instance_init(struct flb_input_instance *ins,
         }
     }
 
+    /* initialize processors */
+    ret = flb_processor_init(ins->processor);
+    if (ret == -1) {
+        return -1;
+    }
+
     return 0;
 }
 
@@ -1253,12 +1259,6 @@ int flb_input_init_all(struct flb_config *config)
         ret = flb_input_instance_init(ins, config);
         if (ret == -1) {
             flb_input_instance_destroy(ins);
-            return -1;
-        }
-
-        /* initialize processors */
-        ret = flb_processor_init(ins->processor);
-        if (ret == -1) {
             return -1;
         }
     }

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1300,6 +1300,12 @@ int flb_output_init_all(struct flb_config *config)
                       flb_output_name(ins));
             return -1;
         }
+
+        /* initialize processors */
+        ret = flb_processor_init(ins->processor);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
     return 0;

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -526,6 +526,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
     struct cfl_kvpair *pair = NULL;
     struct cfl_list *head;
     struct flb_processor_unit *pu;
+    struct flb_filter_instance *f_ins;
 
     if (val->type != CFL_VARIANT_ARRAY) {
         return -1;
@@ -565,6 +566,15 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
 
             if (pair->val->type != CFL_VARIANT_STRING) {
                 continue;
+            }
+            /* If filter plugin in processor unit has its own match rule,
+             * we must release the pre-allocated '*' match at first.
+             */
+            if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
+                if (strcmp(pair->key, "match") == 0) {
+                    f_ins = (struct flb_filter_instance *)pu->ctx;
+                    flb_sds_destroy(f_ins->match);
+                }
             }
 
             ret = flb_processor_unit_set_property(pu, pair->key, pair->val->data.as_string);

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -615,12 +615,6 @@ int flb_processors_load_from_config_format_group(struct flb_processor *proc, str
         }
     }
 
-    /* initialize processors */
-    ret = flb_processor_init(proc);
-    if (ret == -1) {
-        return -1;
-    }
-
     return 0;
 }
 

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -573,7 +573,10 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
             if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
                 if (strcmp(pair->key, "match") == 0) {
                     f_ins = (struct flb_filter_instance *)pu->ctx;
-                    flb_sds_destroy(f_ins->match);
+                    if (f_ins->match != NULL) {
+                        flb_sds_destroy(f_ins->match);
+                        f_ins->match = NULL;
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
In https://github.com/fluent/fluent-bit/issues/7071, users reported SEGV when including rewrite_tag plugin within processor stack.
This can be occurred with initialization order for filter plugins on the stack.
All of plugins must be initialized through `flb_engine_start` to initialize event loop and storage and other required instances correctly.
This PR fixes the invalid initialization of processor stack which includes rewrite_tag plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python

pipeline:
    inputs:
      - name: dummy
        tag: test-tag.raw
        dummy: '{"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}'

        processors:
          logs:
            - name: modify
              match: test-tag.*
              add: hostname monox
            - name: rewrite_tag
              match: test-tag.*
              rule: $tool ^(fluent)$  from.$TAG.new.$tool.$sub['s1']['s2'].out false
              emitter_name: re_emitted

    outputs:
      - name: stdout
        match: '*'

        processors:
          logs:
            - name: lua
              call: add_field
              code: |
                  function add_field(tag, timestamp, record)
                     new_record = record
                     new_record["output"] = "new data"
                     return 1, timestamp, new_record
                  end
```
- [x] Debug log output from testing the change
```log
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/16 16:38:41] [ info] Configuration:
[2023/05/16 16:38:41] [ info]  flush time     | 1.000000 seconds
[2023/05/16 16:38:41] [ info]  grace          | 5 seconds
[2023/05/16 16:38:41] [ info]  daemon         | 0
[2023/05/16 16:38:41] [ info] ___________
[2023/05/16 16:38:41] [ info]  inputs:
[2023/05/16 16:38:41] [ info]      dummy
[2023/05/16 16:38:41] [ info] ___________
[2023/05/16 16:38:41] [ info]  filters:
[2023/05/16 16:38:41] [ info] ___________
[2023/05/16 16:38:41] [ info]  outputs:
[2023/05/16 16:38:41] [ info]      stdout.0
[2023/05/16 16:38:41] [ info] ___________
[2023/05/16 16:38:41] [ info]  collectors:
[2023/05/16 16:38:41] [ info] [fluent bit] version=2.1.3, commit=815496155e, pid=1717500
[2023/05/16 16:38:41] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/16 16:38:41] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/16 16:38:41] [ info] [cmetrics] version=0.6.1
[2023/05/16 16:38:41] [ info] [ctraces ] version=0.3.0
[2023/05/16 16:38:41] [ info] [input:dummy:dummy.0] initializing
[2023/05/16 16:38:41] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/05/16 16:38:41] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2023/05/16 16:38:41] [debug] [filter:modify:modify.0] Initialized modify filter with 0 conditions and 1 rules
[2023/05/16 16:38:41] [ info] [input:emitter:re_emitted] initializing
[2023/05/16 16:38:41] [ info] [input:emitter:re_emitted] storage_strategy='memory' (memory only)
[2023/05/16 16:38:41] [debug] [emitter:re_emitted] created event channels: read=23 write=24
[2023/05/16 16:38:41] [debug] [stdout:stdout.0] created event channels: read=25 write=26
[2023/05/16 16:38:41] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/16 16:38:41] [debug] [router] match rule dummy.0:stdout.0
[2023/05/16 16:38:41] [debug] [router] match rule emitter.1:stdout.0
[2023/05/16 16:38:41] [ info] [sp] stream processor started
[2023/05/16 16:38:41] [debug] [input chunk] update output instances with new chunk size diff=65
[2023/05/16 16:38:42] [debug] [task] created task=0x7f69b0047660 id=0 OK
[2023/05/16 16:38:42] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] from.test-tag.raw.new.fluent.bit.out: [[1684222721.442910671, {}], {"sub"=>{"s1"=>{"s2"=>"bit"}}, "tool"=>"fluent", "output"=>"new data", "hostname"=>"monox"}]
[2023/05/16 16:38:42] [debug] [input chunk] update output instances with new chunk size diff=65
[2023/05/16 16:38:42] [debug] [out flush] cb_destroy coro_id=0
[2023/05/16 16:38:42] [debug] [task] destroy task=0x7f69b0047660 (task_id=0)
[2023/05/16 16:38:43] [debug] [task] created task=0x7f69b0046be0 id=0 OK
[2023/05/16 16:38:43] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] from.test-tag.raw.new.fluent.bit.out: [[1684222722.442936182, {}], {"sub"=>{"s1"=>{"s2"=>"bit"}}, "tool"=>"fluent", "output"=>"new data", "hostname"=>"monox"}]
[2023/05/16 16:38:43] [debug] [input chunk] update output instances with new chunk size diff=65
[2023/05/16 16:38:43] [debug] [out flush] cb_destroy coro_id=1
[2023/05/16 16:38:43] [debug] [task] destroy task=0x7f69b0046be0 (task_id=0)
^C[2023/05/16 16:38:44] [engine] caught signal (SIGINT)
[2023/05/16 16:38:44] [debug] [task] created task=0x7f69b0046e00 id=0 OK
[2023/05/16 16:38:44] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/05/16 16:38:44] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/16 16:38:44] [ info] [input] pausing dummy.0
[0] from.test-tag.raw.new.fluent.bit.out: [[1684222723.442939758, {}], {"sub"=>{"s1"=>{"s2"=>"bit"}}, "tool"=>"fluent", "output"=>"new data", "hostname"=>"monox"}]
[2023/05/16 16:38:44] [debug] [out flush] cb_destroy coro_id=2
[2023/05/16 16:38:44] [debug] [task] destroy task=0x7f69b0046e00 (task_id=0)
[2023/05/16 16:38:44] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/16 16:38:44] [ info] [input] pausing dummy.0
[2023/05/16 16:38:44] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/16 16:38:44] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1717689== 
==1717689== HEAP SUMMARY:
==1717689==     in use at exit: 0 bytes in 0 blocks
==1717689==   total heap usage: 2,992 allocs, 2,992 frees, 3,248,250 bytes allocated
==1717689== 
==1717689== All heap blocks were freed -- no leaks are possible
==1717689== 
==1717689== For lists of detected and suppressed errors, rerun with: -s
==1717689== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
