### PR TITLE
in_kubernetes_filter: fix leak on exception

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -373,6 +373,7 @@ static int get_meta_info_from_request(struct flb_kube *ctx,
     ret = refresh_token_if_needed(ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "failed to refresh token");
+        flb_upstream_conn_release(u_conn);
         return -1;
     }
     


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
