### PR TITLE
in_node_exporter_metrics: update systemd metrics regardless their states

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -184,6 +184,8 @@ struct flb_ne {
     flb_sds_t           systemd_regex_exclude_list_text;
     struct flb_regex   *systemd_regex_include_list;
     struct flb_regex   *systemd_regex_exclude_list;
+    double              libsystemd_version;
+    char               *libsystemd_version_text;
 };
 
 #endif

--- a/plugins/in_node_exporter_metrics/ne_systemd.c
+++ b/plugins/in_node_exporter_metrics/ne_systemd.c
@@ -458,17 +458,15 @@ static int ne_systemd_update_unit_state(struct flb_ne *ctx)
                 result = 1;
             }
 
-            if (!ctx->systemd_initialization_flag) {
-                for(index = 0 ; index < 5 ; index++) {
-                    cmt_gauge_set(ctx->systemd_unit_state,
-                                  timestamp,
-                                  0,
-                                  3,
-                                  (char *[]){ unit.name,
-                                              unit_states[index],
-                                              unit.type
-                                            });
-                }
+            for(index = 0 ; index < 5 ; index++) {
+                cmt_gauge_add(ctx->systemd_unit_state,
+                              timestamp,
+                              0,
+                              3,
+                              (char *[]){ unit.name,
+                                          unit_states[index],
+                                          unit.type
+                                        });
             }
 
             cmt_gauge_inc(ctx->systemd_unit_state,

--- a/plugins/in_node_exporter_metrics/ne_systemd.c
+++ b/plugins/in_node_exporter_metrics/ne_systemd.c
@@ -539,13 +539,21 @@ static int ne_systemd_update_system_state(struct flb_ne *ctx)
             return -1;
         }
 
+        ctx->libsystemd_version_text = version;
+        ctx->libsystemd_version = strtod(version, NULL);
+
         cmt_gauge_set(ctx->systemd_version,
                       timestamp,
-                      strtod(version, NULL),
+                      ctx->libsystemd_version,
                       1,
-                      (char *[]){ version });
-
-        free(version);
+                      (char *[]){ ctx->libsystemd_version_text });
+    }
+    else {
+        cmt_gauge_add(ctx->systemd_version,
+                      timestamp,
+                      0,
+                      1,
+                      (char *[]){ ctx->libsystemd_version_text });
     }
 
     result = get_system_state(ctx, &state);
@@ -792,5 +800,8 @@ int ne_systemd_exit(struct flb_ne *ctx)
         flb_regex_destroy(ctx->systemd_regex_exclude_list);
     }
 
+    if (ctx->libsystemd_version_text != NULL) {
+        flb_free(ctx->libsystemd_version_text);
+    }
     return 0;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
On https://github.com/fluent/fluent-bit/issues/7506, a user reported glitching a place of floating point.
However, I investigated this issue and I found that some of the metrics of systemd tend not to be updated for a long time.

For example, if a systemd unit has an active state, other statues are not updated.
Additionally, for a long time, if it will not be changed the state of a systemd unit, the other activating, active, deactivating, and failed statues are not updated. The current mechanism tends to cause non-updated metrics.
So, we should touch systemd metrics on every interval for updating them.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
    Flush                1
    Log_level            debug

[INPUT]
    Name                 node_exporter_metrics
    Tag                  node_metrics
    Scrape_interval      10s
    metrics              systemd

[OUTPUT]
    Name                 prometheus_remote_write
    Match                node_metrics
    Host                 running.host.of.promethues
    Port                 9090
    Uri                  /api/v1/write
    # Header               Authorization Bearer YOUR_LICENSE_KEY
    Log_response_payload True
    # Tls                  On
    # Tls.verify           On
    # add user-defined labels
    add_label            app fluent-bit
    add_label            color blue

[OUTPUT]
    Name stdout
    Match *
```
- [x] Debug log output from testing the change

```log
Fluent Bit v2.1.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/06/05 17:13:42] [ info] Configuration:
[2023/06/05 17:13:42] [ info]  flush time     | 1.000000 seconds
[2023/06/05 17:13:42] [ info]  grace          | 5 seconds
[2023/06/05 17:13:42] [ info]  daemon         | 0
[2023/06/05 17:13:42] [ info] ___________
[2023/06/05 17:13:42] [ info]  inputs:
[2023/06/05 17:13:42] [ info]      node_exporter_metrics
[2023/06/05 17:13:42] [ info] ___________
[2023/06/05 17:13:42] [ info]  filters:
[2023/06/05 17:13:42] [ info] ___________
[2023/06/05 17:13:42] [ info]  outputs:
[2023/06/05 17:13:42] [ info]      prometheus_remote_write.0
[2023/06/05 17:13:42] [ info]      stdout.1
[2023/06/05 17:13:42] [ info] ___________
[2023/06/05 17:13:42] [ info]  collectors:
[2023/06/05 17:13:42] [ info] [fluent bit] version=2.1.5, commit=525c1a587d, pid=670908
[2023/06/05 17:13:42] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/06/05 17:13:42] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/06/05 17:13:42] [ info] [cmetrics] version=0.6.1
[2023/06/05 17:13:42] [ info] [ctraces ] version=0.3.1
[2023/06/05 17:13:42] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/06/05 17:13:42] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/06/05 17:13:42] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/06/05 17:13:42] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/06/05 17:13:42] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics systemd
[2023/06/05 17:13:42] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/06/05 17:13:42] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/06/05 17:13:42] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=31 write=32
[2023/06/05 17:13:42] [debug] [prometheus_remote_write:prometheus_remote_write.0] created event channels: read=35 write=36
[2023/06/05 17:13:42] [debug] [stdout:stdout.1] created event channels: read=48 write=49
[2023/06/05 17:13:42] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #0 started
[2023/06/05 17:13:42] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #1 started
[2023/06/05 17:13:42] [debug] [router] match rule node_exporter_metrics.0:prometheus_remote_write.0
[2023/06/05 17:13:42] [debug] [router] match rule node_exporter_metrics.0:stdout.1
[2023/06/05 17:13:42] [ info] [output:stdout:stdout.1] worker #0 started
[2023/06/05 17:13:42] [ info] [sp] stream processor started
[2023/06/05 17:13:51] [debug] [input chunk] update output instances with new chunk size diff=158014, records=0, input=node_exporter_metrics.0
[2023/06/05 17:13:52] [debug] [task] created task=0x7f9edc06d520 id=0 OK
[2023/06/05 17:13:52] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] task_id=0 assigned to thread #0
[2023/06/05 17:13:52] [debug] [output:stdout:stdout.1] task_id=0 assigned to thread #0
[2023/06/05 17:13:52] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] cmetrics msgpack size: 158014
<snip>
[2023/06/05 17:13:52] [debug] [out flush] cb_destroy coro_id=0
^C[2023/06/05 17:13:53] [engine] caught signal (SIGINT)
[2023/06/05 17:13:53] [ warn] [engine] service will shutdown in max 5 seconds
[2023/06/05 17:13:53] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/06/05 17:13:53] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] cmetric_id=0 decoded 0-158014 payload_size=266855
[2023/06/05 17:13:53] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] final payload size: 266855
[2023/06/05 17:13:53] [debug] [upstream] KA connection #71 to localhost:9090 is connected
[2023/06/05 17:13:53] [debug] [http_client] not using http_proxy for header
[2023/06/05 17:13:53] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] localhost:9090, HTTP status=204
[2023/06/05 17:13:53] [debug] [upstream] KA connection #71 to localhost:9090 is now available
[2023/06/05 17:13:53] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] http_post result FLB_OK
[2023/06/05 17:13:53] [debug] [out flush] cb_destroy coro_id=0
[2023/06/05 17:13:53] [debug] [task] destroy task=0x7f9edc06d520 (task_id=0)
[2023/06/05 17:13:53] [ info] [engine] service has stopped (0 pending tasks)
[2023/06/05 17:13:53] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/06/05 17:13:53] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
[2023/06/05 17:13:53] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] thread worker #0 stopping...
[2023/06/05 17:13:53] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] thread worker #0 stopped
[2023/06/05 17:13:53] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] thread worker #1 stopping...
[2023/06/05 17:13:53] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] thread worker #1 stopped
[2023/06/05 17:13:53] [ info] [output:stdout:stdout.1] thread worker #0 stopping...
[2023/06/05 17:13:53] [ info] [output:stdout:stdout.1] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==671109== LEAK SUMMARY:
==671109==    definitely lost: 0 bytes in 0 blocks
==671109==    indirectly lost: 0 bytes in 0 blocks
==671109==      possibly lost: 0 bytes in 0 blocks
==671109==    still reachable: 95,170 bytes in 702 blocks
==671109==         suppressed: 0 bytes in 0 blocks
==671109== Reachable blocks (those to which a pointer was found) are not shown.
==671109== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==671109== 
==671109== For lists of detected and suppressed errors, rerun with: -s
==671109== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
