### PR TITLE
in_node_exporter_metrics: textfile: Plug unhandled NULL case

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_textfile_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_textfile_linux.c
@@ -144,6 +144,12 @@ static int textfile_update(struct flb_ne *ctx)
         entry = mk_list_entry(head, struct flb_slist_entry, _head);
         /* Update metrics from text file */
         contents = flb_file_read(entry->str);
+        if (contents == NULL) {
+            flb_plg_debug(ctx->ins, "skip invalid file of prometheus: %s",
+                          entry->str);
+            continue;
+        }
+
         if (flb_sds_len(contents) == 0) {
             flb_plg_debug(ctx->ins, "skip empty payload of prometheus: %s",
                           entry->str);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```python
[SERVICE]
    flush           1
    log_level       debug

[INPUT]
    name            node_exporter_metrics
    tag             fluentbit.metrics.${HOSTNAME}
    scrape_interval 2
    collector.textfile.path /path/to/prom_payloads/prom_metrics/*/*.prom

    metrics textfile

[OUTPUT]
    name stdout
    Match *

```
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==511818== 
==511818== HEAP SUMMARY:
==511818==     in use at exit: 95,170 bytes in 702 blocks
==511818==   total heap usage: 16,152 allocs, 15,450 frees, 50,327,111 bytes allocated
==511818== 
==511818== LEAK SUMMARY:
==511818==    definitely lost: 0 bytes in 0 blocks
==511818==    indirectly lost: 0 bytes in 0 blocks
==511818==      possibly lost: 0 bytes in 0 blocks
==511818==    still reachable: 95,170 bytes in 702 blocks
==511818==         suppressed: 0 bytes in 0 blocks
==511818== Reachable blocks (those to which a pointer was found) are not shown.
==511818== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==511818== 
==511818== For lists of detected and suppressed errors, rerun with: -s
==511818== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
