### PR TITLE
in_tail: teardown and memory initialization fixes

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -86,6 +86,9 @@ static int in_tail_collect_pending(struct flb_input_instance *ins,
             file->size = st.st_size;
             file->pending_bytes = (file->size - file->offset);
         }
+        else {
+            memset(&st, 0, sizeof(struct stat));
+        }
 
         if (file->pending_bytes <= 0) {
             continue;

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1205,14 +1205,6 @@ void flb_tail_file_remove(struct flb_tail_file *file)
     flb_plg_debug(ctx->ins, "inode=%"PRIu64" removing file name %s",
                   file->inode, file->name);
 
-    if (file->sl_log_event_encoder != NULL) {
-        flb_log_event_encoder_destroy(file->sl_log_event_encoder);
-    }
-
-    if (file->ml_log_event_encoder != NULL) {
-        flb_log_event_encoder_destroy(file->ml_log_event_encoder);
-    }
-
     /* remove the multiline.core stream */
     if (ctx->ml_ctx && file->ml_stream_id > 0) {
         /* destroy ml stream */
@@ -1233,6 +1225,14 @@ void flb_tail_file_remove(struct flb_tail_file *file)
     }
 
     msgpack_sbuffer_destroy(&file->mult_sbuf);
+
+    if (file->sl_log_event_encoder != NULL) {
+        flb_log_event_encoder_destroy(file->sl_log_event_encoder);
+    }
+
+    if (file->ml_log_event_encoder != NULL) {
+        flb_log_event_encoder_destroy(file->ml_log_event_encoder);
+    }
 
     flb_sds_destroy(file->dmode_buf);
     flb_sds_destroy(file->dmode_lastline);


### PR DESCRIPTION
This PR fixes a minor error in in_tail where it could access uninitialized 
memory in the pending data collector callback.

Additionally it corrects the teardown order so the log event encoders 
are disposed of after the multiline context (which uses one of them).