### PR TITLE
tls: trim trailing dots from the vhost

### DIFF
--- a/include/fluent-bit/flb_str.h
+++ b/include/fluent-bit/flb_str.h
@@ -55,4 +55,22 @@ static inline int flb_str_emptyval(const char *s)
     return FLB_FALSE;
 }
 
+/*
+ Trim the `c` character sequence to the right of the `*str` string and return a copy.
+ * @param *str Source string;
+ * @param c Character to be trimmed.
+ * @returns a new string, which is a trimmed copy of `*str`.
+*/
+static inline char *flb_rtrim(const char *str, char c) {
+    ssize_t pos = strlen(str);
+
+    while(c == str[--pos]);
+
+    if (pos < 0){
+        return NULL;
+    }
+
+    return flb_strndup(str, pos+1);
+}
+
 #endif

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -497,11 +497,11 @@ int flb_tls_session_create(struct flb_tls *tls,
 
     if (connection->type == FLB_UPSTREAM_CONNECTION) {
         if (connection->upstream->proxied_host != NULL) {
-            vhost = connection->upstream->proxied_host;
+            vhost = flb_rtrim(connection->upstream->proxied_host, '.');
         }
         else {
             if (tls->vhost == NULL) {
-                vhost = connection->upstream->tcp_host;
+                vhost = flb_rtrim(connection->upstream->tcp_host, '.');
             }
         }
     }
@@ -636,6 +636,10 @@ cleanup:
     }
     else {
         connection->tls_session = session;
+    }
+
+    if (vhost != NULL) {
+        flb_free(vhost);
     }
 
     return result;


### PR DESCRIPTION
This PR adds trailing dot trimming to flb_tls_session_create which is meant to support unambiguous domain names as per RFC 1034.


Backport of PR #7418 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

/cc @leonardo-albertovich 
