### PR TITLE
tiger: chunk rollover workaround

### DIFF
--- a/include/fluent-bit/flb_engine_dispatch.h
+++ b/include/fluent-bit/flb_engine_dispatch.h
@@ -26,6 +26,20 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_task.h>
 
+/* FLB_DISPATCHER_RESERVED_CHUNK_MINIMUM defines a lower boundary for the number
+ * of releasable chunks.
+ *
+ * FLB_DISPATCHER_RESERVED_STORAGE_SPACE as defined ensures that the system is
+ * able to ingest N bytes without exceeding the limits (in this PoCs case 10 MB).
+ *
+ * In the real world these souldn't be constants but rather settings and the
+ * storage space setting should be higher than 10 megabytes, especially when
+ * the ingestion volume is rather large.
+*/
+
+#define FLB_DISPATCHER_RESERVED_CHUNK_MINIMUM    5
+#define FLB_DISPATCHER_RESERVED_STORAGE_SPACE    (20 * 1000000)
+
 int flb_engine_dispatch(uint64_t id, struct flb_input_instance *in,
                         struct flb_config *config);
 int flb_engine_dispatch_retry(struct flb_task_retry *retry,

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -359,6 +359,8 @@ struct flb_output_instance {
      */
     size_t total_limit_size;
 
+    size_t releasable_chunks_required;
+
     /* Thread Pool: this is optional for the caller */
     int tp_workers;
     struct flb_tp *tp;

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -98,12 +98,44 @@ int flb_engine_destroy_tasks(struct mk_list *tasks)
     return c;
 }
 
+/* This is a simplistic output plugin storage limit check
+ * ripped from flb_input_chunk_has_overlimit_routes which
+ * we should move to a more appropriate place for the final
+ * patch.
+ */
+static inline int flb_output_instance_can_store(
+                    struct flb_output_instance *o_ins,
+                    size_t chunk_size)
+{
+    if (o_ins->total_limit_size != -1) {
+        if ((o_ins->fs_chunks_size +
+             o_ins->fs_backlog_chunks_size +
+             chunk_size) > o_ins->total_limit_size) {
+            return FLB_FALSE;
+        }
+    }
+
+    return FLB_TRUE;
+}
+
 int flb_engine_flush(struct flb_config *config,
                      struct flb_input_plugin *in_force)
 {
+    struct flb_output_instance *out;
     struct flb_input_instance *in;
     struct flb_input_plugin *p;
     struct mk_list *head;
+
+    mk_list_foreach(head, &config->outputs) {
+        out = mk_list_entry(head, struct flb_output_instance, _head);
+
+        if (!flb_output_instance_can_store(out, FLB_DISPATCHER_RESERVED_STORAGE_SPACE)) {
+            out->releasable_chunks_required = FLB_DISPATCHER_RESERVED_CHUNK_MINIMUM;
+        }
+        else {
+            out->releasable_chunks_required = 0;
+        }
+    }
 
     mk_list_foreach(head, &config->inputs) {
         in = mk_list_entry(head, struct flb_input_instance, _head);


### PR DESCRIPTION
This PR introduces a chunk withholding feature intended to ensure that
the oldest chunks can be disposed in case of extreme congestion.