### PR TITLE
out_opentelemetry: fix memory leak

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -908,6 +908,7 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
             flb_plg_error(ctx->ins,
                           "Error encoding context as opentelemetry");
             result = FLB_ERROR;
+            cmt_destroy(cmt);
             goto exit;
         }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

fix memory leak when cmt_encode_opentelemetry_create fails:

```
[2023/05/18 10:55:04] [error] [output:opentelemetry:opentelemetry.0] Error encoding context as opentelemetry
^C[2023/05/18 10:55:15] [engine] caught signal (SIGINT)
[2023/05/18 10:55:15] [ warn] [engine] service will shutdown in max 10 seconds
[2023/05/18 10:55:15] [ info] [input] pausing storage_backlog.1
[2023/05/18 10:55:16] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/18 10:55:16] [ info] [input] pausing storage_backlog.1
==17803==
==17803== HEAP SUMMARY:
==17803==     in use at exit: 92,948 bytes in 965 blocks
==17803==   total heap usage: 7,336 allocs, 6,371 frees, 3,424,151 bytes allocated
==17803==
==17803== 92,948 (56 direct, 92,892 indirect) bytes in 1 blocks are definitely lost in loss record 42 of 42
==17803==    at 0x4869F34: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==17803==    by 0x83FB73: ctr_create (ctraces.c:47)
==17803==    by 0x875DF3: ctr_decode_msgpack_create (ctr_decode_msgpack.c:681)
==17803==    by 0x6882B7: process_traces (opentelemetry.c:1030)
==17803==    by 0x688867: cb_opentelemetry_flush (opentelemetry.c:1129)
==17803==    by 0x1DE907: output_pre_cb_flush (flb_output.h:559)
==17803==    by 0xB97013: co_switch (aarch64.c:133)
==17803==    by 0xFFFFFFFFFFFFFFFF: ???
==17803==
==17803== LEAK SUMMARY:
==17803==    definitely lost: 56 bytes in 1 blocks
==17803==    indirectly lost: 92,892 bytes in 964 blocks
==17803==      possibly lost: 0 bytes in 0 blocks
==17803==    still reachable: 0 bytes in 0 blocks
==17803==         suppressed: 0 bytes in 0 blocks
==17803==
==17803== For lists of detected and suppressed errors, rerun with: -s
==17803== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[SERVICE]
    Flush                1
    Log_level            info

[INPUT]
    Name                 node_exporter_metrics
    Tag                  node_metrics
    Scrape_interval      2

[OUTPUT]
    Name                     opentelemetry
    Match                    *
    Host                     collector
    Port                     3030
    Log_response_payload     false
    compress gzip
    tls                      off
    tls.verify               off
    Metrics_uri              /v1/metrics
    add_label                app fluent-bit
    add_label                color blue
    #storage.total_limit_size  90M
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
