### PR TITLE
reload: bin: Prevent too short interval of reloading

### DIFF
--- a/include/fluent-bit/flb_error.h
+++ b/include/fluent-bit/flb_error.h
@@ -48,4 +48,7 @@
 /* Coroutine errors */
 #define FLB_ERR_CORO_STACK_SIZE      -600
 
+/* Reloading */
+#define FLB_ERR_RELOADING_IN_PROGRESS 700
+
 #endif

--- a/include/fluent-bit/flb_reload.h
+++ b/include/fluent-bit/flb_reload.h
@@ -25,6 +25,9 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_config_format.h>
 
+#define FLB_RELOAD_IDLE 0
+#define FLB_RELOAD_IN_PROGRESS 1
+
 int flb_reload_property_check_all(struct flb_config *config);
 int flb_reload_reconstruct_cf(struct flb_cf *src_cf, struct flb_cf *dest_cf);
 int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts);

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -113,6 +113,9 @@ void flb_utils_error(int err)
     case FLB_ERR_CFG_PLUGIN_FILE:
         msg = "plugins_file not found";
         break;
+    case FLB_ERR_RELOADING_IN_PROGRESS:
+        msg = "reloading in progress";
+        break;
     default:
         flb_error("(error message is not defined. err=%d)", err);
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

During reloading, it needs to prevent to run hot-reloading due to some of cases cause invalid fluent-bit contexts.
This means that too frequent reloading causes invalid contexts and invalid event loops.
To fix this issue, we need to protect to call flb_reload during hot-reloading is in progress.

Related to https://github.com/fluent/fluent-bit/issues/7427.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name dummy
    Tag dummy.locals

[FILTER]
    Name record_modifier
    Match *
    Record hostname ${HOSTNAME}

[OUTPUT]
    Name  stdout
    Match *
```

In another terminal, execute the following command:

```console
$ killall -HUP fluent-bit; killall -HUP fluent-bit; killall -HUP fluent-bit; 
```

With this PR, fluent-bit doesn't complain with SEGV or invalid arguments on monkey event loop.

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1985525== 
==1985525== HEAP SUMMARY:
==1985525==     in use at exit: 0 bytes in 0 blocks
==1985525==   total heap usage: 14,821 allocs, 14,821 frees, 11,266,672 bytes allocated
==1985525== 
==1985525== All heap blocks were freed -- no leaks are possible
==1985525== 
==1985525== For lists of detected and suppressed errors, rerun with: -s
==1985525== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
