### PR TITLE
multiline: remove incorrect flush 

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -232,7 +232,6 @@ static int package_content(struct flb_ml_stream *mst,
     }
     else {
         if (mst->last_stream_group != stream_group) {
-            flb_ml_flush_stream_group(parser, mst, mst->last_stream_group, FLB_FALSE);
             mst->last_stream_group = stream_group;
         }
     }

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -110,8 +110,8 @@ struct record_check container_mix_input[] = {
 struct record_check container_mix_output[] = {
   {"a1\n"},
   {"a2\n"},
-  {"bbcc"},
   {"ddee\n"},
+  {"bbcc"},
   {"single full"},
   {"1a. some multiline log"},
   {"1b. some multiline log"},
@@ -1431,7 +1431,7 @@ static void test_issue_5504()
     }
     TEST_CHECK(cb != NULL);
 
-    /* Trigger the callback without delay */ 
+    /* Trigger the callback without delay */
     cb(config, ml);
     /* This should not update the last_flush since it is before the timeout */
     TEST_CHECK(ml->last_flush == last_flush);


### PR DESCRIPTION
<!-- Provide summary of changes -->

we are flushing the stream buffer in case it is
different in two consecutive runs, which leads to
incorrect parsing of multiline logs where we have
messages from different streams (stderr & stdout for ex) interleaved

we also update the test case to match the expected output due to the change in flushing logic

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #4387 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```
[INPUT]
  Name tail
  Path ../cri.log
  Multiline.Parser cri
  Read_from_head True

[OUTPUT]
  name stdout
  match *
```

```
2021-11-18T14:47:34.730908438+00:00 stdout P start B
2021-11-18T14:47:34.730908438+00:00 stdout F end B
2021-11-18T14:47:34.730939216+00:00 stdout P C 1
2021-11-18T14:47:34.735454549+00:00 stderr F some log message D in stderr part one
2021-11-18T14:47:34.735482854+00:00 stdout F message C still continued after a line from a different stream
```


- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
Fluent Bit v2.0.14
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/05/25 12:01:47] [ info] [fluent bit] version=2.0.14, commit=36042f0042, pid=35814
[2023/05/25 12:01:47] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/05/25 12:01:47] [ info] [cmetrics] version=0.6.1
[2023/05/25 12:01:47] [ info] [ctraces ] version=0.3.1
[2023/05/25 12:01:47] [ info] [input:tail:tail.0] initializing
[2023/05/25 12:01:47] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/05/25 12:01:47] [ info] [input:tail:tail.0] multiline core started
[2023/05/25 12:01:47] [ info] [sp] stream processor started
[2023/05/25 12:01:47] [ info] [output:stdout:stdout.0] worker #0 started
[2023/05/25 12:01:47] [ info] [input:tail:tail.0] inotify_fs_add(): inode=23031 watch_fd=1 name=../cri.log
[0] tail.0: [1637246854.735454549, {"time"=>"2021-11-18T14:47:34.735454549+00:00", "stream"=>"stderr", "_p"=>"F", "log"=>"D stderr"}]
[1] tail.0: [1637246854.730939216, {"time"=>"2021-11-18T14:47:34.730939216+00:00", "stream"=>"stdout", "_p"=>"P", "log"=>"C1 stdoutC end stdout"}]
[2] tail.0: [1637246854.730908438, {"time"=>"2021-11-18T14:47:34.730908438+00:00", "stream"=>"stdout", "_p"=>"F", "log"=>"test2"}]
[3] tail.0: [1637246854.730908438, {"time"=>"2021-11-18T14:47:34.730908438+00:00", "stream"=>"stdout", "_p"=>"F", "log"=>"test3"}]
[4] tail.0: [1637246854.730908438, {"time"=>"2021-11-18T14:47:34.730908438+00:00", "stream"=>"stdout", "_p"=>"F", "log"=>"test4"}]
^C[2023/05/25 12:01:49] [engine] caught signal (SIGINT)
[2023/05/25 12:01:49] [ warn] [engine] service will shutdown in max 5 seconds
[2023/05/25 12:01:49] [ info] [input] pausing tail.0
[2023/05/25 12:01:50] [ info] [engine] service has stopped (0 pending tasks)
[2023/05/25 12:01:50] [ info] [input] pausing tail.0
[2023/05/25 12:01:50] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/05/25 12:01:50] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=23031 watch_fd=1
[2023/05/25 12:01:50] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==35814==
==35814== HEAP SUMMARY:
==35814==     in use at exit: 0 bytes in 0 blocks
==35814==   total heap usage: 1,750 allocs, 1,750 frees, 1,133,310 bytes allocated
==35814==
==35814== All heap blocks were freed -- no leaks are possible
==35814==
==35814== For lists of detected and suppressed errors, rerun with: -s
==35814== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
