### PR TITLE
downstream: fixed the event loop registration detection mechanism

### DIFF
--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -188,7 +188,7 @@ static int prepare_destroy_conn(struct flb_connection *connection)
     flb_trace("[downstream] destroy connection #%i to %s",
               connection->fd, flb_connection_get_remote_address(connection));
 
-    if (stream->flags & FLB_IO_ASYNC) {
+    if(MK_EVENT_IS_REGISTERED((&connection->event))) {
         mk_event_del(connection->evl, &connection->event);
     }
 

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -188,7 +188,7 @@ static int prepare_destroy_conn(struct flb_connection *connection)
     flb_trace("[downstream] destroy connection #%i to %s",
               connection->fd, flb_connection_get_remote_address(connection));
 
-    if(MK_EVENT_IS_REGISTERED((&connection->event))) {
+    if (MK_EVENT_IS_REGISTERED((&connection->event))) {
         mk_event_del(connection->evl, &connection->event);
     }
 


### PR DESCRIPTION
This PR fixes a longstanding issue in the downstream component where it would not remove connections from the event loop if the stream didn't have the ASYNC flag which caused the event loop to constant activate resulting in service disruption.