### PR TITLE
multiline: make the multiline core use the appropriate scheduler

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -950,15 +950,16 @@ int flb_ml_parsers_init(struct flb_config *ctx)
 
 int flb_ml_auto_flush_init(struct flb_ml *ml)
 {
-    int ret;
-    struct flb_config *ctx;
+    struct flb_sched *scheduler;
+    int               ret;
 
-    if (!ml) {
+    if (ml == NULL) {
         return -1;
     }
 
-    ctx = ml->config;
-    if (!ctx->sched) {
+    scheduler = flb_sched_ctx_get();
+
+    if (scheduler == NULL) {
         flb_error("[multiline] scheduler context has not been created");
         return -1;
     }
@@ -969,11 +970,12 @@ int flb_ml_auto_flush_init(struct flb_ml *ml)
     }
 
     /* Create flush timer */
-    ret = flb_sched_timer_cb_create(ctx->sched,
+    ret = flb_sched_timer_cb_create(scheduler,
                                     FLB_SCHED_TIMER_CB_PERM,
                                     ml->flush_ms,
                                     cb_ml_flush_timer,
                                     ml, NULL);
+
     return ret;
 }
 

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -1402,7 +1402,7 @@ static void test_issue_5504()
 
     /* Set the thread local scheduler */
     flb_sched_ctx_init();
-    flb_sched_ctx_set(sched);
+    flb_sched_ctx_set(config->sched);
 
     ml = flb_ml_create(config, "5504-test");
     TEST_CHECK(ml != NULL);

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -1402,6 +1402,10 @@ static void test_issue_5504()
     config->sched = flb_sched_create(config, config->evl);
     TEST_CHECK(config->sched != NULL);
 
+    /* Set the thread local scheduler */
+    flb_sched_ctx_init();
+    flb_sched_ctx_set(sched);
+
     /* Generate an instance of any multiline parser */
     mlp_i = flb_ml_parser_instance_create(ml, "cri");
     TEST_CHECK(mlp_i != NULL);

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -1389,8 +1389,6 @@ static void test_issue_5504()
 
     /* Initialize environment */
     config = flb_config_init();
-    ml = flb_ml_create(config, "5504-test");
-    TEST_CHECK(ml != NULL);
     
     /* Create the event loop */
     evl = config->evl;
@@ -1405,6 +1403,9 @@ static void test_issue_5504()
     /* Set the thread local scheduler */
     flb_sched_ctx_init();
     flb_sched_ctx_set(sched);
+
+    ml = flb_ml_create(config, "5504-test");
+    TEST_CHECK(ml != NULL);
 
     /* Generate an instance of any multiline parser */
     mlp_i = flb_ml_parser_instance_create(ml, "cri");


### PR DESCRIPTION
This PR fixes a bug in the multiline core where it scheduled flush timer 
in the main pipeline thread rather than the scheduler pertaining to the 
thread it was being initialized on which affects both the tail input plugin 
when running in threaded mode and the multiline filter when used in 
a processor stack (where the input plugin is running in threaded mode).

Note: This is a backport of PR #7445 