### PR TITLE
out_opentelemetry: fix error handling for failed msgpack decoding

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -993,6 +993,8 @@ static int process_traces(struct flb_event_chunk *event_chunk,
                                     event_chunk->size, &off);
     if  (ret != ok) {
         flb_plg_error(ctx->ins, "Error decoding msgpack encoded context");
+        result = FLB_ERROR;
+        goto exit;
     }
 
     /* Create a OpenTelemetry payload */


### PR DESCRIPTION
<!-- Provide summary of changes -->

out_opentelemetry: Added missing goto in case FluentBit is unable to parse the trace payload correctly
ctraces: bump to v0.3.1

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[SERVICE]
    flush 1
    grace 1
    log_level info

[INPUT]
    name opentelemetry
    listen 0.0.0.0
    port 3000

[OUTPUT]
    Name                     opentelemetry
    Match                    *
    Host                     collector
    Port                     3030
    Log_response_payload     false
    compress gzip
    tls                      off
    tls.verify               off
    Traces_uri               /v1/traces
    add_label                app fluent-bit
    add_label                color blue
    #storage.total_limit_size  90M
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
Fluent Bit v2.0.12
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/17 08:03:36] [ info] [fluent bit] version=2.0.12, commit=f9327e827b, pid=38211
[2023/05/17 08:03:36] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/17 08:03:36] [ info] [cmetrics] version=0.6.1
[2023/05/17 08:03:36] [ info] [ctraces ] version=0.3.0
[2023/05/17 08:03:36] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/05/17 08:03:36] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/05/17 08:03:36] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:3000
[2023/05/17 08:03:36] [ info] [sp] stream processor started
[2023/05/17 08:03:40] [error] [output:opentelemetry:opentelemetry.0] Error decoding msgpack encoded context
[2023/05/17 08:03:47] [engine] caught signal (SIGTERM)
[2023/05/17 08:03:47] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/17 08:03:48] [ info] [engine] service has stopped (0 pending tasks)
==38211==
==38211== HEAP SUMMARY:
==38211==     in use at exit: 0 bytes in 0 blocks
==38211==   total heap usage: 4,016 allocs, 4,016 frees, 2,051,452 bytes allocated
==38211==
==38211== All heap blocks were freed -- no leaks are possible
==38211==
==38211== For lists of detected and suppressed errors, rerun with: -s
==38211== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
