### PR TITLE
tiger: output event handling improvements

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -61,6 +61,8 @@
 extern struct flb_aws_error_reporter *error_reporter;
 #endif
 
+#define FLB_ENGINE_OUTPUT_EVENT_BATCH_SIZE 16
+
 FLB_TLS_DEFINE(struct mk_event_loop, flb_engine_evl);
 
 
@@ -127,28 +129,21 @@ static void cb_engine_sched_timer(struct flb_config *ctx, void *data)
     flb_upstream_conn_timeouts(&ctx->upstreams);
 }
 
-static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
-                                      struct flb_config *config)
+static inline int handle_output_event(uint64_t ts,
+                                      struct flb_config *config,
+                                      uint64_t val)
 {
     int ret;
-    int bytes;
     int task_id;
     int out_id;
     int retries;
     int retry_seconds;
     uint32_t type;
     uint32_t key;
-    uint64_t val;
     char *name;
     struct flb_task *task;
     struct flb_task_retry *retry;
     struct flb_output_instance *ins;
-
-    bytes = flb_pipe_r(fd, &val, sizeof(val));
-    if (bytes == -1) {
-        flb_errno();
-        return -1;
-    }
 
     /* Get type and key */
     type = FLB_BITS_U64_HIGH(val);
@@ -360,6 +355,52 @@ static inline int handle_output_event(flb_pipefd_t fd, uint64_t ts,
     return 0;
 }
 
+static inline int handle_output_events(flb_pipefd_t fd,
+                                       struct flb_config *config)
+{
+    uint64_t values[FLB_ENGINE_OUTPUT_EVENT_BATCH_SIZE];
+    int      result;
+    int      bytes;
+    size_t   limit;
+    size_t   index;
+    uint64_t ts;
+
+    memset(&values, 0, sizeof(values));
+
+    bytes = flb_pipe_r(fd, &values, sizeof(values));
+
+    if (bytes == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    limit = floor(bytes / sizeof(uint64_t));
+
+    ts = cmt_time_now();
+
+    for (index = 0 ;
+         index < limit &&
+         index < (sizeof(values) / sizeof(values[0])) ;
+         index++) {
+        if (values[index] == 0) {
+            break;
+        }
+
+        result = handle_output_event(ts, config, values[index]);
+    }
+
+    /* This is wrong, in one hand, if handle_output_event_ fails we should
+     * stop, on the other, we have already consumed the signals from the pipe
+     * so we have to do whatever we can with them.
+     *
+     * And a side effect is that since we have N results but we are not aborting
+     * as soon as we get an error there could be N results to this function which
+     * not only are we not ready to handle but is not even checked at the moment.
+    */
+
+    return result;
+}
+
 static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
 {
     int bytes;
@@ -515,7 +556,6 @@ extern int sb_segregate_chunks(struct flb_config *config);
 int flb_engine_start(struct flb_config *config)
 {
     int ret;
-    uint64_t ts;
     char tmp[16];
     struct flb_time t_flush;
     struct mk_event *event;
@@ -706,103 +746,122 @@ int flb_engine_start(struct flb_config *config)
 
     while (1) {
         mk_event_wait(evl);
-        mk_event_foreach(event, evl) {
-            if (event->type == FLB_ENGINE_EV_CORE) {
-                ret = flb_engine_handle_event(event->fd, event->mask, config);
-                if (ret == FLB_ENGINE_STOP) {
-                    if (config->grace_count == 0) {
-                        flb_warn("[engine] service will shutdown in max %u seconds",
-                                 config->grace);
-                    }
 
-                    /*
-                     * We are preparing to shutdown, we give a graceful time
-                     * of 'config->grace' seconds to process any pending event.
-                     */
-                    event = &config->event_shutdown;
-                    event->mask = MK_EVENT_EMPTY;
-                    event->status = MK_EVENT_NONE;
+        /* These seemingly unnecessary scopes have been added to contain the
+         * definition of __i and __ctx mk_event_foreach makes.
+         * A better way to fix that issue would be to modify the macro to add
+         * a unique suffix to the fields defined AND a scope so we ensure that
+         * under no circumstances will we have name colissions but that can be
+         * done once later on if this PoC is deemed viable.
+        */
 
-                    /*
-                     * Configure a timer of 1 second, on expiration the code will
-                     * jump into the FLB_ENGINE_SHUTDOWN condition where it will
-                     * check if the grace period has finished, or if there are
-                     * any remaining tasks.
-                     *
-                     * If no tasks exists, there is no need to wait for the maximum
-                     * grace period.
-                     */
-                    config->shutdown_fd = mk_event_timeout_create(evl,
-                                                                  1,
-                                                                  0,
-                                                                  event);
-                }
-                else if (ret == FLB_ENGINE_SHUTDOWN) {
-                    if (config->shutdown_fd > 0) {
-                        mk_event_timeout_destroy(config->evl,
-                                                 &config->event_shutdown);
-                    }
-
-                    /* Increase the grace counter */
-                    config->grace_count++;
-
-                    /*
-                     * Grace period has finished, but we need to check if there is
-                     * any pending running task. A running task is associated to an
-                     * output co-routine, since we don't know what's the state or
-                     * resources allocated by that co-routine, the best thing is to
-                     * wait again for the grace period and re-check again.
-                     */
-                    ret = flb_task_running_count(config);
-                    if (ret > 0 && config->grace_count < config->grace) {
-                        if (config->grace_count == 1) {
-                            flb_task_running_print(config);
+        {
+            mk_event_foreach(event, evl) {
+                if (event->type == FLB_ENGINE_EV_CORE) {
+                    ret = flb_engine_handle_event(event->fd, event->mask, config);
+                    if (ret == FLB_ENGINE_STOP) {
+                        if (config->grace_count == 0) {
+                            flb_warn("[engine] service will shutdown in max %u seconds",
+                                     config->grace);
                         }
-                        flb_engine_exit(config);
+
+                        /*
+                         * We are preparing to shutdown, we give a graceful time
+                         * of 'config->grace' seconds to process any pending event.
+                         */
+                        event = &config->event_shutdown;
+                        event->mask = MK_EVENT_EMPTY;
+                        event->status = MK_EVENT_NONE;
+
+                        /*
+                         * Configure a timer of 1 second, on expiration the code will
+                         * jump into the FLB_ENGINE_SHUTDOWN condition where it will
+                         * check if the grace period has finished, or if there are
+                         * any remaining tasks.
+                         *
+                         * If no tasks exists, there is no need to wait for the maximum
+                         * grace period.
+                         */
+                        config->shutdown_fd = mk_event_timeout_create(evl,
+                                                                      1,
+                                                                      0,
+                                                                      event);
                     }
-                    else {
-                        if (ret > 0) {
-                            flb_task_running_print(config);
+                    else if (ret == FLB_ENGINE_SHUTDOWN) {
+                        if (config->shutdown_fd > 0) {
+                            mk_event_timeout_destroy(config->evl,
+                                                     &config->event_shutdown);
                         }
-                        flb_info("[engine] service has stopped (%i pending tasks)",
-                                 ret);
-                        ret = config->exit_status_code;
-                        flb_engine_shutdown(config);
-                        config = NULL;
-                        return ret;
+
+                        /* Increase the grace counter */
+                        config->grace_count++;
+
+                        /*
+                         * Grace period has finished, but we need to check if there is
+                         * any pending running task. A running task is associated to an
+                         * output co-routine, since we don't know what's the state or
+                         * resources allocated by that co-routine, the best thing is to
+                         * wait again for the grace period and re-check again.
+                         */
+                        ret = flb_task_running_count(config);
+                        if (ret > 0 && config->grace_count < config->grace) {
+                            if (config->grace_count == 1) {
+                                flb_task_running_print(config);
+                            }
+                            flb_engine_exit(config);
+                        }
+                        else {
+                            if (ret > 0) {
+                                flb_task_running_print(config);
+                            }
+                            flb_info("[engine] service has stopped (%i pending tasks)",
+                                     ret);
+                            ret = config->exit_status_code;
+                            flb_engine_shutdown(config);
+                            config = NULL;
+                            return ret;
+                        }
                     }
                 }
-            }
-            else if (event->type & FLB_ENGINE_EV_SCHED) {
-                /* Event type registered by the Scheduler */
-                flb_sched_event_handler(config, event);
-            }
-            else if (event->type == FLB_ENGINE_EV_CUSTOM) {
-                event->handler(event);
-            }
-            else if (event->type == FLB_ENGINE_EV_THREAD) {
-                struct flb_upstream_conn *u_conn;
-                struct flb_coro *co;
-
-                /*
-                 * Check if we have some co-routine associated to this event,
-                 * if so, resume the co-routine
-                 */
-                u_conn = (struct flb_upstream_conn *) event;
-                co = u_conn->coro;
-                if (co) {
-                    flb_trace("[engine] resuming coroutine=%p", co);
-                    flb_coro_resume(co);
+                else if (event->type == FLB_ENGINE_EV_OUTPUT) {
+                    /*
+                     * Event originated by an output plugin. likely a Task return
+                     * status.
+                     */
+                    handle_output_events(event->fd, config);
                 }
             }
-            else if (event->type == FLB_ENGINE_EV_OUTPUT) {
-                ts = cmt_time_now();
+        }
 
-                /*
-                 * Event originated by an output plugin. likely a Task return
-                 * status.
-                 */
-                handle_output_event(event->fd, ts, config);
+        {
+            mk_event_foreach(event, evl) {
+                if (event->type & FLB_ENGINE_EV_SCHED) {
+                    /* Event type registered by the Scheduler */
+                    flb_sched_event_handler(config, event);
+                }
+            }
+        }
+
+        {
+            mk_event_foreach(event, evl) {
+                if (event->type == FLB_ENGINE_EV_CUSTOM) {
+                    event->handler(event);
+                }
+                else if (event->type == FLB_ENGINE_EV_THREAD) {
+                    struct flb_upstream_conn *u_conn;
+                    struct flb_coro *co;
+
+                    /*
+                     * Check if we have some co-routine associated to this event,
+                     * if so, resume the co-routine
+                     */
+                    u_conn = (struct flb_upstream_conn *) event;
+                    co = u_conn->coro;
+                    if (co) {
+                        flb_trace("[engine] resuming coroutine=%p", co);
+                        flb_coro_resume(co);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This PR replaces handle_output_event (from the event loops
perspective) with handle_output_events which processes up to
FLB_ENGINE_OUTPUT_EVENT_BATCH_SIZE events per event loop cycle
(currently 16).

Additionally, the event processing stage in the event loop was
decoupled in order to prioritize internal signals over scheduler events
including but not limited to collection timers and other events such
as sockets or file descriptor events.

This is particularly important if we want to ensure that we decrement
the finished flush task reference counters before servicing the
static file collection timers or inotify events which usually try to
ingest data and could fail when trying to drop a chunk that in fact
had already finished trying to flush.