### PR TITLE
custom: add support for section format for custom plugins.

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -481,7 +481,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
             }
 
-            if (strcmp(value, "name") != 0) {
+            if (strcasecmp(value, "name") != 0) {
                 /* value is the 'custom plugin name', create a section instance */
                 if (flb_cf_section_property_add(cf, s->cf_section->properties,
                                                 "name", 4,

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -499,6 +499,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 s->state = STATE_CUSTOM_VAL;
                 value = (char *) event->data.scalar.value;
                 s->key = flb_sds_create(value);
+                if (s->key == NULL) {
+                    flb_error("unable to allocate memory for custom section property key");
+                    return YAML_FAILURE;
+                }
             }
             break;
         case YAML_MAPPING_START_EVENT:
@@ -536,6 +540,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_CUSTOM_VAL;
             value = (char *) event->data.scalar.value;
             s->key = flb_sds_create(value);
+             if (s->key == NULL) {
+                 flb_error("unable to allocate memory for custom section property key");
+                 return YAML_FAILURE;
+             }
             break;
         case YAML_MAPPING_START_EVENT:
             s->state = STATE_CUSTOM;
@@ -555,6 +563,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_CUSTOM_KEY;
             value = (char *) event->data.scalar.value;
             s->val = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for custom section property value");
+                return YAML_FAILURE;
+            }
 
             /* register key/value pair as a property */
             flb_cf_section_property_add(cf, s->cf_section->properties,
@@ -724,6 +736,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_SECTION_VAL;
             value = (char *) event->data.scalar.value;
             s->key = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for section property key");
+                return YAML_FAILURE;
+            }
             break;
         case YAML_MAPPING_END_EVENT:
             s->state = STATE_SECTION;
@@ -740,6 +756,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_SECTION_KEY;
             value = (char *) event->data.scalar.value;
             s->val = flb_sds_create(value);
+            if (s->val == NULL) {
+                flb_error("unable to allocate memory for section property value");
+                return YAML_FAILURE;
+            }
 
             /* Check if the incoming k/v pair set a config environment variable */
             if (s->section == SECTION_ENV) {
@@ -831,6 +851,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_PLUGIN_VAL;
             value = (char *) event->data.scalar.value;
             s->key = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for plugin property key");
+                return YAML_FAILURE;
+            }
             break;
         case YAML_MAPPING_START_EVENT:
             s->state = STATE_PLUGIN_TYPE;
@@ -919,6 +943,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 /* Check if we are entering a 'logs', 'metrics' or 'traces' section */
                 value = (char *) event->data.scalar.value;
                 s->key = flb_sds_create(value);
+                if (s->key == NULL) {
+                    flb_error("unable to allocate memory for processor property key");
+                    return YAML_FAILURE;
+                }
                 s->state = STATE_INPUT_PROCESSOR_LOGS_VAL;
                 break;
             default:
@@ -971,6 +999,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             case YAML_SCALAR_EVENT:
                 value = (char *) event->data.scalar.value;
                 s->key = flb_sds_create(value);
+                if (s->key == NULL) {
+                    flb_error("unable to allocate memory for processor property key");
+                    return YAML_FAILURE;
+                }
                 s->state = STATE_INPUT_PROCESSOR_METRICS_VAL;
                 break;
             default:
@@ -1020,6 +1052,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             case YAML_SCALAR_EVENT:
                 value = (char *) event->data.scalar.value;
                 s->key = flb_sds_create(value);
+                if (s->key == NULL) {
+                    flb_error("unable to allocate memory for processor property key");
+                    return YAML_FAILURE;
+                }
                 s->state = STATE_INPUT_PROCESSOR_TRACES_VAL;
                 break;
             default:
@@ -1058,6 +1094,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_PLUGIN_KEY;
             value = (char *) event->data.scalar.value;
             s->val = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for plugin property value");
+                return YAML_FAILURE;
+            }
 
             /* register key/value pair as a property */
             if (flb_cf_section_property_add(cf, s->cf_section->properties,
@@ -1146,6 +1186,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             /* grab current value (key) */
             value = (char *) event->data.scalar.value;
             s->key = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for group property key");
+                return YAML_FAILURE;
+            }
             break;
         case YAML_MAPPING_START_EVENT:
             break;
@@ -1168,6 +1212,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s->state = STATE_GROUP_KEY;
             value = (char *) event->data.scalar.value;
             s->val = flb_sds_create(value);
+            if (s->key == NULL) {
+                flb_error("unable to allocate memory for group property value");
+                return YAML_FAILURE;
+            }
 
             /* add the kv pair to the active group properties */
             flb_cf_section_property_add(cf, s->cf_group->properties,

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -483,9 +483,11 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
 
             if (strcasecmp(value, "name") != 0) {
                 /* value is the 'custom plugin name', create a section instance */
-                if (flb_cf_section_property_add(cf, s->cf_section->properties,
-                                                "name", 4,
-                                                value, len) < 0) {
+                ret = flb_cf_section_property_add(cf, s->cf_section->properties,
+                                                  "name", 4,
+                                                  value, len);
+                if (ret < 0) {
+                    flb_error("unable to create section: %s", value);
                     return YAML_FAILURE;
                 }
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -481,15 +481,23 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
             }
 
-            /* value is the 'custom plugin name', create a section instance */
-            if (flb_cf_section_property_add(cf, s->cf_section->properties,
-                                            "name", 4,
-                                            value, len) < 0) {
-                return YAML_FAILURE;
-            }
+            if (strcmp(value, "name") != 0) {
+                /* value is the 'custom plugin name', create a section instance */
+                if (flb_cf_section_property_add(cf, s->cf_section->properties,
+                                                "name", 4,
+                                                value, len) < 0) {
+                    return YAML_FAILURE;
+                }
 
-            /* next state are key value pairs for the custom plugin*/
-            s->state = STATE_CUSTOM_KEY_VALUE_PAIR;
+                /* next state are key value pairs for the custom plugin*/
+                s->state = STATE_CUSTOM_KEY_VALUE_PAIR;
+                flb_warn("using old 'name: *properties' format for custom section. "
+                         "this format is deprecated.");
+            } else {
+                s->state = STATE_CUSTOM_VAL;
+                value = (char *) event->data.scalar.value;
+                s->key = flb_sds_create(value);
+            }
             break;
         case YAML_MAPPING_START_EVENT:
             break;


### PR DESCRIPTION
# Summary

Add support for the newer format for custom sections while still supporting the old format, ie:

new format:
```yaml
customs:
  - bar: foo
    foo: bar
```

old format:
```yaml
customs:
  - bar:
      bar: foo
      foo: bar
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
