### PR TITLE
workflows: ensure we install AWS dependencies

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -163,7 +163,7 @@ jobs:
         # For ubuntu map to codename using the disto-info list (CSV)
         run: |
           sudo apt-get update
-          sudo apt-get install -y distro-info
+          sudo apt-get install -y distro-info awscli
           TARGET=${DISTRO%*.arm64v8}
           if [[ "$TARGET" == "ubuntu/"* ]]; then
               UBUNTU_CODENAME=$(cut -d ',' -f 1,3 < "/usr/share/distro-info/ubuntu.csv"|grep "${TARGET##*/}"|cut -d ',' -f 2)
@@ -221,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo-c aptly
+          sudo apt-get install -y createrepo-c aptly awscli
 
       - name: Checkout code for repo metadata construction - always latest
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixes missing dependencies for AWS CLI: https://github.com/fluent/fluent-bit/actions/runs/5210374391/jobs/9401376498

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested using this branch: https://github.com/fluent/fluent-bit/actions/runs/5211769160

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
