### PR TITLE
in_emitter: added automatic threading detection workaround

### DIFF
--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -218,11 +218,6 @@ static int cb_emitter_init(struct flb_input_instance *in,
 
     scheduler = flb_sched_ctx_get();
 
-    if (scheduler == NULL) {
-        flb_error("[emitter] scheduler context has not been created");
-        return -1;
-    }
-
     ctx = flb_calloc(1, sizeof(struct flb_emitter));
     if (!ctx) {
         flb_errno();
@@ -238,6 +233,7 @@ static int cb_emitter_init(struct flb_input_instance *in,
     }
 
     if (scheduler != config->sched &&
+        scheduler != NULL &&
         ctx->ring_buffer_size == 0) {
 
         ctx->ring_buffer_size = DEFAULT_EMITTER_RING_BUFFER_FLUSH_FREQUENCY;

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -128,6 +128,7 @@ int in_emitter_add_record(const char *tag, int tag_len,
         msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
         ret = flb_ring_buffer_write(ctx->msgs, (void *)ec, sizeof(struct em_chunk));
         msgpack_sbuffer_destroy(&ec->mp_sbuf);
+        flb_sds_destroy(ec->tag);
         flb_free(ec);
         return ret;
     }

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -123,9 +123,11 @@ int in_emitter_add_record(const char *tag, int tag_len,
         if (ec == NULL) {
             return -1;
         }
+        msgpack_sbuffer_init(&ec->mp_sbuf);
         ec->tag = flb_sds_create_len(tag, tag_len);
         msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
         ret = flb_ring_buffer_write(ctx->msgs, (void *)ec, sizeof(struct em_chunk));
+        msgpack_sbuffer_destroy(&ec->mp_sbuf);
         flb_free(ec);
         return ret;
     }


### PR DESCRIPTION
This patch uses the scheduler instance from the thread local storage to determine if the filter creating the emitter instance is running in an input plugins thread to transparently switch over to the ring buffer based mechanism.

This is not a definitive solution, it's a workaround.