### PR TITLE
TLS: using dot trimmed tcp_host/proxied_host for vhost

### DIFF
--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -55,15 +55,22 @@ static inline int flb_str_emptyval(const char *s)
     return FLB_FALSE;
 }
 
-static inline char *rtrim(const char *s, char c) {
-    short int n = strlen(s);
+/*
+ Trim the `c` character sequence to the right of the `*str` string and return a copy.
+ * @param *str Source string;
+ * @param c Character to be trimmed.
+ * @returns a new string, which is a trimmed copy of `*str`.
+*/
+static inline char *flb_rtrim(const char *str, char c) {
+    ssize_t pos = strlen(str);
 
-    while(c == s[--n]);
-    if (n < 0){
+    while(c == str[--pos]);
+
+    if (pos < 0){
         return NULL;
     }
 
-    return flb_strndup(s, n+1);
+    return flb_strndup(str, pos+1);
 }
 
 #endif

--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -55,4 +55,15 @@ static inline int flb_str_emptyval(const char *s)
     return FLB_FALSE;
 }
 
+static inline char *rtrim(const char *s, char c) {
+    short int n = strlen(s);
+
+    while(c == s[--n]);
+    if (n < 0){
+        return NULL;
+    }
+
+    return flb_strndup(s, n+1);
+}
+
 #endif

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -497,11 +497,11 @@ int flb_tls_session_create(struct flb_tls *tls,
 
     if (connection->type == FLB_UPSTREAM_CONNECTION) {
         if (connection->upstream->proxied_host != NULL) {
-            vhost = connection->upstream->proxied_host;
+            vhost = rtrim(connection->upstream->proxied_host, '.');
         }
         else {
             if (tls->vhost == NULL) {
-                vhost = connection->upstream->tcp_host;
+                vhost = rtrim(connection->upstream->tcp_host, '.');
             }
         }
     }
@@ -636,6 +636,10 @@ cleanup:
     }
     else {
         connection->tls_session = session;
+    }
+
+    if (vhost != NULL) {
+        flb_free(vhost);
     }
 
     return result;

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -497,11 +497,11 @@ int flb_tls_session_create(struct flb_tls *tls,
 
     if (connection->type == FLB_UPSTREAM_CONNECTION) {
         if (connection->upstream->proxied_host != NULL) {
-            vhost = rtrim(connection->upstream->proxied_host, '.');
+            vhost = flb_rtrim(connection->upstream->proxied_host, '.');
         }
         else {
             if (tls->vhost == NULL) {
-                vhost = rtrim(connection->upstream->tcp_host, '.');
+                vhost = flb_rtrim(connection->upstream->tcp_host, '.');
             }
         }
     }


### PR DESCRIPTION
* tls uses dot trimmed tcp_host/proxied_host for vhost
* new rtrim() function

Fixes #7403


**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
    ```
    [SERVICE]
        Daemon Off
        Flush  1s
        Log_Level debug

    [INPUT]
        Name   dummy
        Tag    dummy.log
        Samples 2

    [OUTPUT]
        Name                tcp
        Host                logstash.redacted.com.
        Port                5059
        Format              json_lines
        json_date_key       @timestamp
        json_date_format    iso8601
        Match               *
        tls                 On
        tls.verify          On
        tls.ca_file         /tmp/ca.crt
        tls.crt_file        /tmp/tls.crt
        tls.key_file        /tmp/tls.key
        tls.debug           4

    [OUTPUT]
        Name   stdout
        Match  *
    ```
- [x] Debug log output from testing the change
    ```
    Fluent Bit v2.1.3
    * Copyright (C) 2015-2022 The Fluent Bit Authors
    * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
    * https://fluentbit.io

    [2023/05/17 05:18:48] [ info] Configuration:
    [2023/05/17 05:18:48] [ info]  flush time     | 1.000000 seconds
    [2023/05/17 05:18:48] [ info]  grace          | 5 seconds
    [2023/05/17 05:18:48] [ info]  daemon         | 0
    [2023/05/17 05:18:48] [ info] ___________
    [2023/05/17 05:18:48] [ info]  inputs:
    [2023/05/17 05:18:48] [ info]      dummy
    [2023/05/17 05:18:48] [ info] ___________
    [2023/05/17 05:18:48] [ info]  filters:
    [2023/05/17 05:18:48] [ info] ___________
    [2023/05/17 05:18:48] [ info]  outputs:
    [2023/05/17 05:18:48] [ info]      tcp.0
    [2023/05/17 05:18:48] [ info]      stdout.1
    [2023/05/17 05:18:48] [ info] ___________
    [2023/05/17 05:18:48] [ info]  collectors:
    [2023/05/17 05:18:48] [ info] [fluent bit] version=2.1.3, commit=14f4561474, pid=15503
    [2023/05/17 05:18:48] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
    [2023/05/17 05:18:48] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
    [2023/05/17 05:18:48] [ info] [cmetrics] version=0.6.1
    [2023/05/17 05:18:48] [ info] [ctraces ] version=0.3.0
    [2023/05/17 05:18:48] [ info] [input:dummy:dummy.0] initializing
    [2023/05/17 05:18:48] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
    [2023/05/17 05:18:48] [debug] [dummy:dummy.0] created event channels: read=22 write=23
    [2023/05/17 05:18:48] [debug] [tcp:tcp.0] created event channels: read=24 write=25
    [2023/05/17 05:18:49] [ info] [output:tcp:tcp.0] worker #0 started
    [2023/05/17 05:18:49] [debug] [stdout:stdout.1] created event channels: read=40 write=41
    [2023/05/17 05:18:49] [ info] [output:tcp:tcp.0] worker #1 started
    [2023/05/17 05:18:49] [debug] [router] match rule dummy.0:tcp.0
    [2023/05/17 05:18:49] [ info] [output:stdout:stdout.1] worker #0 started
    [2023/05/17 05:18:49] [debug] [router] match rule dummy.0:stdout.1
    [2023/05/17 05:18:49] [ info] [sp] stream processor started
    [2023/05/17 05:18:49] [debug] [input chunk] update output instances with new chunk size diff=36
    [2023/05/17 05:18:50] [debug] [task] created task=0x7faab8088510 id=0 OK
    [2023/05/17 05:18:50] [debug] [output:tcp:tcp.0] task_id=0 assigned to thread #0
    [2023/05/17 05:18:50] [debug] [output:stdout:stdout.1] task_id=0 assigned to thread #0
    [0] dummy.log: [[1684315129.222727729, {}], {"message"=>"dummy"}]
    [2023/05/17 05:18:50] [debug] [input chunk] update output instances with new chunk size diff=36
    [2023/05/17 05:18:50] [debug] [out flush] cb_destroy coro_id=0
    [2023/05/17 05:18:50] [debug] [upstream] KA connection #61 to logstash.redacted.com.:5059 is connected
    [2023/05/17 05:18:50] [debug] [upstream] KA connection #61 to logstash.redacted.com.:5059 is now available
    [2023/05/17 05:18:50] [debug] [out flush] cb_destroy coro_id=0
    [2023/05/17 05:18:50] [debug] [task] destroy task=0x7faab8088510 (task_id=0)
    [2023/05/17 05:18:51] [debug] [task] created task=0x7faab8088890 id=0 OK
    [0] dummy.log: [[1684315130.223515189, {}], {"message"=>"dummy"}]
    [2023/05/17 05:18:51] [debug] [output:tcp:tcp.0] task_id=0 assigned to thread #1
    [2023/05/17 05:18:51] [debug] [output:stdout:stdout.1] task_id=0 assigned to thread #0
    [2023/05/17 05:18:51] [debug] [out flush] cb_destroy coro_id=1
    [2023/05/17 05:18:51] [debug] [upstream] KA connection #62 to logstash.redacted.com.:5059 is connected
    [2023/05/17 05:18:51] [debug] [upstream] KA connection #62 to logstash.redacted.com.:5059 is now available
    [2023/05/17 05:18:51] [debug] [out flush] cb_destroy coro_id=0
    [2023/05/17 05:18:51] [debug] [task] destroy task=0x7faab8088890 (task_id=0)
    [2023/05/17 05:19:20] [debug] [upstream] drop keepalive connection #-1 to logstash.redacted.com.:5059 (keepalive idle timeout)
    ```
    <!--  
    Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
    https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
    Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
    -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
    ```
    ==38345== 
    ==38345== HEAP SUMMARY:
    ==38345==     in use at exit: 291,064 bytes in 6,128 blocks
    ==38345==   total heap usage: 21,388 allocs, 15,260 frees, 7,468,915 bytes allocated
    ==38345== 
    ==38345== LEAK SUMMARY:
    ==38345==    definitely lost: 0 bytes in 0 blocks
    ==38345==    indirectly lost: 0 bytes in 0 blocks
    ==38345==      possibly lost: 0 bytes in 0 blocks
    ==38345==    still reachable: 291,064 bytes in 6,128 blocks
    ==38345==         suppressed: 0 bytes in 0 blocks
    ==38345== Rerun with --leak-check=full to see details of leaked memory
    ==38345== 
    ==38345== For lists of detected and suppressed errors, rerun with: -s
    ==38345== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
    ```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets 
(including any new ones) build.\
   `[N/A]`
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).\
  `[N/A]`

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature\
      `[N/A]` 
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.\
  `[N/A]` 
<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
