### PR TITLE
in_windows_exporter_metrics: Fix wrong metrics type of free megabytes

### DIFF
--- a/plugins/in_windows_exporter_metrics/we_logical_disk.c
+++ b/plugins/in_windows_exporter_metrics/we_logical_disk.c
@@ -121,9 +121,9 @@ struct we_perflib_metric_spec logical_disk_metric_specs[] = {
                                 "Total amount of writeing time to the disk",
                                 "volume"),
 
-        WE_PERFLIB_COUNTER_SPEC("free_megabytes",
-                                "Free megabytes on the disk",
-                                "volume"),
+        WE_PERFLIB_GAUGE_SPEC("free_megabytes",
+                              "Free megabytes on the disk",
+                              "volume"),
 
         /* WE_PERFLIB_COUNTER_SPEC("size_megabytes", */
         /*                         "Total amount of free megabytes on the disk", */


### PR DESCRIPTION
free_megabytes metrics should increase/decrease its values. Using gauge type should be correct here instead of using counter type.

Closes https://github.com/fluent/fluent-bit/issues/7493
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
