### PR TITLE
out_opentelemetry: flush multiple traces from one chunk

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -965,7 +965,6 @@ static int process_traces(struct flb_event_chunk *event_chunk,
                           struct flb_input_instance *ins, void *out_context,
                           struct flb_config *config)
 {
-    int ok;
     int ret;
     int result;
     cfl_sds_t encoded_chunk;
@@ -976,7 +975,6 @@ static int process_traces(struct flb_event_chunk *event_chunk,
 
     /* Initialize vars */
     ctx = out_context;
-    ok = 0;
     result = FLB_OK;
 
     buf = flb_sds_create_size(event_chunk->size);
@@ -988,30 +986,33 @@ static int process_traces(struct flb_event_chunk *event_chunk,
     flb_plg_debug(ctx->ins, "ctraces msgpack size: %lu",
                   event_chunk->size);
 
-    ret = ctr_decode_msgpack_create(&ctr,
-                                    (char *) event_chunk->data,
-                                    event_chunk->size, &off);
-    if  (ret != ok) {
-        flb_plg_error(ctx->ins, "Error decoding msgpack encoded context");
-        result = FLB_ERROR;
-        goto exit;
+    while (ctr_decode_msgpack_create(&ctr,
+                                     (char *) event_chunk->data,
+                                     event_chunk->size, &off) == 0) {
+        /* Create a OpenTelemetry payload */
+        encoded_chunk = ctr_encode_opentelemetry_create(ctr);
+        if (encoded_chunk == NULL) {
+            flb_plg_error(ctx->ins,
+                          "Error encoding context as opentelemetry");
+            result = FLB_ERROR;
+            ctr_destroy(ctr);
+            goto exit;
+        }
+
+        /* concat buffer */
+        ret = flb_sds_cat_safe(&buf, encoded_chunk, flb_sds_len(encoded_chunk));
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "Error appending encoded trace to buffer");
+            result = FLB_ERROR;
+            ctr_encode_opentelemetry_destroy(encoded_chunk);
+            ctr_destroy(ctr);
+            goto exit;
+        }
+
+        /* release */
+        ctr_encode_opentelemetry_destroy(encoded_chunk);
+        ctr_destroy(ctr);
     }
-
-    /* Create a OpenTelemetry payload */
-    encoded_chunk = ctr_encode_opentelemetry_create(ctr);
-    if (encoded_chunk == NULL) {
-        flb_plg_error(ctx->ins,
-                      "Error encoding context as opentelemetry");
-        result = FLB_ERROR;
-        goto exit;
-    }
-
-    /* concat buffer */
-    flb_sds_cat_safe(&buf, encoded_chunk, flb_sds_len(encoded_chunk));
-
-    /* release */
-    ctr_encode_opentelemetry_destroy(encoded_chunk);
-    ctr_destroy(ctr);
 
     flb_plg_debug(ctx->ins, "final payload size: %lu", flb_sds_len(buf));
     if (buf && flb_sds_len(buf) > 0) {
@@ -1032,8 +1033,6 @@ static int process_traces(struct flb_event_chunk *event_chunk,
             flb_plg_debug(ctx->ins, "http_post result FLB_RETRY");
         }
     }
-    flb_sds_destroy(buf);
-    buf = NULL;
 
 exit:
     if (buf) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[SERVICE]
    flush 1
    grace 1
    log_level info
    storage.path chunks

[INPUT]
    name opentelemetry
    listen 0.0.0.0
    port 3000
    storage.type filesystem

#[OUTPUT]
#    name stdout
#    match *
[OUTPUT]
    Name                     opentelemetry
    Match                    *
    Host                     collector
    Port                     3030
    Log_response_payload     false
    compress gzip
    tls                      off
    tls.verify               off
    Traces_uri               /v1/traces
    #Logs_uri                 /v1/logs
    #Metrics_uri              /v1/metrics
    add_label                app fluent-bit
    add_label                color blue
    #storage.total_limit_size  90M
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
[2023/05/18 06:34:39] [ info] [fluent bit] version=2.0.12, commit=4c712318b0, pid=63996
[2023/05/18 06:34:39] [ info] [storage] ver=1.4.0, type=memory+filesystem, sync=normal, checksum=off, max_chunks_up=128
[2023/05/18 06:34:39] [ info] [storage] backlog input plugin: storage_backlog.1
[2023/05/18 06:34:39] [ info] [cmetrics] version=0.6.1
[2023/05/18 06:34:39] [ info] [ctraces ] version=0.3.1
[2023/05/18 06:34:39] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/05/18 06:34:39] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='filesystem' (memory + filesystem)
[2023/05/18 06:34:39] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:3000
[2023/05/18 06:34:39] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2023/05/18 06:34:39] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2023/05/18 06:34:39] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2023/05/18 06:34:39] [ info] [sp] stream processor started
[2023/05/18 06:34:46] [ info] [output:opentelemetry:opentelemetry.0] collector:3030, HTTP status=200
^C[2023/05/18 06:34:49] [engine] caught signal (SIGINT)
[2023/05/18 06:34:49] [ warn] [engine] service will shutdown in max 1 seconds
[2023/05/18 06:34:49] [ info] [input] pausing storage_backlog.1
[2023/05/18 06:34:49] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/18 06:34:49] [ info] [input] pausing storage_backlog.1
==63996==
==63996== HEAP SUMMARY:
==63996==     in use at exit: 0 bytes in 0 blocks
==63996==   total heap usage: 19,065 allocs, 19,065 frees, 6,688,426 bytes allocated
==63996==
==63996== All heap blocks were freed -- no leaks are possible
==63996==
==63996== For lists of detected and suppressed errors, rerun with: -s
==63996== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
