### PR TITLE
in_tail: added cleanup / initialization in the pending collector

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -86,6 +86,9 @@ static int in_tail_collect_pending(struct flb_input_instance *ins,
             file->size = st.st_size;
             file->pending_bytes = (file->size - file->offset);
         }
+        else {
+            memset(&st, 0, sizeof(struct stat));
+        }
 
         if (file->pending_bytes <= 0) {
             continue;


### PR DESCRIPTION
This PR fixes a minor error in in_tail where it could access uninitialized
memory in the pending data collector callback.

Note: this is a backport of #7441 