### PR TITLE
in_emitter: remove unused variable

### DIFF
--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -114,7 +114,6 @@ int in_emitter_add_record(const char *tag, int tag_len,
     struct mk_list *head;
     struct em_chunk *ec;
     struct flb_emitter *ctx;
-    int ret;
 
     ctx = (struct flb_emitter *) in->context;
     ec = NULL;

--- a/src/flb_compression.c
+++ b/src/flb_compression.c
@@ -60,8 +60,6 @@ static void flb_decompression_context_adjust_buffer(
 uint8_t *flb_decompression_context_get_append_buffer(
             struct flb_decompression_context *context)
 {
-    uintptr_t input_buffer_offset;
-
     if (context != NULL) {
         flb_decompression_context_adjust_buffer(context);
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1808,7 +1808,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     real_size = flb_input_chunk_get_real_size(ic);
     real_diff = real_size - pre_real_size;
     if (real_diff != 0) {
-        flb_debug("[input chunk] update output instances with new chunk size diff=%d, records=%zu, input=%s",
+        flb_debug("[input chunk] update output instances with new chunk size diff=%zd, records=%zu, input=%s",
                   real_diff, n_records, flb_input_name(in));
         flb_input_chunk_update_output_instances(ic, real_diff);
     }


### PR DESCRIPTION
This patch is to remove 3 warnings.

```
    fluent-bit/plugins/in_emitter/emitter.c:117:9: warning: unused variable ‘ret’ [-Wunused-variable]
      117 |     int ret;
          |         ^~~
```

```
    fluent-bit/src/flb_input_chunk.c: In function ‘input_chunk_append_raw’:
    fluent-bit/src/flb_input_chunk.c:1811:19: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
     1811 |         flb_debug("[input chunk] update output instances with new chunk size diff=%d, records=%zu, input=%s",
          |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1812 |                   real_diff, n_records, flb_input_name(in));
          |                   ~~~~~~~~~
          |                   |
          |                   size_t {aka long unsigned int}
    fluent-bit/include/fluent-bit/flb_log.h:198:47: note: in definition of macro ‘flb_debug’
      198 |         flb_log_print(FLB_LOG_DEBUG, NULL, 0, fmt, ##__VA_ARGS__)
          |                                               ^~~
    fluent-bit/src/flb_input_chunk.c:1811:84: note: format string is defined here
     1811 | ut chunk] update output instances with new chunk size diff=%d, records=%zu, input=%s",
          |                                                            ~^
          |                                                             |
          |                                                             int
          |                                                            %ld
```

```   
    fluent-bit/src/flb_compression.c: In function ‘flb_decompression_context_get_append_buffer’:
    fluent-bit/src/flb_compression.c:63:15: warning: unused variable ‘input_buffer_offset’ [-Wunused-variable]
       63 |     uintptr_t input_buffer_offset;
          |               ^~~~~~~~~~~~~~~~~~~
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
