### PR TITLE
in_kubernetes_events: new input plugin to retrieve Kubernetes Events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ option(FLB_IN_HEALTH                   "Enable Health input plugin"             
 option(FLB_IN_HTTP                     "Enable HTTP input plugin"                     Yes)
 option(FLB_IN_MEM                      "Enable Memory input plugin"                   Yes)
 option(FLB_IN_KAFKA                    "Enable Kafka input plugin"                     No)
+option(FLB_IN_KUBERNETES_EVENTS        "Enabke Kubernetes Events plugin"              Yes)
 option(FLB_IN_KMSG                     "Enable Kernel log input plugin"               Yes)
 option(FLB_IN_LIB                      "Enable library mode input plugin"             Yes)
 option(FLB_IN_RANDOM                   "Enable random input plugin"                   Yes)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -209,6 +209,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   REGISTER_IN_PLUGIN("in_podman_metrics")
 endif()
 
+REGISTER_IN_PLUGIN("in_kubernetes_events")
 REGISTER_IN_PLUGIN("in_kafka")
 REGISTER_IN_PLUGIN("in_fluentbit_metrics")
 REGISTER_IN_PLUGIN("in_prometheus_scrape")

--- a/plugins/in_kubernetes_events/CMakeLists.txt
+++ b/plugins/in_kubernetes_events/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(src
+  kubernetes_events_conf.c
+  kubernetes_events.c)
+
+FLB_PLUGIN(in_kubernetes_events "${src}" "")

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -1,0 +1,336 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_ra_key.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "kubernetes_events.h"
+#include "kubernetes_events_conf.h"
+
+static int timestamp_lookup(struct k8s_events *ctx, char *ts, struct flb_time *tm)
+{
+    time_t time;
+    struct tm t = {0};
+
+    if (strptime(ts, "%Y-%m-%dT%H:%M:%SZ", &t) == NULL) {
+        return -1;
+    }
+
+    time = mktime(&t);
+    if (time == -1) {
+        flb_plg_error(ctx->ins, "invalid timestamp '%s'", ts);
+        return -1;
+    }
+
+    tm->tm.tv_sec = time;
+    tm->tm.tv_nsec = 0;
+
+    return 0;
+}
+
+static int process_events(struct k8s_events *ctx, char *in_data, size_t in_size)
+{
+    int i;
+    int ret;
+    int root_type;
+    int items_found = FLB_FALSE;
+    size_t consumed = 0;
+    char *buf_data;
+    size_t buf_size;
+    size_t off = 0;
+    struct flb_time ts;
+    struct flb_ra_value *rval;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object k;
+    msgpack_object items;
+    msgpack_object entry;
+
+    ret = flb_pack_json(in_data, in_size, &buf_data, &buf_size, &root_type, &consumed);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not process payload, incomplete or bad formed JSON");
+        return -1;
+    }
+
+    /* unpack */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, buf_data, buf_size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        flb_plg_error(ctx->ins, "Cannot unpack response");
+        flb_free(buf_data);
+        return -1;
+    }
+
+    /* lookup the items array */
+    root = result.data;
+    for (i = 0; i < root.via.map.size; i++) {
+        k = root.via.map.ptr[i].key;
+
+        if (k.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (k.via.str.size != 5) {
+            continue;
+        }
+
+        if (strncmp(k.via.str.ptr, "items", 5) != 0) {
+            continue;
+        }
+
+        items = root.via.map.ptr[i].val;
+        if (items.type != MSGPACK_OBJECT_ARRAY) {
+            flb_plg_error(ctx->ins, "Cannot unpack response");
+            break;
+        }
+
+        items_found = FLB_TRUE;
+        break;
+    }
+
+    if (!items_found) {
+        flb_plg_error(ctx->ins, "Cannot unpack response");
+        flb_free(buf_data);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    /* get the resourceVersion of the last item */
+    entry = items.via.array.ptr[items.via.array.size - 1];
+    if (entry.type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "Cannot unpack response");
+        flb_free(buf_data);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    /* lookup resourceVersion */
+    rval = flb_ra_get_value_object(ctx->ra_resource_version, entry);
+    if (!rval || rval->type != FLB_RA_STRING) {
+        flb_plg_error(ctx->ins, "cannot retrieve resourceVersion");
+        flb_free(buf_data);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    /* check if we should process this payload based on the last item resourceVersion */
+    if (ctx->last_resource_version) {
+        /* compare resourceVersion */
+        if (strcmp(rval->val.string, ctx->last_resource_version) == 0) {
+            flb_plg_debug(ctx->ins, "resourceVersion %s is equal to last resourceVersion %s, skipping payload",
+                          rval->val.string, ctx->last_resource_version);
+            flb_free(buf_data);
+            flb_ra_key_value_destroy(rval);
+            msgpack_unpacked_destroy(&result);
+            return 0;
+        }
+        else {
+            cfl_sds_destroy(ctx->last_resource_version);
+            ctx->last_resource_version = cfl_sds_create(rval->val.string);
+        }
+    }
+    else {
+        ctx->last_resource_version = cfl_sds_create(rval->val.string);
+    }
+    flb_ra_key_value_destroy(rval);
+
+    /* reset the log encoder */
+    flb_log_event_encoder_reset(ctx->encoder);
+
+    /* print every item from the items array */
+    for (i = 0; i < items.via.array.size; i++) {
+        entry = items.via.array.ptr[i];
+        if (entry.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "Cannot unpack response");
+            break;
+        }
+
+        /* get event timestamp */
+        rval = flb_ra_get_value_object(ctx->ra_timestamp, entry);
+        if (!rval || rval->type != FLB_RA_STRING) {
+            flb_plg_error(ctx->ins, "cannot retrieve event timestamp");
+            flb_free(buf_data);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        /* convert timestamp */
+        ret = timestamp_lookup(ctx, rval->val.string, &ts);
+        if (ret == -1) {
+            flb_free(buf_data);
+            flb_ra_key_value_destroy(rval);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        flb_ra_key_value_destroy(rval);
+
+        /* encode content as a log event */
+        flb_log_event_encoder_begin_record(ctx->encoder);
+        flb_log_event_encoder_set_timestamp(ctx->encoder, &ts);
+
+        ret = flb_log_event_encoder_set_body_from_msgpack_object(ctx->encoder, &entry);
+        if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+            ret = flb_log_event_encoder_commit_record(ctx->encoder);
+        }
+    }
+
+    if (ctx->encoder->output_length > 0) {
+        flb_input_log_append(ctx->ins, NULL, 0,
+                             ctx->encoder->output_buffer,
+                             ctx->encoder->output_length);
+    }
+
+    flb_free(buf_data);
+    msgpack_unpacked_destroy(&result);
+    return ret;
+}
+
+static int k8s_events_collect(struct flb_input_instance *ins,
+                              struct flb_config *config, void *in_context)
+{
+    int ret;
+    size_t b_sent;
+    struct flb_connection *u_conn = NULL;
+    struct flb_http_client *c = NULL;
+    struct k8s_events *ctx = in_context;
+
+    u_conn = flb_upstream_conn_get(ctx->upstream);
+    if (!u_conn) {
+        flb_plg_error(ins, "upstream connection initialization error");
+        goto exit;
+    }
+
+    c = flb_http_client(u_conn, FLB_HTTP_GET, K8S_EVENTS_KUBE_API_URI,
+                        NULL, 0, ctx->ins->host.name, ctx->ins->host.port, NULL, 0);
+    if (!c) {
+        flb_plg_error(ins, "unable to create http client");
+        goto exit;
+    }
+    flb_http_buffer_size(c, 0);
+
+    ret = flb_http_do(c, &b_sent);
+    if (ret != 0) {
+        flb_plg_error(ins, "http do error");
+        goto exit;
+    }
+
+    if (c->resp.status != 200) {
+        flb_plg_error(ins, "http status code error: %d", c->resp.status);
+        goto exit;
+    }
+
+    if (c->resp.payload_size <= 0) {
+        flb_plg_error(ins, "empty response");
+        goto exit;
+    }
+
+    ret = process_events(ctx, c->resp.payload, c->resp.payload_size);
+
+exit:
+    if (c) {
+        flb_http_client_destroy(c);
+    }
+    if (u_conn) {
+        flb_upstream_conn_release(u_conn);
+    }
+    FLB_INPUT_RETURN(0);
+}
+
+static int k8s_events_init(struct flb_input_instance *ins,
+                           struct flb_config *config, void *data)
+{
+    struct k8s_events *ctx = NULL;
+
+    ctx = k8s_events_conf_create(ins);
+    if (!ctx) {
+        return -1;
+    }
+
+    ctx->coll_id = flb_input_set_collector_time(ins,
+                                                k8s_events_collect,
+                                                1,
+                                                0, config);
+    return 0;
+}
+
+static int k8s_events_exit(void *data, struct flb_config *config)
+{
+    struct k8s_events *ctx = data;
+
+    if (!ctx) {
+        return 0;
+    }
+
+    k8s_events_conf_destroy(ctx);
+    return 0;
+}
+
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    /* Full Kubernetes API server URL */
+    {
+     FLB_CONFIG_MAP_STR, "kube_url", "https://kubernetes.default.svc",
+     0, FLB_FALSE, 0,
+     "Kubernetes API server URL"
+    },
+
+    /* Kubernetes TLS: CA file */
+    {
+     FLB_CONFIG_MAP_STR, "kube_ca_file", K8S_EVENTS_KUBE_CA,
+     0, FLB_TRUE, offsetof(struct k8s_events, tls_ca_file),
+     "Kubernetes TLS CA file"
+    },
+
+    /* Kubernetes TLS: CA certs path */
+    {
+     FLB_CONFIG_MAP_STR, "kube_ca_path", NULL,
+     0, FLB_TRUE, offsetof(struct k8s_events, tls_ca_path),
+     "Kubernetes TLS ca path"
+    },
+
+    /* Kubernetes Token file */
+    {
+     FLB_CONFIG_MAP_STR, "kube_token_file", K8S_EVENTS_KUBE_TOKEN,
+     0, FLB_TRUE, offsetof(struct k8s_events, token_file),
+     "Kubernetes authorization token file"
+    },
+
+    /* EOF */
+    {0}
+};
+
+/* Plugin reference */
+struct flb_input_plugin in_kubernetes_events_plugin = {
+    .name         = "kubernetes_events",
+    .description  = "Kubernetes Events",
+    .cb_init      = k8s_events_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = k8s_events_collect,
+    .cb_flush_buf = NULL,
+    .cb_exit      = k8s_events_exit,
+    .config_map   = config_map,
+    .flags        = FLB_INPUT_NET | FLB_INPUT_CORO | FLB_INPUT_THREADED
+};

--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -1,0 +1,80 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_KUBERNETES_EVENTS_H
+#define FLB_IN_KUBERNETES_EVENTS_H
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_upstream.h>
+#include <fluent-bit/flb_record_accessor.h>
+
+/* Filter context */
+struct k8s_events {
+    int coll_id;
+
+    /* Configuration parameters */
+    char *api_host;
+    int api_port;
+    int api_https;
+    int tls_debug;
+    int tls_verify;
+    int kube_token_ttl;
+
+    /* API Server end point */
+    char kube_url[1024];
+
+    /* TLS CA certificate file */
+    char *tls_ca_path;
+    char *tls_ca_file;
+
+    /* TLS virtual host (optional), set by configmap */
+    flb_sds_t tls_vhost;
+
+    /* Kubernetes Token from FLB_KUBE_TOKEN file */
+    char *token_file;
+    char *token;
+    size_t token_len;
+
+    /* Pre-formatted HTTP Authorization header value */
+    char *auth;
+    size_t auth_len;
+
+    int dns_retries;
+    int dns_wait_time;
+
+    struct flb_tls *tls;
+
+    struct flb_log_event_encoder *encoder;
+
+    /* metadata state */
+    cfl_sds_t last_resource_version;
+    cfl_sds_t last_continue;
+
+    /* record accessor */
+    struct flb_record_accessor *ra_timestamp;
+    struct flb_record_accessor *ra_resource_version;
+
+    /* others */
+    struct flb_config *config;
+    struct flb_upstream *upstream;
+    struct flb_input_instance *ins;
+};
+
+#endif

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -1,0 +1,181 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "kubernetes_events_conf.h"
+
+static int network_init(struct k8s_events *ctx, struct flb_config *config)
+{
+    int io_type = FLB_IO_TCP;
+
+    ctx->upstream = NULL;
+
+    if (ctx->api_https == FLB_TRUE) {
+        if (!ctx->tls_ca_path && !ctx->tls_ca_file) {
+            ctx->tls_ca_file = flb_strdup(K8S_EVENTS_KUBE_CA);
+        }
+
+        /* create a custom TLS context since we use user-defined certs */
+        ctx->tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
+                                  ctx->tls_verify,
+                                  ctx->tls_debug,
+                                  ctx->tls_vhost,
+                                  ctx->tls_ca_path,
+                                  ctx->tls_ca_file,
+                                  NULL, NULL, NULL);
+        if (!ctx->tls) {
+            return -1;
+        }
+
+        io_type = FLB_IO_TLS;
+    }
+
+    /* Create an Upstream context */
+    ctx->upstream = flb_upstream_create(config,
+                                        ctx->api_host,
+                                        ctx->api_port,
+                                        io_type,
+                                        ctx->tls);
+    if (!ctx->upstream) {
+        flb_plg_error(ctx->ins, "network initialization failed");
+        return -1;
+    }
+
+    return 0;
+}
+
+struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
+{
+    int off;
+    int ret;
+    const char *p;
+    const char *url;
+    const char *tmp;
+    struct k8s_events *ctx = NULL;
+
+    ctx = flb_calloc(1, sizeof(struct k8s_events));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->ins = ins;
+
+    /* Load the config map */
+    ret = flb_input_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return NULL;
+    }
+    flb_input_set_context(ins, ctx);
+
+    ctx->encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!ctx->encoder) {
+        flb_plg_error(ins, "could not initialize event encoder");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    /* Record accessor pattern */
+    ctx->ra_timestamp = flb_ra_create(K8S_EVENTS_RA_TIMESTAMP, FLB_TRUE);
+    if (!ctx->ra_timestamp) {
+        flb_plg_error(ctx->ins,
+                      "could not create record accessor for metadata items");
+        return NULL;
+    }
+
+    ctx->ra_resource_version = flb_ra_create(K8S_EVENTS_RA_RESOURCE_VERSION, FLB_TRUE);
+    if (!ctx->ra_resource_version) {
+        flb_plg_error(ctx->ins, "could not create record accessor for resource version");
+        return NULL;
+    }
+
+    /* Get Kubernetes API server */
+    url = flb_input_get_property("kube_url", ins);
+    if (!url) {
+        ctx->api_host = flb_strdup(K8S_EVENTS_KUBE_API_HOST);
+        ctx->api_port =  K8S_EVENTS_KUBE_API_PORT;
+        ctx->api_https = FLB_TRUE;
+    }
+    else {
+        tmp = url;
+
+        /* Check the protocol */
+        if (strncmp(tmp, "http://", 7) == 0) {
+            off = 7;
+            ctx->api_https = FLB_FALSE;
+        }
+        else if (strncmp(tmp, "https://", 8) == 0) {
+            off = 8;
+            ctx->api_https = FLB_TRUE;
+        }
+        else {
+            return NULL;
+        }
+
+        /* Get hostname and TCP port */
+        p = url + off;
+        tmp = strchr(p, ':');
+        if (tmp) {
+            ctx->api_host = flb_strndup(p, tmp - p);
+            tmp++;
+            ctx->api_port = atoi(tmp);
+        }
+        else {
+            ctx->api_host = flb_strdup(p);
+            ctx->api_port = K8S_EVENTS_KUBE_API_PORT;
+        }
+    }
+    snprintf(ctx->kube_url, sizeof(ctx->kube_url) - 1,
+             "%s://%s:%i",
+             ctx->api_https ? "https" : "http",
+             ctx->api_host, ctx->api_port);
+
+    flb_plg_info(ctx->ins, "API server: %s", ctx->kube_url);
+
+    /* network setup */
+    ret = network_init(ctx, ins->config);
+    if (ret == -1) {
+        return NULL;
+    }
+
+    return ctx;
+}
+
+void k8s_events_conf_destroy(struct k8s_events *ctx)
+{
+    if (ctx->ra_timestamp) {
+        flb_ra_destroy(ctx->ra_timestamp);
+    }
+
+    if (ctx->upstream) {
+        flb_upstream_destroy(ctx->upstream);
+    }
+
+    if (ctx->encoder) {
+        flb_log_event_encoder_destroy(ctx->encoder);
+    }
+
+    if (ctx->last_resource_version) {
+        cfl_sds_destroy(ctx->last_resource_version);
+    }
+
+    flb_free(ctx);
+}
+
+
+

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_KUBERNETES_EVENTS_CONF_H
+#define FLB_IN_KUBERNETES_EVENTS_CONF_H
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "kubernetes_events.h"
+
+/* Kubernetes API server info */
+#define K8S_EVENTS_KUBE_API_HOST "kubernetes.default.svc"
+#define K8S_EVENTS_KUBE_API_PORT 443
+#define K8S_EVENTS_KUBE_API_URI  "/api/v1/events/"
+
+/* secrets */
+#define K8S_EVENTS_KUBE_TOKEN          "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define K8S_EVENTS_KUBE_CA             "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+#define K8S_EVENTS_RA_TIMESTAMP        "$metadata['creationTimestamp']"
+#define K8S_EVENTS_RA_RESOURCE_VERSION "$metadata['resourceVersion']"
+
+struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins);
+void k8s_events_conf_destroy(struct k8s_events *ctx);
+
+#endif


### PR DESCRIPTION
The following plugin collects Kubernetes events from the API server. Every second it issue a request over a persistent channel. The plugin is aware about the 'resourceVersion' check and will only process new records when found.

The plugin is still work in process, pendings:

- auth token
- pagination support, process by using the 'continue' field value

as of now the plugin can be tested with `kubectl proxy`, e.g:

 fluent-bit -i kubernetes_events -p kube_url=http://127.0.0.1:8001 -o stdout

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
