### PR TITLE
ci: set a version for Chocolatey

### DIFF
--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -7,6 +7,7 @@ on:
       - synchronize
     paths:
       - 'dockerfiles/Dockerfile'
+      - 'dockerfiles/Dockerfile.windows'
       - 'conf/**'
 
   workflow_dispatch:
@@ -79,3 +80,54 @@ jobs:
           # Ensure we disable buildkit
           DOCKER_BUILDKIT: 0
         shell: bash
+    pr-image-tests-build-windows-images:
+      name: PR - Buildkit docker windows build test
+      runs-on: windows-latest
+      permissions:
+        contents: read
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+
+        - name: Extract metadata from Github
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ github.repository }}/pr-${{ github.event.pull_request.number }}
+            tags: |
+              type=sha
+            flavor: |
+              suffix=-windows
+    
+        - name: Build the windows images
+          id: build
+          uses: docker/build-push-action@v4
+          with:
+            file: ./dockerfiles/Dockerfile.windows
+            context: .
+            platforms: windows/amd64
+            target: production
+            push: false
+            load: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+
+        - name: Sanity check it runs
+          # We do this for a simple check of dependencies
+          run: |
+            docker run --rm -t ${{ steps.meta.outputs.tags }} --help
+          shell: bash
+        
+        - name: Build the debug multi-arch images
+          uses: docker/build-push-action@v4
+          with:
+            file: ./dockerfiles/Dockerfile.windows
+            context: .
+            platforms: windows/amd64
+            target: debug
+            push: false
+            load: false
+

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -82,7 +82,14 @@ jobs:
         shell: bash
     pr-image-tests-build-windows-images:
       name: PR - Docker windows build test, windows 2019
-      runs-on: windows-2019
+      runs-on: windows-${{ matrix.windows-base-version }}
+      strategy:
+        fail-fast: true
+        matrix:
+          windows-base-version: 
+            # https://github.com/fluent/fluent-bit/blob/1d366594a889624ec3003819fe18588aac3f17cd/dockerfiles/Dockerfile.windows#L3
+            - '2019'
+            - '2022'
       permissions:
         contents: read
       steps:
@@ -97,12 +104,12 @@ jobs:
             tags: |
               type=sha
             flavor: |
-              suffix=-windows
+              suffix=-windows-${{ matrix.windows-base-version }}
     
         - name: Build the windows images
           id: build
           run: |
-            docker build -t ${{ steps.meta.outputs.tags }} -f ./dockerfiles/Dockerfile.windows .
+            docker build -t ${{ steps.meta.outputs.tags }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/Dockerfile.windows .
 
         - name: Sanity check it runs
           # We do this for a simple check of dependencies

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -81,7 +81,7 @@ jobs:
           DOCKER_BUILDKIT: 0
         shell: bash
     pr-image-tests-build-windows-images:
-      name: PR - Docker windows build test, windows 2019
+      name: PR - Docker windows build test, windows 2019 and 2022
       runs-on: windows-${{ matrix.windows-base-version }}
       strategy:
         fail-fast: true

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -81,8 +81,8 @@ jobs:
           DOCKER_BUILDKIT: 0
         shell: bash
     pr-image-tests-build-windows-images:
-      name: PR - Buildkit docker windows build test
-      runs-on: windows-latest
+      name: PR - Docker windows build test, windows 2019
+      runs-on: windows-2019
       permissions:
         contents: read
       steps:

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -89,9 +89,6 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v3
 
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v2
-
         - name: Extract metadata from Github
           id: meta
           uses: docker/metadata-action@v4
@@ -104,30 +101,12 @@ jobs:
     
         - name: Build the windows images
           id: build
-          uses: docker/build-push-action@v4
-          with:
-            file: ./dockerfiles/Dockerfile.windows
-            context: .
-            platforms: windows/amd64
-            target: production
-            push: false
-            load: true
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
+          run: |
+            docker build -t ${{ steps.meta.outputs.tags }} -f ./dockerfiles/Dockerfile.windows .
 
         - name: Sanity check it runs
           # We do this for a simple check of dependencies
           run: |
             docker run --rm -t ${{ steps.meta.outputs.tags }} --help
           shell: bash
-        
-        - name: Build the debug multi-arch images
-          uses: docker/build-push-action@v4
-          with:
-            file: ./dockerfiles/Dockerfile.windows
-            context: .
-            platforms: windows/amd64
-            target: debug
-            push: false
-            load: false
 

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -40,6 +40,7 @@ RUN Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '
 
 # Install Chocolatey and OpenSSL: https://github.com/StefanScherer/dockerfiles-windows/blob/main/openssl/Dockerfile
 ENV chocolateyUseWindowsCompression false
+ENV chocolateyVersion '1.4.0'
 RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
     choco feature disable --name showDownloadProgress ; `
     choco install -y openssl;


### PR DESCRIPTION
Fixes #7574 setting Chocolatey version to 1.4.0 since the version doesn't require .NET 4.8, also ensures the host version matches the container version.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
