### PR TITLE
multiline: python: Add support for PEP-657 introduced in Python 3.11

### DIFF
--- a/src/multiline/flb_ml_parser_python.c
+++ b/src/multiline/flb_ml_parser_python.c
@@ -66,21 +66,28 @@ struct flb_ml_parser *flb_ml_parser_python(struct flb_config *config, char *key)
     }
 
     /* rule(:python, /^[\t ]+File /, :python_code) */
-    ret = rule(mlp, "python", "/^[\\t ]+File /", "python_code", NULL);
+    ret = rule(mlp, "python, python_tracehint", "/^[\\t ]+File /", "python_code", NULL);
     if (ret != 0) {
         rule_error(mlp);
         return NULL;
     }
 
-    /* rule(:python_code, /[^\t ]/, :python) */
-    ret = rule(mlp, "python_code", "/[^\\t ]/", "python", NULL);
+    /* rule(:python_code, /[^\t ]/, :python_tracehint) */
+    ret = rule(mlp, "python_code", "/[^\\t ]/", "python_tracehint", NULL);
+    if (ret != 0) {
+        rule_error(mlp);
+        return NULL;
+    }
+
+    /* rule(:python_tracehint, /^[\t ]+[\^~]+/, :python) */
+    ret = rule(mlp, "python_tracehint", "/^[\\t ]+[\\^~]+/", "python", NULL);
     if (ret != 0) {
         rule_error(mlp);
         return NULL;
     }
 
     /* rule(:python, /^(?:[^\s.():]+\.)*[^\s.():]+:/, :start_state) */
-    ret = rule(mlp, "python", "/^(?:[^\\s.():]+\\.)*[^\\s.():]+:/", "start_state", NULL);
+    ret = rule(mlp, "python, python_tracehint", "/^(?:[^\\s.():]+\\.)*[^\\s.():]+:/", "start_state", NULL);
     if (ret != 0) {
         rule_error(mlp);
         return NULL;

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -178,7 +178,17 @@ struct record_check python_input[] = {
   {"  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get\n"},
   {"    raise Exception('spam', 'eggs')\n"},
   {"Exception: ('spam', 'eggs')\n"},
-  {"hello world, not multiline\n"}
+  {"hello world, not multiline\n"},
+  {"Traceback (most recent call last):\n"},
+  {"  File \"/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py\", line 1535, in __call__\n"},
+  {"    rv = self.handle_exception(request, response, e)\n"},
+  {"                                ~~~~~~~~^^^^^^^^\n"},
+  {"  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 17, in start\n"},
+  {"    return get()\n"},
+  {"  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get\n"},
+  {"    raise Exception('spam', 'eggs')\n"},
+  {"                    ^^^^^^\n"},
+  {"Exception: ('spam', 'eggs')\n"}
 };
 
 struct record_check python_output[] = {
@@ -192,7 +202,19 @@ struct record_check python_output[] = {
       "    raise Exception('spam', 'eggs')\n"
       "Exception: ('spam', 'eggs')\n"
   },
-  {"hello world, not multiline\n"}
+  {"hello world, not multiline\n"},
+  {
+      "Traceback (most recent call last):\n"
+      "  File \"/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.5.2/webapp2.py\", line 1535, in __call__\n"
+      "    rv = self.handle_exception(request, response, e)\n"
+      "                                ~~~~~~~~^^^^^^^^\n"
+      "  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 17, in start\n"
+      "    return get()\n"
+      "  File \"/base/data/home/apps/s~nearfieldspy/1.378705245900539993/nearfieldspy.py\", line 5, in get\n"
+      "    raise Exception('spam', 'eggs')\n"
+      "                    ^^^^^^\n"
+      "Exception: ('spam', 'eggs')\n"
+  },
 };
 
 /* Custom example for Elasticsearch stacktrace */
@@ -1431,7 +1453,7 @@ static void test_issue_5504()
     }
     TEST_CHECK(cb != NULL);
 
-    /* Trigger the callback without delay */ 
+    /* Trigger the callback without delay */
     cb(config, ml);
     /* This should not update the last_flush since it is before the timeout */
     TEST_CHECK(ml->last_flush == last_flush);


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch adds an additional rule to the python multiline parser, that matches the fine-grained error locations in tracebacks


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #7478

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [x ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
