### PR TITLE
in_kubernetes_events: call destructor when init failed

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -160,7 +160,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     ctx->encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
     if (!ctx->encoder) {
         flb_plg_error(ins, "could not initialize event encoder");
-        flb_free(ctx);
+        k8s_events_conf_destroy(ctx);
         return NULL;
     }
 
@@ -169,14 +169,14 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     if (!ctx->ra_timestamp) {
         flb_plg_error(ctx->ins,
                       "could not create record accessor for metadata items");
-        flb_free(ctx);
+        k8s_events_conf_destroy(ctx);
         return NULL;
     }
 
     ctx->ra_resource_version = flb_ra_create(K8S_EVENTS_RA_RESOURCE_VERSION, FLB_TRUE);
     if (!ctx->ra_resource_version) {
         flb_plg_error(ctx->ins, "could not create record accessor for resource version");
-        flb_free(ctx);
+        k8s_events_conf_destroy(ctx);
         return NULL;
     }
 
@@ -200,7 +200,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
             ctx->api_https = FLB_TRUE;
         }
         else {
-            flb_free(ctx);
+            k8s_events_conf_destroy(ctx);
             return NULL;
         }
 
@@ -227,7 +227,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     /* network setup */
     ret = network_init(ctx, ins->config);
     if (ret == -1) {
-        flb_free(ctx);
+        k8s_events_conf_destroy(ctx);
         return NULL;
     }
 
@@ -238,7 +238,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
         ctx->db = flb_kubernetes_event_db_open(tmp, ins, ctx, ins->config);
         if (!ctx->db) {
             flb_plg_error(ctx->ins, "could not open/create database");
-            flb_free(ctx);
+            k8s_events_conf_destroy(ctx);
             return NULL;
         }
     }
@@ -251,7 +251,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
                                  0);
         if (ret != SQLITE_OK) {
             flb_plg_error(ctx->ins, "error preparing database SQL statement: stmt_get_kubernetes_event_exists_by_uid");
-            flb_free(ctx);
+            k8s_events_conf_destroy(ctx);
             return NULL;
         }
 
@@ -262,7 +262,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
                                  0);
         if (ret != SQLITE_OK) {
             flb_plg_error(ctx->ins, "error preparing database SQL statement: stmt_insert_kubernetes_event");
-            flb_free(ctx);
+            k8s_events_conf_destroy(ctx);
             return NULL;
         }
 
@@ -273,7 +273,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
                                  0);
         if (ret != SQLITE_OK) {
             flb_plg_error(ctx->ins, "error preparing database SQL statement: stmt_delete_old_kubernetes_events");
-            flb_free(ctx);
+            k8s_events_conf_destroy(ctx);
             return NULL;
         }
     }


### PR DESCRIPTION
This patch is to fix leak when initialization failed.

```
$ valgrind --leak-check=full bin/fluent-bit -i kubernetes_events -p kube_url=ftp://hoge -o stdout
(snip)
==13078== 254 (48 direct, 206 indirect) bytes in 1 blocks are definitely lost in loss record 21 of 27
==13078==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==13078==    by 0x2A40D6: flb_calloc (flb_mem.h:95)
==13078==    by 0x2A8643: flb_ra_create (flb_record_accessor.c:307)
==13078==    by 0x3CAFF4: k8s_events_conf_create (kubernetes_events_conf.c:176)
==13078==    by 0x3C676F: k8s_events_init (kubernetes_events.c:728)
==13078==    by 0x1D4F74: input_thread (flb_input_thread.c:331)
==13078==    by 0x23025E: step_callback (flb_worker.c:43)
==13078==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==13078==    by 0x5068BB3: clone (clone.S:100)
==13078== 
==13078== 258 (48 direct, 210 indirect) bytes in 1 blocks are definitely lost in loss record 22 of 27
==13078==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==13078==    by 0x2A40D6: flb_calloc (flb_mem.h:95)
==13078==    by 0x2A8643: flb_ra_create (flb_record_accessor.c:307)
==13078==    by 0x3CAF06: k8s_events_conf_create (kubernetes_events_conf.c:168)
==13078==    by 0x3C676F: k8s_events_init (kubernetes_events.c:728)
==13078==    by 0x1D4F74: input_thread (flb_input_thread.c:331)
==13078==    by 0x23025E: step_callback (flb_worker.c:43)
==13078==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==13078==    by 0x5068BB3: clone (clone.S:100)
==13078== 
==13078== 408 bytes in 1 blocks are definitely lost in loss record 24 of 27
==13078==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==13078==    by 0x2DC92B: flb_calloc (flb_mem.h:95)
==13078==    by 0x2E08F5: flb_log_event_encoder_create (flb_log_event_encoder.c:82)
==13078==    by 0x3CAE38: k8s_events_conf_create (kubernetes_events_conf.c:160)
==13078==    by 0x3C676F: k8s_events_init (kubernetes_events.c:728)
==13078==    by 0x1D4F74: input_thread (flb_input_thread.c:331)
==13078==    by 0x23025E: step_callback (flb_worker.c:43)
==13078==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==13078==    by 0x5068BB3: clone (clone.S:100)
==13078== 
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

Note: Valgrind reported some leaks of flb_input_thread. We need to fix by another PR.

```
$ valgrind --leak-check=full bin/fluent-bit -i kubernetes_events -p kube_url=ftp://hoge -o stdout
==10413== Memcheck, a memory error detector
==10413== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10413== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==10413== Command: bin/fluent-bit -i kubernetes_events -p kube_url=ftp://hoge -o stdout
==10413== 
Fluent Bit v2.1.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/06/08 21:05:23] [ info] [fluent bit] version=2.1.5, commit=775186c39f, pid=10413
[2023/06/08 21:05:23] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/06/08 21:05:23] [ info] [cmetrics] version=0.6.1
[2023/06/08 21:05:23] [ info] [ctraces ] version=0.3.1
[2023/06/08 21:05:23] [ info] [input:kubernetes_events:kubernetes_events.0] initializing
[2023/06/08 21:05:23] [ info] [input:kubernetes_events:kubernetes_events.0] storage_strategy='memory' (memory only)
[2023/06/08 21:05:23] [error] failed initialize input kubernetes_events.0
[2023/06/08 21:05:23] [error] [input:kubernetes_events:kubernetes_events.0] could not initialize threaded plugin instance
[2023/06/08 21:05:24] [ info] [sp] stream processor started
[2023/06/08 21:05:24] [ info] [output:stdout:stdout.0] worker #0 started
^C[2023/06/08 21:05:29] [engine] caught signal (SIGINT)
[2023/06/08 21:05:29] [ warn] [engine] service will shutdown in max 5 seconds
[2023/06/08 21:05:30] [ info] [engine] service has stopped (0 pending tasks)
[2023/06/08 21:05:30] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/06/08 21:05:30] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==10413== 
==10413== HEAP SUMMARY:
==10413==     in use at exit: 22,336 bytes in 10 blocks
==10413==   total heap usage: 1,609 allocs, 1,599 frees, 451,031 bytes allocated
==10413== 
==10413== 360 (88 direct, 272 indirect) bytes in 1 blocks are definitely lost in loss record 7 of 10
==10413==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==10413==    by 0x215D3D: flb_malloc (flb_mem.h:80)
==10413==    by 0x21A584: flb_sched_create (flb_scheduler.c:526)
==10413==    by 0x1D4D84: input_thread (flb_input_thread.c:302)
==10413==    by 0x23025E: step_callback (flb_worker.c:43)
==10413==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==10413==    by 0x5068BB3: clone (clone.S:100)
==10413== 
==10413== 21,976 (336 direct, 21,640 indirect) bytes in 1 blocks are definitely lost in loss record 10 of 10
==10413==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==10413==    by 0x1CFFE2: flb_calloc (flb_mem.h:95)
==10413==    by 0x1D49F9: input_thread_instance_create (flb_input_thread.c:216)
==10413==    by 0x1D5926: flb_input_thread_instance_init (flb_input_thread.c:519)
==10413==    by 0x1C5F93: flb_input_instance_init (flb_input.c:1170)
==10413==    by 0x1C6332: flb_input_init_all (flb_input.c:1259)
==10413==    by 0x20AD84: flb_engine_start (flb_engine.c:730)
==10413==    by 0x1A6630: flb_lib_worker (flb_lib.c:638)
==10413==    by 0x4FD7B42: start_thread (pthread_create.c:442)
==10413==    by 0x5068BB3: clone (clone.S:100)
==10413== 
==10413== LEAK SUMMARY:
==10413==    definitely lost: 424 bytes in 2 blocks
==10413==    indirectly lost: 21,912 bytes in 8 blocks
==10413==      possibly lost: 0 bytes in 0 blocks
==10413==    still reachable: 0 bytes in 0 blocks
==10413==         suppressed: 0 bytes in 0 blocks
==10413== 
==10413== For lists of detected and suppressed errors, rerun with: -s
==10413== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
