### PR TITLE
out_stackdriver: process traceSampled special field

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -52,6 +52,7 @@
 #define DEFAULT_SEVERITY_KEY "logging.googleapis.com/severity"
 #define DEFAULT_TRACE_KEY "logging.googleapis.com/trace"
 #define DEFAULT_SPAN_ID_KEY "logging.googleapis.com/spanId"
+#define DEFAULT_TRACE_SAMPLED_KEY "logging.googleapis.com/traceSampled"
 #define DEFAULT_LOG_NAME_KEY "logging.googleapis.com/logName"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
@@ -165,6 +166,7 @@ struct flb_stackdriver {
     flb_sds_t severity_key;
     flb_sds_t trace_key;
     flb_sds_t span_id_key;
+    flb_sds_t trace_sampled_key;
     flb_sds_t log_name_key;
     flb_sds_t http_request_key;
     int http_request_key_size;

--- a/tests/runtime/data/stackdriver/stackdriver_test_trace_sampled.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_trace_sampled.h
@@ -1,0 +1,11 @@
+#define TRACE_SAMPLED_CASE_TRUE	"[" \
+    "1591111124," \
+    "{"	\
+        "\"logging.googleapis.com/traceSampled\": true" \
+    "}]"
+
+#define TRACE_SAMPLED_CASE_FALSE	"[" \
+    "1591111124," \
+    "{"	\
+        "\"logging.googleapis.com/traceSampled\": false" \
+    "}]"


### PR DESCRIPTION
This adds support for processing the logging.googleapis.com/traceSampled
special field from the jsonPayload

Addresses: https://github.com/GoogleCloudPlatform/ops-agent/issues/459

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
