### PR TITLE
in_elasticsearch: provide version parameter for configurable server version

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -219,6 +219,12 @@ static struct flb_config_map config_map[] = {
      "Specify hostname or FQDN. This parameter is effective for sniffering node information."
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "version", "8.0.0",
+     0, FLB_TRUE, offsetof(struct flb_in_elasticsearch, es_version),
+     "Specify returning Elasticsearch server version."
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/in_elasticsearch/in_elasticsearch.h
+++ b/plugins/in_elasticsearch/in_elasticsearch.h
@@ -37,6 +37,7 @@ struct flb_in_elasticsearch {
     const char *tag_key;
     const char *meta_key;
     flb_sds_t hostname;
+    flb_sds_t es_version;
     char cluster_name[16];
     char node_name[12];
 

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h
@@ -20,7 +20,8 @@
 #ifndef FLB_IN_ELASTICSEARCH_BULK_PROT
 #define FLB_IN_ELASTICSEARCH_BULK_PROT
 
-#define ES_VERSION_RESPONSE "{\"version\":{\"number\":\"8.0.0\",\"build_flavor\":\"Fluent Bit OSS\"},\"tagline\":\"Fluent Bit's Bulk API compatible endpoint\"}"
+#define ES_VERSION_RESPONSE_TEMPLATE \
+    "{\"version\":{\"number\":\"%s\",\"build_flavor\":\"Fluent Bit OSS\"},\"tagline\":\"Fluent Bit's Bulk API compatible endpoint\"}"
 
 #define ES_NODES_TEMPLATE "{\"_nodes\":{\"total\":1,\"successful\":1,\"failed\":0}," \
     "\"nodes\":{\"%s\":{\"name\":\"%s\",\"version\":\"8.0.0\"," \

--- a/tests/runtime/in_elasticsearch.c
+++ b/tests/runtime/in_elasticsearch.c
@@ -291,7 +291,7 @@ void flb_test_in_elasticsearch_version_configured()
     size_t b_sent;
     char *expected = "\"version\":{\"number\":\"8.1.2\",\"build_flavor\"";
     char *buf = NULL;
-    int port = 9210;
+    int port = 9202;
     char sport[16];
 
     snprintf(sport, 16, "%d", port);
@@ -447,12 +447,12 @@ void flb_test_in_elasticsearch(char *write_op, int port, char *tag)
 
 void flb_test_in_elasticsearch_index_op()
 {
-    flb_test_in_elasticsearch("index", 9202, NULL);
+    flb_test_in_elasticsearch("index", 9203, NULL);
 }
 
 void flb_test_in_elasticsearch_create_op()
 {
-    flb_test_in_elasticsearch("create", 9203, NULL);
+    flb_test_in_elasticsearch("create", 9204, NULL);
 }
 
 void flb_test_in_elasticsearch_invalid(char *write_op, int status, char *expected_op, int port)
@@ -542,17 +542,17 @@ void flb_test_in_elasticsearch_invalid(char *write_op, int status, char *expecte
 
 void flb_test_in_elasticsearch_update_op()
 {
-    flb_test_in_elasticsearch_invalid("update", 403, "update", 9204);
+    flb_test_in_elasticsearch_invalid("update", 403, "update", 9205);
 }
 
 void flb_test_in_elasticsearch_delete_op()
 {
-    flb_test_in_elasticsearch_invalid("delete", 404, "delete", 9205);
+    flb_test_in_elasticsearch_invalid("delete", 404, "delete", 9206);
 }
 
 void flb_test_in_elasticsearch_nonexistent_op()
 {
-    flb_test_in_elasticsearch_invalid("nonexistent", 400, "unknown", 9206);
+    flb_test_in_elasticsearch_invalid("nonexistent", 400, "unknown", 9207);
 }
 
 void flb_test_in_elasticsearch_multi_ops()
@@ -562,7 +562,7 @@ void flb_test_in_elasticsearch_multi_ops()
     struct flb_http_client *c;
     int ret;
     int num;
-    int port = 9207;
+    int port = 9208;
     char sport[16];
     size_t b_sent;
     char *buf = NDJSON_BULK;
@@ -645,7 +645,7 @@ void flb_test_in_elasticsearch_multi_ops_gzip()
     struct flb_http_client *c;
     int ret;
     int num;
-    int port = 9208;
+    int port = 9209;
     char sport[16];
     size_t b_sent;
     char *buf = NDJSON_BULK;
@@ -737,7 +737,7 @@ void flb_test_in_elasticsearch_node_info()
     struct test_ctx *ctx;
     struct flb_http_client *c;
     int ret;
-    int port = 9208;
+    int port = 9210;
     char sport[16];
     size_t b_sent;
     char *expected = "{\"_nodes\":{\"total\":1,\"successful\":1,\"failed\":0},\"nodes\":{\"";
@@ -807,7 +807,7 @@ void flb_test_in_elasticsearch_tag_key()
     int ret;
     int num;
     size_t b_sent;
-    int port = 9209;
+    int port = 9211;
     char sport[16];
 
     char *buf = "{\"index\":{\"_index\":\"fluent-bit\"}}\n{\"test\":\"msg\",\"tag\":\"new_tag\"}\n";

--- a/tests/runtime/in_elasticsearch.c
+++ b/tests/runtime/in_elasticsearch.c
@@ -282,6 +282,75 @@ void flb_test_in_elasticsearch_version()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_in_elasticsearch_version_configured()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    size_t b_sent;
+    char *expected = "\"version\":{\"number\":\"8.1.2\",\"build_flavor\"";
+    char *buf = NULL;
+    int port = 9210;
+    char sport[16];
+
+    snprintf(sport, 16, "%d", port);
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "port", sport,
+                        "version", "8.1.2",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = in_elasticsearch_client_ctx_create(port);
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", port, NULL, 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("in_elasticsearch_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 200)) {
+        TEST_MSG("http response code error. expect: 200, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    buf = strstr(c->resp.payload, expected);
+    if (!TEST_CHECK(buf != NULL)) {
+      TEST_MSG("http request for version info failed");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_in_elasticsearch(char *write_op, int port, char *tag)
 {
     struct flb_lib_out_cb cb_data;
@@ -815,6 +884,7 @@ void flb_test_in_elasticsearch_index_op_with_plugin_tag()
 
 TEST_LIST = {
     {"version", flb_test_in_elasticsearch_version},
+    {"configured_version", flb_test_in_elasticsearch_version_configured},
     {"index_op", flb_test_in_elasticsearch_index_op},
     {"create_op", flb_test_in_elasticsearch_create_op},
     {"update_op", flb_test_in_elasticsearch_update_op},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, in_elasticsearch just returns elasticasearch server version as `8.0.0`.
Some of elasticsearch/opensearch clients wants to newer version of its server.
This PR provides configurable option for elasticsearch server version.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```console
$ bin/fluent-bit -i elasticsearch -p port=9880 -pversion=8.1.2 -o stdout
```
Another terminal
```
$ curl localhost:9880/
{"version":{"number":"8.1.2","build_flavor":"Fluent Bit OSS"},"tagline":"Fluent Bit's Bulk API compatible endpoint"}
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==189199== 
==189199== HEAP SUMMARY:
==189199==     in use at exit: 95,170 bytes in 702 blocks
==189199==   total heap usage: 2,842 allocs, 2,140 frees, 1,548,728 bytes allocated
==189199== 
==189199== LEAK SUMMARY:
==189199==    definitely lost: 0 bytes in 0 blocks
==189199==    indirectly lost: 0 bytes in 0 blocks
==189199==      possibly lost: 0 bytes in 0 blocks
==189199==    still reachable: 95,170 bytes in 702 blocks
==189199==         suppressed: 0 bytes in 0 blocks
==189199== Reachable blocks (those to which a pointer was found) are not shown.
==189199== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==189199== 
==189199== For lists of detected and suppressed errors, rerun with: -s
==189199== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1135

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
