### PR TITLE
workflows: add sanity check on release

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -35,8 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.formatted_version.outputs.replaced }}
-    permissions:
-      contents: read
     steps:
 
       - run: |

--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.formatted_version.outputs.replaced }}
+    permissions:
+      contents: read
     steps:
 
       - run: |

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -31,12 +31,11 @@ jobs:
 
   staging-release-version-check:
     name: Check staging release matches
-    environment: release
     runs-on: ubuntu-latest
     outputs:
       major-version: ${{ steps.get_major_version.outputs.value }}
     permissions:
-      contents: none
+      contents: read
     steps:
     - name: Get the version on staging
       run: |
@@ -63,6 +62,17 @@ jobs:
       shell: bash
       env:
         RELEASE_VERSION: ${{ github.event.inputs.version }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+  
+    # Check we can download the AppVeyor build which confirms it matches the version to release as well as being a successful build
+    - name: Get Appveyor binaries
+      run: |
+        ./packaging/appveyor-download.sh
+      shell: bash
+      env:
+        TAG: v${{ github.event.inputs.version }}
 
   staging-release-generate-package-matrix:
     name: Get package matrix


### PR DESCRIPTION
Addresses #7473 by verifying we both have an AppVeyor build and it is the right version.
It will fail as it cannot find the 2.1.4 binaries for example.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
