### PR TITLE
custom_calyptia: set defaults for calyptia fleet.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -338,10 +338,16 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         flb_input_set_property(ctx->fleet, "api_key", ctx->api_key);
         flb_input_set_property(ctx->fleet, "host", ctx->cloud_host);
         flb_input_set_property(ctx->fleet, "port", ctx->cloud_port);
-        flb_input_set_property(ctx->fleet, "tls", 
-                               (ctx->cloud_tls == 1 ? "on" : "off"));
-        flb_input_set_property(ctx->fleet, "tls.verify",
-                               (ctx->cloud_tls_verify == 1 ? "on" : "off"));
+        if (ctx->cloud_tls == 1) {
+            flb_input_set_property(ctx->fleet, "tls", "on");
+        } else {
+            flb_input_set_property(ctx->fleet, "tls", "off");
+        }
+        if (ctx->cloud_tls_verify == 1) {
+            flb_input_set_property(ctx->fleet, "tls.verify", "on");
+        } else {
+            flb_input_set_property(ctx->fleet, "tls.verify", "off");
+        }
         if (ctx->fleet_config_dir) {
             flb_input_set_property(ctx->fleet, "config_dir", ctx->fleet_config_dir);
         }

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -35,7 +35,6 @@ struct calyptia {
     flb_sds_t cloud_host;
     flb_sds_t cloud_port;
     flb_sds_t machine_id;
-    flb_sds_t fleet_id;
 
 /* used for reporting chunk trace records. */
 #ifdef FLB_HAVE_CHUNK_TRACE
@@ -51,7 +50,14 @@ struct calyptia {
     /* instances */
     struct flb_input_instance *i;
     struct flb_output_instance *o;
+    struct flb_input_instance *fleet;
     struct flb_custom_instance *ins;
+
+    /* Fleet configuration */
+    flb_sds_t fleet_id;                   /* fleet-id  */
+    flb_sds_t fleet_config_dir;           /* fleet configuration directory */
+    int fleet_interval_sec;
+    int fleet_interval_nsec;
 };
 
 /*
@@ -297,10 +303,6 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         flb_output_set_property(ctx->o, "machine_id", ctx->machine_id);
     }
 
-    if (ctx->fleet_id) {
-        flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
-    }
-
     /* Override network details: development purposes only */
     if (ctx->cloud_host) {
         flb_output_set_property(ctx->o, "cloud_host", ctx->cloud_host);
@@ -323,6 +325,29 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     else {
         flb_output_set_property(ctx->o, "tls.verify", "false");
     }
+
+    if (ctx->fleet_id) {
+        flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
+
+        ctx->fleet =  flb_input_new(config, "calyptia_fleet", NULL, FLB_FALSE);
+        if (!ctx->fleet) {
+            flb_plg_error(ctx->ins, "could not load Calyptia Fleet plugin");
+            return -1;
+        }
+
+        flb_input_set_property(ctx->fleet, "api_key", ctx->api_key);
+        flb_input_set_property(ctx->fleet, "host", ctx->cloud_host);
+        flb_input_set_property(ctx->fleet, "port", ctx->cloud_port);
+        flb_input_set_property(ctx->fleet, "tls", 
+                               (ctx->cloud_tls == 1 ? "on" : "off"));
+        flb_input_set_property(ctx->fleet, "tls.verify",
+                               (ctx->cloud_tls_verify == 1 ? "on" : "off"));
+        if (ctx->fleet_config_dir) {
+            flb_input_set_property(ctx->fleet, "config_dir", ctx->fleet_config_dir);
+        }
+        flb_input_set_property(ctx->fleet, "fleet_id", ctx->fleet_id);
+    }
+
 
 #ifdef FLB_HAVE_CHUNK_TRACE
     flb_output_set_property(ctx->o, "pipeline_id", ctx->pipeline_id);
@@ -359,13 +384,13 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_STR, "calyptia_host", NULL,
+     FLB_CONFIG_MAP_STR, "calyptia_host", "cloud-api.calyptia.com",
      0, FLB_TRUE, offsetof(struct calyptia, cloud_host),
      ""
     },
 
     {
-     FLB_CONFIG_MAP_STR, "calyptia_port", NULL,
+     FLB_CONFIG_MAP_STR, "calyptia_port", "443",
      0, FLB_TRUE, offsetof(struct calyptia, cloud_port),
      ""
     },
@@ -396,6 +421,21 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "fleet_id", NULL,
      0, FLB_TRUE, offsetof(struct calyptia, fleet_id),
      "Fleet id to be used when registering agent in a fleet"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "fleet.config_dir", NULL,
+     0, FLB_TRUE, offsetof(struct calyptia, fleet_config_dir),
+     "Base path for the configuration directory."
+    },
+    {
+      FLB_CONFIG_MAP_INT, "fleet.interval_sec", "-1",
+      0, FLB_TRUE, offsetof(struct calyptia, fleet_interval_sec),
+      "Set the collector interval"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "fleet.interval_nsec", "-1",
+      0, FLB_TRUE, offsetof(struct calyptia, fleet_interval_nsec),
+      "Set the collector interval (nanoseconds)"
     },
 
 #ifdef FLB_HAVE_CHUNK_TRACE

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -429,6 +429,10 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
     cfgname = time_fleet_config_filename(ctx, time_last_modified);
     if (access(cfgname, F_OK) == -1 && errno == ENOENT) {
         cfgfp = fopen(cfgname, "w+");
+        if (cfgfp == NULL) {
+            flb_plg_error(ctx->ins, "unable to open configuration file: %s", cfgname);
+            goto http_error;
+        }
         header = flb_sds_create_size(4096);
         flb_sds_printf(&header, 
                        "[INPUT]\n"
@@ -707,5 +711,5 @@ struct flb_input_plugin in_calyptia_fleet_plugin = {
     .cb_flush_buf = NULL,
     .cb_exit      = in_calyptia_fleet_exit,
     .config_map   = config_map,
-    .flags        = FLB_INPUT_NET|FLB_INPUT_CORO|FLB_IO_OPT_TLS
+    .flags        = FLB_INPUT_NET|FLB_INPUT_CORO|FLB_IO_OPT_TLS|FLB_INPUT_PRIVATE
 };


### PR DESCRIPTION
# Summary

Configure calyptia fleet via the custom calyptia plugin so we can set default values for 'host' and 'port' (set to the production calyptia cloud).

This should fix to #7523. It will require using the custom calyptia plugin instead of the input plugin, ie:

```bash
$ # old command line
$ docker run \
  --rm -ti xxxx/fluent-bit \
  -i calyptia_fleet \
  -p API_KEY=$CALYPTIA_CLOUD_TOKEN \
  -p fleet_id=bad53a0e-57a5-4ac4-8b40-0ae20bde49bc \
  -p host=cloud-api.calyptia.com \
  -p port=443 \
  -p tls=on
$ # new command line
docker run \
  --rm -ti xxxx/fluent-bit \
  -C calyptia \
  -p API_KEY=$CALYPTIA_CLOUD_TOKEN \
  -p fleet_id=bad53a0e-57a5-4ac4-8b40-0ae20bde49bc
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
