### PR TITLE
in_kafka: Fix in kafka json parsing

### DIFF
--- a/examples/kafka_filter/Dockerfile
+++ b/examples/kafka_filter/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim as builder
 ENV DEBIAN_FRONTEND noninteractive
-ENV KAFKA_URL https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz
-ENV KAFKA_SHA256 67025feb03eb963a8852d4adc5b2810744f493a672c5992728955e38bed43da8
+ENV KAFKA_URL https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz
+ENV KAFKA_SHA256 a76f17a52b8f2cd31de11571ff366a714820b6e4e02893b0159d09db0edaf998
 
 # hadolint ignore=DL3008
 RUN apt-get update && \

--- a/examples/kafka_filter/kafka.conf
+++ b/examples/kafka_filter/kafka.conf
@@ -8,7 +8,7 @@
     brokers kafka-broker:9092
     topics fb-source
     poll_ms 100
-    data_format json
+    format json
 
 [FILTER]
     Name    lua

--- a/examples/kafka_filter/kafka.conf
+++ b/examples/kafka_filter/kafka.conf
@@ -8,6 +8,7 @@
     brokers kafka-broker:9092
     topics fb-source
     poll_ms 100
+    data_format json
 
 [FILTER]
     Name    lua

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -51,7 +51,7 @@ static int try_json(struct flb_log_event_encoder *log_encoder,
         }
         return ret;
     }
-    flb_log_event_encoder_append_body_binary_body(log_encoder, buf, bufsize);
+    flb_log_event_encoder_append_body_raw_msgpack(log_encoder, buf, bufsize);
     flb_free(buf);
     return 0;
 }

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -19,7 +19,6 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
-#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_time.h>
@@ -129,7 +128,7 @@ static int process_message(struct flb_in_kafka_config *ctx,
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
         if (rkm->payload) {
-            if (ctx->data_format != FLB_IN_KAFKA_DATA_FORMAT_JSON ||
+            if (ctx->format != FLB_IN_KAFKA_FORMAT_JSON ||
                     try_json(log_encoder, rkm)) {
                 ret = flb_log_event_encoder_append_body_string(log_encoder,
                                                                rkm->payload,
@@ -248,14 +247,14 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
-    if (strcasecmp(ctx->data_format_str, "none") == 0) {
-        ctx->data_format = FLB_IN_KAFKA_DATA_FORMAT_NONE;
+    if (strcasecmp(ctx->format_str, "none") == 0) {
+        ctx->format = FLB_IN_KAFKA_FORMAT_NONE;
     }
-    else if (strcasecmp(ctx->data_format_str, "json") == 0) {
-        ctx->data_format = FLB_IN_KAFKA_DATA_FORMAT_JSON;
+    else if (strcasecmp(ctx->format_str, "json") == 0) {
+        ctx->format = FLB_IN_KAFKA_FORMAT_JSON;
     }
     else {
-        flb_plg_error(ins, "config: invalid data_format \"%s\"", ctx->data_format_str);
+        flb_plg_error(ins, "config: invalid format \"%s\"", ctx->format_str);
         goto init_error;
     }
 
@@ -341,8 +340,8 @@ static struct flb_config_map config_map[] = {
     "Set the kafka topics, delimited by commas."
    },
    {
-    FLB_CONFIG_MAP_STR, "data_format", FLB_IN_KAFKA_DEFAULT_DATA_FORMAT,
-    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, data_format_str),
+    FLB_CONFIG_MAP_STR, "format", FLB_IN_KAFKA_DEFAULT_FORMAT,
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, format_str),
     "Set the data format which will be used for parsing records."
    },
    {

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -248,19 +248,14 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
-    conf = flb_input_get_property("data_format", ins);
-    if (!conf) {
-        conf = "none";
-    }
-
-    if (strcasecmp(conf, "none") == 0) {
+    if (strcasecmp(ctx->data_format_str, "none") == 0) {
         ctx->data_format = FLB_IN_KAFKA_DATA_FORMAT_NONE;
     }
-    else if (strcasecmp(conf, "json") == 0) {
+    else if (strcasecmp(ctx->data_format_str, "json") == 0) {
         ctx->data_format = FLB_IN_KAFKA_DATA_FORMAT_JSON;
     }
     else {
-        flb_plg_error(ins, "config: invalid data_format \"%s\"", conf);
+        flb_plg_error(ins, "config: invalid data_format \"%s\"", ctx->data_format_str);
         goto init_error;
     }
 
@@ -346,8 +341,8 @@ static struct flb_config_map config_map[] = {
     "Set the kafka topics, delimited by commas."
    },
    {
-    FLB_CONFIG_MAP_STR, "data_format", (char *)NULL,
-    0, FLB_FALSE, 0,
+    FLB_CONFIG_MAP_STR, "data_format", FLB_IN_KAFKA_DEFAULT_DATA_FORMAT,
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, data_format_str),
     "Set the data format which will be used for parsing records."
    },
    {

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -42,6 +42,7 @@ struct flb_in_kafka_config {
     struct flb_log_event_encoder *log_encoder;
     int poll_ms;
     int data_format;
+    char *data_format_str;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -28,13 +28,20 @@
 #include <fluent-bit/flb_log_event_encoder.h>
 
 
-#define FLB_IN_KAFKA_DEFAULT_POLL_MS  "500"
+#define FLB_IN_KAFKA_DEFAULT_POLL_MS       "500"
+#define FLB_IN_KAFKA_DEFAULT_DATA_FORMAT   "none"
+
+enum {
+    FLB_IN_KAFKA_DATA_FORMAT_NONE,
+    FLB_IN_KAFKA_DATA_FORMAT_JSON,
+};
 
 struct flb_in_kafka_config {
     struct flb_kafka kafka;
     struct flb_input_instance *ins;
     struct flb_log_event_encoder *log_encoder;
     int poll_ms;
+    int data_format;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -29,11 +29,11 @@
 
 
 #define FLB_IN_KAFKA_DEFAULT_POLL_MS       "500"
-#define FLB_IN_KAFKA_DEFAULT_DATA_FORMAT   "none"
+#define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
 
 enum {
-    FLB_IN_KAFKA_DATA_FORMAT_NONE,
-    FLB_IN_KAFKA_DATA_FORMAT_JSON,
+    FLB_IN_KAFKA_FORMAT_NONE,
+    FLB_IN_KAFKA_FORMAT_JSON,
 };
 
 struct flb_in_kafka_config {
@@ -41,8 +41,8 @@ struct flb_in_kafka_config {
     struct flb_input_instance *ins;
     struct flb_log_event_encoder *log_encoder;
     int poll_ms;
-    int data_format;
-    char *data_format_str;
+    int format;
+    char *format_str;
 };
 
 #endif


### PR DESCRIPTION
This fixes json parsing for in_kafka, also add `data_format` configuration option, for explicit parsing control.

Fixes #7481

