### PR TITLE
log_event_encoder: add strerror function for encoder

### DIFF
--- a/include/fluent-bit/flb_log_event_decoder.h
+++ b/include/fluent-bit/flb_log_event_decoder.h
@@ -81,6 +81,6 @@ int flb_event_decoder_decode_object(struct flb_log_event_decoder *context,
 int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
                                struct flb_log_event *record);
 
-const char* flb_log_event_encoder_strerror(int result);
+const char *flb_log_event_encoder_strerror(int error_code);
 
 #endif

--- a/include/fluent-bit/flb_log_event_decoder.h
+++ b/include/fluent-bit/flb_log_event_decoder.h
@@ -81,4 +81,6 @@ int flb_event_decoder_decode_object(struct flb_log_event_decoder *context,
 int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
                                struct flb_log_event *record);
 
+const char* flb_log_event_encoder_strerror(int result);
+
 #endif

--- a/include/fluent-bit/flb_log_event_encoder.h
+++ b/include/fluent-bit/flb_log_event_encoder.h
@@ -250,7 +250,7 @@ int flb_log_event_encoder_append_root_values_unsafe(
         struct flb_log_event_encoder *context,
         ...);
 
-const char* flb_log_event_encoder_strerror(int result);
+const char *flb_log_event_encoder_get_error_description(int error_code);
 
 #define flb_log_event_encoder_append_metadata_values(context,  ...) \
                 flb_log_event_encoder_append_metadata_values_unsafe( \

--- a/include/fluent-bit/flb_log_event_encoder.h
+++ b/include/fluent-bit/flb_log_event_encoder.h
@@ -250,6 +250,8 @@ int flb_log_event_encoder_append_root_values_unsafe(
         struct flb_log_event_encoder *context,
         ...);
 
+const char* flb_log_event_encoder_strerror(int result);
+
 #define flb_log_event_encoder_append_metadata_values(context,  ...) \
                 flb_log_event_encoder_append_metadata_values_unsafe( \
                         context, \

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -301,50 +301,65 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
                                            &context->unpacked_event.data);
 }
 
-const char* flb_log_event_encoder_strerror(int result)
+const char *flb_log_event_decoder_get_error_description(int error_code)
 {
-    switch (result) {
+    const char *ret;
+
+    switch (error_code) {
     case FLB_EVENT_DECODER_SUCCESS:
-        return "Success";
+        ret = "Success";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_INITIALIZATION_FAILURE:
-        return "Initialization failure";
+        ret = "Initialization failure";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_INVALID_CONTEXT:
-        return "Invlaid context";
+        ret = "Invalid context";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_INVALID_ARGUMENT:
-        return "Invalid argument";
+        ret = "Invalid argument";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_ROOT_TYPE:
-        return "Wrong root type";
+        ret = "Wrong root type";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_ROOT_SIZE:
-        return "Wrong root size";
+        ret = "Wrong root size";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_HEADER_TYPE:
-        return "Wrong header type";
+        ret = "Wrong header type";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_HEADER_SIZE:
-        return "Wrong header size";
+        ret = "Wrong header size";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE:
-        return "Wrong timestamp type";
+        ret = "Wrong timestamp type";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_METADATA_TYPE:
-        return "Wrong metadata type";
+        ret = "Wrong metadata type";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_WRONG_BODY_TYPE:
-        return "Wrong body type";
+        ret = "Wrong body type";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_DESERIALIZATION_FAILURE:
-        return "Deserialization failure";
+        ret = "Deserialization failure";
+        break;
 
     case FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA:
-        return "Insufficient data";
+        ret = "Insufficient data";
+        break;
 
     default:
-        return "Unknown error";
+        ret = "Unknown error";
     }
-    return "Never come";
+    return ret;
 }

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -300,3 +300,51 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
                                            event,
                                            &context->unpacked_event.data);
 }
+
+const char* flb_log_event_encoder_strerror(int result)
+{
+    switch (result) {
+    case FLB_EVENT_DECODER_SUCCESS:
+        return "Success";
+
+    case FLB_EVENT_DECODER_ERROR_INITIALIZATION_FAILURE:
+        return "Initialization failure";
+
+    case FLB_EVENT_DECODER_ERROR_INVALID_CONTEXT:
+        return "Invlaid context";
+
+    case FLB_EVENT_DECODER_ERROR_INVALID_ARGUMENT:
+        return "Invalid argument";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_ROOT_TYPE:
+        return "Wrong root type";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_ROOT_SIZE:
+        return "Wrong root size";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_HEADER_TYPE:
+        return "Wrong header type";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_HEADER_SIZE:
+        return "Wrong header size";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE:
+        return "Wrong timestamp type";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_METADATA_TYPE:
+        return "Wrong metadata type";
+
+    case FLB_EVENT_DECODER_ERROR_WRONG_BODY_TYPE:
+        return "Wrong body type";
+
+    case FLB_EVENT_DECODER_ERROR_DESERIALIZATION_FAILURE:
+        return "Deserialization failure";
+
+    case FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA:
+        return "Insufficient data";
+
+    default:
+        return "Unknown error";
+    }
+    return "Never come";
+}

--- a/src/flb_log_event_encoder.c
+++ b/src/flb_log_event_encoder.c
@@ -350,33 +350,42 @@ int flb_log_event_encoder_append_root_values_unsafe(
     return result;
 }
 
-const char *flb_log_event_decoder_strerror(int result)
+const char *flb_log_event_encoder_get_error_description(int error_code)
 {
-    switch (result) {
+    const char *ret;
+
+    switch (error_code) {
     case FLB_EVENT_ENCODER_SUCCESS:
-        return "Success";
+        ret = "Success";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_UNSPECIFIED:
-        return "Unspecified";
+        ret = "Unspecified";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_ALLOCATION_ERROR:
-        return "Allocation error";
+        ret = "Allocation error";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_INVALID_CONTEXT:
-        return "Invalid context";
+        ret = "Invalid context";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT:
-        return "Invalid argument";
+        ret = "Invalid argument";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_SERIALIZATION_FAILURE:
-        return "Serializatoin failure";
+        ret = "Serializatoin failure";
+        break;
 
     case FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE:
-        return "Invalid value type";
+        ret = "Invalid value type";
+        break;
 
     default:
-        return "Unknown error";
+        ret = "Unknown error";
     }
 
-    return "Never come";
+    return ret;
 }

--- a/src/flb_log_event_encoder.c
+++ b/src/flb_log_event_encoder.c
@@ -349,3 +349,34 @@ int flb_log_event_encoder_append_root_values_unsafe(
 
     return result;
 }
+
+const char *flb_log_event_decoder_strerror(int result)
+{
+    switch (result) {
+    case FLB_EVENT_ENCODER_SUCCESS:
+        return "Success";
+
+    case FLB_EVENT_ENCODER_ERROR_UNSPECIFIED:
+        return "Unspecified";
+
+    case FLB_EVENT_ENCODER_ERROR_ALLOCATION_ERROR:
+        return "Allocation error";
+
+    case FLB_EVENT_ENCODER_ERROR_INVALID_CONTEXT:
+        return "Invalid context";
+
+    case FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT:
+        return "Invalid argument";
+
+    case FLB_EVENT_ENCODER_ERROR_SERIALIZATION_FAILURE:
+        return "Serializatoin failure";
+
+    case FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE:
+        return "Invalid value type";
+
+    default:
+        return "Unknown error";
+    }
+
+    return "Never come";
+}


### PR DESCRIPTION
This patch is to add strerror functions for log_event_encoder/decoder to output human readable error.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
