### PR TITLE
processor: inline re-ingestion implementation

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -87,6 +87,7 @@ struct flb_filter_instance {
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *match_regex; /* match rule (regex) based on Tags */
 #endif
+    void *parent;                  /* Parent processor         */
     void *context;                 /* Instance local context   */
     void *data;
     struct flb_filter_plugin *p;   /* original plugin          */

--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -87,7 +87,7 @@ struct flb_filter_instance {
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *match_regex; /* match rule (regex) based on Tags */
 #endif
-    void *parent;                  /* Parent processor         */
+    void *parent_processor;        /* Parent processor         */
     void *context;                 /* Instance local context   */
     void *data;
     struct flb_filter_plugin *p;   /* original plugin          */

--- a/include/fluent-bit/flb_input_log.h
+++ b/include/fluent-bit/flb_input_log.h
@@ -27,13 +27,15 @@ int flb_input_log_append(struct flb_input_instance *ins,
                          const char *tag, size_t tag_len,
                          const void *buf, size_t buf_size);
 
-int flb_input_log_append_ex(struct flb_input_instance *ins,
-                            size_t processor_starting_stage,
-                            const char *tag, size_t tag_len,
-                            const void *buf, size_t buf_size);
-
 int flb_input_log_append_records(struct flb_input_instance *ins,
                                  size_t records,
                                  const char *tag, size_t tag_len,
                                  const void *buf, size_t buf_size);
+
+int flb_input_log_append_skip_processor_stages(struct flb_input_instance *ins,
+                                               size_t processor_starting_stage,
+                                               const char *tag,
+                                               size_t tag_len,
+                                               const void *buf,
+                                               size_t buf_size);
 #endif

--- a/include/fluent-bit/flb_input_log.h
+++ b/include/fluent-bit/flb_input_log.h
@@ -27,6 +27,11 @@ int flb_input_log_append(struct flb_input_instance *ins,
                          const char *tag, size_t tag_len,
                          const void *buf, size_t buf_size);
 
+int flb_input_log_append_ex(struct flb_input_instance *ins,
+                            size_t processor_starting_stage,
+                            const char *tag, size_t tag_len,
+                            const void *buf, size_t buf_size);
+
 int flb_input_log_append_records(struct flb_input_instance *ins,
                                  size_t records,
                                  const char *tag, size_t tag_len,

--- a/include/fluent-bit/flb_input_metric.h
+++ b/include/fluent-bit/flb_input_metric.h
@@ -28,4 +28,8 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
                              const char *tag, size_t tag_len,
                              struct cmt *cmt);
 
+int flb_input_metrics_append_ex(struct flb_input_instance *ins,
+                                size_t processor_starting_stage,
+                                const char *tag, size_t tag_len,
+                                struct cmt *cmt);
 #endif

--- a/include/fluent-bit/flb_input_metric.h
+++ b/include/fluent-bit/flb_input_metric.h
@@ -28,8 +28,9 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
                              const char *tag, size_t tag_len,
                              struct cmt *cmt);
 
-int flb_input_metrics_append_ex(struct flb_input_instance *ins,
-                                size_t processor_starting_stage,
-                                const char *tag, size_t tag_len,
-                                struct cmt *cmt);
+int flb_input_metrics_append_skip_processor_stages(
+        struct flb_input_instance *ins,
+        size_t processor_starting_stage,
+        const char *tag, size_t tag_len,
+        struct cmt *cmt);
 #endif

--- a/include/fluent-bit/flb_input_trace.h
+++ b/include/fluent-bit/flb_input_trace.h
@@ -26,4 +26,10 @@
 int flb_input_trace_append(struct flb_input_instance *ins,
                            const char *tag, size_t tag_len,
                            struct ctrace *ctr);
+
+int flb_input_trace_append_ex(struct flb_input_instance *ins,
+                              size_t processor_starting_stage,
+                              const char *tag, size_t tag_len,
+                              struct ctrace *ctr);
+
 #endif

--- a/include/fluent-bit/flb_input_trace.h
+++ b/include/fluent-bit/flb_input_trace.h
@@ -27,9 +27,10 @@ int flb_input_trace_append(struct flb_input_instance *ins,
                            const char *tag, size_t tag_len,
                            struct ctrace *ctr);
 
-int flb_input_trace_append_ex(struct flb_input_instance *ins,
-                              size_t processor_starting_stage,
-                              const char *tag, size_t tag_len,
-                              struct ctrace *ctr);
+int flb_input_trace_append_skip_processor_stages(
+        struct flb_input_instance *ins,
+        size_t processor_starting_stage,
+        const char *tag, size_t tag_len,
+        struct ctrace *ctr);
 
 #endif

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -621,7 +621,9 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
     if (flb_processor_is_active(o_ins->processor)) {
         if (evc->type == FLB_EVENT_TYPE_LOGS) {
             /* run the processor */
-            ret = flb_processor_run(o_ins->processor, FLB_PROCESSOR_LOGS,
+            ret = flb_processor_run(o_ins->processor,
+                                    0,
+                                    FLB_PROCESSOR_LOGS,
                                     evc->tag, flb_sds_len(evc->tag),
                                     evc->data, evc->size,
                                     &p_buf, &p_size);
@@ -669,6 +671,7 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
                             evc->size,
                             &chunk_offset)) == CMT_DECODE_MSGPACK_SUCCESS) {
                 ret = flb_processor_run(o_ins->processor,
+                                        0,
                                         FLB_PROCESSOR_METRICS,
                                         evc->tag,
                                         flb_sds_len(evc->tag),
@@ -765,6 +768,7 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
                             evc->size,
                             &chunk_offset)) == CTR_DECODE_MSGPACK_SUCCESS) {
                 ret = flb_processor_run(o_ins->processor,
+                                        0,
                                         FLB_PROCESSOR_TRACES,
                                         evc->tag,
                                         flb_sds_len(evc->tag),

--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -67,6 +67,7 @@ struct flb_processor_unit {
     int event_type;
     int unit_type;
     flb_sds_t name;
+    size_t stage;
 
     /*
      * Opaque data type for custom reference (for pipeline filters this
@@ -110,6 +111,7 @@ struct flb_processor {
     struct mk_list metrics;
     struct mk_list traces;
 
+    size_t stage_count;
     /*
      * opaque data type to reference anything specific from the caller, for input
      * plugins this will contain the input instance context.
@@ -194,6 +196,7 @@ int flb_processor_init(struct flb_processor *proc);
 void flb_processor_destroy(struct flb_processor *proc);
 
 int flb_processor_run(struct flb_processor *proc,
+                      size_t starting_stage,
                       int type,
                       const char *tag, size_t tag_len,
                       void *data, size_t data_size,

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -318,8 +318,9 @@ static int ingest_inline(struct flb_rewrite_tag *ctx,
     struct flb_processor      *processor;
     int                        result;
 
-    if (ctx->ins->parent != NULL) {
-        processor_unit = (struct flb_processor_unit *) ctx->ins->parent;
+    if (ctx->ins->parent_processor != NULL) {
+        processor_unit = (struct flb_processor_unit *) \
+                            ctx->ins->parent_processor;
         processor = (struct flb_processor *) processor_unit->parent;
         input_instance = (struct flb_input_instance *) processor->data;
 

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -325,10 +325,11 @@ static int ingest_inline(struct flb_rewrite_tag *ctx,
         input_instance = (struct flb_input_instance *) processor->data;
 
         if (processor->source_plugin_type == FLB_PLUGIN_INPUT) {
-            result = flb_input_log_append_ex(input_instance,
-                                             processor_unit->stage + 1,
-                                             out_tag, flb_sds_len(out_tag),
-                                             buf, buf_size);
+            result = flb_input_log_append_skip_processor_stages(
+                        input_instance,
+                        processor_unit->stage + 1,
+                        out_tag, flb_sds_len(out_tag),
+                        buf, buf_size);
 
             if (result == 0) {
                 return FLB_TRUE;

--- a/src/flb_input_log.c
+++ b/src/flb_input_log.c
@@ -92,10 +92,12 @@ int flb_input_log_append(struct flb_input_instance *ins,
 }
 
 /* Take a msgpack serialized record and enqueue it as a chunk */
-int flb_input_log_append_ex(struct flb_input_instance *ins,
-                            size_t processor_starting_stage,
-                            const char *tag, size_t tag_len,
-                            const void *buf, size_t buf_size)
+int flb_input_log_append_skip_processor_stages(struct flb_input_instance *ins,
+                                               size_t processor_starting_stage,
+                                               const char *tag,
+                                               size_t tag_len,
+                                               const void *buf,
+                                               size_t buf_size)
 {
     return input_log_append(ins,
                             processor_starting_stage,

--- a/src/flb_input_log.c
+++ b/src/flb_input_log.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_processor.h>
 
 static int input_log_append(struct flb_input_instance *ins,
+                            size_t processor_starting_stage,
                             size_t records,
                             const char *tag, size_t tag_len,
                             const void *buf, size_t buf_size)
@@ -47,7 +48,12 @@ static int input_log_append(struct flb_input_instance *ins,
             }
         }
 
-        ret = flb_processor_run(ins->processor, FLB_PROCESSOR_LOGS, tag, tag_len, (char *) buf, buf_size, &out_buf, &out_size);
+        ret = flb_processor_run(ins->processor,
+                                processor_starting_stage,
+                                FLB_PROCESSOR_LOGS,
+                                tag, tag_len,
+                                (char *) buf, buf_size,
+                                &out_buf, &out_size);
         if (ret == -1) {
             return -1;
         }
@@ -81,10 +87,24 @@ int flb_input_log_append(struct flb_input_instance *ins,
     size_t records;
 
     records = flb_mp_count(buf, buf_size);
-    ret = input_log_append(ins, records, tag, tag_len, buf, buf_size);
+    ret = input_log_append(ins, 0, records, tag, tag_len, buf, buf_size);
     return ret;
 }
 
+/* Take a msgpack serialized record and enqueue it as a chunk */
+int flb_input_log_append_ex(struct flb_input_instance *ins,
+                            size_t processor_starting_stage,
+                            const char *tag, size_t tag_len,
+                            const void *buf, size_t buf_size)
+{
+    return input_log_append(ins,
+                            processor_starting_stage,
+                            flb_mp_count(buf, buf_size),
+                            tag,
+                            tag_len,
+                            buf,
+                            buf_size);
+}
 
 /* Take a msgpack serialized record and enqueue it as a chunk */
 int flb_input_log_append_records(struct flb_input_instance *ins,
@@ -94,7 +114,7 @@ int flb_input_log_append_records(struct flb_input_instance *ins,
 {
     int ret;
 
-    ret = input_log_append(ins, records, tag, tag_len, buf, buf_size);
+    ret = input_log_append(ins, 0, records, tag, tag_len, buf, buf_size);
     return ret;
 }
 

--- a/src/flb_input_metric.c
+++ b/src/flb_input_metric.c
@@ -23,10 +23,10 @@
 #include <fluent-bit/flb_input_metric.h>
 #include <fluent-bit/flb_input_plugin.h>
 
-/* Take a metric context and enqueue it as a Metric's Chunk */
-int flb_input_metrics_append(struct flb_input_instance *ins,
-                             const char *tag, size_t tag_len,
-                             struct cmt *cmt)
+static int input_metrics_append(struct flb_input_instance *ins,
+                                size_t processor_starting_stage,
+                                const char *tag, size_t tag_len,
+                                struct cmt *cmt)
 {
     int ret;
     char *mt_buf;
@@ -46,7 +46,13 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
             }
         }
 
-        ret = flb_processor_run(ins->processor, FLB_PROCESSOR_METRICS, tag, tag_len, (char *) cmt, 0, NULL, NULL);
+        ret = flb_processor_run(ins->processor,
+                                processor_starting_stage,
+                                FLB_PROCESSOR_METRICS,
+                                tag,
+                                tag_len,
+                                (char *) cmt,
+                                0, NULL, NULL);
 
         if (ret == -1) {
             return -1;
@@ -64,7 +70,31 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
     /* Append packed metrics */
     ret = flb_input_chunk_append_raw(ins, FLB_INPUT_METRICS, 0,
                                      tag, tag_len, mt_buf, mt_size);
+
     cmt_encode_msgpack_destroy(mt_buf);
 
     return ret;
+}
+
+/* Take a metric context and enqueue it as a Metric's Chunk */
+int flb_input_metrics_append(struct flb_input_instance *ins,
+                             const char *tag, size_t tag_len,
+                             struct cmt *cmt)
+{
+    return input_metrics_append(ins,
+                                0,
+                                tag, tag_len,
+                                cmt);
+}
+
+/* Take a metric context and enqueue it as a Metric's Chunk */
+int flb_input_metrics_append_ex(struct flb_input_instance *ins,
+                                size_t processor_starting_stage,
+                                const char *tag, size_t tag_len,
+                                struct cmt *cmt)
+{
+    return input_metrics_append(ins,
+                                processor_starting_stage,
+                                tag, tag_len,
+                                cmt);
 }

--- a/src/flb_input_metric.c
+++ b/src/flb_input_metric.c
@@ -88,10 +88,11 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
 }
 
 /* Take a metric context and enqueue it as a Metric's Chunk */
-int flb_input_metrics_append_ex(struct flb_input_instance *ins,
-                                size_t processor_starting_stage,
-                                const char *tag, size_t tag_len,
-                                struct cmt *cmt)
+int flb_input_metrics_append_skip_processor_stages(
+        struct flb_input_instance *ins,
+        size_t processor_starting_stage,
+        const char *tag, size_t tag_len,
+        struct cmt *cmt)
 {
     return input_metrics_append(ins,
                                 processor_starting_stage,

--- a/src/flb_input_trace.c
+++ b/src/flb_input_trace.c
@@ -26,10 +26,10 @@
 #include <ctraces/ctraces.h>
 #include <ctraces/ctr_decode_msgpack.h>
 
-/* Take a CTrace context and enqueue it as a Trace chunk */
-int flb_input_trace_append(struct flb_input_instance *ins,
-                           const char *tag, size_t tag_len,
-                           struct ctrace *ctr)
+static int input_trace_append(struct flb_input_instance *ins,
+                              size_t processor_starting_stage,
+                              const char *tag, size_t tag_len,
+                              struct ctrace *ctr)
 {
     int ret;
     char *out_buf;
@@ -49,7 +49,12 @@ int flb_input_trace_append(struct flb_input_instance *ins,
             }
         }
 
-        ret = flb_processor_run(ins->processor, FLB_PROCESSOR_TRACES, tag, tag_len, (char *) ctr, 0, NULL, NULL);
+        ret = flb_processor_run(ins->processor,
+                                processor_starting_stage,
+                                FLB_PROCESSOR_TRACES,
+                                tag, tag_len,
+                                (char *) ctr,
+                                0, NULL, NULL);
 
         if (ret == -1) {
             return -1;
@@ -70,4 +75,27 @@ int flb_input_trace_append(struct flb_input_instance *ins,
     ctr_encode_msgpack_destroy(out_buf);
 
     return ret;
+}
+
+/* Take a CTrace context and enqueue it as a Trace chunk */
+int flb_input_trace_append(struct flb_input_instance *ins,
+                           const char *tag, size_t tag_len,
+                           struct ctrace *ctr)
+{
+    return input_trace_append(ins,
+                              0,
+                              tag, tag_len,
+                              ctr);
+}
+
+/* Take a CTrace context and enqueue it as a Trace chunk */
+int flb_input_trace_append_ex(struct flb_input_instance *ins,
+                              size_t processor_starting_stage,
+                              const char *tag, size_t tag_len,
+                              struct ctrace *ctr)
+{
+    return input_trace_append(ins,
+                              processor_starting_stage,
+                              tag, tag_len,
+                              ctr);
 }

--- a/src/flb_input_trace.c
+++ b/src/flb_input_trace.c
@@ -89,10 +89,11 @@ int flb_input_trace_append(struct flb_input_instance *ins,
 }
 
 /* Take a CTrace context and enqueue it as a Trace chunk */
-int flb_input_trace_append_ex(struct flb_input_instance *ins,
-                              size_t processor_starting_stage,
-                              const char *tag, size_t tag_len,
-                              struct ctrace *ctr)
+int flb_input_trace_append_skip_processor_stages(
+        struct flb_input_instance *ins,
+        size_t processor_starting_stage,
+        const char *tag, size_t tag_len,
+        struct ctrace *ctr)
 {
     return input_trace_append(ins,
                               processor_starting_stage,

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -199,7 +199,7 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
             return NULL;
         }
 
-        f_ins->parent = (void *) pu;
+        f_ins->parent_processor = (void *) pu;
 
         /* matching rule: just set to workaround the pipeline initializer */
         f_ins->match = flb_sds_create("*");

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -97,7 +97,7 @@ static void processor()
     ret = create_msgpack_records(&mp_buf, &mp_size);
     TEST_CHECK(ret == 0);
 
-    ret = flb_processor_run(proc, FLB_PROCESSOR_LOGS, "TEST", 4, mp_buf, mp_size, &out_buf, &out_size);
+    ret = flb_processor_run(proc, 0, FLB_PROCESSOR_LOGS, "TEST", 4, mp_buf, mp_size, &out_buf, &out_size);
 
     if (out_buf != mp_buf) {
         flb_free(out_buf);


### PR DESCRIPTION
This PR adds the concept of processor stages which are just an index that's used to skip the stages that the record has already gone through when re-ingesting them (ie. filter_rewrite_tag) which allows us to resume the process and invoke any remaining processors as expected.