### PR TITLE
packaging: support ARM64 AL2023 builds via Actuated runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - actuated
+    - actuated-aarch64

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -120,6 +120,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Set up Actuated mirror
+        if: contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit')
+        uses: self-actuated/hub-mirror@master
+  
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -105,7 +105,7 @@ jobs:
   call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (contains(matrix.distro, 'arm' ) && 'actuated-aarch64') || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -105,7 +105,8 @@ jobs:
   call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
-    runs-on: ${{ (contains(matrix.distro, 'arm' ) && 'actuated-aarch64') || 'ubuntu-latest' }}
+    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.
+    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-aarch64') || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/pr-package-tests.yaml
+++ b/.github/workflows/pr-package-tests.yaml
@@ -9,8 +9,12 @@ on:
     branches:
       - master
 
-jobs:
+# Cancel any running on push
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   # This job provides this metadata for the other jobs to use.
   pr-package-test-build-get-meta:
     # This is a long test to run so only on-demand for certain PRs

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -13,6 +13,10 @@
           "type": "rpm"
         },
         {
+          "target": "amazonlinux/2023.arm64v8",
+          "type": "rpm"
+        },
+        {
           "target": "centos/7",
           "type": "rpm"
         },


### PR DESCRIPTION
Resolves #6978 and resolves #6300 by re-enabling ARM64 builds of Amazon Linux 2023 but also running all ARM builds on the actuated.dev runners. 

Guarded to only trigger for this repo rather than any forks.
This requires some additional infrastructure set up which needs capturing to ensure it is fully reproducible.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

See package builds in the checks for demonstration of build time improvements.
AL2023 ARM64 actually completes now and in a fraction of the time: https://github.com/fluent/fluent-bit/actions/runs/5204502425/jobs/9388809859?pr=7527

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
