### PR TITLE
in_kubernetes_events: allow listening to a single namespace.

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -44,6 +44,7 @@ struct k8s_events {
     int tls_debug;
     int tls_verify;
     int kube_token_ttl;
+    flb_sds_t namespace;
 
     /* API Server end point */
     char kube_url[1024];

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.h
@@ -29,7 +29,10 @@
 /* Kubernetes API server info */
 #define K8S_EVENTS_KUBE_API_HOST "kubernetes.default.svc"
 #define K8S_EVENTS_KUBE_API_PORT 443
-#define K8S_EVENTS_KUBE_API_URI  "/api/v1/events/"
+// /apis/events.k8s.io/v1/events
+// /apis/events.k8s.io/v1/namespaces/{namespace}/events
+#define K8S_EVENTS_KUBE_API_URI  "/api/v1/events"
+#define K8S_EVENTS_KUBE_NAMESPACE_API_URI  "/api/v1/namespaces/%s/events"
 
 /* secrets */
 #define K8S_EVENTS_KUBE_TOKEN          "/var/run/secrets/kubernetes.io/serviceaccount/token"


### PR DESCRIPTION
# Summary

Add the `kube_namespace` parameter to specify a single namespace to listen to events for. This is crucial when listening to events with a service account that does not have cluster-wide permissions for events.


To create a token

```bash
kubectl create serviceaccount $SVC_ACCOUNT_NAME
kubectl create role $ROLE_EVENTS --verb=get,list --resource=events
kubectl create rolebinding $ROLE_EVENTS_BINDING \
    --serviceaccount=system:serviceaccount:$NAMESPACE:$SVC_ACCOUNT_NAME \
    --role=$ROLE_EVENTS
kubectl create token $SVC_ACCOUNT_NAME > token.txt
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
