### PR TITLE
in_node_exporter_metrics: Make ignoring mount points and filesystem types of regular expressions to be configurable

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -1065,6 +1065,19 @@ static struct flb_config_map config_map[] = {
      "exclude list regular expression"
     },
 
+    /* filesystem specific settings */
+    {
+     FLB_CONFIG_MAP_STR, "filesystem.ignore_mount_point_regex", IGNORED_MOUNT_POINTS,
+     0, FLB_TRUE, offsetof(struct flb_ne, fs_regex_ingore_mount_point_text),
+     "ignore regular expression for mount points"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "filesystem.ignore_filesystem_type_regex", IGNORED_FS_TYPES,
+     0, FLB_TRUE, offsetof(struct flb_ne, fs_regex_ingore_filesystem_type_text),
+     "ignore regular expression for filesystem types"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -30,6 +30,11 @@
 #include <fluent-bit/flb_hash_table.h>
 #include <fluent-bit/flb_metrics.h>
 
+/* filesystem: regex for ignoring mount points and filesystem types */
+
+#define IGNORED_MOUNT_POINTS "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)"
+#define IGNORED_FS_TYPES     "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
+
 struct flb_ne {
     /* configuration */
     flb_sds_t path_procfs;
@@ -142,6 +147,8 @@ struct flb_ne {
     struct cmt_gauge *fs_free_bytes;
     struct cmt_gauge *fs_readonly;
     struct cmt_gauge *fs_size_bytes;
+    flb_sds_t fs_regex_ingore_mount_point_text;
+    flb_sds_t fs_regex_ingore_filesystem_type_text;
 
     struct flb_regex *fs_regex_read_only;
     struct flb_regex *fs_regex_skip_mount;

--- a/plugins/in_node_exporter_metrics/ne_filesystem_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_filesystem_linux.c
@@ -36,9 +36,6 @@
 #define NE_ERROR_MOUNT_POINT_LIST_FETCH_FILE_ACCESS_ERROR -2
 #define NE_ERROR_MOUNT_POINT_LIST_FETCH_CORRUPTED_DATA    -3
 
-#define IGNORED_MOUNT_POINTS "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)"
-#define IGNORED_FS_TYPES     "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
-
 static void unescape_character(cfl_sds_t input_buffer, char character)
 {
     size_t needle_length;
@@ -280,8 +277,8 @@ static int filesystem_update(struct flb_ne *ctx,
 
 int ne_filesystem_init(struct flb_ne *ctx)
 {
-    ctx->fs_regex_skip_mount = flb_regex_create(IGNORED_MOUNT_POINTS);
-    ctx->fs_regex_skip_fs_types = flb_regex_create(IGNORED_FS_TYPES);
+    ctx->fs_regex_skip_mount = flb_regex_create(ctx->fs_regex_ingore_mount_point_text);
+    ctx->fs_regex_skip_fs_types = flb_regex_create(ctx->fs_regex_ingore_filesystem_type_text);
 
     ctx->fs_avail_bytes = cmt_gauge_create(ctx->cmt,
                                            "node",


### PR DESCRIPTION
Closes https://github.com/fluent/fluent-bit/issues/7404

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==1817411== 
==1817411== HEAP SUMMARY:
==1817411==     in use at exit: 0 bytes in 0 blocks
==1817411==   total heap usage: 182,849 allocs, 182,849 frees, 10,069,450,097 bytes allocated
==1817411== 
==1817411== All heap blocks were freed -- no leaks are possible
==1817411== 
==1817411== For lists of detected and suppressed errors, rerun with: -s
==1817411== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1107

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
