### PR TITLE
 tiger: chunk size limit addition

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -195,12 +195,14 @@ struct flb_config {
     void *cio;
     char *storage_path;
     void *storage_input_plugin;
-    char *storage_sync;             /* sync mode */
-    int   storage_metrics;          /* enable/disable storage metrics */
-    int   storage_checksum;         /* checksum enabled */
-    int   storage_max_chunks_up;    /* max number of chunks 'up' in memory */
-    char *storage_bl_mem_limit;     /* storage backlog memory limit */
+    char *storage_sync;               /* sync mode */
+    int   storage_metrics;            /* enable/disable storage metrics */
+    int   storage_checksum;           /* checksum enabled */
+    int   storage_max_chunks_up;      /* max number of chunks 'up' in memory */
+    char *storage_max_chunk_size_str; /* chunk size limit */
+    char *storage_bl_mem_limit;       /* storage backlog memory limit */
     struct flb_storage_metrics *storage_metrics_ctx; /* storage metrics context */
+    size_t storage_max_chunk_size;   /* chunk size limit */
 
     /* Embedded SQL Database support (SQLite3) */
 #ifdef FLB_HAVE_SQLDB
@@ -298,12 +300,13 @@ enum conf_type {
 #define FLB_CONF_DNS_PREFER_IPV4       "dns.prefer_ipv4"
 
 /* Storage / Chunk I/O */
-#define FLB_CONF_STORAGE_PATH          "storage.path"
-#define FLB_CONF_STORAGE_SYNC          "storage.sync"
-#define FLB_CONF_STORAGE_METRICS       "storage.metrics"
-#define FLB_CONF_STORAGE_CHECKSUM      "storage.checksum"
-#define FLB_CONF_STORAGE_BL_MEM_LIMIT  "storage.backlog.mem_limit"
-#define FLB_CONF_STORAGE_MAX_CHUNKS_UP "storage.max_chunks_up"
+#define FLB_CONF_STORAGE_PATH           "storage.path"
+#define FLB_CONF_STORAGE_SYNC           "storage.sync"
+#define FLB_CONF_STORAGE_METRICS        "storage.metrics"
+#define FLB_CONF_STORAGE_CHECKSUM       "storage.checksum"
+#define FLB_CONF_STORAGE_BL_MEM_LIMIT   "storage.backlog.mem_limit"
+#define FLB_CONF_STORAGE_MAX_CHUNKS_UP  "storage.max_chunks_up"
+#define FLB_CONF_STORAGE_MAX_CHUNK_SIZE "storage.max_chunk_size"
 
 /* Coroutines */
 #define FLB_CONF_STR_CORO_STACK_SIZE "Coro_Stack_Size"

--- a/include/fluent-bit/flb_storage.h
+++ b/include/fluent-bit/flb_storage.h
@@ -26,6 +26,7 @@
 #include <chunkio/cio_stats.h>
 
 #define FLB_STORAGE_BL_MEM_LIMIT   "100M"
+#define FLB_STORAGE_MAX_CHUNK_SIZE "2M"
 #define FLB_STORAGE_MAX_CHUNKS_UP  128
 
 struct flb_storage_metrics {

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -138,6 +138,9 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STORAGE_MAX_CHUNKS_UP,
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, storage_max_chunks_up)},
+    {FLB_CONF_STORAGE_MAX_CHUNK_SIZE,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, storage_max_chunk_size_str)},
 
     /* Coroutines */
     {FLB_CONF_STR_CORO_STACK_SIZE,
@@ -418,6 +421,9 @@ void flb_config_exit(struct flb_config *config)
     }
     if (config->storage_bl_mem_limit) {
         flb_free(config->storage_bl_mem_limit);
+    }
+    if (config->storage_max_chunk_size_str) {
+        flb_free(config->storage_max_chunk_size_str);
     }
 
 #ifdef FLB_HAVE_STREAM_PROCESSOR

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1048,6 +1048,7 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     int cio_error;
     int delete_chunk;
     int new_chunk = FLB_FALSE;
+    size_t new_chunk_size;
     size_t out_size;
     struct flb_input_chunk *ic = NULL;
 
@@ -1103,6 +1104,17 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
             *set_down = FLB_TRUE;
         }
     }
+
+    if (ic != NULL) {
+        new_chunk_size = flb_input_chunk_get_real_size(ic);
+        new_chunk_size += chunk_size;
+
+        if (in->config->storage_max_chunk_size > 0 &&
+            in->config->storage_max_chunk_size < new_chunk_size) {
+            ic = NULL;
+        }
+    }
+
 
     /* No chunk was found, we need to create a new one */
     if (!ic) {

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -553,6 +553,25 @@ int flb_storage_create(struct flb_config *ctx)
         }
     }
 
+    if (ctx->storage_max_chunk_size_str == NULL) {
+        ctx->storage_max_chunk_size_str = flb_strdup(FLB_STORAGE_MAX_CHUNK_SIZE);
+
+        if (ctx->storage_max_chunk_size_str == NULL) {
+            flb_errno();
+
+            return -1;
+        }
+    }
+
+    ctx->storage_max_chunk_size = \
+        flb_utils_size_to_bytes(ctx->storage_max_chunk_size_str);
+
+    if (ctx->storage_max_chunk_size == 0) {
+        flb_error("[storage] maximum chunk size cannot be zero");
+
+        return -1;
+    }
+
     /* Create streams for input instances */
     ret = storage_contexts_create(ctx);
     if (ret == -1) {


### PR DESCRIPTION
This PR adds a configurable semi hard limit for the chunk files.

This will break chunks when they reach the limit but it will not break up a single ingestion that should span multiple chunks which means flb_input_chunk_append_raw should not be called with multi megabyte buffers.

