### PR TITLE
out_stackdriver: process traceSampled special field

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1347,6 +1347,23 @@ static int get_severity_level(severity_t * s, const msgpack_object * o,
     return -1;
 }
 
+static int get_trace_sampled(int * trace_sampled_value, const msgpack_object * src_obj,
+                             const flb_sds_t key)
+{
+    msgpack_object tmp;
+    int ret = get_msgpack_obj(&tmp, src_obj, key, flb_sds_len(key), MSGPACK_OBJECT_BOOLEAN);
+    
+    if (ret == 0 && tmp.via.boolean == true) {
+        *trace_sampled_value = FLB_TRUE;
+        return 0;
+    } else if (ret == 0 && tmp.via.boolean == false) {
+        *trace_sampled_value = FLB_FALSE;
+        return 0;        
+    }
+
+    return -1;
+}
+
 static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
                                            const msgpack_object * obj)
 {
@@ -1418,6 +1435,7 @@ static int pack_json_payload(int insert_id_extracted,
         ctx->severity_key,
         ctx->trace_key,
         ctx->span_id_key,
+        ctx->trace_sampled_key,
         ctx->log_name_key,
         stream
         /* more special fields are required to be added, but, if this grows with more
@@ -1598,6 +1616,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     /* Parameters for span id */
     int span_id_extracted = FLB_FALSE;
     flb_sds_t span_id;
+
+    /* Parameters for trace sampled */
+    int trace_sampled_extracted = FLB_FALSE;
+    int trace_sampled = FLB_FALSE;
 
     /* Parameters for log name */
     int log_name_extracted = FLB_FALSE;
@@ -2040,6 +2062,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
          *  "jsonPayload": {...},
          *  "timestamp": "...",
          *  "spanId": "...",
+         *  "traceSampled": <true or false>,
          *  "trace": "..."
          * }
          */
@@ -2066,6 +2089,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         if (ctx->span_id_key
             && get_string(&span_id, obj, ctx->span_id_key) == 0) {
             span_id_extracted = FLB_TRUE;
+            entry_size += 1;
+        }
+
+        /* Extract trace sampled */
+        trace_sampled_extracted = FLB_FALSE;
+        if (ctx->trace_sampled_key
+            && get_trace_sampled(&trace_sampled, obj, ctx->trace_sampled_key) == 0) {
+            trace_sampled_extracted = FLB_TRUE;
             entry_size += 1;
         }
 
@@ -2190,6 +2221,18 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             len = flb_sds_len(span_id);
             msgpack_pack_str_with_body(&mp_pck, span_id, len);
             flb_sds_destroy(span_id);
+        }
+
+        /* Add traceSampled field into the log entry */
+        if (trace_sampled_extracted == FLB_TRUE) {
+            msgpack_pack_str_with_body(&mp_pck, "traceSampled", 12);
+
+            if (trace_sampled == FLB_TRUE) {
+                msgpack_pack_true(&mp_pck);
+            } else {
+                msgpack_pack_false(&mp_pck);
+            }
+
         }
 
         /* Add insertId field into the log entry */
@@ -2588,6 +2631,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "span_id_key", DEFAULT_SPAN_ID_KEY,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, span_id_key),
       "Set the span id key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "trace_sampled_key", DEFAULT_TRACE_SAMPLED_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, trace_sampled_key),
+      "Set the trace sampled key"
     },
     {
       FLB_CONFIG_MAP_STR, "log_name_key", DEFAULT_LOG_NAME_KEY,

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -52,6 +52,7 @@
 #define DEFAULT_SEVERITY_KEY "logging.googleapis.com/severity"
 #define DEFAULT_TRACE_KEY "logging.googleapis.com/trace"
 #define DEFAULT_SPAN_ID_KEY "logging.googleapis.com/spanId"
+#define DEFAULT_TRACE_SAMPLED_KEY "logging.googleapis.com/traceSampled"
 #define DEFAULT_LOG_NAME_KEY "logging.googleapis.com/logName"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
@@ -165,6 +166,7 @@ struct flb_stackdriver {
     flb_sds_t severity_key;
     flb_sds_t trace_key;
     flb_sds_t span_id_key;
+    flb_sds_t trace_sampled_key;
     flb_sds_t log_name_key;
     flb_sds_t http_request_key;
     int http_request_key_size;

--- a/tests/runtime/data/stackdriver/stackdriver_test_trace_sampled.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_trace_sampled.h
@@ -1,0 +1,11 @@
+#define TRACE_SAMPLED_CASE_TRUE	"[" \
+    "1591111124," \
+    "{"	\
+        "\"logging.googleapis.com/traceSampled\": true" \
+    "}]"
+
+#define TRACE_SAMPLED_CASE_FALSE	"[" \
+    "1591111124," \
+    "{"	\
+        "\"logging.googleapis.com/traceSampled\": false" \
+    "}]"


### PR DESCRIPTION
This adds support for processing the logging.googleapis.com/traceSampled
special field from the jsonPayload

Addresses: https://github.com/GoogleCloudPlatform/ops-agent/issues/459

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

Backports: https://github.com/fluent/fluent-bit/pull/7438

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
