### PR TITLE
in_node_exporter_metrics: Prevent to duplicate sysfs path for collecting metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -77,15 +77,29 @@ int ne_utils_file_read_uint64(const char *mount,
     uint64_t val;
     ssize_t bytes;
     char tmp[32];
+    char *find = NULL;
+    int pos = -1;
 
     /* Compose the final path */
-    p = flb_sds_create(mount);
-    if (!p) {
-        return -1;
+    find = strstr(path, mount);
+    if (find != NULL) {
+        pos = find - path;
     }
+    /* If the mount is already concatenated, just using path. */
+    if (find && pos == 0) {
+        p = flb_sds_create(path);
+        if (!p) {
+            return -1;
+        }
+    } else {
+        p = flb_sds_create(mount);
+        if (!p) {
+            return -1;
+        }
 
-    len = strlen(path);
-    flb_sds_cat_safe(&p, path, len);
+        len = strlen(path);
+        flb_sds_cat_safe(&p, path, len);
+    }
 
     if (join_a) {
         flb_sds_cat_safe(&p, "/", 1);

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -148,10 +148,22 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
     FILE *f;
     char line[512];
     char real_path[2048];
+    char *find = NULL;
+    int pos = -1;
+
 
     mk_list_init(list);
 
-    snprintf(real_path, sizeof(real_path) - 1, "%s%s", mount, path);
+    find = strstr(path, mount);
+    if (find != NULL) {
+        pos = find - path;
+    }
+    if (find && pos == 0) {
+        snprintf(real_path, sizeof(real_path) - 1, "%s", path);
+    }
+    else {
+        snprintf(real_path, sizeof(real_path) - 1, "%s%s", mount, path);
+    }
     f = fopen(real_path, "r");
     if (f == NULL) {
         flb_errno();


### PR DESCRIPTION
This is because ne_utils_path_scan already concatenates the supplied mount point as a prefix for path.
We don't need to re-concatenate for path there.

Without this patch, sysfs path should be concatenated twice due to ne_utils_path_scan already set up sysfs included paths after executing glob.

Closes https://github.com/fluent/fluent-bit/issues/7342
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[INPUT]
    Name node_exporter_metrics
    metrics cpu 
    # or
    # metrics cpufreq
    scrape_interval 5
    tag node_exporter

[OUTPUT]
    Name stdout
    Match node_exporter
```
- [x] Debug log output from testing the change
```
Fluent Bit v2.1.3
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/18 16:01:00] [ info] Configuration:
[2023/05/18 16:01:00] [ info]  flush time     | 1.000000 seconds
[2023/05/18 16:01:00] [ info]  grace          | 5 seconds
[2023/05/18 16:01:00] [ info]  daemon         | 0
[2023/05/18 16:01:00] [ info] ___________
[2023/05/18 16:01:00] [ info]  inputs:
[2023/05/18 16:01:00] [ info]      node_exporter_metrics
[2023/05/18 16:01:00] [ info] ___________
[2023/05/18 16:01:00] [ info]  filters:
[2023/05/18 16:01:00] [ info] ___________
[2023/05/18 16:01:00] [ info]  outputs:
[2023/05/18 16:01:00] [ info]      stdout.0
[2023/05/18 16:01:00] [ info] ___________
[2023/05/18 16:01:00] [ info]  collectors:
[2023/05/18 16:01:00] [ info] [fluent bit] version=2.1.3, commit=f3cc2abd5c, pid=1948835
[2023/05/18 16:01:00] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/05/18 16:01:00] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/18 16:01:00] [ info] [cmetrics] version=0.6.1
[2023/05/18 16:01:00] [ info] [ctraces ] version=0.3.1
[2023/05/18 16:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/05/18 16:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/05/18 16:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/05/18 16:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/05/18 16:01:00] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics cpu
[2023/05/18 16:01:00] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics cpufreq
[2023/05/18 16:01:00] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/05/18 16:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/05/18 16:01:00] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=30 write=31
[2023/05/18 16:01:00] [debug] [stdout:stdout.0] created event channels: read=34 write=35
[2023/05/18 16:01:00] [ info] [sp] stream processor started
[2023/05/18 16:01:00] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/18 16:01:06] [debug] [input chunk] update output instances with new chunk size diff=12287
[2023/05/18 16:01:06] [debug] [task] created task=0x7f606c020f20 id=0 OK
[2023/05/18 16:01:06] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="0",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="1",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="4",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="5",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="2",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_core_throttles_total{core="3",package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_package_throttles_total{package="0"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="idle"} = 402529.21000000002
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="iowait"} = 976.21000000000004
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="nice"} = 23.59
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="softirq"} = 102.48999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="system"} = 5406.1800000000003
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="0",mode="user"} = 11987.41
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="idle"} = 14291.5
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="iowait"} = 23.280000000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="nice"} = 25.940000000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="softirq"} = 1549.28
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="system"} = 5086.2799999999997
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="1",mode="user"} = 11969.959999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="idle"} = 14674.1
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="iowait"} = 29.18
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="nice"} = 22.07
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="softirq"} = 56.289999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="system"} = 4902.8699999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="2",mode="user"} = 12156.450000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="idle"} = 14653.870000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="iowait"} = 18.550000000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="nice"} = 17.59
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="softirq"} = 20.629999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="system"} = 4737.46
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="3",mode="user"} = 12282.360000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="idle"} = 14759.110000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="iowait"} = 15.91
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="nice"} = 16.920000000000002
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="softirq"} = 7.7400000000000002
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="system"} = 4761.1199999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="4",mode="user"} = 12046.030000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="idle"} = 14747.15
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="iowait"} = 25.079999999999998
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="nice"} = 15.44
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="softirq"} = 115.06
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="system"} = 4932.8400000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="5",mode="user"} = 12040.549999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="idle"} = 14752.32
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="iowait"} = 17.32
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="nice"} = 17.77
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="softirq"} = 18.760000000000002
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="system"} = 5182.04
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="6",mode="user"} = 12483.370000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="idle"} = 14742.52
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="iowait"} = 21.199999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="nice"} = 19.399999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="softirq"} = 5.5700000000000003
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="system"} = 5055.2299999999996
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="7",mode="user"} = 12117.860000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="idle"} = 14153.07
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="iowait"} = 14.050000000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="nice"} = 21.719999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="softirq"} = 2243.48
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="system"} = 4981.4099999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="8",mode="user"} = 11667.74
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="idle"} = 14659.540000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="iowait"} = 12.890000000000001
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="nice"} = 15.19
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="softirq"} = 5.5999999999999996
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="system"} = 6314.0799999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="9",mode="user"} = 9219.6599999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="idle"} = 14781.459999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="iowait"} = 17.039999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="nice"} = 19.48
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="softirq"} = 19.75
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="system"} = 4990.2799999999997
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="10",mode="user"} = 11326.469999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="idle"} = 14773.76
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="iowait"} = 19.219999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="irq"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="nice"} = 19.399999999999999
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="softirq"} = 89.040000000000006
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="steal"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="system"} = 4932.6999999999998
2023-05-18T07:01:05.690934402Z node_cpu_seconds_total{cpu="11",mode="user"} = 11462.030000000001
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="0",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="0",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="1",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="1",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="2",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="2",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="3",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="3",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="4",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="4",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="5",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="5",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="6",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="6",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="7",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="7",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="8",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="8",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="9",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="9",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="10",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="10",mode="nice"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="11",mode="user"} = 0
2023-05-18T07:01:05.690934402Z node_cpu_guest_seconds_total{cpu="11",mode="nice"} = 0
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="0"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="1"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="10"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="11"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="2"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="3"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="4"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="5"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="6"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="7"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="8"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_max_hertz{cpu="9"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="0"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="1"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="10"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="11"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="2"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="3"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="4"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="5"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="6"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="7"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="8"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_frequency_min_hertz{cpu="9"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="0"} = 1875740000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="1"} = 2404664000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="10"} = 1146639000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="11"} = 800007000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="2"} = 800058000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="3"} = 800095000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="4"} = 800090000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="5"} = 800002000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="6"} = 800032000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="7"} = 800005000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="8"} = 800096000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_hertz{cpu="9"} = 800036000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="0"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="1"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="10"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="11"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="2"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="3"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="4"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="5"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="6"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="7"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="8"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_max_hertz{cpu="9"} = 4600000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="0"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="1"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="10"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="11"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="2"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="3"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="4"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="5"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="6"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="7"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="8"} = 800000000
2023-05-18T07:01:05.691738230Z node_cpu_scaling_frequency_min_hertz{cpu="9"} = 800000000
[2023/05/18 16:01:06] [debug] [out flush] cb_destroy coro_id=0
[2023/05/18 16:01:06] [debug] [task] destroy task=0x7f606c020f20 (task_id=0)
^C[2023/05/18 16:01:07] [engine] caught signal (SIGINT)
[2023/05/18 16:01:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/18 16:01:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/05/18 16:01:07] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/18 16:01:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/05/18 16:01:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
[2023/05/18 16:01:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/18 16:01:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1948588== 
==1948588== HEAP SUMMARY:
==1948588==     in use at exit: 0 bytes in 0 blocks
==1948588==   total heap usage: 7,496 allocs, 7,496 frees, 19,374,121 bytes allocated
==1948588== 
==1948588== All heap blocks were freed -- no leaks are possible
==1948588== 
==1948588== For lists of detected and suppressed errors, rerun with: -s
==1948588== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
