### PR TITLE
in_kubernetes_events: merge in pending fixes and enhancements.

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -41,6 +41,7 @@ static int file_to_buffer(const char *path,
                           char **out_buf, size_t *out_size)
 {
     int ret;
+    int len;
     char *buf;
     ssize_t bytes;
     FILE *fp;
@@ -73,8 +74,16 @@ static int file_to_buffer(const char *path,
 
     fclose(fp);
 
+    // trim new lines
+    for (len = st.st_size; len > 0; len--) {
+        if (buf[len-1] != '\n' && buf[len-1] != '\r') {
+            break;
+        }
+    }
+    buf[len] = '\0';
+
     *out_buf = buf;
-    *out_size = st.st_size;
+    *out_size = len;
 
     return 0;
 }

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -37,6 +37,7 @@
 #include "kubernetes_events.h"
 #include "kubernetes_events_conf.h"
 
+
 static int file_to_buffer(const char *path,
                           char **out_buf, size_t *out_size)
 {
@@ -408,8 +409,10 @@ static int k8s_events_init(struct flb_input_instance *ins,
 
     ctx->coll_id = flb_input_set_collector_time(ins,
                                                 k8s_events_collect,
-                                                1,
-                                                0, config);
+                                                ctx->interval_sec,
+                                                ctx->interval_nsec,
+                                                config);
+
     return 0;
 }
 
@@ -432,6 +435,18 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "kube_url", "https://kubernetes.default.svc",
      0, FLB_FALSE, 0,
      "Kubernetes API server URL"
+    },
+
+    /* Refresh interval */
+    {
+      FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+      0, FLB_TRUE, offsetof(struct k8s_events, interval_sec),
+      "Set the polling interval for each channel"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+      0, FLB_TRUE, offsetof(struct k8s_events, interval_nsec),
+      "Set the polling interval for each channel (sub seconds)"
     },
 
     /* TLS: set debug 'level' */

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -338,6 +338,10 @@ static int k8s_events_collect(struct flb_input_instance *ins,
     struct flb_http_client *c = NULL;
     struct k8s_events *ctx = in_context;
 
+    if (pthread_mutex_trylock(&ctx->lock) != 0) {
+        FLB_INPUT_RETURN(0);
+    }
+
     u_conn = flb_upstream_conn_get(ctx->upstream);
     if (!u_conn) {
         flb_plg_error(ins, "upstream connection initialization error");
@@ -382,6 +386,7 @@ static int k8s_events_collect(struct flb_input_instance *ins,
     }
 
 exit:
+    pthread_mutex_unlock(&ctx->lock);
     if (c) {
         flb_http_client_destroy(c);
     }

--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -77,6 +77,9 @@ struct k8s_events {
     struct flb_config *config;
     struct flb_upstream *upstream;
     struct flb_input_instance *ins;
+
+    /* concurrency lock */
+    pthread_mutex_t lock;
 };
 
 #endif

--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -24,10 +24,14 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_record_accessor.h>
+#define DEFAULT_INTERVAL_SEC "0"
+#define DEFAULT_INTERVAL_NSEC "500000"
 
 /* Filter context */
 struct k8s_events {
     int coll_id;
+    int interval_sec;             /* interval collection time (Second)     */
+    int interval_nsec;            /* interval collection time (Nanosecond) */
 
     /* Configuration parameters */
     char *api_host;

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -67,6 +67,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     const char *url;
     const char *tmp;
     struct k8s_events *ctx = NULL;
+    pthread_mutexattr_t attr;
 
     ctx = flb_calloc(1, sizeof(struct k8s_events));
     if (!ctx) {
@@ -74,6 +75,9 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
         return NULL;
     }
     ctx->ins = ins;
+
+    pthread_mutexattr_init(&attr);
+    pthread_mutex_init(&ctx->lock, &attr);
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);

--- a/plugins/in_kubernetes_events/kubernetes_events_sql.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_sql.h
@@ -1,0 +1,60 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_KUBERNETES_EVENTS_SQL_H
+#define FLB_KUBERNETES_EVENTS_SQL_H
+
+/*
+ * In Fluent Bit we try to have a common convention for table names,
+ * if the table belongs to an input/output plugin, use the plugins name
+ * with the name of the object or type.
+ *
+ * in_kubernetes_events plugin table to track kubernetes events: 
+ *         in_kubernetes_events
+ */
+#define SQL_CREATE_KUBERNETES_EVENTS                                    \
+    "CREATE TABLE IF NOT EXISTS in_kubernetes_events ("                 \
+    "  id              INTEGER PRIMARY KEY,"                            \
+    "  uid             TEXT NOT NULL,"                                  \
+    "  resourceVersion INTEGER NOT NULL,"                               \
+    "  created         INTEGER NOT NULL"                                \
+    ");"
+
+#define SQL_KUBERNETES_EVENT_EXISTS_BY_UID                              \
+    "SELECT COUNT(id) "                                                 \
+    "    FROM in_kubernetes_events "                                    \
+    "    WHERE uid=@uid;"
+
+#define SQL_INSERT_KUBERNETES_EVENTS                                    \
+    "INSERT INTO in_kubernetes_events (uid, resourceVersion, created)"  \
+    "  VALUES (@uid, @resourceVersion, @created);"
+
+#define SQL_DELETE_OLD_KUBERNETES_EVENTS                                \
+    "DELETE FROM in_kubernetes_events WHERE created <= @createdBefore;"
+
+#define SQL_PRAGMA_SYNC                         \
+    "PRAGMA synchronous=%i;"
+
+#define SQL_PRAGMA_JOURNAL_MODE                 \
+    "PRAGMA journal_mode=%s;"
+
+#define SQL_PRAGMA_LOCKING_MODE                 \
+    "PRAGMA locking_mode=EXCLUSIVE;"
+
+#endif


### PR DESCRIPTION
# Summary

This adds the missing functionality for #7494.

This includes:

- Support for limit and continue.
- Saving state via the database.
- Configuration of the polling interval.
- Blocking of concurrent requests by a single instance.

There is also a fix for out-of-order events when using the plugin without a database to save the current state.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
