### PR TITLE
in_node_exporter_metrics: add support for thermal_zone.

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -16,6 +16,7 @@ set(src
   ne_utils.c
   ne_config.c
   ne_systemd.c
+  ne_thermalzone.c
   ne.c
   )
 

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -289,9 +289,6 @@ static void in_ne_pause(void *data, struct flb_config *config)
         }
         flb_input_collector_pause(coll->coll_fd, ctx->ins);
     }
-    if (ctx->coll_thermalzone_fd != -1) {
-        flb_input_collector_pause(ctx->coll_systemd_fd, ctx->ins);
-    }
 }
 
 static void in_ne_resume(void *data, struct flb_config *config)
@@ -307,9 +304,6 @@ static void in_ne_resume(void *data, struct flb_config *config)
             continue;
         }
         flb_input_collector_resume(coll->coll_fd, ctx->ins);
-    }
-    if (ctx->coll_thermalzone_fd != -1) {
-        flb_input_collector_resume(ctx->coll_systemd_fd, ctx->ins);
     }
 }
 

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -43,7 +43,7 @@
 #include "ne_systemd.h"
 #include "ne_processes.h"
 #include "ne_nvme.h"
-#include "ne_thermalzone_linux.h"
+#include "ne_thermalzone.h"
 
 /*
  * Update the metrics, this function is invoked every time 'scrape_interval'

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -33,7 +33,7 @@
 /* Default enabled metrics */
 
 #ifdef __linux__
-#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,filefd,systemd,nvme"
+#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,filefd,systemd,nvme,thermal_zone"
 #elif __APPLE__
 #define NE_DEFAULT_ENABLED_METRICS "cpu,loadavg,meminfo,diskstats,uname,netdev"
 #endif
@@ -206,6 +206,11 @@ struct flb_ne {
 
     /* nvme */
     struct cmt_gauge   *nvme_info;
+
+    /* thermal zone */
+    struct cmt_gauge   *thermalzone_temp;
+    struct cmt_gauge   *cooling_device_cur_state;
+    struct cmt_gauge   *cooling_device_max_state;
 };
 
 struct flb_ne_collector {

--- a/plugins/in_node_exporter_metrics/ne_thermalzone.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_thermalzone_linux.c"
+#else
+
+#include "ne.h"
+
+struct flb_ne_collector thermalzone_collector = {
+    .name = "thermalzone",
+    .cb_init = NULL,
+    .cb_update = NULL,
+    .cb_exit = NULL
+};
+#endif

--- a/plugins/in_node_exporter_metrics/ne_thermalzone.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone.c
@@ -24,7 +24,7 @@
 #include "ne.h"
 
 struct flb_ne_collector thermalzone_collector = {
-    .name = "thermalzone",
+    .name = "thermal_zone",
     .cb_init = NULL,
     .cb_update = NULL,
     .cb_exit = NULL

--- a/plugins/in_node_exporter_metrics/ne_thermalzone.h
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone.h
@@ -1,0 +1,28 @@
+
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_THERMALZONE_H
+#define FLB_IN_NE_THERMALZONE_H
+
+#include "ne.h"
+
+extern struct flb_ne_collector thermalzone_collector;
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_thermalzone.h
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone.h
@@ -1,4 +1,3 @@
-
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*  Fluent Bit

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -43,34 +43,32 @@
 
 int ne_thermalzone_init(struct flb_ne *ctx)
 {
-    struct cmt_gauge *g;
-
-    g = cmt_gauge_create(ctx->cmt, "node", "thermal_zone", "temp",
-                           "Zone temperature in Celsius",
-                           2, (char *[]) {"zone", "type"});
-    if (!g) {
+    ctx->thermalzone_temp = cmt_gauge_create(ctx->cmt, "node", "thermal_zone", "temp",
+                                             "Zone temperature in Celsius",
+                                             2, (char *[]) {"zone", "type"});
+    if (!ctx->thermalzone_temp) {
         flb_plg_error(ctx->ins, "could not initialize thermal zone metrics");
         return -1;
     }
-    ctx->thermalzone_temp = g;
 
-    g = cmt_gauge_create(ctx->cmt, "node", "cooling_device", "cur_state",
-                         "Current throttle state of the cooling device",
-                          2, (char *[]) {"name", "type"});
-    if (!g) {
+    ctx->cooling_device_cur_state = cmt_gauge_create(ctx->cmt, 
+                                                     "node", "cooling_device", "cur_state",
+                                                     "Current throttle state of the cooling device",
+                                                     2, (char *[]) {"name", "type"});
+    if (!ctx->cooling_device_cur_state) {
         flb_plg_error(ctx->ins, "could not initialize cooling device cur_state metric");
         return -1;
     }
-    ctx->cooling_device_cur_state = g;
 
-    g = cmt_gauge_create(ctx->cmt, "node", "cooling_device", "max_state",
-                         "Maximum throttle state of the cooling device",
-                          2, (char *[]) {"name", "type"});
-    if (!g) {
+    ctx->cooling_device_max_state = cmt_gauge_create(ctx->cmt,
+                                                     "node", "cooling_device", "max_state",
+                                                     "Maximum throttle state of the cooling device",
+                                                     2, (char *[]) {"name", "type"});
+    if (!ctx->cooling_device_max_state) {
         flb_plg_error(ctx->ins, "could not initialize cooling device max_state metric");
         return -1;
     }
-    ctx->cooling_device_max_state = g;
+
     return 0;
 }
 

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -103,15 +103,13 @@ int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
     if (ctx->path_sysfs[strlen(ctx->path_sysfs)-1] == '/') {
         path_sysfs_len--;
     }
-    path_sysfs_len = strlen(ctx->path_sysfs);
-    if (ctx->path_sysfs[strlen(ctx->path_sysfs)-1] == '/') {
-        path_sysfs_len--;
-    }
+    /* Set the full_path to the sysfs path */
     if (flb_sds_cat_safe(&full_path_sysfs, ctx->path_sysfs, path_sysfs_len) < 0) {
         flb_slist_destroy(&list);
         flb_sds_destroy(full_path_sysfs);
         return -1;
     }
+    /* Concatenate the base for all thermalzone objects */
     if (flb_sds_cat_safe(&full_path_sysfs, THERMAL_ZONE_BASE,
                          strlen(THERMAL_ZONE_BASE)) < 0) {
         flb_slist_destroy(&list);

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -1,0 +1,202 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+#include <unistd.h>
+
+/*
+ * See kernel documentation for a description:
+ * https://www.kernel.org/doc/html/latest/filesystems/proc.html
+ *
+ * user: normal processes executing in user mode
+ * nice: niced processes executing in user mode
+ * system: processes executing in kernel mode
+ * idle: twiddling thumbs
+ * iowait: In a word, iowait stands for waiting for I/O to complete. But there are several problems:
+ * irq: servicing interrupts
+ * softirq: servicing softirqs
+ * steal: involuntary wait
+ * guest: running a normal guest
+ * guest_nice: running a niced guest
+ *
+ * Ensure to pick the correct version of the documentation, older versions here:
+ * https://github.com/torvalds/linux/tree/master/Documentation
+ */
+/*
+ * Thermal zone stats, reads /sys/class/thermal/thermal_zone*
+ * ----------------------------------------------------------
+ */
+
+int ne_thermalzone_init(struct flb_ne *ctx)
+{
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(ctx->cmt, "node", "thermal_zone", "temp",
+                           "Zone temperature in Celsius",
+                           2, (char *[]) {"zone", "type"});
+    if (!g) {
+        flb_plg_error(ctx->ins, "could not initialize thermal zone metrics");
+        return -1;
+    }
+    ctx->thermalzone_temp = g;
+
+    g = cmt_gauge_create(ctx->cmt, "node", "cooling_device", "cur_state",
+                         "Current throttle state of the cooling device",
+                          2, (char *[]) {"name", "type"});
+    if (!g) {
+        flb_plg_error(ctx->ins, "could not initialize cooling device cur_state metric");
+        return -1;
+    }
+    ctx->cooling_device_cur_state = g;
+
+    g = cmt_gauge_create(ctx->cmt, "node", "cooling_device", "max_state",
+                         "Maximum throttle state of the cooling device",
+                          2, (char *[]) {"name", "type"});
+    if (!g) {
+        flb_plg_error(ctx->ins, "could not initialize cooling device max_state metric");
+        return -1;
+    }
+    ctx->cooling_device_max_state = g;
+    return 0;
+}
+
+int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
+{
+    uint64_t ts;
+    int ret;
+    uint64_t temp = 0;
+    struct mk_list *head;
+    struct mk_list list;
+    struct flb_slist_entry *entry;
+    flb_sds_t type;
+    const char *pattern = "/class/thermal/thermal_zone[0-9]*";
+
+    ts = cfl_time_now();
+
+    ret = ne_utils_path_scan(ctx, ctx->path_sysfs, pattern, NE_SCAN_DIR, &list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&list) == 0) {
+        return 0;
+    }
+
+    /* Process entries */
+    mk_list_foreach(head, &list) {
+        entry = mk_list_entry(head, struct flb_slist_entry, _head);
+
+        /* Core ID */
+        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+                                        entry->str,
+                                        "temp", NULL,
+                                        &temp);
+        if (ret != 0) {
+            continue;
+        }
+
+        ret = ne_utils_file_read_sds(ctx->path_sysfs, entry->str, "type", NULL, &type);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "unable to get type for zone: %s", entry->str);
+            continue;
+        }
+
+        cmt_gauge_set(ctx->thermalzone_temp, ts, ((double)temp)/1000.0,
+                    2, (char *[]) {&entry->str[strlen("/sys/class/thermal/thermal_zone")], type});
+        flb_sds_destroy(type);
+    }
+
+    flb_slist_destroy(&list);
+
+    return 0;
+}
+
+int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
+{
+    uint64_t ts;
+    int ret;
+    uint64_t cur_state = 0;
+    uint64_t max_state = 0;
+    struct mk_list *head;
+    struct mk_list list;
+    struct flb_slist_entry *entry;
+    flb_sds_t type;
+    const char *pattern = "/class/thermal/cooling_device[0-9]*";
+    /* Status arrays */
+    uint64_t core_throttles_set[32][256];
+    uint64_t package_throttles_set[32];
+
+    ts = cfl_time_now();
+
+    ret = ne_utils_path_scan(ctx, ctx->path_sysfs, pattern, NE_SCAN_DIR, &list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&list) == 0) {
+        return 0;
+    }
+
+    /* Reset arrays status */
+    memset(&core_throttles_set, 0, sizeof(core_throttles_set));
+    memset(&package_throttles_set, 0, sizeof(package_throttles_set));
+
+    /* Process entries */
+    mk_list_foreach(head, &list) {
+        entry = mk_list_entry(head, struct flb_slist_entry, _head);
+
+        /* Core ID */
+        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+                                        entry->str,
+                                        "cur_state", NULL,
+                                        &cur_state);
+        if (ret != 0) {
+            continue;
+        }
+
+        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+                                        entry->str,
+                                        "max_state", NULL,
+                                        &max_state);
+        if (ret != 0) {
+            continue;
+        }
+
+        ret = ne_utils_file_read_sds(ctx->path_sysfs, entry->str, "type", NULL, &type);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "unable to get type for zone: %s", entry->str);
+            continue;
+        }
+
+        cmt_gauge_set(ctx->cooling_device_cur_state, ts, ((double)cur_state),
+                    2, (char *[]) {&entry->str[strlen("/sys/class/thermal/cooling_device")], type});
+        cmt_gauge_set(ctx->cooling_device_max_state, ts, ((double)max_state),
+                    2, (char *[]) {&entry->str[strlen("/sys/class/thermal/cooling_device")], type});
+        flb_sds_destroy(type);
+    }
+
+    flb_slist_destroy(&list);
+
+    return 0;
+}

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -71,7 +71,7 @@ int ne_thermalzone_init(struct flb_ne *ctx)
 
 int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
 {
-    uint64_t ts;
+    uint64_t tstamp;
     int ret;
     uint64_t temp = 0;
     struct mk_list *head;
@@ -82,7 +82,7 @@ int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
     int path_sysfs_len;
     char *num;
 
-    ts = cfl_time_now();
+    tstamp = cfl_time_now();
 
     ret = ne_utils_path_scan(ctx, ctx->path_sysfs, THERMAL_ZONE_PATTERN, NE_SCAN_DIR, &list);
     if (ret != 0) {
@@ -142,7 +142,7 @@ int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
             num = entry->str;
         }
 
-        cmt_gauge_set(ctx->thermalzone_temp, ts, ((double) temp)/1000.0,
+        cmt_gauge_set(ctx->thermalzone_temp, tstamp, ((double) temp)/1000.0,
                     2, (char *[]) {num, type});
 
         flb_sds_destroy(type);
@@ -156,7 +156,7 @@ int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
 
 int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
 {
-    uint64_t ts;
+    uint64_t tstamp;
     int ret;
     uint64_t cur_state = 0;
     uint64_t max_state = 0;
@@ -168,7 +168,7 @@ int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
     flb_sds_t full_path_sysfs;
     int path_sysfs_len;
 
-    ts = cfl_time_now();
+    tstamp = cfl_time_now();
 
     ret = ne_utils_path_scan(ctx, ctx->path_sysfs, COOLING_DEVICE_PATTERN, NE_SCAN_DIR, &list);
     if (ret != 0) {
@@ -234,9 +234,9 @@ int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
             num = entry->str;
         }
 
-        cmt_gauge_set(ctx->cooling_device_cur_state, ts, ((double)cur_state),
+        cmt_gauge_set(ctx->cooling_device_cur_state, tstamp, ((double)cur_state),
                     2, (char *[]) {num, type});
-        cmt_gauge_set(ctx->cooling_device_max_state, ts, ((double)max_state),
+        cmt_gauge_set(ctx->cooling_device_max_state, tstamp, ((double)max_state),
                     2, (char *[]) {num, type});
         flb_sds_destroy(type);
     }

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -31,18 +31,7 @@
 
 /*
  * See kernel documentation for a description:
- * https://www.kernel.org/doc/html/latest/filesystems/proc.html
- *
- * user: normal processes executing in user mode
- * nice: niced processes executing in user mode
- * system: processes executing in kernel mode
- * idle: twiddling thumbs
- * iowait: In a word, iowait stands for waiting for I/O to complete. But there are several problems:
- * irq: servicing interrupts
- * softirq: servicing softirqs
- * steal: involuntary wait
- * guest: running a normal guest
- * guest_nice: running a niced guest
+ * https://www.kernel.org/doc/html/latest/driver-api/thermal/sysfs-api.html
  *
  * Ensure to pick the correct version of the documentation, older versions here:
  * https://github.com/torvalds/linux/tree/master/Documentation

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -38,7 +38,7 @@
  * ----------------------------------------------------------
  */
 
-int ne_thermalzone_init(struct flb_ne *ctx)
+static int ne_thermalzone_init(struct flb_ne *ctx)
 {
     ctx->thermalzone_temp = cmt_gauge_create(ctx->cmt, "node", "thermal_zone", "temp",
                                              "Zone temperature in Celsius",
@@ -69,7 +69,7 @@ int ne_thermalzone_init(struct flb_ne *ctx)
     return 0;
 }
 
-int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
+static int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
 {
     uint64_t tstamp;
     int ret;
@@ -154,7 +154,7 @@ int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
     return 0;
 }
 
-int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
+static int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
 {
     uint64_t tstamp;
     int ret;
@@ -246,3 +246,22 @@ int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
 
     return 0;
 }
+
+static int ne_thermalzone_update(struct flb_input_instance *ins, struct flb_config *config, void *in_context)
+{
+    int ret;
+    struct flb_ne *ctx = (struct flb_ne *)in_context;
+
+    ret = ne_thermalzone_update_thermal_zones(ctx);
+    if (ret != 0) {
+        return ret;
+    }
+    return ne_thermalzone_update_cooling_devices(ctx);
+}
+
+struct flb_ne_collector thermalzone_collector = {
+    .name = "thermal_zone",
+    .cb_init = ne_thermalzone_init,
+    .cb_update = ne_thermalzone_update,
+    .cb_exit = NULL
+};

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_THERMALZONE_LINUX_H
+#define FLB_IN_NE_THERMALZONE_LINUX_H
+
+#include "ne.h"
+
+int ne_thermalzone_init(struct flb_ne *ctx);
+int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx);
+int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx);
+
+#endif // FLB_IN_NE_THERMALZONE_LINUX_H

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
@@ -22,8 +22,13 @@
 
 #include "ne.h"
 
+#define THERMAL_ZONE_BASE "/class/thermal/thermal_zone"
+#define THERMAL_ZONE_PATTERN THERMAL_ZONE_BASE "[0-9]*"
+#define COOLING_DEVICE_BASE "/class/thermal/cooling_device"
+#define COOLING_DEVICE_PATTERN COOLING_DEVICE_BASE "[0-9]*"
+
 int ne_thermalzone_init(struct flb_ne *ctx);
 int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx);
 int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx);
 
-#endif // FLB_IN_NE_THERMALZONE_LINUX_H
+#endif

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.h
@@ -27,8 +27,4 @@
 #define COOLING_DEVICE_BASE "/class/thermal/cooling_device"
 #define COOLING_DEVICE_PATTERN COOLING_DEVICE_BASE "[0-9]*"
 
-int ne_thermalzone_init(struct flb_ne *ctx);
-int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx);
-int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx);
-
 #endif

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -91,18 +91,33 @@ int ne_utils_file_read_uint64(const char *mount,
     }
 
     len = strlen(path);
-    flb_sds_cat_safe(&p, path, len);
+    if (flb_sds_cat_safe(&p, path, len) < 0) {
+        flb_sds_destroy(p);
+        return -1;
+    }
 
     if (join_a) {
-        flb_sds_cat_safe(&p, "/", 1);
+        if (flb_sds_cat_safe(&p, "/", 1) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
         len = strlen(join_a);
-        flb_sds_cat_safe(&p, join_a, len);
+        if (flb_sds_cat_safe(&p, join_a, len) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
     }
 
     if (join_b) {
-        flb_sds_cat_safe(&p, "/", 1);
+        if (flb_sds_cat_safe(&p, "/", 1) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
         len = strlen(join_b);
-        flb_sds_cat_safe(&p, join_b, len);
+        if (flb_sds_cat_safe(&p, join_b, len) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
     }
 
     fd = open(p, O_RDONLY);

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -179,14 +179,13 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
 }
 
 /*
- * Read a file and every non-empty line is stored as a flb_slist_entry in the
- * given list.
+ * Read a file and store the first line as a string.
  */
 int ne_utils_file_read_sds(const char *mount, 
                            const char *path, 
-			   const char *join_a, 
-			   const char *join_b,
-			   flb_sds_t *str)
+                           const char *join_a, 
+                           const char *join_b,
+                           flb_sds_t *str)
 {
     int fd;
     int len;
@@ -211,15 +210,27 @@ int ne_utils_file_read_sds(const char *mount,
     flb_sds_cat_safe(&p, path, len);
 
     if (join_a) {
-        flb_sds_cat_safe(&p, "/", 1);
+        if (flb_sds_cat_safe(&p, "/", 1) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
         len = strlen(join_a);
-        flb_sds_cat_safe(&p, join_a, len);
+        if (flb_sds_cat_safe(&p, join_a, len) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
     }
 
     if (join_b) {
-        flb_sds_cat_safe(&p, "/", 1);
+        if (flb_sds_cat_safe(&p, "/", 1) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
         len = strlen(join_b);
-        flb_sds_cat_safe(&p, join_b, len);
+        if (flb_sds_cat_safe(&p, join_b, len) < 0) {
+            flb_sds_destroy(p);
+            return -1;
+        }
     }
 
     fd = open(p, O_RDONLY);
@@ -238,9 +249,9 @@ int ne_utils_file_read_sds(const char *mount,
     close(fd);
 
     for (i = bytes-1; i > 0; i--) {
-	if (tmp[i] != '\n' && tmp[i] != '\r') {
-		break;
-	}
+        if (tmp[i] != '\n' && tmp[i] != '\r') {
+            break;
+        }
     }
 
     *str = flb_sds_create_len(tmp, i+1);

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -178,6 +178,79 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
     return 0;
 }
 
+/*
+ * Read a file and every non-empty line is stored as a flb_slist_entry in the
+ * given list.
+ */
+int ne_utils_file_read_sds(const char *mount, 
+                           const char *path, 
+			   const char *join_a, 
+			   const char *join_b,
+			   flb_sds_t *str)
+{
+    int fd;
+    int len;
+    int i;
+    flb_sds_t p;
+    ssize_t bytes;
+    char tmp[32];
+
+    /* Check the path starts with the mount point to prevent duplication. */
+    if (strncasecmp(path, mount, strlen(mount)) == 0 &&
+        path[strlen(mount)] == '/') {
+        mount = "";
+    }
+
+    /* Compose the final path */
+    p = flb_sds_create(mount);
+    if (!p) {
+        return -1;
+    }
+
+    len = strlen(path);
+    flb_sds_cat_safe(&p, path, len);
+
+    if (join_a) {
+        flb_sds_cat_safe(&p, "/", 1);
+        len = strlen(join_a);
+        flb_sds_cat_safe(&p, join_a, len);
+    }
+
+    if (join_b) {
+        flb_sds_cat_safe(&p, "/", 1);
+        len = strlen(join_b);
+        flb_sds_cat_safe(&p, join_b, len);
+    }
+
+    fd = open(p, O_RDONLY);
+    if (fd == -1) {
+        flb_sds_destroy(p);
+        return -1;
+    }
+    flb_sds_destroy(p);
+
+    bytes = read(fd, &tmp, sizeof(tmp));
+    if (bytes == -1) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    for (i = bytes-1; i > 0; i--) {
+	if (tmp[i] != '\n' && tmp[i] != '\r') {
+		break;
+	}
+    }
+
+    *str = flb_sds_create_len(tmp, i+1);
+    if (*str == NULL) {
+        return -1;
+    }
+
+    return 0;
+}
+
 int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,
                        int expected, struct mk_list *list)
 {

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -33,6 +33,12 @@ int ne_utils_file_read_uint64(const char *mount,
                               const char *join_a, const char *join_b,
                               uint64_t *out_val);
 
+int ne_utils_file_read_sds(const char *mount,
+                           const char *path,
+                           const char *join_a, 
+			   const char *join_b, 
+			   flb_sds_t *str);
+
 int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list);
 int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,
                        int expected, struct mk_list *list);

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -36,8 +36,8 @@ int ne_utils_file_read_uint64(const char *mount,
 int ne_utils_file_read_sds(const char *mount,
                            const char *path,
                            const char *join_a, 
-			   const char *join_b, 
-			   flb_sds_t *str);
+                           const char *join_b, 
+                           flb_sds_t *str);
 
 int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list);
 int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,


### PR DESCRIPTION
# Summary

This patch adds support for reading temperature values from `/sys/calss/thermal_zone`. The labels are replicated from the same behaviour as the prometheus node_exporter.

This plugin provides thermal reporting on linux/arm64, especially for raspberry pi 4 and other similar SBCs.

These sensors are already implemented in the prometheus node_exporter_metrics: https://github.com/prometheus/node_exporter/blob/ed1b8e3d88851806627e4f8262ee26232ca56c2c/collector/thermal_zone_linux.go#L31.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
