### PR TITLE
out_prometheus_remote_write: Handle 400 status as error immediately

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -188,7 +188,8 @@ static int http_post(struct prometheus_remote_write_context *ctx,
          * - 205: Reset content
          *
          */
-        if (c->resp.status < 200 || c->resp.status > 205) {
+        if ((c->resp.status < 200 || c->resp.status > 205) &&
+            c->resp.status != 400) {
             if (ctx->log_response_payload &&
                 c->resp.payload && c->resp.payload_size > 0) {
                 flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i\n%s",
@@ -200,6 +201,21 @@ static int http_post(struct prometheus_remote_write_context *ctx,
                               ctx->host, ctx->port, c->resp.status);
             }
             out_ret = FLB_RETRY;
+        }
+        else if (c->resp.status == 400) {
+            /* Returned 400 status means unrecoverable. Immidiately
+             * returning as a error. */
+            if (ctx->log_response_payload &&
+                c->resp.payload && c->resp.payload_size > 0) {
+                flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i\n%s",
+                              ctx->host, ctx->port,
+                              c->resp.status, c->resp.payload);
+            }
+            else {
+                flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i",
+                              ctx->host, ctx->port, c->resp.status);
+            }
+            out_ret = FLB_ERROR;
         }
         else {
             if (ctx->log_response_payload &&


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the actual specification of Prometheus server, HTTP 400 status means unrecovarable/unacceptable error happens.
We should treat as error once it occurred.
The current actual Prometheus server's code is here:
https://github.com/prometheus/prometheus/blob/ac8abdaacda605bdcd358ec4b6d30e634a0a569a/storage/remote/write_handler.go#L55-L58

`http.StatusBadRequest` means HTTP 400 status.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
 Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```
[SERVICE]
    Flush                1
    Log_level            debug
    HTTP_Server On
    HTTP_Listen 0.0.0.0
    HTTP_Port 2020

[INPUT]
    Name                 node_exporter_metrics
    Tag                  node_metrics
    Scrape_interval      10s
    # metrics              systemd

[OUTPUT]
    Name                 prometheus_remote_write
    Match                node_metrics
    Host                 localhost
    Port                 9090
    Uri                  /api/v1/write
    # Header               Authorization Bearer YOUR_LICENSE_KEY
    Log_response_payload True
    # Tls                  On
    # Tls.verify           On
    # add user-defined labels
    add_label            app fluent-bit
    add_label            color blue

# Note : it would be necessary to replace both YOUR_DATA_SOURCE_NAME and YOUR_LICENSE_KEY
# with real values for this example to work.

[OUTPUT]
    Name stdout
    Match *
```
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==478127== 
==478127== HEAP SUMMARY:
==478127==     in use at exit: 95,170 bytes in 702 blocks
==478127==   total heap usage: 204,324 allocs, 203,622 frees, 5,262,511,672 bytes allocated
==478127== 
==478127== LEAK SUMMARY:
==478127==    definitely lost: 0 bytes in 0 blocks
==478127==    indirectly lost: 0 bytes in 0 blocks
==478127==      possibly lost: 0 bytes in 0 blocks
==478127==    still reachable: 95,170 bytes in 702 blocks
==478127==         suppressed: 0 bytes in 0 blocks
==478127== Reachable blocks (those to which a pointer was found) are not shown.
==478127== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==478127== 
==478127== For lists of detected and suppressed errors, rerun with: -s
==478127== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
