### PR TITLE
in_kubernetes_events: allow setting kube_token_file as empty for use with kubectl proxy.

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -260,9 +260,7 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         }
         return 0;
     }
-
-    if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
-        v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+    if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
         *val = v->via.u64;
         return 0;
     }

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -101,7 +101,7 @@ static int get_http_auth_header(struct k8s_events *ctx)
     char *tk = NULL;
     size_t tk_size = 0;
 
-    if (!ctx->token_file) {
+    if (!ctx->token_file || strlen(ctx->token_file) == 0) {
         return 0;
     }
 
@@ -147,6 +147,10 @@ static int refresh_token_if_needed(struct k8s_events *ctx)
 {
     int expired = FLB_FALSE;
     int ret;
+
+    if (!ctx->token_file || strlen(ctx->token_file) == 0) {
+        return 0;
+    }
 
     if (ctx->token_created > 0) {
         if (time(NULL) > ctx->token_created + ctx->token_ttl) {
@@ -257,7 +261,8 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         return 0;
     }
 
-    if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER || MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+    if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
+        v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
         *val = v->via.u64;
         return 0;
     }


### PR DESCRIPTION
# Summary

When using `kubectl proxy` it is possible to not use a token and skip authentication. This patch allows setting `kube_token_file` as an empty string to avoid having to load the token file.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
