### PR TITLE
processor: added cleanup / initialization in the processor loop

### DIFF
--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -328,6 +328,9 @@ int flb_processor_run(struct flb_processor *proc,
     mk_list_foreach(head, list) {
         pu = mk_list_entry(head, struct flb_processor_unit, _head);
 
+        tmp_buf = NULL;
+        tmp_size = 0;
+
         /* run the unit */
         if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
             /* get the filter context */


### PR DESCRIPTION
This PR fixes the misinterpretation of the result of the multiline filter callback when it returns FLB_FILTER_MODIFIED without setting the output variables.

Even the multiline filter should be fixed to not make the assumption that those variables are pre-primed this is the most pragmatic way of ensuring this bug doesn't get triggered by other filters.
